### PR TITLE
Restore motion blur around the player car

### DIFF
--- a/config/rexglue/analysis/main-xex.toml
+++ b/config/rexglue/analysis/main-xex.toml
@@ -97,8 +97,8 @@ registers = ["r28", "r31"]
 # Runtime write-watch evidence maps
 # this address to the instruction immediately after the active transform slot's
 # position and forward vectors have been stored by sub_82BC5870. The hook always
-# suppresses isolated implausible presentation transforms; structured telemetry
-# remains opt-in and rate-limited in the host implementation.
+# can suppress isolated implausible presentation transforms when explicitly
+# enabled; structured telemetry remains opt-in and rate-limited in the host.
 [[midasm_hook]]
 address = 0x82BC5A3C
 name = "PinyonShiftTraceVehiclePose"

--- a/src/pinyon_shift_app.cpp
+++ b/src/pinyon_shift_app.cpp
@@ -21,15 +21,17 @@
 
 #include <cstdio>
 
-REXCVAR_DEFINE_UINT32(pinyon_shift_config_schema, 1, "Pinyon Shift",
+REXCVAR_DEFINE_UINT32(pinyon_shift_config_schema, 2, "Pinyon Shift",
                       "Pinyon Shift host configuration schema version");
 
 namespace {
 
-constexpr uint32_t kConfigSchema = 1;
+constexpr uint32_t kConfigSchema = 2;
 
-bool EnsureSupportedConfig(const std::filesystem::path& path, bool& created) {
+bool EnsureSupportedConfig(const std::filesystem::path& path, bool& created,
+                           bool& migrated) {
   created = false;
+  migrated = false;
   if (!std::filesystem::exists(path)) {
     std::ofstream output(path, std::ios::binary | std::ios::trunc);
     if (!output) {
@@ -45,7 +47,7 @@ bool EnsureSupportedConfig(const std::filesystem::path& path, bool& created) {
               "mnk_mode = true\n"
               "keybind_start = \"Return\"\n"
               "d3d12_allow_variable_refresh_rate_and_tearing = false\n"
-              "pinyon_shift_stabilize_vehicle_presentation = true\n"
+              "pinyon_shift_stabilize_vehicle_presentation = false\n"
               "pinyon_shift_skip_opening_movies = false\n";
     created = true;
     return output.good();
@@ -57,6 +59,7 @@ bool EnsureSupportedConfig(const std::filesystem::path& path, bool& created) {
   }
   std::ostringstream contents;
   contents << input.rdbuf();
+  input.close();
   const std::string config_text = contents.str();
   const std::regex schema_pattern(
       R"((?:^|\n)\s*pinyon_shift_config_schema\s*=\s*([0-9]+)\s*(?:#.*)?(?:\r?\n|$))");
@@ -65,7 +68,54 @@ bool EnsureSupportedConfig(const std::filesystem::path& path, bool& created) {
     return false;
   }
   try {
-    return std::stoul(match[1].str()) == kConfigSchema;
+    const uint32_t schema = std::stoul(match[1].str());
+    if (schema == kConfigSchema) {
+      return true;
+    }
+    if (schema != 1) {
+      return false;
+    }
+
+    std::string migrated_text = config_text;
+    migrated_text.replace(static_cast<size_t>(match.position(1)),
+                          static_cast<size_t>(match.length(1)),
+                          std::to_string(kConfigSchema));
+    const std::regex stabilization_pattern(
+        R"((?:^|\n)\s*pinyon_shift_stabilize_vehicle_presentation\s*=\s*(true|false)\s*(?:#.*)?(?:\r?\n|$))");
+    std::smatch stabilization_match;
+    if (std::regex_search(migrated_text, stabilization_match,
+                          stabilization_pattern)) {
+      migrated_text.replace(
+          static_cast<size_t>(stabilization_match.position(1)),
+          static_cast<size_t>(stabilization_match.length(1)), "false");
+    } else {
+      if (!migrated_text.empty() && migrated_text.back() != '\n') {
+        migrated_text.push_back('\n');
+      }
+      migrated_text +=
+          "pinyon_shift_stabilize_vehicle_presentation = false\n";
+    }
+
+    std::filesystem::path temporary = path;
+    temporary += L".migrating";
+    {
+      std::ofstream output(temporary, std::ios::binary | std::ios::trunc);
+      if (!output) {
+        return false;
+      }
+      output << migrated_text;
+      if (!output.good()) {
+        return false;
+      }
+    }
+    if (!MoveFileExW(temporary.c_str(), path.c_str(),
+                     MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH)) {
+      std::error_code error;
+      std::filesystem::remove(temporary, error);
+      return false;
+    }
+    migrated = true;
+    return true;
   } catch (const std::exception&) {
     return false;
   }
@@ -94,7 +144,9 @@ void PinyonShiftApp::OnConfigurePaths(rex::PathConfig& paths) {
   paths.config_path = state_root / "config" / "pinyon_shift.toml";
 
   bool config_created = false;
-  if (!EnsureSupportedConfig(paths.config_path, config_created)) {
+  bool config_migrated = false;
+  if (!EnsureSupportedConfig(paths.config_path, config_created,
+                             config_migrated)) {
     diagnostics::RecordEvent("config.unsupported",
                              {{"path", paths.config_path.string()},
                               {"required_schema", std::to_string(kConfigSchema)}});
@@ -118,6 +170,7 @@ void PinyonShiftApp::OnConfigurePaths(rex::PathConfig& paths) {
        {"config", paths.config_path.string()},
        {"config_schema", std::to_string(kConfigSchema)},
        {"config_created", config_created ? "1" : "0"},
+       {"config_migrated", config_migrated ? "1" : "0"},
        {"log", REXCVAR_GET(log_file)}});
 }
 

--- a/src/pinyon_shift_runtime_hooks.cpp
+++ b/src/pinyon_shift_runtime_hooks.cpp
@@ -21,7 +21,7 @@
 REXCVAR_DEFINE_BOOL(pinyon_shift_skip_opening_movies, false, "Pinyon Shift",
                     "Complete XMedia-backed movies immediately");
 REXCVAR_DEFINE_BOOL(
-    pinyon_shift_stabilize_vehicle_presentation, true, "Pinyon Shift",
+    pinyon_shift_stabilize_vehicle_presentation, false, "Pinyon Shift",
     "Suppress isolated implausible player-vehicle presentation transforms");
 
 namespace {

--- a/tools/tests/test_release_contract.py
+++ b/tools/tests/test_release_contract.py
@@ -46,6 +46,17 @@ class ReleaseContractTests(unittest.TestCase):
         }
         self.assertTrue(required.issubset({p.name for p in (ROOT / "tools").glob("*.ps1")}))
 
+    def test_vehicle_presentation_stabilization_is_migrated_to_opt_in(self):
+        app = (ROOT / "src/pinyon_shift_app.cpp").read_text(encoding="utf-8")
+        hooks = (ROOT / "src/pinyon_shift_runtime_hooks.cpp").read_text(encoding="utf-8")
+        self.assertIn("constexpr uint32_t kConfigSchema = 2;", app)
+        self.assertRegex(app, r"pinyon_shift_config_schema,\s*2,")
+        self.assertIn('"pinyon_shift_stabilize_vehicle_presentation = false\\n"', app)
+        self.assertRegex(
+            hooks,
+            r"pinyon_shift_stabilize_vehicle_presentation,\s*false,",
+        )
+
     def test_8bitdo_ultimate_2c_wired_mapping_is_shipped(self):
         mappings = (ROOT / "config/gamecontrollerdb.txt").read_text(encoding="utf-8")
         matching = [


### PR DESCRIPTION
## Summary
- make the player-vehicle presentation stabilizer opt-in so the game-owned pose and motion-vector history stay coherent
- migrate schema-1 configs to schema 2 and disable the stabilizer for existing preview users
- keep the workaround available as a manual fallback

## Validation
- generated fresh dev-era ReXGlue 0.9 translations and completed the native Release build
- ran all 7 release-contract tests
- launched with an isolated schema-1 config and verified startup migrated both the schema and stabilization value, reporting config_migrated=1
- loaded the existing isolated save into free roam during diagnosis

Fixes #2