### PR TITLE
Implement quick and mid-size backlog wins

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [dev, main]
   pull_request:
   workflow_dispatch:
 
@@ -20,5 +20,7 @@ jobs:
         run: .\tools\check-repository-boundary.ps1
       - name: Test release tooling
         run: python -m unittest discover -s tools/tests -p "test_*.py"
+      - name: Check tracked Markdown links
+        run: python tools/check-markdown-links.py
       - name: Build launcher
         run: dotnet build launcher/PinyonShift.Launcher/PinyonShift.Launcher.csproj -c Release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,9 +14,16 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
       - name: Verify public source boundary
         shell: powershell
         run: .\tools\check-repository-boundary.ps1
+      - name: Test release tooling
+        run: python -m unittest discover -s tools/tests -p "test_*.py"
+      - name: Verify release tag and main ancestry
+        if: startsWith(github.ref, 'refs/tags/')
+        run: python tools/verify-release-tag.py --tag "${{ github.ref_name }}"
       - name: Package launcher
         shell: powershell
         run: .\tools\package-launcher.ps1

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -1,0 +1,95 @@
+# Backlog
+
+## Epic: Soak-test diagnostics and performance
+
+Use the 2026-08-25 long-play installation evidence to turn the current
+performance and graphical-correctness signals into reproducible fixes.
+
+- [ ] Gate or demote high-volume `M3_TRACE`, `M4_TRACE`, and `M5_TRACE` reentry diagnostics so release builds do not synchronously write thousands of info-level lines during gameplay; compare performance before and after.
+- [ ] Enable automatic per-frame performance CSV capture for diagnostic playthroughs, including frame time, FPS, draw calls, command-buffer stalls, and texture/pipeline cache hit rates.
+- [ ] Investigate the captured geometry-index corruption signatures, especially oversized lists with counts above the eight-entry limit and unreadable secondary-list pointers; correlate repairs with visible glitches and remove the underlying cause.
+- [ ] Record the exact Pinyon Shift commit, ReXGlue commit, applied patch-set identity, and executable hash in build metadata and structured diagnostics so future soak-test evidence is attributable to a reproducible build.
+
+## Quick wins
+
+These should fit in roughly half a focused day each, including a small automated
+check. They intentionally avoid work already active in the soak-test and ReXGlue
+0.10 migration branches.
+
+- [x] Add a launcher **Reset runtime settings** action that backs up only
+  `pinyon_shift.toml`, recreates the supported default configuration, and opens
+  the backup location. This replaces the current troubleshooting instruction to
+  delete the file manually without touching saves, cache, generated code, or the
+  rest of `.local`.
+- [x] Add a small `tools/summarize-performance.py` command for the per-frame CSV
+  produced by the soak-test epic. Emit sample duration, median and p95 frame
+  time, median FPS, 1% low, draw-call/stall totals, cache hit rates, and a compact
+  JSON or Markdown comparison against one baseline run. Reject empty, truncated,
+  or incompatible captures instead of reporting misleading numbers.
+- [x] Add a checked-in allowlist for the three known code-generation warnings
+  (`0x8241A370`, `0x82AD8138`, and `0x82AD813C`) and a log verifier that fails on
+  any new warning signature. Keep the accepted entries documented rather than
+  silently suppressing them, and re-baseline the allowlist once ReXGlue 0.10
+  lands.
+- [x] Add a safe graphics-experiment preset tool that backs up the host config
+  and can select 4x/8x/16x anisotropic filtering plus `none`/`fxaa`/
+  `fxaa_extreme`. Preserve the current defaults, reject unsupported values, and
+  provide a one-command restore path; do not expose frame-rate or temporal
+  upscaling flags through this tool.
+- [x] Align CI and releases with the new `dev`/`main` branch model: run CI on
+  pushes to `dev`, run the release-contract tests in the release workflow, and
+  reject a release tag when `config/release.json` does not match the tag or the
+  tagged commit is not contained in `main`.
+- [x] Add a tracked-Markdown local-link checker to the asset-free CI suite so
+  renamed docs, scripts, and source references fail before merge. Ignore web
+  links and ignored/private research paths; validate only repository-relative
+  targets that are meant to ship.
+
+## Mid-size wins
+
+These are bounded to about one focused engineer-day each after their listed
+dependency is available. If an item grows beyond that boundary, split the
+instrumentation or tool from the gameplay investigation instead of refactoring
+unrelated systems.
+
+- [x] Add an **Experimental graphics** section to the launcher for anisotropic
+  filtering and FXAA, using the same validated settings as the preset tool.
+  Include an explicit config-schema migration with backup, safe defaults, a
+  reset button, restart-required messaging, diagnostics/support-bundle fields,
+  and release-contract tests. Do not include resolution scaling in the first UI
+  pass.
+- [x] Build a visual-baseline helper that creates exact-build capture folders
+  for front end, garage, daytime/night open world, traffic, race, rewind, and
+  UI-heavy scenes. Generate a manifest plus side-by-side contact sheet from
+  manually captured PNGs, and flag missing or mismatched scene labels. This is a
+  lightweight oracle, not an automated pixel-perfect gameplay test.
+- [x] After the graphics UI and visual-baseline helper are green, add **2x
+  internal resolution** as an experimental, restart-required option with 1x as
+  the recovery default. Use the performance summarizer and representative scene
+  captures to enforce a documented GPU/memory budget before calling it
+  supported.
+- [x] Add a one-variable-at-a-time renderer A/B harness for
+  `readback_memexport`, `clear_memory_page_state`, and
+  `d3d12_submit_on_primary_buffer_end`. Keep shipping defaults unchanged; record
+  the exact config and build fingerprint, and compare both performance and
+  visual evidence. For the memexport test, first count exporting draws, bytes,
+  synchronous fallbacks, and queue/fence waits so a speedup cannot hide lost
+  guest-memory coherency. Exclude `vsync=false` because it changes guest vblank
+  behavior rather than providing a valid FPS unlock.
+- [x] Add a qualification-session command that creates a timestamped run
+  manifest, records operator markers for cold boot, menu, race, save, clean
+  exit, relaunch, and reload, then packages only the relevant logs, hashes, and
+  results. It should make the existing manual admission gates repeatable without
+  trying to automate gameplay input.
+- [x] Add once-per-process SDK-stub reachability reporting: record the first hit
+  for each stubbed import by module, symbol/address, and call count, then emit a
+  bounded shutdown summary and include it in sanitized diagnostics. Use the
+  results to prioritize the 99 stubbed imports by real gameplay reachability
+  rather than raw inventory order.
+
+## Explicitly deferred
+
+Do not treat a frame-rate unlock, native renderer replacement, FSR2/FSR3,
+ultrawide, HDR, or broad generated-source restructuring as a quick or mid-size
+win. The readiness assessments classify those as multi-week or refactor-scale
+projects that need stronger compatibility, visual, and performance oracles first.

--- a/config/rexglue/accepted-codegen-warnings.json
+++ b/config/rexglue/accepted-codegen-warnings.json
@@ -1,0 +1,21 @@
+{
+  "schema_version": 1,
+  "policy": "fail_on_unrecognized_warning_and_missing_expected_warning",
+  "warnings": [
+    {
+      "id": "oversized-function-8241A370",
+      "pattern": "^Function 0x8241A370 is [0-9]+ bytes, exceeds max_file_size_bytes \\([0-9]+\\)$",
+      "reason": "Known deterministic large translation unit; tracked until the function boundary or sharding configuration is deliberately changed."
+    },
+    {
+      "id": "bdz-outside-function-82AD8138",
+      "pattern": "^bdz at 82AD8138 branches outside function to 82AD836C$",
+      "reason": "Known branch to the inferred function boundary; the analysis configuration documents this address."
+    },
+    {
+      "id": "bdz-outside-function-82AD813C",
+      "pattern": "^bdz at 82AD813C branches outside function to 82AD836C$",
+      "reason": "Known branch to the inferred function boundary; the analysis configuration documents this address."
+    }
+  ]
+}

--- a/docs/experimental-graphics.md
+++ b/docs/experimental-graphics.md
@@ -1,0 +1,28 @@
+# Experimental graphics qualification
+
+The launcher exposes validated anisotropic filtering, FXAA, and a restart-only
+2x internal-resolution experiment. The recovery default is 1x. Every save,
+reset, and restore is handled by `tools/set-graphics-experiment.ps1`; it backs
+up only `pinyon_shift.toml` and never changes saves, generated code, or caches.
+
+The 2x option remains explicitly experimental until a candidate run meets all
+of these gates on the same exact build fingerprint as its 1x control:
+
+- all eight scenes accepted by `tools/visual-baseline.py` with no missing or
+  mismatched labels;
+- at least five minutes of compatible per-frame data accepted by
+  `tools/summarize-performance.py`;
+- median frame time no more than 35% slower, p95 frame time no more than 50%
+  slower, and 1% low no more than 35% lower than the 1x control;
+- peak committed GPU memory no more than 1.8 GiB above the 1x control; and
+- no new crash, device-removal, guest-memory coherency, or visual-correctness
+  signature.
+
+If a run fails to start or display correctly, select **Reset defaults** in the
+launcher. This restores 1x resolution and preserves a timestamped backup for
+diagnostics.
+
+Renderer A/B sessions use `tools/renderer-ab.py`. It changes only one temporary
+override at a time, keeps shipping defaults intact, and refuses to compare the
+memexport toggle until the performance evidence includes exporting-draw,
+byte, synchronous-fallback, queue-wait, and fence-wait counters.

--- a/launcher/PinyonShift.Launcher/App.xaml
+++ b/launcher/PinyonShift.Launcher/App.xaml
@@ -81,5 +81,13 @@
             <Setter Property="Padding" Value="14,12"/>
             <Setter Property="CaretBrush" Value="{StaticResource AmberBrush}"/>
         </Style>
+        <Style TargetType="ComboBox">
+            <Setter Property="FontFamily" Value="Bahnschrift, Segoe UI"/>
+            <Setter Property="FontSize" Value="13"/>
+            <Setter Property="Foreground" Value="{StaticResource InkBrush}"/>
+            <Setter Property="Background" Value="{StaticResource FogBrush}"/>
+            <Setter Property="BorderBrush" Value="{StaticResource LineBrush}"/>
+            <Setter Property="Padding" Value="8,6"/>
+        </Style>
     </Application.Resources>
 </Application>

--- a/launcher/PinyonShift.Launcher/MainWindow.xaml
+++ b/launcher/PinyonShift.Launcher/MainWindow.xaml
@@ -191,6 +191,84 @@
                 </Grid>
             </Border>
 
+            <Border Grid.Row="1" Grid.RowSpan="3" x:Name="GraphicsPanel" Background="{StaticResource PanelBrush}"
+                    BorderBrush="{StaticResource LineBrush}" BorderThickness="1" CornerRadius="5"
+                    Margin="0,18,0,0" Visibility="Collapsed"
+                    AutomationProperties.Name="Experimental graphics settings">
+                <Grid Margin="24,20">
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="*"/>
+                        <RowDefinition Height="Auto"/>
+                    </Grid.RowDefinitions>
+                    <DockPanel>
+                        <Button DockPanel.Dock="Right" Content="BACK" Style="{StaticResource QuietButton}"
+                                Click="CloseGraphicsButton_Click" AutomationProperties.Name="Close graphics settings"/>
+                        <StackPanel>
+                            <TextBlock Text="EXPERIMENTAL GRAPHICS" FontSize="10" FontWeight="SemiBold"
+                                       Foreground="{StaticResource AmberBrush}"/>
+                            <TextBlock Text="Tune the translated renderer." FontFamily="Bahnschrift SemiCondensed"
+                                       FontSize="25" FontWeight="SemiBold" Margin="0,5,0,0"/>
+                        </StackPanel>
+                    </DockPanel>
+                    <TextBlock Grid.Row="1" Margin="0,10,0,16" Foreground="{StaticResource MutedBrush}"
+                               TextWrapping="Wrap" LineHeight="19"
+                               Text="Changes are validated and backed up before they are saved. Restart the preview to apply them."/>
+                    <Grid Grid.Row="2">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*"/>
+                            <ColumnDefinition Width="16"/>
+                            <ColumnDefinition Width="*"/>
+                            <ColumnDefinition Width="16"/>
+                            <ColumnDefinition Width="*"/>
+                        </Grid.ColumnDefinitions>
+                        <StackPanel>
+                            <TextBlock Text="TEXTURE FILTERING" FontSize="10" Foreground="{StaticResource MutedBrush}"/>
+                            <ComboBox x:Name="AnisotropyComboBox" Margin="0,8,0,0" SelectedIndex="0"
+                                      AutomationProperties.Name="Texture filtering">
+                                <ComboBoxItem Tag="4"><TextBlock Text="4× anisotropic" Foreground="{StaticResource InkBrush}"/></ComboBoxItem>
+                                <ComboBoxItem Tag="8"><TextBlock Text="8× anisotropic" Foreground="{StaticResource InkBrush}"/></ComboBoxItem>
+                                <ComboBoxItem Tag="16"><TextBlock Text="16× anisotropic" Foreground="{StaticResource InkBrush}"/></ComboBoxItem>
+                            </ComboBox>
+                        </StackPanel>
+                        <StackPanel Grid.Column="2">
+                            <TextBlock Text="EDGE SMOOTHING" FontSize="10" Foreground="{StaticResource MutedBrush}"/>
+                            <ComboBox x:Name="PostEffectComboBox" Margin="0,8,0,0" SelectedIndex="0"
+                                      AutomationProperties.Name="Edge smoothing">
+                                <ComboBoxItem Tag="none"><TextBlock Text="Off" Foreground="{StaticResource InkBrush}"/></ComboBoxItem>
+                                <ComboBoxItem Tag="fxaa"><TextBlock Text="FXAA" Foreground="{StaticResource InkBrush}"/></ComboBoxItem>
+                                <ComboBoxItem Tag="fxaa_extreme"><TextBlock Text="FXAA Extreme" Foreground="{StaticResource InkBrush}"/></ComboBoxItem>
+                            </ComboBox>
+                        </StackPanel>
+                        <StackPanel Grid.Column="4">
+                            <TextBlock Text="INTERNAL RESOLUTION" FontSize="10" Foreground="{StaticResource MutedBrush}"/>
+                            <ComboBox x:Name="ResolutionComboBox" Margin="0,8,0,0" SelectedIndex="0"
+                                      AutomationProperties.Name="Internal resolution">
+                                <ComboBoxItem Tag="1"><TextBlock Text="Native · 1×" Foreground="{StaticResource InkBrush}"/></ComboBoxItem>
+                                <ComboBoxItem Tag="2"><TextBlock Text="Experimental · 2×" Foreground="{StaticResource InkBrush}"/></ComboBoxItem>
+                            </ComboBox>
+                        </StackPanel>
+                    </Grid>
+                    <Border Grid.Row="3" Background="#171B17" BorderBrush="{StaticResource LineBrush}"
+                            BorderThickness="1" CornerRadius="4" Padding="14,11" Margin="0,17,0,0">
+                        <TextBlock x:Name="GraphicsStatusText" Text="Loading current settings…" TextWrapping="Wrap"
+                                   Foreground="{StaticResource MutedBrush}" FontSize="11"
+                                   AutomationProperties.LiveSetting="Polite"/>
+                    </Border>
+                    <StackPanel Grid.Row="5" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,18,0,0">
+                        <Button x:Name="RestoreGraphicsButton" Content="RESTORE BACKUP" Style="{StaticResource QuietButton}"
+                                Margin="0,0,10,0" Click="RestoreGraphicsButton_Click"/>
+                        <Button x:Name="ResetGraphicsButton" Content="RESET DEFAULTS" Style="{StaticResource QuietButton}"
+                                Margin="0,0,10,0" Click="ResetGraphicsButton_Click"/>
+                        <Button x:Name="SaveGraphicsButton" Content="SAVE SETTINGS" Style="{StaticResource ActionButton}"
+                                Click="SaveGraphicsButton_Click"/>
+                    </StackPanel>
+                </Grid>
+            </Border>
+
             <Grid Grid.Row="4" Margin="0,22,0,0">
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="*"/>
@@ -201,6 +279,9 @@
                     <TextBlock Text="I own this copy and dumped it from my own disc." TextWrapping="Wrap"/>
                 </CheckBox>
                 <StackPanel Grid.Column="1" Orientation="Horizontal">
+                    <Button x:Name="GraphicsSettingsButton" Content="GRAPHICS" Style="{StaticResource QuietButton}"
+                            Visibility="Collapsed" Margin="0,0,12,0" Click="GraphicsSettingsButton_Click"
+                            AutomationProperties.HelpText="Open validated experimental graphics settings."/>
                     <Button x:Name="ReportProblemButton" Content="REPORT A PROBLEM" Style="{StaticResource QuietButton}"
                             Margin="0,0,12,0" Click="ReportProblemButton_Click"
                             AutomationProperties.HelpText="Open the Pinyon Shift bug report form on GitHub."/>

--- a/launcher/PinyonShift.Launcher/MainWindow.xaml.cs
+++ b/launcher/PinyonShift.Launcher/MainWindow.xaml.cs
@@ -7,6 +7,7 @@ using System.Security.Cryptography;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Windows;
+using System.Windows.Controls;
 using System.Windows.Media;
 
 namespace PinyonShift.Launcher;
@@ -48,6 +49,7 @@ public partial class MainWindow : Window
         try
         {
             _repositoryRoot = await ResolveRepositoryRootAsync();
+            GraphicsSettingsButton.Visibility = Visibility.Visible;
             BuildLocationText.Text = Path.Combine(_repositoryRoot, ".local");
             AppendLog($"Release source: {_repositoryRoot}");
             StageControllerMappings();
@@ -97,6 +99,7 @@ public partial class MainWindow : Window
             return;
 
         _busy = true;
+        GraphicsSettingsButton.IsEnabled = false;
         _cancellation = new CancellationTokenSource();
         BrowseButton.IsEnabled = false;
         OwnershipCheckBox.IsEnabled = false;
@@ -169,6 +172,7 @@ public partial class MainWindow : Window
         finally
         {
             _busy = false;
+            GraphicsSettingsButton.IsEnabled = true;
             BrowseButton.IsEnabled = true;
             OwnershipCheckBox.IsEnabled = true;
             UpdatePrimaryButton();
@@ -228,6 +232,7 @@ public partial class MainWindow : Window
         if (_busy) return;
 
         _busy = true;
+        GraphicsSettingsButton.IsEnabled = false;
         PrimaryButton.IsEnabled = false;
         PrimaryButton.Content = "GAME RUNNING";
         EyebrowText.Text = "PREVIEW RUNNING";
@@ -293,6 +298,7 @@ public partial class MainWindow : Window
         finally
         {
             _busy = false;
+            GraphicsSettingsButton.IsEnabled = true;
             ReportProblemButton.IsEnabled = true;
             UpdatePrimaryButton();
         }
@@ -353,6 +359,7 @@ public partial class MainWindow : Window
         StatusDot.Fill = FailedBrush;
         CrashIdText.Text = report.CrashId;
         CrashPanel.Visibility = Visibility.Visible;
+        GraphicsPanel.Visibility = Visibility.Collapsed;
         LogPanel.Visibility = Visibility.Collapsed;
         OwnershipCheckBox.Visibility = Visibility.Collapsed;
         ReportProblemButton.Visibility = Visibility.Collapsed;
@@ -452,6 +459,7 @@ public partial class MainWindow : Window
         StatusDot.Fill = CompleteBrush;
         PrimaryButton.Content = "PLAY PINYON SHIFT";
         CrashPanel.Visibility = Visibility.Collapsed;
+        GraphicsPanel.Visibility = Visibility.Collapsed;
         ReportProblemButton.Visibility = Visibility.Visible;
         OpenLogsButton.Visibility = Visibility.Visible;
         OwnershipCheckBox.Visibility = Visibility.Collapsed;
@@ -468,6 +476,7 @@ public partial class MainWindow : Window
         StatusDot.Fill = FailedBrush;
         PrimaryButton.Content = "TRY AGAIN";
         LogPanel.Visibility = Visibility.Visible;
+        GraphicsPanel.Visibility = Visibility.Collapsed;
         OpenLogsButton.Visibility = Visibility.Visible;
         AppendLog($"ERROR: {message}");
     }
@@ -480,6 +489,7 @@ public partial class MainWindow : Window
             step.SetState(StepState.Waiting, WaitingBrush, ActiveBrush, CompleteBrush, FailedBrush);
         PrimaryButton.Content = "VERIFY & BUILD";
         CrashPanel.Visibility = Visibility.Collapsed;
+        GraphicsPanel.Visibility = Visibility.Collapsed;
         ReportProblemButton.Visibility = Visibility.Visible;
         OwnershipCheckBox.Visibility = Visibility.Visible;
     }
@@ -522,6 +532,138 @@ public partial class MainWindow : Window
             "https://github.com/arcanite24/pinyon-shift/issues/new?template=bug.yml")
         { UseShellExecute = true });
 
+    private async void GraphicsSettingsButton_Click(object sender, RoutedEventArgs e)
+    {
+        if (_repositoryRoot is null || _busy || _pendingReport is not null) return;
+        LogPanel.Visibility = Visibility.Collapsed;
+        CrashPanel.Visibility = Visibility.Collapsed;
+        GraphicsPanel.Visibility = Visibility.Visible;
+        GraphicsStatusText.Text = "Loading current settings…";
+        try
+        {
+            ApplyGraphicsResult(await RunGraphicsSettingsToolAsync("Get"));
+            GraphicsStatusText.Text = "Current settings loaded. Saving a change requires a preview restart.";
+        }
+        catch (Exception ex)
+        {
+            GraphicsStatusText.Text = $"Settings could not be loaded: {ex.Message}";
+        }
+    }
+
+    private void CloseGraphicsButton_Click(object sender, RoutedEventArgs e)
+    {
+        GraphicsPanel.Visibility = Visibility.Collapsed;
+        LogPanel.Visibility = Visibility.Visible;
+    }
+
+    private async void SaveGraphicsButton_Click(object sender, RoutedEventArgs e) =>
+        await ChangeGraphicsSettingsAsync("Apply", "Settings saved. Restart the preview to apply them.");
+
+    private async void ResetGraphicsButton_Click(object sender, RoutedEventArgs e)
+    {
+        if (MessageBox.Show(this,
+                "Reset only the Pinyon Shift runtime settings? Your current pinyon_shift.toml will be backed up first.",
+                "Reset runtime settings", MessageBoxButton.OKCancel, MessageBoxImage.Warning) != MessageBoxResult.OK)
+            return;
+        await ChangeGraphicsSettingsAsync("Reset", "Runtime settings reset. Restart the preview to apply them.",
+            revealBackup: true);
+    }
+
+    private async void RestoreGraphicsButton_Click(object sender, RoutedEventArgs e) =>
+        await ChangeGraphicsSettingsAsync("Restore", "Latest settings backup restored. Restart the preview to apply it.");
+
+    private async Task ChangeGraphicsSettingsAsync(string action, string success, bool revealBackup = false)
+    {
+        SetGraphicsControlsEnabled(false);
+        GraphicsStatusText.Text = action == "Apply" ? "Saving validated settings…" : "Updating runtime settings…";
+        try
+        {
+            var result = await RunGraphicsSettingsToolAsync(action);
+            ApplyGraphicsResult(result);
+            GraphicsStatusText.Text = success;
+            if (revealBackup && !string.IsNullOrWhiteSpace(result.BackupPath) && File.Exists(result.BackupPath))
+            {
+                Process.Start(new ProcessStartInfo
+                {
+                    FileName = "explorer.exe",
+                    UseShellExecute = true,
+                    Arguments = $"/select,\"{result.BackupPath}\""
+                });
+            }
+        }
+        catch (Exception ex)
+        {
+            GraphicsStatusText.Text = $"No settings were changed: {ex.Message}";
+        }
+        finally
+        {
+            SetGraphicsControlsEnabled(true);
+        }
+    }
+
+    private async Task<GraphicsResult> RunGraphicsSettingsToolAsync(string action)
+    {
+        if (_repositoryRoot is null) throw new InvalidOperationException("Release source is not ready.");
+        var script = Path.Combine(_repositoryRoot, "tools", "set-graphics-experiment.ps1");
+        if (!File.Exists(script)) throw new FileNotFoundException("The graphics settings tool is missing.", script);
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = "powershell.exe",
+            WorkingDirectory = _repositoryRoot,
+            UseShellExecute = false,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            CreateNoWindow = true
+        };
+        foreach (var argument in new[]
+        {
+            "-NoLogo", "-NoProfile", "-ExecutionPolicy", "Bypass", "-File", script,
+            "-Action", action, "-StateRoot", Path.Combine(_repositoryRoot, ".local", "preview"),
+            "-Anisotropy", SelectedTag(AnisotropyComboBox), "-PostEffect", SelectedTag(PostEffectComboBox),
+            "-ResolutionScale", SelectedTag(ResolutionComboBox), "-Json"
+        }) startInfo.ArgumentList.Add(argument);
+        using var process = Process.Start(startInfo) ??
+            throw new InvalidOperationException("Windows could not start the graphics settings tool.");
+        var outputTask = process.StandardOutput.ReadToEndAsync();
+        var errorTask = process.StandardError.ReadToEndAsync();
+        await process.WaitForExitAsync();
+        var output = await outputTask;
+        var error = await errorTask;
+        if (process.ExitCode != 0)
+            throw new InvalidOperationException(string.IsNullOrWhiteSpace(error) ? "The settings tool stopped." : error.Trim());
+        var result = JsonSerializer.Deserialize<GraphicsResult>(output.Trim(), new JsonSerializerOptions
+        {
+            PropertyNameCaseInsensitive = true
+        });
+        return result ?? throw new InvalidDataException("The settings tool returned an invalid result.");
+    }
+
+    private static string SelectedTag(ComboBox comboBox) =>
+        (comboBox.SelectedItem as ComboBoxItem)?.Tag?.ToString() ?? throw new InvalidOperationException("Choose a setting first.");
+
+    private void ApplyGraphicsResult(GraphicsResult result)
+    {
+        SelectTag(AnisotropyComboBox, result.Settings.Anisotropy.ToString());
+        SelectTag(PostEffectComboBox, result.Settings.PostEffect);
+        SelectTag(ResolutionComboBox, result.Settings.ResolutionScale.ToString());
+    }
+
+    private static void SelectTag(ComboBox comboBox, string value)
+    {
+        comboBox.SelectedItem = comboBox.Items.OfType<ComboBoxItem>()
+            .FirstOrDefault(item => string.Equals(item.Tag?.ToString(), value, StringComparison.OrdinalIgnoreCase));
+    }
+
+    private void SetGraphicsControlsEnabled(bool enabled)
+    {
+        AnisotropyComboBox.IsEnabled = enabled;
+        PostEffectComboBox.IsEnabled = enabled;
+        ResolutionComboBox.IsEnabled = enabled;
+        SaveGraphicsButton.IsEnabled = enabled;
+        ResetGraphicsButton.IsEnabled = enabled;
+        RestoreGraphicsButton.IsEnabled = enabled;
+    }
+
     private sealed record ProgressMessage(string? Stage, int Percent, string? Message);
     private sealed record LaunchResult(
         [property: JsonPropertyName("result")] string? Result,
@@ -534,4 +676,12 @@ public partial class MainWindow : Window
         [property: JsonPropertyName("bundle")] string Bundle,
         [property: JsonPropertyName("issue_url")] string IssueUrl,
         [property: JsonPropertyName("exit_code_hex")] string? ExitCodeHex);
+    private sealed record GraphicsResult(
+        [property: JsonPropertyName("backup_path")] string? BackupPath,
+        [property: JsonPropertyName("settings")] GraphicsSettings Settings,
+        [property: JsonPropertyName("restart_required")] bool RestartRequired);
+    private sealed record GraphicsSettings(
+        [property: JsonPropertyName("anisotropy")] int Anisotropy,
+        [property: JsonPropertyName("post_effect")] string PostEffect,
+        [property: JsonPropertyName("resolution_scale")] int ResolutionScale);
 }

--- a/patches/rexglue/0031-sdk-stub-reachability-summary.patch
+++ b/patches/rexglue/0031-sdk-stub-reachability-summary.patch
@@ -1,0 +1,107 @@
+diff --git a/include/rex/hook.h b/include/rex/hook.h
+index 9cc2abf..ff42af7 100644
+--- a/include/rex/hook.h
++++ b/include/rex/hook.h
+@@ -12,9 +12,12 @@
+ #pragma once
+ 
+ #include <atomic>
++#include <cstdlib>
+ #include <cstring>
++#include <mutex>
+ #include <tuple>
+ #include <type_traits>
++#include <vector>
+ 
+ #include <fmt/format.h>
+ 
+@@ -29,6 +32,71 @@
+ // Hook Macros
+ //=============================================================================
+ 
++namespace rex::diagnostics {
++inline const char* StubModuleName(const char* path) {
++  const char* name = path;
++  for (const char* cursor = path; *cursor; ++cursor) {
++    if (*cursor == '/' || *cursor == '\\') name = cursor + 1;
++  }
++  return name;
++}
++
++class StubReachabilityEntry;
++inline std::mutex stub_reachability_mutex;
++inline std::vector<StubReachabilityEntry*> stub_reachability_entries;
++inline std::once_flag stub_reachability_summary_once;
++inline std::atomic<uint32_t> stub_reachability_dropped{0};
++constexpr size_t kMaximumStubReachabilityEntries = 128;
++inline void EmitStubReachabilitySummary();
++
++class StubReachabilityEntry {
++ public:
++  StubReachabilityEntry(const char* module, const char* symbol) : module_(module), symbol_(symbol) {
++    std::call_once(stub_reachability_summary_once, [] { std::atexit(EmitStubReachabilitySummary); });
++    std::lock_guard lock(stub_reachability_mutex);
++    if (stub_reachability_entries.size() < kMaximumStubReachabilityEntries) {
++      stub_reachability_entries.push_back(this);
++    } else {
++      stub_reachability_dropped.fetch_add(1, std::memory_order_relaxed);
++    }
++  }
++  uint64_t Hit(uint32_t caller) {
++    const uint64_t count = count_.fetch_add(1, std::memory_order_relaxed) + 1;
++    if (count == 1) {
++      first_caller_.store(caller, std::memory_order_relaxed);
++      REXKRNL_INFO("SDK_STUB first module={} symbol={} caller={:08X}", module_, symbol_, caller);
++    }
++    return count;
++  }
++  const char* module() const { return module_; }
++  const char* symbol() const { return symbol_; }
++  uint64_t count() const { return count_.load(std::memory_order_relaxed); }
++  uint32_t first_caller() const { return first_caller_.load(std::memory_order_relaxed); }
++ private:
++  const char* module_;
++  const char* symbol_;
++  std::atomic<uint64_t> count_{0};
++  std::atomic<uint32_t> first_caller_{0};
++};
++
++inline void EmitStubReachabilitySummary() {
++  std::lock_guard lock(stub_reachability_mutex);
++  REXKRNL_INFO("SDK_STUB summary.begin reached={} dropped={}", stub_reachability_entries.size(),
++               stub_reachability_dropped.load(std::memory_order_relaxed));
++  for (const auto* entry : stub_reachability_entries) {
++    REXKRNL_INFO("SDK_STUB summary module={} symbol={} caller={:08X} count={}", entry->module(),
++                 entry->symbol(), entry->first_caller(), entry->count());
++  }
++  REXKRNL_INFO("SDK_STUB summary.end");
++}
++}  // namespace rex::diagnostics
++
++#define REX_TRACK_STUB_REACH(subroutine)                                         \
++  static rex::diagnostics::StubReachabilityEntry rex_stub_reachability_(         \
++      rex::diagnostics::StubModuleName(__FILE__), #subroutine);                  \
++  const uint64_t rex_stub_call_count_ =                                          \
++      rex_stub_reachability_.Hit(static_cast<uint32_t>(ctx.lr))
++
+ // Hook a recompiled function with an auto-marshaled native C++ function.
+ // The native function uses plain types (u32, mapped_u32, etc.) and
+ // HostToGuestFunction handles register translation automatically.
+@@ -70,3 +138,4 @@
+     (void)base;                           \
+-    REX_TRACE_IMPORT_REACH(subroutine);   \
++    REX_TRACK_STUB_REACH(subroutine);     \
++    if (rex_stub_call_count_ == 1)        \
+     REXKRNL_WARN("{} STUB", #subroutine); \
+@@ -77,3 +146,4 @@
+     (void)base;                                     \
+-    REX_TRACE_IMPORT_REACH(subroutine);             \
++    REX_TRACK_STUB_REACH(subroutine);               \
++    if (rex_stub_call_count_ == 1)                  \
+     REXKRNL_WARN("{} STUB - {}", #subroutine, msg); \
+@@ -84,3 +154,4 @@
+     (void)base;                                                                           \
+-    REX_TRACE_IMPORT_REACH(subroutine);                                                   \
++    REX_TRACK_STUB_REACH(subroutine);                                                     \
++    if (rex_stub_call_count_ == 1)                                                        \
+     REXKRNL_WARN("{} STUB - returning {:#x}", #subroutine, static_cast<uint32_t>(value)); \

--- a/patches/rexglue/0032-memexport-coherency-counters.patch
+++ b/patches/rexglue/0032-memexport-coherency-counters.patch
@@ -1,0 +1,115 @@
+diff --git a/include/rex/perf/counter.h b/include/rex/perf/counter.h
+index 167b645..151289a 100644
+--- a/include/rex/perf/counter.h
++++ b/include/rex/perf/counter.h
+@@ -49,6 +49,13 @@ enum class CounterId : uint16_t {
+   kPipelineCacheHits,
+   kPipelineCacheMisses,
+ 
++  // D3D12 memexport coherency
++  kMemexportDraws,
++  kMemexportBytes,
++  kMemexportSyncFallbacks,
++  kMemexportQueueWaits,
++  kMemexportFenceWaits,
++
+   kCount  // sentinel -- must be last
+ };
+ 
+@@ -157,6 +164,11 @@ class Profiler {
+ #define PROFILE_TEXTURE_CACHE_MISS() PERF_counter_inc(kTextureCacheMisses)
+ #define PROFILE_PIPELINE_CACHE_HIT() PERF_counter_inc(kPipelineCacheHits)
+ #define PROFILE_PIPELINE_CACHE_MISS() PERF_counter_inc(kPipelineCacheMisses)
++#define PROFILE_MEMEXPORT_DRAW() PERF_counter_inc(kMemexportDraws)
++#define PROFILE_MEMEXPORT_BYTES(n) PERF_counter_add(kMemexportBytes, n)
++#define PROFILE_MEMEXPORT_SYNC_FALLBACK() PERF_counter_inc(kMemexportSyncFallbacks)
++#define PROFILE_MEMEXPORT_QUEUE_WAIT() PERF_counter_inc(kMemexportQueueWaits)
++#define PROFILE_MEMEXPORT_FENCE_WAIT() PERF_counter_inc(kMemexportFenceWaits)
+ 
+ #else
+ 
+@@ -178,6 +190,11 @@ class Profiler {
+ #define PROFILE_THREAD_EXITED()
+ #define PROFILE_APC_QUEUE_DEPTH(value)
+ #define PROFILE_CRITICAL_REGION_CONTENTION()
++#define PROFILE_MEMEXPORT_DRAW()
++#define PROFILE_MEMEXPORT_BYTES(n)
++#define PROFILE_MEMEXPORT_SYNC_FALLBACK()
++#define PROFILE_MEMEXPORT_QUEUE_WAIT()
++#define PROFILE_MEMEXPORT_FENCE_WAIT()
+ #define PROFILE_TEXTURE_CACHE_HIT()
+ #define PROFILE_TEXTURE_CACHE_MISS()
+ #define PROFILE_PIPELINE_CACHE_HIT()
+diff --git a/src/core/perf/counter.cpp b/src/core/perf/counter.cpp
+index 536009e..7bbe847 100644
+--- a/src/core/perf/counter.cpp
++++ b/src/core/perf/counter.cpp
+@@ -49,6 +49,11 @@ constexpr const char* kCounterNames[] = {
+     "texture_cache_misses",
+     "pipeline_cache_hits",
+     "pipeline_cache_misses",
++    "memexport_draws",
++    "memexport_bytes",
++    "memexport_sync_fallbacks",
++    "memexport_queue_waits",
++    "memexport_fence_waits",
+ };
+ static_assert(std::size(kCounterNames) == kNumCounters, "kCounterNames must match CounterId enum");
+ 
+@@ -72,6 +77,11 @@ constexpr bool kIsGauge[] = {
+     false,  // kTextureCacheMisses
+     false,  // kPipelineCacheHits
+     false,  // kPipelineCacheMisses
++    false,  // kMemexportDraws
++    false,  // kMemexportBytes
++    false,  // kMemexportSyncFallbacks
++    false,  // kMemexportQueueWaits
++    false,  // kMemexportFenceWaits
+ };
+ static_assert(std::size(kIsGauge) == kNumCounters, "kIsGauge must match CounterId enum");
+ 
+diff --git a/src/graphics/d3d12/command_processor.cpp b/src/graphics/d3d12/command_processor.cpp
+index efed1b7..2916251 100644
+--- a/src/graphics/d3d12/command_processor.cpp
++++ b/src/graphics/d3d12/command_processor.cpp
+@@ -2719,6 +2719,7 @@ bool D3D12CommandProcessor::IssueDraw(xenos::PrimitiveType primitive_type, uint3
+   }
+ 
+   if (memexport_used) {
++    PROFILE_MEMEXPORT_DRAW();
+     // Make sure this memexporting draw is ordered with other work using shared
+     // memory as a UAV.
+     // TODO(Triang3l): Find some PM4 command that can be used for indication of
+@@ -2742,6 +2743,7 @@ bool D3D12CommandProcessor::IssueDraw(xenos::PrimitiveType primitive_type, uint3
+         memexport_total_size += memexport_range.size_bytes;
+       }
+       if (memexport_total_size != 0) {
++        PROFILE_MEMEXPORT_BYTES(memexport_total_size);
+         if (REXCVAR_GET(readback_memexport_fast)) {
+           IssueDraw_MemexportReadbackFastPath(memexport_total_size);
+         } else {
+@@ -2775,6 +2777,7 @@ bool D3D12CommandProcessor::IssueDraw_MemexportReadbackFullPath(uint32_t total_s
+     readback_buffer_offset += memexport_range.size_bytes;
+   }
+ 
++  PROFILE_MEMEXPORT_QUEUE_WAIT();
+   if (!AwaitAllQueueOperationsCompletion()) {
+     return true;
+   }
+@@ -2856,6 +2859,7 @@ bool D3D12CommandProcessor::IssueDraw_MemexportReadbackFastPath(uint32_t total_s
+   const uint32_t read_index = 1 - write_index;
+   const uint32_t readback_size = AlignReadbackBufferSize(total_size);
+   if (!ensure_readback_slot(write_index, readback_size)) {
++    PROFILE_MEMEXPORT_SYNC_FALLBACK();
+     return IssueDraw_MemexportReadbackFullPath(total_size);
+   }
+ 
+@@ -2879,6 +2883,8 @@ bool D3D12CommandProcessor::IssueDraw_MemexportReadbackFastPath(uint32_t total_s
+                              readback.submission_written[read_index] &&
+                              readback.submission_written[read_index] <= submission_completed_;
+   if (!previous_slot_ready) {
++    PROFILE_MEMEXPORT_FENCE_WAIT();
++    PROFILE_MEMEXPORT_SYNC_FALLBACK();
+     IssueDraw_MemexportReadbackFullPath(total_size);
+     readback.current_index = read_index;
+     return true;

--- a/src/pinyon_shift_app.cpp
+++ b/src/pinyon_shift_app.cpp
@@ -9,6 +9,7 @@
 #include <regex>
 #include <sstream>
 #include <string>
+#include <system_error>
 
 #include <rex/cvar.h>
 #include <rex/logging.h>
@@ -21,12 +22,12 @@
 
 #include <cstdio>
 
-REXCVAR_DEFINE_UINT32(pinyon_shift_config_schema, 3, "Pinyon Shift",
+REXCVAR_DEFINE_UINT32(pinyon_shift_config_schema, 4, "Pinyon Shift",
                       "Pinyon Shift host configuration schema version");
 
 namespace {
 
-constexpr uint32_t kConfigSchema = 3;
+constexpr uint32_t kConfigSchema = 4;
 
 bool EnsureSupportedConfig(const std::filesystem::path& path, bool& created,
                            bool& migrated) {
@@ -49,7 +50,11 @@ bool EnsureSupportedConfig(const std::filesystem::path& path, bool& created,
               "keybind_start = \"Return\"\n"
               "d3d12_allow_variable_refresh_rate_and_tearing = false\n"
               "pinyon_shift_stabilize_vehicle_presentation = false\n"
-              "pinyon_shift_skip_opening_movies = false\n";
+              "pinyon_shift_skip_opening_movies = false\n"
+              "anisotropic_override = 3\n"
+              "swap_post_effect = \"none\"\n"
+              "draw_resolution_scale_x = 1\n"
+              "draw_resolution_scale_y = 1\n";
     created = true;
     return output.good();
   }
@@ -73,7 +78,17 @@ bool EnsureSupportedConfig(const std::filesystem::path& path, bool& created,
     if (schema == kConfigSchema) {
       return true;
     }
-    if (schema != 1 && schema != 2) {
+    if (schema < 1 || schema > 3) {
+      return false;
+    }
+
+    std::filesystem::path backup = path;
+    backup += L".schema" + std::to_wstring(schema) + L".bak";
+    std::error_code backup_error;
+    std::filesystem::copy_file(path, backup,
+                               std::filesystem::copy_options::skip_existing,
+                               backup_error);
+    if (backup_error && backup_error != std::errc::file_exists) {
       return false;
     }
 
@@ -106,6 +121,23 @@ bool EnsureSupportedConfig(const std::filesystem::path& path, bool& created,
         migrated_text.push_back('\n');
       }
       migrated_text += "keybind_a = \"LMB,Space\"\n";
+    }
+
+    const std::pair<const char*, const char*> graphics_settings[] = {
+        {"anisotropic_override", "anisotropic_override = 3\n"},
+        {"swap_post_effect", "swap_post_effect = \"none\"\n"},
+        {"draw_resolution_scale_x", "draw_resolution_scale_x = 1\n"},
+        {"draw_resolution_scale_y", "draw_resolution_scale_y = 1\n"},
+    };
+    for (const auto& [name, line] : graphics_settings) {
+      const std::regex setting_pattern("(?:^|\\n)\\s*" + std::string(name) +
+                                       "\\s*=", std::regex::icase);
+      if (!std::regex_search(migrated_text, setting_pattern)) {
+        if (!migrated_text.empty() && migrated_text.back() != '\n') {
+          migrated_text.push_back('\n');
+        }
+        migrated_text += line;
+      }
     }
 
     std::filesystem::path temporary = path;
@@ -206,6 +238,9 @@ void PinyonShiftApp::OnPostInitLogging() {
                          rex::cvar::GetFlagByName("draw_resolution_scale_x")},
                         {"draw_resolution_scale_y",
                          rex::cvar::GetFlagByName("draw_resolution_scale_y")},
+                        {"anisotropic_override",
+                         rex::cvar::GetFlagByName("anisotropic_override")},
+                        {"swap_post_effect", rex::cvar::GetFlagByName("swap_post_effect")},
                         {"perf_csv_enabled", perf_csv.empty() ? "0" : "1"},
                         {"perf_csv", perf_csv}});
 }

--- a/tools/build-preview.ps1
+++ b/tools/build-preview.ps1
@@ -39,6 +39,7 @@ if (-not (Test-Path -LiteralPath $rexglueExe -PathType Leaf)) {
 
 Write-PinyonEvent build 72 'Translating the verified game code locally.' -JsonEvents:$JsonEvents
 $generatedTrees = @('default', 'speech', 'xmedia')
+$codegenLog = Join-Path $logs 'codegen.log'
 if ($CleanGenerated -and (Test-Path -LiteralPath $generatedRoot)) {
     Remove-Item -LiteralPath $generatedRoot -Recurse -Force
 }
@@ -51,13 +52,24 @@ foreach ($tree in $generatedTrees) {
 }
 if ($requiresBootstrap) {
     [void](New-Item -ItemType Directory -Force -Path $generatedRoot)
-    & $rexglueExe --log-level info --log-file (Join-Path $logs 'codegen.log') codegen $manifest
+    if (Test-Path -LiteralPath $codegenLog) {
+        Remove-Item -LiteralPath $codegenLog -Force
+    }
+    & $rexglueExe --log-level info --log-file $codegenLog codegen $manifest
     if ($LASTEXITCODE -ne 0) {
         foreach ($tree in $generatedTrees) {
             $stamp = Join-Path $generatedRoot "$tree/codegen.build.stamp"
             if (Test-Path -LiteralPath $stamp) { Remove-Item -LiteralPath $stamp -Force }
         }
         throw 'Local code generation failed; incomplete generation stamps were removed.'
+    }
+    & python (Join-Path $PSScriptRoot 'verify-codegen-log.py') $codegenLog
+    if ($LASTEXITCODE -ne 0) {
+        foreach ($tree in $generatedTrees) {
+            $stamp = Join-Path $generatedRoot "$tree/codegen.build.stamp"
+            if (Test-Path -LiteralPath $stamp) { Remove-Item -LiteralPath $stamp -Force }
+        }
+        throw 'Code generation emitted an unreviewed warning; generation stamps were removed.'
     }
 }
 else {

--- a/tools/check-markdown-links.py
+++ b/tools/check-markdown-links.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""Validate repository-relative links in tracked Markdown files."""
+
+from __future__ import annotations
+
+import pathlib
+import re
+import subprocess
+import sys
+import urllib.parse
+
+
+LINK = re.compile(r"(?<!!)\[[^\]]*\]\((?P<target><[^>]+>|[^)\s]+)(?:\s+['\"][^'\"]*['\"])?\)")
+SCHEMES = ("http://", "https://", "mailto:", "app://")
+
+
+def tracked_markdown(root: pathlib.Path) -> list[pathlib.Path]:
+    completed = subprocess.run(
+        ["git", "ls-files", "-z", "--", "*.md"], cwd=root, check=True, capture_output=True
+    )
+    return [root / path.decode("utf-8") for path in completed.stdout.split(b"\0") if path]
+
+
+def failures(root: pathlib.Path, files: list[pathlib.Path]) -> list[str]:
+    problems: list[str] = []
+    for path in files:
+        text = path.read_text(encoding="utf-8")
+        for line_number, line in enumerate(text.splitlines(), start=1):
+            for match in LINK.finditer(line):
+                raw = match.group("target").strip("<>")
+                if not raw or raw.startswith("#") or raw.lower().startswith(SCHEMES):
+                    continue
+                target_text = urllib.parse.unquote(raw.split("#", 1)[0].split("?", 1)[0])
+                if not target_text:
+                    continue
+                # Public documentation must be portable. Machine-absolute links are
+                # invalid even when they happen to exist on the CI machine.
+                if pathlib.PureWindowsPath(target_text).is_absolute() or target_text.startswith("/"):
+                    problems.append(f"{path.relative_to(root)}:{line_number}: absolute link: {raw}")
+                    continue
+                target = (path.parent / target_text).resolve()
+                try:
+                    target.relative_to(root.resolve())
+                except ValueError:
+                    problems.append(f"{path.relative_to(root)}:{line_number}: link escapes repository: {raw}")
+                    continue
+                if not target.exists():
+                    problems.append(f"{path.relative_to(root)}:{line_number}: missing target: {raw}")
+    return problems
+
+
+def main() -> int:
+    root = pathlib.Path(__file__).resolve().parents[1]
+    try:
+        problems = failures(root, tracked_markdown(root))
+    except (OSError, subprocess.CalledProcessError, UnicodeError) as error:
+        print(f"error: {error}", file=sys.stderr)
+        return 2
+    if problems:
+        print("\n".join(problems), file=sys.stderr)
+        return 1
+    print("Tracked Markdown links are valid.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/create-crash-report.ps1
+++ b/tools/create-crash-report.ps1
@@ -148,7 +148,8 @@ try {
         'mnk_mode', 'keybind_start',
         'd3d12_allow_variable_refresh_rate_and_tearing',
         'pinyon_shift_stabilize_vehicle_presentation', 'pinyon_shift_skip_opening_movies',
-        'resolution', 'vsync', 'draw_resolution_scale_x', 'draw_resolution_scale_y'
+        'resolution', 'vsync', 'anisotropic_override', 'swap_post_effect',
+        'draw_resolution_scale_x', 'draw_resolution_scale_y'
     )
     $configPath = Join-Path $resolvedStateRoot 'config/pinyon_shift.toml'
     $settings = [ordered]@{}

--- a/tools/package-launcher.ps1
+++ b/tools/package-launcher.ps1
@@ -65,7 +65,8 @@ $include = @(
     'tools/build-preview.ps1', 'tools/create-crash-report.ps1', 'tools/install-build-tools.ps1',
     'tools/launch-preview.ps1', 'tools/prepare-rexglue.ps1',
     'tools/provision-toolchain.ps1', 'tools/release-common.ps1',
-    'tools/setup-preview.ps1', 'tools/verify-game.ps1'
+    'tools/set-graphics-experiment.ps1', 'tools/setup-preview.ps1',
+    'tools/verify-codegen-log.py', 'tools/verify-game.ps1'
 )
 foreach ($relative in $include) {
     $source = Join-Path $root $relative

--- a/tools/qualification-session.py
+++ b/tools/qualification-session.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""Record operator-driven qualification markers and package sanitized evidence."""
+from __future__ import annotations
+
+import argparse, hashlib, json, zipfile
+from datetime import datetime, timezone
+from pathlib import Path
+
+MARKERS = ("cold-boot", "menu", "race", "save", "clean-exit", "relaunch", "reload")
+
+def utc() -> str: return datetime.now(timezone.utc).isoformat()
+def digest(path: Path) -> str: return hashlib.sha256(path.read_bytes()).hexdigest()
+def load(path: Path) -> dict: return json.loads(path.read_text(encoding="utf-8"))
+def save(path: Path, value: dict) -> None: path.write_text(json.dumps(value, indent=2) + "\n", encoding="utf-8")
+
+def start(root: Path, build_manifest: Path) -> Path:
+    timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S%fZ")
+    session = root / timestamp
+    session.mkdir(parents=True)
+    manifest = {"schema": "pinyon-shift.qualification.v1", "started_utc": utc(),
+                "build_manifest": json.loads(build_manifest.read_text(encoding="utf-8")), "markers": []}
+    save(session / "manifest.json", manifest)
+    return session
+
+def mark(session: Path, name: str, note: str | None) -> dict:
+    manifest = load(session / "manifest.json")
+    if name not in MARKERS: raise ValueError("unsupported marker")
+    if any(item["name"] == name for item in manifest["markers"]): raise ValueError(f"marker already recorded: {name}")
+    expected = MARKERS[len(manifest["markers"])] if len(manifest["markers"]) < len(MARKERS) else None
+    if name != expected: raise ValueError(f"expected marker {expected}, got {name}")
+    entry = {"name": name, "recorded_utc": utc()}
+    if note: entry["note"] = note[:240]
+    manifest["markers"].append(entry); save(session / "manifest.json", manifest)
+    return entry
+
+def package(session: Path, evidence: list[Path]) -> Path:
+    manifest_path = session / "manifest.json"; manifest = load(manifest_path)
+    names = [item["name"] for item in manifest["markers"]]
+    if names != list(MARKERS): raise ValueError("qualification is incomplete; missing ordered markers")
+    allowed = {".json", ".jsonl", ".log", ".txt", ".csv", ".md", ".svg"}
+    records = []
+    target = session / "qualification-evidence.zip"
+    with zipfile.ZipFile(target, "w", zipfile.ZIP_DEFLATED) as archive:
+        archive.write(manifest_path, "manifest.json")
+        for path in evidence:
+            resolved = path.resolve()
+            if not resolved.is_file() or resolved.suffix.lower() not in allowed:
+                raise ValueError(f"unsafe evidence file: {path}")
+            record = {"name": resolved.name, "sha256": digest(resolved), "size_bytes": resolved.stat().st_size}
+            records.append(record); archive.write(resolved, f"evidence/{resolved.name}")
+        archive.writestr("evidence-index.json", json.dumps(records, indent=2) + "\n")
+    return target
+
+def main() -> int:
+    parser = argparse.ArgumentParser(); sub = parser.add_subparsers(dest="action", required=True)
+    p = sub.add_parser("start"); p.add_argument("root", type=Path); p.add_argument("--build-manifest", type=Path, required=True)
+    p = sub.add_parser("mark"); p.add_argument("session", type=Path); p.add_argument("name", choices=MARKERS); p.add_argument("--note")
+    p = sub.add_parser("package"); p.add_argument("session", type=Path); p.add_argument("--evidence", type=Path, action="append", default=[])
+    args = parser.parse_args()
+    try:
+        result = start(args.root, args.build_manifest) if args.action == "start" else (mark(args.session, args.name, args.note) if args.action == "mark" else package(args.session, args.evidence))
+        print(json.dumps(result if isinstance(result, dict) else {"path": str(result)}, indent=2)); return 0
+    except (OSError, ValueError, json.JSONDecodeError) as exc: parser.exit(2, f"qualification error: {exc}\n")
+if __name__ == "__main__": raise SystemExit(main())

--- a/tools/renderer-ab.py
+++ b/tools/renderer-ab.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Prepare and compare one-variable renderer experiments without changing shipping defaults."""
+from __future__ import annotations
+
+import argparse, hashlib, json
+from datetime import datetime, timezone
+from pathlib import Path
+
+VARIABLES = {"readback_memexport": ("true", "false"), "clear_memory_page_state": ("true", "false"),
+             "d3d12_submit_on_primary_buffer_end": ("true", "false")}
+MEMEXPORT_COUNTERS = ("memexport_draws", "memexport_bytes", "memexport_sync_fallbacks", "memexport_queue_waits", "memexport_fence_waits")
+
+def prepare(root: Path, variable: str, fingerprint: Path) -> Path:
+    build = json.loads(fingerprint.read_text(encoding="utf-8")); stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    session = root / f"{stamp}-{variable}"; session.mkdir(parents=True)
+    manifest = {"schema": "pinyon-shift.renderer-ab.v1", "variable": variable, "shipping_defaults_unchanged": True,
+                "build": build, "variants": [{"name": "control", "value": VARIABLES[variable][0]}, {"name": "candidate", "value": VARIABLES[variable][1]}],
+                "required_evidence": ["performance-summary.json", "visual-validation.json"],
+                "required_memexport_counters": list(MEMEXPORT_COUNTERS) if variable == "readback_memexport" else []}
+    (session / "manifest.json").write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
+    for variant in manifest["variants"]:
+        folder = session / variant["name"]; folder.mkdir()
+        (folder / "override.toml").write_text(f"# Temporary A/B override; do not ship.\n{variable} = {variant['value']}\n", encoding="utf-8")
+    return session
+
+def compare(session: Path) -> dict:
+    manifest = json.loads((session / "manifest.json").read_text(encoding="utf-8")); summaries = {}
+    for variant in ("control", "candidate"):
+        folder = session / variant
+        perf = json.loads((folder / "performance-summary.json").read_text(encoding="utf-8"))
+        visual = json.loads((folder / "visual-validation.json").read_text(encoding="utf-8"))
+        if visual.get("missing"): raise ValueError(f"{variant} visual evidence is incomplete")
+        if manifest["variable"] == "readback_memexport":
+            counters = perf.get("memexport_counters", {})
+            missing = [name for name in MEMEXPORT_COUNTERS if name not in counters]
+            if missing: raise ValueError("memexport evidence lacks counters: " + ", ".join(missing))
+        summaries[variant] = perf
+    result = {"schema": manifest["schema"], "variable": manifest["variable"], "build": manifest["build"],
+              "control_sha256": hashlib.sha256(json.dumps(summaries["control"], sort_keys=True).encode()).hexdigest(),
+              "candidate_sha256": hashlib.sha256(json.dumps(summaries["candidate"], sort_keys=True).encode()).hexdigest(),
+              "comparison": {"median_frame_time_us_delta": summaries["candidate"]["frame_time_us"]["median"] - summaries["control"]["frame_time_us"]["median"],
+                             "p95_frame_time_us_delta": summaries["candidate"]["frame_time_us"]["p95"] - summaries["control"]["frame_time_us"]["p95"]}}
+    (session / "comparison.json").write_text(json.dumps(result, indent=2) + "\n", encoding="utf-8"); return result
+
+def main() -> int:
+    parser = argparse.ArgumentParser(); parser.add_argument("action", choices=("prepare", "compare")); parser.add_argument("path", type=Path)
+    parser.add_argument("--variable", choices=VARIABLES); parser.add_argument("--build-fingerprint", type=Path)
+    args = parser.parse_args()
+    try:
+        if args.action == "prepare":
+            if not args.variable or not args.build_fingerprint: raise ValueError("prepare requires --variable and --build-fingerprint")
+            result = {"path": str(prepare(args.path, args.variable, args.build_fingerprint))}
+        else: result = compare(args.path)
+        print(json.dumps(result, indent=2)); return 0
+    except (OSError, ValueError, KeyError, json.JSONDecodeError) as exc: parser.exit(2, f"renderer A/B error: {exc}\n")
+if __name__ == "__main__": raise SystemExit(main())

--- a/tools/set-graphics-experiment.ps1
+++ b/tools/set-graphics-experiment.ps1
@@ -1,0 +1,157 @@
+[CmdletBinding()]
+param(
+    [ValidateSet('Get', 'Apply', 'Reset', 'Restore')]
+    [string]$Action = 'Get',
+    [ValidateSet(4, 8, 16)]
+    [int]$Anisotropy = 4,
+    [ValidateSet('none', 'fxaa', 'fxaa_extreme')]
+    [string]$PostEffect = 'none',
+    [ValidateSet(1, 2)]
+    [int]$ResolutionScale = 1,
+    [string]$StateRoot,
+    [switch]$Json
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
+$resolvedStateRoot = if ($StateRoot) {
+    [IO.Path]::GetFullPath($StateRoot)
+} else {
+    Join-Path $repoRoot '.local/preview'
+}
+$configDirectory = Join-Path $resolvedStateRoot 'config'
+$configPath = Join-Path $configDirectory 'pinyon_shift.toml'
+$backupDirectory = Join-Path $configDirectory 'backups'
+
+function Get-DefaultConfigText {
+    @'
+# Pinyon Shift host configuration.
+# Schema 4 includes validated experimental graphics settings.
+pinyon_shift_config_schema = 4
+input_backend = "sdl"
+hid_mappings_file = "gamecontrollerdb.txt"
+mnk_mode = true
+keybind_a = "LMB,Space"
+keybind_start = "Return"
+d3d12_allow_variable_refresh_rate_and_tearing = false
+pinyon_shift_stabilize_vehicle_presentation = false
+pinyon_shift_skip_opening_movies = false
+anisotropic_override = 3
+swap_post_effect = "none"
+draw_resolution_scale_x = 1
+draw_resolution_scale_y = 1
+'@
+}
+
+function New-ConfigBackup {
+    if (-not (Test-Path -LiteralPath $configPath -PathType Leaf)) { return $null }
+    [void](New-Item -ItemType Directory -Force -Path $backupDirectory)
+    $stamp = [DateTime]::UtcNow.ToString('yyyyMMddTHHmmssfffZ')
+    $destination = Join-Path $backupDirectory "pinyon_shift-$stamp.toml"
+    Copy-Item -LiteralPath $configPath -Destination $destination
+    $destination
+}
+
+function Get-SchemaVersion([string]$Text) {
+    $match = [regex]::Match($Text,
+        '(?m)^\s*pinyon_shift_config_schema\s*=\s*(?<value>[0-9]+)\s*(?:#.*)?$')
+    if (-not $match.Success) { throw 'The host configuration has no schema version.' }
+    [int]$match.Groups['value'].Value
+}
+
+function Set-TomlValue([string]$Text, [string]$Name, [string]$Value) {
+    $pattern = '(?m)^\s*' + [regex]::Escape($Name) + '\s*=.*$'
+    $replacement = "$Name = $Value"
+    if ([regex]::IsMatch($Text, $pattern)) {
+        return [regex]::Replace($Text, $pattern, $replacement, 1)
+    }
+    $trimmed = $Text.TrimEnd("`r", "`n")
+    "$trimmed`r`n$replacement`r`n"
+}
+
+function Get-TomlValue([string]$Text, [string]$Name, [string]$Default) {
+    $pattern = '(?m)^\s*' + [regex]::Escape($Name) + '\s*=\s*(?<value>[^#\r\n]+)'
+    $match = [regex]::Match($Text, $pattern)
+    if ($match.Success) { return $match.Groups['value'].Value.Trim().Trim('"') }
+    $Default
+}
+
+function Write-Config([string]$Text) {
+    [void](New-Item -ItemType Directory -Force -Path $configDirectory)
+    $temporary = "$configPath.tmp"
+    try {
+        [IO.File]::WriteAllText($temporary, $Text.TrimEnd("`r", "`n") + [Environment]::NewLine,
+            [Text.UTF8Encoding]::new($false))
+        Move-Item -LiteralPath $temporary -Destination $configPath -Force
+    }
+    finally {
+        if (Test-Path -LiteralPath $temporary) { Remove-Item -LiteralPath $temporary -Force }
+    }
+}
+
+function Get-SettingsResult([string]$Text, [string]$BackupPath, [string]$Operation) {
+    $override = [int](Get-TomlValue $Text 'anisotropic_override' '3')
+    $anisotropyValue = switch ($override) { 3 { 4 } 4 { 8 } 5 { 16 } default { 4 } }
+    [ordered]@{
+        schema = 'pinyon-shift.graphics-settings.v1'
+        operation = $Operation.ToLowerInvariant()
+        config_path = $configPath
+        backup_path = $BackupPath
+        settings = [ordered]@{
+            anisotropy = $anisotropyValue
+            post_effect = Get-TomlValue $Text 'swap_post_effect' 'none'
+            resolution_scale = [int](Get-TomlValue $Text 'draw_resolution_scale_x' '1')
+        }
+        restart_required = $Operation -ne 'Get'
+    }
+}
+
+[void](New-Item -ItemType Directory -Force -Path $configDirectory)
+$backup = $null
+switch ($Action) {
+    'Get' {
+        $text = if (Test-Path -LiteralPath $configPath -PathType Leaf) {
+            Get-Content -LiteralPath $configPath -Raw
+        } else { Get-DefaultConfigText }
+        $schema = Get-SchemaVersion $text
+        if ($schema -notin @(1, 2, 3, 4)) { throw "Unsupported host configuration schema: $schema" }
+    }
+    'Reset' {
+        $backup = New-ConfigBackup
+        $text = Get-DefaultConfigText
+        Write-Config $text
+    }
+    'Restore' {
+        if (-not (Test-Path -LiteralPath $backupDirectory -PathType Container)) {
+            throw 'No runtime-settings backup is available.'
+        }
+        $source = Get-ChildItem -LiteralPath $backupDirectory -Filter 'pinyon_shift-*.toml' -File |
+            Sort-Object LastWriteTimeUtc -Descending | Select-Object -First 1
+        if ($null -eq $source) { throw 'No runtime-settings backup is available.' }
+        $backup = New-ConfigBackup
+        $text = Get-Content -LiteralPath $source.FullName -Raw
+        $schema = Get-SchemaVersion $text
+        if ($schema -notin @(1, 2, 3, 4)) { throw "Backup uses unsupported schema: $schema" }
+        Write-Config $text
+    }
+    'Apply' {
+        $text = if (Test-Path -LiteralPath $configPath -PathType Leaf) {
+            Get-Content -LiteralPath $configPath -Raw
+        } else { Get-DefaultConfigText }
+        $schema = Get-SchemaVersion $text
+        if ($schema -notin @(1, 2, 3, 4)) { throw "Unsupported host configuration schema: $schema" }
+        $backup = New-ConfigBackup
+        $text = Set-TomlValue $text 'pinyon_shift_config_schema' '4'
+        $override = switch ($Anisotropy) { 4 { 3 } 8 { 4 } 16 { 5 } }
+        $text = Set-TomlValue $text 'anisotropic_override' ([string]$override)
+        $text = Set-TomlValue $text 'swap_post_effect' ('"' + $PostEffect + '"')
+        $text = Set-TomlValue $text 'draw_resolution_scale_x' ([string]$ResolutionScale)
+        $text = Set-TomlValue $text 'draw_resolution_scale_y' ([string]$ResolutionScale)
+        Write-Config $text
+    }
+}
+
+$result = Get-SettingsResult $text $backup $Action
+if ($Json) { $result | ConvertTo-Json -Depth 5 -Compress } else { [pscustomobject]$result }

--- a/tools/summarize-performance.py
+++ b/tools/summarize-performance.py
@@ -1,0 +1,243 @@
+#!/usr/bin/env python3
+"""Summarize and compare Pinyon Shift per-frame performance captures."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import math
+import pathlib
+import sys
+from typing import Any
+
+
+SCHEMA = "pinyon-shift.performance-summary.v1"
+REQUIRED_COLUMNS = {
+    "frame_time_us",
+    "fps",
+    "draw_calls",
+    "command_buffer_stalls",
+    "texture_cache_hits",
+    "texture_cache_misses",
+    "pipeline_cache_hits",
+    "pipeline_cache_misses",
+}
+TOTAL_COLUMNS = (
+    "draw_calls",
+    "command_buffer_stalls",
+    "texture_cache_hits",
+    "texture_cache_misses",
+    "pipeline_cache_hits",
+    "pipeline_cache_misses",
+)
+MEMEXPORT_COLUMNS = (
+    "memexport_draws",
+    "memexport_bytes",
+    "memexport_sync_fallbacks",
+    "memexport_queue_waits",
+    "memexport_fence_waits",
+)
+
+
+class CaptureError(ValueError):
+    """Raised when a capture cannot produce a trustworthy summary."""
+
+
+def percentile(values: list[float], percentage: float) -> float:
+    ordered = sorted(values)
+    if not ordered:
+        raise CaptureError("capture has no usable frame samples")
+    position = (len(ordered) - 1) * percentage
+    lower = math.floor(position)
+    upper = math.ceil(position)
+    if lower == upper:
+        return ordered[lower]
+    weight = position - lower
+    return ordered[lower] * (1.0 - weight) + ordered[upper] * weight
+
+
+def finite_number(value: str, *, column: str, row_number: int) -> float:
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError) as error:
+        raise CaptureError(f"row {row_number}: {column} is not numeric") from error
+    if not math.isfinite(parsed) or parsed < 0:
+        raise CaptureError(f"row {row_number}: {column} must be a finite non-negative number")
+    return parsed
+
+
+def hit_rate(hits: float, misses: float) -> float | None:
+    total = hits + misses
+    return round(hits * 100.0 / total, 6) if total else None
+
+
+def summarize(path: pathlib.Path) -> dict[str, Any]:
+    if not path.is_file():
+        raise CaptureError(f"capture does not exist: {path}")
+    with path.open("r", encoding="utf-8-sig", newline="") as stream:
+        reader = csv.DictReader(stream)
+        columns = set(reader.fieldnames or ())
+        missing = sorted(REQUIRED_COLUMNS - columns)
+        if missing:
+            raise CaptureError(f"capture is missing required columns: {', '.join(missing)}")
+        available_memexport = columns.intersection(MEMEXPORT_COLUMNS)
+        if available_memexport and available_memexport != set(MEMEXPORT_COLUMNS):
+            missing_memexport = sorted(set(MEMEXPORT_COLUMNS) - available_memexport)
+            raise CaptureError("capture has an incomplete memexport counter set: " + ", ".join(missing_memexport))
+
+        frame_times: list[float] = []
+        totals = {name: 0.0 for name in TOTAL_COLUMNS}
+        memexport_totals = {name: 0.0 for name in MEMEXPORT_COLUMNS} if available_memexport else None
+        rows_seen = 0
+        for row_number, row in enumerate(reader, start=2):
+            rows_seen += 1
+            frame_time = finite_number(row["frame_time_us"], column="frame_time_us", row_number=row_number)
+            row_totals = {
+                name: finite_number(row[name], column=name, row_number=row_number)
+                for name in TOTAL_COLUMNS
+            }
+            row_memexport = ({name: finite_number(row[name], column=name, row_number=row_number)
+                              for name in MEMEXPORT_COLUMNS} if memexport_totals is not None else {})
+            # The runtime writes one initialization row with frame_time_us == 0.
+            # It is valid CSV, but not a displayed frame and must not skew latency.
+            if frame_time == 0:
+                continue
+            frame_times.append(frame_time)
+            for name, value in row_totals.items():
+                totals[name] += value
+            for name, value in row_memexport.items():
+                memexport_totals[name] += value
+
+    if rows_seen == 0:
+        raise CaptureError("capture contains a header but no rows")
+    if len(frame_times) < 2:
+        raise CaptureError("capture must contain at least two non-zero frame samples")
+
+    p50 = percentile(frame_times, 0.50)
+    p95 = percentile(frame_times, 0.95)
+    p99 = percentile(frame_times, 0.99)
+    texture_rate = hit_rate(totals["texture_cache_hits"], totals["texture_cache_misses"])
+    pipeline_rate = hit_rate(totals["pipeline_cache_hits"], totals["pipeline_cache_misses"])
+    normalized_totals = {
+        name: int(value) if value.is_integer() else value for name, value in totals.items()
+    }
+    result = {
+        "schema": SCHEMA,
+        "source": path.name,
+        "frames": {
+            "sample_count": len(frame_times),
+            "measured_duration_seconds": round(sum(frame_times) / 1_000_000.0, 6),
+            "frame_time_us": {
+                "median": round(p50, 3),
+                "p95": round(p95, 3),
+                "p99": round(p99, 3),
+            },
+            "derived_fps": {
+                "median": round(1_000_000.0 / p50, 3),
+                "one_percent_low": round(1_000_000.0 / p99, 3),
+            },
+            "counter_totals": normalized_totals,
+            "cache_hit_rate_percent": {
+                "texture": texture_rate,
+                "pipeline": pipeline_rate,
+            },
+        },
+    }
+    if memexport_totals is not None:
+        result["memexport_counters"] = {
+            name: int(value) if value.is_integer() else value for name, value in memexport_totals.items()
+        }
+    return result
+
+
+def metric(summary: dict[str, Any], *keys: str) -> float:
+    value: Any = summary
+    for key in keys:
+        value = value[key]
+    return float(value)
+
+
+def add_comparison(candidate: dict[str, Any], baseline: dict[str, Any]) -> None:
+    if baseline.get("schema") != SCHEMA:
+        raise CaptureError(f"baseline does not use {SCHEMA}")
+    pairs = {
+        "median_frame_time_us": (("frames", "frame_time_us", "median"), "lower_is_better"),
+        "p95_frame_time_us": (("frames", "frame_time_us", "p95"), "lower_is_better"),
+        "median_fps": (("frames", "derived_fps", "median"), "higher_is_better"),
+        "one_percent_low_fps": (("frames", "derived_fps", "one_percent_low"), "higher_is_better"),
+    }
+    comparison: dict[str, Any] = {"baseline_source": baseline.get("source", "unknown"), "metrics": {}}
+    for name, (path, direction) in pairs.items():
+        before = metric(baseline, *path)
+        after = metric(candidate, *path)
+        if before == 0:
+            raise CaptureError(f"baseline metric is zero: {name}")
+        comparison["metrics"][name] = {
+            "baseline": before,
+            "candidate": after,
+            "delta_percent": round((after - before) * 100.0 / before, 3),
+            "direction": direction,
+        }
+    candidate["comparison"] = comparison
+
+
+def markdown(summary: dict[str, Any]) -> str:
+    frames = summary["frames"]
+    latency = frames["frame_time_us"]
+    fps = frames["derived_fps"]
+    cache = frames["cache_hit_rate_percent"]
+    lines = [
+        f"# Performance summary: {summary['source']}",
+        "",
+        f"- Samples: {frames['sample_count']}",
+        f"- Duration: {frames['measured_duration_seconds']:.3f} s",
+        f"- Median frame time: {latency['median']:.3f} us",
+        f"- P95 frame time: {latency['p95']:.3f} us",
+        f"- Median FPS: {fps['median']:.3f}",
+        f"- 1% low: {fps['one_percent_low']:.3f} FPS",
+        f"- Draw calls: {frames['counter_totals']['draw_calls']}",
+        f"- Command-buffer stalls: {frames['counter_totals']['command_buffer_stalls']}",
+        f"- Texture cache hit rate: {cache['texture'] if cache['texture'] is not None else 'n/a'}%",
+        f"- Pipeline cache hit rate: {cache['pipeline'] if cache['pipeline'] is not None else 'n/a'}%",
+    ]
+    if "comparison" in summary:
+        lines.extend(["", "## Baseline comparison", "", "| Metric | Baseline | Candidate | Delta |", "| --- | ---: | ---: | ---: |"])
+        for name, values in summary["comparison"]["metrics"].items():
+            lines.append(
+                f"| {name.replace('_', ' ')} | {values['baseline']:.3f} | "
+                f"{values['candidate']:.3f} | {values['delta_percent']:+.3f}% |"
+            )
+    return "\n".join(lines) + "\n"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("capture", type=pathlib.Path, help="per-frame CSV capture")
+    parser.add_argument("--baseline", type=pathlib.Path, help="summary JSON to compare against")
+    parser.add_argument("--format", choices=("json", "markdown"), default="json")
+    parser.add_argument("--output", type=pathlib.Path, help="write output to this file")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        result = summarize(args.capture)
+        if args.baseline:
+            with args.baseline.open("r", encoding="utf-8") as stream:
+                add_comparison(result, json.load(stream))
+        rendered = json.dumps(result, indent=2) + "\n" if args.format == "json" else markdown(result)
+        if args.output:
+            args.output.parent.mkdir(parents=True, exist_ok=True)
+            args.output.write_text(rendered, encoding="utf-8")
+        else:
+            sys.stdout.write(rendered)
+        return 0
+    except (CaptureError, json.JSONDecodeError, OSError) as error:
+        print(f"error: {error}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/tests/test_evidence_workflows.py
+++ b/tools/tests/test_evidence_workflows.py
@@ -1,0 +1,62 @@
+import importlib.util
+import json
+import struct
+import tempfile
+import unittest
+import zlib
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+def module(name, path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    value = importlib.util.module_from_spec(spec); spec.loader.exec_module(value)
+    return value
+
+visual = module("visual_baseline", ROOT / "tools/visual-baseline.py")
+qualification = module("qualification_session", ROOT / "tools/qualification-session.py")
+renderer = module("renderer_ab", ROOT / "tools/renderer-ab.py")
+
+def png(path, width=2, height=2):
+    def chunk(kind, data):
+        return struct.pack(">I", len(data)) + kind + data + struct.pack(">I", zlib.crc32(kind + data) & 0xffffffff)
+    rows = b"".join(b"\0" + b"\0\0\0" * width for _ in range(height))
+    path.write_bytes(b"\x89PNG\r\n\x1a\n" + chunk(b"IHDR", struct.pack(">IIBBBBB", width, height, 8, 2, 0, 0, 0)) + chunk(b"IDAT", zlib.compress(rows)) + chunk(b"IEND", b""))
+
+class EvidenceWorkflowTests(unittest.TestCase):
+    def test_visual_session_requires_all_labeled_pngs_and_builds_sheet(self):
+        with tempfile.TemporaryDirectory() as temp:
+            executable = Path(temp) / "pinyon_shift.exe"; executable.write_bytes(b"exact-build")
+            session = visual.create_session(Path(temp), executable)
+            with self.assertRaises(ValueError): visual.validate(session)
+            for scene in visual.SCENES: png(session / "captures" / f"{scene}.png")
+            self.assertEqual([], visual.validate(session)["missing"])
+            sheet = visual.contact_sheet(session)
+            self.assertTrue(sheet.is_file()); self.assertIn("open-world-night", sheet.read_text())
+
+    def test_qualification_enforces_marker_order_and_safe_extensions(self):
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp); build = root / "build.json"; build.write_text('{"commit":"abc"}')
+            session = qualification.start(root / "sessions", build)
+            with self.assertRaises(ValueError): qualification.mark(session, "race", None)
+            for name in qualification.MARKERS: qualification.mark(session, name, None)
+            evidence = root / "events.jsonl"; evidence.write_text("{}\n")
+            self.assertTrue(qualification.package(session, [evidence]).is_file())
+            unsafe = root / "dump.dmp"; unsafe.write_bytes(b"private")
+            with self.assertRaises(ValueError): qualification.package(session, [unsafe])
+
+    def test_renderer_ab_requires_memexport_counters(self):
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp); fingerprint = root / "build.json"; fingerprint.write_text('{"commit":"abc"}')
+            session = renderer.prepare(root, "readback_memexport", fingerprint)
+            summary = {"frame_time_us": {"median": 1000, "p95": 1200}}
+            for variant in ("control", "candidate"):
+                (session / variant / "performance-summary.json").write_text(json.dumps(summary))
+                (session / variant / "visual-validation.json").write_text('{"missing":[]}')
+            with self.assertRaises(ValueError): renderer.compare(session)
+            summary["memexport_counters"] = {name: 0 for name in renderer.MEMEXPORT_COUNTERS}
+            for variant in ("control", "candidate"):
+                (session / variant / "performance-summary.json").write_text(json.dumps(summary))
+            self.assertEqual("readback_memexport", renderer.compare(session)["variable"])
+
+if __name__ == "__main__": unittest.main()

--- a/tools/tests/test_graphics_settings.py
+++ b/tools/tests/test_graphics_settings.py
@@ -1,0 +1,59 @@
+import json
+import pathlib
+import shutil
+import subprocess
+import tempfile
+import unittest
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+TOOL = ROOT / "tools/set-graphics-experiment.ps1"
+POWERSHELL = shutil.which("powershell")
+
+
+@unittest.skipUnless(POWERSHELL, "Windows PowerShell is required")
+class GraphicsSettingsTests(unittest.TestCase):
+    def run_tool(self, state, *arguments):
+        completed = subprocess.run(
+            [POWERSHELL, "-NoLogo", "-NoProfile", "-ExecutionPolicy", "Bypass",
+             "-File", str(TOOL), "-StateRoot", str(state), *arguments, "-Json"],
+            capture_output=True, text=True,
+        )
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+        return json.loads(completed.stdout)
+
+    def test_apply_migrates_schema_and_restore_recovers_previous_file(self):
+        with tempfile.TemporaryDirectory(prefix="pinyon-settings-") as temporary:
+            state = pathlib.Path(temporary)
+            config = state / "config/pinyon_shift.toml"
+            config.parent.mkdir(parents=True)
+            original = "pinyon_shift_config_schema = 1\nmnk_mode = true\ncustom_value = 77\n"
+            config.write_text(original, encoding="utf-8")
+            result = self.run_tool(
+                state, "-Action", "Apply", "-Anisotropy", "16",
+                "-PostEffect", "fxaa", "-ResolutionScale", "2",
+            )
+            updated = config.read_text(encoding="utf-8")
+            self.assertEqual(result["settings"]["anisotropy"], 16)
+            self.assertIn("pinyon_shift_config_schema = 4", updated)
+            self.assertIn("custom_value = 77", updated)
+            self.assertIn("draw_resolution_scale_x = 2", updated)
+            self.assertTrue(pathlib.Path(result["backup_path"]).is_file())
+            self.run_tool(state, "-Action", "Restore")
+            self.assertEqual(config.read_text(encoding="utf-8"), original)
+
+    def test_reset_writes_supported_defaults_and_preserves_backup(self):
+        with tempfile.TemporaryDirectory(prefix="pinyon-settings-") as temporary:
+            state = pathlib.Path(temporary)
+            config = state / "config/pinyon_shift.toml"
+            config.parent.mkdir(parents=True)
+            config.write_text("pinyon_shift_config_schema = 4\nswap_post_effect = \"fxaa\"\n", encoding="utf-8")
+            result = self.run_tool(state, "-Action", "Reset")
+            text = config.read_text(encoding="utf-8")
+            self.assertIn("swap_post_effect = \"none\"", text)
+            self.assertIn("draw_resolution_scale_x = 1", text)
+            self.assertTrue(pathlib.Path(result["backup_path"]).is_file())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/tests/test_performance_summary.py
+++ b/tools/tests/test_performance_summary.py
@@ -1,0 +1,98 @@
+import csv
+import importlib.util
+import json
+import pathlib
+import subprocess
+import sys
+import tempfile
+import unittest
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+TOOL = ROOT / "tools/summarize-performance.py"
+SPEC = importlib.util.spec_from_file_location("summarize_performance", TOOL)
+MODULE = importlib.util.module_from_spec(SPEC)
+assert SPEC and SPEC.loader
+SPEC.loader.exec_module(MODULE)
+
+
+FIELDS = [
+    "frame_time_us", "fps", "draw_calls", "command_buffer_stalls",
+    "texture_cache_hits", "texture_cache_misses", "pipeline_cache_hits",
+    "pipeline_cache_misses",
+]
+
+
+class PerformanceSummaryTests(unittest.TestCase):
+    def test_emits_complete_optional_memexport_totals(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            capture = pathlib.Path(temporary) / "capture.csv"
+            capture.write_text(
+                "frame_time_us,fps,draw_calls,command_buffer_stalls,texture_cache_hits,texture_cache_misses,"
+                "pipeline_cache_hits,pipeline_cache_misses,memexport_draws,memexport_bytes,"
+                "memexport_sync_fallbacks,memexport_queue_waits,memexport_fence_waits\n"
+                "10000,100,1,0,1,0,1,0,2,64,1,1,1\n"
+                "11000,90,1,0,1,0,1,0,3,96,0,0,0\n",
+                encoding="utf-8",
+            )
+            result = MODULE.summarize(capture)
+            self.assertEqual(5, result["memexport_counters"]["memexport_draws"])
+            self.assertEqual(160, result["memexport_counters"]["memexport_bytes"])
+
+    def write_capture(self, path, rows):
+        with path.open("w", encoding="utf-8", newline="") as stream:
+            writer = csv.DictWriter(stream, fieldnames=FIELDS)
+            writer.writeheader()
+            writer.writerows(rows)
+
+    def test_summarizes_runtime_csv_and_ignores_initialization_row(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            capture = pathlib.Path(temporary) / "frames.csv"
+            self.write_capture(capture, [
+                dict.fromkeys(FIELDS, 0),
+                {"frame_time_us": 10_000, "fps": 100, "draw_calls": 10,
+                 "command_buffer_stalls": 1, "texture_cache_hits": 9,
+                 "texture_cache_misses": 1, "pipeline_cache_hits": 20,
+                 "pipeline_cache_misses": 0},
+                {"frame_time_us": 20_000, "fps": 50, "draw_calls": 20,
+                 "command_buffer_stalls": 2, "texture_cache_hits": 8,
+                 "texture_cache_misses": 2, "pipeline_cache_hits": 18,
+                 "pipeline_cache_misses": 2},
+            ])
+            result = MODULE.summarize(capture)
+            self.assertEqual(result["frames"]["sample_count"], 2)
+            self.assertEqual(result["frames"]["measured_duration_seconds"], 0.03)
+            self.assertEqual(result["frames"]["frame_time_us"]["median"], 15_000)
+            self.assertEqual(result["frames"]["counter_totals"]["draw_calls"], 30)
+            self.assertEqual(result["frames"]["cache_hit_rate_percent"]["texture"], 85.0)
+
+    def test_rejects_incomplete_and_truncated_capture(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            capture = pathlib.Path(temporary) / "frames.csv"
+            capture.write_text("frame_time_us,fps\n10000,100\n", encoding="utf-8")
+            completed = subprocess.run(
+                [sys.executable, str(TOOL), str(capture)], capture_output=True, text=True
+            )
+            self.assertEqual(completed.returncode, 2)
+            self.assertIn("missing required columns", completed.stderr)
+
+    def test_compares_with_baseline_summary(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = pathlib.Path(temporary)
+            baseline_csv = root / "baseline.csv"
+            candidate_csv = root / "candidate.csv"
+            row = {"fps": 0, "draw_calls": 1, "command_buffer_stalls": 0,
+                   "texture_cache_hits": 1, "texture_cache_misses": 0,
+                   "pipeline_cache_hits": 1, "pipeline_cache_misses": 0}
+            self.write_capture(baseline_csv, [row | {"frame_time_us": 20_000}, row | {"frame_time_us": 20_000}])
+            self.write_capture(candidate_csv, [row | {"frame_time_us": 10_000}, row | {"frame_time_us": 10_000}])
+            baseline = root / "baseline.json"
+            baseline.write_text(json.dumps(MODULE.summarize(baseline_csv)), encoding="utf-8")
+            result = MODULE.summarize(candidate_csv)
+            MODULE.add_comparison(result, json.loads(baseline.read_text(encoding="utf-8")))
+            metric = result["comparison"]["metrics"]["median_frame_time_us"]
+            self.assertEqual(metric["delta_percent"], -50.0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/tests/test_release_contract.py
+++ b/tools/tests/test_release_contract.py
@@ -32,10 +32,10 @@ class ReleaseContractTests(unittest.TestCase):
 
     def test_rexglue_patches_have_stable_order_and_no_binary_payload(self):
         patches = sorted((ROOT / "patches/rexglue").glob("*.patch"))
-        self.assertEqual(len(patches), 30)
+        self.assertEqual(len(patches), 32)
         self.assertEqual(
             patches[-1].name,
-            "0030-v0.10-deduplicate-resume-alias-registrations.patch",
+            "0032-memexport-coherency-counters.patch",
         )
         self.assertEqual(len(patches), len({path.name[:4] for path in patches}))
         for path in patches:
@@ -103,9 +103,30 @@ class ReleaseContractTests(unittest.TestCase):
         required = {
             "build-preview.ps1", "create-crash-report.ps1", "install-build-tools.ps1", "launch-preview.ps1",
             "prepare-rexglue.ps1", "provision-toolchain.ps1", "release-common.ps1",
-            "setup-preview.ps1", "verify-game.ps1",
+            "set-graphics-experiment.ps1", "setup-preview.ps1", "verify-game.ps1",
         }
         self.assertTrue(required.issubset({p.name for p in (ROOT / "tools").glob("*.ps1")}))
+        package_script = (ROOT / "tools/package-launcher.ps1").read_text(encoding="utf-8")
+        for shipped in ("set-graphics-experiment.ps1", "verify-codegen-log.py"):
+            self.assertIn(shipped, package_script)
+
+    def test_graphics_schema_and_diagnostics_contract(self):
+        app = (ROOT / "src/pinyon_shift_app.cpp").read_text(encoding="utf-8")
+        self.assertIn("constexpr uint32_t kConfigSchema = 4", app)
+        self.assertIn(".schema", app)
+        for setting in ("anisotropic_override", "swap_post_effect", "draw_resolution_scale_x"):
+            self.assertIn(setting, app)
+            self.assertIn(setting, (ROOT / "tools/create-crash-report.ps1").read_text(encoding="utf-8"))
+
+    def test_renderer_and_stub_instrumentation_is_bounded(self):
+        stub_patch = (ROOT / "patches/rexglue/0031-sdk-stub-reachability-summary.patch").read_text(encoding="utf-8")
+        self.assertIn("kMaximumStubReachabilityEntries = 128", stub_patch)
+        self.assertIn("SDK_STUB first module={}", stub_patch)
+        self.assertIn("SDK_STUB summary", stub_patch)
+        memexport_patch = (ROOT / "patches/rexglue/0032-memexport-coherency-counters.patch").read_text(encoding="utf-8")
+        for counter in ("memexport_draws", "memexport_bytes", "memexport_sync_fallbacks",
+                        "memexport_queue_waits", "memexport_fence_waits"):
+            self.assertIn(counter, memexport_patch)
 
     def test_runtime_config_migrates_vehicle_stabilization_and_menu_accept_input(self):
         app = (ROOT / "src/pinyon_shift_app.cpp").read_text(encoding="utf-8")
@@ -113,11 +134,11 @@ class ReleaseContractTests(unittest.TestCase):
         launcher = (ROOT / "launcher/PinyonShift.Launcher/MainWindow.xaml.cs").read_text(
             encoding="utf-8"
         )
-        self.assertIn("constexpr uint32_t kConfigSchema = 3;", app)
-        self.assertRegex(app, r"pinyon_shift_config_schema,\s*3,")
+        self.assertIn("constexpr uint32_t kConfigSchema = 4;", app)
+        self.assertRegex(app, r"pinyon_shift_config_schema,\s*4,")
         self.assertIn('"pinyon_shift_stabilize_vehicle_presentation = false\\n"', app)
         self.assertIn('"keybind_a = \\"LMB,Space\\"\\n"', app)
-        self.assertIn("schema != 1 && schema != 2", app)
+        self.assertIn("schema < 1 || schema > 3", app)
         self.assertIn("Controller A, Space, or left click.", launcher)
         self.assertRegex(
             hooks,

--- a/tools/tests/test_repository_quality.py
+++ b/tools/tests/test_repository_quality.py
@@ -1,0 +1,63 @@
+import importlib.util
+import json
+import pathlib
+import subprocess
+import sys
+import tempfile
+import unittest
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+
+
+def load(name, path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    spec.loader.exec_module(module)
+    return module
+
+
+CODEGEN = load("verify_codegen_log", ROOT / "tools/verify-codegen-log.py")
+LINKS = load("check_markdown_links", ROOT / "tools/check-markdown-links.py")
+
+
+class RepositoryQualityTests(unittest.TestCase):
+    def test_codegen_allowlist_accepts_known_warnings_and_rejects_new_one(self):
+        allowlist = ROOT / "config/rexglue/accepted-codegen-warnings.json"
+        known = [
+            "Function 0x8241A370 is 2536144 bytes, exceeds max_file_size_bytes (2097152)",
+            "bdz at 82AD8138 branches outside function to 82AD836C",
+            "bdz at 82AD813C branches outside function to 82AD836C",
+        ]
+        with tempfile.TemporaryDirectory() as temporary:
+            log = pathlib.Path(temporary) / "codegen.log"
+            log.write_text("\n".join(f"[warning] [codegen] [t1] {line}" for line in known), encoding="utf-8")
+            result = CODEGEN.verify(log, allowlist)
+            self.assertEqual(result["warning_count"], 3)
+            log.write_text(log.read_text(encoding="utf-8") + "\n[warning] [codegen] surprise", encoding="utf-8")
+            with self.assertRaisesRegex(ValueError, "unrecognized warnings"):
+                CODEGEN.verify(log, allowlist)
+
+    def test_tracked_markdown_links_are_valid(self):
+        self.assertEqual(LINKS.failures(ROOT, LINKS.tracked_markdown(ROOT)), [])
+
+    def test_release_tag_matches_declared_version(self):
+        version = json.loads((ROOT / "config/release.json").read_text(encoding="utf-8"))["version"]
+        completed = subprocess.run(
+            [sys.executable, str(ROOT / "tools/verify-release-tag.py"),
+             "--tag", f"v{version}", "--main-ref", "HEAD"],
+            capture_output=True, text=True,
+        )
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+        wrong = subprocess.run(
+            [sys.executable, str(ROOT / "tools/verify-release-tag.py"),
+             "--tag", "v0.0.0-wrong", "--main-ref", "HEAD"],
+            capture_output=True, text=True,
+        )
+        self.assertEqual(wrong.returncode, 2)
+        self.assertIn("does not match", wrong.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/verify-codegen-log.py
+++ b/tools/verify-codegen-log.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""Verify that a ReXGlue codegen log contains only reviewed warnings."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import pathlib
+import re
+import sys
+
+
+WARNING_PREFIX = re.compile(r"\[warning\]\s+\[codegen\](?:\s+\[t\d+\])?\s+(?P<message>.+)$", re.IGNORECASE)
+
+
+def verify(log_path: pathlib.Path, allowlist_path: pathlib.Path) -> dict:
+    config = json.loads(allowlist_path.read_text(encoding="utf-8"))
+    if config.get("schema_version") != 1 or not isinstance(config.get("warnings"), list):
+        raise ValueError("unsupported warning allowlist schema")
+    rules = []
+    for item in config["warnings"]:
+        if not item.get("id") or not item.get("pattern") or not item.get("reason"):
+            raise ValueError("every accepted warning needs id, pattern, and reason")
+        rules.append((item["id"], re.compile(item["pattern"])))
+
+    matches = {identifier: 0 for identifier, _ in rules}
+    unknown: list[str] = []
+    warning_count = 0
+    for line in log_path.read_text(encoding="utf-8", errors="strict").splitlines():
+        marker = WARNING_PREFIX.search(line)
+        if not marker:
+            continue
+        warning_count += 1
+        message = marker.group("message").strip()
+        matching = [identifier for identifier, pattern in rules if pattern.fullmatch(message)]
+        if len(matching) == 1:
+            matches[matching[0]] += 1
+        elif not matching:
+            unknown.append(message)
+        else:
+            unknown.append(f"ambiguous allowlist match: {message}")
+
+    missing = sorted(identifier for identifier, count in matches.items() if count == 0)
+    if unknown or missing:
+        details = []
+        if unknown:
+            details.append("unrecognized warnings: " + " | ".join(sorted(set(unknown))))
+        if missing:
+            details.append("expected warnings not observed: " + ", ".join(missing))
+        raise ValueError("; ".join(details))
+    return {
+        "schema": "pinyon-shift.codegen-warning-verification.v1",
+        "log": log_path.name,
+        "warning_count": warning_count,
+        "accepted": matches,
+    }
+
+
+def main() -> int:
+    root = pathlib.Path(__file__).resolve().parents[1]
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("log", type=pathlib.Path)
+    parser.add_argument(
+        "--allowlist",
+        type=pathlib.Path,
+        default=root / "config/rexglue/accepted-codegen-warnings.json",
+    )
+    args = parser.parse_args()
+    try:
+        print(json.dumps(verify(args.log, args.allowlist), indent=2))
+        return 0
+    except (OSError, ValueError, json.JSONDecodeError) as error:
+        print(f"error: {error}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/verify-release-tag.py
+++ b/tools/verify-release-tag.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""Verify release version/tag agreement and main-branch ancestry."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import pathlib
+import re
+import subprocess
+import sys
+
+
+def git(root: pathlib.Path, *arguments: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(["git", *arguments], cwd=root, text=True, capture_output=True)
+
+
+def verify(root: pathlib.Path, tag: str | None, main_ref: str) -> dict:
+    release = json.loads((root / "config/release.json").read_text(encoding="utf-8"))
+    version = release.get("version")
+    if not isinstance(version, str) or not re.fullmatch(r"[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.-]+)?", version):
+        raise ValueError("config/release.json contains an invalid version")
+    expected_tag = f"v{version}"
+    if tag and tag != expected_tag:
+        raise ValueError(f"release tag {tag!r} does not match {expected_tag!r}")
+
+    ancestry = git(root, "merge-base", "--is-ancestor", "HEAD", main_ref)
+    if ancestry.returncode != 0:
+        if ancestry.returncode == 1:
+            raise ValueError(f"tagged commit is not contained in {main_ref}")
+        raise ValueError(ancestry.stderr.strip() or f"unable to inspect {main_ref}")
+    return {
+        "schema": "pinyon-shift.release-tag-verification.v1",
+        "version": version,
+        "expected_tag": expected_tag,
+        "tag": tag,
+        "main_ref": main_ref,
+        "main_contains_head": True,
+    }
+
+
+def main() -> int:
+    root = pathlib.Path(__file__).resolve().parents[1]
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--tag", default=os.environ.get("GITHUB_REF_NAME"))
+    parser.add_argument("--main-ref", default="refs/remotes/origin/main")
+    parser.add_argument("--allow-no-tag", action="store_true")
+    args = parser.parse_args()
+    if not args.tag and not args.allow_no_tag:
+        print("error: no release tag was provided", file=sys.stderr)
+        return 2
+    try:
+        print(json.dumps(verify(root, args.tag, args.main_ref), indent=2))
+        return 0
+    except (OSError, ValueError, json.JSONDecodeError) as error:
+        print(f"error: {error}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/visual-baseline.py
+++ b/tools/visual-baseline.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""Create and validate exact-build manual visual-baseline sessions."""
+from __future__ import annotations
+
+import argparse, hashlib, json, struct, subprocess
+from datetime import datetime, timezone
+from pathlib import Path
+
+SCENES = ("front-end", "garage", "open-world-day", "open-world-night", "traffic", "race", "rewind", "ui-heavy")
+ROOT = Path(__file__).resolve().parents[1]
+
+def fingerprint(executable: Path | None = None) -> dict:
+    def git(*args: str) -> str:
+        result = subprocess.run(["git", *args], cwd=ROOT, text=True, capture_output=True, check=True)
+        return result.stdout.strip()
+    patch_hasher = hashlib.sha256()
+    for patch in sorted((ROOT / "patches" / "rexglue").glob("*.patch")):
+        patch_hasher.update(patch.name.encode()); patch_hasher.update(b"\0"); patch_hasher.update(patch.read_bytes())
+    data = {"repository_commit": git("rev-parse", "HEAD"),
+            "rexglue_patch_set_sha256": patch_hasher.hexdigest()}
+    try: data["rexglue_commit"] = git("-C", str(ROOT / ".local" / "rexglue"), "rev-parse", "HEAD")
+    except (subprocess.CalledProcessError, FileNotFoundError): data["rexglue_commit"] = None
+    if executable and executable.is_file():
+        data["executable_sha256"] = hashlib.sha256(executable.read_bytes()).hexdigest()
+    else: data["executable_sha256"] = None
+    material = json.dumps(data, sort_keys=True).encode()
+    data["id"] = hashlib.sha256(material).hexdigest()[:16]
+    return data
+
+def png_size(path: Path) -> tuple[int, int]:
+    with path.open("rb") as stream:
+        header = stream.read(24)
+    if len(header) != 24 or header[:8] != b"\x89PNG\r\n\x1a\n" or header[12:16] != b"IHDR":
+        raise ValueError(f"not a valid PNG: {path.name}")
+    return struct.unpack(">II", header[16:24])
+
+def create_session(output: Path, executable: Path | None) -> Path:
+    build = fingerprint(executable)
+    session = output / build["id"]
+    (session / "captures").mkdir(parents=True, exist_ok=True)
+    manifest = {"schema": "pinyon-shift.visual-baseline.v1", "created_utc": datetime.now(timezone.utc).isoformat(),
+                "build": build, "scenes": [{"label": scene, "file": f"captures/{scene}.png"} for scene in SCENES]}
+    (session / "manifest.json").write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
+    return session
+
+def validate(session: Path, allow_missing: bool = False) -> dict:
+    manifest = json.loads((session / "manifest.json").read_text(encoding="utf-8"))
+    labels = [item["label"] for item in manifest.get("scenes", [])]
+    if labels != list(SCENES): raise ValueError("manifest scene labels are missing, reordered, or mismatched")
+    missing, dimensions = [], {}
+    for item in manifest["scenes"]:
+        capture = session / item["file"]
+        if not capture.is_file(): missing.append(item["label"])
+        else: dimensions[item["label"]] = png_size(capture)
+    if missing and not allow_missing: raise ValueError("missing captures: " + ", ".join(missing))
+    return {"schema": manifest["schema"], "build": manifest["build"], "missing": missing, "dimensions": dimensions}
+
+def contact_sheet(session: Path) -> Path:
+    result = validate(session)
+    manifest = json.loads((session / "manifest.json").read_text(encoding="utf-8"))
+    width, tile_height = 1440, 430
+    rows = (len(SCENES) + 1) // 2
+    parts = [f'<svg xmlns="http://www.w3.org/2000/svg" width="{width}" height="{rows*tile_height}" viewBox="0 0 {width} {rows*tile_height}">',
+             '<rect width="100%" height="100%" fill="#101410"/>']
+    for index, item in enumerate(manifest["scenes"]):
+        x, y = (index % 2) * 720, (index // 2) * tile_height
+        href = item["file"].replace("\\", "/")
+        parts += [f'<image href="{href}" x="{x+10}" y="{y+10}" width="700" height="370" preserveAspectRatio="xMidYMid meet"/>',
+                  f'<text x="{x+18}" y="{y+408}" fill="#f1ae36" font-family="sans-serif" font-size="20">{item["label"]}</text>']
+    parts.append("</svg>")
+    target = session / "contact-sheet.svg"
+    target.write_text("\n".join(parts) + "\n", encoding="utf-8")
+    (session / "validation.json").write_text(json.dumps(result, indent=2) + "\n", encoding="utf-8")
+    return target
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("action", choices=("init", "validate", "contact-sheet"))
+    parser.add_argument("path", type=Path)
+    parser.add_argument("--executable", type=Path)
+    parser.add_argument("--allow-missing", action="store_true")
+    args = parser.parse_args()
+    try:
+        if args.action == "init" and not args.executable:
+            raise ValueError("init requires --executable so the capture folder identifies the exact binary")
+        result = create_session(args.path, args.executable) if args.action == "init" else (
+            validate(args.path, args.allow_missing) if args.action == "validate" else contact_sheet(args.path))
+        print(json.dumps(result if isinstance(result, dict) else {"path": str(result)}, indent=2))
+        return 0
+    except (OSError, ValueError, KeyError, json.JSONDecodeError, subprocess.CalledProcessError) as exc:
+        parser.exit(2, f"visual baseline error: {exc}\n")
+if __name__ == "__main__": raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add launcher controls and safe backup/restore tooling for runtime and experimental graphics settings
- add performance, visual-baseline, renderer A/B, and qualification-session evidence helpers
- enforce Markdown links, release-tag ancestry, and reviewed code-generation warnings in CI/release tooling
- add bounded SDK-stub and memexport instrumentation patches
- record the implemented quick and mid-size items in BACKLOG.md

## Rebase integration
- advance the combined runtime config to schema 4, preserving schema-1 motion stabilization and schema-3 menu-input migrations
- renumber the new ReXGlue patches to 0031 and 0032 after the ReXGlue 0.10 migration
- retain dependency-tracked incremental code generation and run the new warning verifier whenever regeneration occurs

## Validation
- all 24 Python tests pass
- launcher Release build passes with zero warnings
- repository boundary check passes
- tracked Markdown link check passes