### PR TITLE
feat(rexglue): add fh1 zpd policy qualification

### DIFF
--- a/config/rexglue/EPIC_05_ZPD_POLICY_GUARD.md
+++ b/config/rexglue/EPIC_05_ZPD_POLICY_GUARD.md
@@ -1,0 +1,77 @@
+# FH1 ZPD END policy and regression guard
+
+EPIC-05 is delivered by
+`patches/rexglue/0040-fh1-zpd-end-policy-and-telemetry.patch` plus host schema,
+qualification-runner, performance-summary, and sanitized support-report
+integration in this project.
+
+## Derivation and scope
+
+Xenia Canary issue [`#1099`](https://github.com/xenia-canary/xenia-canary/issues/1099)
+reports a Forza Horizon post-intro black screen after commit
+[`8a49c03`](https://github.com/xenia-canary/xenia-canary/commit/8a49c0380f1e4dd47538a8d0e3da9cc454786428),
+which relaxed ZPD END detection from a pairwise sentinel to either lane. This
+does not prove causation, so the patch exposes the three interpretations needed
+for a controlled title-specific qualification instead of hard-coding the
+reported workaround.
+
+The supported retail image is title ID `4D5309C9` with executable SHA-256
+`DB40DF605ADE49A612B35A7A24C38F6004BCB17A88ED6B48288DE16DF9E3987C`.
+The project enforces that hash before generation. ReXGlue's `auto` policy is
+scoped to the title ID because the SDK does not receive the project-side image
+hash; unsupported titles retain relaxed sentinel detection with no fallback.
+
+## Policy and diagnostics
+
+Configuration schema 7 adds:
+
+```toml
+zpd_end_policy = "report_layout"
+# report_layout | pairwise_sentinel | relaxed_sentinel
+
+zpd_end_fallback = "pairwise_sentinel"
+# none | pairwise_sentinel | relaxed_sentinel
+```
+
+`report_layout` classifies the `+0x20` record as BEGIN and the `+0x00` record
+as END within each 0x40-byte slot. The optional sentinel fallback is used only
+when an address cannot be classified from that layout. `pairwise_sentinel`
+requires both lanes of either expected pair; `relaxed_sentinel` accepts either
+A lane, preserving the prior ReXGlue interpretation.
+
+Before report memory is cleared, bounded `zpd.event` records expose the
+classification, reason, address, slot, logical state, and the four ZPass/ZFail
+lanes. Identical observations log for the first two occurrences and then at
+powers of two. A `zpd.watchdog` recovery records and replaces any sentinel
+still present after handling, preventing unchanged guest polling. Session CSVs
+and sanitized support reports add:
+
+```text
+zpd_classified_begins
+zpd_classified_ends
+zpd_classified_orphaned_ends
+zpd_policy_fallbacks
+zpd_watchdog_recoveries
+```
+
+These diagnostics contain counters and scalar classification fields only; they
+do not include saves, guest-memory dumps, generated code, or image data.
+
+The qualification gate permits bounded retire-timeout and watchdog fallback
+activity only in diagnostic `strict` mode. Shipping and comparison modes must
+finish with both counters at zero. Every mode must balance classified BEGIN
+and END records without malformed or orphaned reports.
+
+## Qualification and rollback
+
+`tools/qualify-zpd.ps1` provides the six-run legacy/fake/fast/strict policy
+matrix and a ten-cold-boot admission run for the selected policy. Each run uses
+the installed AppData preview state in place, records intro, controller-layout,
+and first-interactive-frame markers, checks the runtime log, and restores the
+original host config in a `finally` block.
+
+Shipping remains `occlusion_query = "legacy"` until the matrix and ten-boot
+admission gate pass. Immediate rollback is selecting `legacy`; that path does
+not consult the new policy. Removing patch `0040` and the schema-7/reporting
+integration removes EPIC-05 while retaining the independently qualified
+EPIC-04 lifecycle.

--- a/config/rexglue/PATCH_DISPOSITIONS.md
+++ b/config/rexglue/PATCH_DISPOSITIONS.md
@@ -106,6 +106,17 @@ all EPIC-04 counters are exported, and `occlusion_query = "legacy"` remains the
 shipping default and immediate rollback path. Removing `0039` restores the
 previous synchronous D3D12 query implementation.
 
+`0040-fh1-zpd-end-policy-and-telemetry` isolates the END-classification signal
+reported in Xenia Canary issue `#1099` and commit `8a49c03`. It adds
+report-layout, pairwise-sentinel, and relaxed-sentinel policies; an optional
+fallback; bounded pre-clear observations; and a final unchanged-sentinel
+watchdog. Title-scoped `auto` selects report layout plus pairwise fallback only
+for FH1 title ID `4D5309C9`; the project separately gates the supported retail
+executable hash. The legacy query path is unchanged and remains the shipping
+default until the six-run matrix and ten-cold-boot admission gate pass.
+Removing `0040` restores EPIC-04 classification behavior without removing its
+logical/physical report lifecycle.
+
 Validation performed on the rebased SDK:
 
 - `unit_tests` and `ppc_tests` build with the pinned Clang 20.1.8 toolchain.

--- a/patches/rexglue/0040-fh1-zpd-end-policy-and-telemetry.patch
+++ b/patches/rexglue/0040-fh1-zpd-end-policy-and-telemetry.patch
@@ -1,0 +1,601 @@
+diff --git a/include/rex/graphics/command_processor.h b/include/rex/graphics/command_processor.h
+index da8e4324702a7df4bc6d04f9ec01f3df0c57318d..9853ec26d6498a4f1133b24d9f17d93844b4399a 100644
+--- a/include/rex/graphics/command_processor.h
++++ b/include/rex/graphics/command_processor.h
+@@ -24,6 +24,7 @@
+ #include <rex/graphics/register_file.h>
+ #include <rex/graphics/registers.h>
+ #include <rex/graphics/xenos.h>
++#include <rex/graphics/zpd_policy.h>
+ #include <rex/memory.h>
+ #include <rex/memory/ring_buffer.h>
+ #include <rex/system/xthread.h>
+@@ -230,6 +231,15 @@ class CommandProcessor {
+   // Shared memexport readback enable state with backend legacy-flag override support.
+   bool IsReadbackMemexportEnabled(bool legacy_backend_flag) const;
+ 
++  ZPDPolicySettings GetZPDPolicySettings() const;
++  ZPDClassificationResult ClassifyZPD(uint32_t report_address,
++                                      const xenos::xe_gpu_depth_sample_counts* report,
++                                      bool logical_active) const;
++  void LogZPDObservation(uint32_t report_address, const xenos::xe_gpu_depth_sample_counts* report,
++                         bool logical_active, const ZPDClassificationResult& classification);
++  void RecoverStalledZPDSentinel(uint32_t report_address,
++                                 xenos::xe_gpu_depth_sample_counts* report);
++
+   memory::Memory* memory_ = nullptr;
+   system::KernelState* kernel_state_ = nullptr;
+   GraphicsSystem* graphics_system_ = nullptr;
+@@ -277,6 +287,10 @@ class CommandProcessor {
+   // name (for explicit-override compatibility).
+   const char* legacy_readback_memexport_cvar_name_ = nullptr;
+ 
++  bool zpd_fake_logical_active_ = false;
++  uint32_t zpd_fake_slot_base_ = 0;
++  ZPDObservationRateLimiter zpd_observation_rate_limiter_;
++
+  private:
+   reg::DC_LUT_30_COLOR gamma_ramp_256_entry_table_[256] = {};
+   reg::DC_LUT_PWL_DATA gamma_ramp_pwl_rgb_[128][3] = {};
+diff --git a/include/rex/graphics/flags.h b/include/rex/graphics/flags.h
+index 321e698b9c5dc27baafdf7f6e0edb23a43684b13..f1ae97787435c80c66c31943a40f33cca4a40e9b 100644
+--- a/include/rex/graphics/flags.h
++++ b/include/rex/graphics/flags.h
+@@ -31,6 +31,8 @@ REXCVAR_DECLARE(bool, readback_memexport);
+ REXCVAR_DECLARE(bool, readback_memexport_fast);
+ REXCVAR_DECLARE(bool, occlusion_query_enable);
+ REXCVAR_DECLARE(std::string, occlusion_query);
++REXCVAR_DECLARE(std::string, zpd_end_policy);
++REXCVAR_DECLARE(std::string, zpd_end_fallback);
+ REXCVAR_DECLARE(int32_t, query_occlusion_fake_sample_count);
+ 
+ // GPU Depth / Render Target Behavior
+diff --git a/include/rex/graphics/zpd_policy.h b/include/rex/graphics/zpd_policy.h
+new file mode 100644
+index 0000000000000000000000000000000000000000..61e0bd0eac9906fb91c41fd88a7777597812e1e1
+--- /dev/null
++++ b/include/rex/graphics/zpd_policy.h
+@@ -0,0 +1,182 @@
++#pragma once
++
++#include <cstdint>
++#include <string_view>
++#include <unordered_map>
++
++#include <rex/graphics/zpd_report.h>
++
++namespace rex::graphics {
++
++enum class ZPDEndPolicy {
++  kReportLayout,
++  kPairwiseSentinel,
++  kRelaxedSentinel,
++};
++
++enum class ZPDEndFallback {
++  kNone,
++  kPairwiseSentinel,
++  kRelaxedSentinel,
++};
++
++enum class ZPDClassification {
++  kBegin,
++  kEnd,
++  kOrphanedEnd,
++  kMalformed,
++};
++
++enum class ZPDClassificationReason {
++  kReportLayoutBegin,
++  kReportLayoutEnd,
++  kPairwiseSentinel,
++  kRelaxedSentinel,
++  kPairwiseFallback,
++  kRelaxedFallback,
++  kNoSentinel,
++  kMalformedLayout,
++};
++
++struct ZPDPolicySettings {
++  ZPDEndPolicy policy = ZPDEndPolicy::kRelaxedSentinel;
++  ZPDEndFallback fallback = ZPDEndFallback::kNone;
++};
++
++struct ZPDClassificationResult {
++  ZPDClassification classification = ZPDClassification::kMalformed;
++  ZPDClassificationReason reason = ZPDClassificationReason::kMalformedLayout;
++  bool pairwise_sentinel = false;
++  bool relaxed_sentinel = false;
++};
++
++struct ZPDObservationRateLimit {
++  uint64_t count = 0;
++  bool overflow_sample = false;
++
++  bool ShouldLog() const { return count <= 2 || (count & (count - 1)) == 0; }
++};
++
++class ZPDObservationRateLimiter {
++ public:
++  static constexpr size_t kMaxSignatures = 128;
++
++  ZPDObservationRateLimit Observe(uint64_t signature) {
++    auto observation = observations_.find(signature);
++    if (observation != observations_.end()) {
++      return {++observation->second, false};
++    }
++    if (observations_.size() < kMaxSignatures) {
++      observations_.emplace(signature, 1);
++      return {1, false};
++    }
++    return {++overflow_count_, true};
++  }
++
++ private:
++  std::unordered_map<uint64_t, uint64_t> observations_;
++  uint64_t overflow_count_ = 0;
++};
++
++inline ZPDPolicySettings ResolveZPDPolicy(std::string_view policy_name,
++                                          std::string_view fallback_name, uint32_t title_id) {
++  constexpr uint32_t kForzaHorizonTitleId = 0x4D5309C9;
++  ZPDPolicySettings settings;
++  if (policy_name == "report_layout" ||
++      (policy_name == "auto" && title_id == kForzaHorizonTitleId)) {
++    settings.policy = ZPDEndPolicy::kReportLayout;
++  } else if (policy_name == "pairwise_sentinel") {
++    settings.policy = ZPDEndPolicy::kPairwiseSentinel;
++  } else {
++    settings.policy = ZPDEndPolicy::kRelaxedSentinel;
++  }
++  if (fallback_name == "pairwise_sentinel" ||
++      (fallback_name == "auto" && title_id == kForzaHorizonTitleId)) {
++    settings.fallback = ZPDEndFallback::kPairwiseSentinel;
++  } else if (fallback_name == "relaxed_sentinel") {
++    settings.fallback = ZPDEndFallback::kRelaxedSentinel;
++  } else {
++    settings.fallback = ZPDEndFallback::kNone;
++  }
++  return settings;
++}
++
++inline ZPDClassificationResult ClassifyZPDReport(uint32_t report_address,
++                                                 const xenos::xe_gpu_depth_sample_counts* report,
++                                                 bool logical_active, ZPDPolicySettings settings) {
++  ZPDClassificationResult result;
++  result.pairwise_sentinel = XenosZPDReport::HasPairwisePendingSentinel(report);
++  result.relaxed_sentinel = XenosZPDReport::HasPendingSentinel(report);
++
++  bool is_end = false;
++  if (settings.policy == ZPDEndPolicy::kReportLayout) {
++    if (XenosZPDReport::IsBeginRecord(report_address)) {
++      result.classification = ZPDClassification::kBegin;
++      result.reason = ZPDClassificationReason::kReportLayoutBegin;
++      return result;
++    }
++    if (XenosZPDReport::IsEndRecord(report_address)) {
++      is_end = true;
++      result.reason = ZPDClassificationReason::kReportLayoutEnd;
++    } else if (settings.fallback == ZPDEndFallback::kPairwiseSentinel && result.pairwise_sentinel) {
++      is_end = true;
++      result.reason = ZPDClassificationReason::kPairwiseFallback;
++    } else if (settings.fallback == ZPDEndFallback::kRelaxedSentinel && result.relaxed_sentinel) {
++      is_end = true;
++      result.reason = ZPDClassificationReason::kRelaxedFallback;
++    } else {
++      result.classification = ZPDClassification::kMalformed;
++      result.reason = ZPDClassificationReason::kMalformedLayout;
++      return result;
++    }
++  } else if (settings.policy == ZPDEndPolicy::kPairwiseSentinel) {
++    is_end = result.pairwise_sentinel;
++    result.reason =
++        is_end ? ZPDClassificationReason::kPairwiseSentinel : ZPDClassificationReason::kNoSentinel;
++  } else {
++    is_end = result.relaxed_sentinel;
++    result.reason =
++        is_end ? ZPDClassificationReason::kRelaxedSentinel : ZPDClassificationReason::kNoSentinel;
++  }
++
++  result.classification =
++      is_end ? (logical_active ? ZPDClassification::kEnd : ZPDClassification::kOrphanedEnd)
++             : ZPDClassification::kBegin;
++  return result;
++}
++
++inline const char* ZPDClassificationName(ZPDClassification classification) {
++  switch (classification) {
++    case ZPDClassification::kBegin:
++      return "begin";
++    case ZPDClassification::kEnd:
++      return "end";
++    case ZPDClassification::kOrphanedEnd:
++      return "orphaned_end";
++    default:
++      return "malformed";
++  }
++}
++
++inline const char* ZPDClassificationReasonName(ZPDClassificationReason reason) {
++  switch (reason) {
++    case ZPDClassificationReason::kReportLayoutBegin:
++      return "report_layout_begin";
++    case ZPDClassificationReason::kReportLayoutEnd:
++      return "report_layout_end";
++    case ZPDClassificationReason::kPairwiseSentinel:
++      return "pairwise_sentinel";
++    case ZPDClassificationReason::kRelaxedSentinel:
++      return "relaxed_sentinel";
++    case ZPDClassificationReason::kPairwiseFallback:
++      return "pairwise_fallback";
++    case ZPDClassificationReason::kRelaxedFallback:
++      return "relaxed_fallback";
++    case ZPDClassificationReason::kNoSentinel:
++      return "no_sentinel";
++    default:
++      return "malformed_layout";
++  }
++}
++
++}  // namespace rex::graphics
+diff --git a/include/rex/graphics/zpd_report.h b/include/rex/graphics/zpd_report.h
+index 348df015e8e9ad9628bdbc6652193254bf47cf3e..1f8db358d22edee684c71d9d0911fb9c61e9ba3e 100644
+--- a/include/rex/graphics/zpd_report.h
++++ b/include/rex/graphics/zpd_report.h
+@@ -46,6 +46,14 @@ struct XenosZPDReport {
+                       report->ZFail_A == kSentinelLE || report->ZFail_A == kSentinelBE);
+   }
+ 
++  static bool HasPairwisePendingSentinel(const xenos::xe_gpu_depth_sample_counts* report) {
++    constexpr uint32_t kSentinelLE = 0xEDFEFFFFu;
++    constexpr uint32_t kSentinelBE = 0xFFFFFEEDu;
++    auto is_sentinel = [](uint32_t value) { return value == kSentinelLE || value == kSentinelBE; };
++    return report && ((is_sentinel(report->ZPass_A) && is_sentinel(report->ZPass_B)) ||
++                      (is_sentinel(report->ZFail_A) && is_sentinel(report->ZFail_B)));
++  }
++
+   static void WriteSampleCount(xenos::xe_gpu_depth_sample_counts* report, uint32_t sample_count) {
+     if (!report) {
+       return;
+diff --git a/include/rex/perf/counter.h b/include/rex/perf/counter.h
+index 0f9b011434540266c9f15195a58325a67080393f..41166885aa0c47c50332533a201f3e6379cfd323 100644
+--- a/include/rex/perf/counter.h
++++ b/include/rex/perf/counter.h
+@@ -72,6 +72,11 @@ enum class CounterId : uint16_t {
+   kZpdFakeFallbacks,
+   kZpdMalformedRecords,
+   kZpdStaleResultRejections,
++  kZpdClassifiedBegins,
++  kZpdClassifiedEnds,
++  kZpdClassifiedOrphanedEnds,
++  kZpdPolicyFallbacks,
++  kZpdWatchdogRecoveries,
+ 
+   kCount  // sentinel -- must be last
+ };
+diff --git a/src/core/perf/counter.cpp b/src/core/perf/counter.cpp
+index d8e6c5801ed006a5681e3c29aeca14571f86add8..e36e0ee998b104df92bf65261efa3e05b6d16ab7 100644
+--- a/src/core/perf/counter.cpp
++++ b/src/core/perf/counter.cpp
+@@ -69,6 +69,11 @@ constexpr const char* kCounterNames[] = {
+     "zpd_fake_fallbacks",
+     "zpd_malformed_records",
+     "zpd_stale_result_rejections",
++    "zpd_classified_begins",
++    "zpd_classified_ends",
++    "zpd_classified_orphaned_ends",
++    "zpd_policy_fallbacks",
++    "zpd_watchdog_recoveries",
+ };
+ static_assert(std::size(kCounterNames) == kNumCounters, "kCounterNames must match CounterId enum");
+ 
+@@ -112,6 +117,11 @@ constexpr bool kIsGauge[] = {
+     false,  // kZpdFakeFallbacks
+     false,  // kZpdMalformedRecords
+     false,  // kZpdStaleResultRejections
++    false,  // kZpdClassifiedBegins
++    false,  // kZpdClassifiedEnds
++    false,  // kZpdClassifiedOrphanedEnds
++    false,  // kZpdPolicyFallbacks
++    false,  // kZpdWatchdogRecoveries
+ };
+ static_assert(std::size(kIsGauge) == kNumCounters, "kIsGauge must match CounterId enum");
+ 
+diff --git a/src/graphics/command_processor.cpp b/src/graphics/command_processor.cpp
+index df5fd198867ca35d7535121b727667965d24819b..03b0ac289763a0e4e8a029244f3fb2f1b332579d 100644
+--- a/src/graphics/command_processor.cpp
++++ b/src/graphics/command_processor.cpp
+@@ -55,6 +55,15 @@ REXCVAR_DEFINE_STRING(occlusion_query, "legacy", "GPU",
+     .allowed({"legacy", "fake", "fast", "strict"})
+     .lifecycle(rex::cvar::Lifecycle::kRequiresRestart);
+ 
++REXCVAR_DEFINE_STRING(zpd_end_policy, "auto", "GPU",
++                      "Classify ZPD END records by title-aware policy.")
++    .allowed({"auto", "report_layout", "pairwise_sentinel", "relaxed_sentinel"})
++    .lifecycle(rex::cvar::Lifecycle::kRequiresRestart);
++REXCVAR_DEFINE_STRING(zpd_end_fallback, "auto", "GPU",
++                      "Fallback when report-layout ZPD classification is inconclusive.")
++    .allowed({"auto", "none", "pairwise_sentinel", "relaxed_sentinel"})
++    .lifecycle(rex::cvar::Lifecycle::kRequiresRestart);
++
+ REXCVAR_DEFINE_STRING(readback_resolve, "none", "GPU",
+                       "Controls CPU readback of render-to-texture resolve results.\n"
+                       " none: Disable readback (default)\n"
+@@ -1258,8 +1267,6 @@ bool CommandProcessor::ExecutePacketType3_EVENT_WRITE_EXT(memory::RingBuffer* re
+ 
+ bool CommandProcessor::ExecutePacketType3_EVENT_WRITE_ZPD(memory::RingBuffer* reader,
+                                                           uint32_t packet, uint32_t count) {
+-  // Set by D3D as BE but struct ABI is LE
+-  const uint32_t kQueryFinished = rex::byte_swap(0xFFFFFEED);
+   assert_true(count == 1);
+   uint32_t initiator = reader->ReadAndSwap<uint32_t>();
+   // Writeback initiator.
+@@ -1270,28 +1277,104 @@ bool CommandProcessor::ExecutePacketType3_EVENT_WRITE_ZPD(memory::RingBuffer* re
+   // As a workaround report some fixed amount of passed samples.
+   auto fake_sample_count = REXCVAR_GET(query_occlusion_fake_sample_count);
+   if (fake_sample_count >= 0) {
+-    auto* pSampleCounts = memory_->TranslatePhysical<xe_gpu_depth_sample_counts*>(
+-        register_file_->values[XE_GPU_REG_RB_SAMPLE_COUNT_ADDR]);
++    uint32_t report_address = register_file_->values[XE_GPU_REG_RB_SAMPLE_COUNT_ADDR];
++    uint32_t record_base = XenosZPDReport::GetRecordBase(report_address);
++    auto* pSampleCounts = record_base
++                              ? memory_->TranslatePhysical<xe_gpu_depth_sample_counts*>(record_base)
++                              : nullptr;
+     if (!pSampleCounts) {
+       return true;
+     }
+-    // 0xFFFFFEED is written to this two locations by D3D only on D3DISSUE_END
+-    // and used to detect a finished query.
+-    bool is_end_via_z_pass =
+-        pSampleCounts->ZPass_A == kQueryFinished || pSampleCounts->ZPass_B == kQueryFinished;
+-    // Older versions of D3D also checks for ZFail (4D5307D5).
+-    bool is_end_via_z_fail =
+-        pSampleCounts->ZFail_A == kQueryFinished || pSampleCounts->ZFail_B == kQueryFinished;
++    bool logical_current = zpd_fake_logical_active_ &&
++                           zpd_fake_slot_base_ == XenosZPDReport::GetSlotBase(report_address);
++    auto classification = ClassifyZPD(report_address, pSampleCounts, logical_current);
++    LogZPDObservation(report_address, pSampleCounts, logical_current, classification);
+     std::memset(pSampleCounts, 0, sizeof(xe_gpu_depth_sample_counts));
+-    if (is_end_via_z_pass || is_end_via_z_fail) {
++    if (classification.classification == ZPDClassification::kEnd ||
++        classification.classification == ZPDClassification::kOrphanedEnd) {
+       pSampleCounts->ZPass_A = fake_sample_count;
+       pSampleCounts->Total_A = fake_sample_count;
++      zpd_fake_logical_active_ = false;
++      zpd_fake_slot_base_ = 0;
++    } else if (classification.classification == ZPDClassification::kBegin) {
++      zpd_fake_logical_active_ = true;
++      zpd_fake_slot_base_ = XenosZPDReport::GetSlotBase(report_address);
+     }
++    RecoverStalledZPDSentinel(report_address, pSampleCounts);
+   }
+ 
+   return true;
+ }
+ 
++ZPDPolicySettings CommandProcessor::GetZPDPolicySettings() const {
++  uint32_t title_id = kernel_state_ ? kernel_state_->title_id() : 0;
++  return ResolveZPDPolicy(REXCVAR_GET(zpd_end_policy), REXCVAR_GET(zpd_end_fallback), title_id);
++}
++
++ZPDClassificationResult CommandProcessor::ClassifyZPD(
++    uint32_t report_address, const xenos::xe_gpu_depth_sample_counts* report,
++    bool logical_active) const {
++  return ClassifyZPDReport(report_address, report, logical_active, GetZPDPolicySettings());
++}
++
++void CommandProcessor::LogZPDObservation(uint32_t report_address,
++                                         const xenos::xe_gpu_depth_sample_counts* report,
++                                         bool logical_active,
++                                         const ZPDClassificationResult& classification) {
++  switch (classification.classification) {
++    case ZPDClassification::kBegin:
++      PERF_counter_inc(kZpdClassifiedBegins);
++      break;
++    case ZPDClassification::kEnd:
++      PERF_counter_inc(kZpdClassifiedEnds);
++      break;
++    case ZPDClassification::kOrphanedEnd:
++      PERF_counter_inc(kZpdClassifiedOrphanedEnds);
++      break;
++    default:
++      PERF_counter_inc(kZpdMalformedRecords);
++      break;
++  }
++  if (classification.reason == ZPDClassificationReason::kPairwiseFallback ||
++      classification.reason == ZPDClassificationReason::kRelaxedFallback) {
++    PERF_counter_inc(kZpdPolicyFallbacks);
++  }
++
++  uint32_t zpass_a = report ? uint32_t(report->ZPass_A) : 0u;
++  uint32_t zpass_b = report ? uint32_t(report->ZPass_B) : 0u;
++  uint32_t zfail_a = report ? uint32_t(report->ZFail_A) : 0u;
++  uint32_t zfail_b = report ? uint32_t(report->ZFail_B) : 0u;
++  uint64_t signature = report_address;
++  for (uint32_t value :
++       {zpass_a, zpass_b, zfail_a, zfail_b, uint32_t(classification.classification),
++        uint32_t(classification.reason), uint32_t(logical_active)}) {
++    signature ^= uint64_t(value) + 0x9E3779B97F4A7C15ull + (signature << 6) + (signature >> 2);
++  }
++  ZPDObservationRateLimit rate_limit = zpd_observation_rate_limiter_.Observe(signature);
++  if (rate_limit.ShouldLog()) {
++    REXGPU_INFO(
++        "zpd.event classification={} reason={} address={:08X} slot={:08X} "
++        "logical_active={} zpass_a={:08X} zpass_b={:08X} zfail_a={:08X} "
++        "zfail_b={:08X} repeat={} rate_limit_bucket={}",
++        ZPDClassificationName(classification.classification),
++        ZPDClassificationReasonName(classification.reason), report_address,
++        XenosZPDReport::GetSlotBase(report_address), logical_active, zpass_a, zpass_b, zfail_a,
++        zfail_b, rate_limit.count, rate_limit.overflow_sample ? "overflow_sample" : "signature");
++  }
++}
++
++void CommandProcessor::RecoverStalledZPDSentinel(uint32_t report_address,
++                                                 xenos::xe_gpu_depth_sample_counts* report) {
++  if (!XenosZPDReport::HasPendingSentinel(report)) {
++    return;
++  }
++  uint32_t fallback = uint32_t(std::max(REXCVAR_GET(query_occlusion_fake_sample_count), 1));
++  XenosZPDReport::WriteSampleCount(report, fallback);
++  PERF_counter_inc(kZpdWatchdogRecoveries);
++  REXGPU_WARN("zpd.watchdog address={:08X} slot={:08X} action=visible_fallback", report_address,
++              XenosZPDReport::GetSlotBase(report_address));
++}
++
+ bool CommandProcessor::ExecutePacketType3Draw(memory::RingBuffer* reader, uint32_t packet,
+                                               const char* opcode_name, uint32_t viz_query_condition,
+                                               uint32_t count_remaining) {
+diff --git a/src/graphics/d3d12/command_processor.cpp b/src/graphics/d3d12/command_processor.cpp
+index fb511da49a2cef13e151e3edc00d219c0596d4a4..e7659550cce093b5b82f0cfed5c7cf4689d6736c 100644
+--- a/src/graphics/d3d12/command_processor.cpp
++++ b/src/graphics/d3d12/command_processor.cpp
+@@ -274,7 +274,12 @@ bool D3D12CommandProcessor::ExecuteModernZPD(memory::RingBuffer* reader, uint32_
+     return true;
+   }
+ 
+-  if (XenosZPDReport::IsBeginRecord(address)) {
++  bool logical_current = zpd_lifecycle_.active().logical_active &&
++                         zpd_lifecycle_.active().slot_base == XenosZPDReport::GetSlotBase(address);
++  ZPDClassificationResult classification = ClassifyZPD(address, guest_report, logical_current);
++  LogZPDObservation(address, guest_report, logical_current, classification);
++
++  if (classification.classification == ZPDClassification::kBegin) {
+     // A new BEGIN implicitly closes an older logical lifetime.
+     if (zpd_lifecycle_.active().logical_active) {
+       ZPDLifecycle::Report* old_report = zpd_lifecycle_.active_report();
+@@ -325,22 +330,24 @@ bool D3D12CommandProcessor::ExecuteModernZPD(memory::RingBuffer* reader, uint32_
+     return true;
+   }
+ 
+-  if (!XenosZPDReport::IsEndRecord(address)) {
+-    PERF_counter_inc(kZpdMalformedRecords);
++  if (classification.classification == ZPDClassification::kMalformed) {
+     if (XenosZPDReport::HasPendingSentinel(guest_report)) {
+       PERF_counter_inc(kZpdFakeFallbacks);
+       XenosZPDReport::WriteSampleCount(guest_report,
+                                        uint32_t(REXCVAR_GET(query_occlusion_fake_sample_count)));
+     }
++    RecoverStalledZPDSentinel(address, guest_report);
+     return true;
+   }
+ 
+   ZPDLifecycle::Report* active_report = zpd_lifecycle_.active_report();
+-  if (!active_report) {
++  if (classification.classification == ZPDClassification::kOrphanedEnd || !active_report ||
++      active_report->slot_base != XenosZPDReport::GetSlotBase(address)) {
+     // Orphan END: never leave the guest polling the sentinel.
+     uint32_t cached = zpd_lifecycle_.CachedDelta(record_base, 1);
+     XenosZPDReport::WriteSampleCount(guest_report, cached);
+     PERF_counter_inc(kZpdFastSpeculativeWrites);
++    RecoverStalledZPDSentinel(address, guest_report);
+     return true;
+   }
+ 
+@@ -372,6 +379,7 @@ bool D3D12CommandProcessor::ExecuteModernZPD(memory::RingBuffer* reader, uint32_
+   } else {
+     AwaitModernZPDReport(handle, 2);
+   }
++  RecoverStalledZPDSentinel(address, guest_report);
+   return true;
+ }
+ 
+diff --git a/tests/unit/graphics/zpd_lifecycle_test.cpp b/tests/unit/graphics/zpd_lifecycle_test.cpp
+index 801e3fdfb820779cf9840bc9393d29d5316c65ac..0e4613a1c5ee7913c731a65f2f53b205d08284fd 100644
+--- a/tests/unit/graphics/zpd_lifecycle_test.cpp
++++ b/tests/unit/graphics/zpd_lifecycle_test.cpp
+@@ -1,6 +1,7 @@
+ #include <catch2/catch_test_macros.hpp>
+ 
+ #include <rex/graphics/zpd_lifecycle.h>
++#include <rex/graphics/zpd_policy.h>
+ 
+ namespace rex::graphics {
+ 
+@@ -59,4 +60,87 @@ TEST_CASE("ZPD normalization preserves one guest sample at 2x", "[graphics][zpd]
+   REQUIRE(ZPDLifecycle::Normalize(uint64_t(UINT32_MAX) * 8, 1, 1) == UINT32_MAX);
+ }
+ 
++TEST_CASE("ZPD policy defaults are title scoped", "[graphics][zpd]") {
++  ZPDPolicySettings forza = ResolveZPDPolicy("auto", "auto", 0x4D5309C9);
++  REQUIRE(forza.policy == ZPDEndPolicy::kReportLayout);
++  REQUIRE(forza.fallback == ZPDEndFallback::kPairwiseSentinel);
++
++  ZPDPolicySettings other = ResolveZPDPolicy("auto", "auto", 0x12345678);
++  REQUIRE(other.policy == ZPDEndPolicy::kRelaxedSentinel);
++  REQUIRE(other.fallback == ZPDEndFallback::kNone);
++}
++
++TEST_CASE("ZPD policies distinguish one-lane and pairwise sentinels", "[graphics][zpd]") {
++  xenos::xe_gpu_depth_sample_counts report = {};
++  report.ZPass_A = 0xEDFEFFFFu;
++
++  auto pairwise = ClassifyZPDReport(0x10000, &report, true,
++                                    {ZPDEndPolicy::kPairwiseSentinel, ZPDEndFallback::kNone});
++  REQUIRE(pairwise.classification == ZPDClassification::kBegin);
++  REQUIRE_FALSE(pairwise.pairwise_sentinel);
++  REQUIRE(pairwise.relaxed_sentinel);
++
++  auto relaxed = ClassifyZPDReport(0x10000, &report, true,
++                                   {ZPDEndPolicy::kRelaxedSentinel, ZPDEndFallback::kNone});
++  REQUIRE(relaxed.classification == ZPDClassification::kEnd);
++  REQUIRE(relaxed.reason == ZPDClassificationReason::kRelaxedSentinel);
++
++  report.ZPass_B = 0xEDFEFFFFu;
++  pairwise = ClassifyZPDReport(0x10000, &report, true,
++                               {ZPDEndPolicy::kPairwiseSentinel, ZPDEndFallback::kNone});
++  REQUIRE(pairwise.classification == ZPDClassification::kEnd);
++  REQUIRE(pairwise.pairwise_sentinel);
++}
++
++TEST_CASE("ZPD report layout classifies ends and orphaned ends", "[graphics][zpd]") {
++  xenos::xe_gpu_depth_sample_counts report = {};
++  auto begin = ClassifyZPDReport(0x10020, &report, false,
++                                 {ZPDEndPolicy::kReportLayout, ZPDEndFallback::kPairwiseSentinel});
++  REQUIRE(begin.classification == ZPDClassification::kBegin);
++  REQUIRE(begin.reason == ZPDClassificationReason::kReportLayoutBegin);
++
++  auto end = ClassifyZPDReport(0x10000, &report, true,
++                               {ZPDEndPolicy::kReportLayout, ZPDEndFallback::kPairwiseSentinel});
++  REQUIRE(end.classification == ZPDClassification::kEnd);
++  REQUIRE(end.reason == ZPDClassificationReason::kReportLayoutEnd);
++
++  auto orphan = ClassifyZPDReport(0x10000, &report, false,
++                                  {ZPDEndPolicy::kReportLayout, ZPDEndFallback::kPairwiseSentinel});
++  REQUIRE(orphan.classification == ZPDClassification::kOrphanedEnd);
++
++  report.ZFail_A = report.ZFail_B = 0xEDFEFFFFu;
++  auto fallback = ClassifyZPDReport(
++      0, &report, true, {ZPDEndPolicy::kReportLayout, ZPDEndFallback::kPairwiseSentinel});
++  REQUIRE(fallback.classification == ZPDClassification::kEnd);
++  REQUIRE(fallback.reason == ZPDClassificationReason::kPairwiseFallback);
++}
++
++TEST_CASE("ZPD observation logging stays bounded", "[graphics][zpd]") {
++  ZPDObservationRateLimiter limiter;
++  for (uint64_t signature = 0; signature < ZPDObservationRateLimiter::kMaxSignatures; ++signature) {
++    auto observation = limiter.Observe(signature);
++    REQUIRE(observation.count == 1);
++    REQUIRE_FALSE(observation.overflow_sample);
++    REQUIRE(observation.ShouldLog());
++  }
++
++  auto first_overflow = limiter.Observe(1000);
++  REQUIRE(first_overflow.count == 1);
++  REQUIRE(first_overflow.overflow_sample);
++  REQUIRE(first_overflow.ShouldLog());
++  auto second_overflow = limiter.Observe(1001);
++  REQUIRE(second_overflow.count == 2);
++  REQUIRE(second_overflow.ShouldLog());
++  auto third_overflow = limiter.Observe(1002);
++  REQUIRE(third_overflow.count == 3);
++  REQUIRE_FALSE(third_overflow.ShouldLog());
++  auto fourth_overflow = limiter.Observe(1003);
++  REQUIRE(fourth_overflow.count == 4);
++  REQUIRE(fourth_overflow.ShouldLog());
++
++  auto repeated = limiter.Observe(0);
++  REQUIRE(repeated.count == 2);
++  REQUIRE_FALSE(repeated.overflow_sample);
++}
++
+ }  // namespace rex::graphics

--- a/src/pinyon_shift_app.cpp
+++ b/src/pinyon_shift_app.cpp
@@ -22,14 +22,14 @@
 
 #include <cstdio>
 
-REXCVAR_DEFINE_UINT32(pinyon_shift_config_schema, 6, "Pinyon Shift",
+REXCVAR_DEFINE_UINT32(pinyon_shift_config_schema, 7, "Pinyon Shift",
                       "Pinyon Shift host configuration schema version");
 REXCVAR_DEFINE_BOOL(pinyon_shift_capture_performance, true, "Pinyon Shift",
                     "Capture lightweight per-frame performance counters to a session CSV");
 
 namespace {
 
-constexpr uint32_t kConfigSchema = 6;
+constexpr uint32_t kConfigSchema = 7;
 
 bool EnsureSupportedConfig(const std::filesystem::path& path, bool& created,
                            bool& migrated) {
@@ -59,7 +59,9 @@ bool EnsureSupportedConfig(const std::filesystem::path& path, bool& created,
               "swap_post_effect = \"none\"\n"
               "draw_resolution_scale_x = 1\n"
               "draw_resolution_scale_y = 1\n"
-              "occlusion_query = \"legacy\"\n";
+              "occlusion_query = \"legacy\"\n"
+              "zpd_end_policy = \"report_layout\"\n"
+              "zpd_end_fallback = \"pairwise_sentinel\"\n";
     created = true;
     return output.good();
   }
@@ -83,7 +85,7 @@ bool EnsureSupportedConfig(const std::filesystem::path& path, bool& created,
     if (schema == kConfigSchema) {
       return true;
     }
-    if (schema < 1 || schema > 5) {
+    if (schema < 1 || schema > 6) {
       return false;
     }
 
@@ -136,6 +138,8 @@ bool EnsureSupportedConfig(const std::filesystem::path& path, bool& created,
         {"draw_resolution_scale_x", "draw_resolution_scale_x = 1\n"},
         {"draw_resolution_scale_y", "draw_resolution_scale_y = 1\n"},
         {"occlusion_query", "occlusion_query = \"legacy\"\n"},
+        {"zpd_end_policy", "zpd_end_policy = \"report_layout\"\n"},
+        {"zpd_end_fallback", "zpd_end_fallback = \"pairwise_sentinel\"\n"},
     };
     for (const auto& [name, line] : graphics_settings) {
       const std::regex setting_pattern("(?:^|\\n)\\s*" + std::string(name) +
@@ -255,6 +259,8 @@ void PinyonShiftApp::OnPostInitLogging() {
                          rex::cvar::GetFlagByName("anisotropic_override")},
                         {"swap_post_effect", rex::cvar::GetFlagByName("swap_post_effect")},
                         {"occlusion_query", rex::cvar::GetFlagByName("occlusion_query")},
+                        {"zpd_end_policy", rex::cvar::GetFlagByName("zpd_end_policy")},
+                        {"zpd_end_fallback", rex::cvar::GetFlagByName("zpd_end_fallback")},
                         {"xma_relaxed_padding_admission",
                          rex::cvar::GetFlagByName(
                              "xma_relaxed_padding_admission")},

--- a/tools/create-crash-report.ps1
+++ b/tools/create-crash-report.ps1
@@ -157,7 +157,10 @@ try {
         'zpd_same_slot_reuse', 'zpd_fast_speculative_writes',
         'zpd_async_result_patches', 'zpd_strict_waits',
         'zpd_strict_wait_time_ns', 'zpd_retire_timeouts', 'zpd_fake_fallbacks',
-        'zpd_malformed_records', 'zpd_stale_result_rejections'
+        'zpd_malformed_records', 'zpd_stale_result_rejections',
+        'zpd_classified_begins', 'zpd_classified_ends',
+        'zpd_classified_orphaned_ends', 'zpd_policy_fallbacks',
+        'zpd_watchdog_recoveries'
     )
     $zpdCounters = [ordered]@{ available = $false }
     foreach ($column in $zpdColumns) { $zpdCounters[$column] = [uint64]0 }
@@ -193,7 +196,8 @@ try {
         'pinyon_shift_capture_performance',
         'pinyon_shift_stabilize_vehicle_presentation', 'pinyon_shift_skip_opening_movies',
         'resolution', 'vsync', 'anisotropic_override', 'swap_post_effect',
-        'draw_resolution_scale_x', 'draw_resolution_scale_y', 'occlusion_query'
+        'draw_resolution_scale_x', 'draw_resolution_scale_y', 'occlusion_query',
+        'zpd_end_policy', 'zpd_end_fallback'
     )
     $configPath = Join-Path $resolvedStateRoot 'config/pinyon_shift.toml'
     $settings = [ordered]@{}

--- a/tools/qualification-session.py
+++ b/tools/qualification-session.py
@@ -6,7 +6,17 @@ import argparse, hashlib, json, zipfile
 from datetime import datetime, timezone
 from pathlib import Path
 
-MARKERS = ("cold-boot", "menu", "race", "save", "clean-exit", "relaunch", "reload")
+MARKERS = (
+    "cold-boot",
+    "intro-movie-complete",
+    "controller-layout-displayed",
+    "first-interactive-frame",
+    "race",
+    "save",
+    "clean-exit",
+    "relaunch",
+    "reload",
+)
 
 def utc() -> str: return datetime.now(timezone.utc).isoformat()
 def digest(path: Path) -> str: return hashlib.sha256(path.read_bytes()).hexdigest()

--- a/tools/qualify-zpd.ps1
+++ b/tools/qualify-zpd.ps1
@@ -1,0 +1,187 @@
+[CmdletBinding()]
+param(
+    [ValidateSet('Plan', 'Matrix', 'Admission')]
+    [string]$Action = 'Plan',
+    [string]$StateRoot,
+    [ValidateRange(1, 20)]
+    [int]$ColdBoots = 10,
+    [ValidateSet('fake', 'fast', 'strict')]
+    [string]$AdmissionMode = 'fast',
+    [ValidateSet('report_layout', 'pairwise_sentinel', 'relaxed_sentinel')]
+    [string]$AdmissionPolicy = 'report_layout',
+    [ValidateSet('none', 'pairwise_sentinel', 'relaxed_sentinel')]
+    [string]$AdmissionFallback = 'pairwise_sentinel',
+    [switch]$Json
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
+$resolvedStateRoot = if ($StateRoot) {
+    [IO.Path]::GetFullPath($StateRoot)
+} else {
+    Join-Path $repoRoot '.local/preview'
+}
+$configPath = Join-Path $resolvedStateRoot 'config/pinyon_shift.toml'
+$logsPath = Join-Path $resolvedStateRoot 'logs'
+$reportsPath = Join-Path $resolvedStateRoot 'reports'
+$buildPath = Join-Path $repoRoot 'out/build/win-amd64-release/pinyon_shift_build.json'
+$powershell = (Get-Process -Id $PID).Path
+
+$matrix = @(
+    [ordered]@{ mode = 'legacy'; policy = 'report_layout'; fallback = 'pairwise_sentinel'; label = 'legacy-existing' },
+    [ordered]@{ mode = 'fake'; policy = 'report_layout'; fallback = 'pairwise_sentinel'; label = 'fake-layout' },
+    [ordered]@{ mode = 'fast'; policy = 'report_layout'; fallback = 'pairwise_sentinel'; label = 'fast-layout' },
+    [ordered]@{ mode = 'strict'; policy = 'report_layout'; fallback = 'pairwise_sentinel'; label = 'strict-layout' },
+    [ordered]@{ mode = 'fast'; policy = 'pairwise_sentinel'; fallback = 'none'; label = 'fast-pairwise' },
+    [ordered]@{ mode = 'fast'; policy = 'relaxed_sentinel'; fallback = 'none'; label = 'fast-relaxed' }
+)
+$runs = @(if ($Action -eq 'Admission') {
+    @(1..$ColdBoots | ForEach-Object {
+        [ordered]@{
+            mode = $AdmissionMode
+            policy = $AdmissionPolicy
+            fallback = $AdmissionFallback
+            label = "admission-$($_.ToString('00'))"
+        }
+    })
+} else { $matrix })
+
+if ($Action -eq 'Plan') {
+    $plan = [ordered]@{
+        schema = 'pinyon-shift.zpd-qualification-plan.v1'
+        matrix = $matrix
+        admission = [ordered]@{
+            required_cold_boots = $ColdBoots
+            mode = $AdmissionMode
+            policy = $AdmissionPolicy
+            fallback = $AdmissionFallback
+        }
+    }
+    if ($Json) { $plan | ConvertTo-Json -Depth 6 -Compress } else { [pscustomobject]$plan }
+    exit 0
+}
+
+if (-not (Test-Path -LiteralPath $configPath -PathType Leaf)) {
+    throw "The qualification requires an existing host config: $configPath"
+}
+if (-not (Test-Path -LiteralPath $buildPath -PathType Leaf)) {
+    throw 'Build provenance is missing. Run tools/build-preview.ps1 first.'
+}
+if (Get-Process -Name pinyon_shift -ErrorAction SilentlyContinue) {
+    throw 'Pinyon Shift is already running.'
+}
+$save = Get-ChildItem -LiteralPath (Join-Path $resolvedStateRoot 'user') -Recurse `
+    -Filter ForzaProfile -File -ErrorAction SilentlyContinue |
+    Where-Object { $_.Directory.Name -eq 'ForzaProfile' } | Select-Object -First 1
+if ($null -eq $save) { throw 'The AppData-backed ForzaProfile save was not found.' }
+
+$originalConfig = Get-Content -LiteralPath $configPath -Raw
+$build = Get-Content -LiteralPath $buildPath -Raw | ConvertFrom-Json
+$results = [Collections.Generic.List[object]]::new()
+$failed = $false
+try {
+    foreach ($run in $runs) {
+        & (Join-Path $PSScriptRoot 'set-graphics-experiment.ps1') -Action Apply `
+            -OcclusionQuery $run.mode -ZpdEndPolicy $run.policy `
+            -ZpdEndFallback $run.fallback -StateRoot $resolvedStateRoot | Out-Null
+        $startedUtc = [DateTime]::UtcNow
+        $launchOutput = & $powershell -NoProfile -File `
+            (Join-Path $PSScriptRoot 'launch-preview.ps1') `
+            -StateRoot $resolvedStateRoot -Json 2>&1
+        $exitCode = $LASTEXITCODE
+        $launchResult = $launchOutput | Select-Object -Last 1 | ConvertFrom-Json
+        if ($launchResult.exit_code -ne $exitCode) {
+            throw "Launcher exit mismatch: process=$($launchResult.exit_code), host=$exitCode"
+        }
+
+        $intro = (Read-Host "[$($run.label)] Intro movie completed? [y/N]") -match '(?i)^y(?:es)?$'
+        $controller = (Read-Host "[$($run.label)] Controller layout displayed? [y/N]") -match '(?i)^y(?:es)?$'
+        $interactive = (Read-Host "[$($run.label)] First interactive menu/gameplay frame reached? [y/N]") -match '(?i)^y(?:es)?$'
+        $visual = if ($run.mode -eq 'fast') {
+            (Read-Host "[$($run.label)] Lighting/lens-flare occlusion looked correct? [y/N]") -match '(?i)^y(?:es)?$'
+        } else { $true }
+
+        $perf = Get-ChildItem -LiteralPath $logsPath -Filter '*.perf.csv' -File |
+            Where-Object { $_.LastWriteTimeUtc -ge $startedUtc.AddSeconds(-2) } |
+            Sort-Object LastWriteTimeUtc | Select-Object -Last 1
+        $events = Get-ChildItem -LiteralPath $logsPath -Filter '*.jsonl' -File |
+            Where-Object { $_.LastWriteTimeUtc -ge $startedUtc.AddSeconds(-2) } |
+            Sort-Object LastWriteTimeUtc | Select-Object -Last 1
+        $summary = if ($perf) {
+            & python (Join-Path $PSScriptRoot 'summarize-performance.py') $perf.FullName |
+                ConvertFrom-Json
+        } else { $null }
+        $errorCount = if ($events) {
+            @(Select-String -LiteralPath $events.FullName `
+                -Pattern 'fatal|exception|assert|device removed' -CaseSensitive:$false).Count
+        } else { 1 }
+        $zpd = if ($summary -and $summary.zpd_counters) { $summary.zpd_counters } else { $null }
+        $strictFallbacksBounded = $null -ne $zpd -and
+            $zpd.zpd_retire_timeouts -le $zpd.zpd_strict_waits -and
+            $zpd.zpd_watchdog_recoveries -le
+                ($zpd.zpd_classified_begins + $zpd.zpd_classified_ends)
+        $fallbacksHealthy = if ($null -eq $zpd) {
+            $false
+        } elseif ($run.mode -eq 'strict') {
+            $strictFallbacksBounded
+        } else {
+            $zpd.zpd_retire_timeouts -eq 0 -and $zpd.zpd_watchdog_recoveries -eq 0
+        }
+        $countersHealthy = $null -ne $zpd -and
+            $zpd.zpd_malformed_records -eq 0 -and
+            $zpd.zpd_classified_orphaned_ends -eq 0 -and
+            $zpd.zpd_classified_begins -eq $zpd.zpd_classified_ends -and
+            $fallbacksHealthy
+        $passed = $exitCode -eq 0 -and $intro -and $controller -and $interactive -and
+            $visual -and $errorCount -eq 0 -and $countersHealthy
+        $results.Add([ordered]@{
+            label = $run.label
+            mode = $run.mode
+            policy = $run.policy
+            fallback = $run.fallback
+            started_utc = $startedUtc.ToString('o')
+            markers = [ordered]@{
+                intro_movie_complete = $intro
+                controller_layout_displayed = $controller
+                first_interactive_frame = $interactive
+                visual_occlusion_correct = $visual
+            }
+            exit_code = $exitCode
+            error_signatures = $errorCount
+            performance_log = if ($perf) { $perf.Name } else { $null }
+            event_log = if ($events) { $events.Name } else { $null }
+            zpd_counters = $zpd
+            passed = $passed
+        })
+        if (-not $passed) {
+            $failed = $true
+            break
+        }
+    }
+}
+finally {
+    [IO.File]::WriteAllText($configPath, $originalConfig,
+        [Text.UTF8Encoding]::new($false))
+}
+
+[void](New-Item -ItemType Directory -Force -Path $reportsPath)
+$stamp = [DateTime]::UtcNow.ToString('yyyyMMddTHHmmssfffZ')
+$reportPath = Join-Path $reportsPath "zpd-qualification-$stamp.json"
+$report = [ordered]@{
+    schema = 'pinyon-shift.zpd-qualification.v1'
+    action = $Action.ToLowerInvariant()
+    build = $build
+    supported_dump = 'forza-horizon-usa-ms-2505-retail-base'
+    required_cold_boots = if ($Action -eq 'Admission') { $ColdBoots } else { 1 }
+    completed_runs = $results.Count
+    passed = -not $failed -and $results.Count -eq $runs.Count
+    original_config_restored = $true
+    runs = $results
+}
+[IO.File]::WriteAllText($reportPath, ($report | ConvertTo-Json -Depth 12) + [Environment]::NewLine,
+    [Text.UTF8Encoding]::new($false))
+$output = [ordered]@{ passed = $report.passed; report = $reportPath; runs = $results.Count }
+if ($Json) { $output | ConvertTo-Json -Compress } else { [pscustomobject]$output }
+if (-not $report.passed) { exit 1 }

--- a/tools/set-graphics-experiment.ps1
+++ b/tools/set-graphics-experiment.ps1
@@ -10,6 +10,10 @@ param(
     [int]$ResolutionScale = 1,
     [ValidateSet('legacy', 'fake', 'fast', 'strict')]
     [string]$OcclusionQuery = 'legacy',
+    [ValidateSet('report_layout', 'pairwise_sentinel', 'relaxed_sentinel')]
+    [string]$ZpdEndPolicy = 'report_layout',
+    [ValidateSet('none', 'pairwise_sentinel', 'relaxed_sentinel')]
+    [string]$ZpdEndFallback = 'pairwise_sentinel',
     [string]$StateRoot,
     [switch]$Json
 )
@@ -30,8 +34,8 @@ $backupDirectory = Join-Path $configDirectory 'backups'
 function Get-DefaultConfigText {
     @'
 # Pinyon Shift host configuration.
-# Schema 6 adds conservative ZPD lifecycle selection.
-pinyon_shift_config_schema = 6
+# Schema 7 adds FH1 ZPD END-policy qualification.
+pinyon_shift_config_schema = 7
 input_backend = "sdl"
 hid_mappings_file = "gamecontrollerdb.txt"
 mnk_mode = true
@@ -46,6 +50,8 @@ swap_post_effect = "none"
 draw_resolution_scale_x = 1
 draw_resolution_scale_y = 1
 occlusion_query = "legacy"
+zpd_end_policy = "report_layout"
+zpd_end_fallback = "pairwise_sentinel"
 '@
 }
 
@@ -108,6 +114,8 @@ function Get-SettingsResult([string]$Text, [string]$BackupPath, [string]$Operati
             post_effect = Get-TomlValue $Text 'swap_post_effect' 'none'
             resolution_scale = [int](Get-TomlValue $Text 'draw_resolution_scale_x' '1')
             occlusion_query = Get-TomlValue $Text 'occlusion_query' 'legacy'
+            zpd_end_policy = Get-TomlValue $Text 'zpd_end_policy' 'report_layout'
+            zpd_end_fallback = Get-TomlValue $Text 'zpd_end_fallback' 'pairwise_sentinel'
         }
         restart_required = $Operation -ne 'Get'
     }
@@ -121,7 +129,7 @@ switch ($Action) {
             Get-Content -LiteralPath $configPath -Raw
         } else { Get-DefaultConfigText }
         $schema = Get-SchemaVersion $text
-        if ($schema -notin @(1, 2, 3, 4, 5, 6)) { throw "Unsupported host configuration schema: $schema" }
+        if ($schema -notin @(1, 2, 3, 4, 5, 6, 7)) { throw "Unsupported host configuration schema: $schema" }
     }
     'Reset' {
         $backup = New-ConfigBackup
@@ -138,7 +146,7 @@ switch ($Action) {
         $backup = New-ConfigBackup
         $text = Get-Content -LiteralPath $source.FullName -Raw
         $schema = Get-SchemaVersion $text
-        if ($schema -notin @(1, 2, 3, 4, 5, 6)) { throw "Backup uses unsupported schema: $schema" }
+        if ($schema -notin @(1, 2, 3, 4, 5, 6, 7)) { throw "Backup uses unsupported schema: $schema" }
         Write-Config $text
     }
     'Apply' {
@@ -146,9 +154,9 @@ switch ($Action) {
             Get-Content -LiteralPath $configPath -Raw
         } else { Get-DefaultConfigText }
         $schema = Get-SchemaVersion $text
-        if ($schema -notin @(1, 2, 3, 4, 5, 6)) { throw "Unsupported host configuration schema: $schema" }
+        if ($schema -notin @(1, 2, 3, 4, 5, 6, 7)) { throw "Unsupported host configuration schema: $schema" }
         $backup = New-ConfigBackup
-        $text = Set-TomlValue $text 'pinyon_shift_config_schema' '6'
+        $text = Set-TomlValue $text 'pinyon_shift_config_schema' '7'
         if (-not [regex]::IsMatch($text, '(?m)^\s*xma_relaxed_padding_admission\s*=')) {
             $text = Set-TomlValue $text 'xma_relaxed_padding_admission' 'false'
         }
@@ -161,6 +169,8 @@ switch ($Action) {
         $text = Set-TomlValue $text 'draw_resolution_scale_x' ([string]$ResolutionScale)
         $text = Set-TomlValue $text 'draw_resolution_scale_y' ([string]$ResolutionScale)
         $text = Set-TomlValue $text 'occlusion_query' ('"' + $OcclusionQuery + '"')
+        $text = Set-TomlValue $text 'zpd_end_policy' ('"' + $ZpdEndPolicy + '"')
+        $text = Set-TomlValue $text 'zpd_end_fallback' ('"' + $ZpdEndFallback + '"')
         Write-Config $text
     }
 }

--- a/tools/summarize-performance.py
+++ b/tools/summarize-performance.py
@@ -56,6 +56,11 @@ ZPD_COLUMNS = (
     "zpd_fake_fallbacks",
     "zpd_malformed_records",
     "zpd_stale_result_rejections",
+    "zpd_classified_begins",
+    "zpd_classified_ends",
+    "zpd_classified_orphaned_ends",
+    "zpd_policy_fallbacks",
+    "zpd_watchdog_recoveries",
 )
 
 

--- a/tools/tests/test_graphics_settings.py
+++ b/tools/tests/test_graphics_settings.py
@@ -8,11 +8,24 @@ import unittest
 
 ROOT = pathlib.Path(__file__).resolve().parents[2]
 TOOL = ROOT / "tools/set-graphics-experiment.ps1"
+QUALIFY_ZPD = ROOT / "tools/qualify-zpd.ps1"
 POWERSHELL = shutil.which("powershell")
 
 
 @unittest.skipUnless(POWERSHELL, "Windows PowerShell is required")
 class GraphicsSettingsTests(unittest.TestCase):
+    def test_zpd_qualification_plan_covers_required_matrix(self):
+        completed = subprocess.run(
+            [POWERSHELL, "-NoLogo", "-NoProfile", "-ExecutionPolicy", "Bypass",
+             "-File", str(QUALIFY_ZPD), "-Action", "Plan", "-Json"],
+            capture_output=True, text=True,
+        )
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+        plan = json.loads(completed.stdout)
+        self.assertEqual(len(plan["matrix"]), 6)
+        self.assertEqual(plan["admission"]["required_cold_boots"], 10)
+        self.assertEqual(plan["matrix"][2]["label"], "fast-layout")
+
     def run_tool(self, state, *arguments):
         completed = subprocess.run(
             [POWERSHELL, "-NoLogo", "-NoProfile", "-ExecutionPolicy", "Bypass",
@@ -33,13 +46,17 @@ class GraphicsSettingsTests(unittest.TestCase):
                 state, "-Action", "Apply", "-Anisotropy", "16",
                 "-PostEffect", "fxaa", "-ResolutionScale", "2",
                 "-OcclusionQuery", "fast",
+                "-ZpdEndPolicy", "pairwise_sentinel",
+                "-ZpdEndFallback", "none",
             )
             updated = config.read_text(encoding="utf-8")
             self.assertEqual(result["settings"]["anisotropy"], 16)
-            self.assertIn("pinyon_shift_config_schema = 6", updated)
+            self.assertIn("pinyon_shift_config_schema = 7", updated)
             self.assertIn("xma_relaxed_padding_admission = false", updated)
             self.assertEqual(result["settings"]["occlusion_query"], "fast")
             self.assertIn('occlusion_query = "fast"', updated)
+            self.assertEqual(result["settings"]["zpd_end_policy"], "pairwise_sentinel")
+            self.assertEqual(result["settings"]["zpd_end_fallback"], "none")
             self.assertIn("custom_value = 77", updated)
             self.assertIn("draw_resolution_scale_x = 2", updated)
             self.assertTrue(pathlib.Path(result["backup_path"]).is_file())
@@ -58,6 +75,8 @@ class GraphicsSettingsTests(unittest.TestCase):
             self.assertIn("draw_resolution_scale_x = 1", text)
             self.assertIn("xma_relaxed_padding_admission = false", text)
             self.assertIn('occlusion_query = "legacy"', text)
+            self.assertIn('zpd_end_policy = "report_layout"', text)
+            self.assertIn('zpd_end_fallback = "pairwise_sentinel"', text)
             self.assertTrue(pathlib.Path(result["backup_path"]).is_file())
 
 

--- a/tools/tests/test_release_contract.py
+++ b/tools/tests/test_release_contract.py
@@ -43,10 +43,10 @@ class ReleaseContractTests(unittest.TestCase):
 
     def test_rexglue_patches_have_stable_order_and_no_binary_payload(self):
         patches = sorted((ROOT / "patches/rexglue").glob("*.patch"))
-        self.assertEqual(len(patches), 39)
+        self.assertEqual(len(patches), 40)
         self.assertEqual(
             patches[-1].name,
-            "0039-gpu-zpd-report-lifecycle-d3d12.patch",
+            "0040-fh1-zpd-end-policy-and-telemetry.patch",
         )
         self.assertEqual(len(patches), len({path.name[:4] for path in patches}))
         for path in patches:
@@ -163,7 +163,7 @@ class ReleaseContractTests(unittest.TestCase):
 
     def test_graphics_schema_and_diagnostics_contract(self):
         app = (ROOT / "src/pinyon_shift_app.cpp").read_text(encoding="utf-8")
-        self.assertIn("constexpr uint32_t kConfigSchema = 6", app)
+        self.assertIn("constexpr uint32_t kConfigSchema = 7", app)
         self.assertIn(".schema", app)
         for setting in ("anisotropic_override", "swap_post_effect", "draw_resolution_scale_x"):
             self.assertIn(setting, app)
@@ -174,6 +174,9 @@ class ReleaseContractTests(unittest.TestCase):
         zpd_patch = ROOT / "patches/rexglue/0039-gpu-zpd-report-lifecycle-d3d12.patch"
         self.assertTrue(zpd_patch.is_file())
         self.assertIn("ZPDLifecycle", zpd_patch.read_text(encoding="utf-8"))
+        policy_patch = ROOT / "patches/rexglue/0040-fh1-zpd-end-policy-and-telemetry.patch"
+        self.assertTrue(policy_patch.is_file())
+        self.assertIn("ZPDClassification", policy_patch.read_text(encoding="utf-8"))
 
     def test_renderer_and_stub_instrumentation_is_bounded(self):
         stub_patch = (ROOT / "patches/rexglue/0031-sdk-stub-reachability-summary.patch").read_text(encoding="utf-8")
@@ -191,12 +194,13 @@ class ReleaseContractTests(unittest.TestCase):
         launcher = (ROOT / "launcher/PinyonShift.Launcher/MainWindow.xaml.cs").read_text(
             encoding="utf-8"
         )
-        self.assertIn("constexpr uint32_t kConfigSchema = 6;", app)
-        self.assertRegex(app, r"pinyon_shift_config_schema,\s*6,")
+        self.assertIn("constexpr uint32_t kConfigSchema = 7;", app)
+        self.assertRegex(app, r"pinyon_shift_config_schema,\s*7,")
         self.assertIn('"pinyon_shift_stabilize_vehicle_presentation = false\\n"', app)
         self.assertIn('"keybind_a = \\"LMB,Space\\"\\n"', app)
-        self.assertIn("schema < 1 || schema > 5", app)
+        self.assertIn("schema < 1 || schema > 6", app)
         self.assertIn('"occlusion_query = \\"legacy\\"\\n"', app)
+        self.assertIn('"zpd_end_policy = \\"report_layout\\"\\n"', app)
         self.assertIn("Controller A, Space, or left click.", launcher)
         self.assertRegex(
             hooks,


### PR DESCRIPTION
## Summary
- add FH1-scoped ZPD END policies with report-layout-first classification
- add bounded classification telemetry, watchdog recovery, and performance counters
- add a six-mode qualification matrix and ten-cold-boot admission runner
- migrate host configuration to schema 7 while retaining legacy occlusion rollback

## Validation
- 35/35 project tests
- ReXGlue: 242 passed, 4 known upstream skips, 2262 assertions
- focused ZPD: 8 cases, 442 assertions
- six-run policy matrix passed
- ten AppData-backed cold boots passed on one build fingerprint
- all admission exits 0; zero fatal/error/assert/device-removal signatures
- 29,189 sampled frames; zero command-buffer stalls

## Build fingerprint
- executable: `5EDF2D807C84EE31DC91935F574EF077F0905BB7C0A89011267BA516988DFAA6`
- ReXGlue patch set: `84B9280BC7C1DFBA0FA937FC1FF8F1DE41C5411060242859724BE39850DDFC07`