### PR TITLE
docs: add optional project sponsorship

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: arcanite24

--- a/README.md
+++ b/README.md
@@ -79,3 +79,12 @@ them. See [Legal and distribution](docs/LEGAL.md) and
 Start with [CONTRIBUTING.md](CONTRIBUTING.md). Repository checks reject disc
 images, executables, generated translations, extracted assets, build products,
 and other machine-local material.
+
+## Supporting the project
+
+Pinyon Shift is and will remain free. If you would like to support its continued
+development, you can [sponsor arcanite24 on GitHub]. Sponsorship is entirely
+optional and does not provide builds, game content, support, or influence over
+the project roadmap.
+
+[sponsor arcanite24 on GitHub]: https://github.com/sponsors/arcanite24


### PR DESCRIPTION
## Summary
- add the native GitHub Sponsor button
- add a quiet README section for optional support
- clarify that sponsorship provides no builds, content, support, or roadmap influence

## Validation
- `git diff --check`