### PR TITLE
feat(renderer): establish graphics hook ownership

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,8 @@ private/
 !/docs/BUILDING.md
 !/docs/LEGAL.md
 !/docs/TROUBLESHOOTING.md
+!/docs/native-renderer/
+!/docs/native-renderer/**
 
 # Build output and tooling state.
 build/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,7 @@ if(WIN32)
         src/pinyon_shift_app.cpp
         src/pinyon_shift_diagnostics.cpp
         src/pinyon_shift_runtime_hooks.cpp
+        src/native_renderer/graphics_hooks.cpp
     )
 else()
     add_executable(pinyon_shift
@@ -29,6 +30,7 @@ else()
         src/pinyon_shift_app.cpp
         src/pinyon_shift_diagnostics.cpp
         src/pinyon_shift_runtime_hooks.cpp
+        src/native_renderer/graphics_hooks.cpp
     )
 endif()
 

--- a/config/rexglue/analysis/main-xex.toml
+++ b/config/rexglue/analysis/main-xex.toml
@@ -4,6 +4,14 @@
 
 includes = ["fh1-post-processing.toml"]
 
+# NR-00 graphics-hook owner. This is the sole title call to VdSwap, observed
+# immediately before the import without changing registers or control flow.
+# Future graphics hooks must dispatch through src/native_renderer/ rather than
+# acquiring a second owner in the general runtime-hooks translation unit.
+[[midasm_hook]]
+address = 0x829EFEB8
+name = "PinyonShiftObserveGraphicsFrame"
+
 # Microsoft CRT non-local jump pair. These must be semantic codegen hooks so a
 # longjmp restores the host-side PPCContext captured at the setjmp call site.
 setjmp_address = 0x82A81E80

--- a/docs/native-renderer/RENDER_PASS_CENSUS.md
+++ b/docs/native-renderer/RENDER_PASS_CENSUS.md
@@ -1,0 +1,55 @@
+# Forza Horizon renderer census
+
+This document is the tracked evidence ledger for NR-00. It records facts about
+the supported USA retail MS-2505 executable only. Unknowns stay explicit until
+a trace or disassembly proves them.
+
+## Baseline
+
+- Pinyon Shift `dev`: `cafc7233fef9e039f163d11023f40eccb22e8fc1`
+- ReXGlue: `v0.10.0` at `f5337cdc947ff6d4c4196737e2c807a48f2a1fc2`
+- ReXGlue patch stack: `0001` through `0043`
+- `default.xex` SHA-256:
+  `DB40DF605ADE49A612B35A7A24C38F6004BCB17A88ED6B48288DE16DF9E3987C`
+
+This replaces the investigation plan's historical `29b48259` baseline. It is
+an inventory update, not a claim that a native renderer exists.
+
+## Hook ownership contract
+
+`src/native_renderer/graphics_hooks.cpp` is the single owner of title-side
+graphics hooks. A hook may observe and dispatch, but with every native-renderer
+cvar at its default it must preserve the original instruction, registers,
+arguments, and control flow. General runtime fixes remain in
+`src/pinyon_shift_runtime_hooks.cpp`.
+
+This first change adds no native RHI, guest payload capture, Xenos suppression,
+or presentation changes. The only setting is
+`pinyon_shift_native_renderer_census`, and it defaults to `false`.
+
+## Verified inventory
+
+| Event | Guest location | Owner / ABI evidence | Mutable state | Status |
+| --- | --- | --- | --- | --- |
+| System command-buffer request | `0x829EFD80` | `sub_829EFB30` calls `VdGetSystemCommandBuffer`; output pointers are passed in `r3` and `r4` | The returned buffer cursor is subsequently written into the graphics-device object | Verified, not hooked |
+| Frame submission | `0x829EFEB8` | `sub_829EFB30` calls the sole `VdSwap` import; continuation is `0x829EFEBC` | Device command-buffer cursor is updated after return | Verified, pass-through hook |
+| Xenos swap packet | ReXGlue `CommandProcessor::ExecutePacketType3_XE_SWAP` | Consumes the `VdSwap` packet and calls backend `IssueSwap` | ReXGlue snapshots/reset per-frame counters before decoding the packet payload | Verified runtime boundary |
+| Draw packet | ReXGlue `PM4_DRAW_INDX` / `PM4_DRAW_INDX_2` | Generic command processor decodes the packet before backend `IssueDraw` | Register-derived draw state is consumed by the backend | Backend boundary verified; title wrapper unknown |
+| Resolve/copy | ReXGlue backend `IssueCopy` | Triggered by the Xenos copy path | Render-target and guest-memory dependencies may be produced | Backend boundary verified; title wrapper unknown |
+
+The frame hook has no register parameters and no conditional jump target. When
+the census is enabled it emits only frame 1 and every 300th frame, containing a
+sequence number, the fixed hook address, and `pass_through` mode. It does not
+read or serialize guest memory.
+
+## Open inventory work
+
+- Prove the FH1 draw-wrapper families and their ABI before adding draw hooks.
+- Locate the title-side resolve and query wrapper families.
+- Establish where each wrapper consumes or clears dirty graphics state.
+- Inventory memexport-producing draws and guest-visible resolve destinations.
+- Map high-level world, vehicle, road, HUD, garage, mirror, shadow, exposure,
+  livery, thumbnail, and rewind dispatch families.
+
+Bounded draw metadata, resolve dependencies, and pass classification belong to
+the subsequent NR-00 pull requests. Unknown work stays on Xenos.

--- a/src/native_renderer/graphics_hooks.cpp
+++ b/src/native_renderer/graphics_hooks.cpp
@@ -1,0 +1,42 @@
+#include <atomic>
+#include <cstdint>
+#include <string>
+
+#include <rex/cvar.h>
+
+#include "pinyon_shift_diagnostics.h"
+
+REXCVAR_DEFINE_BOOL(
+    pinyon_shift_native_renderer_census, false, "Pinyon Shift",
+    "Record bounded native-renderer census frame markers without changing rendering");
+
+namespace {
+
+constexpr uint64_t kFrameSummaryInterval = 300;
+std::atomic<uint64_t> g_frame_sequence{};
+
+}  // namespace
+
+// This translation unit is the single owner for title-side graphics hooks.
+// The hook runs immediately before FH1's sole VdSwap import and intentionally
+// accepts no PPC registers: it cannot mutate guest arguments or control flow.
+// All renderer experiments remain passive until their own explicit cvars are
+// enabled and must dispatch through this owner.
+void PinyonShiftObserveGraphicsFrame() {
+  if (!REXCVAR_GET(pinyon_shift_native_renderer_census)) {
+    return;
+  }
+
+  const uint64_t frame_sequence =
+      g_frame_sequence.fetch_add(1, std::memory_order_relaxed) + 1;
+  if (frame_sequence != 1 && frame_sequence % kFrameSummaryInterval != 0) {
+    return;
+  }
+
+  const std::string frame = std::to_string(frame_sequence);
+  pinyon_shift::diagnostics::RecordEvent(
+      "native_renderer.census.frame",
+      {{"frame_sequence", frame},
+       {"guest_address", "829EFEB8"},
+       {"mode", "pass_through"}});
+}

--- a/tools/tests/test_native_renderer_contract.py
+++ b/tools/tests/test_native_renderer_contract.py
@@ -1,0 +1,52 @@
+import pathlib
+import unittest
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+
+
+class NativeRendererContractTests(unittest.TestCase):
+    def test_graphics_hook_has_one_pass_through_owner(self):
+        analysis = (ROOT / "config/rexglue/analysis/main-xex.toml").read_text(
+            encoding="utf-8"
+        )
+        self.assertEqual(analysis.count('name = "PinyonShiftObserveGraphicsFrame"'), 1)
+        hook = analysis.split('name = "PinyonShiftObserveGraphicsFrame"', 1)[0]
+        hook = hook.rsplit("[[midasm_hook]]", 1)[1]
+        self.assertIn("address = 0x829EFEB8", hook)
+        self.assertNotIn("jump_address", hook)
+        self.assertNotIn("after_instruction", hook)
+        self.assertNotIn("registers", hook)
+
+    def test_census_is_default_off_and_bounded(self):
+        source = (ROOT / "src/native_renderer/graphics_hooks.cpp").read_text(
+            encoding="utf-8"
+        )
+        self.assertIn("pinyon_shift_native_renderer_census, false", source)
+        self.assertIn("kFrameSummaryInterval = 300", source)
+        self.assertIn('"mode", "pass_through"', source)
+        self.assertNotIn("REX_STORE", source)
+        self.assertNotIn("GuestPtr", source)
+
+    def test_first_pr_has_no_native_renderer_or_suppression_api(self):
+        source = (ROOT / "src/native_renderer/graphics_hooks.cpp").read_text(
+            encoding="utf-8"
+        )
+        forbidden = ("native_rhi", "NativeRHI", "IssueDraw", "IssueCopy", "suppress")
+        for token in forbidden:
+            self.assertNotIn(token, source)
+
+        cmake = (ROOT / "CMakeLists.txt").read_text(encoding="utf-8")
+        self.assertEqual(cmake.count("src/native_renderer/graphics_hooks.cpp"), 2)
+
+    def test_census_ledger_tracks_exact_starting_baseline(self):
+        ledger = (ROOT / "docs/native-renderer/RENDER_PASS_CENSUS.md").read_text(
+            encoding="utf-8"
+        )
+        self.assertIn("cafc7233fef9e039f163d11023f40eccb22e8fc1", ledger)
+        self.assertIn("f5337cdc947ff6d4c4196737e2c807a48f2a1fc2", ledger)
+        self.assertIn("Unknown work stays on Xenos.", ledger)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- establish src/native_renderer/graphics_hooks.cpp as the single owner of title-side graphics hooks
- add a default-off, bounded, pass-through frame census at FH1's sole VdSwap call
- track the exact NR-00 baseline, verified boundaries, and explicit unknowns
- add contract tests preventing renderer APIs or suppression from entering this first slice

## Safety boundary
- no native RHI
- no draw or guest payload capture
- no Xenos suppression
- no presentation change
- default-off path preserves guest registers and control flow

## Validation
- python -m unittest discover -s tools/tests -v (49 passed)
- tools/build-preview.ps1 -Parallel 16 (clean commit build)
- ReXGlue unit_tests.exe (245 passed, 4 documented skips; 2274 assertions)
- generated hook verified immediately before VdSwap at 0x829EFEB8
- repository boundary check passed