### PR TITLE
Fix launcher extraction on older Windows

### DIFF
--- a/config/release-toolchain.json
+++ b/config/release-toolchain.json
@@ -15,6 +15,13 @@
     "install_path": ".local/toolchain/mingit-2.55.0.5",
     "executable": "cmd/git.exe"
   },
+  "xz": {
+    "version": "5.8.3",
+    "url": "https://github.com/tukaani-project/xz/releases/download/v5.8.3/xz-5.8.3-windows.zip",
+    "sha256": "8D0048EE51177B11EF1613959C2A268C951F4E7F6FB3706E681E00E34BB6D5E3",
+    "install_path": ".local/toolchain/xz-5.8.3",
+    "executable": "bin_x86-64/xz.exe"
+  },
   "llvm": {
     "version": "20.1.8",
     "url": "https://github.com/llvm/llvm-project/releases/download/llvmorg-20.1.8/clang%2Bllvm-20.1.8-x86_64-pc-windows-msvc.tar.xz",

--- a/config/release.json
+++ b/config/release.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "version": "0.1.0-preview.3",
+  "version": "0.1.0-preview.4",
   "channel": "preview",
   "repository": "https://github.com/arcanite24/pinyon-shift"
 }

--- a/tools/provision-toolchain.ps1
+++ b/tools/provision-toolchain.ps1
@@ -51,6 +51,16 @@ if ($null -eq (Get-Command git.exe -ErrorAction SilentlyContinue)) {
 }
 
 Write-PinyonEvent tools 26 'Preparing the pinned LLVM compiler.' -JsonEvents:$JsonEvents
+$xzRoot = [IO.Path]::GetFullPath((Join-Path $root $config.xz.install_path))
+$xzExe = Join-Path $xzRoot $config.xz.executable
+if (-not (Test-Path -LiteralPath $xzExe -PathType Leaf)) {
+    $archive = Join-Path $downloads "xz-$($config.xz.version)-windows.zip"
+    Invoke-PinyonDownload -Uri $config.xz.url -Destination $archive -Sha256 $config.xz.sha256
+    if (Test-Path -LiteralPath $xzRoot) { Remove-Item -LiteralPath $xzRoot -Recurse -Force }
+    [void](New-Item -ItemType Directory -Force -Path $xzRoot)
+    Expand-Archive -LiteralPath $archive -DestinationPath $xzRoot -Force
+}
+
 $llvmRoot = [IO.Path]::GetFullPath((Join-Path $root $config.llvm.install_path))
 $llvmExe = Join-Path $llvmRoot $config.llvm.executable
 if (-not (Test-Path -LiteralPath $llvmExe -PathType Leaf)) {
@@ -59,8 +69,7 @@ if (-not (Test-Path -LiteralPath $llvmExe -PathType Leaf)) {
     $staging = Resolve-PinyonLocalPath -RelativePath ".local/toolchain/llvm-$($config.llvm.version)-staging"
     if (Test-Path -LiteralPath $staging) { Remove-Item -LiteralPath $staging -Recurse -Force }
     [void](New-Item -ItemType Directory -Force -Path $staging)
-    & tar.exe -xf $archive -C $staging
-    if ($LASTEXITCODE -ne 0) { throw 'Unable to extract the LLVM toolchain.' }
+    Expand-PinyonTarXz -Archive $archive -Destination $staging -XzPath $xzExe
     $children = @(Get-ChildItem -LiteralPath $staging -Directory)
     if ($children.Count -ne 1) { throw 'The LLVM archive layout is not recognized.' }
     if (Test-Path -LiteralPath $llvmRoot) { Remove-Item -LiteralPath $llvmRoot -Recurse -Force }
@@ -83,6 +92,7 @@ $environment = Enter-PinyonBuildEnvironment
 $git = Get-PinyonGit
 foreach ($required in @(
     @{ Name = 'Git'; Path = $git },
+    @{ Name = 'XZ'; Path = $xzExe },
     @{ Name = 'CMake'; Path = $environment.CMake },
     @{ Name = 'Ninja'; Path = $environment.Ninja },
     @{ Name = 'LLVM'; Path = $llvmExe },

--- a/tools/release-common.ps1
+++ b/tools/release-common.ps1
@@ -73,6 +73,41 @@ function Invoke-PinyonDownload {
     }
 }
 
+function Expand-PinyonTarXz {
+    param(
+        [Parameter(Mandatory)] [string]$Archive,
+        [Parameter(Mandatory)] [string]$Destination,
+        [Parameter(Mandatory)] [string]$XzPath
+    )
+    $archive = [IO.Path]::GetFullPath($Archive)
+    $destination = [IO.Path]::GetFullPath($Destination)
+    $xzPath = [IO.Path]::GetFullPath($XzPath)
+    $tarArchive = Join-Path (Split-Path $archive -Parent) `
+        ([IO.Path]::GetFileNameWithoutExtension($archive))
+    if (-not $archive.EndsWith('.tar.xz', [StringComparison]::OrdinalIgnoreCase)) {
+        throw "Expected a .tar.xz archive: $archive"
+    }
+    if (-not (Test-Path -LiteralPath $xzPath -PathType Leaf)) {
+        throw "The pinned XZ extractor is missing: $xzPath"
+    }
+    if (Test-Path -LiteralPath $tarArchive) {
+        Remove-Item -LiteralPath $tarArchive -Force
+    }
+    try {
+        & $xzPath --decompress --keep --force -- $archive
+        if ($LASTEXITCODE -ne 0 -or -not (Test-Path -LiteralPath $tarArchive -PathType Leaf)) {
+            throw 'Unable to decompress the LLVM toolchain archive.'
+        }
+        & tar.exe -xf $tarArchive -C $destination
+        if ($LASTEXITCODE -ne 0) { throw 'Unable to extract the LLVM toolchain.' }
+    }
+    finally {
+        if (Test-Path -LiteralPath $tarArchive) {
+            Remove-Item -LiteralPath $tarArchive -Force
+        }
+    }
+}
+
 function Get-PinyonVisualStudioRoot {
     param([switch]$AllowMissing)
     $config = Get-PinyonReleaseToolchain

--- a/tools/tests/test_release_contract.py
+++ b/tools/tests/test_release_contract.py
@@ -22,7 +22,7 @@ class ReleaseContractTests(unittest.TestCase):
 
     def test_downloads_are_https_and_sha256_pinned(self):
         data = json.loads((ROOT / "config/release-toolchain.json").read_text())
-        for key in ("git", "llvm", "extract_xiso"):
+        for key in ("git", "xz", "llvm", "extract_xiso"):
             item = data[key]
             self.assertTrue(item["url"].startswith("https://"))
             self.assertRegex(item["sha256"], r"^[0-9A-F]{64}$")


### PR DESCRIPTION
## Summary
- provision a SHA-256-pinned XZ binary from the upstream XZ Utils release
- decompress LLVM's `.tar.xz` before invoking Windows `tar.exe`
- advance the launcher payload to `0.1.0-preview.4`

## Validation
- end-to-end synthetic `.tar.xz` extraction and cleanup
- `python -m unittest discover -s tools/tests -p "test_*.py"`
- Release launcher build and package
- repository boundary check

Closes #1