### PR TITLE
feat(renderer): add native output callback contract

### DIFF
--- a/docs/native-renderer/GUEST_OUTPUT_OWNERSHIP.md
+++ b/docs/native-renderer/GUEST_OUTPUT_OWNERSHIP.md
@@ -1,0 +1,20 @@
+# Native guest-output ownership
+
+NR-01A introduces the registration contract only. It does not invoke a native
+renderer, expose D3D12 objects, transition resources, or alter presentation.
+Xenos therefore remains the sole producer and authority for every frame.
+
+The backend-neutral context records output/display dimensions, an opaque output
+format, a submission sequence, and opaque device, command-context, and output
+handles. Backend-specific code will populate those fields in NR-01B while the
+public interface remains independent of D3D12 headers.
+
+Registration is atomic. With no callback registered, invocation returns
+`false`, meaning yield. A registered callback must return `false` without
+recording any output command. Once it records a command that can modify output,
+it must return `true`; later integration will latch failures rather than yield
+after partial modification.
+
+Patch `0046-native-guest-output-callback-contract.patch` includes native unit
+tests for default inert state, claim propagation, yield propagation, and
+unregistration. There is deliberately no swap-path call site in this patch.

--- a/docs/native-renderer/RENDER_PASS_CENSUS.md
+++ b/docs/native-renderer/RENDER_PASS_CENSUS.md
@@ -8,7 +8,7 @@ a trace or disassembly proves them.
 
 - Pinyon Shift `dev`: `cafc7233fef9e039f163d11023f40eccb22e8fc1`
 - ReXGlue: `v0.10.0` at `f5337cdc947ff6d4c4196737e2c807a48f2a1fc2`
-- ReXGlue patch stack: `0001` through `0045`
+- ReXGlue patch stack: `0001` through `0046`
 - `default.xex` SHA-256:
   `DB40DF605ADE49A612B35A7A24C38F6004BCB17A88ED6B48288DE16DF9E3987C`
 

--- a/patches/rexglue/0046-native-guest-output-callback-contract.patch
+++ b/patches/rexglue/0046-native-guest-output-callback-contract.patch
@@ -1,0 +1,149 @@
+diff --git a/include/rex/graphics/graphics_system.h b/include/rex/graphics/graphics_system.h
+index 5ab0e9b..5406fd0 100644
+--- a/include/rex/graphics/graphics_system.h
++++ b/include/rex/graphics/graphics_system.h
+@@ -82,6 +82,17 @@ class GraphicsSystem : public system::IGraphicsSystem {
+   system::GraphicsCopyObserver copy_observer() const {
+     return copy_observer_.load(std::memory_order_acquire);
+   }
++  void SetNativeGuestOutputRenderer(
++      system::NativeGuestOutputRenderer renderer) override {
++    native_guest_output_renderer_.Set(renderer);
++  }
++  bool HasNativeGuestOutputRenderer() const override {
++    return native_guest_output_renderer_.IsRegistered();
++  }
++  const system::NativeGuestOutputRendererRegistration&
++  native_guest_output_renderer() const {
++    return native_guest_output_renderer_;
++  }
+ 
+   void InitializeRingBuffer(uint32_t ptr, uint32_t size_log2) override;
+   void EnableReadPointerWriteBack(uint32_t ptr, uint32_t block_size_log2) override;
+@@ -143,6 +154,7 @@ class GraphicsSystem : public system::IGraphicsSystem {
+ 
+   std::atomic<system::GraphicsDrawObserver> draw_observer_{nullptr};
+   std::atomic<system::GraphicsCopyObserver> copy_observer_{nullptr};
++  system::NativeGuestOutputRendererRegistration native_guest_output_renderer_;
+ 
+   std::atomic_flag host_gpu_loss_reported_;
+ };
+diff --git a/include/rex/system/interfaces/graphics.h b/include/rex/system/interfaces/graphics.h
+index 607a3cd..824daf2 100644
+--- a/include/rex/system/interfaces/graphics.h
++++ b/include/rex/system/interfaces/graphics.h
+@@ -11,6 +11,7 @@
+ 
+ #pragma once
+ 
++#include <atomic>
+ #include <cstdint>
+ #include <filesystem>
+ 
+@@ -31,6 +32,48 @@ class KernelState;
+ 
+ namespace rex::system {
+ 
++enum class NativeGuestOutputBackend : uint32_t {
++  kUnsupported = 0,
++  kD3D12 = 1,
++  kVulkan = 2,
++};
++
++struct NativeGuestOutputRenderContext {
++  NativeGuestOutputBackend backend = NativeGuestOutputBackend::kUnsupported;
++  uint32_t guest_output_width = 0;
++  uint32_t guest_output_height = 0;
++  uint32_t display_width = 0;
++  uint32_t display_height = 0;
++  uint32_t output_format = 0;
++  void* device = nullptr;
++  void* command_context = nullptr;
++  void* guest_output = nullptr;
++  uint64_t submission = 0;
++};
++
++// Returning false yields without modifying guest output. A callback that has
++// recorded any output command must return true.
++using NativeGuestOutputRenderer = bool (*)(
++    const NativeGuestOutputRenderContext& context);
++
++class NativeGuestOutputRendererRegistration {
++ public:
++  void Set(NativeGuestOutputRenderer renderer) {
++    renderer_.store(renderer, std::memory_order_release);
++  }
++  NativeGuestOutputRenderer Get() const {
++    return renderer_.load(std::memory_order_acquire);
++  }
++  bool IsRegistered() const { return Get() != nullptr; }
++  bool Invoke(const NativeGuestOutputRenderContext& context) const {
++    NativeGuestOutputRenderer renderer = Get();
++    return renderer ? renderer(context) : false;
++  }
++
++ private:
++  std::atomic<NativeGuestOutputRenderer> renderer_{nullptr};
++};
++
+ struct GraphicsDrawObservation {
+   uint64_t frame_sequence = 0;
+   uint64_t draw_sequence = 0;
+@@ -112,6 +155,10 @@ class IGraphicsSystem {
+   virtual void SetCopyObserver(GraphicsCopyObserver observer) {
+     (void)observer;
+   }
++  virtual void SetNativeGuestOutputRenderer(NativeGuestOutputRenderer renderer) {
++    (void)renderer;
++  }
++  virtual bool HasNativeGuestOutputRenderer() const { return false; }
+ 
+   // Guest GPU services reached from the xboxkrnl Vd* exports.
+   virtual void SetInterruptCallback(uint32_t callback, uint32_t user_data) {
+diff --git a/tests/unit/CMakeLists.txt b/tests/unit/CMakeLists.txt
+index b3635e2..4f3f823 100644
+--- a/tests/unit/CMakeLists.txt
++++ b/tests/unit/CMakeLists.txt
+@@ -25,6 +25,7 @@ add_executable(unit_tests
+     codegen/output_stamp_test.cpp
+     filesystem/cache_mount_test.cpp
+     graphics/zpd_lifecycle_test.cpp
++    graphics/native_guest_output_test.cpp
+     ui/presentation_pacer_test.cpp
+ )
+ 
+diff --git a/b/tests/unit/graphics/native_guest_output_test.cpp b/tests/unit/graphics/native_guest_output_test.cpp
+new file mode 100644
+index 0000000..b36a37b
+--- /dev/null
++++ b/tests/unit/graphics/native_guest_output_test.cpp
+@@ -0,0 +1,29 @@
++#include <catch2/catch_test_macros.hpp>
++
++#include <rex/system/interfaces/graphics.h>
++
++namespace {
++bool Claim(const rex::system::NativeGuestOutputRenderContext&) { return true; }
++bool Yield(const rex::system::NativeGuestOutputRenderContext&) { return false; }
++}  // namespace
++
++TEST_CASE("native guest output registration defaults to inert yield") {
++  rex::system::NativeGuestOutputRendererRegistration registration;
++  rex::system::NativeGuestOutputRenderContext context;
++  CHECK_FALSE(registration.IsRegistered());
++  CHECK(registration.Get() == nullptr);
++  CHECK_FALSE(registration.Invoke(context));
++}
++
++TEST_CASE("native guest output registration preserves callback result") {
++  rex::system::NativeGuestOutputRendererRegistration registration;
++  rex::system::NativeGuestOutputRenderContext context;
++  registration.Set(&Claim);
++  CHECK(registration.IsRegistered());
++  CHECK(registration.Invoke(context));
++  registration.Set(&Yield);
++  CHECK_FALSE(registration.Invoke(context));
++  registration.Set(nullptr);
++  CHECK_FALSE(registration.IsRegistered());
++  CHECK_FALSE(registration.Invoke(context));
++}

--- a/tools/tests/test_native_renderer_contract.py
+++ b/tools/tests/test_native_renderer_contract.py
@@ -167,6 +167,20 @@ class NativeRendererContractTests(unittest.TestCase):
         cmake = (ROOT / "CMakeLists.txt").read_text(encoding="utf-8")
         self.assertEqual(cmake.count("src/native_renderer/graphics_hooks.cpp"), 2)
 
+    def test_native_guest_output_registration_is_inert_and_backend_neutral(self):
+        patch = (
+            ROOT
+            / "patches/rexglue/0046-native-guest-output-callback-contract.patch"
+        ).read_text(encoding="utf-8")
+        self.assertIn("NativeGuestOutputRenderContext", patch)
+        self.assertIn("NativeGuestOutputBackend", patch)
+        self.assertIn("NativeGuestOutputRendererRegistration", patch)
+        self.assertIn("return renderer ? renderer(context) : false;", patch)
+        self.assertIn("defaults to inert yield", patch)
+        self.assertIn("preserves callback result", patch)
+        for forbidden in ("IssueSwap", "ResourceBarrier", "ClearRenderTargetView"):
+            self.assertNotIn(forbidden, patch)
+
     def test_census_ledger_tracks_exact_starting_baseline(self):
         ledger = (ROOT / "docs/native-renderer/RENDER_PASS_CENSUS.md").read_text(
             encoding="utf-8"

--- a/tools/tests/test_release_contract.py
+++ b/tools/tests/test_release_contract.py
@@ -43,10 +43,10 @@ class ReleaseContractTests(unittest.TestCase):
 
     def test_rexglue_patches_have_stable_order_and_no_binary_payload(self):
         patches = sorted((ROOT / "patches/rexglue").glob("*.patch"))
-        self.assertEqual(len(patches), 45)
+        self.assertEqual(len(patches), 46)
         self.assertEqual(
             patches[-1].name,
-            "0045-graphics-resolve-dependency-observer.patch",
+            "0046-native-guest-output-callback-contract.patch",
         )
         self.assertEqual(len(patches), len({path.name[:4] for path in patches}))
         for path in patches:


### PR DESCRIPTION
## Summary
- add a backend-neutral native guest-output context and callback type
- add atomic registration with default inert yield behavior
- expose registration through the graphics-system interface without invoking it
- document output ownership and the no-partial-modification yield contract

## Validation
- 58 Python repository tests pass
- fresh pinned ReXGlue preparation applies 46/46 patches
- ReXGlue unit suite: 247 passed, 4 documented skips, 2,282/2,282 assertions
- clean preview build at c3c8909, executable SHA-256 6297D10D...05C2B
- AppData inert run: responsive, normal exit, zero native-output/crash/GPU-fatal events

This PR adds no swap invocation, resource transitions, output mutation, native rendering, or Xenos suppression.