### PR TITLE
feat(graphics): add hash-gated fh1 post-processing switches

### DIFF
--- a/config/rexglue/analysis/fh1-post-processing.toml
+++ b/config/rexglue/analysis/fh1-post-processing.toml
@@ -1,0 +1,34 @@
+# Generated substitutions for the exact supported MS-2505 retail base XEX.
+#
+# Source: xenia-canary/game-patches, hash D48ABF1704CE5C4A. The Pinyon Shift
+# build pipeline independently requires default.xex SHA-256
+# DB40DF605ADE49A612B35A7A24C38F6004BCB17A88ED6B48288DE16DF9E3987C.
+# These hooks preserve the original generated instructions when their runtime
+# settings are false. When true, they reproduce the upstream PPC replacements
+# without attempting to patch guest memory after static code generation.
+
+# Upstream replacement 0x60000000 (nop): skip the original instruction.
+[[midasm_hook]]
+address = 0x82D7894C
+name = "PinyonShiftDisableMotionBlur"
+jump_address_on_true = 0x82D78950
+
+# Upstream replacement 0x39600000 (li r11, 0): set r11 and skip the original
+# load at each depth-of-field decision point.
+[[midasm_hook]]
+address = 0x8245B494
+name = "PinyonShiftDisableDepthOfField"
+registers = ["r11"]
+jump_address_on_true = 0x8245B498
+
+[[midasm_hook]]
+address = 0x8245846C
+name = "PinyonShiftDisableDepthOfField"
+registers = ["r11"]
+jump_address_on_true = 0x82458470
+
+[[midasm_hook]]
+address = 0x8245849C
+name = "PinyonShiftDisableDepthOfField"
+registers = ["r11"]
+jump_address_on_true = 0x824584A0

--- a/config/rexglue/analysis/main-xex.toml
+++ b/config/rexglue/analysis/main-xex.toml
@@ -2,6 +2,8 @@
 # Evidence and the rationale for every entry are recorded in the milestone
 # boundary reports under docs/research/.
 
+includes = ["fh1-post-processing.toml"]
+
 # Microsoft CRT non-local jump pair. These must be semantic codegen hooks so a
 # longjmp restores the host-side PPCContext captured at the setjmp call site.
 setjmp_address = 0x82A81E80

--- a/docs/experimental-graphics.md
+++ b/docs/experimental-graphics.md
@@ -1,14 +1,16 @@
 # Experimental graphics qualification
 
-The launcher exposes validated anisotropic filtering, FXAA, and a restart-only
-2x internal-resolution experiment. The recovery default is 1x. Every save,
+The launcher exposes validated anisotropic filtering, FXAA, optional FH1 motion
+blur and depth-of-field removal, and a restart-only 2x internal-resolution
+experiment. The recovery defaults are 1x with both original post-processing
+effects enabled. Every save,
 reset, and restore is handled by `tools/set-graphics-experiment.ps1`; it backs
 up only `pinyon_shift.toml` and never changes saves, generated code, or caches.
 
 The 2x option remains explicitly experimental until a candidate run meets all
 of these gates on the same exact build fingerprint as its 1x control:
 
-- all eight scenes accepted by `tools/visual-baseline.py` with no missing or
+- all ten scenes accepted by `tools/visual-baseline.py` with no missing or
   mismatched labels;
 - at least five minutes of compatible per-frame data accepted by
   `tools/summarize-performance.py`;
@@ -21,6 +23,30 @@ of these gates on the same exact build fingerprint as its 1x control:
 If a run fails to start or display correctly, select **Reset defaults** in the
 launcher. This restores 1x resolution and preserves a timestamped backup for
 diagnostics.
+
+## FH1 post-processing switches
+
+**Disable motion blur** and **Disable depth of field** are generated-code
+substitutions for the exact supported USA retail base executable only. The
+build refuses any `default.xex` whose size and SHA-256 do not match
+`config/supported-dumps.json`. The substitutions reproduce the instruction
+values published for Xenia patch hash `D48ABF1704CE5C4A`; they do not modify
+the extracted executable or patch guest memory at runtime.
+
+Both options default to `false`. With an option disabled, its hook executes the
+original generated instruction. With motion blur removal enabled, the hook
+skips the store at `0x82D7894C` (equivalent to PPC `nop`). With depth-of-field
+removal enabled, the hooks set `r11` to zero and skip the original loads at
+`0x8245B494`, `0x8245846C`, and `0x8245849C` (equivalent to PPC `li r11, 0`).
+Saving either option requires a preview restart. The effective values appear in
+`logging.ready` and privacy-safe support bundles. Build and visual-baseline
+fingerprints include the generated substitution profile and its SHA-256.
+
+Qualification uses the same exact build for the original-effects control and
+each enabled profile. Capture at minimum open-world day, open-world night,
+high-speed race, cockpit, and rewind scenes. Confirm the intended temporal or
+focus effect changes while menus, HUD, car paint, and player-car motion remain
+free of new corruption or jitter.
 
 Renderer A/B sessions use `tools/renderer-ab.py`. It changes only one temporary
 override at a time, keeps shipping defaults intact, and refuses to compare the

--- a/launcher/PinyonShift.Launcher/MainWindow.xaml
+++ b/launcher/PinyonShift.Launcher/MainWindow.xaml
@@ -203,6 +203,7 @@
                         <RowDefinition Height="Auto"/>
                         <RowDefinition Height="Auto"/>
                         <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
                         <RowDefinition Height="*"/>
                         <RowDefinition Height="Auto"/>
                     </Grid.RowDefinitions>
@@ -284,7 +285,24 @@
                             </ComboBox>
                         </StackPanel>
                     </Grid>
-                    <Border Grid.Row="4" x:Name="ShowroomWarning" Background="#241D12"
+                    <Grid Grid.Row="4" Margin="0,17,0,0">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*"/>
+                            <ColumnDefinition Width="16"/>
+                            <ColumnDefinition Width="*"/>
+                        </Grid.ColumnDefinitions>
+                        <CheckBox x:Name="DisableMotionBlurCheckBox" VerticalAlignment="Center"
+                                  Foreground="{StaticResource FogBrush}"
+                                  AutomationProperties.Name="Disable motion blur">
+                            <TextBlock Text="Disable motion blur" TextWrapping="Wrap"/>
+                        </CheckBox>
+                        <CheckBox Grid.Column="2" x:Name="DisableDepthOfFieldCheckBox"
+                                  VerticalAlignment="Center" Foreground="{StaticResource FogBrush}"
+                                  AutomationProperties.Name="Disable depth of field">
+                            <TextBlock Text="Disable depth of field" TextWrapping="Wrap"/>
+                        </CheckBox>
+                    </Grid>
+                    <Border Grid.Row="5" x:Name="ShowroomWarning" Background="#241D12"
                             BorderBrush="{StaticResource AmberBrush}" BorderThickness="1" CornerRadius="4"
                             Padding="14,10" Margin="0,17,0,0" Visibility="Collapsed"
                             AutomationProperties.LiveSetting="Polite">
@@ -292,13 +310,13 @@
                                    FontSize="11"
                                    Text="Accurate showroom uses full synchronous readback. It can sharply reduce frame rate; switch to Shipping 1× before normal driving."/>
                     </Border>
-                    <Border Grid.Row="5" Background="#171B17" BorderBrush="{StaticResource LineBrush}"
+                    <Border Grid.Row="6" Background="#171B17" BorderBrush="{StaticResource LineBrush}"
                             BorderThickness="1" CornerRadius="4" Padding="14,11" Margin="0,17,0,0">
                         <TextBlock x:Name="GraphicsStatusText" Text="Loading current settings…" TextWrapping="Wrap"
                                    Foreground="{StaticResource MutedBrush}" FontSize="11"
                                    AutomationProperties.LiveSetting="Polite"/>
                     </Border>
-                    <StackPanel Grid.Row="7" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,18,0,0">
+                    <StackPanel Grid.Row="8" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,18,0,0">
                         <Button x:Name="RestoreGraphicsButton" Content="RESTORE BACKUP" Style="{StaticResource QuietButton}"
                                 Margin="0,0,10,0" Click="RestoreGraphicsButton_Click"/>
                         <Button x:Name="ResetGraphicsButton" Content="RESET DEFAULTS" Style="{StaticResource QuietButton}"

--- a/launcher/PinyonShift.Launcher/MainWindow.xaml.cs
+++ b/launcher/PinyonShift.Launcher/MainWindow.xaml.cs
@@ -678,7 +678,10 @@ public partial class MainWindow : Window
             "-Anisotropy", SelectedTag(AnisotropyComboBox), "-PostEffect", SelectedTag(PostEffectComboBox),
             "-ResolutionScale", SelectedTag(ResolutionComboBox),
             "-Preset", SelectedTag(GraphicsPresetComboBox),
-            "-ReadbackResolve", SelectedTag(ReadbackResolveComboBox), "-Json"
+            "-ReadbackResolve", SelectedTag(ReadbackResolveComboBox),
+            "-DisableMotionBlur", DisableMotionBlurCheckBox.IsChecked == true ? "true" : "false",
+            "-DisableDepthOfField", DisableDepthOfFieldCheckBox.IsChecked == true ? "true" : "false",
+            "-Json"
         }) startInfo.ArgumentList.Add(argument);
         using var process = Process.Start(startInfo) ??
             throw new InvalidOperationException("Windows could not start the graphics settings tool.");
@@ -709,6 +712,8 @@ public partial class MainWindow : Window
             SelectTag(GraphicsPresetComboBox, result.Settings.Preset);
             SelectTag(ResolutionComboBox, result.Settings.ResolutionScale.ToString());
             SelectTag(ReadbackResolveComboBox, result.Settings.ReadbackResolve);
+            DisableMotionBlurCheckBox.IsChecked = result.Settings.DisableMotionBlur;
+            DisableDepthOfFieldCheckBox.IsChecked = result.Settings.DisableDepthOfField;
         }
         finally
         {
@@ -730,6 +735,8 @@ public partial class MainWindow : Window
         ResolutionComboBox.IsEnabled = enabled;
         GraphicsPresetComboBox.IsEnabled = enabled;
         ReadbackResolveComboBox.IsEnabled = enabled;
+        DisableMotionBlurCheckBox.IsEnabled = enabled;
+        DisableDepthOfFieldCheckBox.IsEnabled = enabled;
         SaveGraphicsButton.IsEnabled = enabled;
         ResetGraphicsButton.IsEnabled = enabled;
         RestoreGraphicsButton.IsEnabled = enabled;
@@ -754,6 +761,8 @@ public partial class MainWindow : Window
     private sealed record GraphicsSettings(
         [property: JsonPropertyName("anisotropy")] int Anisotropy,
         [property: JsonPropertyName("post_effect")] string PostEffect,
+        [property: JsonPropertyName("disable_motion_blur")] bool DisableMotionBlur,
+        [property: JsonPropertyName("disable_depth_of_field")] bool DisableDepthOfField,
         [property: JsonPropertyName("preset")] string Preset,
         [property: JsonPropertyName("resolution_scale")] int ResolutionScale,
         [property: JsonPropertyName("readback_resolve")] string ReadbackResolve,

--- a/src/pinyon_shift_app.cpp
+++ b/src/pinyon_shift_app.cpp
@@ -22,14 +22,14 @@
 
 #include <cstdio>
 
-REXCVAR_DEFINE_UINT32(pinyon_shift_config_schema, 8, "Pinyon Shift",
+REXCVAR_DEFINE_UINT32(pinyon_shift_config_schema, 9, "Pinyon Shift",
                       "Pinyon Shift host configuration schema version");
 REXCVAR_DEFINE_BOOL(pinyon_shift_capture_performance, true, "Pinyon Shift",
                     "Capture lightweight per-frame performance counters to a session CSV");
 
 namespace {
 
-constexpr uint32_t kConfigSchema = 8;
+constexpr uint32_t kConfigSchema = 9;
 
 bool EnsureSupportedConfig(const std::filesystem::path& path, bool& created,
                            bool& migrated) {
@@ -60,6 +60,8 @@ bool EnsureSupportedConfig(const std::filesystem::path& path, bool& created,
               "pinyon_shift_skip_opening_movies = false\n"
               "anisotropic_override = 3\n"
               "swap_post_effect = \"none\"\n"
+              "disable_motion_blur = false\n"
+              "disable_depth_of_field = false\n"
               "draw_resolution_scale_x = 1\n"
               "draw_resolution_scale_y = 1\n"
               "clear_memory_page_state = true\n"
@@ -93,7 +95,7 @@ bool EnsureSupportedConfig(const std::filesystem::path& path, bool& created,
     if (schema == kConfigSchema) {
       return true;
     }
-    if (schema < 1 || schema > 7) {
+    if (schema < 1 || schema > 8) {
       return false;
     }
 
@@ -143,6 +145,8 @@ bool EnsureSupportedConfig(const std::filesystem::path& path, bool& created,
          "xma_relaxed_padding_admission = false\n"},
         {"anisotropic_override", "anisotropic_override = 3\n"},
         {"swap_post_effect", "swap_post_effect = \"none\"\n"},
+        {"disable_motion_blur", "disable_motion_blur = false\n"},
+        {"disable_depth_of_field", "disable_depth_of_field = false\n"},
         {"draw_resolution_scale_x", "draw_resolution_scale_x = 1\n"},
         {"draw_resolution_scale_y", "draw_resolution_scale_y = 1\n"},
         {"vsync", "vsync = true\n"},
@@ -290,6 +294,10 @@ void PinyonShiftApp::OnPostInitLogging() {
                         {"anisotropic_override",
                          rex::cvar::GetFlagByName("anisotropic_override")},
                         {"swap_post_effect", rex::cvar::GetFlagByName("swap_post_effect")},
+                        {"disable_motion_blur",
+                         rex::cvar::GetFlagByName("disable_motion_blur")},
+                        {"disable_depth_of_field",
+                         rex::cvar::GetFlagByName("disable_depth_of_field")},
                         {"occlusion_query", rex::cvar::GetFlagByName("occlusion_query")},
                         {"zpd_end_policy", rex::cvar::GetFlagByName("zpd_end_policy")},
                         {"zpd_end_fallback", rex::cvar::GetFlagByName("zpd_end_fallback")},

--- a/src/pinyon_shift_runtime_hooks.cpp
+++ b/src/pinyon_shift_runtime_hooks.cpp
@@ -24,6 +24,10 @@ REXCVAR_DEFINE_BOOL(pinyon_shift_skip_opening_movies, false, "Pinyon Shift",
 REXCVAR_DEFINE_BOOL(
     pinyon_shift_stabilize_vehicle_presentation, false, "Pinyon Shift",
     "Suppress isolated implausible player-vehicle presentation transforms");
+REXCVAR_DEFINE_BOOL(disable_motion_blur, false, "Pinyon Shift",
+                    "Disable Forza Horizon motion blur");
+REXCVAR_DEFINE_BOOL(disable_depth_of_field, false, "Pinyon Shift",
+                    "Disable Forza Horizon depth of field");
 
 namespace {
 
@@ -325,6 +329,18 @@ bool OpeningMovieSkipRequested() {
 }
 
 }  // namespace
+
+bool PinyonShiftDisableMotionBlur() {
+  return REXCVAR_GET(disable_motion_blur);
+}
+
+bool PinyonShiftDisableDepthOfField(PPCRegister& r11) {
+  if (!REXCVAR_GET(disable_depth_of_field)) {
+    return false;
+  }
+  r11.u64 = 0;
+  return true;
+}
 
 void PinyonShiftCompleteOpeningMovie(PPCRegister& r3, PPCRegister& r30,
                                      PPCRegister& r31) {

--- a/tools/build-preview.ps1
+++ b/tools/build-preview.ps1
@@ -23,6 +23,23 @@ $logs = Resolve-PinyonLocalPath -RelativePath '.local/logs'
 [void](New-Item -ItemType Directory -Force -Path $logs)
 $env:SOURCE_DATE_EPOCH = '1784764800'
 
+$supportedDumps = Get-Content -LiteralPath (Join-Path $root 'config/supported-dumps.json') -Raw |
+    ConvertFrom-Json
+$supportedXex = $supportedDumps.dumps[0].executables |
+    Where-Object { $_.guest_path -eq 'default.xex' } | Select-Object -First 1
+$gameXex = Resolve-PinyonLocalPath -RelativePath '.local/game/base/default.xex'
+if ($null -eq $supportedXex -or -not (Test-Path -LiteralPath $gameXex -PathType Leaf)) {
+    throw 'The supported default.xex is not available for code generation.'
+}
+$gameXexInfo = Get-Item -LiteralPath $gameXex
+$gameXexSha256 = (Get-FileHash -LiteralPath $gameXex -Algorithm SHA256).Hash
+if ($gameXexInfo.Length -ne [int64]$supportedXex.size_bytes -or
+    $gameXexSha256 -ne $supportedXex.sha256) {
+    throw 'default.xex does not match the exact supported EPIC-08 patch target.'
+}
+$guestPatchPath = Join-Path $root 'config/rexglue/analysis/fh1-post-processing.toml'
+$guestPatchSetSha256 = (Get-FileHash -LiteralPath $guestPatchPath -Algorithm SHA256).Hash
+
 Write-PinyonEvent build 62 'Building the local code generator.' -JsonEvents:$JsonEvents
 Push-Location $sdkRoot
 try {
@@ -150,6 +167,9 @@ $result = [ordered]@{
     rexglue_commit = $rexglueCommit
     rexglue_patch_set_sha256 = $patchSetSha256
     rexglue_patch_count = @($patchMarker.patches).Count.ToString()
+    guest_executable_sha256 = $gameXexSha256
+    guest_codegen_patch_profile = 'fh1-retail-base-post-processing-v1'
+    guest_codegen_patch_set_sha256 = $guestPatchSetSha256
 }
 $resultJson = ($result | ConvertTo-Json) + [Environment]::NewLine
 [IO.File]::WriteAllText($manifestPath, $resultJson,

--- a/tools/create-crash-report.ps1
+++ b/tools/create-crash-report.ps1
@@ -233,6 +233,7 @@ try {
         'pinyon_shift_stabilize_vehicle_presentation', 'pinyon_shift_skip_opening_movies',
         'resolution', 'vsync', 'host_present_fps_limit',
         'host_present_sleep_spin', 'anisotropic_override', 'swap_post_effect',
+        'disable_motion_blur', 'disable_depth_of_field',
         'draw_resolution_scale_x', 'draw_resolution_scale_y', 'occlusion_query',
         'zpd_end_policy', 'zpd_end_fallback', 'clear_memory_page_state',
         'readback_resolve', 'readback_resolve_half_pixel_offset',

--- a/tools/set-graphics-experiment.ps1
+++ b/tools/set-graphics-experiment.ps1
@@ -20,6 +20,10 @@ param(
     [string]$ZpdEndFallback = 'pairwise_sentinel',
     [ValidateSet(0, 30, 60)]
     [int]$PresentationFps = 60,
+    [ValidateSet('true', 'false')]
+    [string]$DisableMotionBlur = 'false',
+    [ValidateSet('true', 'false')]
+    [string]$DisableDepthOfField = 'false',
     [string]$StateRoot,
     [switch]$Json
 )
@@ -40,8 +44,8 @@ $backupDirectory = Join-Path $configDirectory 'backups'
 function Get-DefaultConfigText {
     @'
 # Pinyon Shift host configuration.
-# Schema 8 adds FH1 resolve-readback presets.
-pinyon_shift_config_schema = 8
+# Schema 9 adds exact-hash FH1 post-processing switches.
+pinyon_shift_config_schema = 9
 input_backend = "sdl"
 hid_mappings_file = "gamecontrollerdb.txt"
 mnk_mode = true
@@ -56,6 +60,8 @@ pinyon_shift_skip_opening_movies = false
 xma_relaxed_padding_admission = false
 anisotropic_override = 3
 swap_post_effect = "none"
+disable_motion_blur = false
+disable_depth_of_field = false
 draw_resolution_scale_x = 1
 draw_resolution_scale_y = 1
 clear_memory_page_state = true
@@ -146,6 +152,8 @@ function Get-SettingsResult([string]$Text, [string]$BackupPath, [string]$Operati
         settings = [ordered]@{
             anisotropy = $anisotropyValue
             post_effect = Get-TomlValue $Text 'swap_post_effect' 'none'
+            disable_motion_blur = (Get-TomlValue $Text 'disable_motion_blur' 'false') -eq 'true'
+            disable_depth_of_field = (Get-TomlValue $Text 'disable_depth_of_field' 'false') -eq 'true'
             preset = $presetName
             resolution_scale = $resolutionScale
             readback_resolve = $readbackResolve
@@ -173,7 +181,7 @@ switch ($Action) {
             Get-Content -LiteralPath $configPath -Raw
         } else { Get-DefaultConfigText }
         $schema = Get-SchemaVersion $text
-        if ($schema -notin @(1, 2, 3, 4, 5, 6, 7, 8)) { throw "Unsupported host configuration schema: $schema" }
+        if ($schema -notin @(1, 2, 3, 4, 5, 6, 7, 8, 9)) { throw "Unsupported host configuration schema: $schema" }
     }
     'Reset' {
         $backup = New-ConfigBackup
@@ -190,7 +198,7 @@ switch ($Action) {
         $backup = New-ConfigBackup
         $text = Get-Content -LiteralPath $source.FullName -Raw
         $schema = Get-SchemaVersion $text
-        if ($schema -notin @(1, 2, 3, 4, 5, 6, 7, 8)) { throw "Backup uses unsupported schema: $schema" }
+        if ($schema -notin @(1, 2, 3, 4, 5, 6, 7, 8, 9)) { throw "Backup uses unsupported schema: $schema" }
         Write-Config $text
     }
     'Apply' {
@@ -198,9 +206,9 @@ switch ($Action) {
             Get-Content -LiteralPath $configPath -Raw
         } else { Get-DefaultConfigText }
         $schema = Get-SchemaVersion $text
-        if ($schema -notin @(1, 2, 3, 4, 5, 6, 7, 8)) { throw "Unsupported host configuration schema: $schema" }
+        if ($schema -notin @(1, 2, 3, 4, 5, 6, 7, 8, 9)) { throw "Unsupported host configuration schema: $schema" }
         $backup = New-ConfigBackup
-        $text = Set-TomlValue $text 'pinyon_shift_config_schema' '8'
+        $text = Set-TomlValue $text 'pinyon_shift_config_schema' '9'
         if (-not [regex]::IsMatch($text, '(?m)^\s*xma_relaxed_padding_admission\s*=')) {
             $text = Set-TomlValue $text 'xma_relaxed_padding_admission' 'false'
         }
@@ -226,6 +234,8 @@ switch ($Action) {
         $override = switch ($Anisotropy) { 4 { 3 } 8 { 4 } 16 { 5 } }
         $text = Set-TomlValue $text 'anisotropic_override' ([string]$override)
         $text = Set-TomlValue $text 'swap_post_effect' ('"' + $PostEffect + '"')
+        $text = Set-TomlValue $text 'disable_motion_blur' $DisableMotionBlur
+        $text = Set-TomlValue $text 'disable_depth_of_field' $DisableDepthOfField
         $text = Set-TomlValue $text 'draw_resolution_scale_x' ([string]$effectiveResolution)
         $text = Set-TomlValue $text 'draw_resolution_scale_y' ([string]$effectiveResolution)
         $text = Set-TomlValue $text 'vsync' 'true'

--- a/tools/tests/test_graphics_settings.py
+++ b/tools/tests/test_graphics_settings.py
@@ -65,10 +65,12 @@ class GraphicsSettingsTests(unittest.TestCase):
                 "-ZpdEndFallback", "none",
                 "-PresentationFps", "30",
                 "-Preset", "experimental_2x",
+                "-DisableMotionBlur", "true",
+                "-DisableDepthOfField", "true",
             )
             updated = config.read_text(encoding="utf-8")
             self.assertEqual(result["settings"]["anisotropy"], 16)
-            self.assertIn("pinyon_shift_config_schema = 8", updated)
+            self.assertIn("pinyon_shift_config_schema = 9", updated)
             self.assertIn("xma_relaxed_padding_admission = false", updated)
             self.assertEqual(result["settings"]["occlusion_query"], "fast")
             self.assertIn('occlusion_query = "fast"', updated)
@@ -76,6 +78,8 @@ class GraphicsSettingsTests(unittest.TestCase):
             self.assertEqual(result["settings"]["zpd_end_fallback"], "none")
             self.assertEqual(result["settings"]["host_present_fps_limit"], 30)
             self.assertTrue(result["settings"]["host_present_sleep_spin"])
+            self.assertTrue(result["settings"]["disable_motion_blur"])
+            self.assertTrue(result["settings"]["disable_depth_of_field"])
             self.assertIn("custom_value = 77", updated)
             self.assertIn("draw_resolution_scale_x = 2", updated)
             self.assertEqual(result["settings"]["preset"], "experimental_2x")
@@ -94,6 +98,8 @@ class GraphicsSettingsTests(unittest.TestCase):
             result = self.run_tool(state, "-Action", "Reset")
             text = config.read_text(encoding="utf-8")
             self.assertIn("swap_post_effect = \"none\"", text)
+            self.assertIn("disable_motion_blur = false", text)
+            self.assertIn("disable_depth_of_field = false", text)
             self.assertIn("draw_resolution_scale_x = 1", text)
             self.assertIn("xma_relaxed_padding_admission = false", text)
             self.assertIn('occlusion_query = "legacy"', text)
@@ -112,7 +118,7 @@ class GraphicsSettingsTests(unittest.TestCase):
             state = pathlib.Path(temporary)
             config = state / "config/pinyon_shift.toml"
             config.parent.mkdir(parents=True)
-            config.write_text("pinyon_shift_config_schema = 8\nreadback_resolve = \"none\"\n", encoding="utf-8")
+            config.write_text("pinyon_shift_config_schema = 9\nreadback_resolve = \"none\"\n", encoding="utf-8")
             result = self.run_tool(state, "-Action", "Apply", "-Preset", "accurate_showroom")
             text = config.read_text(encoding="utf-8")
             self.assertEqual(result["settings"]["preset"], "accurate_showroom")

--- a/tools/tests/test_release_contract.py
+++ b/tools/tests/test_release_contract.py
@@ -163,7 +163,7 @@ class ReleaseContractTests(unittest.TestCase):
 
     def test_graphics_schema_and_diagnostics_contract(self):
         app = (ROOT / "src/pinyon_shift_app.cpp").read_text(encoding="utf-8")
-        self.assertIn("constexpr uint32_t kConfigSchema = 8", app)
+        self.assertIn("constexpr uint32_t kConfigSchema = 9", app)
         self.assertIn(".schema", app)
         for setting in ("anisotropic_override", "swap_post_effect", "draw_resolution_scale_x"):
             self.assertIn(setting, app)
@@ -223,21 +223,34 @@ class ReleaseContractTests(unittest.TestCase):
         launcher_xaml = (ROOT / "launcher/PinyonShift.Launcher/MainWindow.xaml").read_text(
             encoding="utf-8"
         )
-        self.assertIn("constexpr uint32_t kConfigSchema = 8;", app)
-        self.assertRegex(app, r"pinyon_shift_config_schema,\s*8,")
+        self.assertIn("constexpr uint32_t kConfigSchema = 9;", app)
+        self.assertRegex(app, r"pinyon_shift_config_schema,\s*9,")
         self.assertIn('"pinyon_shift_stabilize_vehicle_presentation = false\\n"', app)
         self.assertIn('"keybind_a = \\"LMB,Space\\"\\n"', app)
-        self.assertIn("schema < 1 || schema > 7", app)
+        self.assertIn("schema < 1 || schema > 8", app)
         self.assertIn('"occlusion_query = \\"legacy\\"\\n"', app)
         self.assertIn('"zpd_end_policy = \\"report_layout\\"\\n"', app)
         self.assertIn('"readback_resolve = \\"none\\"\\n"', app)
         self.assertIn('"clear_memory_page_state = true\\n"', app)
         self.assertIn("Accurate showroom", launcher_xaml)
+        self.assertIn("DisableMotionBlurCheckBox", launcher_xaml)
+        self.assertIn("DisableDepthOfFieldCheckBox", launcher_xaml)
         self.assertIn("Controller A, Space, or left click.", launcher)
         self.assertRegex(
             hooks,
             r"pinyon_shift_stabilize_vehicle_presentation,\s*false,",
         )
+
+    def test_exact_hash_post_processing_substitutions_are_shipped(self):
+        patch = (ROOT / "config/rexglue/analysis/fh1-post-processing.toml").read_text(
+            encoding="utf-8"
+        )
+        for address in ("0x82D7894C", "0x8245B494", "0x8245846C", "0x8245849C"):
+            self.assertIn(address, patch)
+        self.assertIn("DB40DF605ADE49A612B35A7A24C38F6004BCB17A88ED6B48288DE16DF9E3987C", patch)
+        build = (ROOT / "tools/build-preview.ps1").read_text(encoding="utf-8")
+        self.assertIn("guest_codegen_patch_set_sha256", build)
+        self.assertIn("does not match the exact supported EPIC-08 patch target", build)
 
     def test_8bitdo_ultimate_2c_wired_mapping_is_shipped(self):
         mappings = (ROOT / "config/gamecontrollerdb.txt").read_text(encoding="utf-8")

--- a/tools/visual-baseline.py
+++ b/tools/visual-baseline.py
@@ -6,7 +6,8 @@ import argparse, hashlib, json, struct, subprocess
 from datetime import datetime, timezone
 from pathlib import Path
 
-SCENES = ("front-end", "garage", "autoshow", "livery", "open-world-day", "open-world-night", "race", "rewind")
+SCENES = ("front-end", "garage", "autoshow", "livery", "open-world-day",
+          "open-world-night", "high-speed", "cockpit", "race", "rewind")
 ROOT = Path(__file__).resolve().parents[1]
 
 def fingerprint(executable: Path | None = None) -> dict:
@@ -16,8 +17,11 @@ def fingerprint(executable: Path | None = None) -> dict:
     patch_hasher = hashlib.sha256()
     for patch in sorted((ROOT / "patches" / "rexglue").glob("*.patch")):
         patch_hasher.update(patch.name.encode()); patch_hasher.update(b"\0"); patch_hasher.update(patch.read_bytes())
+    guest_patch = ROOT / "config/rexglue/analysis/fh1-post-processing.toml"
     data = {"repository_commit": git("rev-parse", "HEAD"),
-            "rexglue_patch_set_sha256": patch_hasher.hexdigest()}
+            "rexglue_patch_set_sha256": patch_hasher.hexdigest(),
+            "guest_codegen_patch_profile": "fh1-retail-base-post-processing-v1",
+            "guest_codegen_patch_set_sha256": hashlib.sha256(guest_patch.read_bytes()).hexdigest()}
     try: data["rexglue_commit"] = git("-C", str(ROOT / ".local" / "rexglue"), "rev-parse", "HEAD")
     except (subprocess.CalledProcessError, FileNotFoundError): data["rexglue_commit"] = None
     if executable and executable.is_file():


### PR DESCRIPTION
## Summary\n\n- add exact-XEX generated substitutions for the upstream FH1 motion-blur and depth-of-field patches\n- expose restart-required launcher controls with schema migration and support-bundle reporting\n- fingerprint the guest patch profile and extend visual qualification with high-speed and cockpit scenes\n\n## Validation\n\n- clean local code generation and release build\n- generated-code inspection at all four guest addresses\n- launcher Release build\n- 42 Python tests\n- AppData save launch with both options enabled