### PR TITLE
fix(launcher): publish v0.1.1 setup hotfix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.1.1 - 2026-08-27
+
+- Fixed launcher-package builds that completed translation but failed while
+  probing absent Git metadata.
+- Removed the packaged setup workflow's Python dependency by verifying codegen
+  warnings with Windows PowerShell.
+
 ## 0.1.0 - 2026-08-26
 
 - First Windows public playable preview.
@@ -18,5 +25,3 @@
   limitation list after the latest compatibility fixes.
 - Added launcher controls for validated graphics experiments, including 2x
   resolution scaling, anisotropic filtering, and post-effect selection.
-- Fixed launcher-package builds that completed translation but failed while
-  probing absent Git metadata, and removed Python from warning verification.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,3 +18,5 @@
   limitation list after the latest compatibility fixes.
 - Added launcher controls for validated graphics experiments, including 2x
   resolution scaling, anisotropic filtering, and post-effect selection.
+- Fixed launcher-package builds that completed translation but failed while
+  probing absent Git metadata, and removed Python from warning verification.

--- a/config/release.json
+++ b/config/release.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "version": "0.1.0",
+  "version": "0.1.1",
   "channel": "stable",
   "repository": "https://github.com/arcanite24/pinyon-shift"
 }

--- a/launcher/PinyonShift.Launcher/PinyonShift.Launcher.csproj
+++ b/launcher/PinyonShift.Launcher/PinyonShift.Launcher.csproj
@@ -8,9 +8,9 @@
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <AssemblyName>PinyonShiftLauncher</AssemblyName>
     <RootNamespace>PinyonShift.Launcher</RootNamespace>
-    <Version>0.1.0</Version>
-    <AssemblyVersion>0.1.0.0</AssemblyVersion>
-    <FileVersion>0.1.0.0</FileVersion>
+    <Version>0.1.1</Version>
+    <AssemblyVersion>0.1.1.0</AssemblyVersion>
+    <FileVersion>0.1.1.0</FileVersion>
     <Product>Pinyon Shift Launcher</Product>
     <Description>Builds Pinyon Shift locally from a verified user-supplied game disc image.</Description>
     <Authors>Pinyon Shift contributors</Authors>

--- a/tools/build-preview.ps1
+++ b/tools/build-preview.ps1
@@ -63,13 +63,15 @@ if ($requiresBootstrap) {
         }
         throw 'Local code generation failed; incomplete generation stamps were removed.'
     }
-    & python (Join-Path $PSScriptRoot 'verify-codegen-log.py') $codegenLog
-    if ($LASTEXITCODE -ne 0) {
+    try {
+        & (Join-Path $PSScriptRoot 'verify-codegen-log.ps1') -LogPath $codegenLog | Out-Host
+    }
+    catch {
         foreach ($tree in $generatedTrees) {
             $stamp = Join-Path $generatedRoot "$tree/codegen.build.stamp"
             if (Test-Path -LiteralPath $stamp) { Remove-Item -LiteralPath $stamp -Force }
         }
-        throw 'Code generation emitted an unreviewed warning; generation stamps were removed.'
+        throw "Code generation emitted an unreviewed warning; generation stamps were removed. $($_.Exception.Message)"
     }
 }
 else {
@@ -100,24 +102,9 @@ if (-not (Test-Path -LiteralPath $executable -PathType Leaf)) {
 }
 $manifestPath = Resolve-PinyonLocalPath -RelativePath '.local/build.json'
 $git = Get-PinyonGit
-$sourceProvenancePath = Join-Path $root 'config/source-provenance.json'
-$sourceCommit = $null
-$sourceDirty = $false
-$gitCommit = @(& $git -C $root rev-parse HEAD 2>$null | Select-Object -First 1)
-if ($gitCommit.Count -eq 1 -and $gitCommit[0] -match '^[0-9a-fA-F]{40}$') {
-    $sourceCommit = $gitCommit[0].ToLowerInvariant()
-    $sourceDirty = @(& $git -C $root status --porcelain).Count -ne 0
-}
-elseif (Test-Path -LiteralPath $sourceProvenancePath -PathType Leaf) {
-    $sourceProvenance = Get-Content -LiteralPath $sourceProvenancePath -Raw | ConvertFrom-Json
-    if ($sourceProvenance.commit -match '^[0-9a-fA-F]{40}$') {
-        $sourceCommit = $sourceProvenance.commit.ToLowerInvariant()
-        $sourceDirty = [bool]$sourceProvenance.dirty
-    }
-}
-if (-not $sourceCommit) {
-    throw 'Build provenance requires an exact Pinyon Shift commit.'
-}
+$sourceProvenance = Get-PinyonSourceProvenance -Root $root -Git $git
+$sourceCommit = $sourceProvenance.Commit
+$sourceDirty = $sourceProvenance.Dirty
 
 $patchMarkerPath = Join-Path $sdkRoot '.pinyon-patches.json'
 if (-not (Test-Path -LiteralPath $patchMarkerPath -PathType Leaf)) {

--- a/tools/package-launcher.ps1
+++ b/tools/package-launcher.ps1
@@ -66,7 +66,7 @@ $include = @(
     'tools/launch-preview.ps1', 'tools/prepare-rexglue.ps1',
     'tools/provision-toolchain.ps1', 'tools/release-common.ps1',
     'tools/set-graphics-experiment.ps1', 'tools/setup-preview.ps1',
-    'tools/verify-codegen-log.py', 'tools/verify-game.ps1'
+    'tools/verify-codegen-log.ps1', 'tools/verify-game.ps1'
 )
 foreach ($relative in $include) {
     $source = Join-Path $root $relative

--- a/tools/release-common.ps1
+++ b/tools/release-common.ps1
@@ -177,3 +177,40 @@ function Get-PinyonGit {
     }
     $candidate
 }
+
+function Get-PinyonSourceProvenance {
+    param(
+        [Parameter(Mandatory)] [string]$Root,
+        [Parameter(Mandatory)] [string]$Git
+    )
+
+    $sourceCommit = $null
+    $sourceDirty = $false
+    # Launcher payloads are source archives, not Git working trees. Avoid
+    # invoking Git there because Windows PowerShell promotes native stderr to a
+    # terminating error before the packaged provenance fallback can run.
+    if (Test-Path -LiteralPath (Join-Path $Root '.git')) {
+        $gitCommit = @(& $Git -C $Root rev-parse HEAD 2>$null | Select-Object -First 1)
+        if ($gitCommit.Count -eq 1 -and $gitCommit[0] -match '^[0-9a-fA-F]{40}$') {
+            $sourceCommit = $gitCommit[0].ToLowerInvariant()
+            $sourceDirty = @(& $Git -C $Root status --porcelain).Count -ne 0
+        }
+    }
+
+    if (-not $sourceCommit) {
+        $sourceProvenancePath = Join-Path $Root 'config/source-provenance.json'
+        if (Test-Path -LiteralPath $sourceProvenancePath -PathType Leaf) {
+            $sourceProvenance = Get-Content -LiteralPath $sourceProvenancePath -Raw |
+                ConvertFrom-Json
+            if ($sourceProvenance.commit -match '^[0-9a-fA-F]{40}$') {
+                $sourceCommit = $sourceProvenance.commit.ToLowerInvariant()
+                $sourceDirty = [bool]$sourceProvenance.dirty
+            }
+        }
+    }
+
+    if (-not $sourceCommit) {
+        throw 'Build provenance requires an exact Pinyon Shift commit.'
+    }
+    [pscustomobject]@{ Commit = $sourceCommit; Dirty = $sourceDirty }
+}

--- a/tools/tests/test_release_contract.py
+++ b/tools/tests/test_release_contract.py
@@ -154,12 +154,36 @@ class ReleaseContractTests(unittest.TestCase):
         required = {
             "build-preview.ps1", "create-crash-report.ps1", "install-build-tools.ps1", "launch-preview.ps1",
             "prepare-rexglue.ps1", "provision-toolchain.ps1", "release-common.ps1",
-            "set-graphics-experiment.ps1", "setup-preview.ps1", "verify-game.ps1",
+            "set-graphics-experiment.ps1", "setup-preview.ps1", "verify-codegen-log.ps1",
+            "verify-game.ps1",
         }
         self.assertTrue(required.issubset({p.name for p in (ROOT / "tools").glob("*.ps1")}))
         package_script = (ROOT / "tools/package-launcher.ps1").read_text(encoding="utf-8")
-        for shipped in ("set-graphics-experiment.ps1", "verify-codegen-log.py"):
+        for shipped in ("set-graphics-experiment.ps1", "verify-codegen-log.ps1"):
             self.assertIn(shipped, package_script)
+
+    @unittest.skipUnless(shutil.which("powershell"), "Windows PowerShell is required")
+    def test_packaged_source_provenance_does_not_require_a_git_worktree(self):
+        with tempfile.TemporaryDirectory(prefix="pinyon-provenance-") as temporary:
+            root = pathlib.Path(temporary)
+            (root / "config").mkdir()
+            commit = "a" * 40
+            (root / "config/source-provenance.json").write_text(
+                json.dumps({"schema_version": 1, "commit": commit, "dirty": False}),
+                encoding="utf-8",
+            )
+            command = (
+                f". '{ROOT / 'tools/release-common.ps1'}'; "
+                f"$result = Get-PinyonSourceProvenance -Root '{root}' "
+                "-Git 'Z:\\missing\\git.exe'; "
+                "[Console]::Out.Write($result.Commit + '|' + $result.Dirty)"
+            )
+            completed = subprocess.run(
+                ["powershell", "-NoLogo", "-NoProfile", "-Command", command],
+                capture_output=True, text=True,
+            )
+            self.assertEqual(completed.returncode, 0, completed.stderr)
+            self.assertEqual(completed.stdout, commit + "|False")
 
     def test_graphics_schema_and_diagnostics_contract(self):
         app = (ROOT / "src/pinyon_shift_app.cpp").read_text(encoding="utf-8")

--- a/tools/tests/test_repository_quality.py
+++ b/tools/tests/test_repository_quality.py
@@ -1,6 +1,7 @@
 import importlib.util
 import json
 import pathlib
+import shutil
 import subprocess
 import sys
 import tempfile
@@ -38,6 +39,40 @@ class RepositoryQualityTests(unittest.TestCase):
             log.write_text(log.read_text(encoding="utf-8") + "\n[warning] [codegen] surprise", encoding="utf-8")
             with self.assertRaisesRegex(ValueError, "unrecognized warnings"):
                 CODEGEN.verify(log, allowlist)
+
+    @unittest.skipUnless(shutil.which("powershell"), "Windows PowerShell is required")
+    def test_packaged_codegen_verifier_accepts_known_warnings_without_python(self):
+        known = [
+            "Function 0x8241A370 is 2536144 bytes, exceeds max_file_size_bytes (1048576)",
+            "bdz at 82AD8138 branches outside function to 82AD836C",
+            "bdz at 82AD813C branches outside function to 82AD836C",
+        ]
+        with tempfile.TemporaryDirectory() as temporary:
+            log = pathlib.Path(temporary) / "codegen.log"
+            log.write_text(
+                "\n".join(f"[warning] [codegen] [t1] {line}" for line in known),
+                encoding="utf-8",
+            )
+            completed = subprocess.run(
+                ["powershell", "-NoLogo", "-NoProfile", "-ExecutionPolicy", "Bypass",
+                 "-File", str(ROOT / "tools/verify-codegen-log.ps1"),
+                 "-LogPath", str(log)],
+                capture_output=True, text=True,
+            )
+            self.assertEqual(completed.returncode, 0, completed.stderr)
+            self.assertEqual(json.loads(completed.stdout)["warning_count"], 3)
+            log.write_text(
+                log.read_text(encoding="utf-8") + "\n[warning] [codegen] surprise",
+                encoding="utf-8",
+            )
+            rejected = subprocess.run(
+                ["powershell", "-NoLogo", "-NoProfile", "-ExecutionPolicy", "Bypass",
+                 "-File", str(ROOT / "tools/verify-codegen-log.ps1"),
+                 "-LogPath", str(log)],
+                capture_output=True, text=True,
+            )
+            self.assertNotEqual(rejected.returncode, 0)
+            self.assertIn("unrecognized warnings", rejected.stderr)
 
     def test_tracked_markdown_links_are_valid(self):
         self.assertEqual(LINKS.failures(ROOT, LINKS.tracked_markdown(ROOT)), [])

--- a/tools/verify-codegen-log.ps1
+++ b/tools/verify-codegen-log.ps1
@@ -1,0 +1,69 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)] [ValidateNotNullOrEmpty()] [string]$LogPath,
+    [string]$AllowlistPath
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$root = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
+if (-not $AllowlistPath) {
+    $AllowlistPath = Join-Path $root 'config/rexglue/accepted-codegen-warnings.json'
+}
+$resolvedLog = (Resolve-Path -LiteralPath $LogPath).Path
+$resolvedAllowlist = (Resolve-Path -LiteralPath $AllowlistPath).Path
+$config = Get-Content -LiteralPath $resolvedAllowlist -Raw | ConvertFrom-Json
+if ($config.schema_version -ne 1 -or $null -eq $config.warnings) {
+    throw 'Unsupported warning allowlist schema.'
+}
+
+$matches = [ordered]@{}
+foreach ($rule in @($config.warnings)) {
+    if ([string]::IsNullOrWhiteSpace($rule.id) -or
+        [string]::IsNullOrWhiteSpace($rule.pattern) -or
+        [string]::IsNullOrWhiteSpace($rule.reason)) {
+        throw 'Every accepted warning needs id, pattern, and reason.'
+    }
+    $matches[$rule.id] = 0
+}
+
+$warningPrefix = '\[warning\]\s+\[codegen\](?:\s+\[t\d+\])?\s+(?<message>.+)$'
+$unknown = [Collections.Generic.List[string]]::new()
+$warningCount = 0
+foreach ($line in [IO.File]::ReadLines($resolvedLog)) {
+    $marker = [regex]::Match($line, $warningPrefix, [Text.RegularExpressions.RegexOptions]::IgnoreCase)
+    if (-not $marker.Success) { continue }
+    $warningCount++
+    $message = $marker.Groups['message'].Value.Trim()
+    $matching = @($config.warnings | Where-Object {
+        [regex]::IsMatch($message, $_.pattern) -and
+        [regex]::Match($message, $_.pattern).Value -eq $message
+    })
+    if ($matching.Count -eq 1) {
+        $matches[$matching[0].id]++
+    } elseif ($matching.Count -eq 0) {
+        $unknown.Add($message)
+    } else {
+        $unknown.Add("ambiguous allowlist match: $message")
+    }
+}
+
+$missing = @($matches.Keys | Where-Object { $matches[$_] -eq 0 } | Sort-Object)
+if ($unknown.Count -gt 0 -or $missing.Count -gt 0) {
+    $details = [Collections.Generic.List[string]]::new()
+    if ($unknown.Count -gt 0) {
+        $details.Add('unrecognized warnings: ' + (($unknown | Sort-Object -Unique) -join ' | '))
+    }
+    if ($missing.Count -gt 0) {
+        $details.Add('expected warnings not observed: ' + ($missing -join ', '))
+    }
+    throw ($details -join '; ')
+}
+
+[ordered]@{
+    schema = 'pinyon-shift.codegen-warning-verification.v1'
+    log = [IO.Path]::GetFileName($resolvedLog)
+    warning_count = $warningCount
+    accepted = $matches
+} | ConvertTo-Json -Depth 4


### PR DESCRIPTION
## Summary

- make packaged setup use `config/source-provenance.json` without probing absent `.git` metadata
- replace packaged Python warning verification with a Windows PowerShell implementation
- publish the launcher and release metadata as stable version `0.1.1`

## User impact

This fixes the deterministic failure after `pinyon_shift.exe` links in the public `v0.1.0` launcher source package. Existing reports are tracked in #22 and #23.

## Validation

- `python -m unittest discover -s tools/tests -p "test_*.py"` (34 passed)
- `tools/check-repository-boundary.ps1`
- `python tools/check-markdown-links.py`
- `python tools/verify-release-tag.py --tag v0.1.1 --main-ref HEAD`
- `tools/package-launcher.ps1`
- packaged payload provenance check under Windows PowerShell 5.1 with no `.git` directory
- launcher ProductVersion `0.1.1`; packaged provenance commit matches the clean branch head