### PR TITLE
feat(audio): add bounded XMA stall diagnostics

### DIFF
--- a/config/rexglue/EPIC_03_XMA_STALL_DIAGNOSTICS.md
+++ b/config/rexglue/EPIC_03_XMA_STALL_DIAGNOSTICS.md
@@ -22,7 +22,11 @@ The ReXGlue patch changes:
 
 Each XMA context tracks consecutive and total output-space and no-progress
 stalls, recovery count, last successful input offset, and last successful
-output read/write offsets. Warning summaries are emitted only when the
+output read/write offsets. An output-full observation is first treated as
+ordinary decoder backpressure. It becomes a no-space stall only when the next
+work attempt sees the same buffer, input offset, output offsets, admission
+requirement, and remaining capacity. Any changed state is progress and primes
+a new observation instead. Warning summaries are emitted only when the
 per-context lifetime total for a stall class reaches 1, 8, 64, and every 256
 thereafter. Every recovered stall episode is counted, while a recovery warning
 is emitted only when that episode emitted a stall summary. Progress clears only
@@ -54,7 +58,8 @@ encoded or decoded audio payload.
 
 Deterministic unit coverage forces output-space stalls, verifies the bounded
 1/8/64/256 lifetime reporting schedule across transient stall episodes while
-preserving exact recovery totals, forces a no-progress failure with its buffer
+preserving exact recovery totals, proves that changing output state is normal
+backpressure rather than a stall, forces a no-progress failure with its buffer
 and offset preserved, checks lifecycle reset behavior, and proves relaxed
 padding changes admission only when the flag is enabled. Project tests cover
 schema migration, default-off settings, performance aggregation, and sanitized

--- a/config/rexglue/EPIC_03_XMA_STALL_DIAGNOSTICS.md
+++ b/config/rexglue/EPIC_03_XMA_STALL_DIAGNOSTICS.md
@@ -22,9 +22,11 @@ The ReXGlue patch changes:
 
 Each XMA context tracks consecutive and total output-space and no-progress
 stalls, recovery count, last successful input offset, and last successful
-output read/write offsets. Warning summaries are emitted only at consecutive
-counts 1, 8, 64, and every 256 thereafter. Progress after either stall class
-emits one recovery warning and clears only the consecutive runs.
+output read/write offsets. Warning summaries are emitted only when the
+per-context lifetime total for a stall class reaches 1, 8, 64, and every 256
+thereafter. Every recovered stall episode is counted, while a recovery warning
+is emitted only when that episode emitted a stall summary. Progress clears only
+the consecutive runs.
 
 Context metrics reset on clear, disable, release, and established-stream codec
 reinitialization. Process-level performance counters remain independent of
@@ -51,11 +53,12 @@ encoded or decoded audio payload.
 ## Tests, dependencies, and rollback
 
 Deterministic unit coverage forces output-space stalls, verifies the bounded
-1/8/64/256 reporting schedule, observes exactly one recovery, forces a
-no-progress failure with its buffer and offset preserved, checks lifecycle
-reset behavior, and proves relaxed padding changes admission only when the
-flag is enabled. Project tests cover schema migration, default-off settings,
-performance aggregation, and sanitized support-report totals.
+1/8/64/256 lifetime reporting schedule across transient stall episodes while
+preserving exact recovery totals, forces a no-progress failure with its buffer
+and offset preserved, checks lifecycle reset behavior, and proves relaxed
+padding changes admission only when the flag is enabled. Project tests cover
+schema migration, default-off settings, performance aggregation, and sanitized
+support-report totals.
 
 This patch depends on `0036` packet handles and `0037` multi-packet frame
 assembly. Rollback is removal of patch `0038` and the associated schema-5,

--- a/config/rexglue/EPIC_03_XMA_STALL_DIAGNOSTICS.md
+++ b/config/rexglue/EPIC_03_XMA_STALL_DIAGNOSTICS.md
@@ -1,0 +1,63 @@
+# ReXGlue XMA stall diagnostics
+
+EPIC-03 is delivered by
+`patches/rexglue/0038-m4-xma-stall-diagnostics.patch` plus the host-side
+configuration and sanitized-report integration in this project.
+
+## Derivation and scope
+
+The reporting cadence and state fields are adapted from Xenia Canary PR
+[`#974`](https://github.com/xenia-canary/xenia-canary/pull/974). That PR was
+closed without merge and describes its padding behavior as uncertain, so this
+project adopts the diagnostics unconditionally while keeping relaxed padding
+admission explicitly opt-in.
+
+The ReXGlue patch changes:
+
+- `include/rex/audio/xma/context.h`;
+- `include/rex/perf/counter.h`;
+- `src/audio/xma_context.cpp`;
+- `src/core/perf/counter.cpp`;
+- `tests/unit/audio/xma_packet_test.cpp`.
+
+Each XMA context tracks consecutive and total output-space and no-progress
+stalls, recovery count, last successful input offset, and last successful
+output read/write offsets. Warning summaries are emitted only at consecutive
+counts 1, 8, 64, and every 256 thereafter. Progress after either stall class
+emits one recovery warning and clears only the consecutive runs.
+
+Context metrics reset on clear, disable, release, and established-stream codec
+reinitialization. Process-level performance counters remain independent of
+those lifecycle resets so a session CSV retains exact aggregate totals.
+
+## Shipping behavior and support data
+
+Host configuration schema 5 adds:
+
+```toml
+xma_relaxed_padding_admission = false
+```
+
+With the default `false`, decode admission and padding reservation retain the
+qualified strict behavior. When explicitly enabled for an A/B experiment,
+padding is removed from the hard admission minimum and reserved only from
+remaining writable headroom. The setting is recorded with effective session
+configuration.
+
+Sanitized crash/support reports sum the three XMA stall counters from the
+session performance CSV into `report.json`. They do not attach the CSV or any
+encoded or decoded audio payload.
+
+## Tests, dependencies, and rollback
+
+Deterministic unit coverage forces output-space stalls, verifies the bounded
+1/8/64/256 reporting schedule, observes exactly one recovery, forces a
+no-progress failure with its buffer and offset preserved, checks lifecycle
+reset behavior, and proves relaxed padding changes admission only when the
+flag is enabled. Project tests cover schema migration, default-off settings,
+performance aggregation, and sanitized support-report totals.
+
+This patch depends on `0036` packet handles and `0037` multi-packet frame
+assembly. Rollback is removal of patch `0038` and the associated schema-5,
+performance-summary, and support-report integration; EPIC-01 and EPIC-02 remain
+independently active.

--- a/config/rexglue/EPIC_03_XMA_STALL_DIAGNOSTICS.md
+++ b/config/rexglue/EPIC_03_XMA_STALL_DIAGNOSTICS.md
@@ -22,12 +22,12 @@ The ReXGlue patch changes:
 
 Each XMA context tracks consecutive and total output-space and no-progress
 stalls, recovery count, last successful input offset, and last successful
-output read/write offsets. An output-full observation is first treated as
-ordinary decoder backpressure. It becomes a no-space stall only when the next
-work attempt sees the same buffer, input offset, output offsets, admission
-requirement, and remaining capacity. Any changed state is progress and primes
-a new observation instead. Warning summaries are emitted only when the
-per-context lifetime total for a stall class reaches 1, 8, 64, and every 256
+output read/write offsets. Output-full observations are first treated as
+ordinary decoder backpressure. A no-space stall begins only when eight
+consecutive work attempts see the same buffer, input offset, output offsets,
+admission requirement, and remaining capacity. Any changed state is progress
+and primes a new observation instead. Warning summaries are emitted only when
+the per-context lifetime total for a stall class reaches 1, 8, 64, and every 256
 thereafter. Every recovered stall episode is counted, while a recovery warning
 is emitted only when that episode emitted a stall summary. Progress clears only
 the consecutive runs.

--- a/config/rexglue/PATCH_DISPOSITIONS.md
+++ b/config/rexglue/PATCH_DISPOSITIONS.md
@@ -85,9 +85,10 @@ decoder without removing `0036`.
 
 `0038-m4-xma-stall-diagnostics` adapts the low-noise diagnostic design from
 Xenia Canary PR `#974`, without enabling its uncertain padding change by
-default. A no-space event is counted only when the same buffer, input, output,
-and admission state repeats on a later work attempt; a changed observation is
-normal backpressure and progress. Per-context no-space and no-progress lifetime
+default. A no-space event is counted only after the same buffer, input, output,
+and admission state persists for eight consecutive work attempts; a changed
+observation is normal backpressure and progress. Per-context no-space and
+no-progress lifetime
 totals log at counts 1, 8, 64, and every 256, with recovery logs only for
 episodes that emitted a stall summary. Session performance counters preserve
 exact aggregate stall and recovery totals for sanitized support reports. The

--- a/config/rexglue/PATCH_DISPOSITIONS.md
+++ b/config/rexglue/PATCH_DISPOSITIONS.md
@@ -85,11 +85,13 @@ decoder without removing `0036`.
 
 `0038-m4-xma-stall-diagnostics` adapts the low-noise diagnostic design from
 Xenia Canary PR `#974`, without enabling its uncertain padding change by
-  default. Per-context no-space and no-progress lifetime totals log at counts
-  1, 8, 64, and every 256, with recovery logs only for episodes that emitted a
-  stall summary. Session performance
-counters preserve exact aggregate stall and recovery totals for sanitized
-support reports. The optional relaxed-padding admission path is controlled by
+default. A no-space event is counted only when the same buffer, input, output,
+and admission state repeats on a later work attempt; a changed observation is
+normal backpressure and progress. Per-context no-space and no-progress lifetime
+totals log at counts 1, 8, 64, and every 256, with recovery logs only for
+episodes that emitted a stall summary. Session performance counters preserve
+exact aggregate stall and recovery totals for sanitized support reports. The
+optional relaxed-padding admission path is controlled by
 `xma_relaxed_padding_admission = false`; removing `0038` restores strict
 padding admission and removes only EPIC-03 telemetry and tests.
 

--- a/config/rexglue/PATCH_DISPOSITIONS.md
+++ b/config/rexglue/PATCH_DISPOSITIONS.md
@@ -83,6 +83,15 @@ diagnostics, and synthetic coverage exercises one through four packets across
 guest-buffer boundaries. Removing `0037` restores the prior two-payload
 decoder without removing `0036`.
 
+`0038-m4-xma-stall-diagnostics` adapts the low-noise diagnostic design from
+Xenia Canary PR `#974`, without enabling its uncertain padding change by
+default. Per-context no-space and no-progress runs log at counts 1, 8, 64, and
+every 256, with one recovery event when work resumes. Session performance
+counters preserve exact aggregate stall and recovery totals for sanitized
+support reports. The optional relaxed-padding admission path is controlled by
+`xma_relaxed_padding_admission = false`; removing `0038` restores strict
+padding admission and removes only EPIC-03 telemetry and tests.
+
 Validation performed on the rebased SDK:
 
 - `unit_tests` and `ppc_tests` build with the pinned Clang 20.1.8 toolchain.

--- a/config/rexglue/PATCH_DISPOSITIONS.md
+++ b/config/rexglue/PATCH_DISPOSITIONS.md
@@ -85,8 +85,9 @@ decoder without removing `0036`.
 
 `0038-m4-xma-stall-diagnostics` adapts the low-noise diagnostic design from
 Xenia Canary PR `#974`, without enabling its uncertain padding change by
-default. Per-context no-space and no-progress runs log at counts 1, 8, 64, and
-every 256, with one recovery event when work resumes. Session performance
+  default. Per-context no-space and no-progress lifetime totals log at counts
+  1, 8, 64, and every 256, with recovery logs only for episodes that emitted a
+  stall summary. Session performance
 counters preserve exact aggregate stall and recovery totals for sanitized
 support reports. The optional relaxed-padding admission path is controlled by
 `xma_relaxed_padding_admission = false`; removing `0038` restores strict

--- a/patches/rexglue/0038-m4-xma-stall-diagnostics.patch
+++ b/patches/rexglue/0038-m4-xma-stall-diagnostics.patch
@@ -1,8 +1,8 @@
 diff --git a/include/rex/audio/xma/context.h b/include/rex/audio/xma/context.h
-index 4861e40..fe3126c 100644
+index 4861e40..3ed2da2 100644
 --- a/include/rex/audio/xma/context.h
 +++ b/include/rex/audio/xma/context.h
-@@ -205,6 +205,35 @@ struct AssembledXmaPayload {
+@@ -205,6 +205,36 @@ struct AssembledXmaPayload {
    bool valid() const { return status == XmaPayloadStatus::kValid; }
  };
  
@@ -21,7 +21,7 @@ index 4861e40..fe3126c 100644
 +// can be tested without an FFmpeg decoder or guest-memory fixture.
 +class XmaStallTracker {
 + public:
-+  static bool ShouldLogSummary(uint32_t consecutive_count);
++  static bool ShouldLogSummary(uint64_t total_count);
 +
 +  bool NoteNoSpaceStall();
 +  bool NoteNoProgressStall();
@@ -33,12 +33,13 @@ index 4861e40..fe3126c 100644
 +
 + private:
 +  XmaStallMetrics metrics_;
++  bool recovery_log_pending_ = false;
 +};
 +
  // Resolves a logical packet number relative to starting_buffer_index. Packet
  // numbers at or beyond current_buffer_packet_count continue in the alternate
  // guest buffer without losing their index within that buffer.
-@@ -257,6 +286,10 @@ class XmaContext {
+@@ -257,6 +287,10 @@ class XmaContext {
                                               std::span<uint8_t> destination);
    static bool IsValidFrameSize(uint32_t frame_size);
  
@@ -49,7 +50,7 @@ index 4861e40..fe3126c 100644
    void Enable();
    bool Block(bool poll);
    void Clear();
-@@ -306,6 +339,15 @@ class XmaContext {
+@@ -306,6 +340,15 @@ class XmaContext {
    void WarnPacketResolution(const XmaPacketHandle& packet_handle, uint32_t logical_packet_index);
    void WarnPayloadAssembly(const AssembledXmaPayload& payload, uint32_t first_logical_packet,
                             uint32_t frame_offset_in_packet, uint32_t bits_required);
@@ -65,7 +66,7 @@ index 4861e40..fe3126c 100644
  
    void Decode(XMA_CONTEXT_DATA* data);
    void Consume(memory::RingBuffer* output_rb, const XMA_CONTEXT_DATA* data);
-@@ -368,6 +410,7 @@ class XmaContext {
+@@ -368,6 +411,7 @@ class XmaContext {
    // context lifetime rather than once per Work() re-entry.
    uint32_t packet_warning_mask_ = 0;
    uint32_t payload_warning_mask_ = 0;
@@ -108,7 +109,7 @@ index 3541c18..5053a69 100644
  #define PROFILE_VERTICES(n)
  #define PROFILE_CMD_BUFFER_STALL()
 diff --git a/src/audio/xma_context.cpp b/src/audio/xma_context.cpp
-index e723215..16f40a9 100644
+index e723215..26396f0 100644
 --- a/src/audio/xma_context.cpp
 +++ b/src/audio/xma_context.cpp
 @@ -15,9 +15,11 @@
@@ -134,26 +135,30 @@ index e723215..16f40a9 100644
  // Credits for most of this code goes to:
  // https://github.com/koolkdev/libertyv/blob/master/libav_wrapper/xma2dec.c
  
-@@ -43,6 +49,45 @@ using stream::BitStream;
+@@ -43,6 +49,52 @@ using stream::BitStream;
  const uint32_t XmaContext::kBitsPerPacketHeader;
  const uint32_t XmaContext::kOutputMaxSizeBytes;
  
-+bool XmaStallTracker::ShouldLogSummary(uint32_t consecutive_count) {
-+  return consecutive_count == 1 || consecutive_count == 8 ||
-+         consecutive_count == 64 ||
-+         (consecutive_count >= 256 && consecutive_count % 256 == 0);
++bool XmaStallTracker::ShouldLogSummary(uint64_t total_count) {
++  return total_count == 1 || total_count == 8 || total_count == 64 ||
++         (total_count >= 256 && total_count % 256 == 0);
 +}
 +
 +bool XmaStallTracker::NoteNoSpaceStall() {
 +  ++metrics_.consecutive_no_space_stalls;
 +  ++metrics_.total_no_space_stalls;
-+  return ShouldLogSummary(metrics_.consecutive_no_space_stalls);
++  const bool should_log = ShouldLogSummary(metrics_.total_no_space_stalls);
++  recovery_log_pending_ |= should_log;
++  return should_log;
 +}
 +
 +bool XmaStallTracker::NoteNoProgressStall() {
 +  ++metrics_.consecutive_no_progress_stalls;
 +  ++metrics_.total_no_progress_stalls;
-+  return ShouldLogSummary(metrics_.consecutive_no_progress_stalls);
++  const bool should_log =
++      ShouldLogSummary(metrics_.total_no_progress_stalls);
++  recovery_log_pending_ |= should_log;
++  return should_log;
 +}
 +
 +bool XmaStallTracker::NoteProgress(uint32_t input_offset,
@@ -164,23 +169,26 @@ index e723215..16f40a9 100644
 +  if (recovered) {
 +    ++metrics_.total_recoveries;
 +  }
++  const bool should_log_recovery = recovered && recovery_log_pending_;
 +  metrics_.consecutive_no_space_stalls = 0;
 +  metrics_.consecutive_no_progress_stalls = 0;
++  recovery_log_pending_ = false;
 +  metrics_.last_progress_input_offset = input_offset;
 +  metrics_.last_progress_output_read_offset = output_read_offset;
 +  metrics_.last_progress_output_write_offset = output_write_offset;
-+  return recovered;
++  return should_log_recovery;
 +}
 +
 +void XmaStallTracker::Reset(uint32_t initial_input_offset) {
 +  metrics_ = {};
++  recovery_log_pending_ = false;
 +  metrics_.last_progress_input_offset = initial_input_offset;
 +}
 +
  XmaPacketHandle ResolvePacket(const XMA_CONTEXT_DATA& data, uint32_t starting_buffer_index,
                                uint32_t logical_packet_index, uint32_t current_buffer_packet_count) {
    XmaPacketHandle result;
-@@ -82,7 +127,9 @@ bool XmaContext::IsValidFrameSize(uint32_t frame_size) {
+@@ -82,7 +134,9 @@ bool XmaContext::IsValidFrameSize(uint32_t frame_size) {
  }
  
  XmaContext::XmaContext()
@@ -191,7 +199,7 @@ index e723215..16f40a9 100644
  
  XmaContext::~XmaContext() {
    if (av_context_) {
-@@ -162,18 +209,46 @@ bool XmaContext::Work() {
+@@ -162,18 +216,46 @@ bool XmaContext::Work() {
    // Minimum free blocks needed before attempting a decode.
    // Use subframe_decode_count (clamped to 1) instead of full frame size.
    const uint32_t effective_sdc = std::max(static_cast<uint32_t>(1), data.subframe_decode_count);
@@ -239,7 +247,7 @@ index e723215..16f40a9 100644
      if (!data.IsAnyInputBufferValid() || data.error_status == 4) {
        break;
      }
-@@ -249,11 +324,13 @@ void XmaContext::ResetDecoderState() {
+@@ -249,11 +331,13 @@ void XmaContext::ResetDecoderState() {
    loop_start_skip_pending_ = false;
    packet_warning_mask_ = 0;
    payload_warning_mask_ = 0;
@@ -253,7 +261,7 @@ index e723215..16f40a9 100644
  }
  
  void XmaContext::Release() {
-@@ -266,6 +343,85 @@ void XmaContext::Release() {
+@@ -266,6 +350,85 @@ void XmaContext::Release() {
    std::memset(context_ptr, 0, sizeof(XMA_CONTEXT_DATA));
  }
  
@@ -339,7 +347,7 @@ index e723215..16f40a9 100644
  void XmaContext::SwapInputBuffer(XMA_CONTEXT_DATA* data) {
    if (data->current_buffer == 0) {
      data->input_buffer_0_valid = 0;
-@@ -615,7 +771,10 @@ void XmaContext::Consume(memory::RingBuffer* output_rb, const XMA_CONTEXT_DATA*
+@@ -615,7 +778,10 @@ void XmaContext::Consume(memory::RingBuffer* output_rb, const XMA_CONTEXT_DATA*
                                      << data->is_stereo;
      const uint8_t consumed = total_subframes - current_frame_remaining_subframes_;
      if (consumed >= loop_frame_output_limit_) {
@@ -351,7 +359,7 @@ index e723215..16f40a9 100644
        current_frame_remaining_subframes_ = 0;
        loop_frame_output_limit_ = 0;
        return;
-@@ -643,9 +802,13 @@ void XmaContext::Consume(memory::RingBuffer* output_rb, const XMA_CONTEXT_DATA*
+@@ -643,9 +809,13 @@ void XmaContext::Consume(memory::RingBuffer* output_rb, const XMA_CONTEXT_DATA*
    output_rb->Write(raw_frame_.data() + (kOutputBytesPerBlock * raw_frame_read_offset),
                     subframes_to_write * kOutputBytesPerBlock);
  
@@ -368,7 +376,7 @@ index e723215..16f40a9 100644
  
    remaining_subframe_blocks_in_output_buffer_ -= subframes_to_write + headroom;
    current_frame_remaining_subframes_ -= subframes_to_write;
-@@ -657,6 +820,11 @@ int XmaContext::PrepareDecoder(int sample_rate, bool is_two_channel) {
+@@ -657,6 +827,11 @@ int XmaContext::PrepareDecoder(int sample_rate, bool is_two_channel) {
    uint32_t channels = is_two_channel ? 2 : 1;
    if (av_context_->sample_rate != sample_rate ||
        av_context_->channels != static_cast<int>(channels)) {
@@ -405,469 +413,212 @@ index 7bbe847..fc7c7b7 100644
      false,  // kBufferQueueDepth  (set each frame)
      false,  // kFunctionsDispatched
 diff --git a/tests/unit/audio/xma_packet_test.cpp b/tests/unit/audio/xma_packet_test.cpp
-deleted file mode 100644
-index a9db54d..0000000
+index a9db54d..834e6b0 100644
 --- a/tests/unit/audio/xma_packet_test.cpp
-+++ /dev/null
-@@ -1,461 +0,0 @@
--/**
-- * @file        xma_packet_test.cpp
-- * @brief       XMA cross-buffer packet traversal regression tests
-- * @copyright   Copyright (c) 2026 Tom Clay
-- * @license     BSD 3-Clause License
-- */
--
--#include <algorithm>
--#include <array>
--#include <cstring>
--
--#include <catch2/catch_test_macros.hpp>
--
--#include <rex/audio/xma/context.h>
--#include <rex/system/xmemory.h>
--
--#include "test_memory.h"
--
--namespace {
--
--using rex::audio::ResolvePacket;
--using rex::audio::XMA_CONTEXT_DATA;
--using rex::audio::XmaContext;
--using rex::audio::XmaPacketStatus;
--using rex::audio::XmaPayloadStatus;
--
--std::array<uint8_t, sizeof(XMA_CONTEXT_DATA)> EmptyGuestContext() {
--  return {};
--}
--
--XMA_CONTEXT_DATA MakeTwoBufferContext(uint32_t current_buffer = 0) {
--  auto raw = EmptyGuestContext();
--  XMA_CONTEXT_DATA data(raw.data());
--  data.current_buffer = current_buffer;
--  data.input_buffer_0_valid = 1;
--  data.input_buffer_1_valid = 1;
--  data.input_buffer_0_ptr = 0x10000;
--  data.input_buffer_1_ptr = 0x20000;
--  data.input_buffer_0_packet_count = 3;
--  data.input_buffer_1_packet_count = 4;
--  return data;
--}
--
--void SetPacketHeader(uint8_t* packet, uint8_t frame_count,
--                     uint32_t first_frame_offset, uint8_t skip_count) {
--  const uint32_t encoded_offset =
--      first_frame_offset - XmaContext::kBitsPerPacketHeader;
--  packet[0] = static_cast<uint8_t>((frame_count << 2) |
--                                   ((encoded_offset >> 13) & 0x3));
--  packet[1] = static_cast<uint8_t>(encoded_offset >> 5);
--  packet[2] = static_cast<uint8_t>((encoded_offset << 3) | 1);
--  packet[3] = skip_count;
--}
--
--void WriteCrossBufferPayloadBits(uint8_t* current, uint8_t* alternate,
--                                 uint32_t first_payload_bit, uint32_t value,
--                                 uint32_t bit_count) {
--  for (uint32_t i = 0; i < bit_count; ++i) {
--    const uint32_t assembled_bit = first_payload_bit + i;
--    const uint32_t logical_packet =
--        assembled_bit / XmaContext::kBitsPerPacketData;
--    const uint32_t packet_bit =
--        assembled_bit % XmaContext::kBitsPerPacketData;
--    uint8_t* packet =
--        logical_packet == 0
--            ? current
--            : alternate +
--                  (logical_packet - 1) * XmaContext::kBytesPerPacket;
--    uint8_t& byte =
--        packet[XmaContext::kBytesPerPacketHeader + packet_bit / 8];
--    const uint8_t mask = static_cast<uint8_t>(1u << (7 - packet_bit % 8));
--    if (value & (1u << (bit_count - i - 1))) {
--      byte |= mask;
--    } else {
--      byte &= static_cast<uint8_t>(~mask);
--    }
--  }
--}
--
--}  // namespace
--
--TEST_CASE("XMA packet resolution preserves cross-buffer packet indices", "[audio][xma]") {
--  XMA_CONTEXT_DATA data = MakeTwoBufferContext();
--
--  SECTION("current buffer packet zero") {
--    const auto packet = ResolvePacket(data, 0, 0, 3);
--    CHECK(packet.valid());
--    CHECK(packet.buffer_index == 0);
--    CHECK(packet.packet_index == 0);
--  }
--
--  SECTION("current buffer last packet") {
--    const auto packet = ResolvePacket(data, 0, 2, 3);
--    CHECK(packet.valid());
--    CHECK(packet.buffer_index == 0);
--    CHECK(packet.packet_index == 2);
--  }
--
--  SECTION("alternate buffer packet zero") {
--    const auto packet = ResolvePacket(data, 0, 3, 3);
--    CHECK(packet.valid());
--    CHECK(packet.buffer_index == 1);
--    CHECK(packet.packet_index == 0);
--  }
--
--  SECTION("alternate buffer packet one and beyond") {
--    const auto packet = ResolvePacket(data, 0, 5, 3);
--    CHECK(packet.valid());
--    CHECK(packet.buffer_index == 1);
--    CHECK(packet.packet_index == 2);
--  }
--
--  SECTION("starting from buffer one") {
--    const auto packet = ResolvePacket(data, 1, 5, 4);
--    CHECK(packet.valid());
--    CHECK(packet.buffer_index == 0);
--    CHECK(packet.packet_index == 1);
--  }
--}
--
--TEST_CASE("XMA packet resolution rejects unavailable guest packets", "[audio][xma]") {
--  XMA_CONTEXT_DATA data = MakeTwoBufferContext();
--
--  SECTION("alternate buffer invalid") {
--    data.input_buffer_1_valid = 0;
--    CHECK(ResolvePacket(data, 0, 3, 3).status == XmaPacketStatus::kBufferInvalid);
--  }
--
--  SECTION("alternate buffer has null address") {
--    data.input_buffer_1_ptr = 0;
--    CHECK(ResolvePacket(data, 0, 3, 3).status == XmaPacketStatus::kNullAddress);
--  }
--
--  SECTION("alternate buffer is shorter than the requested packet") {
--    data.input_buffer_1_packet_count = 1;
--    const auto packet = ResolvePacket(data, 0, 4, 3);
--    CHECK(packet.status == XmaPacketStatus::kPacketOutOfRange);
--    CHECK(packet.buffer_index == 1);
--    CHECK(packet.packet_index == 1);
--  }
--
--  SECTION("caller packet count disagrees with context") {
--    CHECK(ResolvePacket(data, 0, 0, 2).status == XmaPacketStatus::kInvalidContext);
--  }
--}
--
--TEST_CASE("XMA payload assembly spans up to four packets", "[audio][xma]") {
--  auto& memory = rex::testing::GetTestMemory();
--  auto* virtual_heap = const_cast<rex::memory::BaseHeap*>(memory.LookupHeap(0x10000000));
--  auto* physical_heap = const_cast<rex::memory::BaseHeap*>(memory.LookupHeap(0xA0000000));
--  REQUIRE(virtual_heap != nullptr);
--  REQUIRE(physical_heap != nullptr);
--
--  constexpr uint32_t kReadWrite =
--      rex::memory::kMemoryProtectRead | rex::memory::kMemoryProtectWrite;
--  constexpr uint32_t kReserveCommit =
--      rex::memory::kMemoryAllocationReserve | rex::memory::kMemoryAllocationCommit;
--  uint32_t context_address = 0;
--  uint32_t current_address = 0;
--  uint32_t alternate_address = 0;
--  uint32_t output_address = 0;
--  REQUIRE(virtual_heap->Alloc(4096, 4096, kReserveCommit, kReadWrite, false, &context_address));
--  REQUIRE(physical_heap->Alloc(4096, 4096, kReserveCommit, kReadWrite, false, &current_address));
--  REQUIRE(physical_heap->Alloc(8192, 4096, kReserveCommit, kReadWrite, false, &alternate_address));
--  REQUIRE(physical_heap->Alloc(4096, 4096, kReserveCommit, kReadWrite, false, &output_address));
--
--  uint8_t* current = memory.TranslatePhysical(current_address);
--  uint8_t* alternate = memory.TranslatePhysical(alternate_address);
--  std::memset(current, 0, 4096);
--  std::memset(alternate, 0, 8192);
--  std::memset(current + XmaContext::kBytesPerPacketHeader, 0x11, XmaContext::kBytesPerPacketData);
--  for (uint32_t packet = 0; packet < 3; ++packet) {
--    std::memset(
--        alternate + packet * XmaContext::kBytesPerPacket + XmaContext::kBytesPerPacketHeader,
--        0x22 + packet, XmaContext::kBytesPerPacketData);
--  }
--
--  auto* context_ptr = memory.TranslateVirtual(context_address);
--  std::memset(context_ptr, 0, sizeof(XMA_CONTEXT_DATA));
--  XMA_CONTEXT_DATA data(context_ptr);
--  data.current_buffer = 0;
--  data.input_buffer_0_valid = 1;
--  data.input_buffer_1_valid = 1;
--  data.input_buffer_0_ptr = current_address;
--  data.input_buffer_1_ptr = alternate_address;
--  data.input_buffer_0_packet_count = 1;
--  data.input_buffer_1_packet_count = 3;
--
--  XmaContext context;
--  REQUIRE(context.Setup(2, &memory, context_address) == 0);
--  context.set_is_allocated(true);
--  std::array<uint8_t, XmaContext::kBytesPerPacketData * XmaContext::kMaxAssembledPackets> assembled;
--
--  SECTION("one packet") {
--    const auto result =
--        context.AssemblePacketPayloads(&data, 0, 1, XmaContext::kBitsPerPacketHeader, 8, assembled);
--    CHECK(result.valid());
--    CHECK(result.packet_count == 1);
--    CHECK(result.valid_bits == XmaContext::kBitsPerPacketData);
--    CHECK(assembled.front() == 0x11);
--    CHECK(assembled[XmaContext::kBytesPerPacketData] == 0);
--  }
--
--  SECTION("two packets with a split header") {
--    const auto result = context.AssemblePacketPayloads(&data, 0, 1, XmaContext::kBitsPerPacket - 7,
--                                                       XmaContext::kBitsPerFrameHeader, assembled);
--    CHECK(result.valid());
--    CHECK(result.packet_count == 2);
--    CHECK(assembled.front() == 0x11);
--    CHECK(assembled[XmaContext::kBytesPerPacketData] == 0x22);
--  }
--
--  SECTION("three packets from a late frame start") {
--    const auto result =
--        context.AssemblePacketPayloads(&data, 0, 1, XmaContext::kBitsPerPacket - 7,
--                                       XmaContext::kBitsPerPacketData + 16, assembled);
--    CHECK(result.valid());
--    CHECK(result.packet_count == 3);
--    CHECK(assembled[XmaContext::kBytesPerPacketData] == 0x22);
--    CHECK(assembled[XmaContext::kBytesPerPacketData * 2] == 0x23);
--  }
--
--  SECTION("four packets cross alternate packet zero and later packets") {
--    const auto result = context.AssemblePacketPayloads(&data, 0, 1, XmaContext::kBitsPerPacket - 1,
--                                                       0x7FFE, assembled);
--    CHECK(result.valid());
--    CHECK(result.packet_count == 4);
--    CHECK(assembled.front() == 0x11);
--    CHECK(assembled[XmaContext::kBytesPerPacketData] == 0x22);
--    CHECK(assembled[XmaContext::kBytesPerPacketData * 2] == 0x23);
--    CHECK(assembled[XmaContext::kBytesPerPacketData * 3] == 0x24);
--  }
--
--  SECTION("missing continuation buffer is rejected and zero-filled") {
--    data.input_buffer_1_valid = 0;
--    assembled.fill(0xAA);
--    const auto result =
--        context.AssemblePacketPayloads(&data, 0, 1, XmaContext::kBitsPerPacket - 7, 16, assembled);
--    CHECK(result.status == XmaPayloadStatus::kPacketUnavailable);
--    CHECK(result.failed_packet.status == XmaPacketStatus::kBufferInvalid);
--    CHECK(
--        std::all_of(assembled.begin(), assembled.end(), [](uint8_t value) { return value == 0; }));
--  }
--
--  SECTION("short alternate buffer is rejected") {
--    data.input_buffer_1_packet_count = 1;
--    const auto result =
--        context.AssemblePacketPayloads(&data, 0, 1, XmaContext::kBitsPerPacket - 7,
--                                       XmaContext::kBitsPerPacketData + 16, assembled);
--    CHECK(result.status == XmaPayloadStatus::kPacketUnavailable);
--    CHECK(result.failed_packet.status == XmaPacketStatus::kPacketOutOfRange);
--    CHECK(result.failed_packet.packet_index == 1);
--  }
--
--  SECTION("requests beyond scratch capacity are rejected") {
--    const auto result = context.AssemblePacketPayloads(
--        &data, 0, 1, XmaContext::kBitsPerPacket - 1, XmaContext::kBitsPerPacketData * 4, assembled);
--    CHECK(result.status == XmaPayloadStatus::kCapacityExceeded);
--    CHECK(result.packet_count == 5);
--  }
--
--  SECTION("zero length and invalid offsets are rejected") {
--    CHECK(
--        context.AssemblePacketPayloads(&data, 0, 1, XmaContext::kBitsPerPacketHeader, 0, assembled)
--            .status == XmaPayloadStatus::kZeroLength);
--    CHECK(context.AssemblePacketPayloads(&data, 0, 1, 31, 8, assembled).status ==
--          XmaPayloadStatus::kInvalidFrameOffset);
--    CHECK(context.AssemblePacketPayloads(&data, 0, 1, XmaContext::kBitsPerPacket, 8, assembled)
--              .status == XmaPayloadStatus::kInvalidFrameOffset);
--  }
--
--  SECTION("synthetic three-packet frame decodes and advances") {
--    constexpr uint32_t kFrameOffset = XmaContext::kBitsPerPacket - 7;
--    constexpr uint32_t kFrameSize = XmaContext::kBitsPerPacketData + 16;
--    SetPacketHeader(current, 1, kFrameOffset, 2);
--    SetPacketHeader(alternate + XmaContext::kBytesPerPacket * 2, 1,
--                    XmaContext::kBitsPerPacketHeader, 0xFF);
--    SetPacketHeader(alternate + XmaContext::kBytesPerPacket * 3, 1,
--                    XmaContext::kBitsPerPacketHeader, 0xFF);
--    WriteCrossBufferPayloadBits(
--        current, alternate,
--        kFrameOffset - XmaContext::kBitsPerPacketHeader, kFrameSize,
--        XmaContext::kBitsPerFrameHeader);
--
--    data.input_buffer_1_packet_count = 4;
--    data.input_buffer_read_offset = kFrameOffset;
--    data.output_buffer_valid = 1;
--    data.output_buffer_ptr = output_address;
--    data.output_buffer_block_count = 4;
--    data.output_buffer_write_offset = 1;
--    data.subframe_decode_count = 1;
--    data.Store(context_ptr);
--
--    context.Enable();
--    CHECK(context.Work());
--    XMA_CONTEXT_DATA advanced(context_ptr);
--    CHECK(advanced.error_status == 0);
--    CHECK_FALSE(advanced.IsAnyInputBufferValid());
--    CHECK(advanced.current_buffer == 0);
--    CHECK(advanced.input_buffer_read_offset ==
--          XmaContext::kBitsPerPacketHeader);
--  }
--
--  SECTION("synthetic four-packet frame decodes and advances") {
--    constexpr uint32_t kFrameOffset = XmaContext::kBitsPerPacket - 1;
--    constexpr uint32_t kFrameSize = 0x7FFE;
--    SetPacketHeader(current, 1, kFrameOffset, 3);
--    SetPacketHeader(alternate + XmaContext::kBytesPerPacket * 3, 1,
--                    XmaContext::kBitsPerPacketHeader, 0xFF);
--    WriteCrossBufferPayloadBits(
--        current, alternate,
--        kFrameOffset - XmaContext::kBitsPerPacketHeader, kFrameSize,
--        XmaContext::kBitsPerFrameHeader);
--
--    data.input_buffer_1_packet_count = 4;
--    data.input_buffer_read_offset = kFrameOffset;
--    data.output_buffer_valid = 1;
--    data.output_buffer_ptr = output_address;
--    data.output_buffer_block_count = 4;
--    data.output_buffer_write_offset = 1;
--    data.subframe_decode_count = 1;
--    data.Store(context_ptr);
--
--    context.Enable();
--    CHECK(context.Work());
--    XMA_CONTEXT_DATA advanced(context_ptr);
--    CHECK(advanced.error_status == 0);
--    CHECK_FALSE(advanced.IsAnyInputBufferValid());
--    CHECK(advanced.current_buffer == 0);
--    CHECK(advanced.input_buffer_read_offset ==
--          XmaContext::kBitsPerPacketHeader);
--  }
--
--  context.Release();
--  physical_heap->Release(output_address, nullptr);
--  physical_heap->Release(alternate_address, nullptr);
--  physical_heap->Release(current_address, nullptr);
--  virtual_heap->Release(context_address, nullptr);
--}
--
--TEST_CASE("XMA frame size rejects zero and the sentinel", "[audio][xma]") {
--  CHECK_FALSE(XmaContext::IsValidFrameSize(0));
--  CHECK(XmaContext::IsValidFrameSize(1));
--  CHECK(XmaContext::IsValidFrameSize(0x7FFE));
--  CHECK_FALSE(XmaContext::IsValidFrameSize(0x7FFF));
--}
--
--TEST_CASE("XMA exhausted input retires to a clean idle state", "[audio][xma]") {
--  auto& memory = rex::testing::GetTestMemory();
--  auto* heap = const_cast<rex::memory::BaseHeap*>(memory.LookupHeap(0x10000000));
--  REQUIRE(heap != nullptr);
--
--  uint32_t context_address = 0;
--  REQUIRE(heap->Alloc(
--      4096, 4096, rex::memory::kMemoryAllocationReserve | rex::memory::kMemoryAllocationCommit,
--      rex::memory::kMemoryProtectRead | rex::memory::kMemoryProtectWrite, false, &context_address));
--
--  auto* context_ptr = memory.TranslateVirtual(context_address);
--  std::memset(context_ptr, 0, sizeof(XMA_CONTEXT_DATA));
--  XMA_CONTEXT_DATA data(context_ptr);
--  data.input_buffer_0_valid = 1;
--  data.input_buffer_0_ptr = 0x10000;
--  data.input_buffer_0_packet_count = 1;
--  data.input_buffer_read_offset = XmaContext::kBitsPerPacket;
--  data.output_buffer_valid = 1;
--  data.output_buffer_ptr = 0x30000;
--  data.output_buffer_block_count = 4;
--  data.output_buffer_write_offset = 1;
--  data.subframe_decode_count = 1;
--  data.Store(context_ptr);
--
--  XmaContext context;
--  REQUIRE(context.Setup(0, &memory, context_address) == 0);
--  context.set_is_allocated(true);
--  context.Enable();
--  CHECK(context.Work());
--
--  XMA_CONTEXT_DATA retired(context_ptr);
--  CHECK_FALSE(retired.input_buffer_0_valid);
--  CHECK_FALSE(retired.input_buffer_1_valid);
--  CHECK(retired.current_buffer == 1);
--  CHECK(retired.input_buffer_read_offset == XmaContext::kBitsPerPacketHeader);
--
--  // Re-entry remains idle and leaves the retired state unchanged.
--  context.Enable();
--  CHECK(context.Work());
--  XMA_CONTEXT_DATA idle(context_ptr);
--  CHECK_FALSE(idle.IsAnyInputBufferValid());
--  CHECK(idle.input_buffer_read_offset == XmaContext::kBitsPerPacketHeader);
--
--  context.Release();
--  heap->Release(context_address, nullptr);
--}
--
--TEST_CASE("XMA full-packet skip crosses to an alternate packet beyond zero", "[audio][xma]") {
--  auto& memory = rex::testing::GetTestMemory();
--  auto* virtual_heap = const_cast<rex::memory::BaseHeap*>(memory.LookupHeap(0x10000000));
--  auto* physical_heap = const_cast<rex::memory::BaseHeap*>(memory.LookupHeap(0xA0000000));
--  REQUIRE(virtual_heap != nullptr);
--  REQUIRE(physical_heap != nullptr);
--
--  constexpr uint32_t kReadWrite =
--      rex::memory::kMemoryProtectRead | rex::memory::kMemoryProtectWrite;
--  constexpr uint32_t kReserveCommit =
--      rex::memory::kMemoryAllocationReserve | rex::memory::kMemoryAllocationCommit;
--  uint32_t context_address = 0;
--  uint32_t current_address = 0;
--  uint32_t alternate_address = 0;
--  uint32_t output_address = 0;
--  REQUIRE(virtual_heap->Alloc(4096, 4096, kReserveCommit, kReadWrite, false, &context_address));
--  REQUIRE(physical_heap->Alloc(4096, 4096, kReserveCommit, kReadWrite, false, &current_address));
--  REQUIRE(physical_heap->Alloc(4096, 4096, kReserveCommit, kReadWrite, false, &alternate_address));
--  REQUIRE(physical_heap->Alloc(4096, 4096, kReserveCommit, kReadWrite, false, &output_address));
--
--  uint8_t* current = memory.TranslatePhysical(current_address);
--  uint8_t* alternate = memory.TranslatePhysical(alternate_address);
--  std::memset(current, 0, XmaContext::kBytesPerPacket);
--  std::memset(alternate, 0, XmaContext::kBytesPerPacket * 2);
--  current[3] = 0xFF;
--
--  // Packet 0 has an invalid first-frame offset, forcing the scan to packet 1.
--  alternate[0] = 0x03;
--  alternate[1] = 0xFF;
--  alternate[2] = 0xF8;
--  alternate[XmaContext::kBytesPerPacket + 3] = 0xFF;
--
--  auto* context_ptr = memory.TranslateVirtual(context_address);
--  std::memset(context_ptr, 0, sizeof(XMA_CONTEXT_DATA));
--  XMA_CONTEXT_DATA data(context_ptr);
--  data.input_buffer_0_valid = 1;
--  data.input_buffer_1_valid = 1;
--  data.input_buffer_0_ptr = current_address;
--  data.input_buffer_1_ptr = alternate_address;
--  data.input_buffer_0_packet_count = 1;
--  data.input_buffer_1_packet_count = 2;
--  data.input_buffer_read_offset = XmaContext::kBitsPerPacketHeader;
--  data.output_buffer_valid = 1;
--  data.output_buffer_ptr = output_address;
--  data.output_buffer_block_count = 4;
--  data.output_buffer_write_offset = 1;
--  data.subframe_decode_count = 1;
--  data.Store(context_ptr);
--
--  XmaContext context;
--  REQUIRE(context.Setup(1, &memory, context_address) == 0);
--  context.set_is_allocated(true);
--  context.Enable();
--  CHECK(context.Work());
--
--  XMA_CONTEXT_DATA retired(context_ptr);
--  CHECK_FALSE(retired.IsAnyInputBufferValid());
--  CHECK(retired.current_buffer == 0);
--  CHECK(retired.input_buffer_read_offset == XmaContext::kBitsPerPacketHeader);
--  CHECK(retired.error_status == 0);
--
--  context.Release();
--  physical_heap->Release(output_address, nullptr);
--  physical_heap->Release(alternate_address, nullptr);
--  physical_heap->Release(current_address, nullptr);
--  virtual_heap->Release(context_address, nullptr);
--}
++++ b/tests/unit/audio/xma_packet_test.cpp
+@@ -12,6 +12,7 @@
+ #include <catch2/catch_test_macros.hpp>
+ 
+ #include <rex/audio/xma/context.h>
++#include <rex/cvar.h>
+ #include <rex/system/xmemory.h>
+ 
+ #include "test_memory.h"
+@@ -23,6 +24,13 @@ using rex::audio::XMA_CONTEXT_DATA;
+ using rex::audio::XmaContext;
+ using rex::audio::XmaPacketStatus;
+ using rex::audio::XmaPayloadStatus;
++using rex::audio::XmaStallTracker;
++
++struct ResetRelaxedPaddingAdmission {
++  ~ResetRelaxedPaddingAdmission() {
++    rex::cvar::SetFlagByName("xma_relaxed_padding_admission", "false");
++  }
++};
+ 
+ std::array<uint8_t, sizeof(XMA_CONTEXT_DATA)> EmptyGuestContext() {
+   return {};
+@@ -79,6 +87,183 @@ void WriteCrossBufferPayloadBits(uint8_t* current, uint8_t* alternate,
+ 
+ }  // namespace
+ 
++TEST_CASE("XMA stall diagnostics remain bounded across transient episodes",
++          "[audio][xma][stall]") {
++  XmaStallTracker tracker;
++  tracker.Reset(XmaContext::kBitsPerPacketHeader);
++
++  uint32_t summary_count = 0;
++  uint32_t recovery_log_count = 0;
++  for (uint64_t total = 1; total <= 300; ++total) {
++    const bool expected_summary =
++        total == 1 || total == 8 || total == 64 || total == 256;
++    const bool summary = tracker.NoteNoSpaceStall();
++    INFO("stall total " << total);
++    CHECK(summary == expected_summary);
++    summary_count += summary ? 1 : 0;
++
++    const bool recovery_log = tracker.NoteProgress(
++        static_cast<uint32_t>(total), 0, static_cast<uint8_t>(total));
++    CHECK(recovery_log == expected_summary);
++    recovery_log_count += recovery_log ? 1 : 0;
++  }
++
++  CHECK(summary_count == 4);
++  CHECK(recovery_log_count == 4);
++  CHECK(tracker.metrics().total_no_space_stalls == 300);
++  CHECK(tracker.metrics().total_recoveries == 300);
++  CHECK(tracker.metrics().consecutive_no_space_stalls == 0);
++
++  tracker.Reset(77);
++  CHECK(tracker.metrics().total_no_space_stalls == 0);
++  CHECK(tracker.metrics().total_recoveries == 0);
++  CHECK(tracker.metrics().last_progress_input_offset == 77);
++}
++
++TEST_CASE("XMA strict padding admission reports no-space and recovers",
++          "[audio][xma][stall]") {
++  ResetRelaxedPaddingAdmission reset_padding;
++  REQUIRE(rex::cvar::SetFlagByName("xma_relaxed_padding_admission",
++                                   "false"));
++
++  auto& memory = rex::testing::GetTestMemory();
++  auto* virtual_heap =
++      const_cast<rex::memory::BaseHeap*>(memory.LookupHeap(0x10000000));
++  auto* physical_heap =
++      const_cast<rex::memory::BaseHeap*>(memory.LookupHeap(0xA0000000));
++  REQUIRE(virtual_heap != nullptr);
++  REQUIRE(physical_heap != nullptr);
++
++  constexpr uint32_t kReadWrite =
++      rex::memory::kMemoryProtectRead | rex::memory::kMemoryProtectWrite;
++  constexpr uint32_t kReserveCommit =
++      rex::memory::kMemoryAllocationReserve |
++      rex::memory::kMemoryAllocationCommit;
++  uint32_t context_address = 0;
++  uint32_t input_address = 0;
++  uint32_t output_address = 0;
++  REQUIRE(virtual_heap->Alloc(4096, 4096, kReserveCommit, kReadWrite, false,
++                              &context_address));
++  REQUIRE(physical_heap->Alloc(4096, 4096, kReserveCommit, kReadWrite, false,
++                               &input_address));
++  REQUIRE(physical_heap->Alloc(4096, 4096, kReserveCommit, kReadWrite, false,
++                               &output_address));
++
++  uint8_t* input = memory.TranslatePhysical(input_address);
++  std::memset(input, 0, XmaContext::kBytesPerPacket);
++  input[3] = 0xFF;
++
++  auto* context_ptr = memory.TranslateVirtual(context_address);
++  std::memset(context_ptr, 0, sizeof(XMA_CONTEXT_DATA));
++  XMA_CONTEXT_DATA data(context_ptr);
++  data.input_buffer_0_valid = 1;
++  data.input_buffer_0_ptr = input_address;
++  data.input_buffer_0_packet_count = 1;
++  data.input_buffer_read_offset = XmaContext::kBitsPerPacketHeader;
++  data.output_buffer_valid = 1;
++  data.output_buffer_ptr = output_address;
++  data.output_buffer_block_count = 8;
++  data.output_buffer_read_offset = 0;
++  data.output_buffer_write_offset = 4;
++  data.subframe_decode_count = 4;
++  data.output_buffer_padding = 2;
++  data.Store(context_ptr);
++
++  XmaContext context;
++  REQUIRE(context.Setup(0, &memory, context_address) == 0);
++  context.set_is_allocated(true);
++  context.Enable();
++  CHECK(context.Work());
++  CHECK(context.stall_metrics().total_no_space_stalls == 1);
++  CHECK(context.stall_metrics().total_recoveries == 0);
++
++  REQUIRE(rex::cvar::SetFlagByName("xma_relaxed_padding_admission", "true"));
++  context.Enable();
++  CHECK(context.Work());
++  CHECK(context.stall_metrics().total_no_space_stalls == 1);
++  CHECK(context.stall_metrics().total_recoveries == 1);
++
++  context.Clear();
++  CHECK(context.stall_metrics().total_no_space_stalls == 0);
++  CHECK(context.stall_metrics().total_recoveries == 0);
++  context.Release();
++  physical_heap->Release(output_address, nullptr);
++  physical_heap->Release(input_address, nullptr);
++  virtual_heap->Release(context_address, nullptr);
++}
++
++TEST_CASE("XMA no-progress diagnostics identify and recover malformed input",
++          "[audio][xma][stall]") {
++  auto& memory = rex::testing::GetTestMemory();
++  auto* virtual_heap =
++      const_cast<rex::memory::BaseHeap*>(memory.LookupHeap(0x10000000));
++  auto* physical_heap =
++      const_cast<rex::memory::BaseHeap*>(memory.LookupHeap(0xA0000000));
++  REQUIRE(virtual_heap != nullptr);
++  REQUIRE(physical_heap != nullptr);
++
++  constexpr uint32_t kReadWrite =
++      rex::memory::kMemoryProtectRead | rex::memory::kMemoryProtectWrite;
++  constexpr uint32_t kReserveCommit =
++      rex::memory::kMemoryAllocationReserve |
++      rex::memory::kMemoryAllocationCommit;
++  uint32_t context_address = 0;
++  uint32_t input_address = 0;
++  uint32_t output_address = 0;
++  REQUIRE(virtual_heap->Alloc(4096, 4096, kReserveCommit, kReadWrite, false,
++                              &context_address));
++  REQUIRE(physical_heap->Alloc(4096, 4096, kReserveCommit, kReadWrite, false,
++                               &input_address));
++  REQUIRE(physical_heap->Alloc(4096, 4096, kReserveCommit, kReadWrite, false,
++                               &output_address));
++
++  uint8_t* input = memory.TranslatePhysical(input_address);
++  std::memset(input, 0, XmaContext::kBytesPerPacket);
++
++  auto* context_ptr = memory.TranslateVirtual(context_address);
++  std::memset(context_ptr, 0, sizeof(XMA_CONTEXT_DATA));
++  XMA_CONTEXT_DATA data(context_ptr);
++  data.input_buffer_0_valid = 1;
++  data.input_buffer_0_ptr = input_address;
++  data.input_buffer_0_packet_count = 1;
++  data.input_buffer_read_offset = XmaContext::kBitsPerPacketHeader;
++  data.output_buffer_valid = 1;
++  data.output_buffer_ptr = output_address;
++  data.output_buffer_block_count = 8;
++  data.subframe_decode_count = 1;
++  data.Store(context_ptr);
++
++  XmaContext context;
++  REQUIRE(context.Setup(1, &memory, context_address) == 0);
++  context.set_is_allocated(true);
++  context.Enable();
++  CHECK(context.Work());
++  CHECK(context.stall_metrics().total_no_progress_stalls == 1);
++  CHECK(context.stall_metrics().total_recoveries == 0);
++  XMA_CONTEXT_DATA malformed(context_ptr);
++  CHECK(malformed.error_status == 4);
++
++  input[3] = 0xFF;
++  malformed.error_status = 0;
++  malformed.output_buffer_valid = 1;
++  malformed.Store(context_ptr);
++  context.Enable();
++  CHECK(context.Work());
++  XMA_CONTEXT_DATA recovered(context_ptr);
++  CAPTURE(context.stall_metrics().total_no_progress_stalls,
++          context.stall_metrics().total_recoveries,
++          recovered.input_buffer_0_valid, recovered.input_buffer_1_valid,
++          recovered.current_buffer, recovered.input_buffer_read_offset,
++          recovered.error_status);
++  CHECK(context.stall_metrics().total_no_progress_stalls == 1);
++  CHECK(context.stall_metrics().total_recoveries == 1);
++
++  context.Release();
++  physical_heap->Release(output_address, nullptr);
++  physical_heap->Release(input_address, nullptr);
++  virtual_heap->Release(context_address, nullptr);
++}
++
+ TEST_CASE("XMA packet resolution preserves cross-buffer packet indices", "[audio][xma]") {
+   XMA_CONTEXT_DATA data = MakeTwoBufferContext();
+ 

--- a/patches/rexglue/0038-m4-xma-stall-diagnostics.patch
+++ b/patches/rexglue/0038-m4-xma-stall-diagnostics.patch
@@ -1,8 +1,8 @@
 diff --git a/include/rex/audio/xma/context.h b/include/rex/audio/xma/context.h
-index 4861e40..221cd6a 100644
+index 4861e40..7fe1b57 100644
 --- a/include/rex/audio/xma/context.h
 +++ b/include/rex/audio/xma/context.h
-@@ -205,6 +205,56 @@ struct AssembledXmaPayload {
+@@ -205,6 +205,58 @@ struct AssembledXmaPayload {
    bool valid() const { return status == XmaPayloadStatus::kValid; }
  };
  
@@ -39,6 +39,7 @@ index 4861e40..221cd6a 100644
 +// can be tested without an FFmpeg decoder or guest-memory fixture.
 +class XmaStallTracker {
 + public:
++  static constexpr uint32_t kNoSpaceConfirmationObservations = 8;
 +  static bool ShouldLogSummary(uint64_t total_count);
 +
 +  XmaNoSpaceObservationResult ObserveNoSpace(const XmaNoSpaceObservation& observation);
@@ -52,6 +53,7 @@ index 4861e40..221cd6a 100644
 + private:
 +  XmaStallMetrics metrics_;
 +  XmaNoSpaceObservation no_space_observation_;
++  uint32_t no_space_observation_count_ = 0;
 +  bool has_no_space_observation_ = false;
 +  bool recovery_log_pending_ = false;
 +};
@@ -59,7 +61,7 @@ index 4861e40..221cd6a 100644
  // Resolves a logical packet number relative to starting_buffer_index. Packet
  // numbers at or beyond current_buffer_packet_count continue in the alternate
  // guest buffer without losing their index within that buffer.
-@@ -257,6 +307,8 @@ class XmaContext {
+@@ -257,6 +309,8 @@ class XmaContext {
                                               std::span<uint8_t> destination);
    static bool IsValidFrameSize(uint32_t frame_size);
  
@@ -68,7 +70,7 @@ index 4861e40..221cd6a 100644
    void Enable();
    bool Block(bool poll);
    void Clear();
-@@ -306,6 +358,12 @@ class XmaContext {
+@@ -306,6 +360,12 @@ class XmaContext {
    void WarnPacketResolution(const XmaPacketHandle& packet_handle, uint32_t logical_packet_index);
    void WarnPayloadAssembly(const AssembledXmaPayload& payload, uint32_t first_logical_packet,
                             uint32_t frame_offset_in_packet, uint32_t bits_required);
@@ -81,7 +83,7 @@ index 4861e40..221cd6a 100644
  
    void Decode(XMA_CONTEXT_DATA* data);
    void Consume(memory::RingBuffer* output_rb, const XMA_CONTEXT_DATA* data);
-@@ -368,6 +426,7 @@ class XmaContext {
+@@ -368,6 +428,7 @@ class XmaContext {
    // context lifetime rather than once per Work() re-entry.
    uint32_t packet_warning_mask_ = 0;
    uint32_t payload_warning_mask_ = 0;
@@ -124,7 +126,7 @@ index 3541c18..5053a69 100644
  #define PROFILE_VERTICES(n)
  #define PROFILE_CMD_BUFFER_STALL()
 diff --git a/src/audio/xma_context.cpp b/src/audio/xma_context.cpp
-index e723215..7007c97 100644
+index e723215..5c49db7 100644
 --- a/src/audio/xma_context.cpp
 +++ b/src/audio/xma_context.cpp
 @@ -15,9 +15,11 @@
@@ -150,7 +152,7 @@ index e723215..7007c97 100644
  // Credits for most of this code goes to:
  // https://github.com/koolkdev/libertyv/blob/master/libav_wrapper/xma2dec.c
  
-@@ -43,6 +49,74 @@ using stream::BitStream;
+@@ -43,6 +49,81 @@ using stream::BitStream;
  const uint32_t XmaContext::kBitsPerPacketHeader;
  const uint32_t XmaContext::kOutputMaxSizeBytes;
  
@@ -171,12 +173,17 @@ index e723215..7007c97 100644
 +XmaNoSpaceObservationResult XmaStallTracker::ObserveNoSpace(
 +    const XmaNoSpaceObservation& observation) {
 +  if (has_no_space_observation_ && no_space_observation_.Matches(observation)) {
-+    return {.repeated = true, .log_recovery = false};
++    ++no_space_observation_count_;
++    return {
++        .repeated = no_space_observation_count_ >= kNoSpaceConfirmationObservations,
++        .log_recovery = false,
++    };
 +  }
 +
 +  const bool log_recovery = NoteProgress(observation.input_offset, observation.output_read_offset,
 +                                         observation.output_write_offset);
 +  no_space_observation_ = observation;
++  no_space_observation_count_ = 1;
 +  has_no_space_observation_ = true;
 +  return {.repeated = false, .log_recovery = log_recovery};
 +}
@@ -207,6 +214,7 @@ index e723215..7007c97 100644
 +  const bool should_log_recovery = recovered && recovery_log_pending_;
 +  metrics_.consecutive_no_space_stalls = 0;
 +  metrics_.consecutive_no_progress_stalls = 0;
++  no_space_observation_count_ = 0;
 +  has_no_space_observation_ = false;
 +  recovery_log_pending_ = false;
 +  metrics_.last_progress_input_offset = input_offset;
@@ -217,6 +225,7 @@ index e723215..7007c97 100644
 +
 +void XmaStallTracker::Reset(uint32_t initial_input_offset) {
 +  metrics_ = {};
++  no_space_observation_count_ = 0;
 +  has_no_space_observation_ = false;
 +  recovery_log_pending_ = false;
 +  metrics_.last_progress_input_offset = initial_input_offset;
@@ -225,7 +234,7 @@ index e723215..7007c97 100644
  XmaPacketHandle ResolvePacket(const XMA_CONTEXT_DATA& data, uint32_t starting_buffer_index,
                                uint32_t logical_packet_index, uint32_t current_buffer_packet_count) {
    XmaPacketHandle result;
-@@ -81,8 +155,9 @@ bool XmaContext::IsValidFrameSize(uint32_t frame_size) {
+@@ -81,8 +162,9 @@ bool XmaContext::IsValidFrameSize(uint32_t frame_size) {
    return frame_size != 0 && frame_size != xma::kMaxFrameLength;
  }
  
@@ -237,7 +246,7 @@ index e723215..7007c97 100644
  
  XmaContext::~XmaContext() {
    if (av_context_) {
-@@ -162,18 +237,43 @@ bool XmaContext::Work() {
+@@ -162,18 +244,43 @@ bool XmaContext::Work() {
    // Minimum free blocks needed before attempting a decode.
    // Use subframe_decode_count (clamped to 1) instead of full frame size.
    const uint32_t effective_sdc = std::max(static_cast<uint32_t>(1), data.subframe_decode_count);
@@ -282,7 +291,7 @@ index e723215..7007c97 100644
      if (!data.IsAnyInputBufferValid() || data.error_status == 4) {
        break;
      }
-@@ -249,11 +349,13 @@ void XmaContext::ResetDecoderState() {
+@@ -249,11 +356,13 @@ void XmaContext::ResetDecoderState() {
    loop_start_skip_pending_ = false;
    packet_warning_mask_ = 0;
    payload_warning_mask_ = 0;
@@ -296,7 +305,7 @@ index e723215..7007c97 100644
  }
  
  void XmaContext::Release() {
-@@ -266,6 +368,98 @@ void XmaContext::Release() {
+@@ -266,6 +375,98 @@ void XmaContext::Release() {
    std::memset(context_ptr, 0, sizeof(XMA_CONTEXT_DATA));
  }
  
@@ -395,7 +404,7 @@ index e723215..7007c97 100644
  void XmaContext::SwapInputBuffer(XMA_CONTEXT_DATA* data) {
    if (data->current_buffer == 0) {
      data->input_buffer_0_valid = 0;
-@@ -615,7 +809,9 @@ void XmaContext::Consume(memory::RingBuffer* output_rb, const XMA_CONTEXT_DATA*
+@@ -615,7 +816,9 @@ void XmaContext::Consume(memory::RingBuffer* output_rb, const XMA_CONTEXT_DATA*
                                      << data->is_stereo;
      const uint8_t consumed = total_subframes - current_frame_remaining_subframes_;
      if (consumed >= loop_frame_output_limit_) {
@@ -406,7 +415,7 @@ index e723215..7007c97 100644
        current_frame_remaining_subframes_ = 0;
        loop_frame_output_limit_ = 0;
        return;
-@@ -643,9 +839,12 @@ void XmaContext::Consume(memory::RingBuffer* output_rb, const XMA_CONTEXT_DATA*
+@@ -643,9 +846,12 @@ void XmaContext::Consume(memory::RingBuffer* output_rb, const XMA_CONTEXT_DATA*
    output_rb->Write(raw_frame_.data() + (kOutputBytesPerBlock * raw_frame_read_offset),
                     subframes_to_write * kOutputBytesPerBlock);
  
@@ -422,7 +431,7 @@ index e723215..7007c97 100644
  
    remaining_subframe_blocks_in_output_buffer_ -= subframes_to_write + headroom;
    current_frame_remaining_subframes_ -= subframes_to_write;
-@@ -657,6 +856,11 @@ int XmaContext::PrepareDecoder(int sample_rate, bool is_two_channel) {
+@@ -657,6 +863,11 @@ int XmaContext::PrepareDecoder(int sample_rate, bool is_two_channel) {
    uint32_t channels = is_two_channel ? 2 : 1;
    if (av_context_->sample_rate != sample_rate ||
        av_context_->channels != static_cast<int>(channels)) {
@@ -459,7 +468,7 @@ index 7bbe847..fc7c7b7 100644
      false,  // kBufferQueueDepth  (set each frame)
      false,  // kFunctionsDispatched
 diff --git a/tests/unit/audio/xma_packet_test.cpp b/tests/unit/audio/xma_packet_test.cpp
-index a9db54d..1a87e45 100644
+index a9db54d..c6cf2cd 100644
 --- a/tests/unit/audio/xma_packet_test.cpp
 +++ b/tests/unit/audio/xma_packet_test.cpp
 @@ -12,6 +12,7 @@
@@ -533,7 +542,7 @@ index a9db54d..1a87e45 100644
      const uint8_t mask = static_cast<uint8_t>(1u << (7 - packet_bit % 8));
      if (value & (1u << (bit_count - i - 1))) {
        byte |= mask;
-@@ -79,6 +80,212 @@ void WriteCrossBufferPayloadBits(uint8_t* current, uint8_t* alternate,
+@@ -79,6 +80,220 @@ void WriteCrossBufferPayloadBits(uint8_t* current, uint8_t* alternate,
  
  }  // namespace
  
@@ -583,10 +592,15 @@ index a9db54d..1a87e45 100644
 +      .input_buffer_1_valid = false,
 +  };
 +
-+  auto result = tracker.ObserveNoSpace(observation);
-+  CHECK_FALSE(result.repeated);
-+  CHECK_FALSE(result.log_recovery);
-+  CHECK(tracker.metrics().total_no_space_stalls == 0);
++  rex::audio::XmaNoSpaceObservationResult result;
++  for (uint32_t attempt = 1; attempt < XmaStallTracker::kNoSpaceConfirmationObservations;
++       ++attempt) {
++    result = tracker.ObserveNoSpace(observation);
++    INFO("observation " << attempt);
++    CHECK_FALSE(result.repeated);
++    CHECK_FALSE(result.log_recovery);
++    CHECK(tracker.metrics().total_no_space_stalls == 0);
++  }
 +
 +  result = tracker.ObserveNoSpace(observation);
 +  CHECK(result.repeated);
@@ -653,10 +667,13 @@ index a9db54d..1a87e45 100644
 +  XmaContext context;
 +  REQUIRE(context.Setup(0, &memory, context_address) == 0);
 +  context.set_is_allocated(true);
-+  context.Enable();
-+  CHECK(context.Work());
-+  CHECK(context.stall_metrics().total_no_space_stalls == 0);
-+  CHECK(context.stall_metrics().total_recoveries == 0);
++  for (uint32_t attempt = 1; attempt < XmaStallTracker::kNoSpaceConfirmationObservations;
++       ++attempt) {
++    context.Enable();
++    CHECK(context.Work());
++    CHECK(context.stall_metrics().total_no_space_stalls == 0);
++    CHECK(context.stall_metrics().total_recoveries == 0);
++  }
 +
 +  context.Enable();
 +  CHECK(context.Work());
@@ -746,7 +763,7 @@ index a9db54d..1a87e45 100644
  TEST_CASE("XMA packet resolution preserves cross-buffer packet indices", "[audio][xma]") {
    XMA_CONTEXT_DATA data = MakeTwoBufferContext();
  
-@@ -277,10 +484,8 @@ TEST_CASE("XMA payload assembly spans up to four packets", "[audio][xma]") {
+@@ -277,10 +492,8 @@ TEST_CASE("XMA payload assembly spans up to four packets", "[audio][xma]") {
                      XmaContext::kBitsPerPacketHeader, 0xFF);
      SetPacketHeader(alternate + XmaContext::kBytesPerPacket * 3, 1,
                      XmaContext::kBitsPerPacketHeader, 0xFF);
@@ -759,7 +776,7 @@ index a9db54d..1a87e45 100644
  
      data.input_buffer_1_packet_count = 4;
      data.input_buffer_read_offset = kFrameOffset;
-@@ -297,8 +502,7 @@ TEST_CASE("XMA payload assembly spans up to four packets", "[audio][xma]") {
+@@ -297,8 +510,7 @@ TEST_CASE("XMA payload assembly spans up to four packets", "[audio][xma]") {
      CHECK(advanced.error_status == 0);
      CHECK_FALSE(advanced.IsAnyInputBufferValid());
      CHECK(advanced.current_buffer == 0);
@@ -769,7 +786,7 @@ index a9db54d..1a87e45 100644
    }
  
    SECTION("synthetic four-packet frame decodes and advances") {
-@@ -307,10 +511,8 @@ TEST_CASE("XMA payload assembly spans up to four packets", "[audio][xma]") {
+@@ -307,10 +519,8 @@ TEST_CASE("XMA payload assembly spans up to four packets", "[audio][xma]") {
      SetPacketHeader(current, 1, kFrameOffset, 3);
      SetPacketHeader(alternate + XmaContext::kBytesPerPacket * 3, 1,
                      XmaContext::kBitsPerPacketHeader, 0xFF);
@@ -782,7 +799,7 @@ index a9db54d..1a87e45 100644
  
      data.input_buffer_1_packet_count = 4;
      data.input_buffer_read_offset = kFrameOffset;
-@@ -327,8 +529,7 @@ TEST_CASE("XMA payload assembly spans up to four packets", "[audio][xma]") {
+@@ -327,8 +537,7 @@ TEST_CASE("XMA payload assembly spans up to four packets", "[audio][xma]") {
      CHECK(advanced.error_status == 0);
      CHECK_FALSE(advanced.IsAnyInputBufferValid());
      CHECK(advanced.current_buffer == 0);

--- a/patches/rexglue/0038-m4-xma-stall-diagnostics.patch
+++ b/patches/rexglue/0038-m4-xma-stall-diagnostics.patch
@@ -1,0 +1,873 @@
+diff --git a/include/rex/audio/xma/context.h b/include/rex/audio/xma/context.h
+index 4861e40..fe3126c 100644
+--- a/include/rex/audio/xma/context.h
++++ b/include/rex/audio/xma/context.h
+@@ -205,6 +205,35 @@ struct AssembledXmaPayload {
+   bool valid() const { return status == XmaPayloadStatus::kValid; }
+ };
+ 
++struct XmaStallMetrics {
++  uint32_t consecutive_no_space_stalls = 0;
++  uint32_t consecutive_no_progress_stalls = 0;
++  uint64_t total_no_space_stalls = 0;
++  uint64_t total_no_progress_stalls = 0;
++  uint64_t total_recoveries = 0;
++  uint32_t last_progress_input_offset = 0;
++  uint8_t last_progress_output_read_offset = 0;
++  uint8_t last_progress_output_write_offset = 0;
++};
++
++// State-only helper so the bounded reporting cadence and recovery semantics
++// can be tested without an FFmpeg decoder or guest-memory fixture.
++class XmaStallTracker {
++ public:
++  static bool ShouldLogSummary(uint32_t consecutive_count);
++
++  bool NoteNoSpaceStall();
++  bool NoteNoProgressStall();
++  bool NoteProgress(uint32_t input_offset, uint8_t output_read_offset,
++                    uint8_t output_write_offset);
++  void Reset(uint32_t initial_input_offset);
++
++  const XmaStallMetrics& metrics() const { return metrics_; }
++
++ private:
++  XmaStallMetrics metrics_;
++};
++
+ // Resolves a logical packet number relative to starting_buffer_index. Packet
+ // numbers at or beyond current_buffer_packet_count continue in the alternate
+ // guest buffer without losing their index within that buffer.
+@@ -257,6 +286,10 @@ class XmaContext {
+                                              std::span<uint8_t> destination);
+   static bool IsValidFrameSize(uint32_t frame_size);
+ 
++  const XmaStallMetrics& stall_metrics() const {
++    return stall_tracker_.metrics();
++  }
++
+   void Enable();
+   bool Block(bool poll);
+   void Clear();
+@@ -306,6 +339,15 @@ class XmaContext {
+   void WarnPacketResolution(const XmaPacketHandle& packet_handle, uint32_t logical_packet_index);
+   void WarnPayloadAssembly(const AssembledXmaPayload& payload, uint32_t first_logical_packet,
+                            uint32_t frame_offset_in_packet, uint32_t bits_required);
++  void NoteNoSpaceStall(const XMA_CONTEXT_DATA& data,
++                        int32_t minimum_subframe_decode_count);
++  void NoteNoProgressStall(const XMA_CONTEXT_DATA& data);
++  void NoteProgress(const XMA_CONTEXT_DATA& data,
++                    const memory::RingBuffer& output_rb,
++                    uint32_t previous_input_offset);
++  void ResetStallMetrics();
++  static uint8_t GetOutputPaddingHeadroom(uint8_t requested_padding,
++                                          int32_t remaining_after_write);
+ 
+   void Decode(XMA_CONTEXT_DATA* data);
+   void Consume(memory::RingBuffer* output_rb, const XMA_CONTEXT_DATA* data);
+@@ -368,6 +410,7 @@ class XmaContext {
+   // context lifetime rather than once per Work() re-entry.
+   uint32_t packet_warning_mask_ = 0;
+   uint32_t payload_warning_mask_ = 0;
++  XmaStallTracker stall_tracker_;
+ };
+ 
+ }  // namespace rex::audio
+diff --git a/include/rex/perf/counter.h b/include/rex/perf/counter.h
+index 3541c18..5053a69 100644
+--- a/include/rex/perf/counter.h
++++ b/include/rex/perf/counter.h
+@@ -31,6 +31,9 @@ enum class CounterId : uint16_t {
+ 
+   // Audio
+   kXmaFramesDecoded,
++  kXmaNoSpaceStalls,
++  kXmaNoProgressStalls,
++  kXmaStallRecoveries,
+   kAudioFrameLatencyUs,
+   kBufferQueueDepth,
+ 
+@@ -153,6 +156,9 @@ class Profiler {
+ #define PROFILE_FUNCTION_DISPATCHED() PERF_counter_inc(kFunctionsDispatched)
+ #define PROFILE_INTERRUPT_DISPATCHED() PERF_counter_inc(kInterruptDispatches)
+ #define PROFILE_XMA_FRAME_DECODED() PERF_counter_inc(kXmaFramesDecoded)
++#define PROFILE_XMA_NO_SPACE_STALL() PERF_counter_inc(kXmaNoSpaceStalls)
++#define PROFILE_XMA_NO_PROGRESS_STALL() PERF_counter_inc(kXmaNoProgressStalls)
++#define PROFILE_XMA_STALL_RECOVERY() PERF_counter_inc(kXmaStallRecoveries)
+ #define PROFILE_DRAW_CALL() PERF_counter_inc(kDrawCalls)
+ #define PROFILE_VERTICES(n) PERF_counter_add(kVerticesProcessed, n)
+ #define PROFILE_CMD_BUFFER_STALL() PERF_counter_inc(kCommandBufferStalls)
+@@ -183,6 +189,9 @@ class Profiler {
+ #define PROFILE_FUNCTION_DISPATCHED()
+ #define PROFILE_INTERRUPT_DISPATCHED()
+ #define PROFILE_XMA_FRAME_DECODED()
++#define PROFILE_XMA_NO_SPACE_STALL()
++#define PROFILE_XMA_NO_PROGRESS_STALL()
++#define PROFILE_XMA_STALL_RECOVERY()
+ #define PROFILE_DRAW_CALL()
+ #define PROFILE_VERTICES(n)
+ #define PROFILE_CMD_BUFFER_STALL()
+diff --git a/src/audio/xma_context.cpp b/src/audio/xma_context.cpp
+index e723215..16f40a9 100644
+--- a/src/audio/xma_context.cpp
++++ b/src/audio/xma_context.cpp
+@@ -15,9 +15,11 @@
+ #include <rex/audio/xma/context.h>
+ #include <rex/audio/xma/decoder.h>
+ #include <rex/audio/xma/helpers.h>
++#include <rex/cvar.h>
+ #include <rex/dbg.h>
+ #include <rex/logging.h>
+ #include <rex/memory/ring_buffer.h>
++#include <rex/perf/counter.h>
+ #include <rex/platform.h>
+ #include <rex/stream.h>
+ 
+@@ -33,6 +35,10 @@ extern "C" {
+ #endif
+ }  // extern "C"
+ 
++REXCVAR_DEFINE_BOOL(
++    xma_relaxed_padding_admission, false, "Audio",
++    "Treat XMA output padding as best-effort headroom instead of a hard decode requirement");
++
+ // Credits for most of this code goes to:
+ // https://github.com/koolkdev/libertyv/blob/master/libav_wrapper/xma2dec.c
+ 
+@@ -43,6 +49,45 @@ using stream::BitStream;
+ const uint32_t XmaContext::kBitsPerPacketHeader;
+ const uint32_t XmaContext::kOutputMaxSizeBytes;
+ 
++bool XmaStallTracker::ShouldLogSummary(uint32_t consecutive_count) {
++  return consecutive_count == 1 || consecutive_count == 8 ||
++         consecutive_count == 64 ||
++         (consecutive_count >= 256 && consecutive_count % 256 == 0);
++}
++
++bool XmaStallTracker::NoteNoSpaceStall() {
++  ++metrics_.consecutive_no_space_stalls;
++  ++metrics_.total_no_space_stalls;
++  return ShouldLogSummary(metrics_.consecutive_no_space_stalls);
++}
++
++bool XmaStallTracker::NoteNoProgressStall() {
++  ++metrics_.consecutive_no_progress_stalls;
++  ++metrics_.total_no_progress_stalls;
++  return ShouldLogSummary(metrics_.consecutive_no_progress_stalls);
++}
++
++bool XmaStallTracker::NoteProgress(uint32_t input_offset,
++                                   uint8_t output_read_offset,
++                                   uint8_t output_write_offset) {
++  const bool recovered = metrics_.consecutive_no_space_stalls != 0 ||
++                         metrics_.consecutive_no_progress_stalls != 0;
++  if (recovered) {
++    ++metrics_.total_recoveries;
++  }
++  metrics_.consecutive_no_space_stalls = 0;
++  metrics_.consecutive_no_progress_stalls = 0;
++  metrics_.last_progress_input_offset = input_offset;
++  metrics_.last_progress_output_read_offset = output_read_offset;
++  metrics_.last_progress_output_write_offset = output_write_offset;
++  return recovered;
++}
++
++void XmaStallTracker::Reset(uint32_t initial_input_offset) {
++  metrics_ = {};
++  metrics_.last_progress_input_offset = initial_input_offset;
++}
++
+ XmaPacketHandle ResolvePacket(const XMA_CONTEXT_DATA& data, uint32_t starting_buffer_index,
+                               uint32_t logical_packet_index, uint32_t current_buffer_packet_count) {
+   XmaPacketHandle result;
+@@ -82,7 +127,9 @@ bool XmaContext::IsValidFrameSize(uint32_t frame_size) {
+ }
+ 
+ XmaContext::XmaContext()
+-    : work_completion_event_(rex::thread::Event::CreateAutoResetEvent(false)) {}
++    : work_completion_event_(rex::thread::Event::CreateAutoResetEvent(false)) {
++  ResetStallMetrics();
++}
+ 
+ XmaContext::~XmaContext() {
+   if (av_context_) {
+@@ -162,18 +209,46 @@ bool XmaContext::Work() {
+   // Minimum free blocks needed before attempting a decode.
+   // Use subframe_decode_count (clamped to 1) instead of full frame size.
+   const uint32_t effective_sdc = std::max(static_cast<uint32_t>(1), data.subframe_decode_count);
++  const bool relaxed_padding = REXCVAR_GET(xma_relaxed_padding_admission);
+   const int32_t minimum_subframe_decode_count =
+-      static_cast<int32_t>(effective_sdc) + data.output_buffer_padding;
++      static_cast<int32_t>(effective_sdc) +
++      (relaxed_padding ? 0 : data.output_buffer_padding);
+ 
+   if (minimum_subframe_decode_count > remaining_subframe_blocks_in_output_buffer_) {
++    NoteNoSpaceStall(data, minimum_subframe_decode_count);
+     StoreContextMerged(data, initial_data, context_ptr);
+     return true;
+   }
+ 
+   while (remaining_subframe_blocks_in_output_buffer_ >= minimum_subframe_decode_count) {
++    const uint32_t previous_input_offset = data.input_buffer_read_offset;
++    const uint8_t previous_output_write_offset =
++        static_cast<uint8_t>(output_rb.write_offset() / kOutputBytesPerBlock);
++    const uint8_t previous_current_buffer = data.current_buffer;
++    const bool previous_buffer_0_valid = data.input_buffer_0_valid != 0;
++    const bool previous_buffer_1_valid = data.input_buffer_1_valid != 0;
++    const uint8_t previous_remaining_subframes =
++        current_frame_remaining_subframes_;
++
+     Decode(&data);
+     Consume(&output_rb, &data);
+ 
++    const uint8_t current_output_write_offset =
++        static_cast<uint8_t>(output_rb.write_offset() / kOutputBytesPerBlock);
++    const bool made_progress =
++        data.input_buffer_read_offset != previous_input_offset ||
++        current_output_write_offset != previous_output_write_offset ||
++        current_frame_remaining_subframes_ != previous_remaining_subframes ||
++        data.current_buffer != previous_current_buffer ||
++        (data.input_buffer_0_valid != 0) != previous_buffer_0_valid ||
++        (data.input_buffer_1_valid != 0) != previous_buffer_1_valid;
++    if (made_progress) {
++      NoteProgress(data, output_rb, previous_input_offset);
++    } else {
++      NoteNoProgressStall(data);
++      break;
++    }
++
+     if (!data.IsAnyInputBufferValid() || data.error_status == 4) {
+       break;
+     }
+@@ -249,11 +324,13 @@ void XmaContext::ResetDecoderState() {
+   loop_start_skip_pending_ = false;
+   packet_warning_mask_ = 0;
+   payload_warning_mask_ = 0;
++  ResetStallMetrics();
+ }
+ 
+ void XmaContext::Disable() {
+   std::lock_guard<std::mutex> lock(lock_);
+   set_is_enabled(false);
++  ResetStallMetrics();
+ }
+ 
+ void XmaContext::Release() {
+@@ -266,6 +343,85 @@ void XmaContext::Release() {
+   std::memset(context_ptr, 0, sizeof(XMA_CONTEXT_DATA));
+ }
+ 
++void XmaContext::NoteNoSpaceStall(
++    const XMA_CONTEXT_DATA& data,
++    int32_t minimum_subframe_decode_count) {
++  PROFILE_XMA_NO_SPACE_STALL();
++  if (!stall_tracker_.NoteNoSpaceStall()) {
++    return;
++  }
++  const auto& metrics = stall_tracker_.metrics();
++  REXAPU_WARN(
++      "XmaContext {}: output-space stall x{} (total {}): need {} blocks, "
++      "have {}, buffer {}, input {}, output {}/{}, sdc {}, padding {}, "
++      "relaxed {}, last progress input {} output {}/{}",
++      id(), metrics.consecutive_no_space_stalls,
++      metrics.total_no_space_stalls, minimum_subframe_decode_count,
++      remaining_subframe_blocks_in_output_buffer_, data.current_buffer,
++      data.input_buffer_read_offset, data.output_buffer_read_offset,
++      data.output_buffer_write_offset, data.subframe_decode_count,
++      data.output_buffer_padding,
++      REXCVAR_GET(xma_relaxed_padding_admission) ? 1 : 0,
++      metrics.last_progress_input_offset,
++      metrics.last_progress_output_read_offset,
++      metrics.last_progress_output_write_offset);
++}
++
++void XmaContext::NoteNoProgressStall(const XMA_CONTEXT_DATA& data) {
++  PROFILE_XMA_NO_PROGRESS_STALL();
++  if (!stall_tracker_.NoteNoProgressStall()) {
++    return;
++  }
++  const auto& metrics = stall_tracker_.metrics();
++  REXAPU_WARN(
++      "XmaContext {}: no-progress stall x{} (total {}): buffer {}, input {}, "
++      "output {}/{}, error {}, last progress input {} output {}/{}",
++      id(), metrics.consecutive_no_progress_stalls,
++      metrics.total_no_progress_stalls, data.current_buffer,
++      data.input_buffer_read_offset, data.output_buffer_read_offset,
++      data.output_buffer_write_offset, data.error_status,
++      metrics.last_progress_input_offset,
++      metrics.last_progress_output_read_offset,
++      metrics.last_progress_output_write_offset);
++}
++
++void XmaContext::NoteProgress(const XMA_CONTEXT_DATA& data,
++                              const memory::RingBuffer& output_rb,
++                              uint32_t previous_input_offset) {
++  const auto previous = stall_tracker_.metrics();
++  const uint8_t output_write_offset =
++      static_cast<uint8_t>(output_rb.write_offset() / kOutputBytesPerBlock);
++  if (!stall_tracker_.NoteProgress(data.input_buffer_read_offset,
++                                   data.output_buffer_read_offset,
++                                   output_write_offset)) {
++    return;
++  }
++  PROFILE_XMA_STALL_RECOVERY();
++  REXAPU_WARN(
++      "XmaContext {}: recovered after stalls (no-space {}, no-progress {}): "
++      "buffer {}, input {} -> {}, output {}/{}",
++      id(), previous.consecutive_no_space_stalls,
++      previous.consecutive_no_progress_stalls, data.current_buffer,
++      previous_input_offset, data.input_buffer_read_offset,
++      data.output_buffer_read_offset, output_write_offset);
++}
++
++void XmaContext::ResetStallMetrics() {
++  stall_tracker_.Reset(kBitsPerPacketHeader);
++}
++
++uint8_t XmaContext::GetOutputPaddingHeadroom(
++    uint8_t requested_padding, int32_t remaining_after_write) {
++  if (!REXCVAR_GET(xma_relaxed_padding_admission)) {
++    return requested_padding;
++  }
++  if (remaining_after_write <= 0) {
++    return 0;
++  }
++  return static_cast<uint8_t>(std::min<int32_t>(requested_padding,
++                                                remaining_after_write));
++}
++
+ void XmaContext::SwapInputBuffer(XMA_CONTEXT_DATA* data) {
+   if (data->current_buffer == 0) {
+     data->input_buffer_0_valid = 0;
+@@ -615,7 +771,10 @@ void XmaContext::Consume(memory::RingBuffer* output_rb, const XMA_CONTEXT_DATA*
+                                     << data->is_stereo;
+     const uint8_t consumed = total_subframes - current_frame_remaining_subframes_;
+     if (consumed >= loop_frame_output_limit_) {
+-      remaining_subframe_blocks_in_output_buffer_ -= data->output_buffer_padding;
++      remaining_subframe_blocks_in_output_buffer_ -=
++          GetOutputPaddingHeadroom(
++              static_cast<uint8_t>(data->output_buffer_padding),
++              remaining_subframe_blocks_in_output_buffer_);
+       current_frame_remaining_subframes_ = 0;
+       loop_frame_output_limit_ = 0;
+       return;
+@@ -643,9 +802,13 @@ void XmaContext::Consume(memory::RingBuffer* output_rb, const XMA_CONTEXT_DATA*
+   output_rb->Write(raw_frame_.data() + (kOutputBytesPerBlock * raw_frame_read_offset),
+                    subframes_to_write * kOutputBytesPerBlock);
+ 
+-  const int8_t headroom = (current_frame_remaining_subframes_ - subframes_to_write == 0)
+-                              ? data->output_buffer_padding
+-                              : 0;
++  const int8_t headroom =
++      (current_frame_remaining_subframes_ - subframes_to_write == 0)
++          ? static_cast<int8_t>(GetOutputPaddingHeadroom(
++                static_cast<uint8_t>(data->output_buffer_padding),
++                remaining_subframe_blocks_in_output_buffer_ -
++                    subframes_to_write))
++          : 0;
+ 
+   remaining_subframe_blocks_in_output_buffer_ -= subframes_to_write + headroom;
+   current_frame_remaining_subframes_ -= subframes_to_write;
+@@ -657,6 +820,11 @@ int XmaContext::PrepareDecoder(int sample_rate, bool is_two_channel) {
+   uint32_t channels = is_two_channel ? 2 : 1;
+   if (av_context_->sample_rate != sample_rate ||
+       av_context_->channels != static_cast<int>(channels)) {
++    const bool is_stream_reinitialization =
++        av_context_->sample_rate != 0 || av_context_->channels != 0;
++    if (is_stream_reinitialization) {
++      ResetStallMetrics();
++    }
+     REXAPU_NOISY_DEBUG("XmaContext {}: Codec reinit: rate {} -> {}, channels {} -> {}", id(),
+                        av_context_->sample_rate, sample_rate, av_context_->channels, channels);
+     avcodec_free_context(&av_context_);
+diff --git a/src/core/perf/counter.cpp b/src/core/perf/counter.cpp
+index 7bbe847..fc7c7b7 100644
+--- a/src/core/perf/counter.cpp
++++ b/src/core/perf/counter.cpp
+@@ -38,6 +38,9 @@ constexpr const char* kCounterNames[] = {
+     "command_buffer_stalls",
+     "vertices_processed",
+     "xma_frames_decoded",
++    "xma_no_space_stalls",
++    "xma_no_progress_stalls",
++    "xma_stall_recoveries",
+     "audio_frame_latency_us",
+     "buffer_queue_depth",
+     "functions_dispatched",
+@@ -66,6 +69,9 @@ constexpr bool kIsGauge[] = {
+     false,  // kCommandBufferStalls
+     false,  // kVerticesProcessed
+     false,  // kXmaFramesDecoded
++    false,  // kXmaNoSpaceStalls
++    false,  // kXmaNoProgressStalls
++    false,  // kXmaStallRecoveries
+     false,  // kAudioFrameLatencyUs
+     false,  // kBufferQueueDepth  (set each frame)
+     false,  // kFunctionsDispatched
+diff --git a/tests/unit/audio/xma_packet_test.cpp b/tests/unit/audio/xma_packet_test.cpp
+deleted file mode 100644
+index a9db54d..0000000
+--- a/tests/unit/audio/xma_packet_test.cpp
++++ /dev/null
+@@ -1,461 +0,0 @@
+-/**
+- * @file        xma_packet_test.cpp
+- * @brief       XMA cross-buffer packet traversal regression tests
+- * @copyright   Copyright (c) 2026 Tom Clay
+- * @license     BSD 3-Clause License
+- */
+-
+-#include <algorithm>
+-#include <array>
+-#include <cstring>
+-
+-#include <catch2/catch_test_macros.hpp>
+-
+-#include <rex/audio/xma/context.h>
+-#include <rex/system/xmemory.h>
+-
+-#include "test_memory.h"
+-
+-namespace {
+-
+-using rex::audio::ResolvePacket;
+-using rex::audio::XMA_CONTEXT_DATA;
+-using rex::audio::XmaContext;
+-using rex::audio::XmaPacketStatus;
+-using rex::audio::XmaPayloadStatus;
+-
+-std::array<uint8_t, sizeof(XMA_CONTEXT_DATA)> EmptyGuestContext() {
+-  return {};
+-}
+-
+-XMA_CONTEXT_DATA MakeTwoBufferContext(uint32_t current_buffer = 0) {
+-  auto raw = EmptyGuestContext();
+-  XMA_CONTEXT_DATA data(raw.data());
+-  data.current_buffer = current_buffer;
+-  data.input_buffer_0_valid = 1;
+-  data.input_buffer_1_valid = 1;
+-  data.input_buffer_0_ptr = 0x10000;
+-  data.input_buffer_1_ptr = 0x20000;
+-  data.input_buffer_0_packet_count = 3;
+-  data.input_buffer_1_packet_count = 4;
+-  return data;
+-}
+-
+-void SetPacketHeader(uint8_t* packet, uint8_t frame_count,
+-                     uint32_t first_frame_offset, uint8_t skip_count) {
+-  const uint32_t encoded_offset =
+-      first_frame_offset - XmaContext::kBitsPerPacketHeader;
+-  packet[0] = static_cast<uint8_t>((frame_count << 2) |
+-                                   ((encoded_offset >> 13) & 0x3));
+-  packet[1] = static_cast<uint8_t>(encoded_offset >> 5);
+-  packet[2] = static_cast<uint8_t>((encoded_offset << 3) | 1);
+-  packet[3] = skip_count;
+-}
+-
+-void WriteCrossBufferPayloadBits(uint8_t* current, uint8_t* alternate,
+-                                 uint32_t first_payload_bit, uint32_t value,
+-                                 uint32_t bit_count) {
+-  for (uint32_t i = 0; i < bit_count; ++i) {
+-    const uint32_t assembled_bit = first_payload_bit + i;
+-    const uint32_t logical_packet =
+-        assembled_bit / XmaContext::kBitsPerPacketData;
+-    const uint32_t packet_bit =
+-        assembled_bit % XmaContext::kBitsPerPacketData;
+-    uint8_t* packet =
+-        logical_packet == 0
+-            ? current
+-            : alternate +
+-                  (logical_packet - 1) * XmaContext::kBytesPerPacket;
+-    uint8_t& byte =
+-        packet[XmaContext::kBytesPerPacketHeader + packet_bit / 8];
+-    const uint8_t mask = static_cast<uint8_t>(1u << (7 - packet_bit % 8));
+-    if (value & (1u << (bit_count - i - 1))) {
+-      byte |= mask;
+-    } else {
+-      byte &= static_cast<uint8_t>(~mask);
+-    }
+-  }
+-}
+-
+-}  // namespace
+-
+-TEST_CASE("XMA packet resolution preserves cross-buffer packet indices", "[audio][xma]") {
+-  XMA_CONTEXT_DATA data = MakeTwoBufferContext();
+-
+-  SECTION("current buffer packet zero") {
+-    const auto packet = ResolvePacket(data, 0, 0, 3);
+-    CHECK(packet.valid());
+-    CHECK(packet.buffer_index == 0);
+-    CHECK(packet.packet_index == 0);
+-  }
+-
+-  SECTION("current buffer last packet") {
+-    const auto packet = ResolvePacket(data, 0, 2, 3);
+-    CHECK(packet.valid());
+-    CHECK(packet.buffer_index == 0);
+-    CHECK(packet.packet_index == 2);
+-  }
+-
+-  SECTION("alternate buffer packet zero") {
+-    const auto packet = ResolvePacket(data, 0, 3, 3);
+-    CHECK(packet.valid());
+-    CHECK(packet.buffer_index == 1);
+-    CHECK(packet.packet_index == 0);
+-  }
+-
+-  SECTION("alternate buffer packet one and beyond") {
+-    const auto packet = ResolvePacket(data, 0, 5, 3);
+-    CHECK(packet.valid());
+-    CHECK(packet.buffer_index == 1);
+-    CHECK(packet.packet_index == 2);
+-  }
+-
+-  SECTION("starting from buffer one") {
+-    const auto packet = ResolvePacket(data, 1, 5, 4);
+-    CHECK(packet.valid());
+-    CHECK(packet.buffer_index == 0);
+-    CHECK(packet.packet_index == 1);
+-  }
+-}
+-
+-TEST_CASE("XMA packet resolution rejects unavailable guest packets", "[audio][xma]") {
+-  XMA_CONTEXT_DATA data = MakeTwoBufferContext();
+-
+-  SECTION("alternate buffer invalid") {
+-    data.input_buffer_1_valid = 0;
+-    CHECK(ResolvePacket(data, 0, 3, 3).status == XmaPacketStatus::kBufferInvalid);
+-  }
+-
+-  SECTION("alternate buffer has null address") {
+-    data.input_buffer_1_ptr = 0;
+-    CHECK(ResolvePacket(data, 0, 3, 3).status == XmaPacketStatus::kNullAddress);
+-  }
+-
+-  SECTION("alternate buffer is shorter than the requested packet") {
+-    data.input_buffer_1_packet_count = 1;
+-    const auto packet = ResolvePacket(data, 0, 4, 3);
+-    CHECK(packet.status == XmaPacketStatus::kPacketOutOfRange);
+-    CHECK(packet.buffer_index == 1);
+-    CHECK(packet.packet_index == 1);
+-  }
+-
+-  SECTION("caller packet count disagrees with context") {
+-    CHECK(ResolvePacket(data, 0, 0, 2).status == XmaPacketStatus::kInvalidContext);
+-  }
+-}
+-
+-TEST_CASE("XMA payload assembly spans up to four packets", "[audio][xma]") {
+-  auto& memory = rex::testing::GetTestMemory();
+-  auto* virtual_heap = const_cast<rex::memory::BaseHeap*>(memory.LookupHeap(0x10000000));
+-  auto* physical_heap = const_cast<rex::memory::BaseHeap*>(memory.LookupHeap(0xA0000000));
+-  REQUIRE(virtual_heap != nullptr);
+-  REQUIRE(physical_heap != nullptr);
+-
+-  constexpr uint32_t kReadWrite =
+-      rex::memory::kMemoryProtectRead | rex::memory::kMemoryProtectWrite;
+-  constexpr uint32_t kReserveCommit =
+-      rex::memory::kMemoryAllocationReserve | rex::memory::kMemoryAllocationCommit;
+-  uint32_t context_address = 0;
+-  uint32_t current_address = 0;
+-  uint32_t alternate_address = 0;
+-  uint32_t output_address = 0;
+-  REQUIRE(virtual_heap->Alloc(4096, 4096, kReserveCommit, kReadWrite, false, &context_address));
+-  REQUIRE(physical_heap->Alloc(4096, 4096, kReserveCommit, kReadWrite, false, &current_address));
+-  REQUIRE(physical_heap->Alloc(8192, 4096, kReserveCommit, kReadWrite, false, &alternate_address));
+-  REQUIRE(physical_heap->Alloc(4096, 4096, kReserveCommit, kReadWrite, false, &output_address));
+-
+-  uint8_t* current = memory.TranslatePhysical(current_address);
+-  uint8_t* alternate = memory.TranslatePhysical(alternate_address);
+-  std::memset(current, 0, 4096);
+-  std::memset(alternate, 0, 8192);
+-  std::memset(current + XmaContext::kBytesPerPacketHeader, 0x11, XmaContext::kBytesPerPacketData);
+-  for (uint32_t packet = 0; packet < 3; ++packet) {
+-    std::memset(
+-        alternate + packet * XmaContext::kBytesPerPacket + XmaContext::kBytesPerPacketHeader,
+-        0x22 + packet, XmaContext::kBytesPerPacketData);
+-  }
+-
+-  auto* context_ptr = memory.TranslateVirtual(context_address);
+-  std::memset(context_ptr, 0, sizeof(XMA_CONTEXT_DATA));
+-  XMA_CONTEXT_DATA data(context_ptr);
+-  data.current_buffer = 0;
+-  data.input_buffer_0_valid = 1;
+-  data.input_buffer_1_valid = 1;
+-  data.input_buffer_0_ptr = current_address;
+-  data.input_buffer_1_ptr = alternate_address;
+-  data.input_buffer_0_packet_count = 1;
+-  data.input_buffer_1_packet_count = 3;
+-
+-  XmaContext context;
+-  REQUIRE(context.Setup(2, &memory, context_address) == 0);
+-  context.set_is_allocated(true);
+-  std::array<uint8_t, XmaContext::kBytesPerPacketData * XmaContext::kMaxAssembledPackets> assembled;
+-
+-  SECTION("one packet") {
+-    const auto result =
+-        context.AssemblePacketPayloads(&data, 0, 1, XmaContext::kBitsPerPacketHeader, 8, assembled);
+-    CHECK(result.valid());
+-    CHECK(result.packet_count == 1);
+-    CHECK(result.valid_bits == XmaContext::kBitsPerPacketData);
+-    CHECK(assembled.front() == 0x11);
+-    CHECK(assembled[XmaContext::kBytesPerPacketData] == 0);
+-  }
+-
+-  SECTION("two packets with a split header") {
+-    const auto result = context.AssemblePacketPayloads(&data, 0, 1, XmaContext::kBitsPerPacket - 7,
+-                                                       XmaContext::kBitsPerFrameHeader, assembled);
+-    CHECK(result.valid());
+-    CHECK(result.packet_count == 2);
+-    CHECK(assembled.front() == 0x11);
+-    CHECK(assembled[XmaContext::kBytesPerPacketData] == 0x22);
+-  }
+-
+-  SECTION("three packets from a late frame start") {
+-    const auto result =
+-        context.AssemblePacketPayloads(&data, 0, 1, XmaContext::kBitsPerPacket - 7,
+-                                       XmaContext::kBitsPerPacketData + 16, assembled);
+-    CHECK(result.valid());
+-    CHECK(result.packet_count == 3);
+-    CHECK(assembled[XmaContext::kBytesPerPacketData] == 0x22);
+-    CHECK(assembled[XmaContext::kBytesPerPacketData * 2] == 0x23);
+-  }
+-
+-  SECTION("four packets cross alternate packet zero and later packets") {
+-    const auto result = context.AssemblePacketPayloads(&data, 0, 1, XmaContext::kBitsPerPacket - 1,
+-                                                       0x7FFE, assembled);
+-    CHECK(result.valid());
+-    CHECK(result.packet_count == 4);
+-    CHECK(assembled.front() == 0x11);
+-    CHECK(assembled[XmaContext::kBytesPerPacketData] == 0x22);
+-    CHECK(assembled[XmaContext::kBytesPerPacketData * 2] == 0x23);
+-    CHECK(assembled[XmaContext::kBytesPerPacketData * 3] == 0x24);
+-  }
+-
+-  SECTION("missing continuation buffer is rejected and zero-filled") {
+-    data.input_buffer_1_valid = 0;
+-    assembled.fill(0xAA);
+-    const auto result =
+-        context.AssemblePacketPayloads(&data, 0, 1, XmaContext::kBitsPerPacket - 7, 16, assembled);
+-    CHECK(result.status == XmaPayloadStatus::kPacketUnavailable);
+-    CHECK(result.failed_packet.status == XmaPacketStatus::kBufferInvalid);
+-    CHECK(
+-        std::all_of(assembled.begin(), assembled.end(), [](uint8_t value) { return value == 0; }));
+-  }
+-
+-  SECTION("short alternate buffer is rejected") {
+-    data.input_buffer_1_packet_count = 1;
+-    const auto result =
+-        context.AssemblePacketPayloads(&data, 0, 1, XmaContext::kBitsPerPacket - 7,
+-                                       XmaContext::kBitsPerPacketData + 16, assembled);
+-    CHECK(result.status == XmaPayloadStatus::kPacketUnavailable);
+-    CHECK(result.failed_packet.status == XmaPacketStatus::kPacketOutOfRange);
+-    CHECK(result.failed_packet.packet_index == 1);
+-  }
+-
+-  SECTION("requests beyond scratch capacity are rejected") {
+-    const auto result = context.AssemblePacketPayloads(
+-        &data, 0, 1, XmaContext::kBitsPerPacket - 1, XmaContext::kBitsPerPacketData * 4, assembled);
+-    CHECK(result.status == XmaPayloadStatus::kCapacityExceeded);
+-    CHECK(result.packet_count == 5);
+-  }
+-
+-  SECTION("zero length and invalid offsets are rejected") {
+-    CHECK(
+-        context.AssemblePacketPayloads(&data, 0, 1, XmaContext::kBitsPerPacketHeader, 0, assembled)
+-            .status == XmaPayloadStatus::kZeroLength);
+-    CHECK(context.AssemblePacketPayloads(&data, 0, 1, 31, 8, assembled).status ==
+-          XmaPayloadStatus::kInvalidFrameOffset);
+-    CHECK(context.AssemblePacketPayloads(&data, 0, 1, XmaContext::kBitsPerPacket, 8, assembled)
+-              .status == XmaPayloadStatus::kInvalidFrameOffset);
+-  }
+-
+-  SECTION("synthetic three-packet frame decodes and advances") {
+-    constexpr uint32_t kFrameOffset = XmaContext::kBitsPerPacket - 7;
+-    constexpr uint32_t kFrameSize = XmaContext::kBitsPerPacketData + 16;
+-    SetPacketHeader(current, 1, kFrameOffset, 2);
+-    SetPacketHeader(alternate + XmaContext::kBytesPerPacket * 2, 1,
+-                    XmaContext::kBitsPerPacketHeader, 0xFF);
+-    SetPacketHeader(alternate + XmaContext::kBytesPerPacket * 3, 1,
+-                    XmaContext::kBitsPerPacketHeader, 0xFF);
+-    WriteCrossBufferPayloadBits(
+-        current, alternate,
+-        kFrameOffset - XmaContext::kBitsPerPacketHeader, kFrameSize,
+-        XmaContext::kBitsPerFrameHeader);
+-
+-    data.input_buffer_1_packet_count = 4;
+-    data.input_buffer_read_offset = kFrameOffset;
+-    data.output_buffer_valid = 1;
+-    data.output_buffer_ptr = output_address;
+-    data.output_buffer_block_count = 4;
+-    data.output_buffer_write_offset = 1;
+-    data.subframe_decode_count = 1;
+-    data.Store(context_ptr);
+-
+-    context.Enable();
+-    CHECK(context.Work());
+-    XMA_CONTEXT_DATA advanced(context_ptr);
+-    CHECK(advanced.error_status == 0);
+-    CHECK_FALSE(advanced.IsAnyInputBufferValid());
+-    CHECK(advanced.current_buffer == 0);
+-    CHECK(advanced.input_buffer_read_offset ==
+-          XmaContext::kBitsPerPacketHeader);
+-  }
+-
+-  SECTION("synthetic four-packet frame decodes and advances") {
+-    constexpr uint32_t kFrameOffset = XmaContext::kBitsPerPacket - 1;
+-    constexpr uint32_t kFrameSize = 0x7FFE;
+-    SetPacketHeader(current, 1, kFrameOffset, 3);
+-    SetPacketHeader(alternate + XmaContext::kBytesPerPacket * 3, 1,
+-                    XmaContext::kBitsPerPacketHeader, 0xFF);
+-    WriteCrossBufferPayloadBits(
+-        current, alternate,
+-        kFrameOffset - XmaContext::kBitsPerPacketHeader, kFrameSize,
+-        XmaContext::kBitsPerFrameHeader);
+-
+-    data.input_buffer_1_packet_count = 4;
+-    data.input_buffer_read_offset = kFrameOffset;
+-    data.output_buffer_valid = 1;
+-    data.output_buffer_ptr = output_address;
+-    data.output_buffer_block_count = 4;
+-    data.output_buffer_write_offset = 1;
+-    data.subframe_decode_count = 1;
+-    data.Store(context_ptr);
+-
+-    context.Enable();
+-    CHECK(context.Work());
+-    XMA_CONTEXT_DATA advanced(context_ptr);
+-    CHECK(advanced.error_status == 0);
+-    CHECK_FALSE(advanced.IsAnyInputBufferValid());
+-    CHECK(advanced.current_buffer == 0);
+-    CHECK(advanced.input_buffer_read_offset ==
+-          XmaContext::kBitsPerPacketHeader);
+-  }
+-
+-  context.Release();
+-  physical_heap->Release(output_address, nullptr);
+-  physical_heap->Release(alternate_address, nullptr);
+-  physical_heap->Release(current_address, nullptr);
+-  virtual_heap->Release(context_address, nullptr);
+-}
+-
+-TEST_CASE("XMA frame size rejects zero and the sentinel", "[audio][xma]") {
+-  CHECK_FALSE(XmaContext::IsValidFrameSize(0));
+-  CHECK(XmaContext::IsValidFrameSize(1));
+-  CHECK(XmaContext::IsValidFrameSize(0x7FFE));
+-  CHECK_FALSE(XmaContext::IsValidFrameSize(0x7FFF));
+-}
+-
+-TEST_CASE("XMA exhausted input retires to a clean idle state", "[audio][xma]") {
+-  auto& memory = rex::testing::GetTestMemory();
+-  auto* heap = const_cast<rex::memory::BaseHeap*>(memory.LookupHeap(0x10000000));
+-  REQUIRE(heap != nullptr);
+-
+-  uint32_t context_address = 0;
+-  REQUIRE(heap->Alloc(
+-      4096, 4096, rex::memory::kMemoryAllocationReserve | rex::memory::kMemoryAllocationCommit,
+-      rex::memory::kMemoryProtectRead | rex::memory::kMemoryProtectWrite, false, &context_address));
+-
+-  auto* context_ptr = memory.TranslateVirtual(context_address);
+-  std::memset(context_ptr, 0, sizeof(XMA_CONTEXT_DATA));
+-  XMA_CONTEXT_DATA data(context_ptr);
+-  data.input_buffer_0_valid = 1;
+-  data.input_buffer_0_ptr = 0x10000;
+-  data.input_buffer_0_packet_count = 1;
+-  data.input_buffer_read_offset = XmaContext::kBitsPerPacket;
+-  data.output_buffer_valid = 1;
+-  data.output_buffer_ptr = 0x30000;
+-  data.output_buffer_block_count = 4;
+-  data.output_buffer_write_offset = 1;
+-  data.subframe_decode_count = 1;
+-  data.Store(context_ptr);
+-
+-  XmaContext context;
+-  REQUIRE(context.Setup(0, &memory, context_address) == 0);
+-  context.set_is_allocated(true);
+-  context.Enable();
+-  CHECK(context.Work());
+-
+-  XMA_CONTEXT_DATA retired(context_ptr);
+-  CHECK_FALSE(retired.input_buffer_0_valid);
+-  CHECK_FALSE(retired.input_buffer_1_valid);
+-  CHECK(retired.current_buffer == 1);
+-  CHECK(retired.input_buffer_read_offset == XmaContext::kBitsPerPacketHeader);
+-
+-  // Re-entry remains idle and leaves the retired state unchanged.
+-  context.Enable();
+-  CHECK(context.Work());
+-  XMA_CONTEXT_DATA idle(context_ptr);
+-  CHECK_FALSE(idle.IsAnyInputBufferValid());
+-  CHECK(idle.input_buffer_read_offset == XmaContext::kBitsPerPacketHeader);
+-
+-  context.Release();
+-  heap->Release(context_address, nullptr);
+-}
+-
+-TEST_CASE("XMA full-packet skip crosses to an alternate packet beyond zero", "[audio][xma]") {
+-  auto& memory = rex::testing::GetTestMemory();
+-  auto* virtual_heap = const_cast<rex::memory::BaseHeap*>(memory.LookupHeap(0x10000000));
+-  auto* physical_heap = const_cast<rex::memory::BaseHeap*>(memory.LookupHeap(0xA0000000));
+-  REQUIRE(virtual_heap != nullptr);
+-  REQUIRE(physical_heap != nullptr);
+-
+-  constexpr uint32_t kReadWrite =
+-      rex::memory::kMemoryProtectRead | rex::memory::kMemoryProtectWrite;
+-  constexpr uint32_t kReserveCommit =
+-      rex::memory::kMemoryAllocationReserve | rex::memory::kMemoryAllocationCommit;
+-  uint32_t context_address = 0;
+-  uint32_t current_address = 0;
+-  uint32_t alternate_address = 0;
+-  uint32_t output_address = 0;
+-  REQUIRE(virtual_heap->Alloc(4096, 4096, kReserveCommit, kReadWrite, false, &context_address));
+-  REQUIRE(physical_heap->Alloc(4096, 4096, kReserveCommit, kReadWrite, false, &current_address));
+-  REQUIRE(physical_heap->Alloc(4096, 4096, kReserveCommit, kReadWrite, false, &alternate_address));
+-  REQUIRE(physical_heap->Alloc(4096, 4096, kReserveCommit, kReadWrite, false, &output_address));
+-
+-  uint8_t* current = memory.TranslatePhysical(current_address);
+-  uint8_t* alternate = memory.TranslatePhysical(alternate_address);
+-  std::memset(current, 0, XmaContext::kBytesPerPacket);
+-  std::memset(alternate, 0, XmaContext::kBytesPerPacket * 2);
+-  current[3] = 0xFF;
+-
+-  // Packet 0 has an invalid first-frame offset, forcing the scan to packet 1.
+-  alternate[0] = 0x03;
+-  alternate[1] = 0xFF;
+-  alternate[2] = 0xF8;
+-  alternate[XmaContext::kBytesPerPacket + 3] = 0xFF;
+-
+-  auto* context_ptr = memory.TranslateVirtual(context_address);
+-  std::memset(context_ptr, 0, sizeof(XMA_CONTEXT_DATA));
+-  XMA_CONTEXT_DATA data(context_ptr);
+-  data.input_buffer_0_valid = 1;
+-  data.input_buffer_1_valid = 1;
+-  data.input_buffer_0_ptr = current_address;
+-  data.input_buffer_1_ptr = alternate_address;
+-  data.input_buffer_0_packet_count = 1;
+-  data.input_buffer_1_packet_count = 2;
+-  data.input_buffer_read_offset = XmaContext::kBitsPerPacketHeader;
+-  data.output_buffer_valid = 1;
+-  data.output_buffer_ptr = output_address;
+-  data.output_buffer_block_count = 4;
+-  data.output_buffer_write_offset = 1;
+-  data.subframe_decode_count = 1;
+-  data.Store(context_ptr);
+-
+-  XmaContext context;
+-  REQUIRE(context.Setup(1, &memory, context_address) == 0);
+-  context.set_is_allocated(true);
+-  context.Enable();
+-  CHECK(context.Work());
+-
+-  XMA_CONTEXT_DATA retired(context_ptr);
+-  CHECK_FALSE(retired.IsAnyInputBufferValid());
+-  CHECK(retired.current_buffer == 0);
+-  CHECK(retired.input_buffer_read_offset == XmaContext::kBitsPerPacketHeader);
+-  CHECK(retired.error_status == 0);
+-
+-  context.Release();
+-  physical_heap->Release(output_address, nullptr);
+-  physical_heap->Release(alternate_address, nullptr);
+-  physical_heap->Release(current_address, nullptr);
+-  virtual_heap->Release(context_address, nullptr);
+-}

--- a/patches/rexglue/0038-m4-xma-stall-diagnostics.patch
+++ b/patches/rexglue/0038-m4-xma-stall-diagnostics.patch
@@ -1,8 +1,8 @@
 diff --git a/include/rex/audio/xma/context.h b/include/rex/audio/xma/context.h
-index 4861e40..3ed2da2 100644
+index 4861e40..221cd6a 100644
 --- a/include/rex/audio/xma/context.h
 +++ b/include/rex/audio/xma/context.h
-@@ -205,6 +205,36 @@ struct AssembledXmaPayload {
+@@ -205,6 +205,56 @@ struct AssembledXmaPayload {
    bool valid() const { return status == XmaPayloadStatus::kValid; }
  };
  
@@ -17,56 +17,71 @@ index 4861e40..3ed2da2 100644
 +  uint8_t last_progress_output_write_offset = 0;
 +};
 +
++struct XmaNoSpaceObservation {
++  uint32_t input_offset = 0;
++  int32_t remaining_blocks = 0;
++  int32_t required_blocks = 0;
++  uint8_t current_buffer = 0;
++  uint8_t output_read_offset = 0;
++  uint8_t output_write_offset = 0;
++  bool input_buffer_0_valid = false;
++  bool input_buffer_1_valid = false;
++
++  bool Matches(const XmaNoSpaceObservation& other) const;
++};
++
++struct XmaNoSpaceObservationResult {
++  bool repeated = false;
++  bool log_recovery = false;
++};
++
 +// State-only helper so the bounded reporting cadence and recovery semantics
 +// can be tested without an FFmpeg decoder or guest-memory fixture.
 +class XmaStallTracker {
 + public:
 +  static bool ShouldLogSummary(uint64_t total_count);
 +
++  XmaNoSpaceObservationResult ObserveNoSpace(const XmaNoSpaceObservation& observation);
 +  bool NoteNoSpaceStall();
 +  bool NoteNoProgressStall();
-+  bool NoteProgress(uint32_t input_offset, uint8_t output_read_offset,
-+                    uint8_t output_write_offset);
++  bool NoteProgress(uint32_t input_offset, uint8_t output_read_offset, uint8_t output_write_offset);
 +  void Reset(uint32_t initial_input_offset);
 +
 +  const XmaStallMetrics& metrics() const { return metrics_; }
 +
 + private:
 +  XmaStallMetrics metrics_;
++  XmaNoSpaceObservation no_space_observation_;
++  bool has_no_space_observation_ = false;
 +  bool recovery_log_pending_ = false;
 +};
 +
  // Resolves a logical packet number relative to starting_buffer_index. Packet
  // numbers at or beyond current_buffer_packet_count continue in the alternate
  // guest buffer without losing their index within that buffer.
-@@ -257,6 +287,10 @@ class XmaContext {
+@@ -257,6 +307,8 @@ class XmaContext {
                                               std::span<uint8_t> destination);
    static bool IsValidFrameSize(uint32_t frame_size);
  
-+  const XmaStallMetrics& stall_metrics() const {
-+    return stall_tracker_.metrics();
-+  }
++  const XmaStallMetrics& stall_metrics() const { return stall_tracker_.metrics(); }
 +
    void Enable();
    bool Block(bool poll);
    void Clear();
-@@ -306,6 +340,15 @@ class XmaContext {
+@@ -306,6 +358,12 @@ class XmaContext {
    void WarnPacketResolution(const XmaPacketHandle& packet_handle, uint32_t logical_packet_index);
    void WarnPayloadAssembly(const AssembledXmaPayload& payload, uint32_t first_logical_packet,
                             uint32_t frame_offset_in_packet, uint32_t bits_required);
-+  void NoteNoSpaceStall(const XMA_CONTEXT_DATA& data,
-+                        int32_t minimum_subframe_decode_count);
++  void NoteNoSpaceStall(const XMA_CONTEXT_DATA& data, int32_t minimum_subframe_decode_count);
 +  void NoteNoProgressStall(const XMA_CONTEXT_DATA& data);
-+  void NoteProgress(const XMA_CONTEXT_DATA& data,
-+                    const memory::RingBuffer& output_rb,
++  void NoteProgress(const XMA_CONTEXT_DATA& data, const memory::RingBuffer& output_rb,
 +                    uint32_t previous_input_offset);
 +  void ResetStallMetrics();
-+  static uint8_t GetOutputPaddingHeadroom(uint8_t requested_padding,
-+                                          int32_t remaining_after_write);
++  static uint8_t GetOutputPaddingHeadroom(uint8_t requested_padding, int32_t remaining_after_write);
  
    void Decode(XMA_CONTEXT_DATA* data);
    void Consume(memory::RingBuffer* output_rb, const XMA_CONTEXT_DATA* data);
-@@ -368,6 +411,7 @@ class XmaContext {
+@@ -368,6 +426,7 @@ class XmaContext {
    // context lifetime rather than once per Work() re-entry.
    uint32_t packet_warning_mask_ = 0;
    uint32_t payload_warning_mask_ = 0;
@@ -109,7 +124,7 @@ index 3541c18..5053a69 100644
  #define PROFILE_VERTICES(n)
  #define PROFILE_CMD_BUFFER_STALL()
 diff --git a/src/audio/xma_context.cpp b/src/audio/xma_context.cpp
-index e723215..26396f0 100644
+index e723215..7007c97 100644
 --- a/src/audio/xma_context.cpp
 +++ b/src/audio/xma_context.cpp
 @@ -15,9 +15,11 @@
@@ -135,13 +150,35 @@ index e723215..26396f0 100644
  // Credits for most of this code goes to:
  // https://github.com/koolkdev/libertyv/blob/master/libav_wrapper/xma2dec.c
  
-@@ -43,6 +49,52 @@ using stream::BitStream;
+@@ -43,6 +49,74 @@ using stream::BitStream;
  const uint32_t XmaContext::kBitsPerPacketHeader;
  const uint32_t XmaContext::kOutputMaxSizeBytes;
  
 +bool XmaStallTracker::ShouldLogSummary(uint64_t total_count) {
 +  return total_count == 1 || total_count == 8 || total_count == 64 ||
 +         (total_count >= 256 && total_count % 256 == 0);
++}
++
++bool XmaNoSpaceObservation::Matches(const XmaNoSpaceObservation& other) const {
++  return input_offset == other.input_offset && remaining_blocks == other.remaining_blocks &&
++         required_blocks == other.required_blocks && current_buffer == other.current_buffer &&
++         output_read_offset == other.output_read_offset &&
++         output_write_offset == other.output_write_offset &&
++         input_buffer_0_valid == other.input_buffer_0_valid &&
++         input_buffer_1_valid == other.input_buffer_1_valid;
++}
++
++XmaNoSpaceObservationResult XmaStallTracker::ObserveNoSpace(
++    const XmaNoSpaceObservation& observation) {
++  if (has_no_space_observation_ && no_space_observation_.Matches(observation)) {
++    return {.repeated = true, .log_recovery = false};
++  }
++
++  const bool log_recovery = NoteProgress(observation.input_offset, observation.output_read_offset,
++                                         observation.output_write_offset);
++  no_space_observation_ = observation;
++  has_no_space_observation_ = true;
++  return {.repeated = false, .log_recovery = log_recovery};
 +}
 +
 +bool XmaStallTracker::NoteNoSpaceStall() {
@@ -155,23 +192,22 @@ index e723215..26396f0 100644
 +bool XmaStallTracker::NoteNoProgressStall() {
 +  ++metrics_.consecutive_no_progress_stalls;
 +  ++metrics_.total_no_progress_stalls;
-+  const bool should_log =
-+      ShouldLogSummary(metrics_.total_no_progress_stalls);
++  const bool should_log = ShouldLogSummary(metrics_.total_no_progress_stalls);
 +  recovery_log_pending_ |= should_log;
 +  return should_log;
 +}
 +
-+bool XmaStallTracker::NoteProgress(uint32_t input_offset,
-+                                   uint8_t output_read_offset,
++bool XmaStallTracker::NoteProgress(uint32_t input_offset, uint8_t output_read_offset,
 +                                   uint8_t output_write_offset) {
-+  const bool recovered = metrics_.consecutive_no_space_stalls != 0 ||
-+                         metrics_.consecutive_no_progress_stalls != 0;
++  const bool recovered =
++      metrics_.consecutive_no_space_stalls != 0 || metrics_.consecutive_no_progress_stalls != 0;
 +  if (recovered) {
 +    ++metrics_.total_recoveries;
 +  }
 +  const bool should_log_recovery = recovered && recovery_log_pending_;
 +  metrics_.consecutive_no_space_stalls = 0;
 +  metrics_.consecutive_no_progress_stalls = 0;
++  has_no_space_observation_ = false;
 +  recovery_log_pending_ = false;
 +  metrics_.last_progress_input_offset = input_offset;
 +  metrics_.last_progress_output_read_offset = output_read_offset;
@@ -181,6 +217,7 @@ index e723215..26396f0 100644
 +
 +void XmaStallTracker::Reset(uint32_t initial_input_offset) {
 +  metrics_ = {};
++  has_no_space_observation_ = false;
 +  recovery_log_pending_ = false;
 +  metrics_.last_progress_input_offset = initial_input_offset;
 +}
@@ -188,26 +225,26 @@ index e723215..26396f0 100644
  XmaPacketHandle ResolvePacket(const XMA_CONTEXT_DATA& data, uint32_t starting_buffer_index,
                                uint32_t logical_packet_index, uint32_t current_buffer_packet_count) {
    XmaPacketHandle result;
-@@ -82,7 +134,9 @@ bool XmaContext::IsValidFrameSize(uint32_t frame_size) {
+@@ -81,8 +155,9 @@ bool XmaContext::IsValidFrameSize(uint32_t frame_size) {
+   return frame_size != 0 && frame_size != xma::kMaxFrameLength;
  }
  
- XmaContext::XmaContext()
+-XmaContext::XmaContext()
 -    : work_completion_event_(rex::thread::Event::CreateAutoResetEvent(false)) {}
-+    : work_completion_event_(rex::thread::Event::CreateAutoResetEvent(false)) {
++XmaContext::XmaContext() : work_completion_event_(rex::thread::Event::CreateAutoResetEvent(false)) {
 +  ResetStallMetrics();
 +}
  
  XmaContext::~XmaContext() {
    if (av_context_) {
-@@ -162,18 +216,46 @@ bool XmaContext::Work() {
+@@ -162,18 +237,43 @@ bool XmaContext::Work() {
    // Minimum free blocks needed before attempting a decode.
    // Use subframe_decode_count (clamped to 1) instead of full frame size.
    const uint32_t effective_sdc = std::max(static_cast<uint32_t>(1), data.subframe_decode_count);
 +  const bool relaxed_padding = REXCVAR_GET(xma_relaxed_padding_admission);
    const int32_t minimum_subframe_decode_count =
 -      static_cast<int32_t>(effective_sdc) + data.output_buffer_padding;
-+      static_cast<int32_t>(effective_sdc) +
-+      (relaxed_padding ? 0 : data.output_buffer_padding);
++      static_cast<int32_t>(effective_sdc) + (relaxed_padding ? 0 : data.output_buffer_padding);
  
    if (minimum_subframe_decode_count > remaining_subframe_blocks_in_output_buffer_) {
 +    NoteNoSpaceStall(data, minimum_subframe_decode_count);
@@ -222,21 +259,19 @@ index e723215..26396f0 100644
 +    const uint8_t previous_current_buffer = data.current_buffer;
 +    const bool previous_buffer_0_valid = data.input_buffer_0_valid != 0;
 +    const bool previous_buffer_1_valid = data.input_buffer_1_valid != 0;
-+    const uint8_t previous_remaining_subframes =
-+        current_frame_remaining_subframes_;
++    const uint8_t previous_remaining_subframes = current_frame_remaining_subframes_;
 +
      Decode(&data);
      Consume(&output_rb, &data);
  
 +    const uint8_t current_output_write_offset =
 +        static_cast<uint8_t>(output_rb.write_offset() / kOutputBytesPerBlock);
-+    const bool made_progress =
-+        data.input_buffer_read_offset != previous_input_offset ||
-+        current_output_write_offset != previous_output_write_offset ||
-+        current_frame_remaining_subframes_ != previous_remaining_subframes ||
-+        data.current_buffer != previous_current_buffer ||
-+        (data.input_buffer_0_valid != 0) != previous_buffer_0_valid ||
-+        (data.input_buffer_1_valid != 0) != previous_buffer_1_valid;
++    const bool made_progress = data.input_buffer_read_offset != previous_input_offset ||
++                               current_output_write_offset != previous_output_write_offset ||
++                               current_frame_remaining_subframes_ != previous_remaining_subframes ||
++                               data.current_buffer != previous_current_buffer ||
++                               (data.input_buffer_0_valid != 0) != previous_buffer_0_valid ||
++                               (data.input_buffer_1_valid != 0) != previous_buffer_1_valid;
 +    if (made_progress) {
 +      NoteProgress(data, output_rb, previous_input_offset);
 +    } else {
@@ -247,7 +282,7 @@ index e723215..26396f0 100644
      if (!data.IsAnyInputBufferValid() || data.error_status == 4) {
        break;
      }
-@@ -249,11 +331,13 @@ void XmaContext::ResetDecoderState() {
+@@ -249,11 +349,13 @@ void XmaContext::ResetDecoderState() {
    loop_start_skip_pending_ = false;
    packet_warning_mask_ = 0;
    payload_warning_mask_ = 0;
@@ -261,13 +296,37 @@ index e723215..26396f0 100644
  }
  
  void XmaContext::Release() {
-@@ -266,6 +350,85 @@ void XmaContext::Release() {
+@@ -266,6 +368,98 @@ void XmaContext::Release() {
    std::memset(context_ptr, 0, sizeof(XMA_CONTEXT_DATA));
  }
  
-+void XmaContext::NoteNoSpaceStall(
-+    const XMA_CONTEXT_DATA& data,
-+    int32_t minimum_subframe_decode_count) {
++void XmaContext::NoteNoSpaceStall(const XMA_CONTEXT_DATA& data,
++                                  int32_t minimum_subframe_decode_count) {
++  const auto previous = stall_tracker_.metrics();
++  const XmaNoSpaceObservation observation = {
++      .input_offset = data.input_buffer_read_offset,
++      .remaining_blocks = remaining_subframe_blocks_in_output_buffer_,
++      .required_blocks = minimum_subframe_decode_count,
++      .current_buffer = data.current_buffer,
++      .output_read_offset = data.output_buffer_read_offset,
++      .output_write_offset = data.output_buffer_write_offset,
++      .input_buffer_0_valid = data.input_buffer_0_valid != 0,
++      .input_buffer_1_valid = data.input_buffer_1_valid != 0,
++  };
++  const auto observation_result = stall_tracker_.ObserveNoSpace(observation);
++  if (observation_result.log_recovery) {
++    PROFILE_XMA_STALL_RECOVERY();
++    REXAPU_WARN(
++        "XmaContext {}: recovered after stalls (no-space {}, no-progress "
++        "{}): buffer {}, input {}, output {}/{}",
++        id(), previous.consecutive_no_space_stalls, previous.consecutive_no_progress_stalls,
++        data.current_buffer, data.input_buffer_read_offset, data.output_buffer_read_offset,
++        data.output_buffer_write_offset);
++  }
++  if (!observation_result.repeated) {
++    return;
++  }
++
 +  PROFILE_XMA_NO_SPACE_STALL();
 +  if (!stall_tracker_.NoteNoSpaceStall()) {
 +    return;
@@ -277,16 +336,12 @@ index e723215..26396f0 100644
 +      "XmaContext {}: output-space stall x{} (total {}): need {} blocks, "
 +      "have {}, buffer {}, input {}, output {}/{}, sdc {}, padding {}, "
 +      "relaxed {}, last progress input {} output {}/{}",
-+      id(), metrics.consecutive_no_space_stalls,
-+      metrics.total_no_space_stalls, minimum_subframe_decode_count,
-+      remaining_subframe_blocks_in_output_buffer_, data.current_buffer,
-+      data.input_buffer_read_offset, data.output_buffer_read_offset,
-+      data.output_buffer_write_offset, data.subframe_decode_count,
-+      data.output_buffer_padding,
-+      REXCVAR_GET(xma_relaxed_padding_admission) ? 1 : 0,
-+      metrics.last_progress_input_offset,
-+      metrics.last_progress_output_read_offset,
-+      metrics.last_progress_output_write_offset);
++      id(), metrics.consecutive_no_space_stalls, metrics.total_no_space_stalls,
++      minimum_subframe_decode_count, remaining_subframe_blocks_in_output_buffer_,
++      data.current_buffer, data.input_buffer_read_offset, data.output_buffer_read_offset,
++      data.output_buffer_write_offset, data.subframe_decode_count, data.output_buffer_padding,
++      REXCVAR_GET(xma_relaxed_padding_admission) ? 1 : 0, metrics.last_progress_input_offset,
++      metrics.last_progress_output_read_offset, metrics.last_progress_output_write_offset);
 +}
 +
 +void XmaContext::NoteNoProgressStall(const XMA_CONTEXT_DATA& data) {
@@ -298,23 +353,18 @@ index e723215..26396f0 100644
 +  REXAPU_WARN(
 +      "XmaContext {}: no-progress stall x{} (total {}): buffer {}, input {}, "
 +      "output {}/{}, error {}, last progress input {} output {}/{}",
-+      id(), metrics.consecutive_no_progress_stalls,
-+      metrics.total_no_progress_stalls, data.current_buffer,
-+      data.input_buffer_read_offset, data.output_buffer_read_offset,
-+      data.output_buffer_write_offset, data.error_status,
-+      metrics.last_progress_input_offset,
-+      metrics.last_progress_output_read_offset,
-+      metrics.last_progress_output_write_offset);
++      id(), metrics.consecutive_no_progress_stalls, metrics.total_no_progress_stalls,
++      data.current_buffer, data.input_buffer_read_offset, data.output_buffer_read_offset,
++      data.output_buffer_write_offset, data.error_status, metrics.last_progress_input_offset,
++      metrics.last_progress_output_read_offset, metrics.last_progress_output_write_offset);
 +}
 +
-+void XmaContext::NoteProgress(const XMA_CONTEXT_DATA& data,
-+                              const memory::RingBuffer& output_rb,
++void XmaContext::NoteProgress(const XMA_CONTEXT_DATA& data, const memory::RingBuffer& output_rb,
 +                              uint32_t previous_input_offset) {
 +  const auto previous = stall_tracker_.metrics();
 +  const uint8_t output_write_offset =
 +      static_cast<uint8_t>(output_rb.write_offset() / kOutputBytesPerBlock);
-+  if (!stall_tracker_.NoteProgress(data.input_buffer_read_offset,
-+                                   data.output_buffer_read_offset,
++  if (!stall_tracker_.NoteProgress(data.input_buffer_read_offset, data.output_buffer_read_offset,
 +                                   output_write_offset)) {
 +    return;
 +  }
@@ -322,9 +372,8 @@ index e723215..26396f0 100644
 +  REXAPU_WARN(
 +      "XmaContext {}: recovered after stalls (no-space {}, no-progress {}): "
 +      "buffer {}, input {} -> {}, output {}/{}",
-+      id(), previous.consecutive_no_space_stalls,
-+      previous.consecutive_no_progress_stalls, data.current_buffer,
-+      previous_input_offset, data.input_buffer_read_offset,
++      id(), previous.consecutive_no_space_stalls, previous.consecutive_no_progress_stalls,
++      data.current_buffer, previous_input_offset, data.input_buffer_read_offset,
 +      data.output_buffer_read_offset, output_write_offset);
 +}
 +
@@ -332,34 +381,32 @@ index e723215..26396f0 100644
 +  stall_tracker_.Reset(kBitsPerPacketHeader);
 +}
 +
-+uint8_t XmaContext::GetOutputPaddingHeadroom(
-+    uint8_t requested_padding, int32_t remaining_after_write) {
++uint8_t XmaContext::GetOutputPaddingHeadroom(uint8_t requested_padding,
++                                             int32_t remaining_after_write) {
 +  if (!REXCVAR_GET(xma_relaxed_padding_admission)) {
 +    return requested_padding;
 +  }
 +  if (remaining_after_write <= 0) {
 +    return 0;
 +  }
-+  return static_cast<uint8_t>(std::min<int32_t>(requested_padding,
-+                                                remaining_after_write));
++  return static_cast<uint8_t>(std::min<int32_t>(requested_padding, remaining_after_write));
 +}
 +
  void XmaContext::SwapInputBuffer(XMA_CONTEXT_DATA* data) {
    if (data->current_buffer == 0) {
      data->input_buffer_0_valid = 0;
-@@ -615,7 +778,10 @@ void XmaContext::Consume(memory::RingBuffer* output_rb, const XMA_CONTEXT_DATA*
+@@ -615,7 +809,9 @@ void XmaContext::Consume(memory::RingBuffer* output_rb, const XMA_CONTEXT_DATA*
                                      << data->is_stereo;
      const uint8_t consumed = total_subframes - current_frame_remaining_subframes_;
      if (consumed >= loop_frame_output_limit_) {
 -      remaining_subframe_blocks_in_output_buffer_ -= data->output_buffer_padding;
 +      remaining_subframe_blocks_in_output_buffer_ -=
-+          GetOutputPaddingHeadroom(
-+              static_cast<uint8_t>(data->output_buffer_padding),
-+              remaining_subframe_blocks_in_output_buffer_);
++          GetOutputPaddingHeadroom(static_cast<uint8_t>(data->output_buffer_padding),
++                                   remaining_subframe_blocks_in_output_buffer_);
        current_frame_remaining_subframes_ = 0;
        loop_frame_output_limit_ = 0;
        return;
-@@ -643,9 +809,13 @@ void XmaContext::Consume(memory::RingBuffer* output_rb, const XMA_CONTEXT_DATA*
+@@ -643,9 +839,12 @@ void XmaContext::Consume(memory::RingBuffer* output_rb, const XMA_CONTEXT_DATA*
    output_rb->Write(raw_frame_.data() + (kOutputBytesPerBlock * raw_frame_read_offset),
                     subframes_to_write * kOutputBytesPerBlock);
  
@@ -370,13 +417,12 @@ index e723215..26396f0 100644
 +      (current_frame_remaining_subframes_ - subframes_to_write == 0)
 +          ? static_cast<int8_t>(GetOutputPaddingHeadroom(
 +                static_cast<uint8_t>(data->output_buffer_padding),
-+                remaining_subframe_blocks_in_output_buffer_ -
-+                    subframes_to_write))
++                remaining_subframe_blocks_in_output_buffer_ - subframes_to_write))
 +          : 0;
  
    remaining_subframe_blocks_in_output_buffer_ -= subframes_to_write + headroom;
    current_frame_remaining_subframes_ -= subframes_to_write;
-@@ -657,6 +827,11 @@ int XmaContext::PrepareDecoder(int sample_rate, bool is_two_channel) {
+@@ -657,6 +856,11 @@ int XmaContext::PrepareDecoder(int sample_rate, bool is_two_channel) {
    uint32_t channels = is_two_channel ? 2 : 1;
    if (av_context_->sample_rate != sample_rate ||
        av_context_->channels != static_cast<int>(channels)) {
@@ -413,7 +459,7 @@ index 7bbe847..fc7c7b7 100644
      false,  // kBufferQueueDepth  (set each frame)
      false,  // kFunctionsDispatched
 diff --git a/tests/unit/audio/xma_packet_test.cpp b/tests/unit/audio/xma_packet_test.cpp
-index a9db54d..834e6b0 100644
+index a9db54d..1a87e45 100644
 --- a/tests/unit/audio/xma_packet_test.cpp
 +++ b/tests/unit/audio/xma_packet_test.cpp
 @@ -12,6 +12,7 @@
@@ -424,8 +470,11 @@ index a9db54d..834e6b0 100644
  #include <rex/system/xmemory.h>
  
  #include "test_memory.h"
-@@ -23,6 +24,13 @@ using rex::audio::XMA_CONTEXT_DATA;
+@@ -21,8 +22,16 @@ namespace {
+ using rex::audio::ResolvePacket;
+ using rex::audio::XMA_CONTEXT_DATA;
  using rex::audio::XmaContext;
++using rex::audio::XmaNoSpaceObservation;
  using rex::audio::XmaPacketStatus;
  using rex::audio::XmaPayloadStatus;
 +using rex::audio::XmaStallTracker;
@@ -438,27 +487,71 @@ index a9db54d..834e6b0 100644
  
  std::array<uint8_t, sizeof(XMA_CONTEXT_DATA)> EmptyGuestContext() {
    return {};
-@@ -79,6 +87,183 @@ void WriteCrossBufferPayloadBits(uint8_t* current, uint8_t* alternate,
+@@ -41,33 +50,25 @@ XMA_CONTEXT_DATA MakeTwoBufferContext(uint32_t current_buffer = 0) {
+   return data;
+ }
+ 
+-void SetPacketHeader(uint8_t* packet, uint8_t frame_count,
+-                     uint32_t first_frame_offset, uint8_t skip_count) {
+-  const uint32_t encoded_offset =
+-      first_frame_offset - XmaContext::kBitsPerPacketHeader;
+-  packet[0] = static_cast<uint8_t>((frame_count << 2) |
+-                                   ((encoded_offset >> 13) & 0x3));
++void SetPacketHeader(uint8_t* packet, uint8_t frame_count, uint32_t first_frame_offset,
++                     uint8_t skip_count) {
++  const uint32_t encoded_offset = first_frame_offset - XmaContext::kBitsPerPacketHeader;
++  packet[0] = static_cast<uint8_t>((frame_count << 2) | ((encoded_offset >> 13) & 0x3));
+   packet[1] = static_cast<uint8_t>(encoded_offset >> 5);
+   packet[2] = static_cast<uint8_t>((encoded_offset << 3) | 1);
+   packet[3] = skip_count;
+ }
+ 
+-void WriteCrossBufferPayloadBits(uint8_t* current, uint8_t* alternate,
+-                                 uint32_t first_payload_bit, uint32_t value,
+-                                 uint32_t bit_count) {
++void WriteCrossBufferPayloadBits(uint8_t* current, uint8_t* alternate, uint32_t first_payload_bit,
++                                 uint32_t value, uint32_t bit_count) {
+   for (uint32_t i = 0; i < bit_count; ++i) {
+     const uint32_t assembled_bit = first_payload_bit + i;
+-    const uint32_t logical_packet =
+-        assembled_bit / XmaContext::kBitsPerPacketData;
+-    const uint32_t packet_bit =
+-        assembled_bit % XmaContext::kBitsPerPacketData;
+-    uint8_t* packet =
+-        logical_packet == 0
+-            ? current
+-            : alternate +
+-                  (logical_packet - 1) * XmaContext::kBytesPerPacket;
+-    uint8_t& byte =
+-        packet[XmaContext::kBytesPerPacketHeader + packet_bit / 8];
++    const uint32_t logical_packet = assembled_bit / XmaContext::kBitsPerPacketData;
++    const uint32_t packet_bit = assembled_bit % XmaContext::kBitsPerPacketData;
++    uint8_t* packet = logical_packet == 0
++                          ? current
++                          : alternate + (logical_packet - 1) * XmaContext::kBytesPerPacket;
++    uint8_t& byte = packet[XmaContext::kBytesPerPacketHeader + packet_bit / 8];
+     const uint8_t mask = static_cast<uint8_t>(1u << (7 - packet_bit % 8));
+     if (value & (1u << (bit_count - i - 1))) {
+       byte |= mask;
+@@ -79,6 +80,212 @@ void WriteCrossBufferPayloadBits(uint8_t* current, uint8_t* alternate,
  
  }  // namespace
  
-+TEST_CASE("XMA stall diagnostics remain bounded across transient episodes",
-+          "[audio][xma][stall]") {
++TEST_CASE("XMA stall diagnostics remain bounded across transient episodes", "[audio][xma][stall]") {
 +  XmaStallTracker tracker;
 +  tracker.Reset(XmaContext::kBitsPerPacketHeader);
 +
 +  uint32_t summary_count = 0;
 +  uint32_t recovery_log_count = 0;
 +  for (uint64_t total = 1; total <= 300; ++total) {
-+    const bool expected_summary =
-+        total == 1 || total == 8 || total == 64 || total == 256;
++    const bool expected_summary = total == 1 || total == 8 || total == 64 || total == 256;
 +    const bool summary = tracker.NoteNoSpaceStall();
 +    INFO("stall total " << total);
 +    CHECK(summary == expected_summary);
 +    summary_count += summary ? 1 : 0;
 +
-+    const bool recovery_log = tracker.NoteProgress(
-+        static_cast<uint32_t>(total), 0, static_cast<uint8_t>(total));
++    const bool recovery_log =
++        tracker.NoteProgress(static_cast<uint32_t>(total), 0, static_cast<uint8_t>(total));
 +    CHECK(recovery_log == expected_summary);
 +    recovery_log_count += recovery_log ? 1 : 0;
 +  }
@@ -475,34 +568,67 @@ index a9db54d..834e6b0 100644
 +  CHECK(tracker.metrics().last_progress_input_offset == 77);
 +}
 +
-+TEST_CASE("XMA strict padding admission reports no-space and recovers",
-+          "[audio][xma][stall]") {
++TEST_CASE("XMA output backpressure must repeat before becoming a stall", "[audio][xma][stall]") {
++  XmaStallTracker tracker;
++  tracker.Reset(XmaContext::kBitsPerPacketHeader);
++
++  XmaNoSpaceObservation observation = {
++      .input_offset = XmaContext::kBitsPerPacketHeader,
++      .remaining_blocks = 2,
++      .required_blocks = 6,
++      .current_buffer = 0,
++      .output_read_offset = 0,
++      .output_write_offset = 4,
++      .input_buffer_0_valid = true,
++      .input_buffer_1_valid = false,
++  };
++
++  auto result = tracker.ObserveNoSpace(observation);
++  CHECK_FALSE(result.repeated);
++  CHECK_FALSE(result.log_recovery);
++  CHECK(tracker.metrics().total_no_space_stalls == 0);
++
++  result = tracker.ObserveNoSpace(observation);
++  CHECK(result.repeated);
++  CHECK_FALSE(result.log_recovery);
++  CHECK(tracker.NoteNoSpaceStall());
++  CHECK(tracker.metrics().total_no_space_stalls == 1);
++
++  ++observation.output_read_offset;
++  ++observation.remaining_blocks;
++  result = tracker.ObserveNoSpace(observation);
++  CHECK_FALSE(result.repeated);
++  CHECK(result.log_recovery);
++  CHECK(tracker.metrics().total_recoveries == 1);
++
++  ++observation.output_read_offset;
++  ++observation.remaining_blocks;
++  result = tracker.ObserveNoSpace(observation);
++  CHECK_FALSE(result.repeated);
++  CHECK_FALSE(result.log_recovery);
++  CHECK(tracker.metrics().total_no_space_stalls == 1);
++}
++
++TEST_CASE("XMA strict padding admission reports no-space and recovers", "[audio][xma][stall]") {
 +  ResetRelaxedPaddingAdmission reset_padding;
-+  REQUIRE(rex::cvar::SetFlagByName("xma_relaxed_padding_admission",
-+                                   "false"));
++  REQUIRE(rex::cvar::SetFlagByName("xma_relaxed_padding_admission", "false"));
 +
 +  auto& memory = rex::testing::GetTestMemory();
-+  auto* virtual_heap =
-+      const_cast<rex::memory::BaseHeap*>(memory.LookupHeap(0x10000000));
-+  auto* physical_heap =
-+      const_cast<rex::memory::BaseHeap*>(memory.LookupHeap(0xA0000000));
++  auto* virtual_heap = const_cast<rex::memory::BaseHeap*>(memory.LookupHeap(0x10000000));
++  auto* physical_heap = const_cast<rex::memory::BaseHeap*>(memory.LookupHeap(0xA0000000));
 +  REQUIRE(virtual_heap != nullptr);
 +  REQUIRE(physical_heap != nullptr);
 +
 +  constexpr uint32_t kReadWrite =
 +      rex::memory::kMemoryProtectRead | rex::memory::kMemoryProtectWrite;
 +  constexpr uint32_t kReserveCommit =
-+      rex::memory::kMemoryAllocationReserve |
-+      rex::memory::kMemoryAllocationCommit;
++      rex::memory::kMemoryAllocationReserve | rex::memory::kMemoryAllocationCommit;
 +  uint32_t context_address = 0;
 +  uint32_t input_address = 0;
 +  uint32_t output_address = 0;
-+  REQUIRE(virtual_heap->Alloc(4096, 4096, kReserveCommit, kReadWrite, false,
-+                              &context_address));
-+  REQUIRE(physical_heap->Alloc(4096, 4096, kReserveCommit, kReadWrite, false,
-+                               &input_address));
-+  REQUIRE(physical_heap->Alloc(4096, 4096, kReserveCommit, kReadWrite, false,
-+                               &output_address));
++  REQUIRE(virtual_heap->Alloc(4096, 4096, kReserveCommit, kReadWrite, false, &context_address));
++  REQUIRE(physical_heap->Alloc(4096, 4096, kReserveCommit, kReadWrite, false, &input_address));
++  REQUIRE(physical_heap->Alloc(4096, 4096, kReserveCommit, kReadWrite, false, &output_address));
 +
 +  uint8_t* input = memory.TranslatePhysical(input_address);
 +  std::memset(input, 0, XmaContext::kBytesPerPacket);
@@ -529,6 +655,11 @@ index a9db54d..834e6b0 100644
 +  context.set_is_allocated(true);
 +  context.Enable();
 +  CHECK(context.Work());
++  CHECK(context.stall_metrics().total_no_space_stalls == 0);
++  CHECK(context.stall_metrics().total_recoveries == 0);
++
++  context.Enable();
++  CHECK(context.Work());
 +  CHECK(context.stall_metrics().total_no_space_stalls == 1);
 +  CHECK(context.stall_metrics().total_recoveries == 0);
 +
@@ -550,27 +681,21 @@ index a9db54d..834e6b0 100644
 +TEST_CASE("XMA no-progress diagnostics identify and recover malformed input",
 +          "[audio][xma][stall]") {
 +  auto& memory = rex::testing::GetTestMemory();
-+  auto* virtual_heap =
-+      const_cast<rex::memory::BaseHeap*>(memory.LookupHeap(0x10000000));
-+  auto* physical_heap =
-+      const_cast<rex::memory::BaseHeap*>(memory.LookupHeap(0xA0000000));
++  auto* virtual_heap = const_cast<rex::memory::BaseHeap*>(memory.LookupHeap(0x10000000));
++  auto* physical_heap = const_cast<rex::memory::BaseHeap*>(memory.LookupHeap(0xA0000000));
 +  REQUIRE(virtual_heap != nullptr);
 +  REQUIRE(physical_heap != nullptr);
 +
 +  constexpr uint32_t kReadWrite =
 +      rex::memory::kMemoryProtectRead | rex::memory::kMemoryProtectWrite;
 +  constexpr uint32_t kReserveCommit =
-+      rex::memory::kMemoryAllocationReserve |
-+      rex::memory::kMemoryAllocationCommit;
++      rex::memory::kMemoryAllocationReserve | rex::memory::kMemoryAllocationCommit;
 +  uint32_t context_address = 0;
 +  uint32_t input_address = 0;
 +  uint32_t output_address = 0;
-+  REQUIRE(virtual_heap->Alloc(4096, 4096, kReserveCommit, kReadWrite, false,
-+                              &context_address));
-+  REQUIRE(physical_heap->Alloc(4096, 4096, kReserveCommit, kReadWrite, false,
-+                               &input_address));
-+  REQUIRE(physical_heap->Alloc(4096, 4096, kReserveCommit, kReadWrite, false,
-+                               &output_address));
++  REQUIRE(virtual_heap->Alloc(4096, 4096, kReserveCommit, kReadWrite, false, &context_address));
++  REQUIRE(physical_heap->Alloc(4096, 4096, kReserveCommit, kReadWrite, false, &input_address));
++  REQUIRE(physical_heap->Alloc(4096, 4096, kReserveCommit, kReadWrite, false, &output_address));
 +
 +  uint8_t* input = memory.TranslatePhysical(input_address);
 +  std::memset(input, 0, XmaContext::kBytesPerPacket);
@@ -606,10 +731,9 @@ index a9db54d..834e6b0 100644
 +  CHECK(context.Work());
 +  XMA_CONTEXT_DATA recovered(context_ptr);
 +  CAPTURE(context.stall_metrics().total_no_progress_stalls,
-+          context.stall_metrics().total_recoveries,
-+          recovered.input_buffer_0_valid, recovered.input_buffer_1_valid,
-+          recovered.current_buffer, recovered.input_buffer_read_offset,
-+          recovered.error_status);
++          context.stall_metrics().total_recoveries, recovered.input_buffer_0_valid,
++          recovered.input_buffer_1_valid, recovered.current_buffer,
++          recovered.input_buffer_read_offset, recovered.error_status);
 +  CHECK(context.stall_metrics().total_no_progress_stalls == 1);
 +  CHECK(context.stall_metrics().total_recoveries == 1);
 +
@@ -622,3 +746,49 @@ index a9db54d..834e6b0 100644
  TEST_CASE("XMA packet resolution preserves cross-buffer packet indices", "[audio][xma]") {
    XMA_CONTEXT_DATA data = MakeTwoBufferContext();
  
+@@ -277,10 +484,8 @@ TEST_CASE("XMA payload assembly spans up to four packets", "[audio][xma]") {
+                     XmaContext::kBitsPerPacketHeader, 0xFF);
+     SetPacketHeader(alternate + XmaContext::kBytesPerPacket * 3, 1,
+                     XmaContext::kBitsPerPacketHeader, 0xFF);
+-    WriteCrossBufferPayloadBits(
+-        current, alternate,
+-        kFrameOffset - XmaContext::kBitsPerPacketHeader, kFrameSize,
+-        XmaContext::kBitsPerFrameHeader);
++    WriteCrossBufferPayloadBits(current, alternate, kFrameOffset - XmaContext::kBitsPerPacketHeader,
++                                kFrameSize, XmaContext::kBitsPerFrameHeader);
+ 
+     data.input_buffer_1_packet_count = 4;
+     data.input_buffer_read_offset = kFrameOffset;
+@@ -297,8 +502,7 @@ TEST_CASE("XMA payload assembly spans up to four packets", "[audio][xma]") {
+     CHECK(advanced.error_status == 0);
+     CHECK_FALSE(advanced.IsAnyInputBufferValid());
+     CHECK(advanced.current_buffer == 0);
+-    CHECK(advanced.input_buffer_read_offset ==
+-          XmaContext::kBitsPerPacketHeader);
++    CHECK(advanced.input_buffer_read_offset == XmaContext::kBitsPerPacketHeader);
+   }
+ 
+   SECTION("synthetic four-packet frame decodes and advances") {
+@@ -307,10 +511,8 @@ TEST_CASE("XMA payload assembly spans up to four packets", "[audio][xma]") {
+     SetPacketHeader(current, 1, kFrameOffset, 3);
+     SetPacketHeader(alternate + XmaContext::kBytesPerPacket * 3, 1,
+                     XmaContext::kBitsPerPacketHeader, 0xFF);
+-    WriteCrossBufferPayloadBits(
+-        current, alternate,
+-        kFrameOffset - XmaContext::kBitsPerPacketHeader, kFrameSize,
+-        XmaContext::kBitsPerFrameHeader);
++    WriteCrossBufferPayloadBits(current, alternate, kFrameOffset - XmaContext::kBitsPerPacketHeader,
++                                kFrameSize, XmaContext::kBitsPerFrameHeader);
+ 
+     data.input_buffer_1_packet_count = 4;
+     data.input_buffer_read_offset = kFrameOffset;
+@@ -327,8 +529,7 @@ TEST_CASE("XMA payload assembly spans up to four packets", "[audio][xma]") {
+     CHECK(advanced.error_status == 0);
+     CHECK_FALSE(advanced.IsAnyInputBufferValid());
+     CHECK(advanced.current_buffer == 0);
+-    CHECK(advanced.input_buffer_read_offset ==
+-          XmaContext::kBitsPerPacketHeader);
++    CHECK(advanced.input_buffer_read_offset == XmaContext::kBitsPerPacketHeader);
+   }
+ 
+   context.Release();

--- a/src/pinyon_shift_app.cpp
+++ b/src/pinyon_shift_app.cpp
@@ -22,14 +22,14 @@
 
 #include <cstdio>
 
-REXCVAR_DEFINE_UINT32(pinyon_shift_config_schema, 4, "Pinyon Shift",
+REXCVAR_DEFINE_UINT32(pinyon_shift_config_schema, 5, "Pinyon Shift",
                       "Pinyon Shift host configuration schema version");
 REXCVAR_DEFINE_BOOL(pinyon_shift_capture_performance, true, "Pinyon Shift",
                     "Capture lightweight per-frame performance counters to a session CSV");
 
 namespace {
 
-constexpr uint32_t kConfigSchema = 4;
+constexpr uint32_t kConfigSchema = 5;
 
 bool EnsureSupportedConfig(const std::filesystem::path& path, bool& created,
                            bool& migrated) {
@@ -52,6 +52,7 @@ bool EnsureSupportedConfig(const std::filesystem::path& path, bool& created,
               "keybind_start = \"Return\"\n"
               "d3d12_allow_variable_refresh_rate_and_tearing = false\n"
               "pinyon_shift_capture_performance = true\n"
+              "xma_relaxed_padding_admission = false\n"
               "pinyon_shift_stabilize_vehicle_presentation = false\n"
               "pinyon_shift_skip_opening_movies = false\n"
               "anisotropic_override = 3\n"
@@ -81,7 +82,7 @@ bool EnsureSupportedConfig(const std::filesystem::path& path, bool& created,
     if (schema == kConfigSchema) {
       return true;
     }
-    if (schema < 1 || schema > 3) {
+    if (schema < 1 || schema > 4) {
       return false;
     }
 
@@ -127,6 +128,8 @@ bool EnsureSupportedConfig(const std::filesystem::path& path, bool& created,
     }
 
     const std::pair<const char*, const char*> graphics_settings[] = {
+        {"xma_relaxed_padding_admission",
+         "xma_relaxed_padding_admission = false\n"},
         {"anisotropic_override", "anisotropic_override = 3\n"},
         {"swap_post_effect", "swap_post_effect = \"none\"\n"},
         {"draw_resolution_scale_x", "draw_resolution_scale_x = 1\n"},
@@ -249,6 +252,9 @@ void PinyonShiftApp::OnPostInitLogging() {
                         {"anisotropic_override",
                          rex::cvar::GetFlagByName("anisotropic_override")},
                         {"swap_post_effect", rex::cvar::GetFlagByName("swap_post_effect")},
+                        {"xma_relaxed_padding_admission",
+                         rex::cvar::GetFlagByName(
+                             "xma_relaxed_padding_admission")},
                         {"perf_csv_enabled", perf_csv.empty() ? "0" : "1"},
                         {"perf_csv", perf_csv}});
 }

--- a/tools/create-crash-report.ps1
+++ b/tools/create-crash-report.ps1
@@ -143,10 +143,36 @@ try {
         [void](Write-SanitizedTail $eventLog.FullName (Join-Path $stagingRoot 'session-events.jsonl') 1000 $replacements)
     }
 
+    $xmaStallColumns = @(
+        'xma_no_space_stalls', 'xma_no_progress_stalls', 'xma_stall_recoveries'
+    )
+    $xmaStalls = [ordered]@{
+        available = $false
+        no_space = [uint64]0
+        no_progress = [uint64]0
+        recoveries = [uint64]0
+    }
+    $perfLog = Get-ChildItem -LiteralPath (Join-Path $resolvedStateRoot 'logs') -Filter '*.perf.csv' -File `
+        -ErrorAction SilentlyContinue | Where-Object { $_.LastWriteTimeUtc -ge $StartedUtc.ToUniversalTime().AddSeconds(-2) } |
+        Sort-Object LastWriteTimeUtc | Select-Object -Last 1
+    if ($null -ne $perfLog) {
+        $header = @(Get-Content -LiteralPath $perfLog.FullName -TotalCount 1 -ErrorAction SilentlyContinue)
+        $columns = if ($header.Count -eq 1) { @($header[0].Split(',')) } else { @() }
+        if (@($xmaStallColumns | Where-Object { $_ -notin $columns }).Count -eq 0) {
+            foreach ($row in Import-Csv -LiteralPath $perfLog.FullName) {
+                $xmaStalls.no_space += [uint64]$row.xma_no_space_stalls
+                $xmaStalls.no_progress += [uint64]$row.xma_no_progress_stalls
+                $xmaStalls.recoveries += [uint64]$row.xma_stall_recoveries
+            }
+            $xmaStalls.available = $true
+        }
+    }
+
     $allowedSettings = @(
         'pinyon_shift_config_schema', 'input_backend', 'hid_mappings_file',
         'mnk_mode', 'keybind_start',
         'd3d12_allow_variable_refresh_rate_and_tearing',
+        'xma_relaxed_padding_admission',
         'pinyon_shift_capture_performance',
         'pinyon_shift_stabilize_vehicle_presentation', 'pinyon_shift_skip_opening_movies',
         'resolution', 'vsync', 'anisotropic_override', 'swap_post_effect',
@@ -224,6 +250,9 @@ try {
             gpu = $gpus
         }
         settings = $settings
+        audio = [ordered]@{
+            xma_stalls = $xmaStalls
+        }
         local_dumps = $dumpRecords
         privacy = [ordered]@{
             paths_redacted = $true
@@ -232,6 +261,7 @@ try {
             generated_code_included = $false
             memory_dump_included = $false
             input_capture_included = $false
+            audio_payload_included = $false
         }
     }
     [IO.File]::WriteAllText((Join-Path $stagingRoot 'report.json'),

--- a/tools/set-graphics-experiment.ps1
+++ b/tools/set-graphics-experiment.ps1
@@ -28,8 +28,8 @@ $backupDirectory = Join-Path $configDirectory 'backups'
 function Get-DefaultConfigText {
     @'
 # Pinyon Shift host configuration.
-# Schema 4 includes validated experimental graphics settings.
-pinyon_shift_config_schema = 4
+# Schema 5 adds default-off XMA padding qualification.
+pinyon_shift_config_schema = 5
 input_backend = "sdl"
 hid_mappings_file = "gamecontrollerdb.txt"
 mnk_mode = true
@@ -38,6 +38,7 @@ keybind_start = "Return"
 d3d12_allow_variable_refresh_rate_and_tearing = false
 pinyon_shift_stabilize_vehicle_presentation = false
 pinyon_shift_skip_opening_movies = false
+xma_relaxed_padding_admission = false
 anisotropic_override = 3
 swap_post_effect = "none"
 draw_resolution_scale_x = 1
@@ -116,7 +117,7 @@ switch ($Action) {
             Get-Content -LiteralPath $configPath -Raw
         } else { Get-DefaultConfigText }
         $schema = Get-SchemaVersion $text
-        if ($schema -notin @(1, 2, 3, 4)) { throw "Unsupported host configuration schema: $schema" }
+        if ($schema -notin @(1, 2, 3, 4, 5)) { throw "Unsupported host configuration schema: $schema" }
     }
     'Reset' {
         $backup = New-ConfigBackup
@@ -133,7 +134,7 @@ switch ($Action) {
         $backup = New-ConfigBackup
         $text = Get-Content -LiteralPath $source.FullName -Raw
         $schema = Get-SchemaVersion $text
-        if ($schema -notin @(1, 2, 3, 4)) { throw "Backup uses unsupported schema: $schema" }
+        if ($schema -notin @(1, 2, 3, 4, 5)) { throw "Backup uses unsupported schema: $schema" }
         Write-Config $text
     }
     'Apply' {
@@ -141,9 +142,12 @@ switch ($Action) {
             Get-Content -LiteralPath $configPath -Raw
         } else { Get-DefaultConfigText }
         $schema = Get-SchemaVersion $text
-        if ($schema -notin @(1, 2, 3, 4)) { throw "Unsupported host configuration schema: $schema" }
+        if ($schema -notin @(1, 2, 3, 4, 5)) { throw "Unsupported host configuration schema: $schema" }
         $backup = New-ConfigBackup
-        $text = Set-TomlValue $text 'pinyon_shift_config_schema' '4'
+        $text = Set-TomlValue $text 'pinyon_shift_config_schema' '5'
+        if (-not [regex]::IsMatch($text, '(?m)^\s*xma_relaxed_padding_admission\s*=')) {
+            $text = Set-TomlValue $text 'xma_relaxed_padding_admission' 'false'
+        }
         $override = switch ($Anisotropy) { 4 { 3 } 8 { 4 } 16 { 5 } }
         $text = Set-TomlValue $text 'anisotropic_override' ([string]$override)
         $text = Set-TomlValue $text 'swap_post_effect' ('"' + $PostEffect + '"')

--- a/tools/summarize-performance.py
+++ b/tools/summarize-performance.py
@@ -38,6 +38,11 @@ MEMEXPORT_COLUMNS = (
     "memexport_queue_waits",
     "memexport_fence_waits",
 )
+XMA_STALL_COLUMNS = (
+    "xma_no_space_stalls",
+    "xma_no_progress_stalls",
+    "xma_stall_recoveries",
+)
 
 
 class CaptureError(ValueError):
@@ -85,10 +90,15 @@ def summarize(path: pathlib.Path) -> dict[str, Any]:
         if available_memexport and available_memexport != set(MEMEXPORT_COLUMNS):
             missing_memexport = sorted(set(MEMEXPORT_COLUMNS) - available_memexport)
             raise CaptureError("capture has an incomplete memexport counter set: " + ", ".join(missing_memexport))
+        available_xma_stalls = columns.intersection(XMA_STALL_COLUMNS)
+        if available_xma_stalls and available_xma_stalls != set(XMA_STALL_COLUMNS):
+            missing_xma_stalls = sorted(set(XMA_STALL_COLUMNS) - available_xma_stalls)
+            raise CaptureError("capture has an incomplete XMA stall counter set: " + ", ".join(missing_xma_stalls))
 
         frame_times: list[float] = []
         totals = {name: 0.0 for name in TOTAL_COLUMNS}
         memexport_totals = {name: 0.0 for name in MEMEXPORT_COLUMNS} if available_memexport else None
+        xma_stall_totals = {name: 0.0 for name in XMA_STALL_COLUMNS} if available_xma_stalls else None
         rows_seen = 0
         for row_number, row in enumerate(reader, start=2):
             rows_seen += 1
@@ -99,6 +109,8 @@ def summarize(path: pathlib.Path) -> dict[str, Any]:
             }
             row_memexport = ({name: finite_number(row[name], column=name, row_number=row_number)
                               for name in MEMEXPORT_COLUMNS} if memexport_totals is not None else {})
+            row_xma_stalls = ({name: finite_number(row[name], column=name, row_number=row_number)
+                               for name in XMA_STALL_COLUMNS} if xma_stall_totals is not None else {})
             # The runtime writes one initialization row with frame_time_us == 0.
             # It is valid CSV, but not a displayed frame and must not skew latency.
             if frame_time == 0:
@@ -108,6 +120,8 @@ def summarize(path: pathlib.Path) -> dict[str, Any]:
                 totals[name] += value
             for name, value in row_memexport.items():
                 memexport_totals[name] += value
+            for name, value in row_xma_stalls.items():
+                xma_stall_totals[name] += value
 
     if rows_seen == 0:
         raise CaptureError("capture contains a header but no rows")
@@ -147,6 +161,10 @@ def summarize(path: pathlib.Path) -> dict[str, Any]:
     if memexport_totals is not None:
         result["memexport_counters"] = {
             name: int(value) if value.is_integer() else value for name, value in memexport_totals.items()
+        }
+    if xma_stall_totals is not None:
+        result["xma_stall_counters"] = {
+            name: int(value) if value.is_integer() else value for name, value in xma_stall_totals.items()
         }
     return result
 

--- a/tools/tests/test_graphics_settings.py
+++ b/tools/tests/test_graphics_settings.py
@@ -35,7 +35,8 @@ class GraphicsSettingsTests(unittest.TestCase):
             )
             updated = config.read_text(encoding="utf-8")
             self.assertEqual(result["settings"]["anisotropy"], 16)
-            self.assertIn("pinyon_shift_config_schema = 4", updated)
+            self.assertIn("pinyon_shift_config_schema = 5", updated)
+            self.assertIn("xma_relaxed_padding_admission = false", updated)
             self.assertIn("custom_value = 77", updated)
             self.assertIn("draw_resolution_scale_x = 2", updated)
             self.assertTrue(pathlib.Path(result["backup_path"]).is_file())
@@ -47,11 +48,12 @@ class GraphicsSettingsTests(unittest.TestCase):
             state = pathlib.Path(temporary)
             config = state / "config/pinyon_shift.toml"
             config.parent.mkdir(parents=True)
-            config.write_text("pinyon_shift_config_schema = 4\nswap_post_effect = \"fxaa\"\n", encoding="utf-8")
+            config.write_text("pinyon_shift_config_schema = 5\nswap_post_effect = \"fxaa\"\n", encoding="utf-8")
             result = self.run_tool(state, "-Action", "Reset")
             text = config.read_text(encoding="utf-8")
             self.assertIn("swap_post_effect = \"none\"", text)
             self.assertIn("draw_resolution_scale_x = 1", text)
+            self.assertIn("xma_relaxed_padding_admission = false", text)
             self.assertTrue(pathlib.Path(result["backup_path"]).is_file())
 
 

--- a/tools/tests/test_performance_summary.py
+++ b/tools/tests/test_performance_summary.py
@@ -24,6 +24,22 @@ FIELDS = [
 
 
 class PerformanceSummaryTests(unittest.TestCase):
+    def test_emits_complete_optional_xma_stall_totals(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            capture = pathlib.Path(temporary) / "capture.csv"
+            capture.write_text(
+                "frame_time_us,fps,draw_calls,command_buffer_stalls,texture_cache_hits,texture_cache_misses,"
+                "pipeline_cache_hits,pipeline_cache_misses,xma_no_space_stalls,"
+                "xma_no_progress_stalls,xma_stall_recoveries\n"
+                "10000,100,1,0,1,0,1,0,2,1,0\n"
+                "11000,90,1,0,1,0,1,0,3,0,1\n",
+                encoding="utf-8",
+            )
+            result = MODULE.summarize(capture)
+            self.assertEqual(5, result["xma_stall_counters"]["xma_no_space_stalls"])
+            self.assertEqual(1, result["xma_stall_counters"]["xma_no_progress_stalls"])
+            self.assertEqual(1, result["xma_stall_counters"]["xma_stall_recoveries"])
+
     def test_emits_complete_optional_memexport_totals(self):
         with tempfile.TemporaryDirectory() as temporary:
             capture = pathlib.Path(temporary) / "capture.csv"

--- a/tools/tests/test_release_contract.py
+++ b/tools/tests/test_release_contract.py
@@ -43,10 +43,10 @@ class ReleaseContractTests(unittest.TestCase):
 
     def test_rexglue_patches_have_stable_order_and_no_binary_payload(self):
         patches = sorted((ROOT / "patches/rexglue").glob("*.patch"))
-        self.assertEqual(len(patches), 37)
+        self.assertEqual(len(patches), 38)
         self.assertEqual(
             patches[-1].name,
-            "0037-m4-xma-multipacket-frame-assembly.patch",
+            "0038-m4-xma-stall-diagnostics.patch",
         )
         self.assertEqual(len(patches), len({path.name[:4] for path in patches}))
         for path in patches:
@@ -163,11 +163,13 @@ class ReleaseContractTests(unittest.TestCase):
 
     def test_graphics_schema_and_diagnostics_contract(self):
         app = (ROOT / "src/pinyon_shift_app.cpp").read_text(encoding="utf-8")
-        self.assertIn("constexpr uint32_t kConfigSchema = 4", app)
+        self.assertIn("constexpr uint32_t kConfigSchema = 5", app)
         self.assertIn(".schema", app)
         for setting in ("anisotropic_override", "swap_post_effect", "draw_resolution_scale_x"):
             self.assertIn(setting, app)
             self.assertIn(setting, (ROOT / "tools/create-crash-report.ps1").read_text(encoding="utf-8"))
+        self.assertIn("xma_relaxed_padding_admission = false", app)
+        self.assertIn("xma_no_space_stalls", (ROOT / "tools/create-crash-report.ps1").read_text(encoding="utf-8"))
 
     def test_renderer_and_stub_instrumentation_is_bounded(self):
         stub_patch = (ROOT / "patches/rexglue/0031-sdk-stub-reachability-summary.patch").read_text(encoding="utf-8")
@@ -185,11 +187,11 @@ class ReleaseContractTests(unittest.TestCase):
         launcher = (ROOT / "launcher/PinyonShift.Launcher/MainWindow.xaml.cs").read_text(
             encoding="utf-8"
         )
-        self.assertIn("constexpr uint32_t kConfigSchema = 4;", app)
-        self.assertRegex(app, r"pinyon_shift_config_schema,\s*4,")
+        self.assertIn("constexpr uint32_t kConfigSchema = 5;", app)
+        self.assertRegex(app, r"pinyon_shift_config_schema,\s*5,")
         self.assertIn('"pinyon_shift_stabilize_vehicle_presentation = false\\n"', app)
         self.assertIn('"keybind_a = \\"LMB,Space\\"\\n"', app)
-        self.assertIn("schema < 1 || schema > 3", app)
+        self.assertIn("schema < 1 || schema > 4", app)
         self.assertIn("Controller A, Space, or left click.", launcher)
         self.assertRegex(
             hooks,
@@ -237,6 +239,11 @@ class ReleaseContractTests(unittest.TestCase):
                 json.dumps({"event": "process.start", "path": private_path}) + "\n",
                 encoding="utf-8",
             )
+            (state / "logs" / "session.perf.csv").write_text(
+                "frame_time_us,xma_no_space_stalls,xma_no_progress_stalls,xma_stall_recoveries\n"
+                "10000,2,1,0\n20000,3,0,1\n",
+                encoding="utf-8",
+            )
             crash = state / "crashes" / "test-unhandled.txt"
             crash.write_text(
                 "Pinyon Shift unhandled exception\n"
@@ -277,6 +284,11 @@ class ReleaseContractTests(unittest.TestCase):
             with zipfile.ZipFile(result["bundle"]) as archive:
                 manifest = json.loads(archive.read("report.json"))
             self.assertFalse(manifest["privacy"]["memory_dump_included"])
+            self.assertFalse(manifest["privacy"]["audio_payload_included"])
+            self.assertTrue(manifest["audio"]["xma_stalls"]["available"])
+            self.assertEqual(manifest["audio"]["xma_stalls"]["no_space"], 5)
+            self.assertEqual(manifest["audio"]["xma_stalls"]["no_progress"], 1)
+            self.assertEqual(manifest["audio"]["xma_stalls"]["recoveries"], 1)
             self.assertEqual(manifest["exception"]["fault_offset"], "0x1234")
 
 


### PR DESCRIPTION
## Summary
- add per-context XMA no-space and no-progress stall tracking with bounded diagnostic cadence
- export session stall and recovery counters to performance captures and sanitized support reports
- keep relaxed padding admission opt-in and default-off in schema 5

## Validation
- `python -m unittest discover -s tools/tests -p "test_*.py"` (33 passed)
- ReXGlue `unit_tests.exe` RelWithDebInfo (233 passed, 4 known skips)
- ReXGlue `ppc_tests.exe` RelWithDebInfo (1,460 passed)
- `tools/check-repository-boundary.ps1`
- clean `tools/prepare-rexglue.ps1` application of all 38 patches
- clean `tools/build-preview.ps1 -Parallel 6`
- AppData-backed gameplay smoke run launched against the installed 0.1.0 save

## Safety
- diagnostic logs are rate-bounded at 1, 8, 64, and every 256 consecutive stalls
- support reports contain aggregate counters only and explicitly exclude audio payloads
- relaxed padding behavior remains disabled unless explicitly enabled