### PR TITLE
feat(renderer): add recoverable diagnostic triangle

### DIFF
--- a/docs/native-renderer/GUEST_OUTPUT_OWNERSHIP.md
+++ b/docs/native-renderer/GUEST_OUTPUT_OWNERSHIP.md
@@ -76,3 +76,33 @@ panel backs up every change and provides a dedicated **Reset to Xenos** action
 that changes no unrelated setting. Sanitized crash reports record the
 configured mode, last effective mode, bounded claimed-frame count, and any
 fallback reason.
+
+## NR-01C/D qualification
+
+The clean post-rebase build applied all 49 ReXGlue patches and produced
+executable SHA-256
+`5FD5D2511075B3FF4200F82A99B1A62069F7E08523F374D5159183D5A2D34DD7`.
+All 61 repository tests passed, tracked Markdown links were valid, and the
+ReXGlue unit suite passed 2,282 assertions across 247 test cases with the four
+documented upstream `BitStream::Write` cases skipped.
+
+AppData-backed control session `20260828T015455Z-p33796` ran with `xenos`
+selected. It recorded Xenos as the sole output authority, registered no native
+callback, claimed no frame, emitted no renderer failure, and exited normally.
+
+Diagnostic session `20260828T015607Z-p29900` claimed 2,100 of 2,100 observed
+callbacks. Its final marker reported a 2560 by 1440 guest output, a 1280 by 720
+display, and format identifier 24. Visual inspection confirmed a centered
+full-frame color triangle whose phase changed during sustained presentation.
+The session recorded no callback failure, device removal, TDR, validation
+error, resource-state warning, or presentation deadline miss and exited
+normally. Presentation cadence was 60.002 Hz and simulation cadence was
+29.409 Hz.
+
+Unsupported-mode recovery session `20260828T015729Z-p11548` emitted exactly
+one `unsupported_mode` failure with `fallback=xenos`, registered no native
+callback, claimed no frame, visibly continued through the normal Xenos-rendered
+Microsoft Studios sequence, and exited normally. The launcher recovery command
+also created a timestamped configuration backup and reset only
+`pinyon_shift_native_renderer` to `xenos`; all unrelated graphics settings and
+the AppData save remained unchanged.

--- a/docs/native-renderer/GUEST_OUTPUT_OWNERSHIP.md
+++ b/docs/native-renderer/GUEST_OUTPUT_OWNERSHIP.md
@@ -58,3 +58,21 @@ recorded no callback failure, device removal, TDR, validation error, or
 resource-state warning and exited normally. Presentation cadence remained
 60.003 Hz and simulation cadence 29.793 Hz; the two sessions exercised
 different scene durations and therefore are not treated as a performance A/B.
+
+## Diagnostic triangle and recovery
+
+Patch `0049-native-guest-output-diagnostic-triangle.patch` adds one more
+backend-neutral context operation. Its D3D12 implementation lazily creates a
+small compute pipeline, obtains the output UAV descriptor before recording any
+barrier, dispatches into the command processor's deferred list, and restores
+the presenter-owned internal state. Pipeline or descriptor failure therefore
+yields before output is touched; a failure after registration is latched and
+all later frames yield to Xenos.
+
+The `pinyon_shift_native_renderer` setting accepts `xenos`,
+`diagnostic_clear`, or `diagnostic_triangle`; only the safe `xenos` default and
+the triangle qualification mode are exposed in the launcher. The graphics
+panel backs up every change and provides a dedicated **Reset to Xenos** action
+that changes no unrelated setting. Sanitized crash reports record the
+configured mode, last effective mode, bounded claimed-frame count, and any
+fallback reason.

--- a/docs/native-renderer/RENDER_PASS_CENSUS.md
+++ b/docs/native-renderer/RENDER_PASS_CENSUS.md
@@ -8,7 +8,7 @@ a trace or disassembly proves them.
 
 - Pinyon Shift `dev`: `cafc7233fef9e039f163d11023f40eccb22e8fc1`
 - ReXGlue: `v0.10.0` at `f5337cdc947ff6d4c4196737e2c807a48f2a1fc2`
-- ReXGlue patch stack: `0001` through `0047`
+- ReXGlue patch stack: `0001` through `0049`
 - `default.xex` SHA-256:
   `DB40DF605ADE49A612B35A7A24C38F6004BCB17A88ED6B48288DE16DF9E3987C`
 

--- a/launcher/PinyonShift.Launcher/MainWindow.xaml
+++ b/launcher/PinyonShift.Launcher/MainWindow.xaml
@@ -204,6 +204,7 @@
                         <RowDefinition Height="Auto"/>
                         <RowDefinition Height="Auto"/>
                         <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
                         <RowDefinition Height="*"/>
                         <RowDefinition Height="Auto"/>
                     </Grid.RowDefinitions>
@@ -304,7 +305,16 @@
                             <TextBlock Text="Disable depth of field" TextWrapping="Wrap"/>
                         </CheckBox>
                     </Grid>
-                    <Border Grid.Row="5" x:Name="ShowroomWarning" Background="#241D12"
+                    <StackPanel Grid.Row="5" Margin="0,17,0,0">
+                        <TextBlock Text="NATIVE OUTPUT · DEVELOPER PREVIEW" FontSize="10"
+                                   Foreground="{StaticResource AmberBrush}"/>
+                        <ComboBox x:Name="NativeRendererComboBox" Margin="0,8,0,0" SelectedIndex="0"
+                                  AutomationProperties.Name="Native output renderer">
+                            <ComboBoxItem Tag="xenos"><TextBlock Text="Xenos · safe default" Foreground="{StaticResource InkBrush}"/></ComboBoxItem>
+                            <ComboBoxItem Tag="diagnostic_triangle"><TextBlock Text="Diagnostic triangle · replaces display output" Foreground="{StaticResource InkBrush}"/></ComboBoxItem>
+                        </ComboBox>
+                    </StackPanel>
+                    <Border Grid.Row="6" x:Name="ShowroomWarning" Background="#241D12"
                             BorderBrush="{StaticResource AmberBrush}" BorderThickness="1" CornerRadius="4"
                             Padding="14,10" Margin="0,17,0,0" Visibility="Collapsed"
                             AutomationProperties.LiveSetting="Polite">
@@ -312,13 +322,15 @@
                                    FontSize="11"
                                    Text="Accurate showroom uses full synchronous readback. It can sharply reduce frame rate; switch to Shipping 1× before normal driving."/>
                     </Border>
-                    <Border Grid.Row="6" Background="#171B17" BorderBrush="{StaticResource LineBrush}"
+                    <Border Grid.Row="7" Background="#171B17" BorderBrush="{StaticResource LineBrush}"
                             BorderThickness="1" CornerRadius="4" Padding="14,11" Margin="0,17,0,0">
                         <TextBlock x:Name="GraphicsStatusText" Text="Loading current settings…" TextWrapping="Wrap"
                                    Foreground="{StaticResource MutedBrush}" FontSize="11"
                                    AutomationProperties.LiveSetting="Polite"/>
                     </Border>
-                    <StackPanel Grid.Row="8" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,18,0,0">
+                    <StackPanel Grid.Row="9" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,18,0,0">
+                        <Button x:Name="ResetRendererButton" Content="RESET TO XENOS" Style="{StaticResource QuietButton}"
+                                Margin="0,0,10,0" Click="ResetRendererButton_Click"/>
                         <Button x:Name="RestoreGraphicsButton" Content="RESTORE BACKUP" Style="{StaticResource QuietButton}"
                                 Margin="0,0,10,0" Click="RestoreGraphicsButton_Click"/>
                         <Button x:Name="ResetGraphicsButton" Content="RESET DEFAULTS" Style="{StaticResource QuietButton}"

--- a/launcher/PinyonShift.Launcher/MainWindow.xaml.cs
+++ b/launcher/PinyonShift.Launcher/MainWindow.xaml.cs
@@ -645,6 +645,10 @@ public partial class MainWindow : Window
     private async void RestoreGraphicsButton_Click(object sender, RoutedEventArgs e) =>
         await ChangeGraphicsSettingsAsync("Restore", "Latest settings backup restored. Restart the preview to apply it.");
 
+    private async void ResetRendererButton_Click(object sender, RoutedEventArgs e) =>
+        await ChangeGraphicsSettingsAsync("ResetRenderer",
+            "Native output reset to Xenos. Restart the preview to apply it.");
+
     private async Task ChangeGraphicsSettingsAsync(string action, string success, bool revealBackup = false)
     {
         SetGraphicsControlsEnabled(false);
@@ -699,6 +703,7 @@ public partial class MainWindow : Window
             "-ReadbackResolve", SelectedTag(ReadbackResolveComboBox),
             "-DisableMotionBlur", DisableMotionBlurCheckBox.IsChecked == true ? "true" : "false",
             "-DisableDepthOfField", DisableDepthOfFieldCheckBox.IsChecked == true ? "true" : "false",
+            "-NativeRenderer", SelectedTag(NativeRendererComboBox),
             "-Json"
         }) startInfo.ArgumentList.Add(argument);
         using var process = Process.Start(startInfo) ??
@@ -732,6 +737,7 @@ public partial class MainWindow : Window
             SelectTag(ReadbackResolveComboBox, result.Settings.ReadbackResolve);
             DisableMotionBlurCheckBox.IsChecked = result.Settings.DisableMotionBlur;
             DisableDepthOfFieldCheckBox.IsChecked = result.Settings.DisableDepthOfField;
+            SelectTag(NativeRendererComboBox, result.Settings.NativeRenderer);
         }
         finally
         {
@@ -755,9 +761,11 @@ public partial class MainWindow : Window
         ReadbackResolveComboBox.IsEnabled = enabled;
         DisableMotionBlurCheckBox.IsEnabled = enabled;
         DisableDepthOfFieldCheckBox.IsEnabled = enabled;
+        NativeRendererComboBox.IsEnabled = enabled;
         SaveGraphicsButton.IsEnabled = enabled;
         ResetGraphicsButton.IsEnabled = enabled;
         RestoreGraphicsButton.IsEnabled = enabled;
+        ResetRendererButton.IsEnabled = enabled;
     }
 
     private sealed record ProgressMessage(string? Stage, int Percent, string? Message);
@@ -788,5 +796,6 @@ public partial class MainWindow : Window
         [property: JsonPropertyName("clear_memory_page_state")] bool ClearMemoryPageState,
         [property: JsonPropertyName("readback_memexport")] bool ReadbackMemexport,
         [property: JsonPropertyName("readback_memexport_fast")] bool ReadbackMemexportFast,
-        [property: JsonPropertyName("vsync")] bool Vsync);
+        [property: JsonPropertyName("vsync")] bool Vsync,
+        [property: JsonPropertyName("native_renderer")] string NativeRenderer);
 }

--- a/patches/rexglue/0049-native-guest-output-diagnostic-triangle.patch
+++ b/patches/rexglue/0049-native-guest-output-diagnostic-triangle.patch
@@ -1,0 +1,570 @@
+diff --git a/include/rex/graphics/d3d12/command_processor.h b/include/rex/graphics/d3d12/command_processor.h
+index 7b24447..8ae9f12 100644
+--- a/include/rex/graphics/d3d12/command_processor.h
++++ b/include/rex/graphics/d3d12/command_processor.h
+@@ -196,6 +196,11 @@ class D3D12CommandProcessor : public CommandProcessor {
+   // Returns the text to display in the GPU backend name in the window title.
+   std::string GetWindowTitleText() const;
+ 
++  bool DrawNativeGuestOutputDiagnosticTriangle(ID3D12Resource* resource,
++                                               uint32_t width,
++                                               uint32_t height,
++                                               uint32_t phase);
++
+  protected:
+   bool SetupContext() override;
+   void ShutdownContext() override;
+@@ -608,6 +613,20 @@ class D3D12CommandProcessor : public CommandProcessor {
+   Microsoft::WRL::ComPtr<ID3D12PipelineState> fxaa_pipeline_;
+   Microsoft::WRL::ComPtr<ID3D12PipelineState> fxaa_extreme_pipeline_;
+ 
++  struct NativeGuestOutputTriangleConstants {
++    uint32_t output_size[2];
++    uint32_t phase;
++  };
++  enum class NativeGuestOutputTriangleRootParameter : uint32_t {
++    kConstants,
++    kOutput,
++    kCount,
++  };
++  Microsoft::WRL::ComPtr<ID3D12RootSignature>
++      native_guest_output_triangle_root_signature_;
++  Microsoft::WRL::ComPtr<ID3D12PipelineState>
++      native_guest_output_triangle_pipeline_;
++
+   struct ResolveDownscaleConstants {
+     uint32_t scale_x;
+     uint32_t scale_y;
+diff --git a/include/rex/system/interfaces/graphics.h b/include/rex/system/interfaces/graphics.h
+index c28c97c..608436a 100644
+--- a/include/rex/system/interfaces/graphics.h
++++ b/include/rex/system/interfaces/graphics.h
+@@ -31,6 +31,8 @@ namespace rex::system {
+ struct NativeGuestOutputRenderContext;
+ using NativeGuestOutputClearColor = bool (*)(
+     const NativeGuestOutputRenderContext& context, const float color[4]);
++using NativeGuestOutputDrawDiagnosticTriangle = bool (*)(
++    const NativeGuestOutputRenderContext& context, uint32_t phase);
+ class KernelState;
+ }
+ 
+@@ -54,6 +56,7 @@ struct NativeGuestOutputRenderContext {
+   void* guest_output = nullptr;
+   uint64_t submission = 0;
+   NativeGuestOutputClearColor clear_color = nullptr;
++  NativeGuestOutputDrawDiagnosticTriangle draw_diagnostic_triangle = nullptr;
+ };
+ 
+ // Returning false yields without modifying guest output. A callback that has
+diff --git a/src/graphics/d3d12/command_processor.cpp b/src/graphics/d3d12/command_processor.cpp
+index 62de7a2..f3d92b7 100644
+--- a/src/graphics/d3d12/command_processor.cpp
++++ b/src/graphics/d3d12/command_processor.cpp
+@@ -58,6 +58,7 @@ namespace shaders {
+ #include "../shaders/bytecode/d3d12_5_1/apply_gamma_table_fxaa_luma_cs.h"
+ #include "../shaders/bytecode/d3d12_5_1/fxaa_cs.h"
+ #include "../shaders/bytecode/d3d12_5_1/fxaa_extreme_cs.h"
++#include "../shaders/bytecode/d3d12_5_1/native_guest_output_triangle_cs.h"
+ #include "../shaders/bytecode/d3d12_5_1/resolve_downscale_cs.h"
+ }  // namespace shaders
+ 
+@@ -2090,6 +2091,112 @@ bool ClearNativeGuestOutput(
+   return true;
+ }
+ 
++bool D3D12CommandProcessor::DrawNativeGuestOutputDiagnosticTriangle(
++    ID3D12Resource* resource, uint32_t width, uint32_t height,
++    uint32_t phase) {
++  if (!resource || !width || !height) {
++    return false;
++  }
++
++  const ui::d3d12::D3D12Provider& provider = GetD3D12Provider();
++  ID3D12Device* device = provider.GetDevice();
++  if (!device) {
++    return false;
++  }
++
++  if (!native_guest_output_triangle_root_signature_) {
++    D3D12_ROOT_PARAMETER root_parameters
++        [uint32_t(NativeGuestOutputTriangleRootParameter::kCount)]{};
++    auto& constants = root_parameters
++        [uint32_t(NativeGuestOutputTriangleRootParameter::kConstants)];
++    constants.ParameterType = D3D12_ROOT_PARAMETER_TYPE_32BIT_CONSTANTS;
++    constants.Constants.ShaderRegister = 0;
++    constants.Constants.RegisterSpace = 0;
++    constants.Constants.Num32BitValues =
++        sizeof(NativeGuestOutputTriangleConstants) / sizeof(uint32_t);
++    constants.ShaderVisibility = D3D12_SHADER_VISIBILITY_ALL;
++
++    D3D12_DESCRIPTOR_RANGE output_range{};
++    output_range.RangeType = D3D12_DESCRIPTOR_RANGE_TYPE_UAV;
++    output_range.NumDescriptors = 1;
++    output_range.BaseShaderRegister = 0;
++    output_range.RegisterSpace = 0;
++    output_range.OffsetInDescriptorsFromTableStart = 0;
++    auto& output = root_parameters
++        [uint32_t(NativeGuestOutputTriangleRootParameter::kOutput)];
++    output.ParameterType = D3D12_ROOT_PARAMETER_TYPE_DESCRIPTOR_TABLE;
++    output.DescriptorTable.NumDescriptorRanges = 1;
++    output.DescriptorTable.pDescriptorRanges = &output_range;
++    output.ShaderVisibility = D3D12_SHADER_VISIBILITY_ALL;
++
++    D3D12_ROOT_SIGNATURE_DESC root_signature_desc{};
++    root_signature_desc.NumParameters =
++        uint32_t(NativeGuestOutputTriangleRootParameter::kCount);
++    root_signature_desc.pParameters = root_parameters;
++    root_signature_desc.Flags = D3D12_ROOT_SIGNATURE_FLAG_NONE;
++    *native_guest_output_triangle_root_signature_.ReleaseAndGetAddressOf() =
++        ui::d3d12::util::CreateRootSignature(provider, root_signature_desc);
++    if (!native_guest_output_triangle_root_signature_) {
++      REXGPU_ERROR("Failed to create the native guest-output triangle root signature");
++      return false;
++    }
++  }
++
++  if (!native_guest_output_triangle_pipeline_) {
++    *native_guest_output_triangle_pipeline_.ReleaseAndGetAddressOf() =
++        ui::d3d12::util::CreateComputePipeline(
++            device, shaders::native_guest_output_triangle_cs,
++            sizeof(shaders::native_guest_output_triangle_cs),
++            native_guest_output_triangle_root_signature_.Get());
++    if (!native_guest_output_triangle_pipeline_) {
++      REXGPU_ERROR("Failed to create the native guest-output triangle pipeline");
++      return false;
++    }
++  }
++
++  ui::d3d12::util::DescriptorCpuGpuHandlePair descriptor;
++  if (!RequestOneUseSingleViewDescriptors(1, &descriptor)) {
++    return false;
++  }
++
++  D3D12_UNORDERED_ACCESS_VIEW_DESC view_desc{};
++  view_desc.Format = ui::d3d12::D3D12Presenter::kGuestOutputFormat;
++  view_desc.ViewDimension = D3D12_UAV_DIMENSION_TEXTURE2D;
++  device->CreateUnorderedAccessView(resource, nullptr, &view_desc,
++                                    descriptor.first);
++
++  NativeGuestOutputTriangleConstants triangle_constants{{width, height},
++                                                         phase & 1};
++  PushTransitionBarrier(
++      resource, ui::d3d12::D3D12Presenter::kGuestOutputInternalState,
++      D3D12_RESOURCE_STATE_UNORDERED_ACCESS);
++  deferred_command_list_.D3DSetComputeRootSignature(
++      native_guest_output_triangle_root_signature_.Get());
++  deferred_command_list_.D3DSetComputeRoot32BitConstants(
++      uint32_t(NativeGuestOutputTriangleRootParameter::kConstants),
++      sizeof(triangle_constants) / sizeof(uint32_t), &triangle_constants, 0);
++  deferred_command_list_.D3DSetComputeRootDescriptorTable(
++      uint32_t(NativeGuestOutputTriangleRootParameter::kOutput),
++      descriptor.second);
++  SetExternalPipeline(native_guest_output_triangle_pipeline_.Get());
++  SubmitBarriers();
++  deferred_command_list_.D3DDispatch((width + 7) / 8, (height + 7) / 8, 1);
++  PushTransitionBarrier(resource, D3D12_RESOURCE_STATE_UNORDERED_ACCESS,
++                        ui::d3d12::D3D12Presenter::kGuestOutputInternalState);
++  return true;
++}
++
++bool InvokeNativeGuestOutputDiagnosticTriangle(
++    const system::NativeGuestOutputRenderContext& context, uint32_t phase) {
++  auto* command_processor =
++      static_cast<D3D12CommandProcessor*>(context.command_context);
++  auto* resource = static_cast<ID3D12Resource*>(context.guest_output);
++  return command_processor &&
++         command_processor->DrawNativeGuestOutputDiagnosticTriangle(
++             resource, context.guest_output_width, context.guest_output_height,
++             phase);
++}
++
+ void D3D12CommandProcessor::IssueSwap(uint32_t frontbuffer_ptr, uint32_t frontbuffer_width,
+                                       uint32_t frontbuffer_height) {
+   SCOPE_profile_cpu_f("gpu");
+@@ -2461,6 +2568,8 @@ void D3D12CommandProcessor::IssueSwap(uint32_t frontbuffer_ptr, uint32_t frontbu
+           native_context.guest_output = guest_output_resource;
+           native_context.submission = submission_current_;
+           native_context.clear_color = &ClearNativeGuestOutput;
++          native_context.draw_diagnostic_triangle =
++              &InvokeNativeGuestOutputDiagnosticTriangle;
+           renderer(native_context);
+         }
+         SubmitBarriers();
+diff --git a/src/graphics/shaders/bytecode/d3d12_5_1/native_guest_output_triangle_cs.h b/src/graphics/shaders/bytecode/d3d12_5_1/native_guest_output_triangle_cs.h
+new file mode 100644
+index 0000000..e5309e7
+--- /dev/null
++++ b/src/graphics/shaders/bytecode/d3d12_5_1/native_guest_output_triangle_cs.h
+@@ -0,0 +1,328 @@
++#if 0
++//
++// Generated by Microsoft (R) HLSL Shader Compiler 10.1
++//
++//
++// Buffer Definitions:
++//
++// cbuffer NativeGuestOutputTriangleConstants
++// {
++//
++//   uint2 output_size;                 // Offset:    0 Size:     8
++//   uint phase;                        // Offset:    8 Size:     4
++//
++// }
++//
++//
++// Resource Bindings:
++//
++// Name                                 Type  Format         Dim      ID      HLSL Bind  Count
++// ------------------------------ ---------- ------- ----------- ------- -------------- ------
++// output_texture                        UAV  float4          2d      U0             u0      1
++// NativeGuestOutputTriangleConstants    cbuffer      NA          NA     CB0            cb0      1
++//
++//
++//
++// Input signature:
++//
++// Name                 Index   Mask Register SysValue  Format   Used
++// -------------------- ----- ------ -------- -------- ------- ------
++// no Input
++//
++// Output signature:
++//
++// Name                 Index   Mask Register SysValue  Format   Used
++// -------------------- ----- ------ -------- -------- ------- ------
++// no Output
++cs_5_1
++dcl_globalFlags refactoringAllowed
++dcl_constantbuffer CB0[0:0][1], immediateIndexed, space=0
++dcl_uav_typed_texture2d (float,float,float,float) U0[0:0], space=0
++dcl_input vThreadID.xy
++dcl_temps 3
++dcl_thread_group 8, 8, 1
++uge r0.xy, vThreadID.xyxx, CB0[0][0].xyxx
++or r0.x, r0.y, r0.x
++if_nz r0.x
++  ret
++endif
++utof r0.xy, vThreadID.xyxx
++add r0.xy, r0.xyxx, l(0.500000, 0.500000, 0.000000, 0.000000)
++utof r0.zw, CB0[0][0].xxxy
++div r0.xy, r0.xyxx, r0.zwzz
++add r1.xyzw, r0.yxyx, l(-0.180000, -0.500000, -0.820000, -0.820000)
++mul r0.zw, r1.yyyw, l(0.000000, 0.000000, 0.640000, -0.640000)
++mad r0.zw, r1.xxxz, l(0.000000, 0.000000, -0.320000, -0.320000), -r0.zzzw
++ge r0.zw, l(0.000000, 0.000000, 0.000000, 0.000000), r0.zzzw
++ge r1.x, l(0.000000), r1.z
++and r0.z, r0.z, r1.x
++and r0.z, r0.w, r0.z
++movc r1.y, CB0[0][0].z, l(0.175000), l(0.105000)
++add_sat r2.x, -r0.y, l(1.200000)
++add r0.xy, r0.xyxx, l(0.150000, 0.100000, 0.000000, 0.000000)
++min r2.yz, r0.xxyx, l(0.000000, 1.000000, 1.000000, 0.000000)
++mov r1.xz, l(0.015000,0,0.055000,0)
++movc r0.xyz, r0.zzzz, r2.xyzx, r1.xyzx
++mov r0.w, l(1.000000)
++store_uav_typed U0[0].xyzw, vThreadID.xyyy, r0.xyzw
++ret
++// Approximately 25 instruction slots used
++#endif
++
++const BYTE native_guest_output_triangle_cs[] =
++{
++     68,  88,  66,  67, 188,  85,
++     12,  19, 161, 190,  36, 158,
++    111,  13,  85, 232, 165, 183,
++     13,  29,   1,   0,   0,   0,
++    240,   5,   0,   0,   5,   0,
++      0,   0,  52,   0,   0,   0,
++    244,   1,   0,   0,   4,   2,
++      0,   0,  20,   2,   0,   0,
++     84,   5,   0,   0,  82,  68,
++     69,  70, 184,   1,   0,   0,
++      1,   0,   0,   0, 192,   0,
++      0,   0,   2,   0,   0,   0,
++     60,   0,   0,   0,   1,   5,
++     83,  67,   0, 133,   0,   0,
++    144,   1,   0,   0,  19,  19,
++     68,  37,  60,   0,   0,   0,
++     24,   0,   0,   0,  40,   0,
++      0,   0,  40,   0,   0,   0,
++     36,   0,   0,   0,  12,   0,
++      0,   0,   0,   0,   0,   0,
++    140,   0,   0,   0,   4,   0,
++      0,   0,   5,   0,   0,   0,
++      4,   0,   0,   0, 255, 255,
++    255, 255,   0,   0,   0,   0,
++      1,   0,   0,   0,  12,   0,
++      0,   0,   0,   0,   0,   0,
++      0,   0,   0,   0, 155,   0,
++      0,   0,   0,   0,   0,   0,
++      0,   0,   0,   0,   0,   0,
++      0,   0,   0,   0,   0,   0,
++      0,   0,   0,   0,   1,   0,
++      0,   0,   1,   0,   0,   0,
++      0,   0,   0,   0,   0,   0,
++      0,   0, 111, 117, 116, 112,
++    117, 116,  95, 116, 101, 120,
++    116, 117, 114, 101,   0,  78,
++     97, 116, 105, 118, 101,  71,
++    117, 101, 115, 116,  79, 117,
++    116, 112, 117, 116,  84, 114,
++    105,  97, 110, 103, 108, 101,
++     67, 111, 110, 115, 116,  97,
++    110, 116, 115,   0, 171, 171,
++    155,   0,   0,   0,   2,   0,
++      0,   0, 216,   0,   0,   0,
++     16,   0,   0,   0,   0,   0,
++      0,   0,   0,   0,   0,   0,
++     40,   1,   0,   0,   0,   0,
++      0,   0,   8,   0,   0,   0,
++      2,   0,   0,   0,  60,   1,
++      0,   0,   0,   0,   0,   0,
++    255, 255, 255, 255,   0,   0,
++      0,   0, 255, 255, 255, 255,
++      0,   0,   0,   0,  96,   1,
++      0,   0,   8,   0,   0,   0,
++      4,   0,   0,   0,   2,   0,
++      0,   0, 108,   1,   0,   0,
++      0,   0,   0,   0, 255, 255,
++    255, 255,   0,   0,   0,   0,
++    255, 255, 255, 255,   0,   0,
++      0,   0, 111, 117, 116, 112,
++    117, 116,  95, 115, 105, 122,
++    101,   0, 117, 105, 110, 116,
++     50,   0, 171, 171,   1,   0,
++     19,   0,   1,   0,   2,   0,
++      0,   0,   0,   0,   0,   0,
++      0,   0,   0,   0,   0,   0,
++      0,   0,   0,   0,   0,   0,
++      0,   0,   0,   0,   0,   0,
++     52,   1,   0,   0, 112, 104,
++     97, 115, 101,   0, 100, 119,
++    111, 114, 100,   0,   0,   0,
++     19,   0,   1,   0,   1,   0,
++      0,   0,   0,   0,   0,   0,
++      0,   0,   0,   0,   0,   0,
++      0,   0,   0,   0,   0,   0,
++      0,   0,   0,   0,   0,   0,
++    102,   1,   0,   0,  77, 105,
++     99, 114, 111, 115, 111, 102,
++    116,  32,  40,  82,  41,  32,
++     72,  76,  83,  76,  32,  83,
++    104,  97, 100, 101, 114,  32,
++     67, 111, 109, 112, 105, 108,
++    101, 114,  32,  49,  48,  46,
++     49,   0,  73,  83,  71,  78,
++      8,   0,   0,   0,   0,   0,
++      0,   0,   8,   0,   0,   0,
++     79,  83,  71,  78,   8,   0,
++      0,   0,   0,   0,   0,   0,
++      8,   0,   0,   0,  83,  72,
++     69,  88,  56,   3,   0,   0,
++     81,   0,   5,   0, 206,   0,
++      0,   0, 106,   8,   0,   1,
++     89,   0,   0,   7,  70, 142,
++     48,   0,   0,   0,   0,   0,
++      0,   0,   0,   0,   0,   0,
++      0,   0,   1,   0,   0,   0,
++      0,   0,   0,   0, 156,  24,
++      0,   7,  70, 238,  49,   0,
++      0,   0,   0,   0,   0,   0,
++      0,   0,   0,   0,   0,   0,
++     85,  85,   0,   0,   0,   0,
++      0,   0,  95,   0,   0,   2,
++     50,   0,   2,   0, 104,   0,
++      0,   2,   3,   0,   0,   0,
++    155,   0,   0,   4,   8,   0,
++      0,   0,   8,   0,   0,   0,
++      1,   0,   0,   0,  80,   0,
++      0,   8,  50,   0,  16,   0,
++      0,   0,   0,   0,  70,   0,
++      2,   0,  70, 128,  48,   0,
++      0,   0,   0,   0,   0,   0,
++      0,   0,   0,   0,   0,   0,
++     60,   0,   0,   7,  18,   0,
++     16,   0,   0,   0,   0,   0,
++     26,   0,  16,   0,   0,   0,
++      0,   0,  10,   0,  16,   0,
++      0,   0,   0,   0,  31,   0,
++      4,   3,  10,   0,  16,   0,
++      0,   0,   0,   0,  62,   0,
++      0,   1,  21,   0,   0,   1,
++     86,   0,   0,   4,  50,   0,
++     16,   0,   0,   0,   0,   0,
++     70,   0,   2,   0,   0,   0,
++      0,  10,  50,   0,  16,   0,
++      0,   0,   0,   0,  70,   0,
++     16,   0,   0,   0,   0,   0,
++      2,  64,   0,   0,   0,   0,
++      0,  63,   0,   0,   0,  63,
++      0,   0,   0,   0,   0,   0,
++      0,   0,  86,   0,   0,   7,
++    194,   0,  16,   0,   0,   0,
++      0,   0,   6, 132,  48,   0,
++      0,   0,   0,   0,   0,   0,
++      0,   0,   0,   0,   0,   0,
++     14,   0,   0,   7,  50,   0,
++     16,   0,   0,   0,   0,   0,
++     70,   0,  16,   0,   0,   0,
++      0,   0, 230,  10,  16,   0,
++      0,   0,   0,   0,   0,   0,
++      0,  10, 242,   0,  16,   0,
++      1,   0,   0,   0,  22,   1,
++     16,   0,   0,   0,   0,   0,
++      2,  64,   0,   0, 236,  81,
++     56, 190,   0,   0,   0, 191,
++    133, 235,  81, 191, 133, 235,
++     81, 191,  56,   0,   0,  10,
++    194,   0,  16,   0,   0,   0,
++      0,   0,  86,  13,  16,   0,
++      1,   0,   0,   0,   2,  64,
++      0,   0,   0,   0,   0,   0,
++      0,   0,   0,   0,  10, 215,
++     35,  63,  10, 215,  35, 191,
++     50,   0,   0,  13, 194,   0,
++     16,   0,   0,   0,   0,   0,
++      6,   8,  16,   0,   1,   0,
++      0,   0,   2,  64,   0,   0,
++      0,   0,   0,   0,   0,   0,
++      0,   0,  10, 215, 163, 190,
++     10, 215, 163, 190, 166,  14,
++     16, 128,  65,   0,   0,   0,
++      0,   0,   0,   0,  29,   0,
++      0,  10, 194,   0,  16,   0,
++      0,   0,   0,   0,   2,  64,
++      0,   0,   0,   0,   0,   0,
++      0,   0,   0,   0,   0,   0,
++      0,   0,   0,   0,   0,   0,
++    166,  14,  16,   0,   0,   0,
++      0,   0,  29,   0,   0,   7,
++     18,   0,  16,   0,   1,   0,
++      0,   0,   1,  64,   0,   0,
++      0,   0,   0,   0,  42,   0,
++     16,   0,   1,   0,   0,   0,
++      1,   0,   0,   7,  66,   0,
++     16,   0,   0,   0,   0,   0,
++     42,   0,  16,   0,   0,   0,
++      0,   0,  10,   0,  16,   0,
++      1,   0,   0,   0,   1,   0,
++      0,   7,  66,   0,  16,   0,
++      0,   0,   0,   0,  58,   0,
++     16,   0,   0,   0,   0,   0,
++     42,   0,  16,   0,   0,   0,
++      0,   0,  55,   0,   0,  11,
++     34,   0,  16,   0,   1,   0,
++      0,   0,  42, 128,  48,   0,
++      0,   0,   0,   0,   0,   0,
++      0,   0,   0,   0,   0,   0,
++      1,  64,   0,   0,  52,  51,
++     51,  62,   1,  64,   0,   0,
++     61,  10, 215,  61,   0,  32,
++      0,   8,  18,   0,  16,   0,
++      2,   0,   0,   0,  26,   0,
++     16, 128,  65,   0,   0,   0,
++      0,   0,   0,   0,   1,  64,
++      0,   0, 154, 153, 153,  63,
++      0,   0,   0,  10,  50,   0,
++     16,   0,   0,   0,   0,   0,
++     70,   0,  16,   0,   0,   0,
++      0,   0,   2,  64,   0,   0,
++    154, 153,  25,  62, 205, 204,
++    204,  61,   0,   0,   0,   0,
++      0,   0,   0,   0,  51,   0,
++      0,  10,  98,   0,  16,   0,
++      2,   0,   0,   0,   6,   1,
++     16,   0,   0,   0,   0,   0,
++      2,  64,   0,   0,   0,   0,
++      0,   0,   0,   0, 128,  63,
++      0,   0, 128,  63,   0,   0,
++      0,   0,  54,   0,   0,   8,
++     82,   0,  16,   0,   1,   0,
++      0,   0,   2,  64,   0,   0,
++    143, 194, 117,  60,   0,   0,
++      0,   0, 174,  71,  97,  61,
++      0,   0,   0,   0,  55,   0,
++      0,   9, 114,   0,  16,   0,
++      0,   0,   0,   0, 166,  10,
++     16,   0,   0,   0,   0,   0,
++     70,   2,  16,   0,   2,   0,
++      0,   0,  70,   2,  16,   0,
++      1,   0,   0,   0,  54,   0,
++      0,   5, 130,   0,  16,   0,
++      0,   0,   0,   0,   1,  64,
++      0,   0,   0,   0, 128,  63,
++    164,   0,   0,   7, 242, 224,
++     33,   0,   0,   0,   0,   0,
++      0,   0,   0,   0,  70,   5,
++      2,   0,  70,  14,  16,   0,
++      0,   0,   0,   0,  62,   0,
++      0,   1,  83,  84,  65,  84,
++    148,   0,   0,   0,  25,   0,
++      0,   0,   3,   0,   0,   0,
++      0,   0,   0,   0,   1,   0,
++      0,   0,  10,   0,   0,   0,
++      0,   0,   0,   0,   4,   0,
++      0,   0,   2,   0,   0,   0,
++      1,   0,   0,   0,   0,   0,
++      0,   0,   0,   0,   0,   0,
++      0,   0,   0,   0,   0,   0,
++      0,   0,   0,   0,   0,   0,
++      0,   0,   0,   0,   0,   0,
++      0,   0,   0,   0,   0,   0,
++      0,   0,   0,   0,   0,   0,
++      0,   0,   2,   0,   0,   0,
++      2,   0,   0,   0,   2,   0,
++      0,   0,   0,   0,   0,   0,
++      0,   0,   0,   0,   0,   0,
++      0,   0,   0,   0,   0,   0,
++      0,   0,   0,   0,   0,   0,
++      0,   0,   0,   0,   0,   0,
++      0,   0,   0,   0,   0,   0,
++      0,   0,   0,   0,   0,   0,
++      0,   0,   0,   0,   0,   0,
++      0,   0,   0,   0,   0,   0,
++      0,   0,   0,   0,   1,   0,
++      0,   0
++};
+diff --git a/src/graphics/shaders/native_guest_output_triangle.cs.hlsl b/src/graphics/shaders/native_guest_output_triangle.cs.hlsl
+new file mode 100644
+index 0000000..8de31a8
+--- /dev/null
++++ b/src/graphics/shaders/native_guest_output_triangle.cs.hlsl
+@@ -0,0 +1,38 @@
++cbuffer NativeGuestOutputTriangleConstants : register(b0) {
++  uint2 output_size;
++  uint phase;
++};
++
++RWTexture2D<float4> output_texture : register(u0);
++
++float Edge(float2 a, float2 b, float2 sample_position) {
++  float2 edge = b - a;
++  float2 offset = sample_position - a;
++  return edge.x * offset.y - edge.y * offset.x;
++}
++
++[numthreads(8, 8, 1)]
++void main(uint3 dispatch_thread_id : SV_DispatchThreadID) {
++  if (any(dispatch_thread_id.xy >= output_size)) {
++    return;
++  }
++
++  float2 sample_position =
++      (float2(dispatch_thread_id.xy) + 0.5f) / float2(output_size);
++  const float2 vertex_a = float2(0.50f, 0.18f);
++  const float2 vertex_b = float2(0.18f, 0.82f);
++  const float2 vertex_c = float2(0.82f, 0.82f);
++  float edge_a = Edge(vertex_a, vertex_b, sample_position);
++  float edge_b = Edge(vertex_b, vertex_c, sample_position);
++  float edge_c = Edge(vertex_c, vertex_a, sample_position);
++  bool inside = edge_a <= 0.0f && edge_b <= 0.0f && edge_c <= 0.0f;
++
++  float pulse = phase == 0 ? 0.08f : 0.15f;
++  float3 background = float3(0.015f, 0.025f + pulse, 0.055f);
++  float3 triangle_color = float3(
++      saturate(1.2f - sample_position.y),
++      saturate(sample_position.x + 0.15f),
++      saturate(sample_position.y + 0.1f));
++  output_texture[dispatch_thread_id.xy] =
++      float4(inside ? triangle_color : background, 1.0f);
++}

--- a/src/native_renderer/guest_output_renderer.cpp
+++ b/src/native_renderer/guest_output_renderer.cpp
@@ -11,12 +11,18 @@ REXCVAR_DEFINE_BOOL(
     pinyon_shift_native_renderer_diagnostic_clear, false, "Pinyon Shift",
     "Replace guest output with a diagnostic clear for native-renderer testing")
     .lifecycle(rex::cvar::Lifecycle::kRequiresRestart);
+REXCVAR_DEFINE_STRING(
+    pinyon_shift_native_renderer, "xenos", "Pinyon Shift",
+    "Guest-output renderer: xenos, diagnostic_clear, diagnostic_triangle")
+    .lifecycle(rex::cvar::Lifecycle::kRequiresRestart);
 
 namespace {
 
 std::atomic<bool> g_failure_latched{};
 std::atomic<uint64_t> g_callback_count{};
 std::atomic<uint64_t> g_claimed_count{};
+enum class DiagnosticMode : uint32_t { kClear, kTriangle };
+std::atomic<DiagnosticMode> g_mode{DiagnosticMode::kClear};
 
 bool RenderDiagnosticOutput(
     const rex::system::NativeGuestOutputRenderContext& context) {
@@ -25,8 +31,7 @@ bool RenderDiagnosticOutput(
   if (g_failure_latched.load(std::memory_order_acquire)) {
     return false;
   }
-  if (context.backend != rex::system::NativeGuestOutputBackend::kD3D12 ||
-      !context.clear_color) {
+  if (context.backend != rex::system::NativeGuestOutputBackend::kD3D12) {
     if (!g_failure_latched.exchange(true, std::memory_order_acq_rel)) {
       pinyon_shift::diagnostics::RecordEvent(
           "native_renderer.output.failure",
@@ -35,14 +40,26 @@ bool RenderDiagnosticOutput(
     return false;
   }
 
-  const bool alternate = ((context.submission / 120) & 1) != 0;
-  const float color[4] = {alternate ? 0.04f : 0.85f, 0.16f,
-                          alternate ? 0.55f : 0.03f, 1.0f};
-  if (!context.clear_color(context, color)) {
+  const DiagnosticMode mode = g_mode.load(std::memory_order_relaxed);
+  bool rendered = false;
+  if (mode == DiagnosticMode::kTriangle &&
+      context.draw_diagnostic_triangle) {
+    rendered = context.draw_diagnostic_triangle(
+        context, uint32_t((context.submission / 120) & 1));
+  } else if (mode == DiagnosticMode::kClear && context.clear_color) {
+    const bool alternate = ((context.submission / 120) & 1) != 0;
+    const float color[4] = {alternate ? 0.04f : 0.85f, 0.16f,
+                            alternate ? 0.55f : 0.03f, 1.0f};
+    rendered = context.clear_color(context, color);
+  }
+  if (!rendered) {
     if (!g_failure_latched.exchange(true, std::memory_order_acq_rel)) {
       pinyon_shift::diagnostics::RecordEvent(
           "native_renderer.output.failure",
-          {{"reason", "diagnostic_clear_failed"}, {"fallback", "xenos"}});
+          {{"reason", mode == DiagnosticMode::kTriangle
+                          ? "diagnostic_triangle_failed"
+                          : "diagnostic_clear_failed"},
+           {"fallback", "xenos"}});
     }
     return false;
   }
@@ -60,7 +77,9 @@ bool RenderDiagnosticOutput(
          {"display_width", std::to_string(context.display_width)},
          {"display_height", std::to_string(context.display_height)},
          {"format", std::to_string(context.output_format)},
-         {"mode", "diagnostic_clear"}});
+         {"mode", mode == DiagnosticMode::kTriangle
+                      ? "diagnostic_triangle"
+                      : "diagnostic_clear"}});
   }
   return true;
 }
@@ -70,16 +89,36 @@ bool RenderDiagnosticOutput(
 namespace pinyon_shift::native_renderer {
 
 void InstallGuestOutputRenderer(rex::system::IGraphicsSystem* graphics_system) {
-  if (!graphics_system ||
-      !REXCVAR_GET(pinyon_shift_native_renderer_diagnostic_clear)) {
+  if (!graphics_system) {
     return;
   }
+  const std::string mode = REXCVAR_GET(pinyon_shift_native_renderer);
+  const bool legacy_clear =
+      REXCVAR_GET(pinyon_shift_native_renderer_diagnostic_clear);
+  if (mode == "xenos" && !legacy_clear) {
+    diagnostics::RecordEvent("native_renderer.output.state",
+                             {{"mode", "xenos"}, {"authority", "xenos"}});
+    return;
+  }
+  if (mode != "diagnostic_clear" && mode != "diagnostic_triangle" &&
+      !(mode == "xenos" && legacy_clear)) {
+    diagnostics::RecordEvent(
+        "native_renderer.output.failure",
+        {{"reason", "unsupported_mode"}, {"fallback", "xenos"}});
+    return;
+  }
+  const DiagnosticMode selected_mode =
+      mode == "diagnostic_triangle" ? DiagnosticMode::kTriangle
+                                    : DiagnosticMode::kClear;
+  g_mode.store(selected_mode, std::memory_order_release);
   g_failure_latched.store(false, std::memory_order_release);
   g_callback_count.store(0, std::memory_order_release);
   g_claimed_count.store(0, std::memory_order_release);
   graphics_system->SetNativeGuestOutputRenderer(&RenderDiagnosticOutput);
   diagnostics::RecordEvent("native_renderer.output.installed",
-                           {{"mode", "diagnostic_clear"},
+                           {{"mode", selected_mode == DiagnosticMode::kTriangle
+                                         ? "diagnostic_triangle"
+                                         : "diagnostic_clear"},
                             {"fallback", "xenos"}});
 }
 

--- a/src/pinyon_shift_app.cpp
+++ b/src/pinyon_shift_app.cpp
@@ -24,14 +24,14 @@
 
 #include <cstdio>
 
-REXCVAR_DEFINE_UINT32(pinyon_shift_config_schema, 9, "Pinyon Shift",
+REXCVAR_DEFINE_UINT32(pinyon_shift_config_schema, 10, "Pinyon Shift",
                       "Pinyon Shift host configuration schema version");
 REXCVAR_DEFINE_BOOL(pinyon_shift_capture_performance, true, "Pinyon Shift",
                     "Capture lightweight per-frame performance counters to a session CSV");
 
 namespace {
 
-constexpr uint32_t kConfigSchema = 9;
+constexpr uint32_t kConfigSchema = 10;
 
 bool EnsureSupportedConfig(const std::filesystem::path& path, bool& created,
                            bool& migrated) {
@@ -60,6 +60,7 @@ bool EnsureSupportedConfig(const std::filesystem::path& path, bool& created,
               "xma_relaxed_padding_admission = false\n"
               "pinyon_shift_stabilize_vehicle_presentation = false\n"
               "pinyon_shift_skip_opening_movies = false\n"
+              "pinyon_shift_native_renderer = \"xenos\"\n"
               "anisotropic_override = 3\n"
               "swap_post_effect = \"none\"\n"
               "disable_motion_blur = false\n"
@@ -97,7 +98,7 @@ bool EnsureSupportedConfig(const std::filesystem::path& path, bool& created,
     if (schema == kConfigSchema) {
       return true;
     }
-    if (schema < 1 || schema > 8) {
+    if (schema < 1 || schema > 9) {
       return false;
     }
 
@@ -163,6 +164,8 @@ bool EnsureSupportedConfig(const std::filesystem::path& path, bool& created,
         {"occlusion_query", "occlusion_query = \"legacy\"\n"},
         {"zpd_end_policy", "zpd_end_policy = \"report_layout\"\n"},
         {"zpd_end_fallback", "zpd_end_fallback = \"pairwise_sentinel\"\n"},
+        {"pinyon_shift_native_renderer",
+         "pinyon_shift_native_renderer = \"xenos\"\n"},
     };
     for (const auto& [name, line] : graphics_settings) {
       const std::regex setting_pattern("(?:^|\\n)\\s*" + std::string(name) +
@@ -303,6 +306,9 @@ void PinyonShiftApp::OnPostInitLogging() {
                         {"native_renderer_census",
                          rex::cvar::GetFlagByName(
                              "pinyon_shift_native_renderer_census")},
+                        {"native_renderer",
+                         rex::cvar::GetFlagByName(
+                             "pinyon_shift_native_renderer")},
                         {"occlusion_query", rex::cvar::GetFlagByName("occlusion_query")},
                         {"zpd_end_policy", rex::cvar::GetFlagByName("zpd_end_policy")},
                         {"zpd_end_fallback", rex::cvar::GetFlagByName("zpd_end_fallback")},

--- a/tools/create-crash-report.ps1
+++ b/tools/create-crash-report.ps1
@@ -237,7 +237,8 @@ try {
         'draw_resolution_scale_x', 'draw_resolution_scale_y', 'occlusion_query',
         'zpd_end_policy', 'zpd_end_fallback', 'clear_memory_page_state',
         'readback_resolve', 'readback_resolve_half_pixel_offset',
-        'readback_memexport', 'readback_memexport_fast'
+        'readback_memexport', 'readback_memexport_fast',
+        'pinyon_shift_native_renderer'
     )
     $configPath = Join-Path $resolvedStateRoot 'config/pinyon_shift.toml'
     $settings = [ordered]@{}
@@ -246,6 +247,32 @@ try {
             if ($line -match '^\s*(?<key>[a-zA-Z0-9_]+)\s*=\s*(?<value>.+?)\s*(?:#.*)?$' -and
                 $Matches.key -in $allowedSettings) {
                 $settings[$Matches.key] = $Matches.value
+            }
+        }
+    }
+
+    $nativeRenderer = [ordered]@{
+        configured = if ($settings.Contains('pinyon_shift_native_renderer')) {
+            ([string]$settings['pinyon_shift_native_renderer']).Trim('"')
+        } else { 'xenos' }
+        effective = 'unknown'
+        claimed_frames = [uint64]0
+        failure_reason = $null
+    }
+    if ($null -ne $eventLog) {
+        foreach ($line in Get-Content -LiteralPath $eventLog.FullName -ErrorAction SilentlyContinue) {
+            try { $event = $line | ConvertFrom-Json -ErrorAction Stop } catch { continue }
+            switch ($event.event) {
+                'native_renderer.output.state' { $nativeRenderer.effective = [string]$event.mode }
+                'native_renderer.output.installed' { $nativeRenderer.effective = [string]$event.mode }
+                'native_renderer.output.frame' {
+                    $nativeRenderer.effective = [string]$event.mode
+                    $nativeRenderer.claimed_frames = [uint64]$event.claimed
+                }
+                'native_renderer.output.failure' {
+                    $nativeRenderer.effective = 'xenos'
+                    $nativeRenderer.failure_reason = [string]$event.reason
+                }
             }
         }
     }
@@ -315,6 +342,7 @@ try {
             xma_stalls = $xmaStalls
         }
         graphics = [ordered]@{
+            native_renderer = $nativeRenderer
             zpd = $zpdCounters
             resolve_readback = $resolveCounters
             presentation = $presentationCounters

--- a/tools/set-graphics-experiment.ps1
+++ b/tools/set-graphics-experiment.ps1
@@ -1,6 +1,6 @@
 [CmdletBinding()]
 param(
-    [ValidateSet('Get', 'Apply', 'Reset', 'Restore')]
+    [ValidateSet('Get', 'Apply', 'Reset', 'Restore', 'ResetRenderer')]
     [string]$Action = 'Get',
     [ValidateSet(4, 8, 16)]
     [int]$Anisotropy = 4,
@@ -24,6 +24,8 @@ param(
     [string]$DisableMotionBlur = 'false',
     [ValidateSet('true', 'false')]
     [string]$DisableDepthOfField = 'false',
+    [ValidateSet('xenos', 'diagnostic_triangle')]
+    [string]$NativeRenderer = 'xenos',
     [string]$StateRoot,
     [switch]$Json
 )
@@ -44,8 +46,8 @@ $backupDirectory = Join-Path $configDirectory 'backups'
 function Get-DefaultConfigText {
     @'
 # Pinyon Shift host configuration.
-# Schema 9 adds exact-hash FH1 post-processing switches.
-pinyon_shift_config_schema = 9
+# Schema 10 adds the recoverable native-renderer experiment.
+pinyon_shift_config_schema = 10
 input_backend = "sdl"
 hid_mappings_file = "gamecontrollerdb.txt"
 mnk_mode = true
@@ -57,6 +59,7 @@ host_present_fps_limit = 60
 host_present_sleep_spin = true
 pinyon_shift_stabilize_vehicle_presentation = false
 pinyon_shift_skip_opening_movies = false
+pinyon_shift_native_renderer = "xenos"
 xma_relaxed_padding_admission = false
 anisotropic_override = 3
 swap_post_effect = "none"
@@ -171,6 +174,7 @@ function Get-SettingsResult([string]$Text, [string]$BackupPath, [string]$Operati
             occlusion_query = Get-TomlValue $Text 'occlusion_query' 'legacy'
             zpd_end_policy = Get-TomlValue $Text 'zpd_end_policy' 'report_layout'
             zpd_end_fallback = Get-TomlValue $Text 'zpd_end_fallback' 'pairwise_sentinel'
+            native_renderer = Get-TomlValue $Text 'pinyon_shift_native_renderer' 'xenos'
         }
         restart_required = $Operation -ne 'Get'
     }
@@ -184,7 +188,7 @@ switch ($Action) {
             Get-Content -LiteralPath $configPath -Raw
         } else { Get-DefaultConfigText }
         $schema = Get-SchemaVersion $text
-        if ($schema -notin @(1, 2, 3, 4, 5, 6, 7, 8, 9)) { throw "Unsupported host configuration schema: $schema" }
+        if ($schema -notin @(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)) { throw "Unsupported host configuration schema: $schema" }
     }
     'Reset' {
         $backup = New-ConfigBackup
@@ -201,7 +205,7 @@ switch ($Action) {
         $backup = New-ConfigBackup
         $text = Get-Content -LiteralPath $source.FullName -Raw
         $schema = Get-SchemaVersion $text
-        if ($schema -notin @(1, 2, 3, 4, 5, 6, 7, 8, 9)) { throw "Backup uses unsupported schema: $schema" }
+        if ($schema -notin @(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)) { throw "Backup uses unsupported schema: $schema" }
         Write-Config $text
     }
     'Apply' {
@@ -209,9 +213,9 @@ switch ($Action) {
             Get-Content -LiteralPath $configPath -Raw
         } else { Get-DefaultConfigText }
         $schema = Get-SchemaVersion $text
-        if ($schema -notin @(1, 2, 3, 4, 5, 6, 7, 8, 9)) { throw "Unsupported host configuration schema: $schema" }
+        if ($schema -notin @(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)) { throw "Unsupported host configuration schema: $schema" }
         $backup = New-ConfigBackup
-        $text = Set-TomlValue $text 'pinyon_shift_config_schema' '9'
+        $text = Set-TomlValue $text 'pinyon_shift_config_schema' '10'
         if (-not [regex]::IsMatch($text, '(?m)^\s*xma_relaxed_padding_admission\s*=')) {
             $text = Set-TomlValue $text 'xma_relaxed_padding_admission' 'false'
         }
@@ -254,6 +258,19 @@ switch ($Action) {
         $text = Set-TomlValue $text 'occlusion_query' ('"' + $OcclusionQuery + '"')
         $text = Set-TomlValue $text 'zpd_end_policy' ('"' + $ZpdEndPolicy + '"')
         $text = Set-TomlValue $text 'zpd_end_fallback' ('"' + $ZpdEndFallback + '"')
+        $text = Set-TomlValue $text 'pinyon_shift_native_renderer' ('"' + $NativeRenderer + '"')
+        Write-Config $text
+    }
+    'ResetRenderer' {
+        $text = if (Test-Path -LiteralPath $configPath -PathType Leaf) {
+            Get-Content -LiteralPath $configPath -Raw
+        } else { Get-DefaultConfigText }
+        $schema = Get-SchemaVersion $text
+        if ($schema -notin @(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)) {
+            throw "Unsupported host configuration schema: $schema"
+        }
+        $backup = New-ConfigBackup
+        $text = Set-TomlValue $text 'pinyon_shift_native_renderer' '"xenos"'
         Write-Config $text
     }
 }

--- a/tools/tests/test_graphics_settings.py
+++ b/tools/tests/test_graphics_settings.py
@@ -67,10 +67,11 @@ class GraphicsSettingsTests(unittest.TestCase):
                 "-Preset", "experimental_2x",
                 "-DisableMotionBlur", "true",
                 "-DisableDepthOfField", "true",
+                "-NativeRenderer", "diagnostic_triangle",
             )
             updated = config.read_text(encoding="utf-8")
             self.assertEqual(result["settings"]["anisotropy"], 16)
-            self.assertIn("pinyon_shift_config_schema = 9", updated)
+            self.assertIn("pinyon_shift_config_schema = 10", updated)
             self.assertIn("xma_relaxed_padding_admission = false", updated)
             self.assertEqual(result["settings"]["occlusion_query"], "fast")
             self.assertIn('occlusion_query = "fast"', updated)
@@ -80,6 +81,8 @@ class GraphicsSettingsTests(unittest.TestCase):
             self.assertTrue(result["settings"]["host_present_sleep_spin"])
             self.assertTrue(result["settings"]["disable_motion_blur"])
             self.assertTrue(result["settings"]["disable_depth_of_field"])
+            self.assertEqual(result["settings"]["native_renderer"], "diagnostic_triangle")
+            self.assertIn('pinyon_shift_native_renderer = "diagnostic_triangle"', updated)
             self.assertIn("custom_value = 77", updated)
             self.assertIn("draw_resolution_scale_x = 2", updated)
             self.assertEqual(result["settings"]["preset"], "experimental_2x")
@@ -110,7 +113,26 @@ class GraphicsSettingsTests(unittest.TestCase):
             self.assertIn('clear_memory_page_state = true', text)
             self.assertIn('host_present_fps_limit = 60', text)
             self.assertIn('host_present_sleep_spin = true', text)
+            self.assertIn('pinyon_shift_native_renderer = "xenos"', text)
             self.assertEqual(result["settings"]["preset"], "shipping_1x")
+            self.assertTrue(pathlib.Path(result["backup_path"]).is_file())
+
+    def test_reset_renderer_preserves_other_settings(self):
+        with tempfile.TemporaryDirectory(prefix="pinyon-settings-") as temporary:
+            state = pathlib.Path(temporary)
+            config = state / "config/pinyon_shift.toml"
+            config.parent.mkdir(parents=True)
+            config.write_text(
+                'pinyon_shift_config_schema = 10\n'
+                'pinyon_shift_native_renderer = "diagnostic_triangle"\n'
+                'custom_value = 77\n',
+                encoding="utf-8",
+            )
+            result = self.run_tool(state, "-Action", "ResetRenderer")
+            text = config.read_text(encoding="utf-8")
+            self.assertEqual(result["settings"]["native_renderer"], "xenos")
+            self.assertIn('pinyon_shift_native_renderer = "xenos"', text)
+            self.assertIn("custom_value = 77", text)
             self.assertTrue(pathlib.Path(result["backup_path"]).is_file())
 
     def test_experimental_3x_writes_4k_class_scale_with_fast_readback(self):

--- a/tools/tests/test_native_renderer_contract.py
+++ b/tools/tests/test_native_renderer_contract.py
@@ -200,6 +200,36 @@ class NativeRendererContractTests(unittest.TestCase):
         self.assertIn('{"fallback", "xenos"}', source)
         self.assertIn("context.clear_color(context, color)", source)
 
+    def test_diagnostic_triangle_and_recovery_remain_backend_owned(self):
+        patch = (
+            ROOT / "patches/rexglue/0049-native-guest-output-diagnostic-triangle.patch"
+        ).read_text(encoding="utf-8")
+        self.assertIn("NativeGuestOutputDrawDiagnosticTriangle", patch)
+        self.assertIn("native_guest_output_triangle_cs", patch)
+        self.assertIn("D3DSetComputeRootDescriptorTable", patch)
+        self.assertIn("kGuestOutputInternalState", patch)
+        self.assertNotIn("SetDrawSuppression", patch)
+
+        source = (
+            ROOT / "src/native_renderer/guest_output_renderer.cpp"
+        ).read_text(encoding="utf-8")
+        self.assertIn('pinyon_shift_native_renderer, "xenos"', source)
+        self.assertIn('mode == "diagnostic_triangle"', source)
+        self.assertIn("context.draw_diagnostic_triangle", source)
+        self.assertIn('"unsupported_mode"', source)
+
+        settings = (ROOT / "tools/set-graphics-experiment.ps1").read_text(
+            encoding="utf-8"
+        )
+        self.assertIn("'ResetRenderer'", settings)
+        self.assertIn("pinyon_shift_native_renderer", settings)
+
+        report = (ROOT / "tools/create-crash-report.ps1").read_text(
+            encoding="utf-8"
+        )
+        self.assertIn("claimed_frames", report)
+        self.assertIn("failure_reason", report)
+
     def test_census_ledger_tracks_exact_starting_baseline(self):
         ledger = (ROOT / "docs/native-renderer/RENDER_PASS_CENSUS.md").read_text(
             encoding="utf-8"

--- a/tools/tests/test_release_contract.py
+++ b/tools/tests/test_release_contract.py
@@ -43,10 +43,10 @@ class ReleaseContractTests(unittest.TestCase):
 
     def test_rexglue_patches_have_stable_order_and_no_binary_payload(self):
         patches = sorted((ROOT / "patches/rexglue").glob("*.patch"))
-        self.assertEqual(len(patches), 48)
+        self.assertEqual(len(patches), 49)
         self.assertEqual(
             patches[-1].name,
-            "0048-round-normalized-point-samples-to-xenos-q16.patch",
+            "0049-native-guest-output-diagnostic-triangle.patch",
         )
         self.assertEqual(len(patches), len({path.name[:4] for path in patches}))
         for path in patches:
@@ -187,7 +187,7 @@ class ReleaseContractTests(unittest.TestCase):
 
     def test_graphics_schema_and_diagnostics_contract(self):
         app = (ROOT / "src/pinyon_shift_app.cpp").read_text(encoding="utf-8")
-        self.assertIn("constexpr uint32_t kConfigSchema = 9", app)
+        self.assertIn("constexpr uint32_t kConfigSchema = 10", app)
         self.assertIn(".schema", app)
         for setting in ("anisotropic_override", "swap_post_effect", "draw_resolution_scale_x"):
             self.assertIn(setting, app)
@@ -247,11 +247,11 @@ class ReleaseContractTests(unittest.TestCase):
         launcher_xaml = (ROOT / "launcher/PinyonShift.Launcher/MainWindow.xaml").read_text(
             encoding="utf-8"
         )
-        self.assertIn("constexpr uint32_t kConfigSchema = 9;", app)
-        self.assertRegex(app, r"pinyon_shift_config_schema,\s*9,")
+        self.assertIn("constexpr uint32_t kConfigSchema = 10;", app)
+        self.assertRegex(app, r"pinyon_shift_config_schema,\s*10,")
         self.assertIn('"pinyon_shift_stabilize_vehicle_presentation = false\\n"', app)
         self.assertIn('"keybind_a = \\"LMB,Space\\"\\n"', app)
-        self.assertIn("schema < 1 || schema > 8", app)
+        self.assertIn("schema < 1 || schema > 9", app)
         self.assertIn('"occlusion_query = \\"legacy\\"\\n"', app)
         self.assertIn('"zpd_end_policy = \\"report_layout\\"\\n"', app)
         self.assertIn('"readback_resolve = \\"none\\"\\n"', app)
@@ -259,6 +259,8 @@ class ReleaseContractTests(unittest.TestCase):
         self.assertIn("Accurate showroom", launcher_xaml)
         self.assertIn("DisableMotionBlurCheckBox", launcher_xaml)
         self.assertIn("DisableDepthOfFieldCheckBox", launcher_xaml)
+        self.assertIn("NativeRendererComboBox", launcher_xaml)
+        self.assertIn("ResetRendererButton", launcher_xaml)
         self.assertIn('Environment.GetEnvironmentVariable("PINYON_SHIFT_STATE_ROOT")', launcher)
         self.assertIn('"-StateRoot", _stateRoot', launcher)
         self.assertIn("DetectPendingReport();\n            UpdatePrimaryButton();", launcher)


### PR DESCRIPTION
## Summary
- add a recoverable D3D12 diagnostic-triangle output operation without suppressing guest draws or resolves
- expose restart-scoped Xenos/diagnostic-triangle selection plus a dedicated Reset to Xenos recovery action
- report configured/effective native output state and bounded fallback evidence in support bundles
- preserve Xenos as the safe default and automatic fallback for unsupported or failed initialization

## Validation
- fresh pinned ReXGlue checkout applied all 49 uniquely ordered patches
- clean Release build at `327299e` produced SHA-256 `5FD5D2511075B3FF4200F82A99B1A62069F7E08523F374D5159183D5A2D34DD7`
- `python -m unittest discover -s tools/tests -p 'test_*.py'`: 61 passed
- `python tools/check-markdown-links.py`: passed
- ReXGlue unit suite: 247 passed, 2,282 assertions, 4 documented skips
- AppData Xenos control `20260828T015455Z-p33796`: normal exit, Xenos sole authority, no native frame claims or failures
- diagnostic triangle `20260828T015607Z-p29900`: 2,100/2,100 callbacks claimed, animated triangle visually confirmed, 60.002 Hz presentation, 29.409 Hz simulation, no renderer/GPU/validation/resource-state failures
- unsupported-mode recovery `20260828T015729Z-p11548`: exactly one fallback event, no native callback/claims, normal Xenos-rendered startup visibly confirmed, normal exit
- launcher Reset to Xenos: timestamped backup created and unrelated graphics settings preserved