### PR TITLE
fix(rexglue): assemble multipacket xma frames

### DIFF
--- a/config/rexglue/EPIC_02_XMA_MULTIPACKET_ASSEMBLY.md
+++ b/config/rexglue/EPIC_02_XMA_MULTIPACKET_ASSEMBLY.md
@@ -1,0 +1,46 @@
+# ReXGlue XMA multi-packet frame assembly
+
+EPIC-02 is delivered by
+`patches/rexglue/0037-m4-xma-multipacket-frame-assembly.patch`.
+
+## Derivation and scope
+
+The bounded payload-assembly design is adapted from ReXGlue commit
+[`51b601a`](https://github.com/xXJSONDeruloXx/rexglue-sdk/commit/51b601ab04caf3f1a9a5fcb1455b3a8bb58f5a2a).
+The project patch integrates that behavior with EPIC-01's validated logical
+packet handles rather than reading continuation buffers directly.
+
+The patch changes:
+
+- `include/rex/audio/xma/context.h`;
+- `src/audio/xma_context.cpp`;
+- `tests/unit/audio/xma_packet_test.cpp`.
+
+It expands the scratch buffer from two to four header-free packet payloads.
+One reusable assembler calculates the required packet count with 64-bit
+intermediate arithmetic, resolves every logical packet through EPIC-01, copies
+only validated payload bytes, and zero-fills unused or failed output. Split
+frame headers and complete frame extraction both use this path.
+
+## Failure behavior
+
+Zero-bit requests, offsets outside a packet payload, sentinel frame sizes,
+scratch-capacity overruns, missing continuation buffers, and undersized
+alternate buffers are rejected before decoding. Failures set XMA error status
+`4` and emit at most one payload warning per failure class and decoder stream.
+EPIC-01 continues to bound the more specific packet-resolution warnings.
+
+Next-frame advancement uses the declared frame size rather than the number of
+bits that happened to remain in the first guest packet.
+
+## Tests and rollback
+
+Synthetic coverage exercises one-, two-, three-, and four-packet assembly,
+late frame starts, split headers, alternate-buffer packet `0` and later packet
+indices, missing and short continuations, over-capacity requests, invalid
+offsets, zero-length frames, and the maximum sentinel. Three- and four-packet
+decoder cases also verify clean advancement across the guest-buffer boundary.
+
+Rollback is removal of patch `0037`. It contains only the four-payload scratch
+capacity, assembler, decoder integration, diagnostics, and their tests. EPIC-01
+packet traversal remains independently active.

--- a/config/rexglue/PATCH_DISPOSITIONS.md
+++ b/config/rexglue/PATCH_DISPOSITIONS.md
@@ -75,13 +75,20 @@ guest buffer index and the packet index within that buffer. This patch depends
 on `0017`, whose exhausted-input transition it replaces in place; removing
 `0036` restores the independently applicable `0017` behavior.
 
+`0037-m4-xma-multipacket-frame-assembly` adapts the bounded four-payload XMA
+frame assembler from ReXGlue commit `51b601a` and routes every source packet
+through `0036`'s validated logical packet handles. Split headers and frame data
+share one assembly path, invalid sizes and capacity overruns fail with bounded
+diagnostics, and synthetic coverage exercises one through four packets across
+guest-buffer boundaries. Removing `0037` restores the prior two-payload
+decoder without removing `0036`.
+
 Validation performed on the rebased SDK:
 
 - `unit_tests` and `ppc_tests` build with the pinned Clang 20.1.8 toolchain.
 - 1,460/1,460 PPC instruction tests passed.
-- The 228-test unit suite passed after the two ported test-data corrections and
-  the direct-tail assertion correction (four pre-existing BitStream write cases
-  remain explicitly skipped by upstream).
+- The 234-test unit suite passed: 230 tests passed and four pre-existing
+  BitStream write cases remain explicitly skipped by upstream.
 - No conflict markers, reject files, or binary patch payloads are present.
 
 ## Rollback

--- a/patches/rexglue/0037-m4-xma-multipacket-frame-assembly.patch
+++ b/patches/rexglue/0037-m4-xma-multipacket-frame-assembly.patch
@@ -1,0 +1,769 @@
+diff --git a/include/rex/audio/xma/context.h b/include/rex/audio/xma/context.h
+index efce0ca..4861e40 100644
+--- a/include/rex/audio/xma/context.h
++++ b/include/rex/audio/xma/context.h
+@@ -14,6 +14,7 @@
+ #include <array>
+ #include <atomic>
+ #include <mutex>
++#include <span>
+ 
+ #include <rex/kernel.h>
+ #include <rex/memory.h>
+@@ -186,13 +187,29 @@ struct XmaPacketHandle {
+   bool valid() const { return status == XmaPacketStatus::kValid; }
+ };
+ 
++enum class XmaPayloadStatus : uint8_t {
++  kValid,
++  kInvalidFrameOffset,
++  kZeroLength,
++  kInvalidFrameSize,
++  kCapacityExceeded,
++  kPacketUnavailable,
++};
++
++struct AssembledXmaPayload {
++  uint32_t valid_bits = 0;
++  uint32_t packet_count = 0;
++  XmaPayloadStatus status = XmaPayloadStatus::kInvalidFrameOffset;
++  XmaPacketHandle failed_packet;
++
++  bool valid() const { return status == XmaPayloadStatus::kValid; }
++};
++
+ // Resolves a logical packet number relative to starting_buffer_index. Packet
+ // numbers at or beyond current_buffer_packet_count continue in the alternate
+ // guest buffer without losing their index within that buffer.
+-XmaPacketHandle ResolvePacket(const XMA_CONTEXT_DATA& data,
+-                              uint32_t starting_buffer_index,
+-                              uint32_t logical_packet_index,
+-                              uint32_t current_buffer_packet_count);
++XmaPacketHandle ResolvePacket(const XMA_CONTEXT_DATA& data, uint32_t starting_buffer_index,
++                              uint32_t logical_packet_index, uint32_t current_buffer_packet_count);
+ 
+ static constexpr int kIdToSampleRate[4] = {24000, 32000, 44100, 48000};
+ 
+@@ -204,6 +221,8 @@ class XmaContext {
+   static const uint32_t kBitsPerFrameHeader = 15;
+   static const uint32_t kBytesPerPacketHeader = 4;
+   static const uint32_t kBytesPerPacketData = kBytesPerPacket - kBytesPerPacketHeader;
++  static const uint32_t kBitsPerPacketData = kBytesPerPacketData * 8;
++  static const uint32_t kMaxAssembledPackets = 4;
+ 
+   static const uint32_t kBytesPerSample = 2;
+   static const uint32_t kSamplesPerFrame = 512;
+@@ -231,6 +250,13 @@ class XmaContext {
+   int Setup(uint32_t id, memory::Memory* memory, uint32_t guest_ptr);
+   bool Work();
+ 
++  AssembledXmaPayload AssemblePacketPayloads(XMA_CONTEXT_DATA* data, uint32_t first_logical_packet,
++                                             uint32_t current_input_packet_count,
++                                             uint32_t frame_offset_in_packet,
++                                             uint32_t bits_required,
++                                             std::span<uint8_t> destination);
++  static bool IsValidFrameSize(uint32_t frame_size);
++
+   void Enable();
+   bool Block(bool poll);
+   void Clear();
+@@ -267,20 +293,19 @@ class XmaContext {
+   static uint32_t GetCurrentInputBufferSize(XMA_CONTEXT_DATA* data);
+ 
+   kPacketInfo GetPacketInfo(uint8_t* packet, uint32_t frame_offset);
+-  uint32_t GetAmountOfBitsToRead(uint32_t remaining_stream_bits, uint32_t frame_size);
+   const uint8_t* GetPacket(XMA_CONTEXT_DATA* data, const XmaPacketHandle& packet_handle);
+   const uint8_t* GetNextPacket(XMA_CONTEXT_DATA* data, uint32_t next_packet_index,
+                                uint32_t current_input_packet_count,
+                                XmaPacketHandle* packet_handle = nullptr);
+   uint32_t GetNextPacketReadOffset(uint8_t* buffer, uint32_t next_packet_index,
+                                    uint32_t current_input_packet_count,
+-                                   uint32_t* resolved_packet_index,
+-                                   bool* packet_found);
++                                   uint32_t* resolved_packet_index, bool* packet_found);
+   uint32_t GetNextPacketReadOffset(XMA_CONTEXT_DATA* data, uint32_t next_packet_index,
+                                    uint32_t current_input_packet_count,
+                                    XmaPacketHandle* packet_handle);
+-  void WarnPacketResolution(const XmaPacketHandle& packet_handle,
+-                            uint32_t logical_packet_index);
++  void WarnPacketResolution(const XmaPacketHandle& packet_handle, uint32_t logical_packet_index);
++  void WarnPayloadAssembly(const AssembledXmaPayload& payload, uint32_t first_logical_packet,
++                           uint32_t frame_offset_in_packet, uint32_t bits_required);
+ 
+   void Decode(XMA_CONTEXT_DATA* data);
+   void Consume(memory::RingBuffer* output_rb, const XMA_CONTEXT_DATA* data);
+@@ -313,8 +338,8 @@ class XmaContext {
+   AVCodecContext* av_context_ = nullptr;
+   AVFrame* av_frame_ = nullptr;
+ 
+-  // Packet data buffer (two packets worth for split frame handling)
+-  std::array<uint8_t, kBytesPerPacketData * 2> input_buffer_;
++  // Header-free packet payloads assembled for frames spanning guest packets.
++  std::array<uint8_t, kBytesPerPacketData * kMaxAssembledPackets> input_buffer_;
+   // First byte contains bit offset information
+   std::array<uint8_t, 1 + 4096> xma_frame_;
+   // Conversion buffer for up to 2-channel frame
+@@ -342,6 +367,7 @@ class XmaContext {
+   // One bit per XmaPacketStatus. Malformed guest input is reported once per
+   // context lifetime rather than once per Work() re-entry.
+   uint32_t packet_warning_mask_ = 0;
++  uint32_t payload_warning_mask_ = 0;
+ };
+ 
+ }  // namespace rex::audio
+diff --git a/src/audio/xma_context.cpp b/src/audio/xma_context.cpp
+index 93ee67a..e723215 100644
+--- a/src/audio/xma_context.cpp
++++ b/src/audio/xma_context.cpp
+@@ -43,10 +43,8 @@ using stream::BitStream;
+ const uint32_t XmaContext::kBitsPerPacketHeader;
+ const uint32_t XmaContext::kOutputMaxSizeBytes;
+ 
+-XmaPacketHandle ResolvePacket(const XMA_CONTEXT_DATA& data,
+-                              uint32_t starting_buffer_index,
+-                              uint32_t logical_packet_index,
+-                              uint32_t current_buffer_packet_count) {
++XmaPacketHandle ResolvePacket(const XMA_CONTEXT_DATA& data, uint32_t starting_buffer_index,
++                              uint32_t logical_packet_index, uint32_t current_buffer_packet_count) {
+   XmaPacketHandle result;
+   if (starting_buffer_index > 1 ||
+       current_buffer_packet_count !=
+@@ -79,6 +77,10 @@ XmaPacketHandle ResolvePacket(const XMA_CONTEXT_DATA& data,
+   return result;
+ }
+ 
++bool XmaContext::IsValidFrameSize(uint32_t frame_size) {
++  return frame_size != 0 && frame_size != xma::kMaxFrameLength;
++}
++
+ XmaContext::XmaContext()
+     : work_completion_event_(rex::thread::Event::CreateAutoResetEvent(false)) {}
+ 
+@@ -246,6 +248,7 @@ void XmaContext::ResetDecoderState() {
+   loop_frame_output_limit_ = 0;
+   loop_start_skip_pending_ = false;
+   packet_warning_mask_ = 0;
++  payload_warning_mask_ = 0;
+ }
+ 
+ void XmaContext::Disable() {
+@@ -315,19 +318,13 @@ uint32_t XmaContext::GetCurrentInputBufferSize(XMA_CONTEXT_DATA* data) {
+   return data->GetCurrentInputBufferPacketCount() * kBytesPerPacket;
+ }
+ 
+-uint32_t XmaContext::GetAmountOfBitsToRead(uint32_t remaining_stream_bits, uint32_t frame_size) {
+-  return std::min(remaining_stream_bits, frame_size);
+-}
+-
+-const uint8_t* XmaContext::GetPacket(XMA_CONTEXT_DATA* data,
+-                                     const XmaPacketHandle& packet_handle) {
++const uint8_t* XmaContext::GetPacket(XMA_CONTEXT_DATA* data, const XmaPacketHandle& packet_handle) {
+   if (!packet_handle.valid()) {
+     return nullptr;
+   }
+   const uint32_t buffer_address =
+       data->GetInputBufferAddress(static_cast<uint8_t>(packet_handle.buffer_index));
+-  return memory()->TranslatePhysical(buffer_address) +
+-         packet_handle.packet_index * kBytesPerPacket;
++  return memory()->TranslatePhysical(buffer_address) + packet_handle.packet_index * kBytesPerPacket;
+ }
+ 
+ void XmaContext::WarnPacketResolution(const XmaPacketHandle& packet_handle,
+@@ -341,17 +338,90 @@ void XmaContext::WarnPacketResolution(const XmaPacketHandle& packet_handle,
+     return;
+   }
+   packet_warning_mask_ |= warning_bit;
++  REXAPU_WARN("XmaContext {}: cannot resolve logical packet {} (buffer {}, packet {}, status {})",
++              id(), logical_packet_index, packet_handle.buffer_index, packet_handle.packet_index,
++              static_cast<uint32_t>(packet_handle.status));
++}
++
++AssembledXmaPayload XmaContext::AssemblePacketPayloads(
++    XMA_CONTEXT_DATA* data, uint32_t first_logical_packet, uint32_t current_input_packet_count,
++    uint32_t frame_offset_in_packet, uint32_t bits_required, std::span<uint8_t> destination) {
++  std::fill(destination.begin(), destination.end(), 0);
++
++  AssembledXmaPayload result;
++  if (frame_offset_in_packet < kBitsPerPacketHeader || frame_offset_in_packet >= kBitsPerPacket) {
++    result.status = XmaPayloadStatus::kInvalidFrameOffset;
++    return result;
++  }
++  if (bits_required == 0) {
++    result.status = XmaPayloadStatus::kZeroLength;
++    return result;
++  }
++
++  const uint64_t first_payload_bit =
++      static_cast<uint64_t>(frame_offset_in_packet - kBitsPerPacketHeader);
++  const uint64_t payload_bits_needed = first_payload_bit + bits_required;
++  const uint64_t packet_count = (payload_bits_needed + kBitsPerPacketData - 1) / kBitsPerPacketData;
++  const size_t destination_packet_capacity = destination.size() / kBytesPerPacketData;
++  if (packet_count == 0 || packet_count > destination_packet_capacity ||
++      packet_count > kMaxAssembledPackets) {
++    result.status = XmaPayloadStatus::kCapacityExceeded;
++    result.packet_count = static_cast<uint32_t>(packet_count);
++    return result;
++  }
++
++  result.packet_count = static_cast<uint32_t>(packet_count);
++  for (uint32_t i = 0; i < result.packet_count; ++i) {
++    const uint32_t logical_packet = first_logical_packet + i;
++    const XmaPacketHandle packet =
++        ResolvePacket(*data, data->current_buffer, logical_packet, current_input_packet_count);
++    if (!packet.valid()) {
++      std::fill(destination.begin(), destination.end(), 0);
++      result.status = XmaPayloadStatus::kPacketUnavailable;
++      result.failed_packet = packet;
++      WarnPacketResolution(packet, logical_packet);
++      return result;
++    }
++
++    const uint8_t* packet_data = GetPacket(data, packet);
++    if (!packet_data) {
++      std::fill(destination.begin(), destination.end(), 0);
++      result.status = XmaPayloadStatus::kPacketUnavailable;
++      result.failed_packet = packet;
++      return result;
++    }
++    std::memcpy(destination.data() + i * kBytesPerPacketData, packet_data + kBytesPerPacketHeader,
++                kBytesPerPacketData);
++  }
++
++  result.valid_bits = result.packet_count * kBitsPerPacketData;
++  result.status = XmaPayloadStatus::kValid;
++  return result;
++}
++
++void XmaContext::WarnPayloadAssembly(const AssembledXmaPayload& payload,
++                                     uint32_t first_logical_packet, uint32_t frame_offset_in_packet,
++                                     uint32_t bits_required) {
++  if (payload.valid()) {
++    return;
++  }
++  const uint32_t warning_bit = 1u << static_cast<uint32_t>(payload.status);
++  if (payload_warning_mask_ & warning_bit) {
++    return;
++  }
++  payload_warning_mask_ |= warning_bit;
+   REXAPU_WARN(
+-      "XmaContext {}: cannot resolve logical packet {} (buffer {}, packet {}, status {})",
+-      id(), logical_packet_index, packet_handle.buffer_index, packet_handle.packet_index,
+-      static_cast<uint32_t>(packet_handle.status));
++      "XmaContext {}: cannot assemble payload at packet {}, offset {}, bits {} "
++      "(packets {}, status {})",
++      id(), first_logical_packet, frame_offset_in_packet, bits_required, payload.packet_count,
++      static_cast<uint32_t>(payload.status));
+ }
+ 
+ const uint8_t* XmaContext::GetNextPacket(XMA_CONTEXT_DATA* data, uint32_t next_packet_index,
+                                          uint32_t current_input_packet_count,
+                                          XmaPacketHandle* packet_handle) {
+-  XmaPacketHandle resolved = ResolvePacket(*data, data->current_buffer, next_packet_index,
+-                                           current_input_packet_count);
++  XmaPacketHandle resolved =
++      ResolvePacket(*data, data->current_buffer, next_packet_index, current_input_packet_count);
+   if (packet_handle) {
+     *packet_handle = resolved;
+   }
+@@ -361,8 +431,7 @@ const uint8_t* XmaContext::GetNextPacket(XMA_CONTEXT_DATA* data, uint32_t next_p
+ 
+ uint32_t XmaContext::GetNextPacketReadOffset(uint8_t* buffer, uint32_t next_packet_index,
+                                              uint32_t current_input_packet_count,
+-                                             uint32_t* resolved_packet_index,
+-                                             bool* packet_found) {
++                                             uint32_t* resolved_packet_index, bool* packet_found) {
+   *packet_found = false;
+   while (next_packet_index < current_input_packet_count) {
+     uint8_t* next_packet = buffer + (next_packet_index * kBytesPerPacket);
+@@ -381,12 +450,11 @@ uint32_t XmaContext::GetNextPacketReadOffset(uint8_t* buffer, uint32_t next_pack
+   return kBitsPerPacketHeader;
+ }
+ 
+-uint32_t XmaContext::GetNextPacketReadOffset(XMA_CONTEXT_DATA* data,
+-                                             uint32_t next_packet_index,
++uint32_t XmaContext::GetNextPacketReadOffset(XMA_CONTEXT_DATA* data, uint32_t next_packet_index,
+                                              uint32_t current_input_packet_count,
+                                              XmaPacketHandle* packet_handle) {
+-  XmaPacketHandle resolved = ResolvePacket(*data, data->current_buffer, next_packet_index,
+-                                           current_input_packet_count);
++  XmaPacketHandle resolved =
++      ResolvePacket(*data, data->current_buffer, next_packet_index, current_input_packet_count);
+   if (!resolved.valid()) {
+     WarnPacketResolution(resolved, next_packet_index);
+     *packet_handle = resolved;
+@@ -684,16 +752,14 @@ void XmaContext::Decode(XMA_CONTEXT_DATA* data) {
+ 
+   if (packet_index == -1) {
+     const uint32_t logical_packet_index = data->input_buffer_read_offset / kBitsPerPacket;
+-    XmaPacketHandle resolved = ResolvePacket(*data, data->current_buffer,
+-                                             logical_packet_index,
++    XmaPacketHandle resolved = ResolvePacket(*data, data->current_buffer, logical_packet_index,
+                                              current_input_packet_count);
+     WarnPacketResolution(resolved, logical_packet_index);
+     if (resolved.valid() && resolved.buffer_index != data->current_buffer) {
+       const uint32_t relative_offset = data->input_buffer_read_offset % kBitsPerPacket;
+       SwapInputBuffer(data);
+       data->input_buffer_read_offset =
+-          resolved.packet_index * kBitsPerPacket +
+-          std::max(kBitsPerPacketHeader, relative_offset);
++          resolved.packet_index * kBitsPerPacket + std::max(kBitsPerPacketHeader, relative_offset);
+     } else if (resolved.status == XmaPacketStatus::kBufferInvalid) {
+       // The active buffer is logically exhausted and no continuation is ready.
+       // Retiring it leaves Work() cleanly idle instead of re-entering forever.
+@@ -704,16 +770,14 @@ void XmaContext::Decode(XMA_CONTEXT_DATA* data) {
+     return;
+   }
+ 
+-  XmaPacketHandle current_packet = ResolvePacket(*data, data->current_buffer, packet_index,
+-                                                 current_input_packet_count);
++  XmaPacketHandle current_packet =
++      ResolvePacket(*data, data->current_buffer, packet_index, current_input_packet_count);
+   WarnPacketResolution(current_packet, packet_index);
+   uint8_t* packet = const_cast<uint8_t*>(GetPacket(data, current_packet));
+   if (!packet) {
+     data->error_status = 4;
+     return;
+   }
+-  uint8_t* current_input_buffer = memory()->TranslatePhysical(
+-      data->GetInputBufferAddress(static_cast<uint8_t>(current_packet.buffer_index)));
+   const uint32_t packet_first_frame_offset = xma::GetPacketFrameOffset(packet);
+   uint32_t relative_offset = data->input_buffer_read_offset % kBitsPerPacket;
+ 
+@@ -727,8 +791,8 @@ void XmaContext::Decode(XMA_CONTEXT_DATA* data) {
+   // Full packet skip (0xFF) -- no new frames begin in this packet.
+   if (skip_count == 0xFF) {
+     XmaPacketHandle next_packet;
+-    uint32_t next_input_offset = GetNextPacketReadOffset(
+-        data, packet_index + 1, current_input_packet_count, &next_packet);
++    uint32_t next_input_offset =
++        GetNextPacketReadOffset(data, packet_index + 1, current_input_packet_count, &next_packet);
+     if (next_packet.valid() && next_packet.buffer_index != data->current_buffer) {
+       SwapInputBuffer(data);
+     } else if (!next_packet.valid()) {
+@@ -748,63 +812,42 @@ void XmaContext::Decode(XMA_CONTEXT_DATA* data) {
+ 
+   // Frame header split across packet boundary.
+   if (packet_info.current_frame_size_ == 0) {
+-    XmaPacketHandle next_packet_handle;
+-    const uint8_t* next_packet = GetNextPacket(data, next_packet_index,
+-                                               current_input_packet_count,
+-                                               &next_packet_handle);
+-    if (!next_packet) {
+-      if (next_packet_handle.status == XmaPacketStatus::kBufferInvalid) {
+-        SwapInputBuffer(data);
+-      } else {
+-        data->error_status = 4;
+-      }
++    const AssembledXmaPayload header_payload =
++        AssemblePacketPayloads(data, packet_index, current_input_packet_count, relative_offset,
++                               kBitsPerFrameHeader, input_buffer_);
++    if (!header_payload.valid()) {
++      WarnPayloadAssembly(header_payload, packet_index, relative_offset, kBitsPerFrameHeader);
++      data->error_status = 4;
+       return;
+     }
+-    std::memcpy(input_buffer_.data(), packet + kBytesPerPacketHeader, kBytesPerPacketData);
+-    std::memcpy(input_buffer_.data() + kBytesPerPacketData, next_packet + kBytesPerPacketHeader,
+-                kBytesPerPacketData);
+ 
+-    BitStream combined(input_buffer_.data(), (kBitsPerPacket - kBitsPerPacketHeader) * 2);
++    BitStream combined(input_buffer_.data(), header_payload.valid_bits);
+     combined.SetOffset(relative_offset - kBitsPerPacketHeader);
+-
+-    uint64_t frame_size = combined.Peek(kBitsPerFrameHeader);
+-    if (frame_size == xma::kMaxFrameLength) {
+-      data->error_status = 4;
+-      return;
+-    }
+-    packet_info.current_frame_size_ = static_cast<uint32_t>(frame_size);
++    packet_info.current_frame_size_ = static_cast<uint32_t>(combined.Peek(kBitsPerFrameHeader));
+   }
+ 
+-  BitStream stream(current_input_buffer, (packet_index + 1) * kBitsPerPacket);
+-  stream.SetOffset(data->input_buffer_read_offset);
+-
+-  const uint64_t bits_to_copy = GetAmountOfBitsToRead(static_cast<uint32_t>(stream.BitsRemaining()),
+-                                                      packet_info.current_frame_size_);
+-
+-  if (bits_to_copy == 0) {
+-    REXAPU_ERROR("XmaContext {}: There are no bits to copy!", id());
+-    SwapInputBuffer(data);
++  if (!IsValidFrameSize(packet_info.current_frame_size_)) {
++    AssembledXmaPayload invalid_frame;
++    invalid_frame.status = packet_info.current_frame_size_ == 0
++                               ? XmaPayloadStatus::kZeroLength
++                               : XmaPayloadStatus::kInvalidFrameSize;
++    WarnPayloadAssembly(invalid_frame, packet_index, relative_offset,
++                        packet_info.current_frame_size_);
++    data->error_status = 4;
+     return;
+   }
+ 
+-  if (packet_info.isLastFrameInPacket()) {
+-    if (stream.BitsRemaining() < packet_info.current_frame_size_) {
+-      XmaPacketHandle next_packet_handle;
+-      const uint8_t* next_packet = GetNextPacket(data, next_packet_index,
+-                                                 current_input_packet_count,
+-                                                 &next_packet_handle);
+-      if (!next_packet) {
+-        data->error_status = 4;
+-        return;
+-      }
+-      std::memcpy(input_buffer_.data() + kBytesPerPacketData, next_packet + kBytesPerPacketHeader,
+-                  kBytesPerPacketData);
+-    }
++  const AssembledXmaPayload frame_payload =
++      AssemblePacketPayloads(data, packet_index, current_input_packet_count, relative_offset,
++                             packet_info.current_frame_size_, input_buffer_);
++  if (!frame_payload.valid()) {
++    WarnPayloadAssembly(frame_payload, packet_index, relative_offset,
++                        packet_info.current_frame_size_);
++    data->error_status = 4;
++    return;
+   }
+ 
+-  std::memcpy(input_buffer_.data(), packet + kBytesPerPacketHeader, kBytesPerPacketData);
+-
+-  stream = BitStream(input_buffer_.data(), (kBitsPerPacket - kBitsPerPacketHeader) * 2);
++  BitStream stream(input_buffer_.data(), frame_payload.valid_bits);
+   stream.SetOffset(relative_offset - kBitsPerPacketHeader);
+ 
+   xma_frame_.fill(0);
+@@ -871,14 +914,14 @@ void XmaContext::Decode(XMA_CONTEXT_DATA* data) {
+ 
+   if (!packet_info.isLastFrameInPacket()) {
+     const uint32_t next_frame_offset =
+-        (data->input_buffer_read_offset + bits_to_copy) % kBitsPerPacket;
++        (data->input_buffer_read_offset + packet_info.current_frame_size_) % kBitsPerPacket;
+     data->input_buffer_read_offset = (packet_index * kBitsPerPacket) + next_frame_offset;
+     return;
+   }
+ 
+   XmaPacketHandle next_packet;
+-  uint32_t next_input_offset = GetNextPacketReadOffset(
+-      data, next_packet_index, current_input_packet_count, &next_packet);
++  uint32_t next_input_offset =
++      GetNextPacketReadOffset(data, next_packet_index, current_input_packet_count, &next_packet);
+ 
+   if (next_packet.valid() && next_packet.buffer_index != data->current_buffer) {
+     SwapInputBuffer(data);
+diff --git a/tests/unit/audio/xma_packet_test.cpp b/tests/unit/audio/xma_packet_test.cpp
+index ad136c9..a9db54d 100644
+--- a/tests/unit/audio/xma_packet_test.cpp
++++ b/tests/unit/audio/xma_packet_test.cpp
+@@ -5,6 +5,7 @@
+  * @license     BSD 3-Clause License
+  */
+ 
++#include <algorithm>
+ #include <array>
+ #include <cstring>
+ 
+@@ -21,6 +22,7 @@ using rex::audio::ResolvePacket;
+ using rex::audio::XMA_CONTEXT_DATA;
+ using rex::audio::XmaContext;
+ using rex::audio::XmaPacketStatus;
++using rex::audio::XmaPayloadStatus;
+ 
+ std::array<uint8_t, sizeof(XMA_CONTEXT_DATA)> EmptyGuestContext() {
+   return {};
+@@ -39,6 +41,42 @@ XMA_CONTEXT_DATA MakeTwoBufferContext(uint32_t current_buffer = 0) {
+   return data;
+ }
+ 
++void SetPacketHeader(uint8_t* packet, uint8_t frame_count,
++                     uint32_t first_frame_offset, uint8_t skip_count) {
++  const uint32_t encoded_offset =
++      first_frame_offset - XmaContext::kBitsPerPacketHeader;
++  packet[0] = static_cast<uint8_t>((frame_count << 2) |
++                                   ((encoded_offset >> 13) & 0x3));
++  packet[1] = static_cast<uint8_t>(encoded_offset >> 5);
++  packet[2] = static_cast<uint8_t>((encoded_offset << 3) | 1);
++  packet[3] = skip_count;
++}
++
++void WriteCrossBufferPayloadBits(uint8_t* current, uint8_t* alternate,
++                                 uint32_t first_payload_bit, uint32_t value,
++                                 uint32_t bit_count) {
++  for (uint32_t i = 0; i < bit_count; ++i) {
++    const uint32_t assembled_bit = first_payload_bit + i;
++    const uint32_t logical_packet =
++        assembled_bit / XmaContext::kBitsPerPacketData;
++    const uint32_t packet_bit =
++        assembled_bit % XmaContext::kBitsPerPacketData;
++    uint8_t* packet =
++        logical_packet == 0
++            ? current
++            : alternate +
++                  (logical_packet - 1) * XmaContext::kBytesPerPacket;
++    uint8_t& byte =
++        packet[XmaContext::kBytesPerPacketHeader + packet_bit / 8];
++    const uint8_t mask = static_cast<uint8_t>(1u << (7 - packet_bit % 8));
++    if (value & (1u << (bit_count - i - 1))) {
++      byte |= mask;
++    } else {
++      byte &= static_cast<uint8_t>(~mask);
++    }
++  }
++}
++
+ }  // namespace
+ 
+ TEST_CASE("XMA packet resolution preserves cross-buffer packet indices", "[audio][xma]") {
+@@ -106,6 +144,207 @@ TEST_CASE("XMA packet resolution rejects unavailable guest packets", "[audio][xm
+   }
+ }
+ 
++TEST_CASE("XMA payload assembly spans up to four packets", "[audio][xma]") {
++  auto& memory = rex::testing::GetTestMemory();
++  auto* virtual_heap = const_cast<rex::memory::BaseHeap*>(memory.LookupHeap(0x10000000));
++  auto* physical_heap = const_cast<rex::memory::BaseHeap*>(memory.LookupHeap(0xA0000000));
++  REQUIRE(virtual_heap != nullptr);
++  REQUIRE(physical_heap != nullptr);
++
++  constexpr uint32_t kReadWrite =
++      rex::memory::kMemoryProtectRead | rex::memory::kMemoryProtectWrite;
++  constexpr uint32_t kReserveCommit =
++      rex::memory::kMemoryAllocationReserve | rex::memory::kMemoryAllocationCommit;
++  uint32_t context_address = 0;
++  uint32_t current_address = 0;
++  uint32_t alternate_address = 0;
++  uint32_t output_address = 0;
++  REQUIRE(virtual_heap->Alloc(4096, 4096, kReserveCommit, kReadWrite, false, &context_address));
++  REQUIRE(physical_heap->Alloc(4096, 4096, kReserveCommit, kReadWrite, false, &current_address));
++  REQUIRE(physical_heap->Alloc(8192, 4096, kReserveCommit, kReadWrite, false, &alternate_address));
++  REQUIRE(physical_heap->Alloc(4096, 4096, kReserveCommit, kReadWrite, false, &output_address));
++
++  uint8_t* current = memory.TranslatePhysical(current_address);
++  uint8_t* alternate = memory.TranslatePhysical(alternate_address);
++  std::memset(current, 0, 4096);
++  std::memset(alternate, 0, 8192);
++  std::memset(current + XmaContext::kBytesPerPacketHeader, 0x11, XmaContext::kBytesPerPacketData);
++  for (uint32_t packet = 0; packet < 3; ++packet) {
++    std::memset(
++        alternate + packet * XmaContext::kBytesPerPacket + XmaContext::kBytesPerPacketHeader,
++        0x22 + packet, XmaContext::kBytesPerPacketData);
++  }
++
++  auto* context_ptr = memory.TranslateVirtual(context_address);
++  std::memset(context_ptr, 0, sizeof(XMA_CONTEXT_DATA));
++  XMA_CONTEXT_DATA data(context_ptr);
++  data.current_buffer = 0;
++  data.input_buffer_0_valid = 1;
++  data.input_buffer_1_valid = 1;
++  data.input_buffer_0_ptr = current_address;
++  data.input_buffer_1_ptr = alternate_address;
++  data.input_buffer_0_packet_count = 1;
++  data.input_buffer_1_packet_count = 3;
++
++  XmaContext context;
++  REQUIRE(context.Setup(2, &memory, context_address) == 0);
++  context.set_is_allocated(true);
++  std::array<uint8_t, XmaContext::kBytesPerPacketData * XmaContext::kMaxAssembledPackets> assembled;
++
++  SECTION("one packet") {
++    const auto result =
++        context.AssemblePacketPayloads(&data, 0, 1, XmaContext::kBitsPerPacketHeader, 8, assembled);
++    CHECK(result.valid());
++    CHECK(result.packet_count == 1);
++    CHECK(result.valid_bits == XmaContext::kBitsPerPacketData);
++    CHECK(assembled.front() == 0x11);
++    CHECK(assembled[XmaContext::kBytesPerPacketData] == 0);
++  }
++
++  SECTION("two packets with a split header") {
++    const auto result = context.AssemblePacketPayloads(&data, 0, 1, XmaContext::kBitsPerPacket - 7,
++                                                       XmaContext::kBitsPerFrameHeader, assembled);
++    CHECK(result.valid());
++    CHECK(result.packet_count == 2);
++    CHECK(assembled.front() == 0x11);
++    CHECK(assembled[XmaContext::kBytesPerPacketData] == 0x22);
++  }
++
++  SECTION("three packets from a late frame start") {
++    const auto result =
++        context.AssemblePacketPayloads(&data, 0, 1, XmaContext::kBitsPerPacket - 7,
++                                       XmaContext::kBitsPerPacketData + 16, assembled);
++    CHECK(result.valid());
++    CHECK(result.packet_count == 3);
++    CHECK(assembled[XmaContext::kBytesPerPacketData] == 0x22);
++    CHECK(assembled[XmaContext::kBytesPerPacketData * 2] == 0x23);
++  }
++
++  SECTION("four packets cross alternate packet zero and later packets") {
++    const auto result = context.AssemblePacketPayloads(&data, 0, 1, XmaContext::kBitsPerPacket - 1,
++                                                       0x7FFE, assembled);
++    CHECK(result.valid());
++    CHECK(result.packet_count == 4);
++    CHECK(assembled.front() == 0x11);
++    CHECK(assembled[XmaContext::kBytesPerPacketData] == 0x22);
++    CHECK(assembled[XmaContext::kBytesPerPacketData * 2] == 0x23);
++    CHECK(assembled[XmaContext::kBytesPerPacketData * 3] == 0x24);
++  }
++
++  SECTION("missing continuation buffer is rejected and zero-filled") {
++    data.input_buffer_1_valid = 0;
++    assembled.fill(0xAA);
++    const auto result =
++        context.AssemblePacketPayloads(&data, 0, 1, XmaContext::kBitsPerPacket - 7, 16, assembled);
++    CHECK(result.status == XmaPayloadStatus::kPacketUnavailable);
++    CHECK(result.failed_packet.status == XmaPacketStatus::kBufferInvalid);
++    CHECK(
++        std::all_of(assembled.begin(), assembled.end(), [](uint8_t value) { return value == 0; }));
++  }
++
++  SECTION("short alternate buffer is rejected") {
++    data.input_buffer_1_packet_count = 1;
++    const auto result =
++        context.AssemblePacketPayloads(&data, 0, 1, XmaContext::kBitsPerPacket - 7,
++                                       XmaContext::kBitsPerPacketData + 16, assembled);
++    CHECK(result.status == XmaPayloadStatus::kPacketUnavailable);
++    CHECK(result.failed_packet.status == XmaPacketStatus::kPacketOutOfRange);
++    CHECK(result.failed_packet.packet_index == 1);
++  }
++
++  SECTION("requests beyond scratch capacity are rejected") {
++    const auto result = context.AssemblePacketPayloads(
++        &data, 0, 1, XmaContext::kBitsPerPacket - 1, XmaContext::kBitsPerPacketData * 4, assembled);
++    CHECK(result.status == XmaPayloadStatus::kCapacityExceeded);
++    CHECK(result.packet_count == 5);
++  }
++
++  SECTION("zero length and invalid offsets are rejected") {
++    CHECK(
++        context.AssemblePacketPayloads(&data, 0, 1, XmaContext::kBitsPerPacketHeader, 0, assembled)
++            .status == XmaPayloadStatus::kZeroLength);
++    CHECK(context.AssemblePacketPayloads(&data, 0, 1, 31, 8, assembled).status ==
++          XmaPayloadStatus::kInvalidFrameOffset);
++    CHECK(context.AssemblePacketPayloads(&data, 0, 1, XmaContext::kBitsPerPacket, 8, assembled)
++              .status == XmaPayloadStatus::kInvalidFrameOffset);
++  }
++
++  SECTION("synthetic three-packet frame decodes and advances") {
++    constexpr uint32_t kFrameOffset = XmaContext::kBitsPerPacket - 7;
++    constexpr uint32_t kFrameSize = XmaContext::kBitsPerPacketData + 16;
++    SetPacketHeader(current, 1, kFrameOffset, 2);
++    SetPacketHeader(alternate + XmaContext::kBytesPerPacket * 2, 1,
++                    XmaContext::kBitsPerPacketHeader, 0xFF);
++    SetPacketHeader(alternate + XmaContext::kBytesPerPacket * 3, 1,
++                    XmaContext::kBitsPerPacketHeader, 0xFF);
++    WriteCrossBufferPayloadBits(
++        current, alternate,
++        kFrameOffset - XmaContext::kBitsPerPacketHeader, kFrameSize,
++        XmaContext::kBitsPerFrameHeader);
++
++    data.input_buffer_1_packet_count = 4;
++    data.input_buffer_read_offset = kFrameOffset;
++    data.output_buffer_valid = 1;
++    data.output_buffer_ptr = output_address;
++    data.output_buffer_block_count = 4;
++    data.output_buffer_write_offset = 1;
++    data.subframe_decode_count = 1;
++    data.Store(context_ptr);
++
++    context.Enable();
++    CHECK(context.Work());
++    XMA_CONTEXT_DATA advanced(context_ptr);
++    CHECK(advanced.error_status == 0);
++    CHECK_FALSE(advanced.IsAnyInputBufferValid());
++    CHECK(advanced.current_buffer == 0);
++    CHECK(advanced.input_buffer_read_offset ==
++          XmaContext::kBitsPerPacketHeader);
++  }
++
++  SECTION("synthetic four-packet frame decodes and advances") {
++    constexpr uint32_t kFrameOffset = XmaContext::kBitsPerPacket - 1;
++    constexpr uint32_t kFrameSize = 0x7FFE;
++    SetPacketHeader(current, 1, kFrameOffset, 3);
++    SetPacketHeader(alternate + XmaContext::kBytesPerPacket * 3, 1,
++                    XmaContext::kBitsPerPacketHeader, 0xFF);
++    WriteCrossBufferPayloadBits(
++        current, alternate,
++        kFrameOffset - XmaContext::kBitsPerPacketHeader, kFrameSize,
++        XmaContext::kBitsPerFrameHeader);
++
++    data.input_buffer_1_packet_count = 4;
++    data.input_buffer_read_offset = kFrameOffset;
++    data.output_buffer_valid = 1;
++    data.output_buffer_ptr = output_address;
++    data.output_buffer_block_count = 4;
++    data.output_buffer_write_offset = 1;
++    data.subframe_decode_count = 1;
++    data.Store(context_ptr);
++
++    context.Enable();
++    CHECK(context.Work());
++    XMA_CONTEXT_DATA advanced(context_ptr);
++    CHECK(advanced.error_status == 0);
++    CHECK_FALSE(advanced.IsAnyInputBufferValid());
++    CHECK(advanced.current_buffer == 0);
++    CHECK(advanced.input_buffer_read_offset ==
++          XmaContext::kBitsPerPacketHeader);
++  }
++
++  context.Release();
++  physical_heap->Release(output_address, nullptr);
++  physical_heap->Release(alternate_address, nullptr);
++  physical_heap->Release(current_address, nullptr);
++  virtual_heap->Release(context_address, nullptr);
++}
++
++TEST_CASE("XMA frame size rejects zero and the sentinel", "[audio][xma]") {
++  CHECK_FALSE(XmaContext::IsValidFrameSize(0));
++  CHECK(XmaContext::IsValidFrameSize(1));
++  CHECK(XmaContext::IsValidFrameSize(0x7FFE));
++  CHECK_FALSE(XmaContext::IsValidFrameSize(0x7FFF));
++}
++
+ TEST_CASE("XMA exhausted input retires to a clean idle state", "[audio][xma]") {
+   auto& memory = rex::testing::GetTestMemory();
+   auto* heap = const_cast<rex::memory::BaseHeap*>(memory.LookupHeap(0x10000000));
+@@ -113,10 +352,8 @@ TEST_CASE("XMA exhausted input retires to a clean idle state", "[audio][xma]") {
+ 
+   uint32_t context_address = 0;
+   REQUIRE(heap->Alloc(
+-      4096, 4096,
+-      rex::memory::kMemoryAllocationReserve | rex::memory::kMemoryAllocationCommit,
+-      rex::memory::kMemoryProtectRead | rex::memory::kMemoryProtectWrite, false,
+-      &context_address));
++      4096, 4096, rex::memory::kMemoryAllocationReserve | rex::memory::kMemoryAllocationCommit,
++      rex::memory::kMemoryProtectRead | rex::memory::kMemoryProtectWrite, false, &context_address));
+ 
+   auto* context_ptr = memory.TranslateVirtual(context_address);
+   std::memset(context_ptr, 0, sizeof(XMA_CONTEXT_DATA));
+@@ -155,13 +392,10 @@ TEST_CASE("XMA exhausted input retires to a clean idle state", "[audio][xma]") {
+   heap->Release(context_address, nullptr);
+ }
+ 
+-TEST_CASE("XMA full-packet skip crosses to an alternate packet beyond zero",
+-          "[audio][xma]") {
++TEST_CASE("XMA full-packet skip crosses to an alternate packet beyond zero", "[audio][xma]") {
+   auto& memory = rex::testing::GetTestMemory();
+-  auto* virtual_heap =
+-      const_cast<rex::memory::BaseHeap*>(memory.LookupHeap(0x10000000));
+-  auto* physical_heap =
+-      const_cast<rex::memory::BaseHeap*>(memory.LookupHeap(0xA0000000));
++  auto* virtual_heap = const_cast<rex::memory::BaseHeap*>(memory.LookupHeap(0x10000000));
++  auto* physical_heap = const_cast<rex::memory::BaseHeap*>(memory.LookupHeap(0xA0000000));
+   REQUIRE(virtual_heap != nullptr);
+   REQUIRE(physical_heap != nullptr);
+ 
+@@ -173,14 +407,10 @@ TEST_CASE("XMA full-packet skip crosses to an alternate packet beyond zero",
+   uint32_t current_address = 0;
+   uint32_t alternate_address = 0;
+   uint32_t output_address = 0;
+-  REQUIRE(virtual_heap->Alloc(4096, 4096, kReserveCommit, kReadWrite, false,
+-                              &context_address));
+-  REQUIRE(physical_heap->Alloc(4096, 4096, kReserveCommit, kReadWrite, false,
+-                               &current_address));
+-  REQUIRE(physical_heap->Alloc(4096, 4096, kReserveCommit, kReadWrite, false,
+-                               &alternate_address));
+-  REQUIRE(physical_heap->Alloc(4096, 4096, kReserveCommit, kReadWrite, false,
+-                               &output_address));
++  REQUIRE(virtual_heap->Alloc(4096, 4096, kReserveCommit, kReadWrite, false, &context_address));
++  REQUIRE(physical_heap->Alloc(4096, 4096, kReserveCommit, kReadWrite, false, &current_address));
++  REQUIRE(physical_heap->Alloc(4096, 4096, kReserveCommit, kReadWrite, false, &alternate_address));
++  REQUIRE(physical_heap->Alloc(4096, 4096, kReserveCommit, kReadWrite, false, &output_address));
+ 
+   uint8_t* current = memory.TranslatePhysical(current_address);
+   uint8_t* alternate = memory.TranslatePhysical(alternate_address);

--- a/tools/tests/test_release_contract.py
+++ b/tools/tests/test_release_contract.py
@@ -32,10 +32,10 @@ class ReleaseContractTests(unittest.TestCase):
 
     def test_rexglue_patches_have_stable_order_and_no_binary_payload(self):
         patches = sorted((ROOT / "patches/rexglue").glob("*.patch"))
-        self.assertEqual(len(patches), 36)
+        self.assertEqual(len(patches), 37)
         self.assertEqual(
             patches[-1].name,
-            "0036-m4-xma-cross-buffer-packet-handles.patch",
+            "0037-m4-xma-multipacket-frame-assembly.patch",
         )
         self.assertEqual(len(patches), len({path.name[:4] for path in patches}))
         for path in patches:


### PR DESCRIPTION
## Summary

- add ReXGlue patch 0037 with a bounded four-payload XMA assembler adapted from https://github.com/xXJSONDeruloXx/rexglue-sdk/commit/51b601ab04caf3f1a9a5fcb1455b3a8bb58f5a2a
- resolve every payload through EPIC-01 packet handles and share the path between split frame headers and frame extraction
- reject invalid offsets, zero/sentinel frame sizes, missing packets, short alternate buffers, and scratch-capacity overruns with bounded diagnostics
- cover one through four packets, late starts, cross-buffer packet 0 and later indices, failure cases, and synthetic decoder advancement

## Validation

- `unit_tests.exe '[audio][xma]'`: 170 assertions in 6 test cases passed
- complete `unit_tests.exe`: 230 passed, 4 upstream BitStream cases skipped; 1,129 assertions passed
- complete `ppc_tests.exe`: 1,460 test cases and 5,749 assertions passed
- `tools/build-preview.ps1 -Parallel 6`: succeeded with 37 tracked ReXGlue patches

Gameplay audio qualification remains a follow-up run with the AppData save.