### PR TITLE
chore(release): prepare 0.1.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,20 @@ jobs:
           path: .artifacts/PinyonShift-Launcher.zip
       - name: Attach tagged release
         if: startsWith(github.ref, 'refs/tags/')
+        shell: powershell
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh release create "${{ github.ref_name }}" .artifacts/PinyonShift-Launcher.zip --generate-notes --prerelease --verify-tag
+          RELEASE_TAG: ${{ github.ref_name }}
+        run: |
+          $release = Get-Content config/release.json -Raw | ConvertFrom-Json
+          $arguments = @(
+            'release', 'create', $env:RELEASE_TAG,
+            '.artifacts/PinyonShift-Launcher.zip',
+            '--generate-notes', '--verify-tag'
+          )
+          if ($release.channel -eq 'preview') {
+            $arguments += '--prerelease'
+          } elseif ($release.channel -ne 'stable') {
+            throw "Unsupported release channel: $($release.channel)"
+          }
+          & gh @arguments

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.1.0 - Unreleased
+## 0.1.0 - 2026-08-26
 
 - First Windows public playable preview.
 - Updated the pinned ReXGlue SDK from 0.9.0 to 0.10.0, including its threading,

--- a/config/release.json
+++ b/config/release.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "version": "0.1.0-preview.5",
-  "channel": "preview",
+  "version": "0.1.0",
+  "channel": "stable",
   "repository": "https://github.com/arcanite24/pinyon-shift"
 }

--- a/tools/tests/test_release_contract.py
+++ b/tools/tests/test_release_contract.py
@@ -13,6 +13,16 @@ ROOT = pathlib.Path(__file__).resolve().parents[2]
 
 
 class ReleaseContractTests(unittest.TestCase):
+    def test_release_workflow_publishes_only_preview_channels_as_prereleases(self):
+        workflow = (ROOT / ".github/workflows/release.yml").read_text()
+        self.assertIn("$release.channel -eq 'preview'", workflow)
+        self.assertIn("$release.channel -ne 'stable'", workflow)
+        self.assertIn("$arguments += '--prerelease'", workflow)
+        self.assertNotIn(
+            "--generate-notes --prerelease --verify-tag",
+            workflow,
+        )
+
     def test_supported_dump_uses_exact_hash_and_size(self):
         data = json.loads((ROOT / "config/supported-dumps.json").read_text())
         self.assertEqual(data["policy"]["match"], "exact_sha256_and_size")


### PR DESCRIPTION
## Summary
- promote release metadata from 0.1.0-preview.5 to stable 0.1.0
- publish only preview-channel tags as GitHub prereleases
- finalize the 0.1.0 changelog date

## Validation
- `python -m unittest discover -s tools/tests -p "test_*.py"` (32 passed)
- `.\tools\check-repository-boundary.ps1`