### PR TITLE
feat(graphics): add modern d3d12 zpd lifecycle

### DIFF
--- a/config/rexglue/EPIC_04_ZPD_LIFECYCLE_D3D12.md
+++ b/config/rexglue/EPIC_04_ZPD_LIFECYCLE_D3D12.md
@@ -1,0 +1,80 @@
+# ReXGlue D3D12 ZPD report lifecycle
+
+EPIC-04 is delivered by
+`patches/rexglue/0039-gpu-zpd-report-lifecycle-d3d12.patch` plus host schema,
+performance-summary, and sanitized support-report integration in this project.
+
+## Derivation and scope
+
+The guest report layout and logical/physical query split are adapted from Xenia
+Canary PR [`#1016`](https://github.com/xenia-canary/xenia-canary/pull/1016),
+head commit `d35e0b5359c76d98c758125d529df7af99d8526a`. Pinyon Shift ports only
+the Windows/D3D12 report lifecycle. Vulkan, QueryBatch, VIZ, EXT, and the
+shader-interlock counter path remain deferred as specified by the epic.
+
+The ReXGlue patch adds:
+
+- fixed 0x20-byte record and 0x40-byte slot helpers;
+- logical report handles with per-slot sequence IDs;
+- physical D3D12 segments that close and resolve at every submission boundary;
+- a generation-protected 8,192-entry host query pool;
+- asynchronous fast-mode retirement and late guest result patching;
+- bounded strict retirement with a 2 ms backstop;
+- conservative fake fallback and the pre-existing legacy path;
+- 1x/2x sample-count normalization;
+- the complete EPIC-04 performance-counter set;
+- deterministic layout, segmentation, scaling, and stale-write tests.
+
+Same-slot reuse increments the guest slot sequence before the new lifetime is
+opened. An older result may release its host query index after its fence passes,
+but cannot update guest memory or seed the new slot's cached delta. D3D12 query
+indices also have independent generations so a late resolve cannot be confused
+with a recycled heap entry.
+
+## Configuration and qualification
+
+Host configuration schema 6 adds:
+
+```toml
+occlusion_query = "legacy"
+# legacy | fake | fast | strict
+```
+
+`legacy` remains the shipping default and preserves the previously qualified
+synchronous implementation. `fast` writes a conservative visible value or the
+last current-slot delta, then patches it when all segments retire. `strict`
+closes the containing submission and waits for at most 2 ms; timeout writes a
+visible/cached fallback and rejects the eventual stale result. Resource creation
+or pool exhaustion also falls back without leaving a guest sentinel pending.
+
+Session CSVs and sanitized support reports expose:
+
+```text
+zpd_reports_started
+zpd_reports_ended
+zpd_report_segments
+zpd_same_slot_reuse
+zpd_fast_speculative_writes
+zpd_async_result_patches
+zpd_strict_waits
+zpd_strict_wait_time_ns
+zpd_retire_timeouts
+zpd_fake_fallbacks
+zpd_malformed_records
+zpd_stale_result_rejections
+```
+
+No report contents, guest memory, save data, or image data are included.
+
+## Tests and rollback
+
+The focused lifecycle suite verifies BEGIN/END address classification, a logical
+report accumulated across multiple submissions, same-slot stale-result
+rejection, and scale-normalized sample counts. The complete ReXGlue unit suite,
+D3D12 graphics target, project tests, clean patch replay, release build, and an
+AppData-backed runtime qualification are required before merge.
+
+Rollback is selecting `occlusion_query = "legacy"`. Removing patch `0039` and
+the schema-6/reporting integration fully removes EPIC-04 without affecting the
+audio patches. EPIC-05 owns title-specific END classification and will keep the
+modern modes non-shipping until its cold-boot matrix passes.

--- a/config/rexglue/PATCH_DISPOSITIONS.md
+++ b/config/rexglue/PATCH_DISPOSITIONS.md
@@ -96,6 +96,16 @@ optional relaxed-padding admission path is controlled by
 `xma_relaxed_padding_admission = false`; removing `0038` restores strict
 padding admission and removes only EPIC-03 telemetry and tests.
 
+`0039-gpu-zpd-report-lifecycle-d3d12` adapts the D3D12 portion of Xenia Canary
+PR `#1016` at `d35e0b5`. Fixed guest record/slot helpers feed a logical report
+map whose lifetimes may span multiple host query segments and submissions.
+Per-slot sequence IDs reject stale guest writes, per-index generations protect
+the reusable D3D12 heap, fast mode retires asynchronously, and strict mode has
+a 2 ms backstop. Sample counts are normalized for internal-resolution scaling,
+all EPIC-04 counters are exported, and `occlusion_query = "legacy"` remains the
+shipping default and immediate rollback path. Removing `0039` restores the
+previous synchronous D3D12 query implementation.
+
 Validation performed on the rebased SDK:
 
 - `unit_tests` and `ppc_tests` build with the pinned Clang 20.1.8 toolchain.

--- a/patches/rexglue/0039-gpu-zpd-report-lifecycle-d3d12.patch
+++ b/patches/rexglue/0039-gpu-zpd-report-lifecycle-d3d12.patch
@@ -1,0 +1,984 @@
+diff --git a/tests/unit/CMakeLists.txt b/tests/unit/CMakeLists.txt
+index 382e315..8efd68d 100644
+--- a/tests/unit/CMakeLists.txt
++++ b/tests/unit/CMakeLists.txt
+@@ -24,6 +24,7 @@ add_executable(unit_tests
+     codegen/output_partition_test.cpp
+     codegen/output_stamp_test.cpp
+     filesystem/cache_mount_test.cpp
++    graphics/zpd_lifecycle_test.cpp
+ )
+ 
+ target_sources(unit_tests PRIVATE
+diff --git a/include/rex/graphics/zpd_report.h b/include/rex/graphics/zpd_report.h
+new file mode 100644
+index 0000000..348df01
+--- /dev/null
++++ b/include/rex/graphics/zpd_report.h
+@@ -0,0 +1,74 @@
++/**
++ ******************************************************************************
++ * Xenia : Xbox 360 Emulator Research Project                                 *
++ ******************************************************************************
++ * Copyright 2026 Ben Vanik. All rights reserved.                             *
++ * Released under the BSD license - see LICENSE in the root for more details. *
++ ******************************************************************************
++ */
++
++#pragma once
++
++#include <algorithm>
++#include <cstdint>
++
++#include <rex/graphics/xenos.h>
++
++namespace rex::graphics {
++
++// Guest-memory layout helpers for Xenos ZPD reports. A slot contains an END
++// record at +0x00 and a BEGIN record at +0x20.
++struct XenosZPDReport {
++  static constexpr uint32_t kRecordSizeBytes = 0x20;
++  static constexpr uint32_t kRecordAlignMask = ~(kRecordSizeBytes - 1);
++  static constexpr uint32_t kSlotSizeBytes = 0x40;
++  static constexpr uint32_t kSlotAlignMask = ~(kSlotSizeBytes - 1);
++
++  static constexpr uint32_t GetRecordBase(uint32_t address) { return address & kRecordAlignMask; }
++  static constexpr uint32_t GetSlotBase(uint32_t address) { return address & kSlotAlignMask; }
++  static constexpr uint32_t GetBeginRecordBase(uint32_t address) {
++    return GetSlotBase(address) + kRecordSizeBytes;
++  }
++  static constexpr uint32_t GetEndRecordBase(uint32_t address) { return GetSlotBase(address); }
++  static constexpr bool IsBeginRecord(uint32_t address) {
++    uint32_t record_base = GetRecordBase(address);
++    return record_base && record_base == GetBeginRecordBase(record_base);
++  }
++  static constexpr bool IsEndRecord(uint32_t address) {
++    uint32_t record_base = GetRecordBase(address);
++    return record_base && record_base == GetEndRecordBase(record_base);
++  }
++
++  static bool HasPendingSentinel(const xenos::xe_gpu_depth_sample_counts* report) {
++    constexpr uint32_t kSentinelLE = 0xEDFEFFFFu;
++    constexpr uint32_t kSentinelBE = 0xFFFFFEEDu;
++    return report && (report->ZPass_A == kSentinelLE || report->ZPass_A == kSentinelBE ||
++                      report->ZFail_A == kSentinelLE || report->ZFail_A == kSentinelBE);
++  }
++
++  static void WriteSampleCount(xenos::xe_gpu_depth_sample_counts* report, uint32_t sample_count) {
++    if (!report) {
++      return;
++    }
++    report->Total_A = sample_count;
++    report->Total_B = 0;
++    report->ZFail_A = 0;
++    report->ZFail_B = 0;
++    report->ZPass_A = sample_count;
++    report->ZPass_B = 0;
++    report->StencilFail_A = 0;
++    report->StencilFail_B = 0;
++  }
++
++  static void WriteReportDelta(xenos::xe_gpu_depth_sample_counts* begin_report,
++                               xenos::xe_gpu_depth_sample_counts* end_report, uint32_t begin_value,
++                               uint32_t delta_value, bool write_begin_report) {
++    uint32_t end_value = begin_value + delta_value;
++    if (write_begin_report && begin_report && begin_report != end_report) {
++      WriteSampleCount(begin_report, begin_value);
++    }
++    WriteSampleCount(end_report, end_value);
++  }
++};
++
++}  // namespace rex::graphics
+diff --git a/include/rex/graphics/zpd_lifecycle.h b/include/rex/graphics/zpd_lifecycle.h
+new file mode 100644
+index 0000000..83844fc
+--- /dev/null
++++ b/include/rex/graphics/zpd_lifecycle.h
+@@ -0,0 +1,225 @@
++#pragma once
++
++#include <algorithm>
++#include <cstdint>
++#include <unordered_map>
++
++#include <rex/graphics/zpd_report.h>
++
++namespace rex::graphics {
++
++enum class ZPDMode {
++  kLegacy,
++  kFake,
++  kFast,
++  kStrict,
++};
++
++// Backend-independent logical ZPD state. Host query allocation and retirement
++// stay in the renderer, while this controller owns guest slot lifetimes and
++// rejects stale asynchronous results after same-slot reuse.
++class ZPDLifecycle {
++ public:
++  using ReportHandle = uint64_t;
++  static constexpr ReportHandle kInvalidReportHandle = 0;
++
++  struct Report {
++    uint64_t accumulated_samples = 0;
++    uint64_t first_submission = 0;
++    uint64_t last_submission = 0;
++    uint64_t slot_sequence_id = 0;
++    uint32_t slot_base = 0;
++    uint32_t begin_record = 0;
++    uint32_t end_record = 0;
++    uint32_t begin_value = 0;
++    uint32_t cached_delta = 0;
++    uint32_t pending_segments = 0;
++    bool has_cached_delta = false;
++    bool ended = false;
++  };
++
++  struct ActiveSegment {
++    ReportHandle report_handle = kInvalidReportHandle;
++    uint32_t slot_base = 0;
++    bool segment_active = false;
++    bool segment_pending_begin = false;
++    bool logical_active = false;
++  };
++
++  struct BeginResult {
++    ReportHandle report_handle = kInvalidReportHandle;
++    uint64_t slot_sequence_id = 0;
++    bool same_slot_reuse = false;
++  };
++
++  BeginResult Begin(uint32_t report_address) {
++    uint32_t slot_base = XenosZPDReport::GetSlotBase(report_address);
++    if (!slot_base) {
++      return {};
++    }
++    bool same_slot_reuse = HasPendingSlot(slot_base);
++    uint64_t sequence = ++slot_sequences_[slot_base];
++    ReportHandle handle = next_report_handle_++;
++    if (handle == kInvalidReportHandle) {
++      handle = next_report_handle_++;
++    }
++    Report& report = reports_[handle];
++    report.slot_base = slot_base;
++    report.slot_sequence_id = sequence;
++    report.begin_record = XenosZPDReport::GetBeginRecordBase(slot_base);
++    report.end_record = XenosZPDReport::GetEndRecordBase(slot_base);
++    report.begin_value = slot_values_[slot_base];
++    auto cached = cached_deltas_.find(report.end_record);
++    if (cached != cached_deltas_.end()) {
++      report.cached_delta = cached->second;
++      report.has_cached_delta = true;
++    }
++    active_ = {handle, slot_base, false, true, true};
++    return {handle, sequence, same_slot_reuse};
++  }
++
++  bool End(uint32_t report_address) {
++    Report* report = active_report();
++    if (!report) {
++      return false;
++    }
++    uint32_t record = XenosZPDReport::GetRecordBase(report_address);
++    if (record) {
++      report->end_record = record;
++    }
++    report->ended = true;
++    active_.logical_active = false;
++    active_.segment_pending_begin = false;
++    return true;
++  }
++
++  bool SegmentOpened() {
++    if (!active_.logical_active || !active_.segment_pending_begin) {
++      return false;
++    }
++    active_.segment_active = true;
++    active_.segment_pending_begin = false;
++    return true;
++  }
++
++  bool SegmentClosed(uint64_t submission) {
++    Report* report = active_report();
++    if (!report || !active_.segment_active) {
++      return false;
++    }
++    if (!report->pending_segments) {
++      report->first_submission = submission;
++    }
++    report->last_submission = submission;
++    ++report->pending_segments;
++    active_.segment_active = false;
++    active_.segment_pending_begin = active_.logical_active;
++    return true;
++  }
++
++  bool Resolve(ReportHandle handle, uint64_t raw_samples, uint32_t scale_x, uint32_t scale_y,
++               uint32_t& delta_out, bool& commit_out, Report& report_out) {
++    auto it = reports_.find(handle);
++    if (it == reports_.end()) {
++      return false;
++    }
++    Report& report = it->second;
++    if (report.pending_segments) {
++      --report.pending_segments;
++    }
++    report.accumulated_samples += raw_samples;
++    report_out = report;
++    delta_out = Normalize(report.accumulated_samples, scale_x, scale_y);
++    bool current = IsCurrent(report);
++    commit_out = report.ended && report.pending_segments == 0 && current;
++    if (report.ended && report.pending_segments == 0) {
++      if (current) {
++        cached_deltas_[report.end_record] = delta_out;
++        slot_values_[report.slot_base] = report.begin_value + delta_out;
++      }
++      report_out = report;
++      reports_.erase(it);
++    }
++    return true;
++  }
++
++  bool Abandon(ReportHandle handle, uint32_t fallback_delta, Report& report_out, bool& commit_out) {
++    auto it = reports_.find(handle);
++    if (it == reports_.end()) {
++      return false;
++    }
++    report_out = it->second;
++    commit_out = IsCurrent(report_out);
++    if (commit_out) {
++      slot_values_[report_out.slot_base] = report_out.begin_value + fallback_delta;
++    }
++    reports_.erase(it);
++    if (active_.report_handle == handle) {
++      active_ = {};
++    }
++    return true;
++  }
++
++  Report* active_report() { return Find(active_.report_handle); }
++  const Report* active_report() const { return Find(active_.report_handle); }
++  Report* Find(ReportHandle handle) {
++    auto it = reports_.find(handle);
++    return it == reports_.end() ? nullptr : &it->second;
++  }
++  const Report* Find(ReportHandle handle) const {
++    auto it = reports_.find(handle);
++    return it == reports_.end() ? nullptr : &it->second;
++  }
++  const ActiveSegment& active() const { return active_; }
++  ActiveSegment& active() { return active_; }
++  bool IsCurrent(const Report& report) const {
++    auto it = slot_sequences_.find(report.slot_base);
++    return it != slot_sequences_.end() && it->second == report.slot_sequence_id;
++  }
++  bool HasPendingSlot(uint32_t slot_base) const {
++    for (const auto& item : reports_) {
++      if (item.second.slot_base == slot_base) {
++        return true;
++      }
++    }
++    return false;
++  }
++  ReportHandle OldestPendingSlot(uint32_t slot_base) const {
++    ReportHandle oldest = kInvalidReportHandle;
++    for (const auto& item : reports_) {
++      if (item.second.slot_base == slot_base && item.second.pending_segments &&
++          (oldest == kInvalidReportHandle || item.first < oldest)) {
++        oldest = item.first;
++      }
++    }
++    return oldest;
++  }
++  uint32_t CachedDelta(uint32_t end_record, uint32_t fallback = 1) const {
++    auto it = cached_deltas_.find(end_record);
++    return it == cached_deltas_.end() ? fallback : it->second;
++  }
++  void Reset() {
++    next_report_handle_ = 1;
++    slot_sequences_.clear();
++    slot_values_.clear();
++    cached_deltas_.clear();
++    reports_.clear();
++    active_ = {};
++  }
++
++  static uint32_t Normalize(uint64_t samples, uint32_t scale_x, uint32_t scale_y) {
++    uint64_t scale = uint64_t(std::max(scale_x, 1u)) * std::max(scale_y, 1u);
++    uint64_t normalized = scale <= 1 ? samples : (samples + (scale >> 1)) / scale;
++    return uint32_t(std::min<uint64_t>(normalized, UINT32_MAX));
++  }
++
++ private:
++  ReportHandle next_report_handle_ = 1;
++  std::unordered_map<uint32_t, uint64_t> slot_sequences_;
++  std::unordered_map<uint32_t, uint32_t> slot_values_;
++  std::unordered_map<uint32_t, uint32_t> cached_deltas_;
++  std::unordered_map<ReportHandle, Report> reports_;
++  ActiveSegment active_{};
++};
++
++}  // namespace rex::graphics
+diff --git a/tests/unit/graphics/zpd_lifecycle_test.cpp b/tests/unit/graphics/zpd_lifecycle_test.cpp
+new file mode 100644
+index 0000000..801e3fd
+--- /dev/null
++++ b/tests/unit/graphics/zpd_lifecycle_test.cpp
+@@ -0,0 +1,62 @@
++#include <catch2/catch_test_macros.hpp>
++
++#include <rex/graphics/zpd_lifecycle.h>
++
++namespace rex::graphics {
++
++TEST_CASE("ZPD report layout identifies begin and end records", "[graphics][zpd]") {
++  constexpr uint32_t slot = 0x1000;
++  REQUIRE(XenosZPDReport::GetSlotBase(slot + 0x37) == slot);
++  REQUIRE(XenosZPDReport::IsEndRecord(slot));
++  REQUIRE(XenosZPDReport::IsBeginRecord(slot + 0x20));
++  REQUIRE_FALSE(XenosZPDReport::IsBeginRecord(slot));
++  REQUIRE_FALSE(XenosZPDReport::IsEndRecord(slot + 0x20));
++}
++
++TEST_CASE("ZPD logical report accumulates submission segments", "[graphics][zpd]") {
++  ZPDLifecycle lifecycle;
++  auto begin = lifecycle.Begin(0x1020);
++  REQUIRE(begin.report_handle != ZPDLifecycle::kInvalidReportHandle);
++  REQUIRE(lifecycle.SegmentOpened());
++  REQUIRE(lifecycle.SegmentClosed(7));
++  REQUIRE(lifecycle.SegmentOpened());
++  REQUIRE(lifecycle.SegmentClosed(8));
++  REQUIRE(lifecycle.End(0x1000));
++
++  uint32_t delta = 0;
++  bool commit = false;
++  ZPDLifecycle::Report report;
++  REQUIRE(lifecycle.Resolve(begin.report_handle, 12, 1, 1, delta, commit, report));
++  REQUIRE(delta == 12);
++  REQUIRE_FALSE(commit);
++  REQUIRE(lifecycle.Resolve(begin.report_handle, 20, 1, 1, delta, commit, report));
++  REQUIRE(delta == 32);
++  REQUIRE(commit);
++  REQUIRE(lifecycle.Find(begin.report_handle) == nullptr);
++}
++
++TEST_CASE("ZPD stale result is rejected after same-slot reuse", "[graphics][zpd]") {
++  ZPDLifecycle lifecycle;
++  auto old_begin = lifecycle.Begin(0x2020);
++  REQUIRE(lifecycle.SegmentOpened());
++  REQUIRE(lifecycle.SegmentClosed(3));
++  REQUIRE(lifecycle.End(0x2000));
++
++  auto new_begin = lifecycle.Begin(0x2020);
++  REQUIRE(new_begin.same_slot_reuse);
++  uint32_t delta = 0;
++  bool commit = true;
++  ZPDLifecycle::Report report;
++  REQUIRE(lifecycle.Resolve(old_begin.report_handle, 99, 1, 1, delta, commit, report));
++  REQUIRE_FALSE(commit);
++  REQUIRE(lifecycle.CachedDelta(0x2000, 7) == 7);
++  REQUIRE(lifecycle.Find(new_begin.report_handle) != nullptr);
++}
++
++TEST_CASE("ZPD normalization preserves one guest sample at 2x", "[graphics][zpd]") {
++  REQUIRE(ZPDLifecycle::Normalize(4, 2, 2) == 1);
++  REQUIRE(ZPDLifecycle::Normalize(5, 2, 2) == 1);
++  REQUIRE(ZPDLifecycle::Normalize(uint64_t(UINT32_MAX) * 8, 1, 1) == UINT32_MAX);
++}
++
++}  // namespace rex::graphics
+diff --git a/include/rex/graphics/flags.h b/include/rex/graphics/flags.h
+index 2cf24c4..321e698 100644
+--- a/include/rex/graphics/flags.h
++++ b/include/rex/graphics/flags.h
+@@ -30,6 +30,7 @@ REXCVAR_DECLARE(bool, readback_resolve_half_pixel_offset);
+ REXCVAR_DECLARE(bool, readback_memexport);
+ REXCVAR_DECLARE(bool, readback_memexport_fast);
+ REXCVAR_DECLARE(bool, occlusion_query_enable);
++REXCVAR_DECLARE(std::string, occlusion_query);
+ REXCVAR_DECLARE(int32_t, query_occlusion_fake_sample_count);
+ 
+ // GPU Depth / Render Target Behavior
+diff --git a/include/rex/perf/counter.h b/include/rex/perf/counter.h
+index 5053a69..0f9b011 100644
+--- a/include/rex/perf/counter.h
++++ b/include/rex/perf/counter.h
+@@ -59,6 +59,20 @@ enum class CounterId : uint16_t {
+   kMemexportQueueWaits,
+   kMemexportFenceWaits,
+ 
++  // D3D12 ZPD report lifecycle
++  kZpdReportsStarted,
++  kZpdReportsEnded,
++  kZpdReportSegments,
++  kZpdSameSlotReuse,
++  kZpdFastSpeculativeWrites,
++  kZpdAsyncResultPatches,
++  kZpdStrictWaits,
++  kZpdStrictWaitTimeNs,
++  kZpdRetireTimeouts,
++  kZpdFakeFallbacks,
++  kZpdMalformedRecords,
++  kZpdStaleResultRejections,
++
+   kCount  // sentinel -- must be last
+ };
+ 
+diff --git a/src/core/perf/counter.cpp b/src/core/perf/counter.cpp
+index fc7c7b7..d8e6c58 100644
+--- a/src/core/perf/counter.cpp
++++ b/src/core/perf/counter.cpp
+@@ -57,6 +57,18 @@ constexpr const char* kCounterNames[] = {
+     "memexport_sync_fallbacks",
+     "memexport_queue_waits",
+     "memexport_fence_waits",
++    "zpd_reports_started",
++    "zpd_reports_ended",
++    "zpd_report_segments",
++    "zpd_same_slot_reuse",
++    "zpd_fast_speculative_writes",
++    "zpd_async_result_patches",
++    "zpd_strict_waits",
++    "zpd_strict_wait_time_ns",
++    "zpd_retire_timeouts",
++    "zpd_fake_fallbacks",
++    "zpd_malformed_records",
++    "zpd_stale_result_rejections",
+ };
+ static_assert(std::size(kCounterNames) == kNumCounters, "kCounterNames must match CounterId enum");
+ 
+@@ -88,6 +100,18 @@ constexpr bool kIsGauge[] = {
+     false,  // kMemexportSyncFallbacks
+     false,  // kMemexportQueueWaits
+     false,  // kMemexportFenceWaits
++    false,  // kZpdReportsStarted
++    false,  // kZpdReportsEnded
++    false,  // kZpdReportSegments
++    false,  // kZpdSameSlotReuse
++    false,  // kZpdFastSpeculativeWrites
++    false,  // kZpdAsyncResultPatches
++    false,  // kZpdStrictWaits
++    false,  // kZpdStrictWaitTimeNs
++    false,  // kZpdRetireTimeouts
++    false,  // kZpdFakeFallbacks
++    false,  // kZpdMalformedRecords
++    false,  // kZpdStaleResultRejections
+ };
+ static_assert(std::size(kIsGauge) == kNumCounters, "kIsGauge must match CounterId enum");
+ 
+diff --git a/src/graphics/command_processor.cpp b/src/graphics/command_processor.cpp
+index c4fc5f5..df5fd19 100644
+--- a/src/graphics/command_processor.cpp
++++ b/src/graphics/command_processor.cpp
+@@ -46,6 +46,15 @@ REXCVAR_DEFINE_BOOL(clear_memory_page_state, true, "GPU",
+ REXCVAR_DEFINE_BOOL(occlusion_query_enable, true, "GPU", "Enable host occlusion query handling")
+     .lifecycle(rex::cvar::Lifecycle::kHotReload);
+ 
++REXCVAR_DEFINE_STRING(occlusion_query, "legacy", "GPU",
++                      "Select ZPD occlusion report handling.\n"
++                      " legacy: Existing synchronous renderer path (default)\n"
++                      " fake: Guest-visible fake sample counts\n"
++                      " fast: Asynchronous host queries with speculative writes\n"
++                      " strict: Bounded host-query retirement before writeback")
++    .allowed({"legacy", "fake", "fast", "strict"})
++    .lifecycle(rex::cvar::Lifecycle::kRequiresRestart);
++
+ REXCVAR_DEFINE_STRING(readback_resolve, "none", "GPU",
+                       "Controls CPU readback of render-to-texture resolve results.\n"
+                       " none: Disable readback (default)\n"
+@@ -1393,12 +1402,11 @@ bool CommandProcessor::ExecutePacketType3Draw(memory::RingBuffer* reader, uint32
+               "major_mode={} explicit_major={} output_path=0x{:08X} path_select={} "
+               "hos_control=0x{:08X} tess_mode={} rb_modecontrol=0x{:08X} edram_mode={}",
+               opcode_name, packet, vgt_draw_initiator.value,
+-              uint32_t(vgt_draw_initiator.num_indices),
+-              uint32_t(vgt_draw_initiator.prim_type), uint32_t(vgt_draw_initiator.source_select),
+-              uint32_t(vgt_draw_initiator.index_size), uint32_t(vgt_draw_initiator.major_mode),
+-              uint32_t(major_mode_explicit), vgt_output_path_cntl.value,
+-              uint32_t(vgt_output_path_cntl.path_select), vgt_hos_cntl.value,
+-              uint32_t(vgt_hos_cntl.tess_mode), rb_modecontrol.value,
++              uint32_t(vgt_draw_initiator.num_indices), uint32_t(vgt_draw_initiator.prim_type),
++              uint32_t(vgt_draw_initiator.source_select), uint32_t(vgt_draw_initiator.index_size),
++              uint32_t(vgt_draw_initiator.major_mode), uint32_t(major_mode_explicit),
++              vgt_output_path_cntl.value, uint32_t(vgt_output_path_cntl.path_select),
++              vgt_hos_cntl.value, uint32_t(vgt_hos_cntl.tess_mode), rb_modecontrol.value,
+               uint32_t(rb_modecontrol.edram_mode));
+         }
+         REXGPU_ERROR(
+diff --git a/include/rex/graphics/d3d12/command_processor.h b/include/rex/graphics/d3d12/command_processor.h
+index 96d362b..b9c89d6 100644
+--- a/include/rex/graphics/d3d12/command_processor.h
++++ b/include/rex/graphics/d3d12/command_processor.h
+@@ -36,6 +36,7 @@
+ #include <rex/graphics/registers.h>
+ #include <rex/graphics/util/draw.h>
+ #include <rex/graphics/xenos.h>
++#include <rex/graphics/zpd_lifecycle.h>
+ #include <rex/system/kernel_state.h>
+ #include <rex/ui/d3d12/d3d12_descriptor_heap_pool.h>
+ #include <rex/ui/d3d12/d3d12_provider.h>
+@@ -412,6 +413,15 @@ class D3D12CommandProcessor : public CommandProcessor {
+   uint64_t NormalizeOcclusionSamples(uint64_t samples) const;
+   void WriteGuestOcclusionResult(xenos::xe_gpu_depth_sample_counts* sample_counts,
+                                  uint64_t samples);
++  ZPDMode GetZPDMode() const;
++  bool ExecuteModernZPD(memory::RingBuffer* reader, uint32_t packet, uint32_t count);
++  bool AcquireModernOcclusionQuery(uint32_t& host_index_out, uint32_t& generation_out);
++  void ReleaseModernOcclusionQuery(uint32_t host_index, uint32_t generation);
++  bool OpenModernZPDSegment();
++  bool CloseModernZPDSegment();
++  void RetireModernZPDQueries();
++  bool AwaitModernZPDReport(ZPDLifecycle::ReportHandle report_handle, uint32_t timeout_ms);
++  void WriteModernZPDReport(const ZPDLifecycle::Report& report, uint32_t delta);
+   void InvalidateAllVertexBufferResidency();
+   void InvalidateVertexBufferResidency(uint32_t vfetch_index);
+   void InvalidateVertexBufferResidencyRange(uint32_t first_vfetch, uint32_t last_vfetch);
+@@ -659,6 +669,20 @@ class D3D12CommandProcessor : public CommandProcessor {
+     uint32_t host_index = UINT32_MAX;
+     bool valid = false;
+   } active_occlusion_query_;
++  struct PendingModernOcclusionQuery {
++    uint64_t submission = 0;
++    uint32_t host_index = UINT32_MAX;
++    uint32_t generation = 0;
++    ZPDLifecycle::ReportHandle report_handle = ZPDLifecycle::kInvalidReportHandle;
++  };
++  ZPDLifecycle zpd_lifecycle_;
++  std::vector<uint32_t> modern_occlusion_query_free_indices_;
++  std::vector<uint32_t> modern_occlusion_query_generations_;
++  std::deque<PendingModernOcclusionQuery> modern_occlusion_queries_pending_;
++  uint32_t modern_occlusion_query_active_index_ = UINT32_MAX;
++  uint32_t modern_occlusion_query_active_generation_ = 0;
++  ZPDLifecycle::ReportHandle modern_occlusion_query_active_report_ =
++      ZPDLifecycle::kInvalidReportHandle;
+   struct VertexBufferState {
+     uint32_t address = UINT32_MAX;
+     uint32_t size = UINT32_MAX;
+diff --git a/src/graphics/d3d12/command_processor.cpp b/src/graphics/d3d12/command_processor.cpp
+index e38fdb1..fb511da 100644
+--- a/src/graphics/d3d12/command_processor.cpp
++++ b/src/graphics/d3d12/command_processor.cpp
+@@ -10,6 +10,7 @@
+  */
+ 
+ #include <algorithm>
++#include <chrono>
+ #include <cstdarg>
+ #include <cstring>
+ #include <sstream>
+@@ -152,6 +153,13 @@ void D3D12CommandProcessor::InitializeShaderStorage(const std::filesystem::path&
+ 
+ bool D3D12CommandProcessor::ExecutePacketType3_EVENT_WRITE_ZPD(memory::RingBuffer* reader,
+                                                                uint32_t packet, uint32_t count) {
++  ZPDMode mode = GetZPDMode();
++  if (mode == ZPDMode::kFast || mode == ZPDMode::kStrict) {
++    return ExecuteModernZPD(reader, packet, count);
++  }
++  if (mode == ZPDMode::kFake) {
++    return CommandProcessor::ExecutePacketType3_EVENT_WRITE_ZPD(reader, packet, count);
++  }
+   if (!REXCVAR_GET(occlusion_query_enable) || !occlusion_query_resources_available_) {
+     return CommandProcessor::ExecutePacketType3_EVENT_WRITE_ZPD(reader, packet, count);
+   }
+@@ -217,6 +225,156 @@ bool D3D12CommandProcessor::ExecutePacketType3_EVENT_WRITE_ZPD(memory::RingBuffe
+   return true;
+ }
+ 
++ZPDMode D3D12CommandProcessor::GetZPDMode() const {
++  const std::string& mode = REXCVAR_GET(occlusion_query);
++  if (mode == "fake") {
++    return ZPDMode::kFake;
++  }
++  if (mode == "fast") {
++    return ZPDMode::kFast;
++  }
++  if (mode == "strict") {
++    return ZPDMode::kStrict;
++  }
++  return ZPDMode::kLegacy;
++}
++
++bool D3D12CommandProcessor::ExecuteModernZPD(memory::RingBuffer* reader, uint32_t packet,
++                                             uint32_t count) {
++  assert_true(count == 1);
++  uint32_t initiator = reader->ReadAndSwap<uint32_t>();
++  WriteRegister(XE_GPU_REG_VGT_EVENT_INITIATOR, initiator & 0x3F);
++
++  if (!REXCVAR_GET(occlusion_query_enable) || !occlusion_query_resources_available_) {
++    PERF_counter_inc(kZpdFakeFallbacks);
++    // The packet payload has already been consumed, so reproduce the safe fake
++    // completion locally instead of delegating to the base packet reader.
++    uint32_t address = register_file_->values[XE_GPU_REG_RB_SAMPLE_COUNT_ADDR];
++    auto* report = memory_->TranslatePhysical<xenos::xe_gpu_depth_sample_counts*>(address);
++    if (report && XenosZPDReport::HasPendingSentinel(report)) {
++      XenosZPDReport::WriteSampleCount(report,
++                                       uint32_t(REXCVAR_GET(query_occlusion_fake_sample_count)));
++    }
++    return true;
++  }
++
++  RetireModernZPDQueries();
++  if (!BeginSubmission(true)) {
++    PERF_counter_inc(kZpdFakeFallbacks);
++    return true;
++  }
++
++  uint32_t address = register_file_->values[XE_GPU_REG_RB_SAMPLE_COUNT_ADDR];
++  uint32_t record_base = XenosZPDReport::GetRecordBase(address);
++  auto* guest_report =
++      record_base ? memory_->TranslatePhysical<xenos::xe_gpu_depth_sample_counts*>(record_base)
++                  : nullptr;
++  if (!guest_report) {
++    PERF_counter_inc(kZpdMalformedRecords);
++    return true;
++  }
++
++  if (XenosZPDReport::IsBeginRecord(address)) {
++    // A new BEGIN implicitly closes an older logical lifetime.
++    if (zpd_lifecycle_.active().logical_active) {
++      ZPDLifecycle::Report* old_report = zpd_lifecycle_.active_report();
++      ZPDLifecycle::ReportHandle old_handle = zpd_lifecycle_.active().report_handle;
++      uint32_t old_end = old_report ? old_report->end_record : 0;
++      if (old_end) {
++        CloseModernZPDSegment();
++        zpd_lifecycle_.End(old_end);
++        PERF_counter_inc(kZpdReportsEnded);
++        old_report = zpd_lifecycle_.Find(old_handle);
++        if (old_report && old_report->pending_segments == 0) {
++          WriteModernZPDReport(*old_report, 1);
++          ZPDLifecycle::Report abandoned;
++          bool commit = false;
++          zpd_lifecycle_.Abandon(old_handle, 1, abandoned, commit);
++          PERF_counter_inc(kZpdFakeFallbacks);
++        } else if (old_report && GetZPDMode() == ZPDMode::kFast) {
++          uint32_t speculative = old_report->has_cached_delta ? old_report->cached_delta : 1;
++          WriteModernZPDReport(*old_report, speculative);
++          PERF_counter_inc(kZpdFastSpeculativeWrites);
++        } else if (old_report) {
++          AwaitModernZPDReport(old_handle, 2);
++          BeginSubmission(true);
++        }
++      }
++    }
++    uint32_t slot_base = XenosZPDReport::GetSlotBase(address);
++    bool same_slot_reuse = zpd_lifecycle_.HasPendingSlot(slot_base);
++    if (same_slot_reuse && GetZPDMode() == ZPDMode::kStrict) {
++      ZPDLifecycle::ReportHandle pending = zpd_lifecycle_.OldestPendingSlot(slot_base);
++      if (pending != ZPDLifecycle::kInvalidReportHandle) {
++        AwaitModernZPDReport(pending, 2);
++        // Awaiting closes the current submission. Reopen before BeginQuery.
++        BeginSubmission(true);
++      }
++    }
++    std::memset(guest_report, 0, sizeof(*guest_report));
++    auto begin = zpd_lifecycle_.Begin(address);
++    if (begin.report_handle == ZPDLifecycle::kInvalidReportHandle) {
++      PERF_counter_inc(kZpdMalformedRecords);
++      return true;
++    }
++    PERF_counter_inc(kZpdReportsStarted);
++    if (same_slot_reuse || begin.same_slot_reuse) {
++      PERF_counter_inc(kZpdSameSlotReuse);
++    }
++    OpenModernZPDSegment();
++    return true;
++  }
++
++  if (!XenosZPDReport::IsEndRecord(address)) {
++    PERF_counter_inc(kZpdMalformedRecords);
++    if (XenosZPDReport::HasPendingSentinel(guest_report)) {
++      PERF_counter_inc(kZpdFakeFallbacks);
++      XenosZPDReport::WriteSampleCount(guest_report,
++                                       uint32_t(REXCVAR_GET(query_occlusion_fake_sample_count)));
++    }
++    return true;
++  }
++
++  ZPDLifecycle::Report* active_report = zpd_lifecycle_.active_report();
++  if (!active_report) {
++    // Orphan END: never leave the guest polling the sentinel.
++    uint32_t cached = zpd_lifecycle_.CachedDelta(record_base, 1);
++    XenosZPDReport::WriteSampleCount(guest_report, cached);
++    PERF_counter_inc(kZpdFastSpeculativeWrites);
++    return true;
++  }
++
++  ZPDLifecycle::ReportHandle handle = zpd_lifecycle_.active().report_handle;
++  CloseModernZPDSegment();
++  zpd_lifecycle_.End(address);
++  PERF_counter_inc(kZpdReportsEnded);
++
++  active_report = zpd_lifecycle_.Find(handle);
++  if (!active_report) {
++    return true;
++  }
++
++  if (active_report->pending_segments == 0) {
++    // Pool exhaustion or a failed segment open must still release guest
++    // polling. Unknown visibility is conservatively treated as visible.
++    WriteModernZPDReport(*active_report, 1);
++    ZPDLifecycle::Report abandoned;
++    bool commit = false;
++    zpd_lifecycle_.Abandon(handle, 1, abandoned, commit);
++    PERF_counter_inc(kZpdFakeFallbacks);
++    return true;
++  }
++
++  if (GetZPDMode() == ZPDMode::kFast) {
++    uint32_t speculative = active_report->has_cached_delta ? active_report->cached_delta : 1;
++    WriteModernZPDReport(*active_report, speculative);
++    PERF_counter_inc(kZpdFastSpeculativeWrites);
++  } else {
++    AwaitModernZPDReport(handle, 2);
++  }
++  return true;
++}
++
+ bool D3D12CommandProcessor::PushTransitionBarrier(ID3D12Resource* resource,
+                                                   D3D12_RESOURCE_STATES old_state,
+                                                   D3D12_RESOURCE_STATES new_state,
+@@ -3150,6 +3308,7 @@ void D3D12CommandProcessor::CheckSubmissionFence(uint64_t await_submission) {
+   if (submission_completed_ < await_submission) {
+     REXGPU_ERROR("Failed to await a submission completion Direct3D 12 fence");
+   }
++  RetireModernZPDQueries();
+   if (submission_completed_ <= submission_completed_before) {
+     // Not updated - no need to reclaim or download things.
+     return;
+@@ -3374,6 +3533,11 @@ bool D3D12CommandProcessor::BeginSubmission(bool is_guest_command) {
+     texture_cache_->BeginFrame();
+   }
+ 
++  if ((GetZPDMode() == ZPDMode::kFast || GetZPDMode() == ZPDMode::kStrict) &&
++      zpd_lifecycle_.active().segment_pending_begin) {
++    OpenModernZPDSegment();
++  }
++
+   return true;
+ }
+ 
+@@ -3408,7 +3572,10 @@ bool D3D12CommandProcessor::EndSubmission(bool is_swap) {
+   if (submission_open_) {
+     assert_false(scratch_buffer_used_);
+ 
+-    if (active_occlusion_query_.valid && occlusion_query_heap_) {
++    if ((GetZPDMode() == ZPDMode::kFast || GetZPDMode() == ZPDMode::kStrict) &&
++        modern_occlusion_query_active_index_ != UINT32_MAX) {
++      CloseModernZPDSegment();
++    } else if (active_occlusion_query_.valid && occlusion_query_heap_) {
+       deferred_command_list_.D3DEndQuery(occlusion_query_heap_.Get(), D3D12_QUERY_TYPE_OCCLUSION,
+                                          active_occlusion_query_.host_index);
+       active_occlusion_query_ = {};
+@@ -4811,6 +4978,13 @@ ID3D12Resource* D3D12CommandProcessor::RequestReadbackBuffer(uint32_t size) {
+ bool D3D12CommandProcessor::InitializeOcclusionQueryResources() {
+   active_occlusion_query_ = {};
+   occlusion_query_cursor_ = 0;
++  zpd_lifecycle_.Reset();
++  modern_occlusion_query_free_indices_.clear();
++  modern_occlusion_query_generations_.clear();
++  modern_occlusion_queries_pending_.clear();
++  modern_occlusion_query_active_index_ = UINT32_MAX;
++  modern_occlusion_query_active_generation_ = 0;
++  modern_occlusion_query_active_report_ = ZPDLifecycle::kInvalidReportHandle;
+   occlusion_query_resources_available_ = false;
+   occlusion_query_heap_.Reset();
+   occlusion_query_readback_.Reset();
+@@ -4857,13 +5031,31 @@ bool D3D12CommandProcessor::InitializeOcclusionQueryResources() {
+   }
+ 
+   occlusion_query_readback_mapping_ = reinterpret_cast<uint64_t*>(mapping);
++  modern_occlusion_query_generations_.resize(kMaxOcclusionQueries, 0);
++  modern_occlusion_query_free_indices_.reserve(kMaxOcclusionQueries);
++  for (uint32_t i = kMaxOcclusionQueries; i != 0; --i) {
++    modern_occlusion_query_free_indices_.push_back(i - 1);
++  }
+   occlusion_query_resources_available_ = true;
+   return true;
+ }
+ 
+ void D3D12CommandProcessor::ShutdownOcclusionQueryResources() {
++  if (modern_occlusion_query_active_index_ != UINT32_MAX && submission_open_ &&
++      occlusion_query_heap_ && occlusion_query_readback_) {
++    CloseModernZPDSegment();
++    EndSubmission(false);
++  }
+   DisableHostOcclusionQueries();
+ 
++  zpd_lifecycle_.Reset();
++  modern_occlusion_query_free_indices_.clear();
++  modern_occlusion_query_generations_.clear();
++  modern_occlusion_queries_pending_.clear();
++  modern_occlusion_query_active_index_ = UINT32_MAX;
++  modern_occlusion_query_active_generation_ = 0;
++  modern_occlusion_query_active_report_ = ZPDLifecycle::kInvalidReportHandle;
++
+   if (occlusion_query_readback_ && occlusion_query_readback_mapping_) {
+     occlusion_query_readback_->Unmap(0, nullptr);
+   }
+@@ -4993,6 +5185,164 @@ void D3D12CommandProcessor::WriteGuestOcclusionResult(
+   sample_counts->StencilFail_B = 0;
+ }
+ 
++bool D3D12CommandProcessor::AcquireModernOcclusionQuery(uint32_t& host_index_out,
++                                                        uint32_t& generation_out) {
++  RetireModernZPDQueries();
++  if (modern_occlusion_query_free_indices_.empty()) {
++    return false;
++  }
++  host_index_out = modern_occlusion_query_free_indices_.back();
++  modern_occlusion_query_free_indices_.pop_back();
++  generation_out = ++modern_occlusion_query_generations_[host_index_out];
++  if (!generation_out) {
++    generation_out = ++modern_occlusion_query_generations_[host_index_out];
++  }
++  return true;
++}
++
++void D3D12CommandProcessor::ReleaseModernOcclusionQuery(uint32_t host_index, uint32_t generation) {
++  if (host_index >= modern_occlusion_query_generations_.size() ||
++      modern_occlusion_query_generations_[host_index] != generation) {
++    return;
++  }
++  modern_occlusion_query_free_indices_.push_back(host_index);
++}
++
++bool D3D12CommandProcessor::OpenModernZPDSegment() {
++  if (!submission_open_ || !occlusion_query_heap_ ||
++      modern_occlusion_query_active_index_ != UINT32_MAX ||
++      !zpd_lifecycle_.active().logical_active || !zpd_lifecycle_.active().segment_pending_begin) {
++    return false;
++  }
++  uint32_t index = UINT32_MAX;
++  uint32_t generation = 0;
++  if (!AcquireModernOcclusionQuery(index, generation)) {
++    return false;
++  }
++  deferred_command_list_.D3DBeginQuery(occlusion_query_heap_.Get(), D3D12_QUERY_TYPE_OCCLUSION,
++                                       index);
++  modern_occlusion_query_active_index_ = index;
++  modern_occlusion_query_active_generation_ = generation;
++  modern_occlusion_query_active_report_ = zpd_lifecycle_.active().report_handle;
++  zpd_lifecycle_.SegmentOpened();
++  return true;
++}
++
++bool D3D12CommandProcessor::CloseModernZPDSegment() {
++  if (modern_occlusion_query_active_index_ == UINT32_MAX || !submission_open_ ||
++      !occlusion_query_heap_ || !occlusion_query_readback_) {
++    return false;
++  }
++  uint32_t index = modern_occlusion_query_active_index_;
++  uint32_t generation = modern_occlusion_query_active_generation_;
++  ZPDLifecycle::ReportHandle handle = modern_occlusion_query_active_report_;
++  modern_occlusion_query_active_index_ = UINT32_MAX;
++  modern_occlusion_query_active_generation_ = 0;
++  modern_occlusion_query_active_report_ = ZPDLifecycle::kInvalidReportHandle;
++
++  deferred_command_list_.D3DEndQuery(occlusion_query_heap_.Get(), D3D12_QUERY_TYPE_OCCLUSION,
++                                     index);
++  deferred_command_list_.D3DResolveQueryData(
++      occlusion_query_heap_.Get(), D3D12_QUERY_TYPE_OCCLUSION, index, 1,
++      occlusion_query_readback_.Get(), sizeof(uint64_t) * index);
++  modern_occlusion_queries_pending_.push_back({submission_current_, index, generation, handle});
++  zpd_lifecycle_.SegmentClosed(submission_current_);
++  PERF_counter_inc(kZpdReportSegments);
++  return true;
++}
++
++void D3D12CommandProcessor::RetireModernZPDQueries() {
++  if (!submission_fence_ || modern_occlusion_queries_pending_.empty()) {
++    return;
++  }
++  submission_completed_ = std::max(submission_completed_, submission_fence_->GetCompletedValue());
++  while (!modern_occlusion_queries_pending_.empty() &&
++         modern_occlusion_queries_pending_.front().submission <= submission_completed_) {
++    PendingModernOcclusionQuery pending = modern_occlusion_queries_pending_.front();
++    modern_occlusion_queries_pending_.pop_front();
++    bool generation_matches =
++        pending.host_index < modern_occlusion_query_generations_.size() &&
++        modern_occlusion_query_generations_[pending.host_index] == pending.generation;
++    uint64_t samples = generation_matches && occlusion_query_readback_mapping_
++                           ? occlusion_query_readback_mapping_[pending.host_index]
++                           : 0;
++    uint32_t delta = 0;
++    bool commit = false;
++    ZPDLifecycle::Report report;
++    bool resolved =
++        generation_matches &&
++        zpd_lifecycle_.Resolve(pending.report_handle, samples,
++                               texture_cache_ ? texture_cache_->draw_resolution_scale_x() : 1,
++                               texture_cache_ ? texture_cache_->draw_resolution_scale_y() : 1,
++                               delta, commit, report);
++    if (!resolved || !commit) {
++      if (!zpd_lifecycle_.Find(pending.report_handle)) {
++        PERF_counter_inc(kZpdStaleResultRejections);
++      }
++    } else {
++      WriteModernZPDReport(report, delta);
++      PERF_counter_inc(kZpdAsyncResultPatches);
++    }
++    ReleaseModernOcclusionQuery(pending.host_index, pending.generation);
++  }
++}
++
++bool D3D12CommandProcessor::AwaitModernZPDReport(ZPDLifecycle::ReportHandle report_handle,
++                                                 uint32_t timeout_ms) {
++  if (!zpd_lifecycle_.Find(report_handle)) {
++    return true;
++  }
++  if (submission_open_) {
++    EndSubmission(false);
++  }
++  PERF_counter_inc(kZpdStrictWaits);
++  auto wait_start = std::chrono::steady_clock::now();
++  uint64_t wait_submission = 0;
++  for (const PendingModernOcclusionQuery& pending : modern_occlusion_queries_pending_) {
++    if (pending.report_handle == report_handle) {
++      wait_submission = std::max(wait_submission, pending.submission);
++    }
++  }
++  bool signaled = wait_submission == 0 || submission_completed_ >= wait_submission;
++  if (!signaled && submission_fence_ &&
++      SUCCEEDED(
++          submission_fence_->SetEventOnCompletion(wait_submission, fence_completion_event_))) {
++    signaled = WaitForSingleObject(fence_completion_event_, timeout_ms) == WAIT_OBJECT_0;
++  }
++  auto elapsed = std::chrono::steady_clock::now() - wait_start;
++  PERF_counter_add(kZpdStrictWaitTimeNs,
++                   std::chrono::duration_cast<std::chrono::nanoseconds>(elapsed).count());
++  if (signaled) {
++    RetireModernZPDQueries();
++    return zpd_lifecycle_.Find(report_handle) == nullptr;
++  }
++
++  ZPDLifecycle::Report report;
++  bool commit = false;
++  uint32_t fallback = 1;
++  if (const ZPDLifecycle::Report* pending = zpd_lifecycle_.Find(report_handle)) {
++    fallback = pending->has_cached_delta ? pending->cached_delta : 1;
++  }
++  if (zpd_lifecycle_.Abandon(report_handle, fallback, report, commit) && commit) {
++    WriteModernZPDReport(report, fallback);
++  }
++  PERF_counter_inc(kZpdRetireTimeouts);
++  return false;
++}
++
++void D3D12CommandProcessor::WriteModernZPDReport(const ZPDLifecycle::Report& report,
++                                                 uint32_t delta) {
++  auto* begin =
++      report.begin_record
++          ? memory_->TranslatePhysical<xenos::xe_gpu_depth_sample_counts*>(report.begin_record)
++          : nullptr;
++  auto* end =
++      report.end_record
++          ? memory_->TranslatePhysical<xenos::xe_gpu_depth_sample_counts*>(report.end_record)
++          : nullptr;
++  XenosZPDReport::WriteReportDelta(begin, end, report.begin_value, delta, begin && begin != end);
++}
++
+ void D3D12CommandProcessor::WriteGammaRampSRV(bool is_pwl,
+                                               D3D12_CPU_DESCRIPTOR_HANDLE handle) const {
+   ID3D12Device* device = GetD3D12Provider().GetDevice();
+

--- a/src/pinyon_shift_app.cpp
+++ b/src/pinyon_shift_app.cpp
@@ -22,14 +22,14 @@
 
 #include <cstdio>
 
-REXCVAR_DEFINE_UINT32(pinyon_shift_config_schema, 5, "Pinyon Shift",
+REXCVAR_DEFINE_UINT32(pinyon_shift_config_schema, 6, "Pinyon Shift",
                       "Pinyon Shift host configuration schema version");
 REXCVAR_DEFINE_BOOL(pinyon_shift_capture_performance, true, "Pinyon Shift",
                     "Capture lightweight per-frame performance counters to a session CSV");
 
 namespace {
 
-constexpr uint32_t kConfigSchema = 5;
+constexpr uint32_t kConfigSchema = 6;
 
 bool EnsureSupportedConfig(const std::filesystem::path& path, bool& created,
                            bool& migrated) {
@@ -58,7 +58,8 @@ bool EnsureSupportedConfig(const std::filesystem::path& path, bool& created,
               "anisotropic_override = 3\n"
               "swap_post_effect = \"none\"\n"
               "draw_resolution_scale_x = 1\n"
-              "draw_resolution_scale_y = 1\n";
+              "draw_resolution_scale_y = 1\n"
+              "occlusion_query = \"legacy\"\n";
     created = true;
     return output.good();
   }
@@ -82,7 +83,7 @@ bool EnsureSupportedConfig(const std::filesystem::path& path, bool& created,
     if (schema == kConfigSchema) {
       return true;
     }
-    if (schema < 1 || schema > 4) {
+    if (schema < 1 || schema > 5) {
       return false;
     }
 
@@ -134,6 +135,7 @@ bool EnsureSupportedConfig(const std::filesystem::path& path, bool& created,
         {"swap_post_effect", "swap_post_effect = \"none\"\n"},
         {"draw_resolution_scale_x", "draw_resolution_scale_x = 1\n"},
         {"draw_resolution_scale_y", "draw_resolution_scale_y = 1\n"},
+        {"occlusion_query", "occlusion_query = \"legacy\"\n"},
     };
     for (const auto& [name, line] : graphics_settings) {
       const std::regex setting_pattern("(?:^|\\n)\\s*" + std::string(name) +
@@ -252,6 +254,7 @@ void PinyonShiftApp::OnPostInitLogging() {
                         {"anisotropic_override",
                          rex::cvar::GetFlagByName("anisotropic_override")},
                         {"swap_post_effect", rex::cvar::GetFlagByName("swap_post_effect")},
+                        {"occlusion_query", rex::cvar::GetFlagByName("occlusion_query")},
                         {"xma_relaxed_padding_admission",
                          rex::cvar::GetFlagByName(
                              "xma_relaxed_padding_admission")},

--- a/tools/create-crash-report.ps1
+++ b/tools/create-crash-report.ps1
@@ -152,6 +152,15 @@ try {
         no_progress = [uint64]0
         recoveries = [uint64]0
     }
+    $zpdColumns = @(
+        'zpd_reports_started', 'zpd_reports_ended', 'zpd_report_segments',
+        'zpd_same_slot_reuse', 'zpd_fast_speculative_writes',
+        'zpd_async_result_patches', 'zpd_strict_waits',
+        'zpd_strict_wait_time_ns', 'zpd_retire_timeouts', 'zpd_fake_fallbacks',
+        'zpd_malformed_records', 'zpd_stale_result_rejections'
+    )
+    $zpdCounters = [ordered]@{ available = $false }
+    foreach ($column in $zpdColumns) { $zpdCounters[$column] = [uint64]0 }
     $perfLog = Get-ChildItem -LiteralPath (Join-Path $resolvedStateRoot 'logs') -Filter '*.perf.csv' -File `
         -ErrorAction SilentlyContinue | Where-Object { $_.LastWriteTimeUtc -ge $StartedUtc.ToUniversalTime().AddSeconds(-2) } |
         Sort-Object LastWriteTimeUtc | Select-Object -Last 1
@@ -166,6 +175,14 @@ try {
             }
             $xmaStalls.available = $true
         }
+        if (@($zpdColumns | Where-Object { $_ -notin $columns }).Count -eq 0) {
+            foreach ($row in Import-Csv -LiteralPath $perfLog.FullName) {
+                foreach ($column in $zpdColumns) {
+                    $zpdCounters[$column] += [uint64]$row.$column
+                }
+            }
+            $zpdCounters.available = $true
+        }
     }
 
     $allowedSettings = @(
@@ -176,7 +193,7 @@ try {
         'pinyon_shift_capture_performance',
         'pinyon_shift_stabilize_vehicle_presentation', 'pinyon_shift_skip_opening_movies',
         'resolution', 'vsync', 'anisotropic_override', 'swap_post_effect',
-        'draw_resolution_scale_x', 'draw_resolution_scale_y'
+        'draw_resolution_scale_x', 'draw_resolution_scale_y', 'occlusion_query'
     )
     $configPath = Join-Path $resolvedStateRoot 'config/pinyon_shift.toml'
     $settings = [ordered]@{}
@@ -252,6 +269,9 @@ try {
         settings = $settings
         audio = [ordered]@{
             xma_stalls = $xmaStalls
+        }
+        graphics = [ordered]@{
+            zpd = $zpdCounters
         }
         local_dumps = $dumpRecords
         privacy = [ordered]@{

--- a/tools/set-graphics-experiment.ps1
+++ b/tools/set-graphics-experiment.ps1
@@ -8,6 +8,8 @@ param(
     [string]$PostEffect = 'none',
     [ValidateSet(1, 2)]
     [int]$ResolutionScale = 1,
+    [ValidateSet('legacy', 'fake', 'fast', 'strict')]
+    [string]$OcclusionQuery = 'legacy',
     [string]$StateRoot,
     [switch]$Json
 )
@@ -28,8 +30,8 @@ $backupDirectory = Join-Path $configDirectory 'backups'
 function Get-DefaultConfigText {
     @'
 # Pinyon Shift host configuration.
-# Schema 5 adds default-off XMA padding qualification.
-pinyon_shift_config_schema = 5
+# Schema 6 adds conservative ZPD lifecycle selection.
+pinyon_shift_config_schema = 6
 input_backend = "sdl"
 hid_mappings_file = "gamecontrollerdb.txt"
 mnk_mode = true
@@ -43,6 +45,7 @@ anisotropic_override = 3
 swap_post_effect = "none"
 draw_resolution_scale_x = 1
 draw_resolution_scale_y = 1
+occlusion_query = "legacy"
 '@
 }
 
@@ -104,6 +107,7 @@ function Get-SettingsResult([string]$Text, [string]$BackupPath, [string]$Operati
             anisotropy = $anisotropyValue
             post_effect = Get-TomlValue $Text 'swap_post_effect' 'none'
             resolution_scale = [int](Get-TomlValue $Text 'draw_resolution_scale_x' '1')
+            occlusion_query = Get-TomlValue $Text 'occlusion_query' 'legacy'
         }
         restart_required = $Operation -ne 'Get'
     }
@@ -117,7 +121,7 @@ switch ($Action) {
             Get-Content -LiteralPath $configPath -Raw
         } else { Get-DefaultConfigText }
         $schema = Get-SchemaVersion $text
-        if ($schema -notin @(1, 2, 3, 4, 5)) { throw "Unsupported host configuration schema: $schema" }
+        if ($schema -notin @(1, 2, 3, 4, 5, 6)) { throw "Unsupported host configuration schema: $schema" }
     }
     'Reset' {
         $backup = New-ConfigBackup
@@ -134,7 +138,7 @@ switch ($Action) {
         $backup = New-ConfigBackup
         $text = Get-Content -LiteralPath $source.FullName -Raw
         $schema = Get-SchemaVersion $text
-        if ($schema -notin @(1, 2, 3, 4, 5)) { throw "Backup uses unsupported schema: $schema" }
+        if ($schema -notin @(1, 2, 3, 4, 5, 6)) { throw "Backup uses unsupported schema: $schema" }
         Write-Config $text
     }
     'Apply' {
@@ -142,17 +146,21 @@ switch ($Action) {
             Get-Content -LiteralPath $configPath -Raw
         } else { Get-DefaultConfigText }
         $schema = Get-SchemaVersion $text
-        if ($schema -notin @(1, 2, 3, 4, 5)) { throw "Unsupported host configuration schema: $schema" }
+        if ($schema -notin @(1, 2, 3, 4, 5, 6)) { throw "Unsupported host configuration schema: $schema" }
         $backup = New-ConfigBackup
-        $text = Set-TomlValue $text 'pinyon_shift_config_schema' '5'
+        $text = Set-TomlValue $text 'pinyon_shift_config_schema' '6'
         if (-not [regex]::IsMatch($text, '(?m)^\s*xma_relaxed_padding_admission\s*=')) {
             $text = Set-TomlValue $text 'xma_relaxed_padding_admission' 'false'
+        }
+        if (-not [regex]::IsMatch($text, '(?m)^\s*occlusion_query\s*=')) {
+            $text = Set-TomlValue $text 'occlusion_query' '"legacy"'
         }
         $override = switch ($Anisotropy) { 4 { 3 } 8 { 4 } 16 { 5 } }
         $text = Set-TomlValue $text 'anisotropic_override' ([string]$override)
         $text = Set-TomlValue $text 'swap_post_effect' ('"' + $PostEffect + '"')
         $text = Set-TomlValue $text 'draw_resolution_scale_x' ([string]$ResolutionScale)
         $text = Set-TomlValue $text 'draw_resolution_scale_y' ([string]$ResolutionScale)
+        $text = Set-TomlValue $text 'occlusion_query' ('"' + $OcclusionQuery + '"')
         Write-Config $text
     }
 }

--- a/tools/summarize-performance.py
+++ b/tools/summarize-performance.py
@@ -43,6 +43,20 @@ XMA_STALL_COLUMNS = (
     "xma_no_progress_stalls",
     "xma_stall_recoveries",
 )
+ZPD_COLUMNS = (
+    "zpd_reports_started",
+    "zpd_reports_ended",
+    "zpd_report_segments",
+    "zpd_same_slot_reuse",
+    "zpd_fast_speculative_writes",
+    "zpd_async_result_patches",
+    "zpd_strict_waits",
+    "zpd_strict_wait_time_ns",
+    "zpd_retire_timeouts",
+    "zpd_fake_fallbacks",
+    "zpd_malformed_records",
+    "zpd_stale_result_rejections",
+)
 
 
 class CaptureError(ValueError):
@@ -94,11 +108,16 @@ def summarize(path: pathlib.Path) -> dict[str, Any]:
         if available_xma_stalls and available_xma_stalls != set(XMA_STALL_COLUMNS):
             missing_xma_stalls = sorted(set(XMA_STALL_COLUMNS) - available_xma_stalls)
             raise CaptureError("capture has an incomplete XMA stall counter set: " + ", ".join(missing_xma_stalls))
+        available_zpd = columns.intersection(ZPD_COLUMNS)
+        if available_zpd and available_zpd != set(ZPD_COLUMNS):
+            missing_zpd = sorted(set(ZPD_COLUMNS) - available_zpd)
+            raise CaptureError("capture has an incomplete ZPD counter set: " + ", ".join(missing_zpd))
 
         frame_times: list[float] = []
         totals = {name: 0.0 for name in TOTAL_COLUMNS}
         memexport_totals = {name: 0.0 for name in MEMEXPORT_COLUMNS} if available_memexport else None
         xma_stall_totals = {name: 0.0 for name in XMA_STALL_COLUMNS} if available_xma_stalls else None
+        zpd_totals = {name: 0.0 for name in ZPD_COLUMNS} if available_zpd else None
         rows_seen = 0
         for row_number, row in enumerate(reader, start=2):
             rows_seen += 1
@@ -111,6 +130,8 @@ def summarize(path: pathlib.Path) -> dict[str, Any]:
                               for name in MEMEXPORT_COLUMNS} if memexport_totals is not None else {})
             row_xma_stalls = ({name: finite_number(row[name], column=name, row_number=row_number)
                                for name in XMA_STALL_COLUMNS} if xma_stall_totals is not None else {})
+            row_zpd = ({name: finite_number(row[name], column=name, row_number=row_number)
+                        for name in ZPD_COLUMNS} if zpd_totals is not None else {})
             # The runtime writes one initialization row with frame_time_us == 0.
             # It is valid CSV, but not a displayed frame and must not skew latency.
             if frame_time == 0:
@@ -122,6 +143,8 @@ def summarize(path: pathlib.Path) -> dict[str, Any]:
                 memexport_totals[name] += value
             for name, value in row_xma_stalls.items():
                 xma_stall_totals[name] += value
+            for name, value in row_zpd.items():
+                zpd_totals[name] += value
 
     if rows_seen == 0:
         raise CaptureError("capture contains a header but no rows")
@@ -165,6 +188,10 @@ def summarize(path: pathlib.Path) -> dict[str, Any]:
     if xma_stall_totals is not None:
         result["xma_stall_counters"] = {
             name: int(value) if value.is_integer() else value for name, value in xma_stall_totals.items()
+        }
+    if zpd_totals is not None:
+        result["zpd_counters"] = {
+            name: int(value) if value.is_integer() else value for name, value in zpd_totals.items()
         }
     return result
 

--- a/tools/tests/test_graphics_settings.py
+++ b/tools/tests/test_graphics_settings.py
@@ -32,11 +32,14 @@ class GraphicsSettingsTests(unittest.TestCase):
             result = self.run_tool(
                 state, "-Action", "Apply", "-Anisotropy", "16",
                 "-PostEffect", "fxaa", "-ResolutionScale", "2",
+                "-OcclusionQuery", "fast",
             )
             updated = config.read_text(encoding="utf-8")
             self.assertEqual(result["settings"]["anisotropy"], 16)
-            self.assertIn("pinyon_shift_config_schema = 5", updated)
+            self.assertIn("pinyon_shift_config_schema = 6", updated)
             self.assertIn("xma_relaxed_padding_admission = false", updated)
+            self.assertEqual(result["settings"]["occlusion_query"], "fast")
+            self.assertIn('occlusion_query = "fast"', updated)
             self.assertIn("custom_value = 77", updated)
             self.assertIn("draw_resolution_scale_x = 2", updated)
             self.assertTrue(pathlib.Path(result["backup_path"]).is_file())
@@ -54,6 +57,7 @@ class GraphicsSettingsTests(unittest.TestCase):
             self.assertIn("swap_post_effect = \"none\"", text)
             self.assertIn("draw_resolution_scale_x = 1", text)
             self.assertIn("xma_relaxed_padding_admission = false", text)
+            self.assertIn('occlusion_query = "legacy"', text)
             self.assertTrue(pathlib.Path(result["backup_path"]).is_file())
 
 

--- a/tools/tests/test_performance_summary.py
+++ b/tools/tests/test_performance_summary.py
@@ -24,6 +24,20 @@ FIELDS = [
 
 
 class PerformanceSummaryTests(unittest.TestCase):
+    def test_emits_complete_optional_zpd_totals(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            capture = pathlib.Path(temporary) / "capture.csv"
+            zpd_columns = list(MODULE.ZPD_COLUMNS)
+            fields = FIELDS + zpd_columns
+            with capture.open("w", encoding="utf-8", newline="") as stream:
+                writer = csv.DictWriter(stream, fieldnames=fields)
+                writer.writeheader()
+                writer.writerow(dict.fromkeys(fields, 1) | {"frame_time_us": 10_000})
+                writer.writerow(dict.fromkeys(fields, 2) | {"frame_time_us": 11_000})
+            result = MODULE.summarize(capture)
+            self.assertEqual(3, result["zpd_counters"]["zpd_reports_started"])
+            self.assertEqual(3, result["zpd_counters"]["zpd_stale_result_rejections"])
+
     def test_emits_complete_optional_xma_stall_totals(self):
         with tempfile.TemporaryDirectory() as temporary:
             capture = pathlib.Path(temporary) / "capture.csv"

--- a/tools/tests/test_release_contract.py
+++ b/tools/tests/test_release_contract.py
@@ -43,10 +43,10 @@ class ReleaseContractTests(unittest.TestCase):
 
     def test_rexglue_patches_have_stable_order_and_no_binary_payload(self):
         patches = sorted((ROOT / "patches/rexglue").glob("*.patch"))
-        self.assertEqual(len(patches), 38)
+        self.assertEqual(len(patches), 39)
         self.assertEqual(
             patches[-1].name,
-            "0038-m4-xma-stall-diagnostics.patch",
+            "0039-gpu-zpd-report-lifecycle-d3d12.patch",
         )
         self.assertEqual(len(patches), len({path.name[:4] for path in patches}))
         for path in patches:
@@ -163,13 +163,17 @@ class ReleaseContractTests(unittest.TestCase):
 
     def test_graphics_schema_and_diagnostics_contract(self):
         app = (ROOT / "src/pinyon_shift_app.cpp").read_text(encoding="utf-8")
-        self.assertIn("constexpr uint32_t kConfigSchema = 5", app)
+        self.assertIn("constexpr uint32_t kConfigSchema = 6", app)
         self.assertIn(".schema", app)
         for setting in ("anisotropic_override", "swap_post_effect", "draw_resolution_scale_x"):
             self.assertIn(setting, app)
             self.assertIn(setting, (ROOT / "tools/create-crash-report.ps1").read_text(encoding="utf-8"))
         self.assertIn("xma_relaxed_padding_admission = false", app)
         self.assertIn("xma_no_space_stalls", (ROOT / "tools/create-crash-report.ps1").read_text(encoding="utf-8"))
+        self.assertIn("zpd_stale_result_rejections", (ROOT / "tools/create-crash-report.ps1").read_text(encoding="utf-8"))
+        zpd_patch = ROOT / "patches/rexglue/0039-gpu-zpd-report-lifecycle-d3d12.patch"
+        self.assertTrue(zpd_patch.is_file())
+        self.assertIn("ZPDLifecycle", zpd_patch.read_text(encoding="utf-8"))
 
     def test_renderer_and_stub_instrumentation_is_bounded(self):
         stub_patch = (ROOT / "patches/rexglue/0031-sdk-stub-reachability-summary.patch").read_text(encoding="utf-8")
@@ -187,11 +191,12 @@ class ReleaseContractTests(unittest.TestCase):
         launcher = (ROOT / "launcher/PinyonShift.Launcher/MainWindow.xaml.cs").read_text(
             encoding="utf-8"
         )
-        self.assertIn("constexpr uint32_t kConfigSchema = 5;", app)
-        self.assertRegex(app, r"pinyon_shift_config_schema,\s*5,")
+        self.assertIn("constexpr uint32_t kConfigSchema = 6;", app)
+        self.assertRegex(app, r"pinyon_shift_config_schema,\s*6,")
         self.assertIn('"pinyon_shift_stabilize_vehicle_presentation = false\\n"', app)
         self.assertIn('"keybind_a = \\"LMB,Space\\"\\n"', app)
-        self.assertIn("schema < 1 || schema > 4", app)
+        self.assertIn("schema < 1 || schema > 5", app)
+        self.assertIn('"occlusion_query = \\"legacy\\"\\n"', app)
         self.assertIn("Controller A, Space, or left click.", launcher)
         self.assertRegex(
             hooks,


### PR DESCRIPTION
## Summary
- port segmented D3D12 ZPD logical-report lifecycle with generation-safe query reuse
- add fast, strict, fake, and legacy modes with conservative legacy shipping default
- export sanitized ZPD qualification counters and schema-6 tooling

## Validation
- clean replay of all 39 ReXGlue patches
- full release preview build (	ools/build-preview.ps1 -Parallel 16)
- 34 project tests passed
- focused ZPD suite: 29 assertions in 4 test cases
- AppData-backed fast-mode run: 1,220,121 frames over 40,643 seconds, 30.019 median FPS
- 61,647 reports started/ended and async-patched; zero timeout, fallback, malformed, stale, or command-buffer-stall events
- normal exit and orderly shutdown; original host config restored to legacy