### PR TITLE
feat(renderer): add bounded draw census

### DIFF
--- a/docs/native-renderer/RENDER_PASS_CENSUS.md
+++ b/docs/native-renderer/RENDER_PASS_CENSUS.md
@@ -8,7 +8,7 @@ a trace or disassembly proves them.
 
 - Pinyon Shift `dev`: `cafc7233fef9e039f163d11023f40eccb22e8fc1`
 - ReXGlue: `v0.10.0` at `f5337cdc947ff6d4c4196737e2c807a48f2a1fc2`
-- ReXGlue patch stack: `0001` through `0043`
+- ReXGlue patch stack: `0001` through `0044`
 - `default.xex` SHA-256:
   `DB40DF605ADE49A612B35A7A24C38F6004BCB17A88ED6B48288DE16DF9E3987C`
 
@@ -36,6 +36,44 @@ or presentation changes. The only setting is
 | Xenos swap packet | ReXGlue `CommandProcessor::ExecutePacketType3_XE_SWAP` | Consumes the `VdSwap` packet and calls backend `IssueSwap` | ReXGlue snapshots/reset per-frame counters before decoding the packet payload | Verified runtime boundary |
 | Draw packet | ReXGlue `PM4_DRAW_INDX` / `PM4_DRAW_INDX_2` | Generic command processor decodes the packet before backend `IssueDraw` | Register-derived draw state is consumed by the backend | Backend boundary verified; title wrapper unknown |
 | Resolve/copy | ReXGlue backend `IssueCopy` | Triggered by the Xenos copy path | Render-target and guest-memory dependencies may be produced | Backend boundary verified; title wrapper unknown |
+
+## Bounded draw observation
+
+Patch `0044-graphics-draw-observer.patch` adds an optional, backend-neutral
+observer immediately before `IssueDraw`. The observer is not registered unless
+`pinyon_shift_native_renderer_census` is enabled before startup. The default-off
+path performs one null observer check and leaves draw submission unchanged.
+
+Each observation contains sequence numbers, primitive/index metadata, shader
+hashes, render-target/depth/scissor register values, and a memexport flag. It
+does not contain shader code, constants, texture data, vertex/index contents,
+or any other guest payload.
+
+Pinyon hashes those fields into a fixed 4096-entry table. Element count remains
+in each sample but is excluded from the signature so repeated geometry using
+the same pipeline and target groups into one pass identity. Every 300 emulated
+frames it emits one window record and at most the 16 most frequent signatures.
+The window record reports both `unique_signatures` and explicit
+`overflow_draws`; saturation never causes an unbounded allocation or per-draw
+log stream. This is census evidence only and does not classify or suppress a
+draw.
+
+### Local qualification snapshot — 2026-08-27
+
+The census-enabled Release build was launched through `launch-preview.ps1`
+against the installed `0.1.0` AppData save and exited normally. Two consecutive
+open-world windows produced:
+
+| Frames | Draws | Unique signatures | Overflow draws |
+|---:|---:|---:|---:|
+| 301–600 | 922,750 | 686 | 0 |
+| 601–900 | 1,006,435 | 458 | 0 |
+
+Each window emitted exactly the configured maximum of 16 ranked summaries, no
+crash/error/GPU-loss event was recorded, and Xenos remained the only renderer.
+An earlier 256-entry prototype that hashed raw draw initiators saturated in the
+same route; the recorded result above validates the coarser pass identity and
+4096-entry fixed capacity that replaced it.
 
 The frame hook has no register parameters and no conditional jump target. When
 the census is enabled it emits only frame 1 and every 300th frame, containing a

--- a/patches/rexglue/0044-graphics-draw-observer.patch
+++ b/patches/rexglue/0044-graphics-draw-observer.patch
@@ -1,0 +1,152 @@
+diff --git a/include/rex/graphics/command_processor.h b/include/rex/graphics/command_processor.h
+index 9853ec2..137274e 100644
+--- a/include/rex/graphics/command_processor.h
++++ b/include/rex/graphics/command_processor.h
+@@ -275,6 +275,8 @@ class CommandProcessor {
+ 
+   Shader* active_vertex_shader_ = nullptr;
+   Shader* active_pixel_shader_ = nullptr;
++  uint64_t observation_frame_sequence_ = 1;
++  uint64_t observation_draw_sequence_ = 0;
+ 
+   bool paused_ = false;
+ 
+diff --git a/include/rex/graphics/graphics_system.h b/include/rex/graphics/graphics_system.h
+index ac6b056..2f92ddc 100644
+--- a/include/rex/graphics/graphics_system.h
++++ b/include/rex/graphics/graphics_system.h
+@@ -70,6 +70,12 @@ class GraphicsSystem : public system::IGraphicsSystem {
+ 
+   RegisterFile* register_file() { return &register_file_; }
+   CommandProcessor* command_processor() const { return command_processor_.get(); }
++  void SetDrawObserver(system::GraphicsDrawObserver observer) override {
++    draw_observer_.store(observer, std::memory_order_release);
++  }
++  system::GraphicsDrawObserver draw_observer() const {
++    return draw_observer_.load(std::memory_order_acquire);
++  }
+ 
+   void InitializeRingBuffer(uint32_t ptr, uint32_t size_log2) override;
+   void EnableReadPointerWriteBack(uint32_t ptr, uint32_t block_size_log2) override;
+@@ -129,6 +135,8 @@ class GraphicsSystem : public system::IGraphicsSystem {
+  private:
+   std::unique_ptr<::rex::ui::Presenter> presenter_;
+ 
++  std::atomic<system::GraphicsDrawObserver> draw_observer_{nullptr};
++
+   std::atomic_flag host_gpu_loss_reported_;
+ };
+ 
+diff --git a/include/rex/system/interfaces/graphics.h b/include/rex/system/interfaces/graphics.h
+index d54df86..fb8a3c1 100644
+--- a/include/rex/system/interfaces/graphics.h
++++ b/include/rex/system/interfaces/graphics.h
+@@ -31,6 +31,31 @@ class KernelState;
+ 
+ namespace rex::system {
+ 
++struct GraphicsDrawObservation {
++  uint64_t frame_sequence = 0;
++  uint64_t draw_sequence = 0;
++  uint64_t vertex_shader_hash = 0;
++  uint64_t pixel_shader_hash = 0;
++  uint32_t packet = 0;
++  uint32_t initiator = 0;
++  uint32_t primitive_type = 0;
++  uint32_t index_count = 0;
++  uint32_t source_select = 0;
++  uint32_t index_buffer_address = 0;
++  uint32_t index_buffer_length = 0;
++  uint32_t surface_info = 0;
++  uint32_t color_info[4] = {};
++  uint32_t depth_info = 0;
++  uint32_t window_scissor_tl = 0;
++  uint32_t window_scissor_br = 0;
++  uint32_t rb_modecontrol = 0;
++  bool indexed = false;
++  bool major_mode_explicit = false;
++  bool vertex_memexport = false;
++};
++
++using GraphicsDrawObserver = void (*)(const GraphicsDrawObservation& observation);
++
+ class IGraphicsSystem {
+  public:
+   virtual ~IGraphicsSystem() = default;
+@@ -57,6 +82,12 @@ class IGraphicsSystem {
+   virtual ui::GraphicsProvider* provider() const { return nullptr; }
+   virtual ui::Presenter* presenter() const { return nullptr; }
+ 
++  // Optional read-only command-stream observation. Backends invoke this
++  // before draw submission and observers cannot alter draw behavior.
++  virtual void SetDrawObserver(GraphicsDrawObserver observer) {
++    (void)observer;
++  }
++
+   // Guest GPU services reached from the xboxkrnl Vd* exports.
+   virtual void SetInterruptCallback(uint32_t callback, uint32_t user_data) {
+     (void)callback;
+diff --git a/src/graphics/command_processor.cpp b/src/graphics/command_processor.cpp
+index 03b0ac2..48c7421 100644
+--- a/src/graphics/command_processor.cpp
++++ b/src/graphics/command_processor.cpp
+@@ -25,6 +25,7 @@
+ #include <rex/graphics/command_processor.h>
+ #include <rex/graphics/flags.h>
+ #include <rex/graphics/graphics_system.h>
++#include <rex/graphics/pipeline/shader/shader.h>
+ #include <rex/graphics/pipeline/texture/info.h>
+ #include <rex/graphics/sampler_info.h>
+ #include <rex/graphics/xenos.h>
+@@ -979,6 +980,9 @@ bool CommandProcessor::ExecutePacketType3_XE_SWAP(memory::RingBuffer* reader, ui
+ 
+   IssueSwap(frontbuffer_ptr, frontbuffer_width, frontbuffer_height);
+ 
++  ++observation_frame_sequence_;
++  observation_draw_sequence_ = 0;
++
+   ++counter_;
+   return true;
+ }
+@@ -1471,6 +1475,41 @@ bool CommandProcessor::ExecutePacketType3Draw(memory::RingBuffer* reader, uint32
+ 
+       bool major_mode_explicit =
+           xenos::IsMajorModeExplicit(vgt_draw_initiator.major_mode, vgt_draw_initiator.prim_type);
++      auto draw_observer = graphics_system_->draw_observer();
++      if (draw_observer) {
++        system::GraphicsDrawObservation observation;
++        observation.frame_sequence = observation_frame_sequence_;
++        observation.draw_sequence = ++observation_draw_sequence_;
++        observation.vertex_shader_hash =
++            active_vertex_shader_ ? active_vertex_shader_->ucode_data_hash() : 0;
++        observation.pixel_shader_hash =
++            active_pixel_shader_ ? active_pixel_shader_->ucode_data_hash() : 0;
++        observation.packet = packet;
++        observation.initiator = vgt_draw_initiator.value;
++        observation.primitive_type = uint32_t(vgt_draw_initiator.prim_type);
++        observation.index_count = vgt_draw_initiator.num_indices;
++        observation.source_select = uint32_t(vgt_draw_initiator.source_select);
++        observation.indexed = is_indexed;
++        observation.major_mode_explicit = major_mode_explicit;
++        observation.vertex_memexport =
++            active_vertex_shader_ && !active_vertex_shader_->memexport_stream_constants().empty();
++        if (is_indexed) {
++          observation.index_buffer_address = index_buffer_info.guest_base;
++          observation.index_buffer_length = uint32_t(index_buffer_info.length);
++        }
++        observation.surface_info = register_file_->Get<reg::RB_SURFACE_INFO>().value;
++        for (uint32_t i = 0; i < 4; ++i) {
++          observation.color_info[i] =
++              (*register_file_)[reg::RB_COLOR_INFO::rt_register_indices[i]];
++        }
++        observation.depth_info = register_file_->Get<reg::RB_DEPTH_INFO>().value;
++        observation.window_scissor_tl =
++            register_file_->Get<reg::PA_SC_WINDOW_SCISSOR_TL>().value;
++        observation.window_scissor_br =
++            register_file_->Get<reg::PA_SC_WINDOW_SCISSOR_BR>().value;
++        observation.rb_modecontrol = register_file_->Get<reg::RB_MODECONTROL>().value;
++        draw_observer(observation);
++      }
+       draw_succeeded = IssueDraw(vgt_draw_initiator.prim_type, vgt_draw_initiator.num_indices,
+                                  is_indexed ? &index_buffer_info : nullptr, major_mode_explicit);
+       if (!draw_succeeded) {

--- a/src/native_renderer/graphics_hooks.cpp
+++ b/src/native_renderer/graphics_hooks.cpp
@@ -1,21 +1,211 @@
+#include <algorithm>
+#include <array>
 #include <atomic>
+#include <cstddef>
 #include <cstdint>
 #include <string>
 
+#include <fmt/format.h>
 #include <rex/cvar.h>
+#include <rex/system/interfaces/graphics.h>
 
+#include "native_renderer/graphics_hooks.h"
 #include "pinyon_shift_diagnostics.h"
 
 REXCVAR_DEFINE_BOOL(
     pinyon_shift_native_renderer_census, false, "Pinyon Shift",
-    "Record bounded native-renderer census frame markers without changing rendering");
+    "Record bounded native-renderer census metadata without changing rendering")
+    .lifecycle(rex::cvar::Lifecycle::kRequiresRestart);
 
 namespace {
 
 constexpr uint64_t kFrameSummaryInterval = 300;
+constexpr size_t kSignatureCapacity = 4096;
+constexpr size_t kSummaryLimit = 16;
 std::atomic<uint64_t> g_frame_sequence{};
 
+struct DrawSignatureEntry {
+  uint64_t signature = 0;
+  uint64_t draw_count = 0;
+  uint64_t first_frame = 0;
+  uint64_t last_frame = 0;
+  rex::system::GraphicsDrawObservation sample;
+};
+
+struct DrawCensus {
+  std::array<DrawSignatureEntry, kSignatureCapacity> entries{};
+  uint64_t window_first_frame = 0;
+  uint64_t window_draw_count = 0;
+  uint64_t unique_signature_count = 0;
+  uint64_t overflow_draw_count = 0;
+};
+
+DrawCensus g_draw_census;
+
+uint64_t HashCombine(uint64_t hash, uint64_t value) {
+  value += 0x9E3779B97F4A7C15ull + (hash << 6) + (hash >> 2);
+  return hash ^ value;
+}
+
+uint64_t DrawSignature(const rex::system::GraphicsDrawObservation& observation) {
+  uint64_t hash = 0xCBF29CE484222325ull;
+  for (uint64_t value :
+       {observation.vertex_shader_hash, observation.pixel_shader_hash,
+        uint64_t(observation.primitive_type),
+        uint64_t(observation.source_select), uint64_t(observation.indexed),
+        uint64_t(observation.major_mode_explicit),
+        uint64_t(observation.vertex_memexport),
+        uint64_t(observation.surface_info),
+        uint64_t(observation.color_info[0]),
+        uint64_t(observation.color_info[1]),
+        uint64_t(observation.color_info[2]),
+        uint64_t(observation.color_info[3]), uint64_t(observation.depth_info),
+        uint64_t(observation.window_scissor_tl),
+        uint64_t(observation.window_scissor_br),
+        uint64_t(observation.rb_modecontrol)}) {
+    hash = HashCombine(hash, value);
+  }
+  return hash ? hash : 1;
+}
+
+void EmitDrawCensusWindow(uint64_t next_frame) {
+  std::array<size_t, kSignatureCapacity> order{};
+  for (size_t i = 0; i < order.size(); ++i) {
+    order[i] = i;
+  }
+  std::sort(order.begin(), order.end(), [](size_t left, size_t right) {
+    const DrawSignatureEntry& left_entry = g_draw_census.entries[left];
+    const DrawSignatureEntry& right_entry = g_draw_census.entries[right];
+    if (left_entry.draw_count != right_entry.draw_count) {
+      return left_entry.draw_count > right_entry.draw_count;
+    }
+    return left_entry.signature < right_entry.signature;
+  });
+
+  const std::string first_frame =
+      std::to_string(g_draw_census.window_first_frame);
+  const std::string last_frame = std::to_string(next_frame - 1);
+  const std::string draws = std::to_string(g_draw_census.window_draw_count);
+  const std::string unique =
+      std::to_string(g_draw_census.unique_signature_count);
+  const std::string overflow =
+      std::to_string(g_draw_census.overflow_draw_count);
+  const std::string capacity = std::to_string(kSignatureCapacity);
+  pinyon_shift::diagnostics::RecordEvent("native_renderer.census.draw_window",
+                                         {{"first_frame", first_frame},
+                                          {"last_frame", last_frame},
+                                          {"draws", draws},
+                                          {"unique_signatures", unique},
+                                          {"overflow_draws", overflow},
+                                          {"signature_capacity", capacity},
+                                          {"summary_limit", "16"}});
+
+  size_t emitted = 0;
+  for (size_t index : order) {
+    const DrawSignatureEntry& entry = g_draw_census.entries[index];
+    if (!entry.draw_count || emitted == kSummaryLimit) {
+      break;
+    }
+    const auto& sample = entry.sample;
+    const std::string rank = std::to_string(++emitted);
+    const std::string count = std::to_string(entry.draw_count);
+    const std::string first = std::to_string(entry.first_frame);
+    const std::string last = std::to_string(entry.last_frame);
+    const std::string index_count = std::to_string(sample.index_count);
+    const std::string signature = fmt::format("{:016X}", entry.signature);
+    const std::string vertex_shader =
+        fmt::format("{:016X}", sample.vertex_shader_hash);
+    const std::string pixel_shader =
+        fmt::format("{:016X}", sample.pixel_shader_hash);
+    const std::string primitive = std::to_string(sample.primitive_type);
+    const std::string target_state = fmt::format(
+        "{:08X}:{:08X}:{:08X}:{:08X}:{:08X}:{:08X}", sample.surface_info,
+        sample.color_info[0], sample.color_info[1], sample.color_info[2],
+        sample.color_info[3], sample.depth_info);
+    const std::string scissor = fmt::format(
+        "{:08X}:{:08X}", sample.window_scissor_tl, sample.window_scissor_br);
+    const std::string index_buffer = fmt::format(
+        "{:08X}:{}", sample.index_buffer_address, sample.index_buffer_length);
+    const std::string flags =
+        fmt::format("indexed={};explicit_major={};memexport={}", sample.indexed,
+                    sample.major_mode_explicit, sample.vertex_memexport);
+    pinyon_shift::diagnostics::RecordEvent(
+        "native_renderer.census.draw_signature",
+        {{"rank", rank},
+         {"signature", signature},
+         {"draws", count},
+         {"first_frame", first},
+         {"last_frame", last},
+         {"vertex_shader", vertex_shader},
+         {"pixel_shader", pixel_shader},
+         {"primitive", primitive},
+         {"index_count", index_count},
+         {"target_state", target_state},
+         {"scissor", scissor},
+         {"index_buffer", index_buffer},
+         {"flags", flags}});
+  }
+
+  g_draw_census = {};
+}
+
+void ObserveDraw(const rex::system::GraphicsDrawObservation& observation) {
+  if (!g_draw_census.window_first_frame) {
+    g_draw_census.window_first_frame = observation.frame_sequence;
+  } else if (observation.frame_sequence >=
+             g_draw_census.window_first_frame + kFrameSummaryInterval) {
+    EmitDrawCensusWindow(observation.frame_sequence);
+    g_draw_census.window_first_frame = observation.frame_sequence;
+  }
+
+  ++g_draw_census.window_draw_count;
+  const uint64_t signature = DrawSignature(observation);
+  size_t index = size_t(signature % kSignatureCapacity);
+  for (size_t probe = 0; probe < kSignatureCapacity; ++probe) {
+    DrawSignatureEntry& entry = g_draw_census.entries[index];
+    if (!entry.draw_count) {
+      entry.signature = signature;
+      entry.draw_count = 1;
+      entry.first_frame = observation.frame_sequence;
+      entry.last_frame = observation.frame_sequence;
+      entry.sample = observation;
+      ++g_draw_census.unique_signature_count;
+      return;
+    }
+    if (entry.signature == signature) {
+      ++entry.draw_count;
+      entry.last_frame = observation.frame_sequence;
+      return;
+    }
+    index = (index + 1) % kSignatureCapacity;
+  }
+  ++g_draw_census.overflow_draw_count;
+}
+
 }  // namespace
+
+namespace pinyon_shift::native_renderer {
+
+void InstallDrawCensus(rex::system::IGraphicsSystem* graphics_system) {
+  if (!graphics_system || !REXCVAR_GET(pinyon_shift_native_renderer_census)) {
+    return;
+  }
+  g_draw_census = {};
+  graphics_system->SetDrawObserver(&ObserveDraw);
+  const std::string capacity = std::to_string(kSignatureCapacity);
+  diagnostics::RecordEvent("native_renderer.census.installed",
+                           {{"signature_capacity", capacity},
+                            {"summary_limit", "16"},
+                            {"mode", "pass_through"}});
+}
+
+void UninstallDrawCensus(rex::system::IGraphicsSystem* graphics_system) {
+  if (graphics_system) {
+    graphics_system->SetDrawObserver(nullptr);
+  }
+}
+
+}  // namespace pinyon_shift::native_renderer
 
 // This translation unit is the single owner for title-side graphics hooks.
 // The hook runs immediately before FH1's sole VdSwap import and intentionally

--- a/src/native_renderer/graphics_hooks.h
+++ b/src/native_renderer/graphics_hooks.h
@@ -1,0 +1,12 @@
+#pragma once
+
+namespace rex::system {
+class IGraphicsSystem;
+}
+
+namespace pinyon_shift::native_renderer {
+
+void InstallDrawCensus(rex::system::IGraphicsSystem* graphics_system);
+void UninstallDrawCensus(rex::system::IGraphicsSystem* graphics_system);
+
+}  // namespace pinyon_shift::native_renderer

--- a/src/pinyon_shift_app.cpp
+++ b/src/pinyon_shift_app.cpp
@@ -18,6 +18,7 @@
 #include <rex/system/kernel_state.h>
 #include <rex/system/xthread.h>
 
+#include "native_renderer/graphics_hooks.h"
 #include "pinyon_shift_diagnostics.h"
 
 #include <cstdio>
@@ -298,6 +299,9 @@ void PinyonShiftApp::OnPostInitLogging() {
                          rex::cvar::GetFlagByName("disable_motion_blur")},
                         {"disable_depth_of_field",
                          rex::cvar::GetFlagByName("disable_depth_of_field")},
+                        {"native_renderer_census",
+                         rex::cvar::GetFlagByName(
+                             "pinyon_shift_native_renderer_census")},
                         {"occlusion_query", rex::cvar::GetFlagByName("occlusion_query")},
                         {"zpd_end_policy", rex::cvar::GetFlagByName("zpd_end_policy")},
                         {"zpd_end_fallback", rex::cvar::GetFlagByName("zpd_end_fallback")},
@@ -331,6 +335,8 @@ void PinyonShiftApp::OnPostLoadXexImage() {
 
 void PinyonShiftApp::OnPostSetup() {
   pinyon_shift::diagnostics::RefreshCrashReporter();
+  pinyon_shift::native_renderer::InstallDrawCensus(
+      runtime() ? runtime()->graphics_system() : nullptr);
   pinyon_shift::diagnostics::RecordEvent(
       "runtime.setup.complete",
       {{"memory", runtime() && runtime()->memory() ? "1" : "0"},
@@ -365,6 +371,8 @@ bool PinyonShiftApp::OnWindowCloseRequested() {
 }
 
 void PinyonShiftApp::OnShutdown() {
+  pinyon_shift::native_renderer::UninstallDrawCensus(
+      runtime() ? runtime()->graphics_system() : nullptr);
   RecordShutdownOnce();
 }
 

--- a/tools/tests/test_native_renderer_contract.py
+++ b/tools/tests/test_native_renderer_contract.py
@@ -24,9 +24,46 @@ class NativeRendererContractTests(unittest.TestCase):
         )
         self.assertIn("pinyon_shift_native_renderer_census, false", source)
         self.assertIn("kFrameSummaryInterval = 300", source)
+        self.assertIn("kSignatureCapacity = 4096", source)
+        self.assertIn("kSummaryLimit = 16", source)
+        self.assertIn("unique_signature_count", source)
+        self.assertIn("overflow_draw_count", source)
+        self.assertIn("kRequiresRestart", source)
         self.assertIn('"mode", "pass_through"', source)
         self.assertNotIn("REX_STORE", source)
         self.assertNotIn("GuestPtr", source)
+
+    def test_draw_observer_is_read_only_and_contains_no_payload(self):
+        patch = (ROOT / "patches/rexglue/0044-graphics-draw-observer.patch").read_text(
+            encoding="utf-8"
+        )
+        self.assertIn("GraphicsDrawObservation", patch)
+        self.assertIn("auto draw_observer = graphics_system_->draw_observer();", patch)
+        self.assertIn("if (draw_observer) {", patch)
+        self.assertIn("draw_observer(observation);", patch)
+        self.assertLess(
+            patch.index("draw_observer(observation);"),
+            patch.index("draw_succeeded = IssueDraw"),
+        )
+        self.assertLess(
+            patch.index("if (draw_observer) {"),
+            patch.index("GraphicsDrawObservation observation;"),
+        )
+        self.assertIn("vertex_shader_hash", patch)
+        self.assertIn("pixel_shader_hash", patch)
+        self.assertIn("vertex_memexport", patch)
+        for forbidden in ("shader_code", "texture_data", "vertex_data", "payload"):
+            self.assertNotIn(forbidden, patch)
+
+        source = (ROOT / "src/native_renderer/graphics_hooks.cpp").read_text(
+            encoding="utf-8"
+        )
+        signature = source.split("DrawSignature(", 1)[1].split(
+            "EmitDrawCensusWindow", 1
+        )[0]
+        self.assertIn("observation.primitive_type", signature)
+        self.assertIn("observation.source_select", signature)
+        self.assertNotIn("observation.initiator", signature)
 
     def test_first_pr_has_no_native_renderer_or_suppression_api(self):
         source = (ROOT / "src/native_renderer/graphics_hooks.cpp").read_text(

--- a/tools/tests/test_release_contract.py
+++ b/tools/tests/test_release_contract.py
@@ -43,10 +43,10 @@ class ReleaseContractTests(unittest.TestCase):
 
     def test_rexglue_patches_have_stable_order_and_no_binary_payload(self):
         patches = sorted((ROOT / "patches/rexglue").glob("*.patch"))
-        self.assertEqual(len(patches), 43)
+        self.assertEqual(len(patches), 44)
         self.assertEqual(
             patches[-1].name,
-            "0043-host-presentation-pacing-and-counters.patch",
+            "0044-graphics-draw-observer.patch",
         )
         self.assertEqual(len(patches), len({path.name[:4] for path in patches}))
         for path in patches:


### PR DESCRIPTION
## Summary

- add a backend-neutral, read-only draw observer immediately before Xenos draw submission
- aggregate shader, target, primitive, index, scissor, and memexport metadata into fixed 300-frame windows
- keep the feature restart-gated, default-off, payload-free, and strictly pass-through
- document the AppData qualification route and zero-overflow open-world results

## Safety

- no native rendering or emulated draw/resolve suppression
- the disabled path performs one null observer check and does not build metadata
- capture storage is fixed at 4096 signatures with at most 16 summaries per window
- Xenos remains the only renderer and fallback behavior is unchanged

## Validation

- `python -m unittest discover -s tools/tests -v` (50 passed)
- `tools/prepare-rexglue.ps1` (44 patches applied from the pinned SDK)
- `tools/build-preview.ps1 -Parallel 16` (clean commit-bound Release build)
- ReXGlue `unit_tests.exe` (245 passed, 4 documented skips)
- AppData census route: 1,929,185 draws across two open-world windows, zero overflow, zero crash/error/GPU-loss events, normal exit