### PR TITLE
feat(renderer): add diagnostic guest output clear

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,7 @@ if(WIN32)
         src/pinyon_shift_diagnostics.cpp
         src/pinyon_shift_runtime_hooks.cpp
         src/native_renderer/graphics_hooks.cpp
+        src/native_renderer/guest_output_renderer.cpp
     )
 else()
     add_executable(pinyon_shift
@@ -31,6 +32,7 @@ else()
         src/pinyon_shift_diagnostics.cpp
         src/pinyon_shift_runtime_hooks.cpp
         src/native_renderer/graphics_hooks.cpp
+        src/native_renderer/guest_output_renderer.cpp
     )
 endif()
 

--- a/docs/native-renderer/GUEST_OUTPUT_OWNERSHIP.md
+++ b/docs/native-renderer/GUEST_OUTPUT_OWNERSHIP.md
@@ -17,4 +17,26 @@ after partial modification.
 
 Patch `0046-native-guest-output-callback-contract.patch` includes native unit
 tests for default inert state, claim propagation, yield propagation, and
-unregistration. There is deliberately no swap-path call site in this patch.
+unregistration. There is deliberately no swap-path call site in that patch.
+
+## D3D12 ownership
+
+Patch `0047-d3d12-native-guest-output-context.patch` invokes a registered
+callback after Xenos gamma and optional FXAA have completed, while the existing
+command-processor submission is still open. The guest-output texture is in the
+presenter's internal state at entry. Backend operations queue transitions and
+commands into that same deferred list and restore the internal state before the
+presenter receives the image.
+
+The first operation is a full-output floating-point clear. Descriptor
+allocation occurs before any barrier or clear is recorded; allocation failure
+therefore yields safely with Xenos still authoritative. Once the operation
+records a transition, it returns success and the title callback must claim the
+frame.
+
+Pinyon's `pinyon_shift_native_renderer_diagnostic_clear` experiment defaults to
+off and requires restart. When enabled it alternates two unmistakable clear
+colors, records bounded frame diagnostics, and latches any unsupported context
+or clear failure back to Xenos. The experiment does not skip or suppress any
+guest draw or resolve—the diagnostic clear occurs after the complete Xenos
+frame solely to qualify output ownership.

--- a/docs/native-renderer/GUEST_OUTPUT_OWNERSHIP.md
+++ b/docs/native-renderer/GUEST_OUTPUT_OWNERSHIP.md
@@ -40,3 +40,21 @@ colors, records bounded frame diagnostics, and latches any unsupported context
 or clear failure back to Xenos. The experiment does not skip or suppress any
 guest draw or resolve—the diagnostic clear occurs after the complete Xenos
 frame solely to qualify output ownership.
+
+## NR-01B qualification
+
+The clean `884b554` build applied all 47 ReXGlue patches and produced executable
+SHA-256 `3786D55CEE60E9F5B087B58A86DA07A61975C19F1157F6EB4EEB3DB82AF953E2`.
+The ReXGlue unit suite passed 2,282 assertions across 247 test cases, with the
+four documented upstream `BitStream::Write` cases skipped.
+
+AppData-backed control session `20260828T011525Z-p33512` ran with the experiment
+disabled, remained responsive, emitted no native-output or error events, and
+exited normally. Enabled session `20260828T011624Z-p41092` then claimed 4,500 of
+4,500 observed callbacks. The bounded markers reported a 2560 by 1440 guest
+output, a 1280 by 720 display, and format identifier 24. Visual inspection
+confirmed alternating full-frame orange/red and blue phases. The session
+recorded no callback failure, device removal, TDR, validation error, or
+resource-state warning and exited normally. Presentation cadence remained
+60.003 Hz and simulation cadence 29.793 Hz; the two sessions exercised
+different scene durations and therefore are not treated as a performance A/B.

--- a/docs/native-renderer/RENDER_PASS_CENSUS.md
+++ b/docs/native-renderer/RENDER_PASS_CENSUS.md
@@ -8,7 +8,7 @@ a trace or disassembly proves them.
 
 - Pinyon Shift `dev`: `cafc7233fef9e039f163d11023f40eccb22e8fc1`
 - ReXGlue: `v0.10.0` at `f5337cdc947ff6d4c4196737e2c807a48f2a1fc2`
-- ReXGlue patch stack: `0001` through `0046`
+- ReXGlue patch stack: `0001` through `0047`
 - `default.xex` SHA-256:
   `DB40DF605ADE49A612B35A7A24C38F6004BCB17A88ED6B48288DE16DF9E3987C`
 

--- a/patches/rexglue/0047-d3d12-native-guest-output-context.patch
+++ b/patches/rexglue/0047-d3d12-native-guest-output-context.patch
@@ -1,0 +1,157 @@
+diff --git a/include/rex/graphics/d3d12/deferred_command_list.h b/include/rex/graphics/d3d12/deferred_command_list.h
+index 7f1eb7f..7a7d488 100644
+--- a/include/rex/graphics/d3d12/deferred_command_list.h
++++ b/include/rex/graphics/d3d12/deferred_command_list.h
+@@ -91,6 +91,24 @@ class DeferredCommandList {
+     }
+   }
+ 
++  void D3DClearUnorderedAccessViewFloat(
++      D3D12_GPU_DESCRIPTOR_HANDLE view_gpu_handle_in_current_heap,
++      D3D12_CPU_DESCRIPTOR_HANDLE view_cpu_handle, ID3D12Resource* resource,
++      const FLOAT values[4], UINT num_rects, const D3D12_RECT* rects) {
++    auto args = reinterpret_cast<ClearUnorderedAccessViewHeader*>(
++        WriteCommand(Command::kD3DClearUnorderedAccessViewFloat,
++                     sizeof(ClearUnorderedAccessViewHeader) +
++                         num_rects * sizeof(D3D12_RECT)));
++    args->view_gpu_handle_in_current_heap = view_gpu_handle_in_current_heap;
++    args->view_cpu_handle = view_cpu_handle;
++    args->resource = resource;
++    std::memcpy(args->values_float, values, 4 * sizeof(FLOAT));
++    args->num_rects = num_rects;
++    if (num_rects != 0) {
++      std::memcpy(args + 1, rects, num_rects * sizeof(D3D12_RECT));
++    }
++  }
++
+   void D3DCopyBufferRegion(ID3D12Resource* dst_buffer, UINT64 dst_offset,
+                            ID3D12Resource* src_buffer, UINT64 src_offset, UINT64 num_bytes) {
+     auto& args = *reinterpret_cast<D3DCopyBufferRegionArguments*>(
+@@ -456,6 +474,7 @@ class DeferredCommandList {
+     kD3DClearDepthStencilView,
+     kD3DClearRenderTargetView,
+     kD3DClearUnorderedAccessViewUint,
++    kD3DClearUnorderedAccessViewFloat,
+     kD3DCopyBufferRegion,
+     kD3DCopyResource,
+     kCopyTexture,
+diff --git a/include/rex/system/interfaces/graphics.h b/include/rex/system/interfaces/graphics.h
+index 824daf2..c28c97c 100644
+--- a/include/rex/system/interfaces/graphics.h
++++ b/include/rex/system/interfaces/graphics.h
+@@ -27,6 +27,10 @@ class Presenter;
+ class WindowedAppContext;
+ }  // namespace rex::ui
+ namespace rex::system {
++
++struct NativeGuestOutputRenderContext;
++using NativeGuestOutputClearColor = bool (*)(
++    const NativeGuestOutputRenderContext& context, const float color[4]);
+ class KernelState;
+ }
+ 
+@@ -49,6 +53,7 @@ struct NativeGuestOutputRenderContext {
+   void* command_context = nullptr;
+   void* guest_output = nullptr;
+   uint64_t submission = 0;
++  NativeGuestOutputClearColor clear_color = nullptr;
+ };
+ 
+ // Returning false yields without modifying guest output. A callback that has
+diff --git a/src/graphics/d3d12/command_processor.cpp b/src/graphics/d3d12/command_processor.cpp
+index ea0f1cc..62de7a2 100644
+--- a/src/graphics/d3d12/command_processor.cpp
++++ b/src/graphics/d3d12/command_processor.cpp
+@@ -2057,6 +2057,39 @@ void D3D12CommandProcessor::OnGammaRampPWLValueWritten() {
+   gamma_ramp_pwl_up_to_date_ = false;
+ }
+ 
++bool ClearNativeGuestOutput(
++    const system::NativeGuestOutputRenderContext& context,
++    const float color[4]) {
++  auto* command_processor =
++      static_cast<D3D12CommandProcessor*>(context.command_context);
++  auto* resource = static_cast<ID3D12Resource*>(context.guest_output);
++  auto* device = static_cast<ID3D12Device*>(context.device);
++  if (!command_processor || !resource || !device || !color) {
++    return false;
++  }
++
++  ui::d3d12::util::DescriptorCpuGpuHandlePair descriptor;
++  if (!command_processor->RequestOneUseSingleViewDescriptors(1, &descriptor)) {
++    return false;
++  }
++
++  D3D12_UNORDERED_ACCESS_VIEW_DESC view_desc{};
++  view_desc.Format = ui::d3d12::D3D12Presenter::kGuestOutputFormat;
++  view_desc.ViewDimension = D3D12_UAV_DIMENSION_TEXTURE2D;
++  device->CreateUnorderedAccessView(resource, nullptr, &view_desc,
++                                    descriptor.first);
++  command_processor->PushTransitionBarrier(
++      resource, ui::d3d12::D3D12Presenter::kGuestOutputInternalState,
++      D3D12_RESOURCE_STATE_UNORDERED_ACCESS);
++  command_processor->SubmitBarriers();
++  command_processor->GetDeferredCommandList().D3DClearUnorderedAccessViewFloat(
++      descriptor.second, descriptor.first, resource, color, 0, nullptr);
++  command_processor->PushTransitionBarrier(
++      resource, D3D12_RESOURCE_STATE_UNORDERED_ACCESS,
++      ui::d3d12::D3D12Presenter::kGuestOutputInternalState);
++  return true;
++}
++
+ void D3D12CommandProcessor::IssueSwap(uint32_t frontbuffer_ptr, uint32_t frontbuffer_width,
+                                       uint32_t frontbuffer_height) {
+   SCOPE_profile_cpu_f("gpu");
+@@ -2154,7 +2187,8 @@ void D3D12CommandProcessor::IssueSwap(uint32_t frontbuffer_ptr, uint32_t frontbu
+   presenter->RefreshGuestOutput(
+       guest_output_width, guest_output_height, display_width, display_height,
+       [this, &swap_texture_srv_desc, frontbuffer_format, swap_texture_resource, guest_output_width,
+-       guest_output_height](ui::Presenter::GuestOutputRefreshContext& context) -> bool {
++       guest_output_height, display_width,
++       display_height](ui::Presenter::GuestOutputRefreshContext& context) -> bool {
+         const ui::d3d12::D3D12Provider& provider = GetD3D12Provider();
+         ID3D12Device* device = provider.GetDevice();
+ 
+@@ -2413,6 +2447,23 @@ void D3D12CommandProcessor::IssueSwap(uint32_t frontbuffer_ptr, uint32_t frontbu
+         // presenter so it can submit its own commands for displaying it to the
+         // queue.
+         SubmitBarriers();
++        if (auto renderer = graphics_system_->native_guest_output_renderer().Get()) {
++          system::NativeGuestOutputRenderContext native_context;
++          native_context.backend = system::NativeGuestOutputBackend::kD3D12;
++          native_context.guest_output_width = guest_output_width;
++          native_context.guest_output_height = guest_output_height;
++          native_context.display_width = display_width;
++          native_context.display_height = display_height;
++          native_context.output_format =
++              uint32_t(ui::d3d12::D3D12Presenter::kGuestOutputFormat);
++          native_context.device = device;
++          native_context.command_context = this;
++          native_context.guest_output = guest_output_resource;
++          native_context.submission = submission_current_;
++          native_context.clear_color = &ClearNativeGuestOutput;
++          renderer(native_context);
++        }
++        SubmitBarriers();
+         EndSubmission(true);
+         return true;
+       });
+diff --git a/src/graphics/d3d12/deferred_command_list.cpp b/src/graphics/d3d12/deferred_command_list.cpp
+index e6d6277..2c208d1 100644
+--- a/src/graphics/d3d12/deferred_command_list.cpp
++++ b/src/graphics/d3d12/deferred_command_list.cpp
+@@ -60,6 +60,14 @@ void DeferredCommandList::Execute(ID3D12GraphicsCommandList* command_list,
+             args.values_uint, args.num_rects,
+             args.num_rects ? reinterpret_cast<const D3D12_RECT*>(&args + 1) : nullptr);
+       } break;
++      case Command::kD3DClearUnorderedAccessViewFloat: {
++        auto& args = *reinterpret_cast<const ClearUnorderedAccessViewHeader*>(stream);
++        command_list->ClearUnorderedAccessViewFloat(
++            args.view_gpu_handle_in_current_heap, args.view_cpu_handle,
++            args.resource, args.values_float, args.num_rects,
++            args.num_rects ? reinterpret_cast<const D3D12_RECT*>(&args + 1)
++                           : nullptr);
++      } break;
+       case Command::kD3DCopyBufferRegion: {
+         auto& args = *reinterpret_cast<const D3DCopyBufferRegionArguments*>(stream);
+         command_list->CopyBufferRegion(args.dst_buffer, args.dst_offset, args.src_buffer,

--- a/src/native_renderer/guest_output_renderer.cpp
+++ b/src/native_renderer/guest_output_renderer.cpp
@@ -1,0 +1,93 @@
+#include <atomic>
+#include <string>
+
+#include <rex/cvar.h>
+#include <rex/system/interfaces/graphics.h>
+
+#include "native_renderer/guest_output_renderer.h"
+#include "pinyon_shift_diagnostics.h"
+
+REXCVAR_DEFINE_BOOL(
+    pinyon_shift_native_renderer_diagnostic_clear, false, "Pinyon Shift",
+    "Replace guest output with a diagnostic clear for native-renderer testing")
+    .lifecycle(rex::cvar::Lifecycle::kRequiresRestart);
+
+namespace {
+
+std::atomic<bool> g_failure_latched{};
+std::atomic<uint64_t> g_callback_count{};
+std::atomic<uint64_t> g_claimed_count{};
+
+bool RenderDiagnosticOutput(
+    const rex::system::NativeGuestOutputRenderContext& context) {
+  const uint64_t callback =
+      g_callback_count.fetch_add(1, std::memory_order_relaxed) + 1;
+  if (g_failure_latched.load(std::memory_order_acquire)) {
+    return false;
+  }
+  if (context.backend != rex::system::NativeGuestOutputBackend::kD3D12 ||
+      !context.clear_color) {
+    if (!g_failure_latched.exchange(true, std::memory_order_acq_rel)) {
+      pinyon_shift::diagnostics::RecordEvent(
+          "native_renderer.output.failure",
+          {{"reason", "unsupported_context"}, {"fallback", "xenos"}});
+    }
+    return false;
+  }
+
+  const bool alternate = ((context.submission / 120) & 1) != 0;
+  const float color[4] = {alternate ? 0.04f : 0.85f, 0.16f,
+                          alternate ? 0.55f : 0.03f, 1.0f};
+  if (!context.clear_color(context, color)) {
+    if (!g_failure_latched.exchange(true, std::memory_order_acq_rel)) {
+      pinyon_shift::diagnostics::RecordEvent(
+          "native_renderer.output.failure",
+          {{"reason", "diagnostic_clear_failed"}, {"fallback", "xenos"}});
+    }
+    return false;
+  }
+
+  const uint64_t claimed =
+      g_claimed_count.fetch_add(1, std::memory_order_relaxed) + 1;
+  if (callback == 1 || callback % 300 == 0) {
+    pinyon_shift::diagnostics::RecordEvent(
+        "native_renderer.output.frame",
+        {{"callback", std::to_string(callback)},
+         {"claimed", std::to_string(claimed)},
+         {"submission", std::to_string(context.submission)},
+         {"guest_width", std::to_string(context.guest_output_width)},
+         {"guest_height", std::to_string(context.guest_output_height)},
+         {"display_width", std::to_string(context.display_width)},
+         {"display_height", std::to_string(context.display_height)},
+         {"format", std::to_string(context.output_format)},
+         {"mode", "diagnostic_clear"}});
+  }
+  return true;
+}
+
+}  // namespace
+
+namespace pinyon_shift::native_renderer {
+
+void InstallGuestOutputRenderer(rex::system::IGraphicsSystem* graphics_system) {
+  if (!graphics_system ||
+      !REXCVAR_GET(pinyon_shift_native_renderer_diagnostic_clear)) {
+    return;
+  }
+  g_failure_latched.store(false, std::memory_order_release);
+  g_callback_count.store(0, std::memory_order_release);
+  g_claimed_count.store(0, std::memory_order_release);
+  graphics_system->SetNativeGuestOutputRenderer(&RenderDiagnosticOutput);
+  diagnostics::RecordEvent("native_renderer.output.installed",
+                           {{"mode", "diagnostic_clear"},
+                            {"fallback", "xenos"}});
+}
+
+void UninstallGuestOutputRenderer(
+    rex::system::IGraphicsSystem* graphics_system) {
+  if (graphics_system) {
+    graphics_system->SetNativeGuestOutputRenderer(nullptr);
+  }
+}
+
+}  // namespace pinyon_shift::native_renderer

--- a/src/native_renderer/guest_output_renderer.h
+++ b/src/native_renderer/guest_output_renderer.h
@@ -1,0 +1,12 @@
+#pragma once
+
+namespace rex::system {
+class IGraphicsSystem;
+}
+
+namespace pinyon_shift::native_renderer {
+
+void InstallGuestOutputRenderer(rex::system::IGraphicsSystem* graphics_system);
+void UninstallGuestOutputRenderer(rex::system::IGraphicsSystem* graphics_system);
+
+}  // namespace pinyon_shift::native_renderer

--- a/src/pinyon_shift_app.cpp
+++ b/src/pinyon_shift_app.cpp
@@ -19,6 +19,7 @@
 #include <rex/system/xthread.h>
 
 #include "native_renderer/graphics_hooks.h"
+#include "native_renderer/guest_output_renderer.h"
 #include "pinyon_shift_diagnostics.h"
 
 #include <cstdio>
@@ -335,6 +336,8 @@ void PinyonShiftApp::OnPostLoadXexImage() {
 
 void PinyonShiftApp::OnPostSetup() {
   pinyon_shift::diagnostics::RefreshCrashReporter();
+  pinyon_shift::native_renderer::InstallGuestOutputRenderer(
+      runtime() ? runtime()->graphics_system() : nullptr);
   pinyon_shift::native_renderer::InstallGraphicsCensus(
       runtime() ? runtime()->graphics_system() : nullptr);
   pinyon_shift::diagnostics::RecordEvent(
@@ -371,6 +374,8 @@ bool PinyonShiftApp::OnWindowCloseRequested() {
 }
 
 void PinyonShiftApp::OnShutdown() {
+  pinyon_shift::native_renderer::UninstallGuestOutputRenderer(
+      runtime() ? runtime()->graphics_system() : nullptr);
   pinyon_shift::native_renderer::UninstallGraphicsCensus(
       runtime() ? runtime()->graphics_system() : nullptr);
   RecordShutdownOnce();

--- a/tools/tests/test_native_renderer_contract.py
+++ b/tools/tests/test_native_renderer_contract.py
@@ -181,6 +181,25 @@ class NativeRendererContractTests(unittest.TestCase):
         for forbidden in ("IssueSwap", "ResourceBarrier", "ClearRenderTargetView"):
             self.assertNotIn(forbidden, patch)
 
+    def test_d3d12_guest_output_callback_preserves_state_and_fallback(self):
+        patch = (
+            ROOT / "patches/rexglue/0047-d3d12-native-guest-output-context.patch"
+        ).read_text(encoding="utf-8")
+        self.assertIn("NativeGuestOutputClearColor", patch)
+        self.assertIn("D3DClearUnorderedAccessViewFloat", patch)
+        self.assertIn("kGuestOutputInternalState", patch)
+        self.assertIn("native_guest_output_renderer().Get()", patch)
+        self.assertIn("native_context.backend", patch)
+        self.assertNotIn("SetDrawSuppression", patch)
+
+        source = (
+            ROOT / "src/native_renderer/guest_output_renderer.cpp"
+        ).read_text(encoding="utf-8")
+        self.assertIn("pinyon_shift_native_renderer_diagnostic_clear, false", source)
+        self.assertIn("g_failure_latched", source)
+        self.assertIn('{"fallback", "xenos"}', source)
+        self.assertIn("context.clear_color(context, color)", source)
+
     def test_census_ledger_tracks_exact_starting_baseline(self):
         ledger = (ROOT / "docs/native-renderer/RENDER_PASS_CENSUS.md").read_text(
             encoding="utf-8"

--- a/tools/tests/test_release_contract.py
+++ b/tools/tests/test_release_contract.py
@@ -43,10 +43,10 @@ class ReleaseContractTests(unittest.TestCase):
 
     def test_rexglue_patches_have_stable_order_and_no_binary_payload(self):
         patches = sorted((ROOT / "patches/rexglue").glob("*.patch"))
-        self.assertEqual(len(patches), 46)
+        self.assertEqual(len(patches), 47)
         self.assertEqual(
             patches[-1].name,
-            "0046-native-guest-output-callback-contract.patch",
+            "0047-d3d12-native-guest-output-context.patch",
         )
         self.assertEqual(len(patches), len({path.name[:4] for path in patches}))
         for path in patches:


### PR DESCRIPTION
## Summary

- populate the native guest-output callback from the D3D12 command processor
- reuse its deferred command list, barriers, descriptor allocation, and submission timeline
- add a default-off, restart-gated diagnostic clear with bounded claim/failure telemetry
- retain Xenos authority on yield or initialization failure and suppress no guest work

## Validation

- fresh ReXGlue preparation: 47/47 patches applied
- ReXGlue unit suite: 247 passed, 4 documented skips, 2,282 assertions passed
- repository suite: 59 tests passed
- tracked Markdown links valid
- clean release build at `b9433ee`, executable SHA-256 `3786D55CEE60E9F5B087B58A86DA07A61975C19F1157F6EB4EEB3DB82AF953E2`
- default-off AppData session `20260828T011525Z-p33512`: responsive, no native-output/error events, normal exit
- enabled AppData session `20260828T011624Z-p41092`: 4,500/4,500 callbacks claimed, alternating clear phases visually confirmed, no failure/device removal/TDR/validation/resource-state event, normal exit