### PR TITLE
feat(renderer): classify marked census scenes

### DIFF
--- a/config/native-renderer/pass-classifier.json
+++ b/config/native-renderer/pass-classifier.json
@@ -1,0 +1,18 @@
+{
+  "schema": "pinyon-shift.pass-classifier.v1",
+  "maximum_drift_records": 32,
+  "rules": [
+    {
+      "scene": "front_end",
+      "family": "front_end_observed",
+      "confidence": "medium",
+      "evidence": "exact signature observed in qualified front-end capture 20260828T002134Z-p41584",
+      "signatures": [
+        "F891D6525E633C08", "71A4D4F4577B3DE0", "A2347A8A0640CBFA",
+        "87CBF4CFD41E8BBB", "E0A75E386F935963", "CE9ADDC1A08C7468",
+        "EA23250CBAEFD05D", "391909B2C8BCE781", "29619D07A5B2DE0A",
+        "8B9E2E27325048EF", "A415B84D19C8E936"
+      ]
+    }
+  ]
+}

--- a/docs/native-renderer/PASS_CLASSIFICATION.md
+++ b/docs/native-renderer/PASS_CLASSIFICATION.md
@@ -1,0 +1,69 @@
+# Native-renderer pass classification
+
+This is the NR-00E classifier contract for the supported USA retail MS-2505
+executable. It classifies census identities from evidence; it does not infer
+semantic roles from resolution, pitch, shader hashes, or timing alone.
+
+## Safety model
+
+The tracked manifest at `config/native-renderer/pass-classifier.json` matches
+an exact draw signature only within an operator-selected scene. Each rule has a
+family, confidence, and evidence string. A signature with no exact rule is
+`retained_unknown`, remains on Xenos, and is never suppression-eligible.
+
+Classification is report-only. It cannot skip a draw, redirect a resolve, read
+guest payloads, or submit native graphics work. Gate B remains closed.
+
+## Scene markers
+
+The capture wrapper accepts one of these bounded operator markers:
+
+- `front_end`
+- `garage`
+- `open_world_day`
+- `open_world_night`
+- `traffic`
+- `race`
+- `rewind`
+- `pause`
+- `save_reload`
+- `unmarked`
+
+For example:
+
+```powershell
+.\tools\capture-native-renderer-census.ps1 `
+  -StateRoot "$env:LOCALAPPDATA\PinyonShift\source\0.1.0\.local\preview" `
+  -Scene front_end
+```
+
+The marker is passed only to the child process and recorded as
+`native_renderer.census.scene_marker`. Invalid or missing runtime values become
+`invalid` or `unmarked`; they cannot accidentally match another scene.
+
+## Drift and reports
+
+`summarize-native-renderer-census.py` joins the marker, draw census, dependency
+graph, and tracked classifier. Its deterministic output contains:
+
+- classified and observed draw counts plus coverage percentage;
+- draw totals by pass family;
+- the evidence and confidence attached to every matched signature;
+- at most 32 unmatched drift records, ordered by draw count;
+- an explicit drift-overflow count; and
+- the `retained_on_xenos` unknown policy.
+
+The manifest currently recognizes only the 11 exact signatures from qualified
+front-end session `20260828T002134Z-p41584`. They are named
+`front_end_observed` at medium confidence: the scene and identity are proven,
+but their finer UI, composite, clear, and presentation roles are not. No rule
+exists yet for garage, world, traffic, race, rewind, pause, or save/reload.
+
+## Promotion rule
+
+A drift signature may enter the manifest only after a reproducible marked
+capture identifies it, the associated targets and dependencies are reviewed,
+and its evidence is recorded. A semantic family requires stronger hook or
+visual evidence than recurrence alone. Changing classification never changes
+rendering behavior; suppression has separate gates and remains forbidden in
+NR-00.

--- a/docs/native-renderer/PASS_CLASSIFICATION.md
+++ b/docs/native-renderer/PASS_CLASSIFICATION.md
@@ -67,3 +67,29 @@ and its evidence is recorded. A semantic family requires stronger hook or
 visual evidence than recurrence alone. Changing classification never changes
 rendering behavior; suppression has separate gates and remains forbidden in
 NR-00.
+
+## Qualification snapshot — 2026-08-27
+
+Clean commit `6460ea8` was launched against the installed AppData save with
+the `front_end` marker. Session `20260828T002957Z-p39648` reached 1,500 frames,
+exited normally, and produced this deterministic report:
+
+- 83,665 observed and classified draws (100% coverage).
+- One `front_end_observed` family and zero drift signatures.
+- 2,890 resolves and two resolve-to-texture dependencies.
+- Zero classifier overflow, census overflow, crash, GPU-loss, or fatal events.
+
+The clean executable SHA-256 was
+`67F27E6E3039DB1B79606F18EA62F03DD4F3ED40BFD0B5405DE2A22B2D22F748`.
+
+An equal-duration census-disabled control run used the same build and save.
+After discarding 120 warm-up samples, the enabled/control comparison was:
+
+| Mode | Samples | Median frame time | p95 frame time | Median FPS |
+| --- | ---: | ---: | ---: | ---: |
+| Census disabled | 1,319 | 16,620 us | 18,606 us | 60 |
+| Census + classifier capture | 1,421 | 16,630 us | 18,643 us | 60 |
+
+The observed deltas were 10 us at median (0.06%) and 37 us at p95 (0.20%).
+This front-end result proves the disabled path has no material overhead in the
+captured scene; it does not replace the required open-world and race captures.

--- a/docs/native-renderer/RENDER_PASS_CENSUS.md
+++ b/docs/native-renderer/RENDER_PASS_CENSUS.md
@@ -90,7 +90,9 @@ read or serialize guest memory.
   livery, thumbnail, and rewind dispatch families.
 
 Resolve-to-texture dependency tracking is documented in
-`GUEST_VISIBLE_RENDER_DEPENDENCIES.md`. Pass classification, CPU-read
-observation, and presentation provenance remain subsequent NR-00 work.
+`GUEST_VISIBLE_RENDER_DEPENDENCIES.md`. The evidence-based classifier and scene
+capture contract are documented in `PASS_CLASSIFICATION.md`. Scene coverage,
+CPU-read observation, and presentation provenance remain subsequent NR-00
+work.
 
 Unknown work stays on Xenos.

--- a/src/native_renderer/graphics_hooks.cpp
+++ b/src/native_renderer/graphics_hooks.cpp
@@ -32,11 +32,15 @@ constexpr uint64_t kGuestPageSize = 4096;
 std::atomic<uint64_t> g_frame_sequence{};
 
 std::string CensusSceneMarker() {
-  const char* value = std::getenv("PINYON_SHIFT_NATIVE_RENDERER_SCENE");
-  if (!value || !*value) {
+  char* value = nullptr;
+  size_t length = 0;
+  if (_dupenv_s(&value, &length, "PINYON_SHIFT_NATIVE_RENDERER_SCENE") != 0 ||
+      !value || length <= 1) {
+    std::free(value);
     return "unmarked";
   }
   std::string marker(value);
+  std::free(value);
   if (marker.size() > 32 ||
       !std::all_of(marker.begin(), marker.end(), [](unsigned char character) {
         return (character >= 'a' && character <= 'z') || character == '_';

--- a/src/native_renderer/graphics_hooks.cpp
+++ b/src/native_renderer/graphics_hooks.cpp
@@ -3,6 +3,7 @@
 #include <atomic>
 #include <cstddef>
 #include <cstdint>
+#include <cstdlib>
 #include <cstring>
 #include <string>
 #include <type_traits>
@@ -29,6 +30,21 @@ constexpr size_t kResolvePageCapacity = 32768;
 constexpr size_t kResolveSummaryLimit = 32;
 constexpr uint64_t kGuestPageSize = 4096;
 std::atomic<uint64_t> g_frame_sequence{};
+
+std::string CensusSceneMarker() {
+  const char* value = std::getenv("PINYON_SHIFT_NATIVE_RENDERER_SCENE");
+  if (!value || !*value) {
+    return "unmarked";
+  }
+  std::string marker(value);
+  if (marker.size() > 32 ||
+      !std::all_of(marker.begin(), marker.end(), [](unsigned char character) {
+        return (character >= 'a' && character <= 'z') || character == '_';
+      })) {
+    return "invalid";
+  }
+  return marker;
+}
 
 struct DrawSignatureEntry {
   uint64_t signature = 0;
@@ -611,13 +627,17 @@ void InstallGraphicsCensus(rex::system::IGraphicsSystem* graphics_system) {
   graphics_system->SetDrawObserver(&ObserveDraw);
   graphics_system->SetCopyObserver(&ObserveCopy);
   const std::string capacity = std::to_string(kSignatureCapacity);
+  const std::string scene = CensusSceneMarker();
   diagnostics::RecordEvent("native_renderer.census.installed",
                            {{"signature_capacity", capacity},
                             {"summary_limit", "16"},
                             {"resolve_target_capacity", "4096"},
                             {"resolve_page_capacity", "32768"},
                             {"resolve_summary_limit", "32"},
+                            {"scene", scene},
                             {"mode", "pass_through"}});
+  diagnostics::RecordEvent("native_renderer.census.scene_marker",
+                           {{"scene", scene}, {"source", "operator"}});
 }
 
 void UninstallGraphicsCensus(rex::system::IGraphicsSystem* graphics_system) {

--- a/tools/capture-native-renderer-census.ps1
+++ b/tools/capture-native-renderer-census.ps1
@@ -1,6 +1,10 @@
 [CmdletBinding()]
 param(
     [string]$StateRoot,
+    [ValidateSet('unmarked', 'front_end', 'garage', 'open_world_day',
+        'open_world_night', 'traffic', 'race', 'rewind', 'pause',
+        'save_reload')]
+    [string]$Scene = 'unmarked',
     [switch]$Json
 )
 
@@ -37,11 +41,14 @@ if (@(Get-Process -Name 'pinyon_shift' -ErrorAction SilentlyContinue).Count -ne 
 }
 
 $savedCensus = $env:REX_PINYON_SHIFT_NATIVE_RENDERER_CENSUS
+$savedScene = $env:PINYON_SHIFT_NATIVE_RENDERER_SCENE
 try {
     $env:REX_PINYON_SHIFT_NATIVE_RENDERER_CENSUS = 'true'
+    $env:PINYON_SHIFT_NATIVE_RENDERER_SCENE = $Scene
     & (Join-Path $PSScriptRoot 'launch-preview.ps1') `
         -StateRoot $resolvedStateRoot -Json:$Json
 }
 finally {
     $env:REX_PINYON_SHIFT_NATIVE_RENDERER_CENSUS = $savedCensus
+    $env:PINYON_SHIFT_NATIVE_RENDERER_SCENE = $savedScene
 }

--- a/tools/summarize-native-renderer-census.py
+++ b/tools/summarize-native-renderer-census.py
@@ -11,6 +11,8 @@ from typing import Any, Iterable
 
 SCHEMA = "pinyon-shift.native-renderer-census.v1"
 PREFIX = "native_renderer.census."
+ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_CLASSIFIER = ROOT / "config/native-renderer/pass-classifier.json"
 
 
 def read_events(paths: Iterable[Path]) -> list[dict[str, Any]]:
@@ -49,11 +51,87 @@ def select_session(events: list[dict[str, Any]], requested: str | None) -> str:
     return str(candidates[-1])
 
 
-def summarize(paths: Iterable[Path], session: str | None = None) -> dict[str, Any]:
+def load_classifier(path: Path) -> dict[str, Any]:
+    classifier = json.loads(path.read_text(encoding="utf-8"))
+    if classifier.get("schema") != "pinyon-shift.pass-classifier.v1":
+        raise ValueError(f"unsupported pass-classifier schema: {path}")
+    return classifier
+
+
+def classify_signatures(
+    signatures: list[dict[str, Any]], scene: str, classifier: dict[str, Any]
+) -> dict[str, Any]:
+    matches: dict[str, dict[str, str]] = {}
+    for rule in classifier.get("rules", []):
+        if rule.get("scene") != scene:
+            continue
+        for signature in rule.get("signatures", []):
+            if signature in matches:
+                raise ValueError(f"duplicate classifier signature for {scene}: {signature}")
+            matches[signature] = rule
+
+    family_draws: dict[str, int] = {}
+    classified_draws = 0
+    drift: list[dict[str, Any]] = []
+    for signature in signatures:
+        draws = integer(signature, "draws")
+        rule = matches.get(str(signature["signature"]))
+        if rule:
+            family = str(rule["family"])
+            confidence = str(rule["confidence"])
+            evidence = str(rule["evidence"])
+            classified_draws += draws
+        else:
+            family = "retained_unknown"
+            confidence = "unknown"
+            evidence = "no exact scene-qualified rule; Xenos retained"
+            drift.append(
+                {
+                    "signature": signature["signature"],
+                    "draws": draws,
+                    "reason": "unmatched_signature",
+                }
+            )
+        signature.update(
+            {"family": family, "confidence": confidence, "evidence": evidence}
+        )
+        family_draws[family] = family_draws.get(family, 0) + draws
+
+    observed_draws = sum(integer(signature, "draws") for signature in signatures)
+    limit = int(classifier.get("maximum_drift_records", 32))
+    drift.sort(key=lambda record: (-record["draws"], record["signature"]))
+    return {
+        "scene": scene,
+        "observed_draws": observed_draws,
+        "classified_draws": classified_draws,
+        "classified_percent": (
+            round(classified_draws * 100.0 / observed_draws, 3)
+            if observed_draws
+            else 0.0
+        ),
+        "families": [
+            {"family": family, "draws": draws}
+            for family, draws in sorted(family_draws.items())
+        ],
+        "drift_count": len(drift),
+        "drift_overflow": max(0, len(drift) - limit),
+        "drift": drift[:limit],
+        "unknown_policy": "retained_on_xenos",
+    }
+
+
+def summarize(
+    paths: Iterable[Path], session: str | None = None,
+    classifier_path: Path = DEFAULT_CLASSIFIER,
+) -> dict[str, Any]:
     paths = list(paths)
     events = read_events(paths)
     selected_session = select_session(events, session)
     events = [event for event in events if event.get("session") == selected_session]
+    marker_events = [
+        event for event in events if event.get("event") == f"{PREFIX}scene_marker"
+    ]
+    scene = str(marker_events[-1].get("scene", "unmarked")) if marker_events else "unmarked"
 
     draw_signatures: dict[str, dict[str, Any]] = {}
     dependencies: dict[str, dict[str, Any]] = {}
@@ -131,17 +209,22 @@ def summarize(paths: Iterable[Path], session: str | None = None) -> dict[str, An
 
     private_fields = {"pid", "tid", "utc", "schema", "event", "session"}
     clean = lambda event: {key: value for key, value in event.items() if key not in private_fields}
+    cleaned_signatures = [
+        clean(record)
+        for _, record in sorted(
+            draw_signatures.items(), key=lambda item: (-integer(item[1], "draws"), item[0])
+        )
+    ]
+    classification = classify_signatures(
+        cleaned_signatures, scene, load_classifier(classifier_path)
+    )
     return {
         "schema": SCHEMA,
         "session": selected_session,
         "sources": [str(path) for path in paths],
         "totals": totals,
-        "draw_signatures": [
-            clean(record)
-            for _, record in sorted(
-                draw_signatures.items(), key=lambda item: (-integer(item[1], "draws"), item[0])
-            )
-        ],
+        "classification": classification,
+        "draw_signatures": cleaned_signatures,
         "resolve_dependencies": [
             clean(record) for _, record in sorted(dependencies.items())
         ],
@@ -158,13 +241,17 @@ def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("logs", nargs="+", type=Path, help="diagnostic JSONL files")
     parser.add_argument("--session", help="specific diagnostic session id")
+    parser.add_argument(
+        "--classifier", type=Path, default=DEFAULT_CLASSIFIER,
+        help="pass-classifier manifest",
+    )
     parser.add_argument("--output", "-o", type=Path, help="write inventory JSON")
     return parser.parse_args()
 
 
 def main() -> int:
     args = parse_args()
-    result = summarize(args.logs, args.session)
+    result = summarize(args.logs, args.session, args.classifier)
     rendered = json.dumps(result, indent=2) + "\n"
     if args.output:
         args.output.write_text(rendered, encoding="utf-8")

--- a/tools/tests/test_native_renderer_census.py
+++ b/tools/tests/test_native_renderer_census.py
@@ -15,6 +15,66 @@ SPEC.loader.exec_module(MODULE)
 
 
 class NativeRendererCensusTests(unittest.TestCase):
+    def test_classifier_matches_scene_rules_and_bounds_drift(self):
+        events = [
+            {"event": "native_renderer.census.installed", "session": "run"},
+            {
+                "event": "native_renderer.census.scene_marker",
+                "session": "run",
+                "scene": "front_end",
+            },
+            {
+                "event": "native_renderer.census.draw_signature",
+                "session": "run",
+                "signature": "KNOWN",
+                "draws": "99",
+            },
+            {
+                "event": "native_renderer.census.draw_signature",
+                "session": "run",
+                "signature": "DRIFT_B",
+                "draws": "2",
+            },
+            {
+                "event": "native_renderer.census.draw_signature",
+                "session": "run",
+                "signature": "DRIFT_A",
+                "draws": "3",
+            },
+        ]
+        classifier = {
+            "schema": "pinyon-shift.pass-classifier.v1",
+            "maximum_drift_records": 1,
+            "rules": [
+                {
+                    "scene": "front_end",
+                    "family": "front_end_observed",
+                    "confidence": "medium",
+                    "evidence": "test evidence",
+                    "signatures": ["KNOWN"],
+                }
+            ],
+        }
+        with tempfile.TemporaryDirectory() as temp:
+            log = Path(temp) / "events.jsonl"
+            manifest = Path(temp) / "classifier.json"
+            log.write_text(
+                "\n".join(json.dumps(event) for event in events) + "\n",
+                encoding="utf-8",
+            )
+            manifest.write_text(json.dumps(classifier), encoding="utf-8")
+            result = MODULE.summarize([log], classifier_path=manifest)
+
+        classification = result["classification"]
+        self.assertEqual("front_end", classification["scene"])
+        self.assertEqual(99, classification["classified_draws"])
+        self.assertEqual(2, classification["drift_count"])
+        self.assertEqual(1, classification["drift_overflow"])
+        self.assertEqual("DRIFT_A", classification["drift"][0]["signature"])
+        self.assertEqual(
+            "retained_unknown", result["draw_signatures"][1]["family"]
+        )
+
     def test_summarizer_selects_latest_session_and_merges_dependencies(self):
         events = [
             {"event": "native_renderer.census.installed", "session": "old"},

--- a/tools/tests/test_native_renderer_contract.py
+++ b/tools/tests/test_native_renderer_contract.py
@@ -51,6 +51,28 @@ class NativeRendererContractTests(unittest.TestCase):
         self.assertNotIn("REX_STORE", source)
         self.assertNotIn("GuestPtr", source)
 
+    def test_scene_markers_and_classifier_are_explicit_and_safe(self):
+        source = (ROOT / "src/native_renderer/graphics_hooks.cpp").read_text(
+            encoding="utf-8"
+        )
+        capture = (ROOT / "tools/capture-native-renderer-census.ps1").read_text(
+            encoding="utf-8"
+        )
+        classifier = (
+            ROOT / "config/native-renderer/pass-classifier.json"
+        ).read_text(encoding="utf-8")
+        summarizer = (
+            ROOT / "tools/summarize-native-renderer-census.py"
+        ).read_text(encoding="utf-8")
+
+        self.assertIn("native_renderer.census.scene_marker", source)
+        self.assertIn("PINYON_SHIFT_NATIVE_RENDERER_SCENE", source)
+        self.assertIn("[ValidateSet('unmarked', 'front_end', 'garage'", capture)
+        self.assertIn('"maximum_drift_records": 32', classifier)
+        self.assertIn('"confidence": "medium"', classifier)
+        self.assertIn('"retained_unknown"', summarizer)
+        self.assertIn('"retained_on_xenos"', summarizer)
+
     def test_resolve_dependency_observer_is_passive_and_payload_free(self):
         patch = (
             ROOT


### PR DESCRIPTION
## Summary
- add bounded operator scene markers to native-renderer census captures
- classify exact scene-qualified signatures with explicit evidence and confidence
- retain all unmatched work on Xenos and report at most 32 drift records plus overflow
- document the classifier safety contract and qualified front-end evidence

## Validation
- 57 Python tests pass
- tracked Markdown links pass
- clean preview build at commit 501a00f, executable SHA-256 67F27E6E...2F748
- AppData front-end capture: 1,500 frames, 83,665/83,665 classified draws, zero drift/overflow/errors, normal exit
- matched disabled control: median +10 us (0.06%), p95 +37 us (0.20%), median 60 FPS

Gate B remains closed. This PR adds no native rendering or Xenos suppression.