### PR TITLE
test(ppc): verify partial vector store semantics

### DIFF
--- a/config/rexglue/EPIC_07_PARTIAL_VECTOR_STORES.md
+++ b/config/rexglue/EPIC_07_PARTIAL_VECTOR_STORES.md
@@ -1,0 +1,76 @@
+# PPC partial vector-store semantic qualification
+
+EPIC-07 adds generated-native-code regression coverage for `stvlx` and
+`stvrx` in `0042-ppc-partial-vector-store-regression-tests.patch`. It verifies
+the existing ReXGlue lowering; it does not import or change Xenia's x64 JIT
+implementation.
+
+## Evidence and scope
+
+Xenia Canary commit `30ac9d7be69bf7d9e9cc5d92d126cc62c58b8f48`
+replaced an incorrect shuffle/blend lowering after partial vector stores were
+observed corrupting optimized guest memcpy heads and tails. Its semantic cases
+are applicable to ReXGlue even though its emitter implementation is not.
+
+Source: <https://github.com/xenia-canary/xenia-canary/commit/30ac9d7be69bf7d9e9cc5d92d126cc62c58b8f48>
+
+## Coverage
+
+The patch adds one PPC assembly fixture that ReXGlue recompiles to host C++ and
+executes through `ppc_tests`:
+
+- deterministic `stvlx` and `stvrx` offsets `0`, `1`, `4`, `8`, `12`, and
+  `15`;
+- byte-distinct source vectors and destination sentinels, checking every byte;
+- preserved bytes outside each partial write range;
+- `RA == RB` effective-address alias cases;
+- unaligned-source memcpy head and tail sequences using `lvsl`, two `lvx`
+  instructions, `vperm`, and the relevant partial store;
+- two reference-model differential tests, each with 256 deterministic random
+  source vectors, destination sentinels, and offsets.
+
+The differential harness initializes the vector in guest byte order, computes
+the expected 16-byte destination independently, executes the generated host
+function, and compares the full destination block byte-for-byte. The fixed
+seed `0x5EED07A1` makes every failure reproducible.
+
+Run the focused suite and write a provenance-complete JSON report with:
+
+```powershell
+.\tools\qualify-partial-vector-store.ps1
+```
+
+The report records the project and ReXGlue revisions, ordered patch set,
+generated source and executable fingerprints, compiler, configuration scope,
+test counts, seed, and exact test output. Renderer and GPU fields are recorded
+as not applicable because this qualification executes CPU-generated code only.
+
+## Qualification result
+
+The 2026-08-27 clean-stack qualification passed 20 focused generated-code
+cases with 800 assertions. This comprises 18 deterministic, alias, and memcpy
+fixtures plus 256 reference comparisons for each instruction. The complete PPC
+suite passed 1,480 test cases and 6,549 assertions; the complete ReXGlue unit
+suite passed 242 test cases and 2,262 assertions with four pre-existing
+BitStream write cases skipped.
+
+The generated function source fingerprint was
+`A5E28D4699F1345374A613C6DE6C0EDB4231A5C920524F3B6277057FEF584F8C` and
+the focused test executable fingerprint was
+`DB3AE056533C1047F5B08EA7A035A2D8A96FAFFDAD12BFD850EEFCA8C5A1B891`.
+
+## Mutation sensitivity
+
+Qualification must also be repeated locally with two temporary mutations:
+
+1. reverse the source-vector byte index in one partial-store lowering;
+2. shift a destination range by one byte so a preserved sentinel is overwritten.
+
+The focused suite must fail for both mutations. Neither mutation belongs in
+the project patch. Both controls failed 10 of 20 focused cases before the
+clean patch stack was rematerialized and requalified.
+
+## Rollback
+
+Removing patch `0042` and this qualification wrapper removes only regression
+coverage and reporting. Runtime code and shipping defaults are unchanged.

--- a/config/rexglue/PATCH_DISPOSITIONS.md
+++ b/config/rexglue/PATCH_DISPOSITIONS.md
@@ -125,11 +125,18 @@ Shipping 1×, delayed Experimental 2×, and opt-in Accurate showroom presets.
 Removing `0041` removes telemetry only; selecting Shipping 1× remains the
 immediate runtime rollback to `readback_resolve = "none"`.
 
+`0042-ppc-partial-vector-store-regression-tests` imports only the semantic
+test intent from Xenia Canary commit `30ac9d7`, not its x64 JIT implementation.
+Generated native code is checked at offsets 0, 1, 4, 8, 12, and 15 for guest
+byte order and preserved destination bytes, with address aliases, unaligned
+memcpy head/tail sequences, and 512 seeded randomized differential cases.
+The patch changes no runtime lowering; removing it removes test coverage only.
+
 Validation performed on the rebased SDK:
 
 - `unit_tests` and `ppc_tests` build with the pinned Clang 20.1.8 toolchain.
-- 1,460/1,460 PPC instruction tests passed.
-- The 234-test unit suite passed: 230 tests passed and four pre-existing
+- 1,480/1,480 PPC instruction tests passed with 6,549 assertions.
+- The 246-test unit suite passed: 242 tests passed and four pre-existing
   BitStream write cases remain explicitly skipped by upstream.
 - No conflict markers, reject files, or binary patch payloads are present.
 

--- a/patches/rexglue/0042-ppc-partial-vector-store-regression-tests.patch
+++ b/patches/rexglue/0042-ppc-partial-vector-store-regression-tests.patch
@@ -1,0 +1,304 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: "Brandon G. Neri" <arcaniteamp@gmail.com>
+Date: Thu, 27 Aug 2026 14:35:00 -0600
+Subject: [PATCH] ppc verify partial vector store semantics
+
+Derived from the semantic regression cases in Xenia Canary commit
+30ac9d7be69bf7d9e9cc5d92d126cc62c58b8f48. This patch does not copy the
+Xenia x64 JIT implementation. It extends ReXGlue's generated-host-code PPC
+tests with deterministic offsets, untouched-byte sentinels, guest byte-order
+checks, address aliases, unaligned memcpy head and tail sequences, and two
+seeded 256-case differential tests.
+
+Files touched:
+- resources/templates/test/ppc_test_cases_cpp.inja
+- src/rexglue/commands/test_recompiler.cpp
+- tests/ppc/asm/instr_partial_vector_store.s
+
+Behavioral intent: verify existing stvlx/stvrx lowering without changing it.
+Dependencies: ReXGlue v0.10.0 test-recompiler and PPC test pipeline.
+Rollback: remove this patch; runtime behavior is unchanged.
+---
+ resources/templates/test/ppc_test_cases_cpp.inja |  47 ++++++
+ src/rexglue/commands/test_recompiler.cpp         |   9 ++
+ tests/ppc/asm/instr_partial_vector_store.s       | 179 +++++++++++++++++++++++
+ 3 files changed, 235 insertions(+)
+ create mode 100644 tests/ppc/asm/instr_partial_vector_store.s
+
+diff --git a/resources/templates/test/ppc_test_cases_cpp.inja b/resources/templates/test/ppc_test_cases_cpp.inja
+index ebc731b..aeff1bd 100644
+--- a/resources/templates/test/ppc_test_cases_cpp.inja
++++ b/resources/templates/test/ppc_test_cases_cpp.inja
+@@ -2,6 +2,7 @@
+ // DO NOT EDIT - this file is auto-generated
+ 
+ #include <catch2/catch_test_macros.hpp>
++#include <array>
+ #include <cstdint>
+ #include <cstring>
+ #include <stdexcept>
+@@ -31,6 +32,13 @@ static rex::memory::Memory& get_memory() {
+     return memory;
+ }
+ 
++static uint32_t partial_store_random(uint32_t& state) {
++    state ^= state << 13;
++    state ^= state >> 17;
++    state ^= state << 5;
++    return state;
++}
++
+ ## for test in tests
+ TEST_CASE("{{ test.name }}", "[ppc][{{ test.category }}][{{ test.stem }}]") {
+     auto& mem = get_memory();
+@@ -91,4 +99,43 @@ TEST_CASE("{{ test.name }}", "[ppc][{{ test.category }}][{{ test.stem }}]") {
+ ## endfor
+ }
+ 
++## if test.partial_store_differential
++TEST_CASE("{{ test.name }}.randomized_differential",
++          "[ppc][memory][partial_vector_store][differential]") {
++    auto& mem = get_memory();
++    uint8_t* memory = mem.virtual_membase();
++    constexpr uint32_t kBaseAddress = 0x10002000;
++    constexpr uint32_t kIterations = 256;
++    uint32_t random_state = 0x5EED07A1;
++
++    for (uint32_t iteration = 0; iteration < kIterations; ++iteration) {
++        PPCContext ctx{};
++        ctx.fpscr.loadFromHost();
++        std::array<uint8_t, 16> source{};
++        std::array<uint8_t, 16> expected{};
++        for (size_t i = 0; i < expected.size(); ++i) {
++            source[i] = static_cast<uint8_t>(partial_store_random(random_state));
++            expected[i] = static_cast<uint8_t>(partial_store_random(random_state));
++            memory[kBaseAddress + i] = expected[i];
++            ctx.v5.u8[15 - i] = source[i];
++        }
++        const uint32_t offset = partial_store_random(random_state) & 0xF;
++        ctx.r4.u64 = kBaseAddress;
++        ctx.r6.u64 = offset;
++
++## if test.partial_store_kind == "left"
++        for (uint32_t i = offset; i < 16; ++i)
++            expected[i] = source[i - offset];
++## else
++        for (uint32_t i = 0; i < offset; ++i)
++            expected[i] = source[16 - offset + i];
++## endif
++
++        {{ test.symbol }}(ctx, memory);
++        INFO("seed=0x5EED07A1 iteration=" << iteration << " offset=" << offset);
++        REQUIRE(std::memcmp(memory + kBaseAddress, expected.data(), expected.size()) == 0);
++    }
++}
++## endif
++
+ ## endfor
+diff --git a/src/rexglue/commands/test_recompiler.cpp b/src/rexglue/commands/test_recompiler.cpp
+index 179b2df..a1014d4 100644
+--- a/src/rexglue/commands/test_recompiler.cpp
++++ b/src/rexglue/commands/test_recompiler.cpp
+@@ -432,6 +432,15 @@ bool RecompileTests(std::string_view binDir, std::string_view asmDir, std::strin
+       testJson["inputs"]["memory"] = SerializeMemory(spec.mem_inputs);
+       testJson["outputs"]["registers"] = SerializeRegisters(spec.outputs);
+       testJson["outputs"]["memory"] = SerializeMemory(spec.mem_outputs);
++      if (spec.name == "test_stvlx_differential") {
++        testJson["partial_store_differential"] = true;
++        testJson["partial_store_kind"] = "left";
++      } else if (spec.name == "test_stvrx_differential") {
++        testJson["partial_store_differential"] = true;
++        testJson["partial_store_kind"] = "right";
++      } else {
++        testJson["partial_store_differential"] = false;
++      }
+       templateData["tests"].push_back(testJson);
+       ++totalTests;
+     }
+diff --git a/tests/ppc/asm/instr_partial_vector_store.s b/tests/ppc/asm/instr_partial_vector_store.s
+new file mode 100644
+index 0000000..99d110b
+--- /dev/null
++++ b/tests/ppc/asm/instr_partial_vector_store.s
+@@ -0,0 +1,179 @@
++# Generated-code regression coverage for Xbox 360 partial vector stores.
++# The source vector is guest bytes 00..0F and destination sentinels are A0..AF.
++
++test_stvlx_offset_0:
++  #_ MEMORY_IN 10002000 A0A1A2A3 A4A5A6A7 A8A9AAAB ACADAEAF
++  #_ REGISTER_IN r4 0x10002000
++  #_ REGISTER_IN r6 0
++  #_ REGISTER_IN v5 [00010203, 04050607, 08090A0B, 0C0D0E0F]
++  stvlx v5, r4, r6
++  blr
++  #_ MEMORY_OUT 10002000 00010203 04050607 08090A0B 0C0D0E0F
++
++test_stvlx_offset_1:
++  #_ MEMORY_IN 10002000 A0A1A2A3 A4A5A6A7 A8A9AAAB ACADAEAF
++  #_ REGISTER_IN r4 0x10002000
++  #_ REGISTER_IN r6 1
++  #_ REGISTER_IN v5 [00010203, 04050607, 08090A0B, 0C0D0E0F]
++  stvlx v5, r4, r6
++  blr
++  #_ MEMORY_OUT 10002000 A0000102 03040506 0708090A 0B0C0D0E
++
++test_stvlx_offset_4:
++  #_ MEMORY_IN 10002000 A0A1A2A3 A4A5A6A7 A8A9AAAB ACADAEAF
++  #_ REGISTER_IN r4 0x10002000
++  #_ REGISTER_IN r6 4
++  #_ REGISTER_IN v5 [00010203, 04050607, 08090A0B, 0C0D0E0F]
++  stvlx v5, r4, r6
++  blr
++  #_ MEMORY_OUT 10002000 A0A1A2A3 00010203 04050607 08090A0B
++
++test_stvlx_offset_8:
++  #_ MEMORY_IN 10002000 A0A1A2A3 A4A5A6A7 A8A9AAAB ACADAEAF
++  #_ REGISTER_IN r4 0x10002000
++  #_ REGISTER_IN r6 8
++  #_ REGISTER_IN v5 [00010203, 04050607, 08090A0B, 0C0D0E0F]
++  stvlx v5, r4, r6
++  blr
++  #_ MEMORY_OUT 10002000 A0A1A2A3 A4A5A6A7 00010203 04050607
++
++test_stvlx_offset_12:
++  #_ MEMORY_IN 10002000 A0A1A2A3 A4A5A6A7 A8A9AAAB ACADAEAF
++  #_ REGISTER_IN r4 0x10002000
++  #_ REGISTER_IN r6 12
++  #_ REGISTER_IN v5 [00010203, 04050607, 08090A0B, 0C0D0E0F]
++  stvlx v5, r4, r6
++  blr
++  #_ MEMORY_OUT 10002000 A0A1A2A3 A4A5A6A7 A8A9AAAB 00010203
++
++test_stvlx_offset_15:
++  #_ MEMORY_IN 10002000 A0A1A2A3 A4A5A6A7 A8A9AAAB ACADAEAF
++  #_ REGISTER_IN r4 0x10002000
++  #_ REGISTER_IN r6 15
++  #_ REGISTER_IN v5 [00010203, 04050607, 08090A0B, 0C0D0E0F]
++  stvlx v5, r4, r6
++  blr
++  #_ MEMORY_OUT 10002000 A0A1A2A3 A4A5A6A7 A8A9AAAB ACADAE00
++
++test_stvrx_offset_0:
++  #_ MEMORY_IN 10002000 A0A1A2A3 A4A5A6A7 A8A9AAAB ACADAEAF
++  #_ REGISTER_IN r4 0x10002000
++  #_ REGISTER_IN r6 0
++  #_ REGISTER_IN v5 [00010203, 04050607, 08090A0B, 0C0D0E0F]
++  stvrx v5, r4, r6
++  blr
++  #_ MEMORY_OUT 10002000 A0A1A2A3 A4A5A6A7 A8A9AAAB ACADAEAF
++
++test_stvrx_offset_1:
++  #_ MEMORY_IN 10002000 A0A1A2A3 A4A5A6A7 A8A9AAAB ACADAEAF
++  #_ REGISTER_IN r4 0x10002000
++  #_ REGISTER_IN r6 1
++  #_ REGISTER_IN v5 [00010203, 04050607, 08090A0B, 0C0D0E0F]
++  stvrx v5, r4, r6
++  blr
++  #_ MEMORY_OUT 10002000 0FA1A2A3 A4A5A6A7 A8A9AAAB ACADAEAF
++
++test_stvrx_offset_4:
++  #_ MEMORY_IN 10002000 A0A1A2A3 A4A5A6A7 A8A9AAAB ACADAEAF
++  #_ REGISTER_IN r4 0x10002000
++  #_ REGISTER_IN r6 4
++  #_ REGISTER_IN v5 [00010203, 04050607, 08090A0B, 0C0D0E0F]
++  stvrx v5, r4, r6
++  blr
++  #_ MEMORY_OUT 10002000 0C0D0E0F A4A5A6A7 A8A9AAAB ACADAEAF
++
++test_stvrx_offset_8:
++  #_ MEMORY_IN 10002000 A0A1A2A3 A4A5A6A7 A8A9AAAB ACADAEAF
++  #_ REGISTER_IN r4 0x10002000
++  #_ REGISTER_IN r6 8
++  #_ REGISTER_IN v5 [00010203, 04050607, 08090A0B, 0C0D0E0F]
++  stvrx v5, r4, r6
++  blr
++  #_ MEMORY_OUT 10002000 08090A0B 0C0D0E0F A8A9AAAB ACADAEAF
++
++test_stvrx_offset_12:
++  #_ MEMORY_IN 10002000 A0A1A2A3 A4A5A6A7 A8A9AAAB ACADAEAF
++  #_ REGISTER_IN r4 0x10002000
++  #_ REGISTER_IN r6 12
++  #_ REGISTER_IN v5 [00010203, 04050607, 08090A0B, 0C0D0E0F]
++  stvrx v5, r4, r6
++  blr
++  #_ MEMORY_OUT 10002000 04050607 08090A0B 0C0D0E0F ACADAEAF
++
++test_stvrx_offset_15:
++  #_ MEMORY_IN 10002000 A0A1A2A3 A4A5A6A7 A8A9AAAB ACADAEAF
++  #_ REGISTER_IN r4 0x10002000
++  #_ REGISTER_IN r6 15
++  #_ REGISTER_IN v5 [00010203, 04050607, 08090A0B, 0C0D0E0F]
++  stvrx v5, r4, r6
++  blr
++  #_ MEMORY_OUT 10002000 01020304 05060708 090A0B0C 0D0E0FAF
++
++# RA and RB alias. Their sum is 0x10002004, exercising address calculation
++# before the source vector is consumed by generated native code.
++test_stvlx_address_alias:
++  #_ MEMORY_IN 10002000 A0A1A2A3 A4A5A6A7 A8A9AAAB ACADAEAF
++  #_ REGISTER_IN r4 0x08001002
++  #_ REGISTER_IN v5 [00010203, 04050607, 08090A0B, 0C0D0E0F]
++  stvlx v5, r4, r4
++  blr
++  #_ MEMORY_OUT 10002000 A0A1A2A3 00010203 04050607 08090A0B
++
++test_stvrx_address_alias:
++  #_ MEMORY_IN 10002000 A0A1A2A3 A4A5A6A7 A8A9AAAB ACADAEAF
++  #_ REGISTER_IN r4 0x08001002
++  #_ REGISTER_IN v5 [00010203, 04050607, 08090A0B, 0C0D0E0F]
++  stvrx v5, r4, r4
++  blr
++  #_ MEMORY_OUT 10002000 0C0D0E0F A4A5A6A7 A8A9AAAB ACADAEAF
++
++# Optimized memcpy head: assemble 16 guest bytes from an unaligned source,
++# then write only the destination bytes from its unaligned head onward.
++test_stvlx_memcpy_head:
++  #_ MEMORY_IN 10002100 00010203 04050607 08090A0B 0C0D0E0F 10111213 14151617 18191A1B 1C1D1E1F
++  #_ MEMORY_IN 10002200 A0A1A2A3 A4A5A6A7 A8A9AAAB ACADAEAF
++  #_ REGISTER_IN r4 0x10002101
++  #_ REGISTER_IN r5 0x1000220C
++  lvsl v2, r4, r0
++  lvx v3, r4, r0
++  addi r7, r4, 16
++  lvx v4, r7, r0
++  vperm v5, v3, v4, v2
++  stvlx v5, r5, r0
++  blr
++  #_ MEMORY_OUT 10002200 A0A1A2A3 A4A5A6A7 A8A9AAAB 01020304
++
++# Optimized memcpy tail: use the same unaligned source assembly and store the
++# final four bytes before the destination boundary while preserving its tail.
++test_stvrx_memcpy_tail:
++  #_ MEMORY_IN 10002100 00010203 04050607 08090A0B 0C0D0E0F 10111213 14151617 18191A1B 1C1D1E1F
++  #_ MEMORY_IN 10002200 A0A1A2A3 A4A5A6A7 A8A9AAAB ACADAEAF
++  #_ REGISTER_IN r4 0x10002101
++  #_ REGISTER_IN r5 0x10002204
++  lvsl v2, r4, r0
++  lvx v3, r4, r0
++  addi r7, r4, 16
++  lvx v4, r7, r0
++  vperm v5, v3, v4, v2
++  stvrx v5, r5, r0
++  blr
++  #_ MEMORY_OUT 10002200 0D0E0F10 A4A5A6A7 A8A9AAAB ACADAEAF
++
++# These labels opt into the generated, seeded randomized differential harness.
++test_stvlx_differential:
++  #_ MEMORY_IN 10002000 A0A1A2A3 A4A5A6A7 A8A9AAAB ACADAEAF
++  #_ REGISTER_IN r4 0x10002000
++  #_ REGISTER_IN r6 8
++  #_ REGISTER_IN v5 [00010203, 04050607, 08090A0B, 0C0D0E0F]
++  stvlx v5, r4, r6
++  blr
++  #_ MEMORY_OUT 10002000 A0A1A2A3 A4A5A6A7 00010203 04050607
++
++test_stvrx_differential:
++  #_ MEMORY_IN 10002000 A0A1A2A3 A4A5A6A7 A8A9AAAB ACADAEAF
++  #_ REGISTER_IN r4 0x10002000
++  #_ REGISTER_IN r6 8
++  #_ REGISTER_IN v5 [00010203, 04050607, 08090A0B, 0C0D0E0F]
++  stvrx v5, r4, r6
++  blr
++  #_ MEMORY_OUT 10002000 08090A0B 0C0D0E0F A8A9AAAB ACADAEAF
+-- 
+2.51.0.windows.1

--- a/tools/qualify-partial-vector-store.ps1
+++ b/tools/qualify-partial-vector-store.ps1
@@ -1,0 +1,98 @@
+[CmdletBinding()]
+param(
+    [string]$ReportPath,
+    [ValidateRange(1, 4096)] [int]$RandomIterations = 256
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+if (Test-Path variable:PSNativeCommandUseErrorActionPreference) {
+    $PSNativeCommandUseErrorActionPreference = $false
+}
+
+. (Join-Path $PSScriptRoot 'release-common.ps1')
+$root = Get-PinyonRepoRoot
+$config = Get-PinyonReleaseToolchain
+$git = Get-PinyonGit
+$sdkRoot = Resolve-PinyonLocalPath -RelativePath $config.rexglue.path
+$testExe = Join-Path $sdkRoot 'out/win-amd64/Release/ppc_tests.exe'
+$generatedRoot = Join-Path $sdkRoot 'out/build/win-amd64/tests/ppc/generated'
+$patchMarkerPath = Join-Path $sdkRoot '.pinyon-patches.json'
+
+foreach ($required in @($testExe, $patchMarkerPath,
+        (Join-Path $generatedRoot 'ppc_test_functions.cpp'),
+        (Join-Path $generatedRoot 'ppc_test_cases.cpp'))) {
+    if (-not (Test-Path -LiteralPath $required -PathType Leaf)) {
+        throw "Partial-vector-store qualification requires: $required"
+    }
+}
+
+if ($RandomIterations -ne 256) {
+    throw 'The generated regression harness currently uses exactly 256 iterations per instruction.'
+}
+
+$filter = '[instr_partial_vector_store],[partial_vector_store]'
+$testOutput = (& $testExe $filter --reporter compact 2>&1 | Out-String).Trim()
+$testExitCode = $LASTEXITCODE
+$summaryMatch = [regex]::Match($testOutput,
+    'All tests passed \((?<assertions>[0-9]+) assertions in (?<cases>[0-9]+) test cases\)')
+$passed = $testExitCode -eq 0 -and $summaryMatch.Success
+
+$patchMarker = Get-Content -LiteralPath $patchMarkerPath -Raw | ConvertFrom-Json
+$sourceCommit = (& $git -C $root rev-parse HEAD).Trim().ToLowerInvariant()
+$sourceDirty = @(& $git -C $root status --porcelain).Count -ne 0
+$rexglueCommit = (& $git -C $sdkRoot rev-parse HEAD).Trim().ToLowerInvariant()
+$compilerPath = Join-Path (Join-Path $root $config.llvm.install_path) 'bin/clang++.exe'
+$compilerVersion = (& $compilerPath --version | Select-Object -First 1)
+$generatedFunctionsPath = Join-Path $generatedRoot 'ppc_test_functions.cpp'
+$generatedTestsPath = Join-Path $generatedRoot 'ppc_test_cases.cpp'
+
+if ([string]::IsNullOrWhiteSpace($ReportPath)) {
+    $reportsRoot = Resolve-PinyonLocalPath -RelativePath '.local/reports'
+    [void](New-Item -ItemType Directory -Force -Path $reportsRoot)
+    $stamp = [DateTime]::UtcNow.ToString('yyyyMMddTHHmmssfffZ')
+    $ReportPath = Join-Path $reportsRoot "partial-vector-store-qualification-$stamp.json"
+} else {
+    $ReportPath = [IO.Path]::GetFullPath($ReportPath)
+    [void](New-Item -ItemType Directory -Force -Path (Split-Path $ReportPath -Parent))
+}
+
+$report = [ordered]@{
+    schema = 'pinyon-shift.partial-vector-store-qualification.v1'
+    created_utc = [DateTime]::UtcNow.ToString('o')
+    passed = $passed
+    suite = [ordered]@{
+        filter = $filter
+        deterministic_offsets = @(0, 1, 4, 8, 12, 15)
+        random_seed = '0x5EED07A1'
+        random_iterations_per_instruction = $RandomIterations
+        test_cases = if ($summaryMatch.Success) { [int]$summaryMatch.Groups['cases'].Value } else { 0 }
+        assertions = if ($summaryMatch.Success) { [int]$summaryMatch.Groups['assertions'].Value } else { 0 }
+        output = $testOutput
+    }
+    provenance = [ordered]@{
+        pinyon_shift_commit = $sourceCommit
+        pinyon_shift_dirty = $sourceDirty
+        rexglue_base_commit = $rexglueCommit
+        rexglue_patch_set_sha256 = (Get-FileHash -LiteralPath $patchMarkerPath -Algorithm SHA256).Hash
+        ordered_patches = @($patchMarker.patches | ForEach-Object {
+            [ordered]@{ name = $_.name; sha256 = $_.sha256 }
+        })
+        generated_functions_sha256 = (Get-FileHash -LiteralPath $generatedFunctionsPath -Algorithm SHA256).Hash
+        generated_tests_sha256 = (Get-FileHash -LiteralPath $generatedTestsPath -Algorithm SHA256).Hash
+        test_executable_sha256 = (Get-FileHash -LiteralPath $testExe -Algorithm SHA256).Hash
+        compiler = $compilerVersion
+        renderer = 'not_applicable_cpu_semantics'
+        gpu_driver = 'not_applicable_cpu_semantics'
+        config_schema = 8
+        effective_settings = 'not_applicable_generated_cpu_test'
+    }
+}
+
+[IO.File]::WriteAllText($ReportPath, ($report | ConvertTo-Json -Depth 8) + [Environment]::NewLine,
+    [Text.UTF8Encoding]::new($false))
+$report
+
+if (-not $passed) {
+    throw "Partial-vector-store qualification failed. Report: $ReportPath"
+}

--- a/tools/tests/test_release_contract.py
+++ b/tools/tests/test_release_contract.py
@@ -43,10 +43,10 @@ class ReleaseContractTests(unittest.TestCase):
 
     def test_rexglue_patches_have_stable_order_and_no_binary_payload(self):
         patches = sorted((ROOT / "patches/rexglue").glob("*.patch"))
-        self.assertEqual(len(patches), 41)
+        self.assertEqual(len(patches), 42)
         self.assertEqual(
             patches[-1].name,
-            "0041-fh1-resolve-readback-counters.patch",
+            "0042-ppc-partial-vector-store-regression-tests.patch",
         )
         self.assertEqual(len(patches), len({path.name[:4] for path in patches}))
         for path in patches:
@@ -183,6 +183,22 @@ class ReleaseContractTests(unittest.TestCase):
         for counter in ("resolve_readback_requests", "resolve_readback_bytes",
                         "resolve_readback_full_waits", "resolve_readback_wait_time_ns"):
             self.assertIn(counter, resolve_text)
+
+    def test_partial_vector_store_qualification_contract(self):
+        patch = ROOT / "patches/rexglue/0042-ppc-partial-vector-store-regression-tests.patch"
+        self.assertTrue(patch.is_file())
+        patch_text = patch.read_text(encoding="utf-8")
+        for marker in ("test_stvlx_offset_0", "test_stvlx_offset_15",
+                       "test_stvrx_offset_0", "test_stvrx_offset_15",
+                       "test_stvlx_memcpy_head", "test_stvrx_memcpy_tail",
+                       "randomized_differential", "0x5EED07A1"):
+            self.assertIn(marker, patch_text)
+        qualifier = (ROOT / "tools/qualify-partial-vector-store.ps1").read_text(
+            encoding="utf-8"
+        )
+        self.assertIn("pinyon-shift.partial-vector-store-qualification.v1", qualifier)
+        self.assertIn("ordered_patches", qualifier)
+        self.assertIn("generated_functions_sha256", qualifier)
 
     def test_renderer_and_stub_instrumentation_is_bounded(self):
         stub_patch = (ROOT / "patches/rexglue/0031-sdk-stub-reachability-summary.patch").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- add EPIC-07 generated-native-code regression coverage for `stvlx` and `stvrx`
- cover required offsets, guest byte order, preserved sentinels, address aliases, and unaligned memcpy head/tail sequences
- add two seeded 256-case differential reference tests and a provenance-complete qualification report
- import only semantic test intent from Xenia Canary `30ac9d7`; runtime lowering and shipping defaults are unchanged

## Validation
- focused qualification: 20 cases, 800 assertions passed
- full PPC suite: 1,480 cases, 6,549 assertions passed
- ReXGlue unit suite: 242 passed, four pre-existing upstream skips, 2,262 assertions
- project suite: 40 passed
- byte-order negative control: 10 of 20 focused cases failed as expected
- preserved-byte negative control: 10 of 20 focused cases failed as expected
- patch stack rematerialized cleanly from pinned ReXGlue v0.10.0 with 42 ordered patches

## Provenance
- source commit: `247e34805c15d886d5c5f29c074c03dce6c3a2e7` (clean)
- generated functions SHA-256: `A5E28D4699F1345374A613C6DE6C0EDB4231A5C920524F3B6277057FEF584F8C`
- test executable SHA-256: `DB3AE056533C1047F5B08EA7A035A2D8A96FAFFDAD12BFD850EEFCA8C5A1B891`

This is a CPU generated-code qualification epic, so an AppData gameplay run is not applicable.