### PR TITLE
feat(graphics): add fh1 resolve readback presets

### DIFF
--- a/config/rexglue/EPIC_06_RESOLVE_READBACK_PRESETS.md
+++ b/config/rexglue/EPIC_06_RESOLVE_READBACK_PRESETS.md
@@ -1,0 +1,84 @@
+# FH1 resolve-readback presets and telemetry
+
+EPIC-06 combines ReXGlue's existing resolve-readback modes with schema-8 host
+presets, launcher controls, renderer A/B evidence, and the bounded D3D12
+telemetry in `patches/rexglue/0041-fh1-resolve-readback-counters.patch`.
+
+## Evidence and scope
+
+The FH1 compatibility tracker and community settings identify two distinct
+correctness cases: delayed `fast` readback for scaled-render artifacts and
+synchronous `full` readback for garage, autoshow, thumbnail, and livery
+accuracy. `full` is intentionally opt-in because it serializes GPU and CPU
+work. The project does not detect scenes or modify game assets.
+
+Sources:
+
+- <https://github.com/xenia-canary/game-compatibility/issues/30>
+- <https://github.com/xenia-manager/optimized-settings/blob/main/settings/4D5309C9.toml>
+
+## Presets
+
+| Preset | Resolution | Resolve readback | Half-pixel sample | Intended use |
+| --- | ---: | --- | --- | --- |
+| Shipping 1× | 1× | `none` | off | Normal driving and release default |
+| Experimental 2× | 2× | `fast` | on | Scaled rendering without colored-car artifacts |
+| Accurate showroom | 1× | `full` | off | Garage, autoshow, thumbnails, and liveries |
+
+All presets keep `clear_memory_page_state`, `readback_memexport`,
+`readback_memexport_fast`, and `vsync` enabled. The launcher exposes
+`none`, `fast`, `some`, and `full` for controlled experiments, labels full
+readback as expensive, and preserves backup/reset/restore behavior.
+
+## Metrics
+
+Patch `0041` adds per-frame CSV counters at the D3D12 resolve path:
+
+```text
+resolve_readback_requests
+resolve_readback_bytes
+resolve_readback_fast_copies
+resolve_readback_cache_misses
+resolve_readback_full_waits
+resolve_readback_wait_time_ns
+```
+
+Requests count non-empty resolve ranges entering readback. Bytes count only
+copies committed to guest memory. Cache misses identify delayed modes that
+must synchronize because no prior slot is usable. Full waits count every
+synchronous resolve wait, including a delayed-mode miss, and wait time records
+the measured wall-clock duration of those waits.
+
+The performance summarizer and sanitized crash report aggregate these scalar
+counters. Renderer A/B sessions require them for `readback_resolve` and accept
+`fast`, `some`, or `full` as the candidate against a `none` control. The visual
+baseline covers front end, garage, autoshow, livery, day, night, race, and
+rewind scenes on an exact build fingerprint.
+
+## AppData qualification
+
+The 2026-08-27 qualification used the installed `0.1.0` AppData save and the
+release candidate with executable SHA-256
+`C075F20F40BCCB29E9EACFB1E1B392508B6F50726BAFBBDF8BC55DAE9FC78160`.
+All three profiles completed without a matching fatal, error, exception,
+assert, or device-removed signature.
+
+| Profile | Median FPS | 1% low FPS | Resolve requests | Bytes copied | Full waits |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| Shipping 1× | 56.836 | 20.300 | 0 | 0 | 0 |
+| Experimental 2× | 55.777 | 19.866 | 73,767 | 61,139,881,984 | 143 |
+| Accurate showroom | 53.785 | 12.267 | 78,458 | 71,649,955,840 | 78,458 |
+
+Experimental 2× kept the live car body free of the documented random colored
+artifacts. Accurate showroom displayed a clean representative Mustang photo
+and car asset. A previously generated Audi thumbnail in the existing save
+remained corrupted; the qualification did not alter or regenerate save data,
+and the clean representative asset was used for the acceptance check.
+
+## Rollback
+
+Selecting Shipping 1× immediately returns to `readback_resolve = "none"`.
+Reset writes the same conservative preset after backing up the prior file;
+restore recovers the newest backup. Removing patch `0041` removes telemetry
+only—the existing readback implementation and schema-8 host controls remain
+independently reversible.

--- a/config/rexglue/PATCH_DISPOSITIONS.md
+++ b/config/rexglue/PATCH_DISPOSITIONS.md
@@ -117,6 +117,14 @@ default until the six-run matrix and ten-cold-boot admission gate pass.
 Removing `0040` restores EPIC-04 classification behavior without removing its
 logical/physical report lifecycle.
 
+`0041-fh1-resolve-readback-counters` instruments the existing D3D12 resolve
+readback path without changing its policy. It counts requests, guest-copy
+bytes, fast copies, delayed-slot cache misses, synchronous waits, and measured
+wait time. Schema 8 and the launcher use those counters to qualify conservative
+Shipping 1×, delayed Experimental 2×, and opt-in Accurate showroom presets.
+Removing `0041` removes telemetry only; selecting Shipping 1× remains the
+immediate runtime rollback to `readback_resolve = "none"`.
+
 Validation performed on the rebased SDK:
 
 - `unit_tests` and `ppc_tests` build with the pinned Clang 20.1.8 toolchain.

--- a/launcher/PinyonShift.Launcher/MainWindow.xaml
+++ b/launcher/PinyonShift.Launcher/MainWindow.xaml
@@ -201,6 +201,8 @@
                         <RowDefinition Height="Auto"/>
                         <RowDefinition Height="Auto"/>
                         <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
                         <RowDefinition Height="*"/>
                         <RowDefinition Height="Auto"/>
                     </Grid.RowDefinitions>
@@ -217,7 +219,36 @@
                     <TextBlock Grid.Row="1" Margin="0,10,0,16" Foreground="{StaticResource MutedBrush}"
                                TextWrapping="Wrap" LineHeight="19"
                                Text="Changes are validated and backed up before they are saved. Restart the preview to apply them."/>
-                    <Grid Grid.Row="2">
+                    <Grid Grid.Row="2" Margin="0,0,0,16">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="1.15*"/>
+                            <ColumnDefinition Width="16"/>
+                            <ColumnDefinition Width="*"/>
+                        </Grid.ColumnDefinitions>
+                        <StackPanel>
+                            <TextBlock Text="FH1 PRESET" FontSize="10" Foreground="{StaticResource MutedBrush}"/>
+                            <ComboBox x:Name="GraphicsPresetComboBox" Margin="0,8,0,0" SelectedIndex="0"
+                                      SelectionChanged="GraphicsPresetComboBox_SelectionChanged"
+                                      AutomationProperties.Name="Forza Horizon graphics preset">
+                                <ComboBoxItem Tag="shipping_1x"><TextBlock Text="Shipping 1× · balanced" Foreground="{StaticResource InkBrush}"/></ComboBoxItem>
+                                <ComboBoxItem Tag="experimental_2x"><TextBlock Text="Experimental 2× · fast readback" Foreground="{StaticResource InkBrush}"/></ComboBoxItem>
+                                <ComboBoxItem Tag="accurate_showroom"><TextBlock Text="Accurate showroom · expensive" Foreground="{StaticResource InkBrush}"/></ComboBoxItem>
+                                <ComboBoxItem Tag="custom"><TextBlock Text="Custom · manual" Foreground="{StaticResource InkBrush}"/></ComboBoxItem>
+                            </ComboBox>
+                        </StackPanel>
+                        <StackPanel Grid.Column="2">
+                            <TextBlock Text="RESOLVE READBACK" FontSize="10" Foreground="{StaticResource MutedBrush}"/>
+                            <ComboBox x:Name="ReadbackResolveComboBox" Margin="0,8,0,0" SelectedIndex="0"
+                                      SelectionChanged="GraphicsControl_SelectionChanged"
+                                      AutomationProperties.Name="Resolve readback mode">
+                                <ComboBoxItem Tag="none"><TextBlock Text="Off · normal driving" Foreground="{StaticResource InkBrush}"/></ComboBoxItem>
+                                <ComboBoxItem Tag="fast"><TextBlock Text="Fast · previous frame" Foreground="{StaticResource InkBrush}"/></ComboBoxItem>
+                                <ComboBoxItem Tag="some"><TextBlock Text="Some · cache misses" Foreground="{StaticResource InkBrush}"/></ComboBoxItem>
+                                <ComboBoxItem Tag="full"><TextBlock Text="Full · synchronous" Foreground="{StaticResource InkBrush}"/></ComboBoxItem>
+                            </ComboBox>
+                        </StackPanel>
+                    </Grid>
+                    <Grid Grid.Row="3">
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition Width="*"/>
                             <ColumnDefinition Width="16"/>
@@ -246,19 +277,28 @@
                         <StackPanel Grid.Column="4">
                             <TextBlock Text="INTERNAL RESOLUTION" FontSize="10" Foreground="{StaticResource MutedBrush}"/>
                             <ComboBox x:Name="ResolutionComboBox" Margin="0,8,0,0" SelectedIndex="0"
+                                      SelectionChanged="GraphicsControl_SelectionChanged"
                                       AutomationProperties.Name="Internal resolution">
                                 <ComboBoxItem Tag="1"><TextBlock Text="Native · 1×" Foreground="{StaticResource InkBrush}"/></ComboBoxItem>
                                 <ComboBoxItem Tag="2"><TextBlock Text="Experimental · 2×" Foreground="{StaticResource InkBrush}"/></ComboBoxItem>
                             </ComboBox>
                         </StackPanel>
                     </Grid>
-                    <Border Grid.Row="3" Background="#171B17" BorderBrush="{StaticResource LineBrush}"
+                    <Border Grid.Row="4" x:Name="ShowroomWarning" Background="#241D12"
+                            BorderBrush="{StaticResource AmberBrush}" BorderThickness="1" CornerRadius="4"
+                            Padding="14,10" Margin="0,17,0,0" Visibility="Collapsed"
+                            AutomationProperties.LiveSetting="Polite">
+                        <TextBlock TextWrapping="Wrap" LineHeight="18" Foreground="{StaticResource FogBrush}"
+                                   FontSize="11"
+                                   Text="Accurate showroom uses full synchronous readback. It can sharply reduce frame rate; switch to Shipping 1× before normal driving."/>
+                    </Border>
+                    <Border Grid.Row="5" Background="#171B17" BorderBrush="{StaticResource LineBrush}"
                             BorderThickness="1" CornerRadius="4" Padding="14,11" Margin="0,17,0,0">
                         <TextBlock x:Name="GraphicsStatusText" Text="Loading current settings…" TextWrapping="Wrap"
                                    Foreground="{StaticResource MutedBrush}" FontSize="11"
                                    AutomationProperties.LiveSetting="Polite"/>
                     </Border>
-                    <StackPanel Grid.Row="5" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,18,0,0">
+                    <StackPanel Grid.Row="7" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,18,0,0">
                         <Button x:Name="RestoreGraphicsButton" Content="RESTORE BACKUP" Style="{StaticResource QuietButton}"
                                 Margin="0,0,10,0" Click="RestoreGraphicsButton_Click"/>
                         <Button x:Name="ResetGraphicsButton" Content="RESET DEFAULTS" Style="{StaticResource QuietButton}"

--- a/launcher/PinyonShift.Launcher/MainWindow.xaml.cs
+++ b/launcher/PinyonShift.Launcher/MainWindow.xaml.cs
@@ -28,6 +28,7 @@ public partial class MainWindow : Window
     private string? _gameExecutable;
     private CrashReport? _pendingReport;
     private bool _busy;
+    private bool _applyingGraphicsResult;
 
     private static readonly Brush WaitingBrush = new SolidColorBrush(Color.FromRgb(57, 64, 57));
     private static readonly Brush ActiveBrush = new SolidColorBrush(Color.FromRgb(241, 174, 54));
@@ -559,6 +560,61 @@ public partial class MainWindow : Window
     private async void SaveGraphicsButton_Click(object sender, RoutedEventArgs e) =>
         await ChangeGraphicsSettingsAsync("Apply", "Settings saved. Restart the preview to apply them.");
 
+    private void GraphicsPresetComboBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
+    {
+        if (_applyingGraphicsResult || GraphicsPresetComboBox.SelectedItem is null ||
+            ResolutionComboBox is null || ReadbackResolveComboBox is null) return;
+        _applyingGraphicsResult = true;
+        try
+        {
+            switch (SelectedTag(GraphicsPresetComboBox))
+            {
+                case "shipping_1x":
+                    SelectTag(ResolutionComboBox, "1");
+                    SelectTag(ReadbackResolveComboBox, "none");
+                    break;
+                case "experimental_2x":
+                    SelectTag(ResolutionComboBox, "2");
+                    SelectTag(ReadbackResolveComboBox, "fast");
+                    break;
+                case "accurate_showroom":
+                    SelectTag(ResolutionComboBox, "1");
+                    SelectTag(ReadbackResolveComboBox, "full");
+                    break;
+            }
+        }
+        finally
+        {
+            _applyingGraphicsResult = false;
+        }
+        UpdateShowroomWarning();
+    }
+
+    private void GraphicsControl_SelectionChanged(object sender, SelectionChangedEventArgs e)
+    {
+        if (_applyingGraphicsResult || ResolutionComboBox?.SelectedItem is null ||
+            ReadbackResolveComboBox?.SelectedItem is null || GraphicsPresetComboBox is null) return;
+        var inferred = (SelectedTag(ResolutionComboBox), SelectedTag(ReadbackResolveComboBox)) switch
+        {
+            ("1", "none") => "shipping_1x",
+            ("2", "fast") => "experimental_2x",
+            (_, "full") => "accurate_showroom",
+            _ => "custom"
+        };
+        _applyingGraphicsResult = true;
+        SelectTag(GraphicsPresetComboBox, inferred);
+        _applyingGraphicsResult = false;
+        UpdateShowroomWarning();
+    }
+
+    private void UpdateShowroomWarning()
+    {
+        if (ShowroomWarning is null || ReadbackResolveComboBox?.SelectedItem is null) return;
+        ShowroomWarning.Visibility = SelectedTag(ReadbackResolveComboBox) == "full"
+            ? Visibility.Visible
+            : Visibility.Collapsed;
+    }
+
     private async void ResetGraphicsButton_Click(object sender, RoutedEventArgs e)
     {
         if (MessageBox.Show(this,
@@ -620,7 +676,9 @@ public partial class MainWindow : Window
             "-NoLogo", "-NoProfile", "-ExecutionPolicy", "Bypass", "-File", script,
             "-Action", action, "-StateRoot", Path.Combine(_repositoryRoot, ".local", "preview"),
             "-Anisotropy", SelectedTag(AnisotropyComboBox), "-PostEffect", SelectedTag(PostEffectComboBox),
-            "-ResolutionScale", SelectedTag(ResolutionComboBox), "-Json"
+            "-ResolutionScale", SelectedTag(ResolutionComboBox),
+            "-Preset", SelectedTag(GraphicsPresetComboBox),
+            "-ReadbackResolve", SelectedTag(ReadbackResolveComboBox), "-Json"
         }) startInfo.ArgumentList.Add(argument);
         using var process = Process.Start(startInfo) ??
             throw new InvalidOperationException("Windows could not start the graphics settings tool.");
@@ -643,9 +701,20 @@ public partial class MainWindow : Window
 
     private void ApplyGraphicsResult(GraphicsResult result)
     {
-        SelectTag(AnisotropyComboBox, result.Settings.Anisotropy.ToString());
-        SelectTag(PostEffectComboBox, result.Settings.PostEffect);
-        SelectTag(ResolutionComboBox, result.Settings.ResolutionScale.ToString());
+        _applyingGraphicsResult = true;
+        try
+        {
+            SelectTag(AnisotropyComboBox, result.Settings.Anisotropy.ToString());
+            SelectTag(PostEffectComboBox, result.Settings.PostEffect);
+            SelectTag(GraphicsPresetComboBox, result.Settings.Preset);
+            SelectTag(ResolutionComboBox, result.Settings.ResolutionScale.ToString());
+            SelectTag(ReadbackResolveComboBox, result.Settings.ReadbackResolve);
+        }
+        finally
+        {
+            _applyingGraphicsResult = false;
+        }
+        UpdateShowroomWarning();
     }
 
     private static void SelectTag(ComboBox comboBox, string value)
@@ -659,6 +728,8 @@ public partial class MainWindow : Window
         AnisotropyComboBox.IsEnabled = enabled;
         PostEffectComboBox.IsEnabled = enabled;
         ResolutionComboBox.IsEnabled = enabled;
+        GraphicsPresetComboBox.IsEnabled = enabled;
+        ReadbackResolveComboBox.IsEnabled = enabled;
         SaveGraphicsButton.IsEnabled = enabled;
         ResetGraphicsButton.IsEnabled = enabled;
         RestoreGraphicsButton.IsEnabled = enabled;
@@ -683,5 +754,12 @@ public partial class MainWindow : Window
     private sealed record GraphicsSettings(
         [property: JsonPropertyName("anisotropy")] int Anisotropy,
         [property: JsonPropertyName("post_effect")] string PostEffect,
-        [property: JsonPropertyName("resolution_scale")] int ResolutionScale);
+        [property: JsonPropertyName("preset")] string Preset,
+        [property: JsonPropertyName("resolution_scale")] int ResolutionScale,
+        [property: JsonPropertyName("readback_resolve")] string ReadbackResolve,
+        [property: JsonPropertyName("readback_resolve_half_pixel_offset")] bool ReadbackHalfPixelOffset,
+        [property: JsonPropertyName("clear_memory_page_state")] bool ClearMemoryPageState,
+        [property: JsonPropertyName("readback_memexport")] bool ReadbackMemexport,
+        [property: JsonPropertyName("readback_memexport_fast")] bool ReadbackMemexportFast,
+        [property: JsonPropertyName("vsync")] bool Vsync);
 }

--- a/patches/rexglue/0041-fh1-resolve-readback-counters.patch
+++ b/patches/rexglue/0041-fh1-resolve-readback-counters.patch
@@ -1,0 +1,132 @@
+diff --git a/include/rex/perf/counter.h b/include/rex/perf/counter.h
+index 4116688..edf4823 100644
+--- a/include/rex/perf/counter.h
++++ b/include/rex/perf/counter.h
+@@ -59,6 +59,14 @@ enum class CounterId : uint16_t {
+   kMemexportQueueWaits,
+   kMemexportFenceWaits,
+ 
++  // D3D12 resolve readback
++  kResolveReadbackRequests,
++  kResolveReadbackBytes,
++  kResolveReadbackFastCopies,
++  kResolveReadbackCacheMisses,
++  kResolveReadbackFullWaits,
++  kResolveReadbackWaitTimeNs,
++
+   // D3D12 ZPD report lifecycle
+   kZpdReportsStarted,
+   kZpdReportsEnded,
+@@ -196,6 +204,12 @@ class Profiler {
+ #define PROFILE_MEMEXPORT_SYNC_FALLBACK() PERF_counter_inc(kMemexportSyncFallbacks)
+ #define PROFILE_MEMEXPORT_QUEUE_WAIT() PERF_counter_inc(kMemexportQueueWaits)
+ #define PROFILE_MEMEXPORT_FENCE_WAIT() PERF_counter_inc(kMemexportFenceWaits)
++#define PROFILE_RESOLVE_READBACK_REQUEST() PERF_counter_inc(kResolveReadbackRequests)
++#define PROFILE_RESOLVE_READBACK_BYTES(n) PERF_counter_add(kResolveReadbackBytes, n)
++#define PROFILE_RESOLVE_READBACK_FAST_COPY() PERF_counter_inc(kResolveReadbackFastCopies)
++#define PROFILE_RESOLVE_READBACK_CACHE_MISS() PERF_counter_inc(kResolveReadbackCacheMisses)
++#define PROFILE_RESOLVE_READBACK_FULL_WAIT() PERF_counter_inc(kResolveReadbackFullWaits)
++#define PROFILE_RESOLVE_READBACK_WAIT_TIME_NS(n) PERF_counter_add(kResolveReadbackWaitTimeNs, n)
+ 
+ #else
+ 
+@@ -225,6 +239,12 @@ class Profiler {
+ #define PROFILE_MEMEXPORT_SYNC_FALLBACK()
+ #define PROFILE_MEMEXPORT_QUEUE_WAIT()
+ #define PROFILE_MEMEXPORT_FENCE_WAIT()
++#define PROFILE_RESOLVE_READBACK_REQUEST()
++#define PROFILE_RESOLVE_READBACK_BYTES(n)
++#define PROFILE_RESOLVE_READBACK_FAST_COPY()
++#define PROFILE_RESOLVE_READBACK_CACHE_MISS()
++#define PROFILE_RESOLVE_READBACK_FULL_WAIT()
++#define PROFILE_RESOLVE_READBACK_WAIT_TIME_NS(n)
+ #define PROFILE_TEXTURE_CACHE_HIT()
+ #define PROFILE_TEXTURE_CACHE_MISS()
+ #define PROFILE_PIPELINE_CACHE_HIT()
+diff --git a/src/core/perf/counter.cpp b/src/core/perf/counter.cpp
+index e36e0ee..4759bed 100644
+--- a/src/core/perf/counter.cpp
++++ b/src/core/perf/counter.cpp
+@@ -57,6 +57,12 @@ constexpr const char* kCounterNames[] = {
+     "memexport_sync_fallbacks",
+     "memexport_queue_waits",
+     "memexport_fence_waits",
++    "resolve_readback_requests",
++    "resolve_readback_bytes",
++    "resolve_readback_fast_copies",
++    "resolve_readback_cache_misses",
++    "resolve_readback_full_waits",
++    "resolve_readback_wait_time_ns",
+     "zpd_reports_started",
+     "zpd_reports_ended",
+     "zpd_report_segments",
+@@ -105,6 +111,12 @@ constexpr bool kIsGauge[] = {
+     false,  // kMemexportSyncFallbacks
+     false,  // kMemexportQueueWaits
+     false,  // kMemexportFenceWaits
++    false,  // kResolveReadbackRequests
++    false,  // kResolveReadbackBytes
++    false,  // kResolveReadbackFastCopies
++    false,  // kResolveReadbackCacheMisses
++    false,  // kResolveReadbackFullWaits
++    false,  // kResolveReadbackWaitTimeNs
+     false,  // kZpdReportsStarted
+     false,  // kZpdReportsEnded
+     false,  // kZpdReportSegments
+diff --git a/src/graphics/d3d12/command_processor.cpp b/src/graphics/d3d12/command_processor.cpp
+index e765955..4b93a31 100644
+--- a/src/graphics/d3d12/command_processor.cpp
++++ b/src/graphics/d3d12/command_processor.cpp
+@@ -3069,6 +3069,8 @@ bool D3D12CommandProcessor::IssueCopy_ReadbackResolvePath() {
+     return true;
+   }
+ 
++  PROFILE_RESOLVE_READBACK_REQUEST();
++
+   if (!memory_->TranslatePhysical(written_address)) {
+     return true;
+   }
+@@ -3244,19 +3246,30 @@ bool D3D12CommandProcessor::IssueCopy_ReadbackResolvePath() {
+   ReadbackResolveMode readback_mode = GetReadbackResolveMode(REXCVAR_GET(d3d12_readback_resolve));
+   bool use_delayed_sync =
+       readback_mode == ReadbackResolveMode::kFast || readback_mode == ReadbackResolveMode::kSome;
++  auto await_resolve_readback = [&]() {
++    PROFILE_RESOLVE_READBACK_FULL_WAIT();
++    auto wait_start = std::chrono::steady_clock::now();
++    bool completed = AwaitAllQueueOperationsCompletion();
++    auto wait_time_ns = std::chrono::duration_cast<std::chrono::nanoseconds>(
++                            std::chrono::steady_clock::now() - wait_start)
++                            .count();
++    PROFILE_RESOLVE_READBACK_WAIT_TIME_NS(wait_time_ns);
++    return completed;
++  };
+   uint32_t read_index = write_index;
+   if (use_delayed_sync) {
+     read_index = 1 - write_index;
+-  } else if (!AwaitAllQueueOperationsCompletion()) {
++  } else if (!await_resolve_readback()) {
+     return true;
+   }
+ 
+   bool is_cache_miss = false;
+   if (use_delayed_sync && (!rb.buffers[read_index] || written_length > rb.sizes[read_index] ||
+                            !rb.mapped_data[read_index])) {
++    PROFILE_RESOLVE_READBACK_CACHE_MISS();
+     is_cache_miss = true;
+     read_index = write_index;
+-    if (!AwaitAllQueueOperationsCompletion()) {
++    if (!await_resolve_readback()) {
+       return true;
+     }
+   }
+@@ -3267,6 +3280,10 @@ bool D3D12CommandProcessor::IssueCopy_ReadbackResolvePath() {
+     uint8_t* destination = memory_->TranslatePhysical(written_address);
+     if (destination) {
+       std::memcpy(destination, static_cast<uint8_t*>(rb.mapped_data[read_index]), written_length);
++      PROFILE_RESOLVE_READBACK_BYTES(written_length);
++      if (readback_mode == ReadbackResolveMode::kFast) {
++        PROFILE_RESOLVE_READBACK_FAST_COPY();
++      }
+     }
+   }
+ 

--- a/src/pinyon_shift_app.cpp
+++ b/src/pinyon_shift_app.cpp
@@ -22,14 +22,14 @@
 
 #include <cstdio>
 
-REXCVAR_DEFINE_UINT32(pinyon_shift_config_schema, 7, "Pinyon Shift",
+REXCVAR_DEFINE_UINT32(pinyon_shift_config_schema, 8, "Pinyon Shift",
                       "Pinyon Shift host configuration schema version");
 REXCVAR_DEFINE_BOOL(pinyon_shift_capture_performance, true, "Pinyon Shift",
                     "Capture lightweight per-frame performance counters to a session CSV");
 
 namespace {
 
-constexpr uint32_t kConfigSchema = 7;
+constexpr uint32_t kConfigSchema = 8;
 
 bool EnsureSupportedConfig(const std::filesystem::path& path, bool& created,
                            bool& migrated) {
@@ -51,6 +51,7 @@ bool EnsureSupportedConfig(const std::filesystem::path& path, bool& created,
               "keybind_a = \"LMB,Space\"\n"
               "keybind_start = \"Return\"\n"
               "d3d12_allow_variable_refresh_rate_and_tearing = false\n"
+              "vsync = true\n"
               "pinyon_shift_capture_performance = true\n"
               "xma_relaxed_padding_admission = false\n"
               "pinyon_shift_stabilize_vehicle_presentation = false\n"
@@ -59,6 +60,11 @@ bool EnsureSupportedConfig(const std::filesystem::path& path, bool& created,
               "swap_post_effect = \"none\"\n"
               "draw_resolution_scale_x = 1\n"
               "draw_resolution_scale_y = 1\n"
+              "clear_memory_page_state = true\n"
+              "readback_resolve = \"none\"\n"
+              "readback_resolve_half_pixel_offset = false\n"
+              "readback_memexport = true\n"
+              "readback_memexport_fast = true\n"
               "occlusion_query = \"legacy\"\n"
               "zpd_end_policy = \"report_layout\"\n"
               "zpd_end_fallback = \"pairwise_sentinel\"\n";
@@ -85,7 +91,7 @@ bool EnsureSupportedConfig(const std::filesystem::path& path, bool& created,
     if (schema == kConfigSchema) {
       return true;
     }
-    if (schema < 1 || schema > 6) {
+    if (schema < 1 || schema > 7) {
       return false;
     }
 
@@ -137,6 +143,13 @@ bool EnsureSupportedConfig(const std::filesystem::path& path, bool& created,
         {"swap_post_effect", "swap_post_effect = \"none\"\n"},
         {"draw_resolution_scale_x", "draw_resolution_scale_x = 1\n"},
         {"draw_resolution_scale_y", "draw_resolution_scale_y = 1\n"},
+        {"vsync", "vsync = true\n"},
+        {"clear_memory_page_state", "clear_memory_page_state = true\n"},
+        {"readback_resolve", "readback_resolve = \"none\"\n"},
+        {"readback_resolve_half_pixel_offset",
+         "readback_resolve_half_pixel_offset = false\n"},
+        {"readback_memexport", "readback_memexport = true\n"},
+        {"readback_memexport_fast", "readback_memexport_fast = true\n"},
         {"occlusion_query", "occlusion_query = \"legacy\"\n"},
         {"zpd_end_policy", "zpd_end_policy = \"report_layout\"\n"},
         {"zpd_end_fallback", "zpd_end_fallback = \"pairwise_sentinel\"\n"},
@@ -255,6 +268,17 @@ void PinyonShiftApp::OnPostInitLogging() {
                          rex::cvar::GetFlagByName("draw_resolution_scale_x")},
                         {"draw_resolution_scale_y",
                          rex::cvar::GetFlagByName("draw_resolution_scale_y")},
+                        {"clear_memory_page_state",
+                         rex::cvar::GetFlagByName("clear_memory_page_state")},
+                        {"readback_resolve",
+                         rex::cvar::GetFlagByName("readback_resolve")},
+                        {"readback_resolve_half_pixel_offset",
+                         rex::cvar::GetFlagByName(
+                             "readback_resolve_half_pixel_offset")},
+                        {"readback_memexport",
+                         rex::cvar::GetFlagByName("readback_memexport")},
+                        {"readback_memexport_fast",
+                         rex::cvar::GetFlagByName("readback_memexport_fast")},
                         {"anisotropic_override",
                          rex::cvar::GetFlagByName("anisotropic_override")},
                         {"swap_post_effect", rex::cvar::GetFlagByName("swap_post_effect")},

--- a/tools/create-crash-report.ps1
+++ b/tools/create-crash-report.ps1
@@ -187,6 +187,24 @@ try {
             $zpdCounters.available = $true
         }
     }
+    $resolveColumns = @(
+        'resolve_readback_requests', 'resolve_readback_bytes',
+        'resolve_readback_fast_copies', 'resolve_readback_cache_misses',
+        'resolve_readback_full_waits', 'resolve_readback_wait_time_ns'
+    )
+    $resolveCounters = [ordered]@{ available = $false }
+    foreach ($column in $resolveColumns) { $resolveCounters[$column] = [uint64]0 }
+    if ($perfLog) {
+        $columns = @((Get-Content -LiteralPath $perfLog.FullName -TotalCount 1) -split ',')
+        if (@($resolveColumns | Where-Object { $_ -notin $columns }).Count -eq 0) {
+            foreach ($row in Import-Csv -LiteralPath $perfLog.FullName) {
+                foreach ($column in $resolveColumns) {
+                    $resolveCounters[$column] += [uint64]$row.$column
+                }
+            }
+            $resolveCounters.available = $true
+        }
+    }
 
     $allowedSettings = @(
         'pinyon_shift_config_schema', 'input_backend', 'hid_mappings_file',
@@ -197,7 +215,9 @@ try {
         'pinyon_shift_stabilize_vehicle_presentation', 'pinyon_shift_skip_opening_movies',
         'resolution', 'vsync', 'anisotropic_override', 'swap_post_effect',
         'draw_resolution_scale_x', 'draw_resolution_scale_y', 'occlusion_query',
-        'zpd_end_policy', 'zpd_end_fallback'
+        'zpd_end_policy', 'zpd_end_fallback', 'clear_memory_page_state',
+        'readback_resolve', 'readback_resolve_half_pixel_offset',
+        'readback_memexport', 'readback_memexport_fast'
     )
     $configPath = Join-Path $resolvedStateRoot 'config/pinyon_shift.toml'
     $settings = [ordered]@{}
@@ -276,6 +296,7 @@ try {
         }
         graphics = [ordered]@{
             zpd = $zpdCounters
+            resolve_readback = $resolveCounters
         }
         local_dumps = $dumpRecords
         privacy = [ordered]@{

--- a/tools/qualify-resolve.ps1
+++ b/tools/qualify-resolve.ps1
@@ -1,0 +1,171 @@
+[CmdletBinding()]
+param(
+    [ValidateSet('Plan', 'Run')]
+    [string]$Action = 'Plan',
+    [string]$StateRoot,
+    [switch]$Json
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
+$resolvedStateRoot = if ($StateRoot) {
+    [IO.Path]::GetFullPath($StateRoot)
+} else {
+    Join-Path $repoRoot '.local/preview'
+}
+$configPath = Join-Path $resolvedStateRoot 'config/pinyon_shift.toml'
+$logsPath = Join-Path $resolvedStateRoot 'logs'
+$reportsPath = Join-Path $resolvedStateRoot 'reports'
+$buildPath = Join-Path $repoRoot 'out/build/win-amd64-release/pinyon_shift_build.json'
+$powershell = (Get-Process -Id $PID).Path
+
+$profiles = @(
+    [ordered]@{
+        preset = 'shipping_1x'
+        label = 'shipping-1x'
+        markers = @('front_end', 'open_world_day', 'open_world_night', 'race', 'rewind')
+    },
+    [ordered]@{
+        preset = 'experimental_2x'
+        label = 'experimental-2x'
+        markers = @('garage', 'autoshow', 'livery', 'colored_artifacts_absent')
+    },
+    [ordered]@{
+        preset = 'accurate_showroom'
+        label = 'accurate-showroom'
+        markers = @('garage', 'autoshow', 'livery', 'assets_correct')
+    }
+)
+
+if ($Action -eq 'Plan') {
+    $plan = [ordered]@{
+        schema = 'pinyon-shift.resolve-qualification-plan.v1'
+        profiles = $profiles
+        restore_original_config = $true
+        candidate_scenes = @(
+            'front-end', 'garage', 'autoshow', 'livery',
+            'open-world-day', 'open-world-night', 'race', 'rewind'
+        )
+    }
+    if ($Json) { $plan | ConvertTo-Json -Depth 6 -Compress } else { [pscustomobject]$plan }
+    exit 0
+}
+
+if (-not (Test-Path -LiteralPath $configPath -PathType Leaf)) {
+    throw "Resolve qualification requires an existing host config: $configPath"
+}
+if (-not (Test-Path -LiteralPath $buildPath -PathType Leaf)) {
+    throw 'Build provenance is missing. Run tools/build-preview.ps1 first.'
+}
+if (Get-Process -Name pinyon_shift -ErrorAction SilentlyContinue) {
+    throw 'Pinyon Shift is already running.'
+}
+$save = Get-ChildItem -LiteralPath (Join-Path $resolvedStateRoot 'user') -Recurse `
+    -Filter ForzaProfile -File -ErrorAction SilentlyContinue |
+    Where-Object { $_.Directory.Name -eq 'ForzaProfile' } | Select-Object -First 1
+if ($null -eq $save) { throw 'The AppData-backed ForzaProfile save was not found.' }
+
+$originalConfig = Get-Content -LiteralPath $configPath -Raw
+$build = Get-Content -LiteralPath $buildPath -Raw | ConvertFrom-Json
+$results = [Collections.Generic.List[object]]::new()
+$failed = $false
+try {
+    foreach ($profile in $profiles) {
+        & (Join-Path $PSScriptRoot 'set-graphics-experiment.ps1') -Action Apply `
+            -Preset $profile.preset -StateRoot $resolvedStateRoot | Out-Null
+        $startedUtc = [DateTime]::UtcNow
+        $launchOutput = & $powershell -NoProfile -File `
+            (Join-Path $PSScriptRoot 'launch-preview.ps1') `
+            -StateRoot $resolvedStateRoot -Json 2>&1
+        $exitCode = $LASTEXITCODE
+        $launchResult = $launchOutput | Select-Object -Last 1 | ConvertFrom-Json
+        if ($launchResult.exit_code -ne $exitCode) {
+            throw "Launcher exit mismatch: process=$($launchResult.exit_code), host=$exitCode"
+        }
+
+        $markers = [ordered]@{}
+        foreach ($marker in $profile.markers) {
+            $label = $marker.Replace('_', ' ')
+            $markers[$marker] = ((Read-Host "[$($profile.label)] $label verified? [y/N]") `
+                -match '(?i)^y(?:es)?$')
+        }
+
+        $perf = Get-ChildItem -LiteralPath $logsPath -Filter '*.perf.csv' -File |
+            Where-Object { $_.LastWriteTimeUtc -ge $startedUtc.AddSeconds(-2) } |
+            Sort-Object LastWriteTimeUtc | Select-Object -Last 1
+        $events = Get-ChildItem -LiteralPath $logsPath -Filter '*.jsonl' -File |
+            Where-Object { $_.LastWriteTimeUtc -ge $startedUtc.AddSeconds(-2) } |
+            Sort-Object LastWriteTimeUtc | Select-Object -Last 1
+        $summary = if ($perf) {
+            & python (Join-Path $PSScriptRoot 'summarize-performance.py') $perf.FullName |
+                ConvertFrom-Json
+        } else { $null }
+        $errorCount = if ($events) {
+            @(Select-String -LiteralPath $events.FullName `
+                -Pattern 'fatal|error|exception|assert|device.?removed' -CaseSensitive:$false).Count
+        } else { 1 }
+        $resolve = if ($summary -and $summary.resolve_readback_counters) {
+            $summary.resolve_readback_counters
+        } else { $null }
+        $countersHealthy = if ($null -eq $resolve) {
+            $false
+        } elseif ($profile.preset -eq 'shipping_1x') {
+            $resolve.resolve_readback_requests -eq 0 -and
+                $resolve.resolve_readback_bytes -eq 0 -and
+                $resolve.resolve_readback_full_waits -eq 0
+        } elseif ($profile.preset -eq 'experimental_2x') {
+            $resolve.resolve_readback_requests -gt 0 -and
+                $resolve.resolve_readback_bytes -gt 0 -and
+                $resolve.resolve_readback_fast_copies -gt 0
+        } else {
+            $resolve.resolve_readback_requests -gt 0 -and
+                $resolve.resolve_readback_bytes -gt 0 -and
+                $resolve.resolve_readback_full_waits -gt 0 -and
+                $resolve.resolve_readback_wait_time_ns -gt 0
+        }
+        $markersHealthy = @($markers.Values | Where-Object { -not $_ }).Count -eq 0
+        $passed = $exitCode -eq 0 -and $markersHealthy -and $errorCount -eq 0 -and
+            $countersHealthy
+        $results.Add([ordered]@{
+            label = $profile.label
+            preset = $profile.preset
+            started_utc = $startedUtc.ToString('o')
+            markers = $markers
+            exit_code = $exitCode
+            error_signatures = $errorCount
+            performance_log = if ($perf) { $perf.Name } else { $null }
+            event_log = if ($events) { $events.Name } else { $null }
+            frame_summary = if ($summary) { $summary.frames } else { $null }
+            resolve_readback_counters = $resolve
+            passed = $passed
+        })
+        if (-not $passed) {
+            $failed = $true
+            break
+        }
+    }
+}
+finally {
+    [IO.File]::WriteAllText($configPath, $originalConfig,
+        [Text.UTF8Encoding]::new($false))
+}
+
+[void](New-Item -ItemType Directory -Force -Path $reportsPath)
+$stamp = [DateTime]::UtcNow.ToString('yyyyMMddTHHmmssfffZ')
+$reportPath = Join-Path $reportsPath "resolve-qualification-$stamp.json"
+$report = [ordered]@{
+    schema = 'pinyon-shift.resolve-qualification.v1'
+    build = $build
+    supported_dump = 'forza-horizon-usa-ms-2505-retail-base'
+    completed_runs = $results.Count
+    passed = -not $failed -and $results.Count -eq $profiles.Count
+    original_config_restored = $true
+    runs = $results
+}
+[IO.File]::WriteAllText($reportPath, ($report | ConvertTo-Json -Depth 12) + [Environment]::NewLine,
+    [Text.UTF8Encoding]::new($false))
+$output = [ordered]@{ passed = $report.passed; report = $reportPath; runs = $results.Count }
+if ($Json) { $output | ConvertTo-Json -Compress } else { [pscustomobject]$output }
+if (-not $report.passed) { exit 1 }

--- a/tools/renderer-ab.py
+++ b/tools/renderer-ab.py
@@ -6,17 +6,34 @@ import argparse, hashlib, json
 from datetime import datetime, timezone
 from pathlib import Path
 
-VARIABLES = {"readback_memexport": ("true", "false"), "clear_memory_page_state": ("true", "false"),
-             "d3d12_submit_on_primary_buffer_end": ("true", "false")}
+VARIABLES = {
+    "readback_memexport": ("true", "false"),
+    "readback_resolve": ("none", "fast"),
+    "clear_memory_page_state": ("true", "false"),
+    "d3d12_submit_on_primary_buffer_end": ("true", "false"),
+    "async_shader_compilation": ("true", "false"),
+}
+READBACK_RESOLVE_VALUES = ("fast", "some", "full")
 MEMEXPORT_COUNTERS = ("memexport_draws", "memexport_bytes", "memexport_sync_fallbacks", "memexport_queue_waits", "memexport_fence_waits")
+RESOLVE_COUNTERS = ("resolve_readback_requests", "resolve_readback_bytes", "resolve_readback_fast_copies",
+                    "resolve_readback_cache_misses", "resolve_readback_full_waits", "resolve_readback_wait_time_ns")
+RESOLVE_SCENES = ("front-end", "garage", "autoshow", "livery", "open-world-day", "open-world-night", "race", "rewind")
 
-def prepare(root: Path, variable: str, fingerprint: Path) -> Path:
+def prepare(root: Path, variable: str, fingerprint: Path, candidate_value: str | None = None) -> Path:
+    control, default_candidate = VARIABLES[variable]
+    candidate = candidate_value or default_candidate
+    if variable == "readback_resolve" and candidate not in READBACK_RESOLVE_VALUES:
+        raise ValueError("readback_resolve candidate must be fast, some, or full")
+    if variable != "readback_resolve" and candidate_value is not None:
+        raise ValueError("custom candidate values are supported only for readback_resolve")
     build = json.loads(fingerprint.read_text(encoding="utf-8")); stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
     session = root / f"{stamp}-{variable}"; session.mkdir(parents=True)
     manifest = {"schema": "pinyon-shift.renderer-ab.v1", "variable": variable, "shipping_defaults_unchanged": True,
-                "build": build, "variants": [{"name": "control", "value": VARIABLES[variable][0]}, {"name": "candidate", "value": VARIABLES[variable][1]}],
+                "build": build, "variants": [{"name": "control", "value": control}, {"name": "candidate", "value": candidate}],
                 "required_evidence": ["performance-summary.json", "visual-validation.json"],
-                "required_memexport_counters": list(MEMEXPORT_COUNTERS) if variable == "readback_memexport" else []}
+                "required_memexport_counters": list(MEMEXPORT_COUNTERS) if variable == "readback_memexport" else [],
+                "required_resolve_counters": list(RESOLVE_COUNTERS) if variable == "readback_resolve" else [],
+                "required_visual_scenes": list(RESOLVE_SCENES) if variable == "readback_resolve" else []}
     (session / "manifest.json").write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
     for variant in manifest["variants"]:
         folder = session / variant["name"]; folder.mkdir()
@@ -34,22 +51,31 @@ def compare(session: Path) -> dict:
             counters = perf.get("memexport_counters", {})
             missing = [name for name in MEMEXPORT_COUNTERS if name not in counters]
             if missing: raise ValueError("memexport evidence lacks counters: " + ", ".join(missing))
+        if manifest["variable"] == "readback_resolve":
+            counters = perf.get("resolve_readback_counters", {})
+            missing = [name for name in RESOLVE_COUNTERS if name not in counters]
+            if missing: raise ValueError("resolve evidence lacks counters: " + ", ".join(missing))
         summaries[variant] = perf
+    def frame_times(summary: dict) -> dict:
+        return summary.get("frames", summary)["frame_time_us"]
+    control_latency = frame_times(summaries["control"])
+    candidate_latency = frame_times(summaries["candidate"])
     result = {"schema": manifest["schema"], "variable": manifest["variable"], "build": manifest["build"],
               "control_sha256": hashlib.sha256(json.dumps(summaries["control"], sort_keys=True).encode()).hexdigest(),
               "candidate_sha256": hashlib.sha256(json.dumps(summaries["candidate"], sort_keys=True).encode()).hexdigest(),
-              "comparison": {"median_frame_time_us_delta": summaries["candidate"]["frame_time_us"]["median"] - summaries["control"]["frame_time_us"]["median"],
-                             "p95_frame_time_us_delta": summaries["candidate"]["frame_time_us"]["p95"] - summaries["control"]["frame_time_us"]["p95"]}}
+              "comparison": {"median_frame_time_us_delta": candidate_latency["median"] - control_latency["median"],
+                             "p95_frame_time_us_delta": candidate_latency["p95"] - control_latency["p95"]}}
     (session / "comparison.json").write_text(json.dumps(result, indent=2) + "\n", encoding="utf-8"); return result
 
 def main() -> int:
     parser = argparse.ArgumentParser(); parser.add_argument("action", choices=("prepare", "compare")); parser.add_argument("path", type=Path)
     parser.add_argument("--variable", choices=VARIABLES); parser.add_argument("--build-fingerprint", type=Path)
+    parser.add_argument("--candidate-value")
     args = parser.parse_args()
     try:
         if args.action == "prepare":
             if not args.variable or not args.build_fingerprint: raise ValueError("prepare requires --variable and --build-fingerprint")
-            result = {"path": str(prepare(args.path, args.variable, args.build_fingerprint))}
+            result = {"path": str(prepare(args.path, args.variable, args.build_fingerprint, args.candidate_value))}
         else: result = compare(args.path)
         print(json.dumps(result, indent=2)); return 0
     except (OSError, ValueError, KeyError, json.JSONDecodeError) as exc: parser.exit(2, f"renderer A/B error: {exc}\n")

--- a/tools/set-graphics-experiment.ps1
+++ b/tools/set-graphics-experiment.ps1
@@ -8,6 +8,10 @@ param(
     [string]$PostEffect = 'none',
     [ValidateSet(1, 2)]
     [int]$ResolutionScale = 1,
+    [ValidateSet('custom', 'shipping_1x', 'experimental_2x', 'accurate_showroom')]
+    [string]$Preset = 'custom',
+    [ValidateSet('none', 'fast', 'some', 'full')]
+    [string]$ReadbackResolve = 'none',
     [ValidateSet('legacy', 'fake', 'fast', 'strict')]
     [string]$OcclusionQuery = 'legacy',
     [ValidateSet('report_layout', 'pairwise_sentinel', 'relaxed_sentinel')]
@@ -34,14 +38,15 @@ $backupDirectory = Join-Path $configDirectory 'backups'
 function Get-DefaultConfigText {
     @'
 # Pinyon Shift host configuration.
-# Schema 7 adds FH1 ZPD END-policy qualification.
-pinyon_shift_config_schema = 7
+# Schema 8 adds FH1 resolve-readback presets.
+pinyon_shift_config_schema = 8
 input_backend = "sdl"
 hid_mappings_file = "gamecontrollerdb.txt"
 mnk_mode = true
 keybind_a = "LMB,Space"
 keybind_start = "Return"
 d3d12_allow_variable_refresh_rate_and_tearing = false
+vsync = true
 pinyon_shift_stabilize_vehicle_presentation = false
 pinyon_shift_skip_opening_movies = false
 xma_relaxed_padding_admission = false
@@ -49,6 +54,11 @@ anisotropic_override = 3
 swap_post_effect = "none"
 draw_resolution_scale_x = 1
 draw_resolution_scale_y = 1
+clear_memory_page_state = true
+readback_resolve = "none"
+readback_resolve_half_pixel_offset = false
+readback_memexport = true
+readback_memexport_fast = true
 occlusion_query = "legacy"
 zpd_end_policy = "report_layout"
 zpd_end_fallback = "pairwise_sentinel"
@@ -104,15 +114,41 @@ function Write-Config([string]$Text) {
 function Get-SettingsResult([string]$Text, [string]$BackupPath, [string]$Operation) {
     $override = [int](Get-TomlValue $Text 'anisotropic_override' '3')
     $anisotropyValue = switch ($override) { 3 { 4 } 4 { 8 } 5 { 16 } default { 4 } }
+    $resolutionScale = [int](Get-TomlValue $Text 'draw_resolution_scale_x' '1')
+    $readbackResolve = Get-TomlValue $Text 'readback_resolve' 'none'
+    $halfPixel = (Get-TomlValue $Text 'readback_resolve_half_pixel_offset' 'false') -eq 'true'
+    $clearPageState = (Get-TomlValue $Text 'clear_memory_page_state' 'true') -eq 'true'
+    $memexport = (Get-TomlValue $Text 'readback_memexport' 'true') -eq 'true'
+    $memexportFast = (Get-TomlValue $Text 'readback_memexport_fast' 'true') -eq 'true'
+    $vsyncEnabled = (Get-TomlValue $Text 'vsync' 'true') -eq 'true'
+    $presetName = if ($clearPageState -and $readbackResolve -eq 'full') {
+        'accurate_showroom'
+    } elseif ($clearPageState -and $resolutionScale -eq 2 -and
+        $readbackResolve -eq 'fast' -and $halfPixel) {
+        'experimental_2x'
+    } elseif ($clearPageState -and $resolutionScale -eq 1 -and
+        $readbackResolve -eq 'none' -and -not $halfPixel -and $memexport -and
+        $memexportFast -and $vsyncEnabled) {
+        'shipping_1x'
+    } else {
+        'custom'
+    }
     [ordered]@{
-        schema = 'pinyon-shift.graphics-settings.v1'
+        schema = 'pinyon-shift.graphics-settings.v2'
         operation = $Operation.ToLowerInvariant()
         config_path = $configPath
         backup_path = $BackupPath
         settings = [ordered]@{
             anisotropy = $anisotropyValue
             post_effect = Get-TomlValue $Text 'swap_post_effect' 'none'
-            resolution_scale = [int](Get-TomlValue $Text 'draw_resolution_scale_x' '1')
+            preset = $presetName
+            resolution_scale = $resolutionScale
+            readback_resolve = $readbackResolve
+            readback_resolve_half_pixel_offset = $halfPixel
+            clear_memory_page_state = $clearPageState
+            readback_memexport = $memexport
+            readback_memexport_fast = $memexportFast
+            vsync = $vsyncEnabled
             occlusion_query = Get-TomlValue $Text 'occlusion_query' 'legacy'
             zpd_end_policy = Get-TomlValue $Text 'zpd_end_policy' 'report_layout'
             zpd_end_fallback = Get-TomlValue $Text 'zpd_end_fallback' 'pairwise_sentinel'
@@ -129,7 +165,7 @@ switch ($Action) {
             Get-Content -LiteralPath $configPath -Raw
         } else { Get-DefaultConfigText }
         $schema = Get-SchemaVersion $text
-        if ($schema -notin @(1, 2, 3, 4, 5, 6, 7)) { throw "Unsupported host configuration schema: $schema" }
+        if ($schema -notin @(1, 2, 3, 4, 5, 6, 7, 8)) { throw "Unsupported host configuration schema: $schema" }
     }
     'Reset' {
         $backup = New-ConfigBackup
@@ -146,7 +182,7 @@ switch ($Action) {
         $backup = New-ConfigBackup
         $text = Get-Content -LiteralPath $source.FullName -Raw
         $schema = Get-SchemaVersion $text
-        if ($schema -notin @(1, 2, 3, 4, 5, 6, 7)) { throw "Backup uses unsupported schema: $schema" }
+        if ($schema -notin @(1, 2, 3, 4, 5, 6, 7, 8)) { throw "Backup uses unsupported schema: $schema" }
         Write-Config $text
     }
     'Apply' {
@@ -154,20 +190,42 @@ switch ($Action) {
             Get-Content -LiteralPath $configPath -Raw
         } else { Get-DefaultConfigText }
         $schema = Get-SchemaVersion $text
-        if ($schema -notin @(1, 2, 3, 4, 5, 6, 7)) { throw "Unsupported host configuration schema: $schema" }
+        if ($schema -notin @(1, 2, 3, 4, 5, 6, 7, 8)) { throw "Unsupported host configuration schema: $schema" }
         $backup = New-ConfigBackup
-        $text = Set-TomlValue $text 'pinyon_shift_config_schema' '7'
+        $text = Set-TomlValue $text 'pinyon_shift_config_schema' '8'
         if (-not [regex]::IsMatch($text, '(?m)^\s*xma_relaxed_padding_admission\s*=')) {
             $text = Set-TomlValue $text 'xma_relaxed_padding_admission' 'false'
         }
         if (-not [regex]::IsMatch($text, '(?m)^\s*occlusion_query\s*=')) {
             $text = Set-TomlValue $text 'occlusion_query' '"legacy"'
         }
+        $effectiveResolution = switch ($Preset) {
+            'shipping_1x' { 1 }
+            'experimental_2x' { 2 }
+            'accurate_showroom' { 1 }
+            default { $ResolutionScale }
+        }
+        $effectiveReadback = switch ($Preset) {
+            'shipping_1x' { 'none' }
+            'experimental_2x' { 'fast' }
+            'accurate_showroom' { 'full' }
+            default { $ReadbackResolve }
+        }
+        $effectiveHalfPixel = $Preset -eq 'experimental_2x' -or
+            ($Preset -eq 'custom' -and $effectiveResolution -eq 2 -and
+                $effectiveReadback -ne 'none')
+        $effectiveHalfPixelText = if ($effectiveHalfPixel) { 'true' } else { 'false' }
         $override = switch ($Anisotropy) { 4 { 3 } 8 { 4 } 16 { 5 } }
         $text = Set-TomlValue $text 'anisotropic_override' ([string]$override)
         $text = Set-TomlValue $text 'swap_post_effect' ('"' + $PostEffect + '"')
-        $text = Set-TomlValue $text 'draw_resolution_scale_x' ([string]$ResolutionScale)
-        $text = Set-TomlValue $text 'draw_resolution_scale_y' ([string]$ResolutionScale)
+        $text = Set-TomlValue $text 'draw_resolution_scale_x' ([string]$effectiveResolution)
+        $text = Set-TomlValue $text 'draw_resolution_scale_y' ([string]$effectiveResolution)
+        $text = Set-TomlValue $text 'vsync' 'true'
+        $text = Set-TomlValue $text 'clear_memory_page_state' 'true'
+        $text = Set-TomlValue $text 'readback_resolve' ('"' + $effectiveReadback + '"')
+        $text = Set-TomlValue $text 'readback_resolve_half_pixel_offset' $effectiveHalfPixelText
+        $text = Set-TomlValue $text 'readback_memexport' 'true'
+        $text = Set-TomlValue $text 'readback_memexport_fast' 'true'
         $text = Set-TomlValue $text 'occlusion_query' ('"' + $OcclusionQuery + '"')
         $text = Set-TomlValue $text 'zpd_end_policy' ('"' + $ZpdEndPolicy + '"')
         $text = Set-TomlValue $text 'zpd_end_fallback' ('"' + $ZpdEndFallback + '"')

--- a/tools/summarize-performance.py
+++ b/tools/summarize-performance.py
@@ -38,6 +38,14 @@ MEMEXPORT_COLUMNS = (
     "memexport_queue_waits",
     "memexport_fence_waits",
 )
+RESOLVE_READBACK_COLUMNS = (
+    "resolve_readback_requests",
+    "resolve_readback_bytes",
+    "resolve_readback_fast_copies",
+    "resolve_readback_cache_misses",
+    "resolve_readback_full_waits",
+    "resolve_readback_wait_time_ns",
+)
 XMA_STALL_COLUMNS = (
     "xma_no_space_stalls",
     "xma_no_progress_stalls",
@@ -109,6 +117,10 @@ def summarize(path: pathlib.Path) -> dict[str, Any]:
         if available_memexport and available_memexport != set(MEMEXPORT_COLUMNS):
             missing_memexport = sorted(set(MEMEXPORT_COLUMNS) - available_memexport)
             raise CaptureError("capture has an incomplete memexport counter set: " + ", ".join(missing_memexport))
+        available_resolve = columns.intersection(RESOLVE_READBACK_COLUMNS)
+        if available_resolve and available_resolve != set(RESOLVE_READBACK_COLUMNS):
+            missing_resolve = sorted(set(RESOLVE_READBACK_COLUMNS) - available_resolve)
+            raise CaptureError("capture has an incomplete resolve-readback counter set: " + ", ".join(missing_resolve))
         available_xma_stalls = columns.intersection(XMA_STALL_COLUMNS)
         if available_xma_stalls and available_xma_stalls != set(XMA_STALL_COLUMNS):
             missing_xma_stalls = sorted(set(XMA_STALL_COLUMNS) - available_xma_stalls)
@@ -121,6 +133,8 @@ def summarize(path: pathlib.Path) -> dict[str, Any]:
         frame_times: list[float] = []
         totals = {name: 0.0 for name in TOTAL_COLUMNS}
         memexport_totals = {name: 0.0 for name in MEMEXPORT_COLUMNS} if available_memexport else None
+        resolve_totals = ({name: 0.0 for name in RESOLVE_READBACK_COLUMNS}
+                          if available_resolve else None)
         xma_stall_totals = {name: 0.0 for name in XMA_STALL_COLUMNS} if available_xma_stalls else None
         zpd_totals = {name: 0.0 for name in ZPD_COLUMNS} if available_zpd else None
         rows_seen = 0
@@ -133,6 +147,8 @@ def summarize(path: pathlib.Path) -> dict[str, Any]:
             }
             row_memexport = ({name: finite_number(row[name], column=name, row_number=row_number)
                               for name in MEMEXPORT_COLUMNS} if memexport_totals is not None else {})
+            row_resolve = ({name: finite_number(row[name], column=name, row_number=row_number)
+                            for name in RESOLVE_READBACK_COLUMNS} if resolve_totals is not None else {})
             row_xma_stalls = ({name: finite_number(row[name], column=name, row_number=row_number)
                                for name in XMA_STALL_COLUMNS} if xma_stall_totals is not None else {})
             row_zpd = ({name: finite_number(row[name], column=name, row_number=row_number)
@@ -146,6 +162,8 @@ def summarize(path: pathlib.Path) -> dict[str, Any]:
                 totals[name] += value
             for name, value in row_memexport.items():
                 memexport_totals[name] += value
+            for name, value in row_resolve.items():
+                resolve_totals[name] += value
             for name, value in row_xma_stalls.items():
                 xma_stall_totals[name] += value
             for name, value in row_zpd.items():
@@ -189,6 +207,10 @@ def summarize(path: pathlib.Path) -> dict[str, Any]:
     if memexport_totals is not None:
         result["memexport_counters"] = {
             name: int(value) if value.is_integer() else value for name, value in memexport_totals.items()
+        }
+    if resolve_totals is not None:
+        result["resolve_readback_counters"] = {
+            name: int(value) if value.is_integer() else value for name, value in resolve_totals.items()
         }
     if xma_stall_totals is not None:
         result["xma_stall_counters"] = {

--- a/tools/tests/test_evidence_workflows.py
+++ b/tools/tests/test_evidence_workflows.py
@@ -59,4 +59,20 @@ class EvidenceWorkflowTests(unittest.TestCase):
                 (session / variant / "performance-summary.json").write_text(json.dumps(summary))
             self.assertEqual("readback_memexport", renderer.compare(session)["variable"])
 
+    def test_renderer_ab_requires_resolve_counters_and_supports_full(self):
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp); fingerprint = root / "build.json"; fingerprint.write_text('{"commit":"abc"}')
+            session = renderer.prepare(root, "readback_resolve", fingerprint, "full")
+            manifest = json.loads((session / "manifest.json").read_text())
+            self.assertEqual("full", manifest["variants"][1]["value"])
+            summary = {"frames": {"frame_time_us": {"median": 1000, "p95": 1200}}}
+            for variant in ("control", "candidate"):
+                (session / variant / "performance-summary.json").write_text(json.dumps(summary))
+                (session / variant / "visual-validation.json").write_text('{"missing":[]}')
+            with self.assertRaises(ValueError): renderer.compare(session)
+            summary["resolve_readback_counters"] = {name: 0 for name in renderer.RESOLVE_COUNTERS}
+            for variant in ("control", "candidate"):
+                (session / variant / "performance-summary.json").write_text(json.dumps(summary))
+            self.assertEqual("readback_resolve", renderer.compare(session)["variable"])
+
 if __name__ == "__main__": unittest.main()

--- a/tools/tests/test_graphics_settings.py
+++ b/tools/tests/test_graphics_settings.py
@@ -9,11 +9,26 @@ import unittest
 ROOT = pathlib.Path(__file__).resolve().parents[2]
 TOOL = ROOT / "tools/set-graphics-experiment.ps1"
 QUALIFY_ZPD = ROOT / "tools/qualify-zpd.ps1"
+QUALIFY_RESOLVE = ROOT / "tools/qualify-resolve.ps1"
 POWERSHELL = shutil.which("powershell")
 
 
 @unittest.skipUnless(POWERSHELL, "Windows PowerShell is required")
 class GraphicsSettingsTests(unittest.TestCase):
+    def test_resolve_qualification_plan_covers_presets_and_scenes(self):
+        completed = subprocess.run(
+            [POWERSHELL, "-NoLogo", "-NoProfile", "-ExecutionPolicy", "Bypass",
+             "-File", str(QUALIFY_RESOLVE), "-Action", "Plan", "-Json"],
+            capture_output=True, text=True,
+        )
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+        plan = json.loads(completed.stdout)
+        self.assertEqual(
+            [item["preset"] for item in plan["profiles"]],
+            ["shipping_1x", "experimental_2x", "accurate_showroom"],
+        )
+        self.assertEqual(len(plan["candidate_scenes"]), 8)
+
     def test_zpd_qualification_plan_covers_required_matrix(self):
         completed = subprocess.run(
             [POWERSHELL, "-NoLogo", "-NoProfile", "-ExecutionPolicy", "Bypass",
@@ -48,10 +63,11 @@ class GraphicsSettingsTests(unittest.TestCase):
                 "-OcclusionQuery", "fast",
                 "-ZpdEndPolicy", "pairwise_sentinel",
                 "-ZpdEndFallback", "none",
+                "-Preset", "experimental_2x",
             )
             updated = config.read_text(encoding="utf-8")
             self.assertEqual(result["settings"]["anisotropy"], 16)
-            self.assertIn("pinyon_shift_config_schema = 7", updated)
+            self.assertIn("pinyon_shift_config_schema = 8", updated)
             self.assertIn("xma_relaxed_padding_admission = false", updated)
             self.assertEqual(result["settings"]["occlusion_query"], "fast")
             self.assertIn('occlusion_query = "fast"', updated)
@@ -59,6 +75,9 @@ class GraphicsSettingsTests(unittest.TestCase):
             self.assertEqual(result["settings"]["zpd_end_fallback"], "none")
             self.assertIn("custom_value = 77", updated)
             self.assertIn("draw_resolution_scale_x = 2", updated)
+            self.assertEqual(result["settings"]["preset"], "experimental_2x")
+            self.assertEqual(result["settings"]["readback_resolve"], "fast")
+            self.assertTrue(result["settings"]["readback_resolve_half_pixel_offset"])
             self.assertTrue(pathlib.Path(result["backup_path"]).is_file())
             self.run_tool(state, "-Action", "Restore")
             self.assertEqual(config.read_text(encoding="utf-8"), original)
@@ -77,6 +96,23 @@ class GraphicsSettingsTests(unittest.TestCase):
             self.assertIn('occlusion_query = "legacy"', text)
             self.assertIn('zpd_end_policy = "report_layout"', text)
             self.assertIn('zpd_end_fallback = "pairwise_sentinel"', text)
+            self.assertIn('readback_resolve = "none"', text)
+            self.assertIn('readback_resolve_half_pixel_offset = false', text)
+            self.assertIn('clear_memory_page_state = true', text)
+            self.assertEqual(result["settings"]["preset"], "shipping_1x")
+            self.assertTrue(pathlib.Path(result["backup_path"]).is_file())
+
+    def test_accurate_showroom_is_explicit_and_preserves_backup(self):
+        with tempfile.TemporaryDirectory(prefix="pinyon-settings-") as temporary:
+            state = pathlib.Path(temporary)
+            config = state / "config/pinyon_shift.toml"
+            config.parent.mkdir(parents=True)
+            config.write_text("pinyon_shift_config_schema = 8\nreadback_resolve = \"none\"\n", encoding="utf-8")
+            result = self.run_tool(state, "-Action", "Apply", "-Preset", "accurate_showroom")
+            text = config.read_text(encoding="utf-8")
+            self.assertEqual(result["settings"]["preset"], "accurate_showroom")
+            self.assertEqual(result["settings"]["readback_resolve"], "full")
+            self.assertIn('readback_resolve = "full"', text)
             self.assertTrue(pathlib.Path(result["backup_path"]).is_file())
 
 

--- a/tools/tests/test_performance_summary.py
+++ b/tools/tests/test_performance_summary.py
@@ -24,6 +24,21 @@ FIELDS = [
 
 
 class PerformanceSummaryTests(unittest.TestCase):
+    def test_emits_complete_optional_resolve_readback_totals(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            capture = pathlib.Path(temporary) / "capture.csv"
+            resolve_columns = list(MODULE.RESOLVE_READBACK_COLUMNS)
+            fields = FIELDS + resolve_columns
+            with capture.open("w", encoding="utf-8", newline="") as stream:
+                writer = csv.DictWriter(stream, fieldnames=fields)
+                writer.writeheader()
+                writer.writerow(dict.fromkeys(fields, 1) | {"frame_time_us": 10_000})
+                writer.writerow(dict.fromkeys(fields, 2) | {"frame_time_us": 11_000})
+            result = MODULE.summarize(capture)
+            counters = result["resolve_readback_counters"]
+            self.assertEqual(3, counters["resolve_readback_requests"])
+            self.assertEqual(3, counters["resolve_readback_wait_time_ns"])
+
     def test_emits_complete_optional_zpd_totals(self):
         with tempfile.TemporaryDirectory() as temporary:
             capture = pathlib.Path(temporary) / "capture.csv"

--- a/tools/tests/test_release_contract.py
+++ b/tools/tests/test_release_contract.py
@@ -43,10 +43,10 @@ class ReleaseContractTests(unittest.TestCase):
 
     def test_rexglue_patches_have_stable_order_and_no_binary_payload(self):
         patches = sorted((ROOT / "patches/rexglue").glob("*.patch"))
-        self.assertEqual(len(patches), 40)
+        self.assertEqual(len(patches), 41)
         self.assertEqual(
             patches[-1].name,
-            "0040-fh1-zpd-end-policy-and-telemetry.patch",
+            "0041-fh1-resolve-readback-counters.patch",
         )
         self.assertEqual(len(patches), len({path.name[:4] for path in patches}))
         for path in patches:
@@ -163,7 +163,7 @@ class ReleaseContractTests(unittest.TestCase):
 
     def test_graphics_schema_and_diagnostics_contract(self):
         app = (ROOT / "src/pinyon_shift_app.cpp").read_text(encoding="utf-8")
-        self.assertIn("constexpr uint32_t kConfigSchema = 7", app)
+        self.assertIn("constexpr uint32_t kConfigSchema = 8", app)
         self.assertIn(".schema", app)
         for setting in ("anisotropic_override", "swap_post_effect", "draw_resolution_scale_x"):
             self.assertIn(setting, app)
@@ -177,6 +177,12 @@ class ReleaseContractTests(unittest.TestCase):
         policy_patch = ROOT / "patches/rexglue/0040-fh1-zpd-end-policy-and-telemetry.patch"
         self.assertTrue(policy_patch.is_file())
         self.assertIn("ZPDClassification", policy_patch.read_text(encoding="utf-8"))
+        resolve_patch = ROOT / "patches/rexglue/0041-fh1-resolve-readback-counters.patch"
+        self.assertTrue(resolve_patch.is_file())
+        resolve_text = resolve_patch.read_text(encoding="utf-8")
+        for counter in ("resolve_readback_requests", "resolve_readback_bytes",
+                        "resolve_readback_full_waits", "resolve_readback_wait_time_ns"):
+            self.assertIn(counter, resolve_text)
 
     def test_renderer_and_stub_instrumentation_is_bounded(self):
         stub_patch = (ROOT / "patches/rexglue/0031-sdk-stub-reachability-summary.patch").read_text(encoding="utf-8")
@@ -194,13 +200,19 @@ class ReleaseContractTests(unittest.TestCase):
         launcher = (ROOT / "launcher/PinyonShift.Launcher/MainWindow.xaml.cs").read_text(
             encoding="utf-8"
         )
-        self.assertIn("constexpr uint32_t kConfigSchema = 7;", app)
-        self.assertRegex(app, r"pinyon_shift_config_schema,\s*7,")
+        launcher_xaml = (ROOT / "launcher/PinyonShift.Launcher/MainWindow.xaml").read_text(
+            encoding="utf-8"
+        )
+        self.assertIn("constexpr uint32_t kConfigSchema = 8;", app)
+        self.assertRegex(app, r"pinyon_shift_config_schema,\s*8,")
         self.assertIn('"pinyon_shift_stabilize_vehicle_presentation = false\\n"', app)
         self.assertIn('"keybind_a = \\"LMB,Space\\"\\n"', app)
-        self.assertIn("schema < 1 || schema > 6", app)
+        self.assertIn("schema < 1 || schema > 7", app)
         self.assertIn('"occlusion_query = \\"legacy\\"\\n"', app)
         self.assertIn('"zpd_end_policy = \\"report_layout\\"\\n"', app)
+        self.assertIn('"readback_resolve = \\"none\\"\\n"', app)
+        self.assertIn('"clear_memory_page_state = true\\n"', app)
+        self.assertIn("Accurate showroom", launcher_xaml)
         self.assertIn("Controller A, Space, or left click.", launcher)
         self.assertRegex(
             hooks,

--- a/tools/visual-baseline.py
+++ b/tools/visual-baseline.py
@@ -6,7 +6,7 @@ import argparse, hashlib, json, struct, subprocess
 from datetime import datetime, timezone
 from pathlib import Path
 
-SCENES = ("front-end", "garage", "open-world-day", "open-world-night", "traffic", "race", "rewind", "ui-heavy")
+SCENES = ("front-end", "garage", "autoshow", "livery", "open-world-day", "open-world-night", "race", "rewind")
 ROOT = Path(__file__).resolve().parents[1]
 
 def fingerprint(executable: Path | None = None) -> dict:


### PR DESCRIPTION
## Summary
- add EPIC-06 shipping, experimental 2x, and accurate showroom resolve-readback presets
- add safe graphics experiment backup/reset/restore workflows and launcher controls
- add ReXGlue resolve-readback counters plus crash, performance, and qualification reporting
- document measured tradeoffs and the legacy cached-thumbnail caveat

## Validation
- `python -m unittest discover -s tools/tests -p 'test_*.py'` (39 passed)
- `dotnet build launcher/PinyonShift.Launcher/PinyonShift.Launcher.csproj -c Release` (0 warnings, 0 errors)
- `tools/build-preview.ps1`
- `.local/rexglue/out/win-amd64/Release/unit_tests.exe` (242 passed, 4 documented skips, 2262 assertions)
- AppData qualification: passed all three presets with zero error signatures

## Qualification results
- shipping 1x: 56.836 median FPS, 20.300 1% low, zero resolve readbacks
- experimental 2x: 55.777 median FPS, 19.866 1% low, clean live car body
- accurate showroom: 53.785 median FPS, 12.267 1% low, clean representative Mustang thumbnail and car asset

The previously cached Audi thumbnail remains corrupt because it was produced by an older run; the workflow deliberately does not mutate or reset the user's save data.