### PR TITLE
feat(renderer): track resolved texture dependencies

### DIFF
--- a/docs/native-renderer/GUEST_VISIBLE_RENDER_DEPENDENCIES.md
+++ b/docs/native-renderer/GUEST_VISIBLE_RENDER_DEPENDENCIES.md
@@ -97,11 +97,22 @@ that keeps suppression disabled.
 
 ## Qualification status
 
-The implementation and clean-build checks belong to the NR-00D pull request.
-A representative AppData-backed runtime capture must still record resolve and
-dependency counts, zero crash/GPU-loss events, bounded overflow values, and a
-normal exit before this ledger can carry a runtime snapshot.
+The NR-00D implementation was qualified with AppData-backed session
+`20260828T002134Z-p41584` on clean commit `d9a0d60`. The run reached 1,500
+emulated frames and exited normally. Its deterministic inventory reported:
 
-Gate B remains closed after that capture. CPU-read observation, presentation
+- 83,401 observed draws across 11 signatures.
+- 2,802 successful resolves totaling 10,558,832,640 bytes.
+- 1,397 later draws sampling a resolved target.
+- Two distinct resolve-to-texture dependency transitions.
+- Zero draw, target, and page-capacity overflows.
+- Zero crash, GPU-loss, and fatal diagnostic events.
+
+The clean executable SHA-256 was
+`D4A415992CF893553CF6AD6CF4821B8169EC8B741607D553BEE6E78162414662`.
+The machine-readable inventory remains a local evidence artifact because its
+source log contains machine-specific paths and session identifiers.
+
+Gate B remains closed after this capture. CPU-read observation, presentation
 provenance, and semantic classification are separate evidence tasks, not facts
 that may be inferred from the absence of a texture-fetch match.

--- a/docs/native-renderer/GUEST_VISIBLE_RENDER_DEPENDENCIES.md
+++ b/docs/native-renderer/GUEST_VISIBLE_RENDER_DEPENDENCIES.md
@@ -1,0 +1,107 @@
+# Guest-visible render dependencies
+
+This is the evidence ledger for NR-00D on the supported USA retail MS-2505
+executable. It describes what the renderer census proves, what remains unknown,
+and which unknowns block future draw or resolve suppression.
+
+## Safety conclusion
+
+No render target is suppression-eligible yet. The census can prove that a
+successful D3D12 resolve destination is sampled by a later vertex or pixel
+shader texture fetch. It does not yet prove that an unsampled target is
+presentation-only, that the guest CPU never reads it, or that it has no query,
+memexport, livery, thumbnail, mirror, exposure, shadow, or rewind role.
+
+Those missing facts keep Gate B closed. Xenos executes every draw and resolve,
+and all observer APIs are read-only and default-off.
+
+## Observation boundary
+
+ReXGlue patch `0045-graphics-resolve-dependency-observer.patch` extends the
+existing optional draw observer with texture-fetch addresses, conditional-draw
+state, and visibility-query state. It also adds a D3D12 copy observer after the
+existing resolve path returns. A copy record contains success, destination
+address and length, frame/copy sequence, and bounded register metadata.
+
+The observer does not contain shader code, texture bytes, constants, render
+target contents, vertex/index data, or any other guest payload. When no
+observer is registered, draw submission and resolve behavior are unchanged.
+
+## Bounded dependency graph
+
+The title-side census keeps two fixed-capacity tables for the lifetime of the
+process:
+
+- 4,096 resolve destinations keyed by guest physical base address.
+- 32,768 guest 4 KiB pages mapped to the most recently resolved destination.
+
+Each resolve range is page-indexed. Each later used base or mip texture fetch
+looks up its page and is accepted only when its exact address remains inside
+the destination's latest byte range. A draw is counted once per matched target,
+even when multiple fetch constants refer to it. Page, target, failed-copy, and
+zero-length overflow conditions are reported explicitly.
+
+The graph emits one `native_renderer.census.resolve_dependency` transition the
+first time each tracked target is sampled. This stream is bounded by the 4,096
+target capacity. Every 300 emulated frames it also emits one aggregate
+`resolve_window` record and at most 32 ranked `resolve_target` summaries. The
+graph remains persistent across windows so a later scene can still link to an
+earlier resolve.
+
+## Current classification matrix
+
+| Dependency question | Evidence available now | Current classification |
+| --- | --- | --- |
+| Later draw samples output | Resolve byte range matched against a used vertex/pixel base or mip fetch | `true` when observed; otherwise `unobserved`, not false |
+| Final presentation only | No native presentation-source observer yet | `unknown_uninstrumented` |
+| Guest CPU reads output | No bounded shared-memory read observer yet | `unknown_uninstrumented` |
+| Query depends on output | Conditional and active visibility-query state are correlated with sampling draws, but causality is not established | `related_draw_observed` or `unknown_uninstrumented` |
+| Memexport interaction | Sampling draws record whether the vertex shader has memexport | Correlation only; never proof of independence |
+| Livery / thumbnail / mirror / exposure / shadow / rewind | No pass classifier has assigned semantic roles yet | `unknown_unclassified` |
+| Safe to suppress | Requires all relevant dependencies to be replaced or proven unnecessary | `false` |
+
+An address absent from the dependency stream is not proof that it is
+presentation-only. Capacity overflow, an unobserved CPU read, a non-texture
+consumer, or an unclassified scene role may still exist.
+
+## Capture and inventory workflow
+
+Run the default-off census through the normal preview launcher. With the
+installed save, the explicit command is:
+
+```powershell
+.\tools\capture-native-renderer-census.ps1 `
+  -StateRoot "$env:LOCALAPPDATA\PinyonShift\source\0.1.0\.local\preview"
+```
+
+The wrapper verifies that the selected state root contains a `ForzaProfile`,
+refuses to launch over an existing process, sets only the census cvar for that
+child run, and delegates to `tools/launch-preview.ps1`. If `-StateRoot` is
+omitted, it selects the newest installed preview profile without copying or
+changing the save.
+
+Convert the diagnostic JSONL to a deterministic inventory with:
+
+```powershell
+$eventLog = Get-ChildItem "$stateRoot\logs\*.jsonl" |
+  Sort-Object LastWriteTimeUtc -Descending | Select-Object -First 1
+python .\tools\summarize-native-renderer-census.py `
+  $eventLog.FullName `
+  --output ".artifacts\native-renderer-census.json"
+```
+
+The summarizer selects the latest census-enabled session unless `--session` is
+provided. Its output includes aggregated draw signatures, every emitted
+resolve-to-texture dependency, overflow totals, and an explicit safety object
+that keeps suppression disabled.
+
+## Qualification status
+
+The implementation and clean-build checks belong to the NR-00D pull request.
+A representative AppData-backed runtime capture must still record resolve and
+dependency counts, zero crash/GPU-loss events, bounded overflow values, and a
+normal exit before this ledger can carry a runtime snapshot.
+
+Gate B remains closed after that capture. CPU-read observation, presentation
+provenance, and semantic classification are separate evidence tasks, not facts
+that may be inferred from the absence of a texture-fetch match.

--- a/docs/native-renderer/RENDER_PASS_CENSUS.md
+++ b/docs/native-renderer/RENDER_PASS_CENSUS.md
@@ -8,7 +8,7 @@ a trace or disassembly proves them.
 
 - Pinyon Shift `dev`: `cafc7233fef9e039f163d11023f40eccb22e8fc1`
 - ReXGlue: `v0.10.0` at `f5337cdc947ff6d4c4196737e2c807a48f2a1fc2`
-- ReXGlue patch stack: `0001` through `0044`
+- ReXGlue patch stack: `0001` through `0045`
 - `default.xex` SHA-256:
   `DB40DF605ADE49A612B35A7A24C38F6004BCB17A88ED6B48288DE16DF9E3987C`
 
@@ -89,5 +89,8 @@ read or serialize guest memory.
 - Map high-level world, vehicle, road, HUD, garage, mirror, shadow, exposure,
   livery, thumbnail, and rewind dispatch families.
 
-Bounded draw metadata, resolve dependencies, and pass classification belong to
-the subsequent NR-00 pull requests. Unknown work stays on Xenos.
+Resolve-to-texture dependency tracking is documented in
+`GUEST_VISIBLE_RENDER_DEPENDENCIES.md`. Pass classification, CPU-read
+observation, and presentation provenance remain subsequent NR-00 work.
+
+Unknown work stays on Xenos.

--- a/patches/rexglue/0045-graphics-resolve-dependency-observer.patch
+++ b/patches/rexglue/0045-graphics-resolve-dependency-observer.patch
@@ -1,0 +1,294 @@
+diff --git a/include/rex/graphics/command_processor.h b/include/rex/graphics/command_processor.h
+index 137274e..96dfb59 100644
+--- a/include/rex/graphics/command_processor.h
++++ b/include/rex/graphics/command_processor.h
+@@ -277,6 +277,7 @@ class CommandProcessor {
+   Shader* active_pixel_shader_ = nullptr;
+   uint64_t observation_frame_sequence_ = 1;
+   uint64_t observation_draw_sequence_ = 0;
++  uint64_t observation_copy_sequence_ = 0;
+ 
+   bool paused_ = false;
+ 
+diff --git a/include/rex/graphics/d3d12/command_processor.h b/include/rex/graphics/d3d12/command_processor.h
+index b9c89d6..7b24447 100644
+--- a/include/rex/graphics/d3d12/command_processor.h
++++ b/include/rex/graphics/d3d12/command_processor.h
+@@ -366,7 +366,8 @@ class D3D12CommandProcessor : public CommandProcessor {
+                                   uint32_t normalized_color_mask);
+   bool UpdateBindings(const D3D12Shader* vertex_shader, const D3D12Shader* pixel_shader,
+                       ID3D12RootSignature* root_signature, bool shared_memory_is_uav);
+-  bool IssueCopy_ReadbackResolvePath();
++  bool IssueCopy_ReadbackResolvePath(uint32_t& written_address_out,
++                                     uint32_t& written_length_out);
+   bool IssueDraw_MemexportReadbackFullPath(uint32_t total_size);
+   bool IssueDraw_MemexportReadbackFastPath(uint32_t total_size);
+ 
+diff --git a/include/rex/graphics/graphics_system.h b/include/rex/graphics/graphics_system.h
+index 2f92ddc..5ab0e9b 100644
+--- a/include/rex/graphics/graphics_system.h
++++ b/include/rex/graphics/graphics_system.h
+@@ -76,6 +76,12 @@ class GraphicsSystem : public system::IGraphicsSystem {
+   system::GraphicsDrawObserver draw_observer() const {
+     return draw_observer_.load(std::memory_order_acquire);
+   }
++  void SetCopyObserver(system::GraphicsCopyObserver observer) override {
++    copy_observer_.store(observer, std::memory_order_release);
++  }
++  system::GraphicsCopyObserver copy_observer() const {
++    return copy_observer_.load(std::memory_order_acquire);
++  }
+ 
+   void InitializeRingBuffer(uint32_t ptr, uint32_t size_log2) override;
+   void EnableReadPointerWriteBack(uint32_t ptr, uint32_t block_size_log2) override;
+@@ -136,6 +142,7 @@ class GraphicsSystem : public system::IGraphicsSystem {
+   std::unique_ptr<::rex::ui::Presenter> presenter_;
+ 
+   std::atomic<system::GraphicsDrawObserver> draw_observer_{nullptr};
++  std::atomic<system::GraphicsCopyObserver> copy_observer_{nullptr};
+ 
+   std::atomic_flag host_gpu_loss_reported_;
+ };
+diff --git a/include/rex/system/interfaces/graphics.h b/include/rex/system/interfaces/graphics.h
+index fb8a3c1..607a3cd 100644
+--- a/include/rex/system/interfaces/graphics.h
++++ b/include/rex/system/interfaces/graphics.h
+@@ -49,6 +49,11 @@ struct GraphicsDrawObservation {
+   uint32_t window_scissor_tl = 0;
+   uint32_t window_scissor_br = 0;
+   uint32_t rb_modecontrol = 0;
++  uint32_t viz_query_condition = 0;
++  uint32_t pa_sc_viz_query = 0;
++  uint32_t texture_fetch_mask = 0;
++  uint32_t texture_fetch_addresses[32] = {};
++  uint32_t texture_fetch_mip_addresses[32] = {};
+   bool indexed = false;
+   bool major_mode_explicit = false;
+   bool vertex_memexport = false;
+@@ -56,6 +61,23 @@ struct GraphicsDrawObservation {
+ 
+ using GraphicsDrawObserver = void (*)(const GraphicsDrawObservation& observation);
+ 
++struct GraphicsCopyObservation {
++  uint64_t frame_sequence = 0;
++  uint64_t copy_sequence = 0;
++  uint32_t written_address = 0;
++  uint32_t written_length = 0;
++  uint32_t rb_copy_control = 0;
++  uint32_t rb_copy_dest_base = 0;
++  uint32_t rb_copy_dest_info = 0;
++  uint32_t rb_copy_dest_pitch = 0;
++  uint32_t surface_info = 0;
++  uint32_t color_info[4] = {};
++  uint32_t depth_info = 0;
++  bool succeeded = false;
++};
++
++using GraphicsCopyObserver = void (*)(const GraphicsCopyObservation& observation);
++
+ class IGraphicsSystem {
+  public:
+   virtual ~IGraphicsSystem() = default;
+@@ -87,6 +109,9 @@ class IGraphicsSystem {
+   virtual void SetDrawObserver(GraphicsDrawObserver observer) {
+     (void)observer;
+   }
++  virtual void SetCopyObserver(GraphicsCopyObserver observer) {
++    (void)observer;
++  }
+ 
+   // Guest GPU services reached from the xboxkrnl Vd* exports.
+   virtual void SetInterruptCallback(uint32_t callback, uint32_t user_data) {
+diff --git a/src/graphics/command_processor.cpp b/src/graphics/command_processor.cpp
+index 48c7421..795d5ed 100644
+--- a/src/graphics/command_processor.cpp
++++ b/src/graphics/command_processor.cpp
+@@ -982,6 +982,7 @@ bool CommandProcessor::ExecutePacketType3_XE_SWAP(memory::RingBuffer* reader, ui
+ 
+   ++observation_frame_sequence_;
+   observation_draw_sequence_ = 0;
++  observation_copy_sequence_ = 0;
+ 
+   ++counter_;
+   return true;
+@@ -1508,6 +1509,26 @@ bool CommandProcessor::ExecutePacketType3Draw(memory::RingBuffer* reader, uint32
+         observation.window_scissor_br =
+             register_file_->Get<reg::PA_SC_WINDOW_SCISSOR_BR>().value;
+         observation.rb_modecontrol = register_file_->Get<reg::RB_MODECONTROL>().value;
++        observation.viz_query_condition = viz_query_condition;
++        observation.pa_sc_viz_query = viz_query.value;
++        auto capture_texture_fetches = [&](Shader* shader) {
++          if (!shader) {
++            return;
++          }
++          for (const Shader::TextureBinding& binding : shader->texture_bindings()) {
++            const uint32_t fetch_index = binding.fetch_constant;
++            if (fetch_index >= 32) {
++              continue;
++            }
++            const xenos::xe_gpu_texture_fetch_t fetch =
++                register_file_->GetTextureFetch(fetch_index);
++            observation.texture_fetch_mask |= uint32_t(1) << fetch_index;
++            observation.texture_fetch_addresses[fetch_index] = fetch.base_address << 12;
++            observation.texture_fetch_mip_addresses[fetch_index] = fetch.mip_address << 12;
++          }
++        };
++        capture_texture_fetches(active_vertex_shader_);
++        capture_texture_fetches(active_pixel_shader_);
+         draw_observer(observation);
+       }
+       draw_succeeded = IssueDraw(vgt_draw_initiator.prim_type, vgt_draw_initiator.num_indices,
+diff --git a/src/graphics/d3d12/command_processor.cpp b/src/graphics/d3d12/command_processor.cpp
+index 4b93a31..ea0f1cc 100644
+--- a/src/graphics/d3d12/command_processor.cpp
++++ b/src/graphics/d3d12/command_processor.cpp
+@@ -3049,39 +3049,64 @@ bool D3D12CommandProcessor::IssueCopy() {
+   if (!BeginSubmission(true)) {
+     return false;
+   }
++  uint32_t written_address = 0;
++  uint32_t written_length = 0;
+   ReadbackResolveMode readback_mode = GetReadbackResolveMode(REXCVAR_GET(d3d12_readback_resolve));
++  bool copy_succeeded;
+   if (readback_mode == ReadbackResolveMode::kDisabled) {
+-    uint32_t written_address, written_length;
+-    return render_target_cache_->Resolve(*memory_, *shared_memory_, *texture_cache_,
+-                                         written_address, written_length);
++    copy_succeeded = render_target_cache_->Resolve(*memory_, *shared_memory_, *texture_cache_,
++                                                   written_address, written_length);
++  } else {
++    copy_succeeded = IssueCopy_ReadbackResolvePath(written_address, written_length);
++  }
++
++  auto copy_observer = graphics_system_->copy_observer();
++  if (copy_observer) {
++    system::GraphicsCopyObservation observation;
++    observation.frame_sequence = observation_frame_sequence_;
++    observation.copy_sequence = ++observation_copy_sequence_;
++    observation.written_address = written_address;
++    observation.written_length = written_length;
++    observation.rb_copy_control = register_file_->Get<reg::RB_COPY_CONTROL>().value;
++    observation.rb_copy_dest_base = (*register_file_)[XE_GPU_REG_RB_COPY_DEST_BASE];
++    observation.rb_copy_dest_info = register_file_->Get<reg::RB_COPY_DEST_INFO>().value;
++    observation.rb_copy_dest_pitch = register_file_->Get<reg::RB_COPY_DEST_PITCH>().value;
++    observation.surface_info = register_file_->Get<reg::RB_SURFACE_INFO>().value;
++    for (uint32_t i = 0; i < 4; ++i) {
++      observation.color_info[i] =
++          (*register_file_)[reg::RB_COLOR_INFO::rt_register_indices[i]];
++    }
++    observation.depth_info = register_file_->Get<reg::RB_DEPTH_INFO>().value;
++    observation.succeeded = copy_succeeded;
++    copy_observer(observation);
+   }
+-  return IssueCopy_ReadbackResolvePath();
++  return copy_succeeded;
+ }
+ 
+-bool D3D12CommandProcessor::IssueCopy_ReadbackResolvePath() {
+-  uint32_t written_address, written_length;
+-  if (!render_target_cache_->Resolve(*memory_, *shared_memory_, *texture_cache_, written_address,
+-                                     written_length)) {
++bool D3D12CommandProcessor::IssueCopy_ReadbackResolvePath(uint32_t& written_address_out,
++                                                         uint32_t& written_length_out) {
++  if (!render_target_cache_->Resolve(*memory_, *shared_memory_, *texture_cache_,
++                                     written_address_out, written_length_out)) {
+     return false;
+   }
+ 
+-  if (!written_length) {
++  if (!written_length_out) {
+     return true;
+   }
+ 
+   PROFILE_RESOLVE_READBACK_REQUEST();
+ 
+-  if (!memory_->TranslatePhysical(written_address)) {
++  if (!memory_->TranslatePhysical(written_address_out)) {
+     return true;
+   }
+ 
+   bool is_scaled = texture_cache_->IsDrawResolutionScaled();
+-  uint64_t resolve_key = MakeReadbackResolveKey(written_address, written_length);
++  uint64_t resolve_key = MakeReadbackResolveKey(written_address_out, written_length_out);
+   ReadbackBuffer& rb = readback_buffers_[resolve_key];
+   rb.last_used_frame = frame_current_;
+ 
+   uint32_t write_index = rb.current_index;
+-  uint32_t size = AlignReadbackBufferSize(written_length);
++  uint32_t size = AlignReadbackBufferSize(written_length_out);
+ 
+   if (size > rb.sizes[write_index]) {
+     const ui::d3d12::D3D12Provider& provider = GetD3D12Provider();
+@@ -3133,7 +3158,7 @@ bool D3D12CommandProcessor::IssueCopy_ReadbackResolvePath() {
+       return true;
+     }
+     uint32_t tile_size_1x = 32 * 32 * (uint32_t(1) << pixel_size_log2);
+-    uint32_t tile_count = written_length / tile_size_1x;
++    uint32_t tile_count = written_length_out / tile_size_1x;
+     if (!tile_count) {
+       return true;
+     }
+@@ -3144,7 +3169,7 @@ bool D3D12CommandProcessor::IssueCopy_ReadbackResolvePath() {
+       return true;
+     }
+ 
+-    uint32_t downscale_buffer_size = AlignReadbackBufferSize(written_length);
++    uint32_t downscale_buffer_size = AlignReadbackBufferSize(written_length_out);
+     if (downscale_buffer_size > resolve_downscale_buffer_size_) {
+       const ui::d3d12::D3D12Provider& provider = GetD3D12Provider();
+       ID3D12Device* device = provider.GetDevice();
+@@ -3196,7 +3221,7 @@ bool D3D12CommandProcessor::IssueCopy_ReadbackResolvePath() {
+                                         scaled_resolve_buffer, aligned_scaled_length,
+                                         source_offset);
+     uint32_t aligned_written_length =
+-        rex::align(written_length, uint32_t(D3D12_RAW_UAV_SRV_BYTE_ALIGNMENT));
++        rex::align(written_length_out, uint32_t(D3D12_RAW_UAV_SRV_BYTE_ALIGNMENT));
+     ui::d3d12::util::CreateBufferRawUAV(device, downscale_descriptors[1].first,
+                                         resolve_downscale_buffer_.Get(), aligned_written_length, 0);
+ 
+@@ -3230,7 +3255,8 @@ bool D3D12CommandProcessor::IssueCopy_ReadbackResolvePath() {
+                           D3D12_RESOURCE_STATE_COPY_SOURCE);
+     SubmitBarriers();
+     deferred_command_list_.D3DCopyBufferRegion(rb.buffers[write_index], 0,
+-                                               resolve_downscale_buffer_.Get(), 0, written_length);
++                                               resolve_downscale_buffer_.Get(), 0,
++                                               written_length_out);
+     PushTransitionBarrier(resolve_downscale_buffer_.Get(), D3D12_RESOURCE_STATE_COPY_SOURCE,
+                           D3D12_RESOURCE_STATE_UNORDERED_ACCESS);
+     texture_cache_->TransitionCurrentScaledResolveRange(D3D12_RESOURCE_STATE_UNORDERED_ACCESS);
+@@ -3240,7 +3266,7 @@ bool D3D12CommandProcessor::IssueCopy_ReadbackResolvePath() {
+     SubmitBarriers();
+     ID3D12Resource* shared_memory_buffer = shared_memory_->GetBuffer();
+     deferred_command_list_.D3DCopyBufferRegion(rb.buffers[write_index], 0, shared_memory_buffer,
+-                                               written_address, written_length);
++                                               written_address_out, written_length_out);
+   }
+ 
+   ReadbackResolveMode readback_mode = GetReadbackResolveMode(REXCVAR_GET(d3d12_readback_resolve));
+@@ -3264,7 +3290,7 @@ bool D3D12CommandProcessor::IssueCopy_ReadbackResolvePath() {
+   }
+ 
+   bool is_cache_miss = false;
+-  if (use_delayed_sync && (!rb.buffers[read_index] || written_length > rb.sizes[read_index] ||
++  if (use_delayed_sync && (!rb.buffers[read_index] || written_length_out > rb.sizes[read_index] ||
+                            !rb.mapped_data[read_index])) {
+     PROFILE_RESOLVE_READBACK_CACHE_MISS();
+     is_cache_miss = true;
+@@ -3275,12 +3301,13 @@ bool D3D12CommandProcessor::IssueCopy_ReadbackResolvePath() {
+   }
+ 
+   bool should_copy = (readback_mode == ReadbackResolveMode::kSome) ? is_cache_miss : true;
+-  if (should_copy && rb.buffers[read_index] && written_length <= rb.sizes[read_index] &&
++  if (should_copy && rb.buffers[read_index] && written_length_out <= rb.sizes[read_index] &&
+       rb.mapped_data[read_index]) {
+-    uint8_t* destination = memory_->TranslatePhysical(written_address);
++    uint8_t* destination = memory_->TranslatePhysical(written_address_out);
+     if (destination) {
+-      std::memcpy(destination, static_cast<uint8_t*>(rb.mapped_data[read_index]), written_length);
+-      PROFILE_RESOLVE_READBACK_BYTES(written_length);
++      std::memcpy(destination, static_cast<uint8_t*>(rb.mapped_data[read_index]),
++                  written_length_out);
++      PROFILE_RESOLVE_READBACK_BYTES(written_length_out);
+       if (readback_mode == ReadbackResolveMode::kFast) {
+         PROFILE_RESOLVE_READBACK_FAST_COPY();
+       }

--- a/src/native_renderer/graphics_hooks.cpp
+++ b/src/native_renderer/graphics_hooks.cpp
@@ -3,7 +3,9 @@
 #include <atomic>
 #include <cstddef>
 #include <cstdint>
+#include <cstring>
 #include <string>
+#include <type_traits>
 
 #include <fmt/format.h>
 #include <rex/cvar.h>
@@ -95,6 +97,17 @@ struct DependencyCensus {
 };
 
 DependencyCensus g_dependency_census;
+
+static_assert(std::is_trivially_copyable_v<DrawCensus>);
+static_assert(std::is_trivially_copyable_v<DependencyCensus>);
+
+void ResetDrawCensus() {
+  std::memset(&g_draw_census, 0, sizeof(g_draw_census));
+}
+
+void ResetDependencyCensus() {
+  std::memset(&g_dependency_census, 0, sizeof(g_dependency_census));
+}
 
 uint64_t HashCombine(uint64_t hash, uint64_t value) {
   value += 0x9E3779B97F4A7C15ull + (hash << 6) + (hash >> 2);
@@ -412,7 +425,7 @@ void EmitDrawCensusWindow(uint64_t last_frame_value) {
          {"flags", flags}});
   }
 
-  g_draw_census = {};
+  ResetDrawCensus();
 }
 
 void ObserveCopy(const rex::system::GraphicsCopyObservation& observation) {
@@ -593,8 +606,8 @@ void InstallGraphicsCensus(rex::system::IGraphicsSystem* graphics_system) {
   if (!graphics_system || !REXCVAR_GET(pinyon_shift_native_renderer_census)) {
     return;
   }
-  g_draw_census = {};
-  g_dependency_census = {};
+  ResetDrawCensus();
+  ResetDependencyCensus();
   graphics_system->SetDrawObserver(&ObserveDraw);
   graphics_system->SetCopyObserver(&ObserveCopy);
   const std::string capacity = std::to_string(kSignatureCapacity);

--- a/src/native_renderer/graphics_hooks.cpp
+++ b/src/native_renderer/graphics_hooks.cpp
@@ -22,6 +22,10 @@ namespace {
 constexpr uint64_t kFrameSummaryInterval = 300;
 constexpr size_t kSignatureCapacity = 4096;
 constexpr size_t kSummaryLimit = 16;
+constexpr size_t kResolveTargetCapacity = 4096;
+constexpr size_t kResolvePageCapacity = 32768;
+constexpr size_t kResolveSummaryLimit = 32;
+constexpr uint64_t kGuestPageSize = 4096;
 std::atomic<uint64_t> g_frame_sequence{};
 
 struct DrawSignatureEntry {
@@ -35,6 +39,7 @@ struct DrawSignatureEntry {
 struct DrawCensus {
   std::array<DrawSignatureEntry, kSignatureCapacity> entries{};
   uint64_t window_first_frame = 0;
+  uint64_t window_last_frame = 0;
   uint64_t window_draw_count = 0;
   uint64_t unique_signature_count = 0;
   uint64_t overflow_draw_count = 0;
@@ -42,9 +47,270 @@ struct DrawCensus {
 
 DrawCensus g_draw_census;
 
+struct ResolveTargetEntry {
+  uint32_t address = 0;
+  uint32_t length = 0;
+  uint32_t maximum_length = 0;
+  uint32_t last_fetch_index = 0;
+  uint64_t resolve_count = 0;
+  uint64_t resolved_bytes = 0;
+  uint64_t first_resolve_frame = 0;
+  uint64_t last_resolve_frame = 0;
+  uint64_t sampled_draw_count = 0;
+  uint64_t sample_reference_count = 0;
+  uint64_t first_sample_frame = 0;
+  uint64_t last_sample_frame = 0;
+  uint64_t conditional_sample_draw_count = 0;
+  uint64_t query_state_sample_draw_count = 0;
+  uint64_t memexport_sample_draw_count = 0;
+  uint64_t window_resolve_count = 0;
+  uint64_t window_sampled_draw_count = 0;
+  bool last_fetch_was_mip = false;
+  rex::system::GraphicsCopyObservation sample;
+};
+
+struct ResolvePageEntry {
+  uint32_t page = 0;
+  uint32_t target_index_plus_one = 0;
+};
+
+struct DependencyCensus {
+  std::array<ResolveTargetEntry, kResolveTargetCapacity> targets{};
+  std::array<ResolvePageEntry, kResolvePageCapacity> pages{};
+  uint64_t window_first_frame = 0;
+  uint64_t window_last_frame = 0;
+  uint64_t window_resolve_count = 0;
+  uint64_t window_resolve_bytes = 0;
+  uint64_t window_failed_copy_count = 0;
+  uint64_t window_zero_length_copy_count = 0;
+  uint64_t window_sampled_draw_count = 0;
+  uint64_t window_sample_reference_count = 0;
+  uint64_t window_sampled_target_count = 0;
+  uint64_t window_query_draw_count = 0;
+  uint64_t window_memexport_draw_count = 0;
+  uint64_t target_count = 0;
+  uint64_t target_overflow_count = 0;
+  uint64_t page_count = 0;
+  uint64_t page_overflow_count = 0;
+};
+
+DependencyCensus g_dependency_census;
+
 uint64_t HashCombine(uint64_t hash, uint64_t value) {
   value += 0x9E3779B97F4A7C15ull + (hash << 6) + (hash >> 2);
   return hash ^ value;
+}
+
+size_t ResolveTargetIndex(uint32_t address) {
+  size_t index = size_t(HashCombine(0xCBF29CE484222325ull, address) %
+                        kResolveTargetCapacity);
+  for (size_t probe = 0; probe < kResolveTargetCapacity; ++probe) {
+    const ResolveTargetEntry& entry = g_dependency_census.targets[index];
+    if (!entry.resolve_count || entry.address == address) {
+      return index;
+    }
+    index = (index + 1) % kResolveTargetCapacity;
+  }
+  return kResolveTargetCapacity;
+}
+
+void MapResolvePage(uint32_t page, size_t target_index) {
+  size_t index = size_t(HashCombine(0x9E3779B97F4A7C15ull, page) %
+                        kResolvePageCapacity);
+  for (size_t probe = 0; probe < kResolvePageCapacity; ++probe) {
+    ResolvePageEntry& entry = g_dependency_census.pages[index];
+    if (!entry.target_index_plus_one) {
+      entry.page = page;
+      entry.target_index_plus_one = uint32_t(target_index + 1);
+      ++g_dependency_census.page_count;
+      return;
+    }
+    if (entry.page == page) {
+      entry.target_index_plus_one = uint32_t(target_index + 1);
+      return;
+    }
+    index = (index + 1) % kResolvePageCapacity;
+  }
+  ++g_dependency_census.page_overflow_count;
+}
+
+void MapResolveRange(size_t target_index, uint32_t address, uint32_t length) {
+  const uint64_t first_page = uint64_t(address) / kGuestPageSize;
+  const uint64_t last_address = uint64_t(address) + uint64_t(length) - 1;
+  const uint64_t last_page = last_address / kGuestPageSize;
+  const uint64_t page_count = last_page - first_page + 1;
+  const uint64_t bounded_page_count =
+      std::min<uint64_t>(page_count, kResolvePageCapacity);
+  for (uint64_t offset = 0; offset < bounded_page_count; ++offset) {
+    MapResolvePage(uint32_t(first_page + offset), target_index);
+  }
+  if (page_count > bounded_page_count) {
+    g_dependency_census.page_overflow_count +=
+        page_count - bounded_page_count;
+  }
+}
+
+size_t FindResolveTarget(uint32_t address) {
+  const uint32_t page = uint32_t(uint64_t(address) / kGuestPageSize);
+  size_t index = size_t(HashCombine(0x9E3779B97F4A7C15ull, page) %
+                        kResolvePageCapacity);
+  for (size_t probe = 0; probe < kResolvePageCapacity; ++probe) {
+    const ResolvePageEntry& page_entry = g_dependency_census.pages[index];
+    if (!page_entry.target_index_plus_one) {
+      return kResolveTargetCapacity;
+    }
+    if (page_entry.page == page) {
+      const size_t target_index = page_entry.target_index_plus_one - 1;
+      const ResolveTargetEntry& target =
+          g_dependency_census.targets[target_index];
+      const uint64_t target_end =
+          uint64_t(target.address) + uint64_t(target.length);
+      return address >= target.address && uint64_t(address) < target_end
+                 ? target_index
+                 : kResolveTargetCapacity;
+    }
+    index = (index + 1) % kResolvePageCapacity;
+  }
+  return kResolveTargetCapacity;
+}
+
+void BeginDependencyWindow(uint64_t frame) {
+  if (!g_dependency_census.window_first_frame) {
+    g_dependency_census.window_first_frame = frame;
+  }
+  g_dependency_census.window_last_frame =
+      std::max(g_dependency_census.window_last_frame, frame);
+}
+
+void ResetDependencyWindow() {
+  g_dependency_census.window_first_frame = 0;
+  g_dependency_census.window_last_frame = 0;
+  g_dependency_census.window_resolve_count = 0;
+  g_dependency_census.window_resolve_bytes = 0;
+  g_dependency_census.window_failed_copy_count = 0;
+  g_dependency_census.window_zero_length_copy_count = 0;
+  g_dependency_census.window_sampled_draw_count = 0;
+  g_dependency_census.window_sample_reference_count = 0;
+  g_dependency_census.window_sampled_target_count = 0;
+  g_dependency_census.window_query_draw_count = 0;
+  g_dependency_census.window_memexport_draw_count = 0;
+  for (ResolveTargetEntry& target : g_dependency_census.targets) {
+    target.window_resolve_count = 0;
+    target.window_sampled_draw_count = 0;
+  }
+}
+
+void EmitDependencyCensusWindow() {
+  if (!g_dependency_census.window_first_frame) {
+    return;
+  }
+
+  const auto number = [](uint64_t value) { return std::to_string(value); };
+  pinyon_shift::diagnostics::RecordEvent(
+      "native_renderer.census.resolve_window",
+      {{"first_frame", number(g_dependency_census.window_first_frame)},
+       {"last_frame", number(g_dependency_census.window_last_frame)},
+       {"resolves", number(g_dependency_census.window_resolve_count)},
+       {"resolve_bytes", number(g_dependency_census.window_resolve_bytes)},
+       {"failed_copies", number(g_dependency_census.window_failed_copy_count)},
+       {"zero_length_copies",
+        number(g_dependency_census.window_zero_length_copy_count)},
+       {"sampled_draws",
+        number(g_dependency_census.window_sampled_draw_count)},
+       {"sample_references",
+        number(g_dependency_census.window_sample_reference_count)},
+       {"sampled_targets",
+        number(g_dependency_census.window_sampled_target_count)},
+       {"query_draws", number(g_dependency_census.window_query_draw_count)},
+       {"memexport_draws",
+        number(g_dependency_census.window_memexport_draw_count)},
+       {"tracked_targets", number(g_dependency_census.target_count)},
+       {"target_overflow", number(g_dependency_census.target_overflow_count)},
+       {"tracked_pages", number(g_dependency_census.page_count)},
+       {"page_overflow", number(g_dependency_census.page_overflow_count)},
+       {"target_capacity", "4096"},
+       {"page_capacity", "32768"},
+       {"summary_limit", "32"}});
+
+  std::array<size_t, kResolveTargetCapacity> order{};
+  for (size_t i = 0; i < order.size(); ++i) {
+    order[i] = i;
+  }
+  std::sort(order.begin(), order.end(), [](size_t left, size_t right) {
+    const ResolveTargetEntry& left_entry =
+        g_dependency_census.targets[left];
+    const ResolveTargetEntry& right_entry =
+        g_dependency_census.targets[right];
+    const uint64_t left_activity = left_entry.window_resolve_count +
+                                   left_entry.window_sampled_draw_count;
+    const uint64_t right_activity = right_entry.window_resolve_count +
+                                    right_entry.window_sampled_draw_count;
+    if (left_activity != right_activity) {
+      return left_activity > right_activity;
+    }
+    return left_entry.address < right_entry.address;
+  });
+
+  size_t emitted = 0;
+  for (size_t target_index : order) {
+    const ResolveTargetEntry& target =
+        g_dependency_census.targets[target_index];
+    if ((!target.window_resolve_count && !target.window_sampled_draw_count) ||
+        emitted == kResolveSummaryLimit) {
+      break;
+    }
+    const bool sampled = target.sampled_draw_count != 0;
+    const std::string query_relation =
+        target.conditional_sample_draw_count ||
+                target.query_state_sample_draw_count
+            ? "related_draw_observed"
+            : "unknown_uninstrumented";
+    pinyon_shift::diagnostics::RecordEvent(
+        "native_renderer.census.resolve_target",
+        {{"rank", number(++emitted)},
+         {"address", fmt::format("{:08X}", target.address)},
+         {"length", number(target.length)},
+         {"maximum_length", number(target.maximum_length)},
+         {"resolves", number(target.resolve_count)},
+         {"resolved_bytes", number(target.resolved_bytes)},
+         {"first_resolve_frame", number(target.first_resolve_frame)},
+         {"last_resolve_frame", number(target.last_resolve_frame)},
+         {"sampled_later", sampled ? "true" : "unobserved"},
+         {"sampled_draws", number(target.sampled_draw_count)},
+         {"sample_references", number(target.sample_reference_count)},
+         {"first_sample_frame", number(target.first_sample_frame)},
+         {"last_sample_frame", number(target.last_sample_frame)},
+         {"conditional_sample_draws",
+          number(target.conditional_sample_draw_count)},
+         {"query_state_sample_draws",
+          number(target.query_state_sample_draw_count)},
+         {"memexport_sample_draws",
+          number(target.memexport_sample_draw_count)},
+         {"last_fetch_index", number(target.last_fetch_index)},
+         {"last_fetch_kind", target.last_fetch_was_mip ? "mip" : "base"},
+         {"copy_state",
+          fmt::format("{:08X}:{:08X}:{:08X}:{:08X}",
+                      target.sample.rb_copy_control,
+                      target.sample.rb_copy_dest_info,
+                      target.sample.rb_copy_dest_pitch,
+                      target.sample.surface_info)},
+         {"presentation_only", "unknown_uninstrumented"},
+         {"guest_cpu_read", "unknown_uninstrumented"},
+         {"query_dependency", query_relation},
+         {"semantic_role", "unknown_unclassified"},
+         {"suppression_eligible", "false"}});
+  }
+
+  ResetDependencyWindow();
+}
+
+void AdvanceDependencyWindow(uint64_t frame) {
+  if (g_dependency_census.window_first_frame &&
+      frame >= g_dependency_census.window_first_frame +
+                   kFrameSummaryInterval) {
+    EmitDependencyCensusWindow();
+  }
+  BeginDependencyWindow(frame);
 }
 
 uint64_t DrawSignature(const rex::system::GraphicsDrawObservation& observation) {
@@ -68,7 +334,7 @@ uint64_t DrawSignature(const rex::system::GraphicsDrawObservation& observation) 
   return hash ? hash : 1;
 }
 
-void EmitDrawCensusWindow(uint64_t next_frame) {
+void EmitDrawCensusWindow(uint64_t last_frame_value) {
   std::array<size_t, kSignatureCapacity> order{};
   for (size_t i = 0; i < order.size(); ++i) {
     order[i] = i;
@@ -84,7 +350,7 @@ void EmitDrawCensusWindow(uint64_t next_frame) {
 
   const std::string first_frame =
       std::to_string(g_draw_census.window_first_frame);
-  const std::string last_frame = std::to_string(next_frame - 1);
+  const std::string last_frame = std::to_string(last_frame_value);
   const std::string draws = std::to_string(g_draw_census.window_draw_count);
   const std::string unique =
       std::to_string(g_draw_census.unique_signature_count);
@@ -149,14 +415,151 @@ void EmitDrawCensusWindow(uint64_t next_frame) {
   g_draw_census = {};
 }
 
+void ObserveCopy(const rex::system::GraphicsCopyObservation& observation) {
+  AdvanceDependencyWindow(observation.frame_sequence);
+  if (!observation.succeeded) {
+    ++g_dependency_census.window_failed_copy_count;
+    return;
+  }
+  if (!observation.written_length) {
+    ++g_dependency_census.window_zero_length_copy_count;
+    return;
+  }
+
+  ++g_dependency_census.window_resolve_count;
+  g_dependency_census.window_resolve_bytes += observation.written_length;
+  const size_t target_index = ResolveTargetIndex(observation.written_address);
+  if (target_index == kResolveTargetCapacity) {
+    ++g_dependency_census.target_overflow_count;
+    return;
+  }
+
+  ResolveTargetEntry& target = g_dependency_census.targets[target_index];
+  if (!target.resolve_count) {
+    target.address = observation.written_address;
+    target.first_resolve_frame = observation.frame_sequence;
+    ++g_dependency_census.target_count;
+  }
+  target.length = observation.written_length;
+  target.maximum_length =
+      std::max(target.maximum_length, observation.written_length);
+  ++target.resolve_count;
+  target.resolved_bytes += observation.written_length;
+  target.last_resolve_frame = observation.frame_sequence;
+  ++target.window_resolve_count;
+  target.sample = observation;
+  MapResolveRange(target_index, observation.written_address,
+                  observation.written_length);
+}
+
+void EmitResolvedTextureDependency(
+    const rex::system::GraphicsDrawObservation& observation,
+    const ResolveTargetEntry& target, uint32_t fetch_index, bool is_mip) {
+  pinyon_shift::diagnostics::RecordEvent(
+      "native_renderer.census.resolve_dependency",
+      {{"address", fmt::format("{:08X}", target.address)},
+       {"length", std::to_string(target.length)},
+       {"resolve_frame", std::to_string(target.last_resolve_frame)},
+       {"sample_frame", std::to_string(observation.frame_sequence)},
+       {"sample_draw", std::to_string(observation.draw_sequence)},
+       {"fetch_index", std::to_string(fetch_index)},
+       {"fetch_kind", is_mip ? "mip" : "base"},
+       {"conditional_draw",
+        observation.viz_query_condition ? "true" : "false"},
+       {"query_state", (observation.pa_sc_viz_query & 1) ? "true" : "false"},
+       {"memexport_draw", observation.vertex_memexport ? "true" : "false"},
+       {"presentation_only", "unknown_uninstrumented"},
+       {"guest_cpu_read", "unknown_uninstrumented"},
+       {"query_dependency", "unknown_uninstrumented"},
+       {"semantic_role", "unknown_unclassified"},
+       {"suppression_eligible", "false"}});
+}
+
+void ObserveResolvedFetch(
+    const rex::system::GraphicsDrawObservation& observation,
+    uint32_t fetch_index, uint32_t address, bool is_mip,
+    std::array<size_t, 64>& sampled_targets, size_t& sampled_target_count) {
+  if (!address) {
+    return;
+  }
+  const size_t target_index = FindResolveTarget(address);
+  if (target_index == kResolveTargetCapacity) {
+    return;
+  }
+
+  ResolveTargetEntry& target = g_dependency_census.targets[target_index];
+  ++target.sample_reference_count;
+  ++g_dependency_census.window_sample_reference_count;
+  target.last_fetch_index = fetch_index;
+  target.last_fetch_was_mip = is_mip;
+  for (size_t i = 0; i < sampled_target_count; ++i) {
+    if (sampled_targets[i] == target_index) {
+      return;
+    }
+  }
+  sampled_targets[sampled_target_count++] = target_index;
+
+  const bool first_sample = !target.sampled_draw_count;
+  if (first_sample) {
+    target.first_sample_frame = observation.frame_sequence;
+  }
+  if (!target.window_sampled_draw_count) {
+    ++g_dependency_census.window_sampled_target_count;
+  }
+  ++target.sampled_draw_count;
+  ++target.window_sampled_draw_count;
+  target.last_sample_frame = observation.frame_sequence;
+  if (observation.viz_query_condition) {
+    ++target.conditional_sample_draw_count;
+  }
+  if (observation.pa_sc_viz_query & 1) {
+    ++target.query_state_sample_draw_count;
+  }
+  if (observation.vertex_memexport) {
+    ++target.memexport_sample_draw_count;
+  }
+  if (first_sample) {
+    EmitResolvedTextureDependency(observation, target, fetch_index, is_mip);
+  }
+}
+
 void ObserveDraw(const rex::system::GraphicsDrawObservation& observation) {
+  AdvanceDependencyWindow(observation.frame_sequence);
+  const bool query_draw = observation.viz_query_condition ||
+                          (observation.pa_sc_viz_query & 1);
+  if (query_draw) {
+    ++g_dependency_census.window_query_draw_count;
+  }
+  if (observation.vertex_memexport) {
+    ++g_dependency_census.window_memexport_draw_count;
+  }
+
+  std::array<size_t, 64> sampled_targets{};
+  size_t sampled_target_count = 0;
+  for (uint32_t fetch_index = 0; fetch_index < 32; ++fetch_index) {
+    if (!(observation.texture_fetch_mask & (uint32_t(1) << fetch_index))) {
+      continue;
+    }
+    ObserveResolvedFetch(observation, fetch_index,
+                         observation.texture_fetch_addresses[fetch_index], false,
+                         sampled_targets, sampled_target_count);
+    ObserveResolvedFetch(
+        observation, fetch_index,
+        observation.texture_fetch_mip_addresses[fetch_index], true,
+        sampled_targets, sampled_target_count);
+  }
+  if (sampled_target_count) {
+    ++g_dependency_census.window_sampled_draw_count;
+  }
+
   if (!g_draw_census.window_first_frame) {
     g_draw_census.window_first_frame = observation.frame_sequence;
   } else if (observation.frame_sequence >=
              g_draw_census.window_first_frame + kFrameSummaryInterval) {
-    EmitDrawCensusWindow(observation.frame_sequence);
+    EmitDrawCensusWindow(observation.frame_sequence - 1);
     g_draw_census.window_first_frame = observation.frame_sequence;
   }
+  g_draw_census.window_last_frame = observation.frame_sequence;
 
   ++g_draw_census.window_draw_count;
   const uint64_t signature = DrawSignature(observation);
@@ -186,23 +589,33 @@ void ObserveDraw(const rex::system::GraphicsDrawObservation& observation) {
 
 namespace pinyon_shift::native_renderer {
 
-void InstallDrawCensus(rex::system::IGraphicsSystem* graphics_system) {
+void InstallGraphicsCensus(rex::system::IGraphicsSystem* graphics_system) {
   if (!graphics_system || !REXCVAR_GET(pinyon_shift_native_renderer_census)) {
     return;
   }
   g_draw_census = {};
+  g_dependency_census = {};
   graphics_system->SetDrawObserver(&ObserveDraw);
+  graphics_system->SetCopyObserver(&ObserveCopy);
   const std::string capacity = std::to_string(kSignatureCapacity);
   diagnostics::RecordEvent("native_renderer.census.installed",
                            {{"signature_capacity", capacity},
                             {"summary_limit", "16"},
+                            {"resolve_target_capacity", "4096"},
+                            {"resolve_page_capacity", "32768"},
+                            {"resolve_summary_limit", "32"},
                             {"mode", "pass_through"}});
 }
 
-void UninstallDrawCensus(rex::system::IGraphicsSystem* graphics_system) {
+void UninstallGraphicsCensus(rex::system::IGraphicsSystem* graphics_system) {
   if (graphics_system) {
     graphics_system->SetDrawObserver(nullptr);
+    graphics_system->SetCopyObserver(nullptr);
   }
+  if (g_draw_census.window_first_frame && g_draw_census.window_draw_count) {
+    EmitDrawCensusWindow(g_draw_census.window_last_frame);
+  }
+  EmitDependencyCensusWindow();
 }
 
 }  // namespace pinyon_shift::native_renderer

--- a/src/native_renderer/graphics_hooks.h
+++ b/src/native_renderer/graphics_hooks.h
@@ -6,7 +6,7 @@ class IGraphicsSystem;
 
 namespace pinyon_shift::native_renderer {
 
-void InstallDrawCensus(rex::system::IGraphicsSystem* graphics_system);
-void UninstallDrawCensus(rex::system::IGraphicsSystem* graphics_system);
+void InstallGraphicsCensus(rex::system::IGraphicsSystem* graphics_system);
+void UninstallGraphicsCensus(rex::system::IGraphicsSystem* graphics_system);
 
 }  // namespace pinyon_shift::native_renderer

--- a/src/pinyon_shift_app.cpp
+++ b/src/pinyon_shift_app.cpp
@@ -335,7 +335,7 @@ void PinyonShiftApp::OnPostLoadXexImage() {
 
 void PinyonShiftApp::OnPostSetup() {
   pinyon_shift::diagnostics::RefreshCrashReporter();
-  pinyon_shift::native_renderer::InstallDrawCensus(
+  pinyon_shift::native_renderer::InstallGraphicsCensus(
       runtime() ? runtime()->graphics_system() : nullptr);
   pinyon_shift::diagnostics::RecordEvent(
       "runtime.setup.complete",
@@ -371,7 +371,7 @@ bool PinyonShiftApp::OnWindowCloseRequested() {
 }
 
 void PinyonShiftApp::OnShutdown() {
-  pinyon_shift::native_renderer::UninstallDrawCensus(
+  pinyon_shift::native_renderer::UninstallGraphicsCensus(
       runtime() ? runtime()->graphics_system() : nullptr);
   RecordShutdownOnce();
 }

--- a/tools/capture-native-renderer-census.ps1
+++ b/tools/capture-native-renderer-census.ps1
@@ -1,0 +1,47 @@
+[CmdletBinding()]
+param(
+    [string]$StateRoot,
+    [switch]$Json
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+if (-not $StateRoot) {
+    $sourceRoot = Join-Path $env:LOCALAPPDATA 'PinyonShift\source'
+    $profile = Get-ChildItem -LiteralPath $sourceRoot -Recurse -File -ErrorAction SilentlyContinue |
+        Where-Object { $_.Name -eq 'ForzaProfile' -and $_.Directory.Name -eq 'ForzaProfile' } |
+        Sort-Object LastWriteTimeUtc -Descending |
+        Select-Object -First 1
+    if ($null -eq $profile) {
+        throw "No installed preview ForzaProfile was found under $sourceRoot"
+    }
+    $separator = [IO.Path]::DirectorySeparatorChar
+    $marker = "${separator}user${separator}"
+    $markerIndex = $profile.FullName.IndexOf($marker, [StringComparison]::OrdinalIgnoreCase)
+    if ($markerIndex -lt 0) {
+        throw "The discovered profile is not under a preview user tree: $($profile.FullName)"
+    }
+    $StateRoot = $profile.FullName.Substring(0, $markerIndex)
+}
+
+$resolvedStateRoot = [IO.Path]::GetFullPath($StateRoot)
+$profiles = @(Get-ChildItem -LiteralPath (Join-Path $resolvedStateRoot 'user') `
+    -Recurse -File -ErrorAction SilentlyContinue |
+    Where-Object { $_.Name -eq 'ForzaProfile' -and $_.Directory.Name -eq 'ForzaProfile' })
+if ($profiles.Count -eq 0) {
+    throw "No ForzaProfile save exists under $resolvedStateRoot\user"
+}
+if (@(Get-Process -Name 'pinyon_shift' -ErrorAction SilentlyContinue).Count -ne 0) {
+    throw 'Pinyon Shift is already running.'
+}
+
+$savedCensus = $env:REX_PINYON_SHIFT_NATIVE_RENDERER_CENSUS
+try {
+    $env:REX_PINYON_SHIFT_NATIVE_RENDERER_CENSUS = 'true'
+    & (Join-Path $PSScriptRoot 'launch-preview.ps1') `
+        -StateRoot $resolvedStateRoot -Json:$Json
+}
+finally {
+    $env:REX_PINYON_SHIFT_NATIVE_RENDERER_CENSUS = $savedCensus
+}

--- a/tools/summarize-native-renderer-census.py
+++ b/tools/summarize-native-renderer-census.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python3
+"""Build a bounded machine-readable inventory from renderer census JSONL."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any, Iterable
+
+
+SCHEMA = "pinyon-shift.native-renderer-census.v1"
+PREFIX = "native_renderer.census."
+
+
+def read_events(paths: Iterable[Path]) -> list[dict[str, Any]]:
+    events: list[dict[str, Any]] = []
+    for path in paths:
+        with path.open("r", encoding="utf-8") as source:
+            for line_number, line in enumerate(source, 1):
+                if not line.strip():
+                    continue
+                try:
+                    event = json.loads(line)
+                except json.JSONDecodeError as error:
+                    raise ValueError(f"{path}:{line_number}: invalid JSON: {error}") from error
+                if str(event.get("event", "")).startswith(PREFIX):
+                    events.append(event)
+    return events
+
+
+def integer(event: dict[str, Any], key: str) -> int:
+    return int(event.get(key, 0))
+
+
+def select_session(events: list[dict[str, Any]], requested: str | None) -> str:
+    if requested:
+        if not any(event.get("session") == requested for event in events):
+            raise ValueError(f"census session not found: {requested}")
+        return requested
+    installed = [
+        event.get("session", "")
+        for event in events
+        if event.get("event") == f"{PREFIX}installed"
+    ]
+    candidates = installed or [event.get("session", "") for event in events]
+    if not candidates or not candidates[-1]:
+        raise ValueError("no native-renderer census session found")
+    return str(candidates[-1])
+
+
+def summarize(paths: Iterable[Path], session: str | None = None) -> dict[str, Any]:
+    paths = list(paths)
+    events = read_events(paths)
+    selected_session = select_session(events, session)
+    events = [event for event in events if event.get("session") == selected_session]
+
+    draw_signatures: dict[str, dict[str, Any]] = {}
+    dependencies: dict[str, dict[str, Any]] = {}
+    resolve_targets: dict[str, dict[str, Any]] = {}
+    totals = {
+        "draws": 0,
+        "resolves": 0,
+        "resolve_bytes": 0,
+        "sampled_draws": 0,
+        "sample_references": 0,
+        "query_draws": 0,
+        "memexport_draws": 0,
+        "draw_overflow": 0,
+        "target_overflow": 0,
+        "page_overflow": 0,
+    }
+
+    for event in events:
+        kind = event.get("event")
+        if kind == f"{PREFIX}draw_window":
+            totals["draws"] += integer(event, "draws")
+            totals["draw_overflow"] += integer(event, "overflow_draws")
+        elif kind == f"{PREFIX}draw_signature":
+            key = str(event["signature"])
+            record = draw_signatures.get(key)
+            if record is None:
+                draw_signatures[key] = dict(event)
+            else:
+                record["draws"] = str(integer(record, "draws") + integer(event, "draws"))
+                record["first_frame"] = str(
+                    min(integer(record, "first_frame"), integer(event, "first_frame"))
+                )
+                record["last_frame"] = str(
+                    max(integer(record, "last_frame"), integer(event, "last_frame"))
+                )
+        elif kind == f"{PREFIX}resolve_window":
+            for key in (
+                "resolves",
+                "resolve_bytes",
+                "sampled_draws",
+                "sample_references",
+                "query_draws",
+                "memexport_draws",
+            ):
+                totals[key] += integer(event, key)
+            for key in ("target_overflow", "page_overflow"):
+                totals[key] = max(totals[key], integer(event, key))
+        elif kind == f"{PREFIX}resolve_dependency":
+            dependencies.setdefault(str(event["address"]), dict(event))
+        elif kind == f"{PREFIX}resolve_target":
+            address = str(event["address"])
+            existing = resolve_targets.get(address)
+            if existing is None or integer(event, "last_resolve_frame") >= integer(
+                existing, "last_resolve_frame"
+            ):
+                resolve_targets[address] = dict(event)
+
+    for address, target in resolve_targets.items():
+        if address in dependencies:
+            dependencies[address].update(
+                {
+                    key: target[key]
+                    for key in (
+                        "resolves",
+                        "resolved_bytes",
+                        "sampled_draws",
+                        "sample_references",
+                        "conditional_sample_draws",
+                        "query_state_sample_draws",
+                        "memexport_sample_draws",
+                    )
+                    if key in target
+                }
+            )
+
+    private_fields = {"pid", "tid", "utc", "schema", "event", "session"}
+    clean = lambda event: {key: value for key, value in event.items() if key not in private_fields}
+    return {
+        "schema": SCHEMA,
+        "session": selected_session,
+        "sources": [str(path) for path in paths],
+        "totals": totals,
+        "draw_signatures": [
+            clean(record)
+            for _, record in sorted(
+                draw_signatures.items(), key=lambda item: (-integer(item[1], "draws"), item[0])
+            )
+        ],
+        "resolve_dependencies": [
+            clean(record) for _, record in sorted(dependencies.items())
+        ],
+        "safety": {
+            "suppression_allowed": False,
+            "guest_cpu_reads": "unknown_uninstrumented",
+            "presentation_only": "unknown_uninstrumented",
+            "semantic_roles": "unknown_unclassified",
+        },
+    }
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("logs", nargs="+", type=Path, help="diagnostic JSONL files")
+    parser.add_argument("--session", help="specific diagnostic session id")
+    parser.add_argument("--output", "-o", type=Path, help="write inventory JSON")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    result = summarize(args.logs, args.session)
+    rendered = json.dumps(result, indent=2) + "\n"
+    if args.output:
+        args.output.write_text(rendered, encoding="utf-8")
+    else:
+        print(rendered, end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/tests/test_native_renderer_census.py
+++ b/tools/tests/test_native_renderer_census.py
@@ -1,0 +1,85 @@
+import importlib.util
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SPEC = importlib.util.spec_from_file_location(
+    "native_renderer_census",
+    ROOT / "tools/summarize-native-renderer-census.py",
+)
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+class NativeRendererCensusTests(unittest.TestCase):
+    def test_summarizer_selects_latest_session_and_merges_dependencies(self):
+        events = [
+            {"event": "native_renderer.census.installed", "session": "old"},
+            {"event": "native_renderer.census.draw_window", "session": "old", "draws": "9"},
+            {"event": "native_renderer.census.installed", "session": "new"},
+            {
+                "event": "native_renderer.census.draw_window",
+                "session": "new",
+                "draws": "100",
+                "overflow_draws": "0",
+            },
+            {
+                "event": "native_renderer.census.resolve_window",
+                "session": "new",
+                "resolves": "7",
+                "resolve_bytes": "4096",
+                "sampled_draws": "3",
+                "sample_references": "4",
+                "query_draws": "1",
+                "memexport_draws": "2",
+                "target_overflow": "0",
+                "page_overflow": "0",
+            },
+            {
+                "event": "native_renderer.census.resolve_dependency",
+                "session": "new",
+                "address": "00123000",
+                "length": "4096",
+                "suppression_eligible": "false",
+            },
+            {
+                "event": "native_renderer.census.resolve_target",
+                "session": "new",
+                "address": "00123000",
+                "last_resolve_frame": "42",
+                "resolves": "7",
+                "resolved_bytes": "28672",
+                "sampled_draws": "3",
+                "sample_references": "4",
+                "conditional_sample_draws": "1",
+                "query_state_sample_draws": "0",
+                "memexport_sample_draws": "2",
+            },
+        ]
+        with tempfile.TemporaryDirectory() as temp:
+            log = Path(temp) / "events.jsonl"
+            log.write_text(
+                "\n".join(json.dumps(event) for event in events) + "\n",
+                encoding="utf-8",
+            )
+            result = MODULE.summarize([log])
+
+        self.assertEqual("new", result["session"])
+        self.assertEqual(100, result["totals"]["draws"])
+        self.assertEqual(7, result["totals"]["resolves"])
+        self.assertEqual("7", result["resolve_dependencies"][0]["resolves"])
+        self.assertFalse(result["safety"]["suppression_allowed"])
+
+    def test_summarizer_rejects_missing_session(self):
+        with tempfile.TemporaryDirectory() as temp:
+            log = Path(temp) / "events.jsonl"
+            log.write_text("{}\n", encoding="utf-8")
+            with self.assertRaises(ValueError):
+                MODULE.summarize([log])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/tests/test_native_renderer_contract.py
+++ b/tools/tests/test_native_renderer_contract.py
@@ -26,12 +26,59 @@ class NativeRendererContractTests(unittest.TestCase):
         self.assertIn("kFrameSummaryInterval = 300", source)
         self.assertIn("kSignatureCapacity = 4096", source)
         self.assertIn("kSummaryLimit = 16", source)
+        self.assertIn("kResolveTargetCapacity = 4096", source)
+        self.assertIn("kResolvePageCapacity = 32768", source)
+        self.assertIn("kResolveSummaryLimit = 32", source)
         self.assertIn("unique_signature_count", source)
         self.assertIn("overflow_draw_count", source)
         self.assertIn("kRequiresRestart", source)
         self.assertIn('"mode", "pass_through"', source)
         self.assertNotIn("REX_STORE", source)
         self.assertNotIn("GuestPtr", source)
+
+    def test_resolve_dependency_observer_is_passive_and_payload_free(self):
+        patch = (
+            ROOT
+            / "patches/rexglue/0045-graphics-resolve-dependency-observer.patch"
+        ).read_text(encoding="utf-8")
+        self.assertIn("GraphicsCopyObservation", patch)
+        self.assertIn("GraphicsCopyObserver", patch)
+        self.assertIn("texture_fetch_addresses", patch)
+        self.assertIn("texture_fetch_mip_addresses", patch)
+        self.assertIn("copy_observer(observation);", patch)
+        self.assertLess(
+            patch.index("copy_succeeded = render_target_cache_->Resolve"),
+            patch.index("copy_observer(observation);"),
+        )
+        for forbidden in (
+            "shader_code",
+            "texture_data",
+            "render_target_data",
+            "vertex_data",
+            "payload",
+            "suppress",
+        ):
+            self.assertNotIn(forbidden, patch)
+
+        source = (ROOT / "src/native_renderer/graphics_hooks.cpp").read_text(
+            encoding="utf-8"
+        )
+        self.assertIn('"native_renderer.census.resolve_dependency"', source)
+        self.assertIn('"unknown_uninstrumented"', source)
+        self.assertIn('{"suppression_eligible", "false"}', source)
+        self.assertIn("page_count > bounded_page_count", source)
+        self.assertNotIn("REX_STORE", source)
+
+    def test_dependency_ledger_keeps_gate_b_closed(self):
+        ledger = (
+            ROOT / "docs/native-renderer/GUEST_VISIBLE_RENDER_DEPENDENCIES.md"
+        ).read_text(encoding="utf-8")
+        self.assertIn("No render target is suppression-eligible yet.", ledger)
+        self.assertIn("Gate B remains closed", ledger)
+        self.assertIn("unknown_uninstrumented", ledger)
+        self.assertIn("unknown_unclassified", ledger)
+        self.assertIn("capture-native-renderer-census.ps1", ledger)
+        self.assertIn("summarize-native-renderer-census.py", ledger)
 
     def test_draw_observer_is_read_only_and_contains_no_payload(self):
         patch = (ROOT / "patches/rexglue/0044-graphics-draw-observer.patch").read_text(
@@ -65,11 +112,18 @@ class NativeRendererContractTests(unittest.TestCase):
         self.assertIn("observation.source_select", signature)
         self.assertNotIn("observation.initiator", signature)
 
-    def test_first_pr_has_no_native_renderer_or_suppression_api(self):
+    def test_census_has_no_native_renderer_or_suppression_api(self):
         source = (ROOT / "src/native_renderer/graphics_hooks.cpp").read_text(
             encoding="utf-8"
         )
-        forbidden = ("native_rhi", "NativeRHI", "IssueDraw", "IssueCopy", "suppress")
+        forbidden = (
+            "native_rhi",
+            "NativeRHI",
+            "IssueDraw",
+            "IssueCopy",
+            "SetDrawSuppression",
+            "SetCopySuppression",
+        )
         for token in forbidden:
             self.assertNotIn(token, source)
 

--- a/tools/tests/test_native_renderer_contract.py
+++ b/tools/tests/test_native_renderer_contract.py
@@ -6,6 +6,21 @@ ROOT = pathlib.Path(__file__).resolve().parents[2]
 
 
 class NativeRendererContractTests(unittest.TestCase):
+    def test_census_storage_is_reset_without_large_stack_temporaries(self) -> None:
+        source = (ROOT / "src/native_renderer/graphics_hooks.cpp").read_text(
+            encoding="utf-8"
+        )
+
+        self.assertNotIn("g_draw_census = {};", source)
+        self.assertNotIn("g_dependency_census = {};", source)
+        self.assertIn(
+            "std::memset(&g_draw_census, 0, sizeof(g_draw_census));", source
+        )
+        self.assertIn(
+            "std::memset(&g_dependency_census, 0, sizeof(g_dependency_census));",
+            source,
+        )
+
     def test_graphics_hook_has_one_pass_through_owner(self):
         analysis = (ROOT / "config/rexglue/analysis/main-xex.toml").read_text(
             encoding="utf-8"

--- a/tools/tests/test_release_contract.py
+++ b/tools/tests/test_release_contract.py
@@ -43,10 +43,10 @@ class ReleaseContractTests(unittest.TestCase):
 
     def test_rexglue_patches_have_stable_order_and_no_binary_payload(self):
         patches = sorted((ROOT / "patches/rexglue").glob("*.patch"))
-        self.assertEqual(len(patches), 44)
+        self.assertEqual(len(patches), 45)
         self.assertEqual(
             patches[-1].name,
-            "0044-graphics-draw-observer.patch",
+            "0045-graphics-resolve-dependency-observer.patch",
         )
         self.assertEqual(len(patches), len({path.name[:4] for path in patches}))
         for path in patches:


### PR DESCRIPTION
## Summary
- observe successful D3D12 resolves and used texture-fetch addresses without changing rendering
- build a bounded guest-address dependency census with explicit overflow and safety state
- add AppData capture and deterministic inventory tooling
- document a qualified 1,500-frame runtime capture while keeping Gate B closed

## Validation
- 55 Python tests pass
- all tracked Markdown links pass
- fresh ReXGlue patch preparation: 45/45 patches
- ReXGlue unit suite: 245 passed, 4 documented skips, 2,274 assertions
- clean preview build at commit d9a0d60
- AppData session 20260828T002134Z-p41584: normal exit, 1,500 frames, 2 dependency transitions, zero capacity overflows, zero crash/GPU-fatal events