### PR TITLE
perf(pacing): stabilize host presentation cadence

### DIFF
--- a/patches/rexglue/0043-host-presentation-pacing-and-counters.patch
+++ b/patches/rexglue/0043-host-presentation-pacing-and-counters.patch
@@ -1,0 +1,347 @@
+diff --git a/include/rex/perf/counter.h b/include/rex/perf/counter.h
+--- a/include/rex/perf/counter.h
++++ b/include/rex/perf/counter.h
+@@ -87,5 +87,16 @@ enum class CounterId : uint16_t {
+   kZpdPolicyFallbacks,
+   kZpdWatchdogRecoveries,
+ 
++  // Guest timing and host presentation pacing
++  kGuestVblankCount,
++  kGuestVblankDeltaNs,
++  kSimulationTickCount,
++  kPresentCount,
++  kPresentDeltaNs,
++  kPresentQueueDepth,
++  kPresentDeadlineMisses,
++  kDuplicatePresentCount,
++  kDroppedPresentCount,
++
+   kCount  // sentinel -- must be last
+ };
+@@ -222,5 +233,14 @@ class Profiler {
+ #define PROFILE_RESOLVE_READBACK_CACHE_MISS() PERF_counter_inc(kResolveReadbackCacheMisses)
+ #define PROFILE_RESOLVE_READBACK_FULL_WAIT() PERF_counter_inc(kResolveReadbackFullWaits)
+ #define PROFILE_RESOLVE_READBACK_WAIT_TIME_NS(n) PERF_counter_add(kResolveReadbackWaitTimeNs, n)
++#define PROFILE_GUEST_VBLANK() PERF_counter_inc(kGuestVblankCount)
++#define PROFILE_GUEST_VBLANK_DELTA_NS(value) PERF_counter_set(kGuestVblankDeltaNs, value)
++#define PROFILE_SIMULATION_TICK() PERF_counter_inc(kSimulationTickCount)
++#define PROFILE_PRESENT() PERF_counter_inc(kPresentCount)
++#define PROFILE_PRESENT_DELTA_NS(value) PERF_counter_set(kPresentDeltaNs, value)
++#define PROFILE_PRESENT_QUEUE_DEPTH(value) PERF_counter_set(kPresentQueueDepth, value)
++#define PROFILE_PRESENT_DEADLINE_MISS(n) PERF_counter_add(kPresentDeadlineMisses, n)
++#define PROFILE_DUPLICATE_PRESENT() PERF_counter_inc(kDuplicatePresentCount)
++#define PROFILE_DROPPED_PRESENT() PERF_counter_inc(kDroppedPresentCount)
+ 
+ #else
+@@ -276,5 +296,14 @@ class Profiler {
+ #define PROFILE_TEXTURE_CACHE_MISS()
+ #define PROFILE_PIPELINE_CACHE_HIT()
+ #define PROFILE_PIPELINE_CACHE_MISS()
++#define PROFILE_GUEST_VBLANK()
++#define PROFILE_GUEST_VBLANK_DELTA_NS(value)
++#define PROFILE_SIMULATION_TICK()
++#define PROFILE_PRESENT()
++#define PROFILE_PRESENT_DELTA_NS(value)
++#define PROFILE_PRESENT_QUEUE_DEPTH(value)
++#define PROFILE_PRESENT_DEADLINE_MISS(n)
++#define PROFILE_DUPLICATE_PRESENT()
++#define PROFILE_DROPPED_PRESENT()
+ 
+ #endif
+diff --git a/include/rex/ui/presentation_pacer.h b/include/rex/ui/presentation_pacer.h
+new file mode 100644
+--- /dev/null
++++ b/include/rex/ui/presentation_pacer.h
+@@ -0,0 +1,59 @@
++#pragma once
++
++#include <algorithm>
++#include <cstdint>
++
++namespace rex::ui {
++
++struct PresentationPacingDecision {
++  int64_t deadline_ns = 0;
++  int64_t wait_ns = 0;
++  uint64_t missed_deadlines = 0;
++};
++
++// Monotonic fixed-rate deadline scheduler. The caller owns the clock and wait
++// strategy so this remains deterministic and independently testable.
++class PresentationDeadlineScheduler {
++ public:
++  PresentationPacingDecision Plan(int64_t now_ns, uint32_t fps_limit) {
++    if (!fps_limit) {
++      Reset();
++      return {};
++    }
++
++    const int64_t interval_ns =
++        std::max<int64_t>(1, 1000000000LL / int64_t(fps_limit));
++    if (!initialized_ || interval_ns != interval_ns_) {
++      initialized_ = true;
++      interval_ns_ = interval_ns;
++      next_deadline_ns_ = now_ns;
++    }
++
++    PresentationPacingDecision decision;
++    decision.deadline_ns = next_deadline_ns_;
++    if (now_ns < next_deadline_ns_) {
++      decision.wait_ns = next_deadline_ns_ - now_ns;
++      next_deadline_ns_ += interval_ns_;
++      return decision;
++    }
++
++    const int64_t lateness_ns = now_ns - next_deadline_ns_;
++    decision.missed_deadlines = uint64_t(lateness_ns / interval_ns_);
++    next_deadline_ns_ +=
++        int64_t(decision.missed_deadlines + 1) * interval_ns_;
++    return decision;
++  }
++
++  void Reset() {
++    initialized_ = false;
++    interval_ns_ = 0;
++    next_deadline_ns_ = 0;
++  }
++
++ private:
++  bool initialized_ = false;
++  int64_t interval_ns_ = 0;
++  int64_t next_deadline_ns_ = 0;
++};
++
++}  // namespace rex::ui
+diff --git a/include/rex/ui/presenter.h b/include/rex/ui/presenter.h
+--- a/include/rex/ui/presenter.h
++++ b/include/rex/ui/presenter.h
+@@ -31,6 +31,7 @@
+ #include <rex/platform.h>
+ #include <rex/types.h>
+ #include <rex/ui/flags.h>
++#include <rex/ui/presentation_pacer.h>
+ #include <rex/ui/surface.h>
+ #include <rex/ui/ui_drawer.h>
+ 
+@@ -951,6 +952,7 @@ class Presenter {
+   // These two images can be accessed by painting in parallel, in an unordered
+   // way, with guest output refreshing.
+   std::atomic<uint32_t> guest_output_mailbox_acquired_and_ready_{0};
++  std::atomic<uint64_t> guest_output_refresh_sequence_{0};
+   // The "writable" image is different than both "acquired" and "ready" and is
+   // accessible only by the guest output refreshing - it's the image that the
+   // refresher may write to.
+@@ -972,6 +974,13 @@ class Presenter {
+   // happens as part of painting.
+   std::mutex guest_output_mailbox_consumer_mutex_;
+ 
++  // Presentation can originate on the UI or guest-output thread. Serialize
++  // host pacing state without coupling it to guest vblank or mailbox timing.
++  std::mutex presentation_pacing_mutex_;
++  PresentationDeadlineScheduler presentation_deadline_scheduler_;
++  uint64_t last_presented_refresh_sequence_ = UINT64_MAX;
++  int64_t last_present_time_ns_ = 0;
++
+   std::array<GuestOutputProperties, kGuestOutputMailboxSize> guest_output_properties_;
+   // Accessible only by refreshing, whether the last refresh contained an image
+   // rather than being blank.
+diff --git a/src/core/perf/counter.cpp b/src/core/perf/counter.cpp
+--- a/src/core/perf/counter.cpp
++++ b/src/core/perf/counter.cpp
+@@ -95,4 +95,13 @@ constexpr const char* kCounterNames[] = {
+     "zpd_classified_orphaned_ends",
+     "zpd_policy_fallbacks",
+     "zpd_watchdog_recoveries",
++    "guest_vblank_count",
++    "guest_vblank_delta_ns",
++    "simulation_tick_count",
++    "present_count",
++    "present_delta_ns",
++    "present_queue_depth",
++    "present_deadline_misses",
++    "duplicate_present_count",
++    "dropped_present_count",
+ };
+@@ -158,4 +167,13 @@ constexpr bool kIsGauge[] = {
+     false,  // kZpdClassifiedOrphanedEnds
+     false,  // kZpdPolicyFallbacks
+     false,  // kZpdWatchdogRecoveries
++    false,  // kGuestVblankCount
++    false,  // kGuestVblankDeltaNs
++    false,  // kSimulationTickCount
++    false,  // kPresentCount
++    false,  // kPresentDeltaNs
++    false,  // kPresentQueueDepth
++    false,  // kPresentDeadlineMisses
++    false,  // kDuplicatePresentCount
++    false,  // kDroppedPresentCount
+ };
+diff --git a/src/graphics/graphics_system.cpp b/src/graphics/graphics_system.cpp
+--- a/src/graphics/graphics_system.cpp
++++ b/src/graphics/graphics_system.cpp
+@@ -13,3 +13,4 @@
+ #include <algorithm>
+ #include <cctype>
++#include <chrono>
+ #include <cstdint>
+@@ -24,4 +25,5 @@
+ #include <rex/graphics/flags.h>
+ #include <rex/kernel/xboxkrnl/video.h>
+ #include <rex/logging.h>
++#include <rex/perf/counter.h>
+ #include <rex/stream.h>
+@@ -320,4 +322,15 @@ void GraphicsSystem::MarkVblank() {
+   // TODO: Enable profiling once ported
+   // SCOPE_profile_cpu_f("gpu");
+ 
++  using VblankClock = std::chrono::steady_clock;
++  static std::atomic<int64_t> last_vblank_ns{0};
++  const int64_t now_ns = std::chrono::duration_cast<std::chrono::nanoseconds>(
++                             VblankClock::now().time_since_epoch())
++                             .count();
++  const int64_t previous_ns = last_vblank_ns.exchange(now_ns, std::memory_order_relaxed);
++  PROFILE_GUEST_VBLANK();
++  if (previous_ns) {
++    PROFILE_GUEST_VBLANK_DELTA_NS(now_ns - previous_ns);
++  }
++
+   // Increment vblank counter (so the game sees us making progress).
+diff --git a/src/ui/presenter.cpp b/src/ui/presenter.cpp
+--- a/src/ui/presenter.cpp
++++ b/src/ui/presenter.cpp
+@@ -12,9 +12,12 @@
+ #include <algorithm>
+ #include <atomic>
+ #include <cctype>
++#include <chrono>
++#include <thread>
+ #include <utility>
+ 
+ #include <rex/assert.h>
+ #include <rex/cvar.h>
+ #include <rex/logging.h>
++#include <rex/perf/counter.h>
+ #include <rex/platform.h>
+@@ -29,4 +32,11 @@
+ REXCVAR_DEFINE_BOOL(host_present_from_non_ui_thread, true, "UI/Presenter",
+                     "Allow presentation from non-UI thread");
+ 
++REXCVAR_DEFINE_INT32(host_present_fps_limit, 60, "UI/Presenter",
++                     "Host presentation FPS limit (0 disables pacing)")
++    .range(0, 240);
++
++REXCVAR_DEFINE_BOOL(host_present_sleep_spin, true, "UI/Presenter",
++                    "Use a sleep/yield hybrid for host presentation pacing");
++
+ REXCVAR_DEFINE_BOOL(present_letterbox, true, "UI/Presenter",
+@@ -592,4 +602,11 @@ bool Presenter::RefreshGuestOutput(
+       last_acquired_and_ready,
+       (last_acquired_and_ready & 3) | (guest_output_mailbox_writable_ << 2),
+       std::memory_order_acq_rel, std::memory_order_relaxed)) {}
++  const uint32_t published_acquired = last_acquired_and_ready & 3;
++  const uint32_t replaced_ready = (last_acquired_and_ready >> 2) & 3;
++  if (replaced_ready != published_acquired) {
++    PROFILE_DROPPED_PRESENT();
++  }
++  guest_output_refresh_sequence_.fetch_add(1, std::memory_order_release);
++  PROFILE_PRESENT_QUEUE_DEPTH(1);
+   // Now, it's known that `ready == writable` on the host presentation side.
+@@ -839,4 +856,5 @@ std::unique_lock<std::mutex> Presenter::ConsumeGuestOutput(
+     desired_acquired_and_ready =
+         (old_acquired_and_ready & ~uint32_t(3)) | (old_acquired_and_ready >> 2);
+   }
++  PROFILE_PRESENT_QUEUE_DEPTH(0);
+   uint32_t mailbox_index = desired_acquired_and_ready & 3;
+@@ -1497,5 +1515,45 @@ bool Presenter::InSurfaceOnMonitorFromUIThread() const {
+ Presenter::PaintResult Presenter::PaintAndPresent(bool execute_ui_drawers) {
+   assert_false(execute_ui_drawers && !is_in_ui_thread_paint_);
+   assert_true(surface_paint_connection_state_ == SurfacePaintConnectionState::kConnectedPaintable);
++  std::lock_guard<std::mutex> pacing_lock(presentation_pacing_mutex_);
++  using PresentationClock = std::chrono::steady_clock;
++  auto now = PresentationClock::now();
++  const int64_t now_ns = std::chrono::duration_cast<std::chrono::nanoseconds>(
++                             now.time_since_epoch())
++                             .count();
++  const auto pacing = presentation_deadline_scheduler_.Plan(
++      now_ns, uint32_t(REXCVAR_GET(host_present_fps_limit)));
++  if (pacing.missed_deadlines) {
++    PROFILE_PRESENT_DEADLINE_MISS(int64_t(pacing.missed_deadlines));
++  }
++  if (pacing.wait_ns > 0) {
++    auto deadline = PresentationClock::time_point(
++        std::chrono::nanoseconds(pacing.deadline_ns));
++    if (REXCVAR_GET(host_present_sleep_spin) && pacing.wait_ns > 500000) {
++      std::this_thread::sleep_until(deadline - std::chrono::microseconds(500));
++      while (PresentationClock::now() < deadline) {
++        std::this_thread::yield();
++      }
++    } else {
++      std::this_thread::sleep_until(deadline);
++    }
++  }
+   PaintResult result = PaintAndPresentImpl(execute_ui_drawers);
++  if (result == PaintResult::kPresented || result == PaintResult::kPresentedSuboptimal) {
++    const int64_t present_time_ns =
++        std::chrono::duration_cast<std::chrono::nanoseconds>(
++            PresentationClock::now().time_since_epoch())
++            .count();
++    PROFILE_PRESENT();
++    if (last_present_time_ns_) {
++      PROFILE_PRESENT_DELTA_NS(present_time_ns - last_present_time_ns_);
++    }
++    last_present_time_ns_ = present_time_ns;
++    const uint64_t refresh_sequence =
++        guest_output_refresh_sequence_.load(std::memory_order_acquire);
++    if (refresh_sequence == last_presented_refresh_sequence_) {
++      PROFILE_DUPLICATE_PRESENT();
++    }
++    last_presented_refresh_sequence_ = refresh_sequence;
++  }
+   switch (result) {
+diff --git a/tests/unit/CMakeLists.txt b/tests/unit/CMakeLists.txt
+--- a/tests/unit/CMakeLists.txt
++++ b/tests/unit/CMakeLists.txt
+@@ -25,3 +25,4 @@ add_executable(unit_tests
+     filesystem/cache_mount_test.cpp
+     graphics/zpd_lifecycle_test.cpp
++    ui/presentation_pacer_test.cpp
+ )
+diff --git a/tests/unit/ui/presentation_pacer_test.cpp b/tests/unit/ui/presentation_pacer_test.cpp
+new file mode 100644
+--- /dev/null
++++ b/tests/unit/ui/presentation_pacer_test.cpp
+@@ -0,0 +1,34 @@
++#include <catch2/catch_test_macros.hpp>
++
++#include <rex/ui/presentation_pacer.h>
++
++TEST_CASE("presentation pacer advances fixed monotonic deadlines", "[ui][pacing]") {
++  rex::ui::PresentationDeadlineScheduler scheduler;
++  auto first = scheduler.Plan(1000000000LL, 60);
++  REQUIRE(first.wait_ns == 0);
++  REQUIRE(first.missed_deadlines == 0);
++
++  auto second = scheduler.Plan(1005000000LL, 60);
++  REQUIRE(second.deadline_ns == 1016666666LL);
++  REQUIRE(second.wait_ns == 11666666LL);
++  REQUIRE(second.missed_deadlines == 0);
++}
++
++TEST_CASE("presentation pacer reports skipped deadlines without drift", "[ui][pacing]") {
++  rex::ui::PresentationDeadlineScheduler scheduler;
++  scheduler.Plan(0, 60);
++  auto late = scheduler.Plan(50000000LL, 60);
++  REQUIRE(late.missed_deadlines == 2);
++  REQUIRE(late.wait_ns == 0);
++  auto recovered = scheduler.Plan(60000000LL, 60);
++  REQUIRE(recovered.deadline_ns == 66666664LL);
++  REQUIRE(recovered.wait_ns == 6666664LL);
++}
++
++TEST_CASE("presentation pacer supports 30 fps and disabling", "[ui][pacing]") {
++  rex::ui::PresentationDeadlineScheduler scheduler;
++  scheduler.Plan(2000000000LL, 30);
++  REQUIRE(scheduler.Plan(2010000000LL, 30).wait_ns == 23333333LL);
++  REQUIRE(scheduler.Plan(2020000000LL, 0).wait_ns == 0);
++  REQUIRE(scheduler.Plan(2020000000LL, 60).wait_ns == 0);
++}

--- a/src/pinyon_shift_app.cpp
+++ b/src/pinyon_shift_app.cpp
@@ -52,6 +52,8 @@ bool EnsureSupportedConfig(const std::filesystem::path& path, bool& created,
               "keybind_start = \"Return\"\n"
               "d3d12_allow_variable_refresh_rate_and_tearing = false\n"
               "vsync = true\n"
+              "host_present_fps_limit = 60\n"
+              "host_present_sleep_spin = true\n"
               "pinyon_shift_capture_performance = true\n"
               "xma_relaxed_padding_admission = false\n"
               "pinyon_shift_stabilize_vehicle_presentation = false\n"
@@ -144,6 +146,8 @@ bool EnsureSupportedConfig(const std::filesystem::path& path, bool& created,
         {"draw_resolution_scale_x", "draw_resolution_scale_x = 1\n"},
         {"draw_resolution_scale_y", "draw_resolution_scale_y = 1\n"},
         {"vsync", "vsync = true\n"},
+        {"host_present_fps_limit", "host_present_fps_limit = 60\n"},
+        {"host_present_sleep_spin", "host_present_sleep_spin = true\n"},
         {"clear_memory_page_state", "clear_memory_page_state = true\n"},
         {"readback_resolve", "readback_resolve = \"none\"\n"},
         {"readback_resolve_half_pixel_offset",
@@ -264,6 +268,10 @@ void PinyonShiftApp::OnPostInitLogging() {
                         {"renderer", "d3d12"},
                         {"resolution", rex::cvar::GetFlagByName("resolution")},
                         {"vsync", rex::cvar::GetFlagByName("vsync")},
+                        {"host_present_fps_limit",
+                         rex::cvar::GetFlagByName("host_present_fps_limit")},
+                        {"host_present_sleep_spin",
+                         rex::cvar::GetFlagByName("host_present_sleep_spin")},
                         {"draw_resolution_scale_x",
                          rex::cvar::GetFlagByName("draw_resolution_scale_x")},
                         {"draw_resolution_scale_y",

--- a/src/pinyon_shift_runtime_hooks.cpp
+++ b/src/pinyon_shift_runtime_hooks.cpp
@@ -13,6 +13,7 @@
 #include <rex/cvar.h>
 #include <rex/memory.h>
 #include <rex/ppc/context.h>
+#include <rex/perf/counter.h>
 #include <rex/system/kernel_state.h>
 #include <rex/system/xmemory.h>
 
@@ -347,6 +348,7 @@ void PinyonShiftCompleteOpeningMovie(PPCRegister& r3, PPCRegister& r30,
 }
 
 void PinyonShiftTraceFrameTelemetry(PPCRegister& r28, PPCRegister& r31) {
+  PROFILE_SIMULATION_TICK();
   if (r28.u32 == 0) {
     return;
   }

--- a/tools/create-crash-report.ps1
+++ b/tools/create-crash-report.ps1
@@ -164,6 +164,16 @@ try {
     )
     $zpdCounters = [ordered]@{ available = $false }
     foreach ($column in $zpdColumns) { $zpdCounters[$column] = [uint64]0 }
+    $presentationColumns = @(
+        'guest_vblank_count', 'guest_vblank_delta_ns',
+        'simulation_tick_count', 'present_count', 'present_delta_ns',
+        'present_queue_depth', 'present_deadline_misses',
+        'duplicate_present_count', 'dropped_present_count'
+    )
+    $presentationCounters = [ordered]@{ available = $false }
+    foreach ($column in $presentationColumns) {
+        $presentationCounters[$column] = [uint64]0
+    }
     $perfLog = Get-ChildItem -LiteralPath (Join-Path $resolvedStateRoot 'logs') -Filter '*.perf.csv' -File `
         -ErrorAction SilentlyContinue | Where-Object { $_.LastWriteTimeUtc -ge $StartedUtc.ToUniversalTime().AddSeconds(-2) } |
         Sort-Object LastWriteTimeUtc | Select-Object -Last 1
@@ -185,6 +195,14 @@ try {
                 }
             }
             $zpdCounters.available = $true
+        }
+        if (@($presentationColumns | Where-Object { $_ -notin $columns }).Count -eq 0) {
+            foreach ($row in Import-Csv -LiteralPath $perfLog.FullName) {
+                foreach ($column in $presentationColumns) {
+                    $presentationCounters[$column] += [uint64]$row.$column
+                }
+            }
+            $presentationCounters.available = $true
         }
     }
     $resolveColumns = @(
@@ -213,7 +231,8 @@ try {
         'xma_relaxed_padding_admission',
         'pinyon_shift_capture_performance',
         'pinyon_shift_stabilize_vehicle_presentation', 'pinyon_shift_skip_opening_movies',
-        'resolution', 'vsync', 'anisotropic_override', 'swap_post_effect',
+        'resolution', 'vsync', 'host_present_fps_limit',
+        'host_present_sleep_spin', 'anisotropic_override', 'swap_post_effect',
         'draw_resolution_scale_x', 'draw_resolution_scale_y', 'occlusion_query',
         'zpd_end_policy', 'zpd_end_fallback', 'clear_memory_page_state',
         'readback_resolve', 'readback_resolve_half_pixel_offset',
@@ -297,6 +316,7 @@ try {
         graphics = [ordered]@{
             zpd = $zpdCounters
             resolve_readback = $resolveCounters
+            presentation = $presentationCounters
         }
         local_dumps = $dumpRecords
         privacy = [ordered]@{

--- a/tools/set-graphics-experiment.ps1
+++ b/tools/set-graphics-experiment.ps1
@@ -18,6 +18,8 @@ param(
     [string]$ZpdEndPolicy = 'report_layout',
     [ValidateSet('none', 'pairwise_sentinel', 'relaxed_sentinel')]
     [string]$ZpdEndFallback = 'pairwise_sentinel',
+    [ValidateSet(0, 30, 60)]
+    [int]$PresentationFps = 60,
     [string]$StateRoot,
     [switch]$Json
 )
@@ -47,6 +49,8 @@ keybind_a = "LMB,Space"
 keybind_start = "Return"
 d3d12_allow_variable_refresh_rate_and_tearing = false
 vsync = true
+host_present_fps_limit = 60
+host_present_sleep_spin = true
 pinyon_shift_stabilize_vehicle_presentation = false
 pinyon_shift_skip_opening_movies = false
 xma_relaxed_padding_admission = false
@@ -121,6 +125,7 @@ function Get-SettingsResult([string]$Text, [string]$BackupPath, [string]$Operati
     $memexport = (Get-TomlValue $Text 'readback_memexport' 'true') -eq 'true'
     $memexportFast = (Get-TomlValue $Text 'readback_memexport_fast' 'true') -eq 'true'
     $vsyncEnabled = (Get-TomlValue $Text 'vsync' 'true') -eq 'true'
+    $presentationFps = [int](Get-TomlValue $Text 'host_present_fps_limit' '60')
     $presetName = if ($clearPageState -and $readbackResolve -eq 'full') {
         'accurate_showroom'
     } elseif ($clearPageState -and $resolutionScale -eq 2 -and
@@ -149,6 +154,9 @@ function Get-SettingsResult([string]$Text, [string]$BackupPath, [string]$Operati
             readback_memexport = $memexport
             readback_memexport_fast = $memexportFast
             vsync = $vsyncEnabled
+            host_present_fps_limit = $presentationFps
+            host_present_sleep_spin =
+                (Get-TomlValue $Text 'host_present_sleep_spin' 'true') -eq 'true'
             occlusion_query = Get-TomlValue $Text 'occlusion_query' 'legacy'
             zpd_end_policy = Get-TomlValue $Text 'zpd_end_policy' 'report_layout'
             zpd_end_fallback = Get-TomlValue $Text 'zpd_end_fallback' 'pairwise_sentinel'
@@ -221,6 +229,8 @@ switch ($Action) {
         $text = Set-TomlValue $text 'draw_resolution_scale_x' ([string]$effectiveResolution)
         $text = Set-TomlValue $text 'draw_resolution_scale_y' ([string]$effectiveResolution)
         $text = Set-TomlValue $text 'vsync' 'true'
+        $text = Set-TomlValue $text 'host_present_fps_limit' ([string]$PresentationFps)
+        $text = Set-TomlValue $text 'host_present_sleep_spin' 'true'
         $text = Set-TomlValue $text 'clear_memory_page_state' 'true'
         $text = Set-TomlValue $text 'readback_resolve' ('"' + $effectiveReadback + '"')
         $text = Set-TomlValue $text 'readback_resolve_half_pixel_offset' $effectiveHalfPixelText

--- a/tools/summarize-performance.py
+++ b/tools/summarize-performance.py
@@ -70,6 +70,17 @@ ZPD_COLUMNS = (
     "zpd_policy_fallbacks",
     "zpd_watchdog_recoveries",
 )
+PRESENTATION_COLUMNS = (
+    "guest_vblank_count",
+    "guest_vblank_delta_ns",
+    "simulation_tick_count",
+    "present_count",
+    "present_delta_ns",
+    "present_queue_depth",
+    "present_deadline_misses",
+    "duplicate_present_count",
+    "dropped_present_count",
+)
 
 
 class CaptureError(ValueError):
@@ -129,6 +140,13 @@ def summarize(path: pathlib.Path) -> dict[str, Any]:
         if available_zpd and available_zpd != set(ZPD_COLUMNS):
             missing_zpd = sorted(set(ZPD_COLUMNS) - available_zpd)
             raise CaptureError("capture has an incomplete ZPD counter set: " + ", ".join(missing_zpd))
+        available_presentation = columns.intersection(PRESENTATION_COLUMNS)
+        if available_presentation and available_presentation != set(PRESENTATION_COLUMNS):
+            missing_presentation = sorted(set(PRESENTATION_COLUMNS) - available_presentation)
+            raise CaptureError(
+                "capture has an incomplete presentation counter set: "
+                + ", ".join(missing_presentation)
+            )
 
         frame_times: list[float] = []
         totals = {name: 0.0 for name in TOTAL_COLUMNS}
@@ -137,6 +155,14 @@ def summarize(path: pathlib.Path) -> dict[str, Any]:
                           if available_resolve else None)
         xma_stall_totals = {name: 0.0 for name in XMA_STALL_COLUMNS} if available_xma_stalls else None
         zpd_totals = {name: 0.0 for name in ZPD_COLUMNS} if available_zpd else None
+        presentation_totals = (
+            {name: 0.0 for name in PRESENTATION_COLUMNS}
+            if available_presentation else None
+        )
+        presentation_delta_samples = {
+            "guest_vblank_delta_ns": 0,
+            "present_delta_ns": 0,
+        }
         rows_seen = 0
         for row_number, row in enumerate(reader, start=2):
             rows_seen += 1
@@ -153,6 +179,10 @@ def summarize(path: pathlib.Path) -> dict[str, Any]:
                                for name in XMA_STALL_COLUMNS} if xma_stall_totals is not None else {})
             row_zpd = ({name: finite_number(row[name], column=name, row_number=row_number)
                         for name in ZPD_COLUMNS} if zpd_totals is not None else {})
+            row_presentation = ({
+                name: finite_number(row[name], column=name, row_number=row_number)
+                for name in PRESENTATION_COLUMNS
+            } if presentation_totals is not None else {})
             # The runtime writes one initialization row with frame_time_us == 0.
             # It is valid CSV, but not a displayed frame and must not skew latency.
             if frame_time == 0:
@@ -168,6 +198,10 @@ def summarize(path: pathlib.Path) -> dict[str, Any]:
                 xma_stall_totals[name] += value
             for name, value in row_zpd.items():
                 zpd_totals[name] += value
+            for name, value in row_presentation.items():
+                presentation_totals[name] += value
+                if name in presentation_delta_samples and value > 0:
+                    presentation_delta_samples[name] += 1
 
     if rows_seen == 0:
         raise CaptureError("capture contains a header but no rows")
@@ -219,6 +253,34 @@ def summarize(path: pathlib.Path) -> dict[str, Any]:
     if zpd_totals is not None:
         result["zpd_counters"] = {
             name: int(value) if value.is_integer() else value for name, value in zpd_totals.items()
+        }
+    if presentation_totals is not None:
+        duration_seconds = sum(frame_times) / 1_000_000.0
+        counters = {
+            name: int(value) if value.is_integer() else value
+            for name, value in presentation_totals.items()
+        }
+        result["presentation"] = {
+            "counters": counters,
+            "cadence_hz": {
+                "guest_vblank": round(counters["guest_vblank_count"] / duration_seconds, 3),
+                "simulation_tick": round(counters["simulation_tick_count"] / duration_seconds, 3),
+                "present": round(counters["present_count"] / duration_seconds, 3),
+            },
+            "mean_delta_ms": {
+                "guest_vblank": round(
+                    counters["guest_vblank_delta_ns"]
+                    / max(1, presentation_delta_samples["guest_vblank_delta_ns"])
+                    / 1_000_000.0,
+                    3,
+                ),
+                "present": round(
+                    counters["present_delta_ns"]
+                    / max(1, presentation_delta_samples["present_delta_ns"])
+                    / 1_000_000.0,
+                    3,
+                ),
+            },
         }
     return result
 
@@ -280,6 +342,19 @@ def markdown(summary: dict[str, Any]) -> str:
                 f"| {name.replace('_', ' ')} | {values['baseline']:.3f} | "
                 f"{values['candidate']:.3f} | {values['delta_percent']:+.3f}% |"
             )
+    if "presentation" in summary:
+        pacing = summary["presentation"]
+        lines.extend([
+            "",
+            "## Presentation pacing",
+            "",
+            f"- Guest vblank cadence: {pacing['cadence_hz']['guest_vblank']:.3f} Hz",
+            f"- Simulation cadence: {pacing['cadence_hz']['simulation_tick']:.3f} Hz",
+            f"- Host present cadence: {pacing['cadence_hz']['present']:.3f} Hz",
+            f"- Present deadline misses: {pacing['counters']['present_deadline_misses']}",
+            f"- Duplicate presents: {pacing['counters']['duplicate_present_count']}",
+            f"- Dropped presents: {pacing['counters']['dropped_present_count']}",
+        ])
     return "\n".join(lines) + "\n"
 
 

--- a/tools/tests/test_graphics_settings.py
+++ b/tools/tests/test_graphics_settings.py
@@ -63,6 +63,7 @@ class GraphicsSettingsTests(unittest.TestCase):
                 "-OcclusionQuery", "fast",
                 "-ZpdEndPolicy", "pairwise_sentinel",
                 "-ZpdEndFallback", "none",
+                "-PresentationFps", "30",
                 "-Preset", "experimental_2x",
             )
             updated = config.read_text(encoding="utf-8")
@@ -73,6 +74,8 @@ class GraphicsSettingsTests(unittest.TestCase):
             self.assertIn('occlusion_query = "fast"', updated)
             self.assertEqual(result["settings"]["zpd_end_policy"], "pairwise_sentinel")
             self.assertEqual(result["settings"]["zpd_end_fallback"], "none")
+            self.assertEqual(result["settings"]["host_present_fps_limit"], 30)
+            self.assertTrue(result["settings"]["host_present_sleep_spin"])
             self.assertIn("custom_value = 77", updated)
             self.assertIn("draw_resolution_scale_x = 2", updated)
             self.assertEqual(result["settings"]["preset"], "experimental_2x")
@@ -99,6 +102,8 @@ class GraphicsSettingsTests(unittest.TestCase):
             self.assertIn('readback_resolve = "none"', text)
             self.assertIn('readback_resolve_half_pixel_offset = false', text)
             self.assertIn('clear_memory_page_state = true', text)
+            self.assertIn('host_present_fps_limit = 60', text)
+            self.assertIn('host_present_sleep_spin = true', text)
             self.assertEqual(result["settings"]["preset"], "shipping_1x")
             self.assertTrue(pathlib.Path(result["backup_path"]).is_file())
 

--- a/tools/tests/test_performance_summary.py
+++ b/tools/tests/test_performance_summary.py
@@ -24,6 +24,35 @@ FIELDS = [
 
 
 class PerformanceSummaryTests(unittest.TestCase):
+    def test_emits_presentation_cadence_and_totals(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            capture = pathlib.Path(temporary) / "capture.csv"
+            presentation_columns = list(MODULE.PRESENTATION_COLUMNS)
+            fields = FIELDS + presentation_columns
+            with capture.open("w", encoding="utf-8", newline="") as stream:
+                writer = csv.DictWriter(stream, fieldnames=fields)
+                writer.writeheader()
+                base = dict.fromkeys(fields, 0)
+                writer.writerow(base | {
+                    "frame_time_us": 20_000, "guest_vblank_count": 1,
+                    "guest_vblank_delta_ns": 16_666_666,
+                    "simulation_tick_count": 1, "present_count": 1,
+                    "present_delta_ns": 33_333_333,
+                })
+                writer.writerow(base | {
+                    "frame_time_us": 20_000, "guest_vblank_count": 1,
+                    "guest_vblank_delta_ns": 16_666_666,
+                    "simulation_tick_count": 1, "present_count": 1,
+                    "present_delta_ns": 33_333_333,
+                    "present_deadline_misses": 1,
+                })
+            pacing = MODULE.summarize(capture)["presentation"]
+            self.assertEqual(pacing["cadence_hz"]["guest_vblank"], 50.0)
+            self.assertEqual(pacing["cadence_hz"]["simulation_tick"], 50.0)
+            self.assertEqual(pacing["cadence_hz"]["present"], 50.0)
+            self.assertEqual(pacing["mean_delta_ms"]["present"], 33.333)
+            self.assertEqual(pacing["counters"]["present_deadline_misses"], 1)
+
     def test_emits_complete_optional_resolve_readback_totals(self):
         with tempfile.TemporaryDirectory() as temporary:
             capture = pathlib.Path(temporary) / "capture.csv"

--- a/tools/tests/test_release_contract.py
+++ b/tools/tests/test_release_contract.py
@@ -43,10 +43,10 @@ class ReleaseContractTests(unittest.TestCase):
 
     def test_rexglue_patches_have_stable_order_and_no_binary_payload(self):
         patches = sorted((ROOT / "patches/rexglue").glob("*.patch"))
-        self.assertEqual(len(patches), 42)
+        self.assertEqual(len(patches), 43)
         self.assertEqual(
             patches[-1].name,
-            "0042-ppc-partial-vector-store-regression-tests.patch",
+            "0043-host-presentation-pacing-and-counters.patch",
         )
         self.assertEqual(len(patches), len({path.name[:4] for path in patches}))
         for path in patches:
@@ -167,6 +167,10 @@ class ReleaseContractTests(unittest.TestCase):
         self.assertIn(".schema", app)
         for setting in ("anisotropic_override", "swap_post_effect", "draw_resolution_scale_x"):
             self.assertIn(setting, app)
+            self.assertIn(setting, (ROOT / "tools/create-crash-report.ps1").read_text(encoding="utf-8"))
+        for setting in ("host_present_fps_limit", "host_present_sleep_spin"):
+            self.assertIn(setting, app)
+            self.assertIn(setting, (ROOT / "tools/set-graphics-experiment.ps1").read_text(encoding="utf-8"))
             self.assertIn(setting, (ROOT / "tools/create-crash-report.ps1").read_text(encoding="utf-8"))
         self.assertIn("xma_relaxed_padding_admission = false", app)
         self.assertIn("xma_no_space_stalls", (ROOT / "tools/create-crash-report.ps1").read_text(encoding="utf-8"))


### PR DESCRIPTION
## Summary
- pace host presentation with monotonic 60/30 Hz deadlines independent of guest timing
- expose guest, simulation, present, queue, duplicate, drop, and miss counters
- add diagnostic configuration, report aggregation, and performance-summary coverage

## Validation
- clean 43-patch ReXGlue materialization and production build
- ReXGlue unit suite: 249 cases, 245 passed, 4 known skips, 2274 assertions
- pacing unit suite: 3 cases, 12 assertions
- tool suite: 41 tests passed
- AppData gameplay: 60.006 Hz guest vblank, 29.479 Hz simulation, 59.625 Hz host presentation
- manual gameplay qualification confirmed stable visuals, input, and audio