### PR TITLE
fix(launcher): harden setup toolchain isolation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 - Added resilient ReXGlue/submodule download retries, disabled SDL's optional
   libusb probe on Windows, and made Xbox menu acceptance accessible through
   Space or left click with an in-launcher control hint.
+- Made launcher setup ignore quoted `PATH` entry syntax when initializing the
+  Microsoft build environment and always use the verified pinned MinGit.
 - Restored motion blur around the player car and removed the stale gameplay
   limitation list after the latest compatibility fixes.
 - Added launcher controls for validated graphics experiments, including 2x

--- a/tools/provision-toolchain.ps1
+++ b/tools/provision-toolchain.ps1
@@ -39,15 +39,13 @@ if ([string]::IsNullOrWhiteSpace($vsRoot)) {
 }
 
 Write-PinyonEvent tools 23 'Preparing Git.' -JsonEvents:$JsonEvents
-if ($null -eq (Get-Command git.exe -ErrorAction SilentlyContinue)) {
-    $gitRoot = [IO.Path]::GetFullPath((Join-Path $root $config.git.install_path))
-    $gitExe = Join-Path $gitRoot $config.git.executable
-    if (-not (Test-Path -LiteralPath $gitExe -PathType Leaf)) {
-        $archive = Join-Path $downloads "mingit-$($config.git.version).zip"
-        Invoke-PinyonDownload -Uri $config.git.url -Destination $archive -Sha256 $config.git.sha256
-        [void](New-Item -ItemType Directory -Force -Path $gitRoot)
-        Expand-Archive -LiteralPath $archive -DestinationPath $gitRoot -Force
-    }
+$gitRoot = [IO.Path]::GetFullPath((Join-Path $root $config.git.install_path))
+$gitExe = Join-Path $gitRoot $config.git.executable
+if (-not (Test-Path -LiteralPath $gitExe -PathType Leaf)) {
+    $archive = Join-Path $downloads "mingit-$($config.git.version).zip"
+    Invoke-PinyonDownload -Uri $config.git.url -Destination $archive -Sha256 $config.git.sha256
+    [void](New-Item -ItemType Directory -Force -Path $gitRoot)
+    Expand-Archive -LiteralPath $archive -DestinationPath $gitRoot -Force
 }
 
 Write-PinyonEvent tools 26 'Preparing the pinned LLVM compiler.' -JsonEvents:$JsonEvents

--- a/tools/release-common.ps1
+++ b/tools/release-common.ps1
@@ -123,12 +123,33 @@ function Get-PinyonVisualStudioRoot {
     $root
 }
 
+function ConvertTo-PinyonCommandPath {
+    param([AllowEmptyString()] [string]$PathValue)
+
+    $entries = @($PathValue -split ';' | ForEach-Object {
+        $entry = $_.Trim()
+        if ($entry.Length -ge 2 -and $entry.StartsWith('"') -and $entry.EndsWith('"')) {
+            $entry = $entry.Substring(1, $entry.Length - 2).Trim()
+        }
+        if (-not [string]::IsNullOrWhiteSpace($entry)) { $entry }
+    })
+    $entries -join ';'
+}
+
 function Enter-PinyonBuildEnvironment {
     $root = Get-PinyonRepoRoot
     $config = Get-PinyonReleaseToolchain
     $vsRoot = Get-PinyonVisualStudioRoot
     $devCmd = Join-Path $vsRoot 'Common7/Tools/VsDevCmd.bat'
-    $lines = @(& $env:ComSpec /d /s /c "`"$devCmd`" -arch=x64 -host_arch=x64 >nul && set")
+    $inheritedPath = $env:PATH
+    try {
+        # Quoted PATH entries containing parentheses break VsDevCmd's batch parser.
+        $env:PATH = ConvertTo-PinyonCommandPath -PathValue $inheritedPath
+        $lines = @(& $env:ComSpec /d /s /c "`"$devCmd`" -arch=x64 -host_arch=x64 >nul && set")
+    }
+    finally {
+        $env:PATH = $inheritedPath
+    }
     if ($LASTEXITCODE -ne 0) { throw 'Unable to initialize the Microsoft x64 build environment.' }
     foreach ($line in $lines) {
         $separator = $line.IndexOf('=')
@@ -148,8 +169,6 @@ function Enter-PinyonBuildEnvironment {
 }
 
 function Get-PinyonGit {
-    $system = Get-Command git.exe -ErrorAction SilentlyContinue
-    if ($null -ne $system) { return $system.Source }
     $root = Get-PinyonRepoRoot
     $config = Get-PinyonReleaseToolchain
     $candidate = Join-Path (Join-Path $root $config.git.install_path) $config.git.executable

--- a/tools/tests/test_release_contract.py
+++ b/tools/tests/test_release_contract.py
@@ -1,5 +1,6 @@
 import getpass
 import json
+import os
 import pathlib
 import shutil
 import subprocess
@@ -98,6 +99,46 @@ class ReleaseContractTests(unittest.TestCase):
         self.assertNotIn("clone --recursive", prepare)
         self.assertIn("-DSDL_HIDAPI_LIBUSB=OFF", build)
         self.assertIn("set(SDL_HIDAPI_LIBUSB OFF CACHE BOOL", cmake)
+
+    def test_release_setup_uses_pinned_git_and_normalizes_command_path(self):
+        common = (ROOT / "tools/release-common.ps1").read_text(encoding="utf-8")
+        provision = (ROOT / "tools/provision-toolchain.ps1").read_text(
+            encoding="utf-8"
+        )
+
+        get_git = common.split("function Get-PinyonGit", 1)[1]
+        self.assertNotIn("Get-Command git.exe", get_git)
+        self.assertIn("$config.git.install_path", get_git)
+        self.assertNotIn("Get-Command git.exe", provision)
+        self.assertIn("$config.git.install_path", provision)
+        self.assertIn("ConvertTo-PinyonCommandPath", common)
+        self.assertIn("$inheritedPath = $env:PATH", common)
+
+    @unittest.skipUnless(shutil.which("powershell"), "Windows PowerShell is required")
+    def test_command_path_removes_entry_quotes_without_losing_parentheses(self):
+        command = (
+            ". ./tools/release-common.ps1; "
+            "[Console]::Out.Write((ConvertTo-PinyonCommandPath "
+            "-PathValue $env:PINYON_TEST_PATH))"
+        )
+        environment = os.environ.copy()
+        environment["PINYON_TEST_PATH"] = (
+            'C:\\Windows;"C:\\Program Files (x86)\\Steam\\ext\\bin";'
+            "C:\\Tools"
+        )
+        completed = subprocess.run(
+            ["powershell", "-NoLogo", "-NoProfile", "-Command", command],
+            cwd=ROOT,
+            env=environment,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+        self.assertEqual(
+            completed.stdout,
+            "C:\\Windows;C:\\Program Files (x86)\\Steam\\ext\\bin;C:\\Tools",
+        )
 
     def test_launcher_payload_has_every_required_script(self):
         required = {


### PR DESCRIPTION
## Summary

- normalize quoted PATH entries before invoking the Visual Studio developer environment
- always provision and use the SHA-256-pinned MinGit instead of a system Git installation
- add release-contract coverage for both toolchain isolation behaviors

## Validation

- python -m unittest discover -s tools/tests -p test_*.py (31 passed)
- dotnet build launcher/PinyonShift.Launcher/PinyonShift.Launcher.csproj -c Release (0 warnings, 0 errors)
- tools/package-launcher.ps1
- reproduced the quoted Steam PATH failure before the fix and verified Visual Studio initialization succeeds after it

Closes #11
Closes #14