### PR TITLE
fix(launcher): enable play for existing builds

### DIFF
--- a/launcher/PinyonShift.Launcher/MainWindow.xaml.cs
+++ b/launcher/PinyonShift.Launcher/MainWindow.xaml.cs
@@ -59,6 +59,7 @@ public partial class MainWindow : Window
             StageControllerMappings();
             DetectExistingBuild();
             DetectPendingReport();
+            UpdatePrimaryButton();
         }
         catch (Exception ex)
         {

--- a/tools/tests/test_release_contract.py
+++ b/tools/tests/test_release_contract.py
@@ -237,6 +237,7 @@ class ReleaseContractTests(unittest.TestCase):
         self.assertIn("DisableDepthOfFieldCheckBox", launcher_xaml)
         self.assertIn('Environment.GetEnvironmentVariable("PINYON_SHIFT_STATE_ROOT")', launcher)
         self.assertIn('"-StateRoot", _stateRoot', launcher)
+        self.assertIn("DetectPendingReport();\n            UpdatePrimaryButton();", launcher)
         self.assertIn("Controller A, Space, or left click.", launcher)
         self.assertRegex(
             hooks,


### PR DESCRIPTION
## Summary
- refresh the primary action after startup build/report detection
- keep Play enabled when an existing preview is launched with an external state root
- add a release-contract regression assertion

## Tests
- python -m unittest tools.tests.test_release_contract
- dotnet build launcher/PinyonShift.Launcher/PinyonShift.Launcher.csproj -c Release
- visually confirmed the Play button is enabled with the AppData state root