### PR TITLE
feat(renderer): add deterministic native shader packs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@
 *.live
 *.pirs
 *.stfs
+*.dxil
+*.pnsp
 TU_*
 assets/
 game/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,7 @@ if(WIN32)
         src/pinyon_shift_runtime_hooks.cpp
         src/native_renderer/graphics_hooks.cpp
         src/native_renderer/guest_output_renderer.cpp
+        src/native_renderer/shader_pack.cpp
     )
 else()
     add_executable(pinyon_shift
@@ -33,6 +34,7 @@ else()
         src/pinyon_shift_runtime_hooks.cpp
         src/native_renderer/graphics_hooks.cpp
         src/native_renderer/guest_output_renderer.cpp
+        src/native_renderer/shader_pack.cpp
     )
 endif()
 
@@ -50,5 +52,5 @@ add_custom_target(pinyon_shift_stage_controller_mappings ALL
     VERBATIM)
 
 if(WIN32)
-    target_link_libraries(pinyon_shift PRIVATE dbghelp)
+    target_link_libraries(pinyon_shift PRIVATE bcrypt dbghelp)
 endif()

--- a/config/repository-policy.json
+++ b/config/repository-policy.json
@@ -7,6 +7,8 @@
     ".live",
     ".pirs",
     ".stfs",
+    ".dxil",
+    ".pnsp",
     ".exe",
     ".dll",
     ".pdb",

--- a/docs/native-renderer/SHADER_PACK_FORMAT.md
+++ b/docs/native-renderer/SHADER_PACK_FORMAT.md
@@ -1,0 +1,91 @@
+# Native shader pack format
+
+NR-02A uses a deterministic local package for host-consumable D3D12 shader
+bytecode. The public repository contains this format, its builder, and shader
+identity metadata only. Extracted guest shaders, translated source, DXIL, and
+completed packs are locally derived artifacts and must remain under `.local`.
+
+## Stable identity
+
+A shader entry is identified by this ordered tuple:
+
+1. stage: `vertex` or `pixel`;
+2. the 64-bit guest shader hash reported by ReXGlue; and
+3. a 64-bit specialization mask defined by the future candidate replay path.
+
+The specialization mask is explicit even when it is zero. Runtime lookup must
+never silently fall back from one specialization to another. A missing exact
+identity is a coverage failure and leaves the isolated native draw unavailable;
+it does not affect the authoritative Xenos frame.
+
+## Local manifest
+
+The builder consumes UTF-8 JSON with this shape:
+
+```json
+{
+  "schema": "pinyon-shift.native-shader-pack.v1",
+  "backend": "d3d12",
+  "entries": [
+    {
+      "stage": "vertex",
+      "guest_hash": "0123456789ABCDEF",
+      "specialization_mask": "0000000000000000",
+      "bytecode": "dxil/0123456789ABCDEF.dxil",
+      "sha256": "64 hexadecimal digits"
+    }
+  ]
+}
+```
+
+Bytecode paths must resolve inside the manifest directory. Every file must be a
+non-empty DXIL container beginning with `DXBC`, must be no larger than 16 MiB,
+and must match its declared SHA-256. Duplicate identities are rejected.
+
+Build and independently verify a pack with:
+
+```powershell
+python .\tools\native-shader-pack.py build `
+  .\.local\native-renderer\shader-manifest.json `
+  --output .\.local\native-renderer\pinyon-shift-d3d12.pnsp
+python .\tools\native-shader-pack.py verify `
+  .\.local\native-renderer\pinyon-shift-d3d12.pnsp
+```
+
+## Binary layout
+
+All integers are unsigned little-endian. The file begins with an 80-byte
+header, followed by fixed 68-byte entries, followed by 16-byte-aligned DXIL
+payloads.
+
+| Header field | Type | Meaning |
+| --- | --- | --- |
+| Magic | 8 bytes | ASCII `PNYNSHPK` |
+| Version | `u32` | `1` |
+| Header size | `u32` | `80` |
+| Entry size | `u32` | `68` |
+| Entry count | `u32` | bounded to 65,535 |
+| Index offset | `u64` | always 80 in version 1 |
+| Data offset | `u64` | first byte after the fixed index |
+| Data size | `u64` | complete aligned payload region |
+| Content SHA-256 | 32 bytes | hash of the index and payload region |
+
+Each entry stores an 8-bit stage, an 8-bit bytecode format (`1` for DXIL), a
+zero 16-bit reserved field, guest hash, specialization mask, payload-relative
+offset, payload size, and the 32-byte SHA-256 of its DXIL payload.
+
+Entries are sorted by the complete stable identity. The builder writes through
+an atomic temporary file. Verification checks the file-wide content hash,
+every entry hash and range, DXIL magic, identity order, uniqueness, and all
+bounded sizes before any shader is exposed to a renderer.
+
+## Public-source and fallback rules
+
+- Do not commit manifests containing extracted shader paths or hashes unless
+  those values are independently distributable metadata approved for the
+  public boundary.
+- Never commit translated guest shader source, DXIL, or `.pnsp` output.
+- A corrupt pack, unknown version, unsupported stage, missing identity, or
+  failed hash is explicit failure. The isolated NR-02 renderer yields and
+  Xenos remains authoritative.
+- This package does not enable guest draw or resolve suppression.

--- a/docs/native-renderer/SHADER_PACK_FORMAT.md
+++ b/docs/native-renderer/SHADER_PACK_FORMAT.md
@@ -89,3 +89,32 @@ bounded sizes before any shader is exposed to a renderer.
   failed hash is explicit failure. The isolated NR-02 renderer yields and
   Xenos remains authoritative.
 - This package does not enable guest draw or resolve suppression.
+
+## NR-02A qualification
+
+Clean commit `5938136` built with all 49 ReXGlue patches and produced
+executable SHA-256
+`27163174F2180837FF7BCBDDA7028EA68275F70B2E38B7ED0B9B410E9107BC33`.
+All 68 repository tests passed, tracked Markdown links were valid, and the
+public-source boundary reported zero violations.
+
+The builder produced the same 212-byte one-entry qualification pack regardless
+of manifest order. Its SHA-256 was
+`BFB4A386B4F3840048088E186E55CC6AD534F6D3AB109DA2600B7572FD3390EE`,
+and an independent verify operation accepted every range and digest. Unit tests
+also rejected duplicate identities, mismatched hashes, path traversal,
+non-DXIL input, and content corruption.
+
+AppData-backed session `20260828T023642Z-p41636` loaded that pack and recorded
+one D3D12 entry while separately retaining Xenos output authority. Visual
+inspection confirmed the normal Xenos-rendered startup sequence. The session
+claimed no native frame, recorded no shader-pack failure, device removal, TDR,
+validation warning, resource-state warning, or presentation deadline miss, and
+exited normally. Presentation cadence was 59.994 Hz and simulation cadence was
+29.209 Hz.
+
+Recovery session `20260828T023747Z-p9136` selected a missing pack. It emitted
+exactly one sanitized `validation_failed` event with `fallback=xenos`, then
+recorded Xenos as output authority, claimed no native frame, and exited
+normally without another error signal. Neither qualification run changed or
+copied the AppData save.

--- a/src/native_renderer/guest_output_renderer.cpp
+++ b/src/native_renderer/guest_output_renderer.cpp
@@ -1,19 +1,22 @@
 #include <atomic>
+#include <filesystem>
 #include <string>
 
 #include <rex/cvar.h>
 #include <rex/system/interfaces/graphics.h>
 
 #include "native_renderer/guest_output_renderer.h"
+#include "native_renderer/shader_pack.h"
 #include "pinyon_shift_diagnostics.h"
 
-REXCVAR_DEFINE_BOOL(
-    pinyon_shift_native_renderer_diagnostic_clear, false, "Pinyon Shift",
-    "Replace guest output with a diagnostic clear for native-renderer testing")
+REXCVAR_DEFINE_BOOL(pinyon_shift_native_renderer_diagnostic_clear, false, "Pinyon Shift",
+                    "Replace guest output with a diagnostic clear for native-renderer testing")
     .lifecycle(rex::cvar::Lifecycle::kRequiresRestart);
-REXCVAR_DEFINE_STRING(
-    pinyon_shift_native_renderer, "xenos", "Pinyon Shift",
-    "Guest-output renderer: xenos, diagnostic_clear, diagnostic_triangle")
+REXCVAR_DEFINE_STRING(pinyon_shift_native_renderer, "xenos", "Pinyon Shift",
+                      "Guest-output renderer: xenos, diagnostic_clear, diagnostic_triangle")
+    .lifecycle(rex::cvar::Lifecycle::kRequiresRestart);
+REXCVAR_DEFINE_STRING(pinyon_shift_native_shader_pack, "", "Pinyon Shift",
+                      "Local NR-02 D3D12 shader pack path; empty disables pack loading")
     .lifecycle(rex::cvar::Lifecycle::kRequiresRestart);
 
 namespace {
@@ -23,11 +26,10 @@ std::atomic<uint64_t> g_callback_count{};
 std::atomic<uint64_t> g_claimed_count{};
 enum class DiagnosticMode : uint32_t { kClear, kTriangle };
 std::atomic<DiagnosticMode> g_mode{DiagnosticMode::kClear};
+pinyon_shift::native_renderer::ShaderPack g_shader_pack;
 
-bool RenderDiagnosticOutput(
-    const rex::system::NativeGuestOutputRenderContext& context) {
-  const uint64_t callback =
-      g_callback_count.fetch_add(1, std::memory_order_relaxed) + 1;
+bool RenderDiagnosticOutput(const rex::system::NativeGuestOutputRenderContext& context) {
+  const uint64_t callback = g_callback_count.fetch_add(1, std::memory_order_relaxed) + 1;
   if (g_failure_latched.load(std::memory_order_acquire)) {
     return false;
   }
@@ -42,30 +44,25 @@ bool RenderDiagnosticOutput(
 
   const DiagnosticMode mode = g_mode.load(std::memory_order_relaxed);
   bool rendered = false;
-  if (mode == DiagnosticMode::kTriangle &&
-      context.draw_diagnostic_triangle) {
-    rendered = context.draw_diagnostic_triangle(
-        context, uint32_t((context.submission / 120) & 1));
+  if (mode == DiagnosticMode::kTriangle && context.draw_diagnostic_triangle) {
+    rendered = context.draw_diagnostic_triangle(context, uint32_t((context.submission / 120) & 1));
   } else if (mode == DiagnosticMode::kClear && context.clear_color) {
     const bool alternate = ((context.submission / 120) & 1) != 0;
-    const float color[4] = {alternate ? 0.04f : 0.85f, 0.16f,
-                            alternate ? 0.55f : 0.03f, 1.0f};
+    const float color[4] = {alternate ? 0.04f : 0.85f, 0.16f, alternate ? 0.55f : 0.03f, 1.0f};
     rendered = context.clear_color(context, color);
   }
   if (!rendered) {
     if (!g_failure_latched.exchange(true, std::memory_order_acq_rel)) {
       pinyon_shift::diagnostics::RecordEvent(
           "native_renderer.output.failure",
-          {{"reason", mode == DiagnosticMode::kTriangle
-                          ? "diagnostic_triangle_failed"
-                          : "diagnostic_clear_failed"},
+          {{"reason", mode == DiagnosticMode::kTriangle ? "diagnostic_triangle_failed"
+                                                        : "diagnostic_clear_failed"},
            {"fallback", "xenos"}});
     }
     return false;
   }
 
-  const uint64_t claimed =
-      g_claimed_count.fetch_add(1, std::memory_order_relaxed) + 1;
+  const uint64_t claimed = g_claimed_count.fetch_add(1, std::memory_order_relaxed) + 1;
   if (callback == 1 || callback % 300 == 0) {
     pinyon_shift::diagnostics::RecordEvent(
         "native_renderer.output.frame",
@@ -77,9 +74,7 @@ bool RenderDiagnosticOutput(
          {"display_width", std::to_string(context.display_width)},
          {"display_height", std::to_string(context.display_height)},
          {"format", std::to_string(context.output_format)},
-         {"mode", mode == DiagnosticMode::kTriangle
-                      ? "diagnostic_triangle"
-                      : "diagnostic_clear"}});
+         {"mode", mode == DiagnosticMode::kTriangle ? "diagnostic_triangle" : "diagnostic_clear"}});
   }
   return true;
 }
@@ -92,9 +87,23 @@ void InstallGuestOutputRenderer(rex::system::IGraphicsSystem* graphics_system) {
   if (!graphics_system) {
     return;
   }
+  const std::string shader_pack_path = REXCVAR_GET(pinyon_shift_native_shader_pack);
+  g_shader_pack.Reset();
+  if (!shader_pack_path.empty()) {
+    const auto* shader_pack_path_begin = reinterpret_cast<const char8_t*>(shader_pack_path.data());
+    const std::filesystem::path local_shader_pack_path(
+        std::u8string(shader_pack_path_begin, shader_pack_path_begin + shader_pack_path.size()));
+    if (g_shader_pack.Load(local_shader_pack_path)) {
+      diagnostics::RecordEvent(
+          "native_renderer.shader_pack.ready",
+          {{"entries", std::to_string(g_shader_pack.entry_count())}, {"backend", "d3d12"}});
+    } else {
+      diagnostics::RecordEvent("native_renderer.shader_pack.failure",
+                               {{"reason", "validation_failed"}, {"fallback", "xenos"}});
+    }
+  }
   const std::string mode = REXCVAR_GET(pinyon_shift_native_renderer);
-  const bool legacy_clear =
-      REXCVAR_GET(pinyon_shift_native_renderer_diagnostic_clear);
+  const bool legacy_clear = REXCVAR_GET(pinyon_shift_native_renderer_diagnostic_clear);
   if (mode == "xenos" && !legacy_clear) {
     diagnostics::RecordEvent("native_renderer.output.state",
                              {{"mode", "xenos"}, {"authority", "xenos"}});
@@ -102,31 +111,29 @@ void InstallGuestOutputRenderer(rex::system::IGraphicsSystem* graphics_system) {
   }
   if (mode != "diagnostic_clear" && mode != "diagnostic_triangle" &&
       !(mode == "xenos" && legacy_clear)) {
-    diagnostics::RecordEvent(
-        "native_renderer.output.failure",
-        {{"reason", "unsupported_mode"}, {"fallback", "xenos"}});
+    diagnostics::RecordEvent("native_renderer.output.failure",
+                             {{"reason", "unsupported_mode"}, {"fallback", "xenos"}});
     return;
   }
   const DiagnosticMode selected_mode =
-      mode == "diagnostic_triangle" ? DiagnosticMode::kTriangle
-                                    : DiagnosticMode::kClear;
+      mode == "diagnostic_triangle" ? DiagnosticMode::kTriangle : DiagnosticMode::kClear;
   g_mode.store(selected_mode, std::memory_order_release);
   g_failure_latched.store(false, std::memory_order_release);
   g_callback_count.store(0, std::memory_order_release);
   g_claimed_count.store(0, std::memory_order_release);
   graphics_system->SetNativeGuestOutputRenderer(&RenderDiagnosticOutput);
-  diagnostics::RecordEvent("native_renderer.output.installed",
-                           {{"mode", selected_mode == DiagnosticMode::kTriangle
-                                         ? "diagnostic_triangle"
-                                         : "diagnostic_clear"},
-                            {"fallback", "xenos"}});
+  diagnostics::RecordEvent(
+      "native_renderer.output.installed",
+      {{"mode",
+        selected_mode == DiagnosticMode::kTriangle ? "diagnostic_triangle" : "diagnostic_clear"},
+       {"fallback", "xenos"}});
 }
 
-void UninstallGuestOutputRenderer(
-    rex::system::IGraphicsSystem* graphics_system) {
+void UninstallGuestOutputRenderer(rex::system::IGraphicsSystem* graphics_system) {
   if (graphics_system) {
     graphics_system->SetNativeGuestOutputRenderer(nullptr);
   }
+  g_shader_pack.Reset();
 }
 
 }  // namespace pinyon_shift::native_renderer

--- a/src/native_renderer/shader_pack.cpp
+++ b/src/native_renderer/shader_pack.cpp
@@ -1,0 +1,285 @@
+#include "native_renderer/shader_pack.h"
+
+#include <algorithm>
+#include <array>
+#include <cstring>
+#include <exception>
+#include <fstream>
+#include <limits>
+#include <type_traits>
+#include <utility>
+
+#ifdef _WIN32
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#include <windows.h>
+
+#include <bcrypt.h>
+#endif
+
+namespace pinyon_shift::native_renderer {
+namespace {
+
+constexpr std::array<std::byte, 8> kMagic{std::byte{'P'}, std::byte{'N'}, std::byte{'Y'},
+                                          std::byte{'N'}, std::byte{'S'}, std::byte{'H'},
+                                          std::byte{'P'}, std::byte{'K'}};
+constexpr uint32_t kVersion = 1;
+constexpr uint32_t kHeaderSize = 80;
+constexpr uint32_t kEntrySize = 68;
+constexpr uint8_t kDxilFormat = 1;
+constexpr uint32_t kMaximumEntryCount = 65'535;
+constexpr uint64_t kMaximumBytecodeSize = 16 * 1024 * 1024;
+constexpr uint64_t kMaximumPackSize = 512 * 1024 * 1024;
+
+void SetError(std::string* error, std::string message) {
+  if (error) {
+    *error = std::move(message);
+  }
+}
+
+template <typename T>
+bool ReadLittle(std::span<const std::byte> source, size_t offset, T* value) {
+  static_assert(std::is_unsigned_v<T>);
+  if (!value || offset > source.size() || source.size() - offset < sizeof(T)) {
+    return false;
+  }
+  T result = 0;
+  for (size_t index = 0; index < sizeof(T); ++index) {
+    result |= T(std::to_integer<uint8_t>(source[offset + index])) << (index * 8);
+  }
+  *value = result;
+  return true;
+}
+
+bool CheckedAdd(uint64_t left, uint64_t right, uint64_t* result) {
+  if (!result || right > std::numeric_limits<uint64_t>::max() - left) {
+    return false;
+  }
+  *result = left + right;
+  return true;
+}
+
+bool CheckedMultiply(uint64_t left, uint64_t right, uint64_t* result) {
+  if (!result || (left && right > std::numeric_limits<uint64_t>::max() / left)) {
+    return false;
+  }
+  *result = left * right;
+  return true;
+}
+
+bool ComputeSha256(std::span<const std::byte> source, std::array<std::byte, 32>* digest) {
+#ifdef _WIN32
+  if (!digest || source.size() > std::numeric_limits<ULONG>::max()) {
+    return false;
+  }
+  BCRYPT_ALG_HANDLE algorithm = nullptr;
+  BCRYPT_HASH_HANDLE hash = nullptr;
+  DWORD object_size = 0;
+  DWORD returned_size = 0;
+  std::vector<UCHAR> object;
+  bool succeeded = false;
+  if (!BCRYPT_SUCCESS(
+          BCryptOpenAlgorithmProvider(&algorithm, BCRYPT_SHA256_ALGORITHM, nullptr, 0)) ||
+      !BCRYPT_SUCCESS(BCryptGetProperty(algorithm, BCRYPT_OBJECT_LENGTH,
+                                        reinterpret_cast<PUCHAR>(&object_size), sizeof(object_size),
+                                        &returned_size, 0))) {
+    goto cleanup;
+  }
+  object.resize(object_size);
+  if (!BCRYPT_SUCCESS(
+          BCryptCreateHash(algorithm, &hash, object.data(), object_size, nullptr, 0, 0)) ||
+      !BCRYPT_SUCCESS(
+          BCryptHashData(hash, const_cast<PUCHAR>(reinterpret_cast<const UCHAR*>(source.data())),
+                         static_cast<ULONG>(source.size()), 0)) ||
+      !BCRYPT_SUCCESS(BCryptFinishHash(hash, reinterpret_cast<PUCHAR>(digest->data()),
+                                       static_cast<ULONG>(digest->size()), 0))) {
+    goto cleanup;
+  }
+  succeeded = true;
+
+cleanup:
+  if (hash) {
+    BCryptDestroyHash(hash);
+  }
+  if (algorithm) {
+    BCryptCloseAlgorithmProvider(algorithm, 0);
+  }
+  return succeeded;
+#else
+  (void)source;
+  (void)digest;
+  return false;
+#endif
+}
+
+bool EqualBytes(std::span<const std::byte> left, std::span<const std::byte> right) {
+  return left.size() == right.size() && std::equal(left.begin(), left.end(), right.begin());
+}
+
+}  // namespace
+
+bool ShaderPack::Load(const std::filesystem::path& path, std::string* error) {
+  Reset();
+  if (error) {
+    error->clear();
+  }
+  try {
+    std::error_code file_error;
+    const uint64_t file_size = std::filesystem::file_size(path, file_error);
+    if (file_error || file_size < kHeaderSize || file_size > kMaximumPackSize ||
+        file_size > std::numeric_limits<size_t>::max()) {
+      SetError(error, "shader pack size is outside the supported range");
+      return false;
+    }
+    std::vector<std::byte> file_data(static_cast<size_t>(file_size));
+    std::ifstream stream(path, std::ios::binary);
+    if (!stream.read(reinterpret_cast<char*>(file_data.data()),
+                     static_cast<std::streamsize>(file_data.size())) ||
+        stream.peek() != std::char_traits<char>::eof()) {
+      SetError(error, "shader pack could not be read completely");
+      return false;
+    }
+    const std::span<const std::byte> bytes(file_data);
+    if (!EqualBytes(bytes.first(kMagic.size()), kMagic)) {
+      SetError(error, "shader pack magic is invalid");
+      return false;
+    }
+
+    uint32_t version = 0;
+    uint32_t header_size = 0;
+    uint32_t entry_size = 0;
+    uint32_t entry_count = 0;
+    uint64_t index_offset = 0;
+    uint64_t data_offset = 0;
+    uint64_t data_size = 0;
+    if (!ReadLittle(bytes, 8, &version) || !ReadLittle(bytes, 12, &header_size) ||
+        !ReadLittle(bytes, 16, &entry_size) || !ReadLittle(bytes, 20, &entry_count) ||
+        !ReadLittle(bytes, 24, &index_offset) || !ReadLittle(bytes, 32, &data_offset) ||
+        !ReadLittle(bytes, 40, &data_size) || version != kVersion || header_size != kHeaderSize ||
+        entry_size != kEntrySize || entry_count == 0 || entry_count > kMaximumEntryCount ||
+        index_offset != kHeaderSize) {
+      SetError(error, "shader pack header is unsupported or invalid");
+      return false;
+    }
+
+    uint64_t index_size = 0;
+    uint64_t expected_data_offset = 0;
+    uint64_t expected_file_size = 0;
+    if (!CheckedMultiply(entry_count, entry_size, &index_size) ||
+        !CheckedAdd(index_offset, index_size, &expected_data_offset) ||
+        !CheckedAdd(data_offset, data_size, &expected_file_size) ||
+        data_offset != expected_data_offset || expected_file_size != file_size) {
+      SetError(error, "shader pack index or payload range is invalid");
+      return false;
+    }
+
+    std::array<std::byte, 32> content_digest{};
+    if (!ComputeSha256(bytes.subspan(static_cast<size_t>(index_offset)), &content_digest)) {
+      SetError(error, "shader pack SHA-256 computation failed");
+      return false;
+    }
+    if (!EqualBytes(content_digest, bytes.subspan(48, content_digest.size()))) {
+      SetError(error, "shader pack content SHA-256 does not match");
+      return false;
+    }
+
+    std::vector<Entry> entries;
+    entries.reserve(entry_count);
+    uint64_t previous_payload_end = 0;
+    for (uint32_t index = 0; index < entry_count; ++index) {
+      const size_t entry_offset = static_cast<size_t>(index_offset + uint64_t(index) * entry_size);
+      const uint8_t stage_value = std::to_integer<uint8_t>(bytes[entry_offset]);
+      const uint8_t bytecode_format = std::to_integer<uint8_t>(bytes[entry_offset + 1]);
+      uint16_t reserved = 0;
+      uint64_t guest_hash = 0;
+      uint64_t specialization_mask = 0;
+      uint64_t payload_offset = 0;
+      uint64_t payload_size = 0;
+      if (!ReadLittle(bytes, entry_offset + 2, &reserved) ||
+          !ReadLittle(bytes, entry_offset + 4, &guest_hash) ||
+          !ReadLittle(bytes, entry_offset + 12, &specialization_mask) ||
+          !ReadLittle(bytes, entry_offset + 20, &payload_offset) ||
+          !ReadLittle(bytes, entry_offset + 28, &payload_size) || reserved != 0 ||
+          (stage_value != uint8_t(ShaderStage::kVertex) &&
+           stage_value != uint8_t(ShaderStage::kPixel)) ||
+          bytecode_format != kDxilFormat || payload_size == 0 ||
+          payload_size > kMaximumBytecodeSize || payload_offset % 16 != 0 ||
+          payload_offset < previous_payload_end) {
+        SetError(error, "shader pack entry identity or bounds are invalid");
+        return false;
+      }
+      uint64_t payload_end = 0;
+      uint64_t absolute_payload_offset = 0;
+      if (!CheckedAdd(payload_offset, payload_size, &payload_end) || payload_end > data_size ||
+          !CheckedAdd(data_offset, payload_offset, &absolute_payload_offset) ||
+          absolute_payload_offset > std::numeric_limits<size_t>::max()) {
+        SetError(error, "shader pack entry escapes the payload");
+        return false;
+      }
+      const auto padding =
+          bytes.subspan(static_cast<size_t>(data_offset + previous_payload_end),
+                        static_cast<size_t>(payload_offset - previous_payload_end));
+      if (std::any_of(padding.begin(), padding.end(),
+                      [](std::byte value) { return value != std::byte{}; })) {
+        SetError(error, "shader pack payload padding is not zero");
+        return false;
+      }
+      const auto bytecode = bytes.subspan(static_cast<size_t>(absolute_payload_offset),
+                                          static_cast<size_t>(payload_size));
+      constexpr std::array<std::byte, 4> kDxbc{std::byte{'D'}, std::byte{'X'}, std::byte{'B'},
+                                               std::byte{'C'}};
+      if (bytecode.size() < kDxbc.size() || !EqualBytes(bytecode.first(kDxbc.size()), kDxbc)) {
+        SetError(error, "shader pack entry is not a DXIL container");
+        return false;
+      }
+      std::array<std::byte, 32> bytecode_digest{};
+      if (!ComputeSha256(bytecode, &bytecode_digest) ||
+          !EqualBytes(bytecode_digest, bytes.subspan(entry_offset + 36, bytecode_digest.size()))) {
+        SetError(error, "shader pack entry SHA-256 does not match");
+        return false;
+      }
+      const ShaderIdentity identity{static_cast<ShaderStage>(stage_value), guest_hash,
+                                    specialization_mask};
+      if (!entries.empty() && !(entries.back().identity < identity)) {
+        SetError(error, "shader pack identities are duplicated or not sorted");
+        return false;
+      }
+      entries.push_back({identity, absolute_payload_offset, payload_size});
+      previous_payload_end = payload_end;
+    }
+    if (previous_payload_end != data_size) {
+      SetError(error, "shader pack payload contains unreferenced trailing data");
+      return false;
+    }
+
+    file_data_ = std::move(file_data);
+    entries_ = std::move(entries);
+    return true;
+  } catch (const std::exception& exception) {
+    SetError(error, std::string("shader pack load failed: ") + exception.what());
+    return false;
+  }
+}
+
+void ShaderPack::Reset() {
+  entries_.clear();
+  file_data_.clear();
+}
+
+std::span<const std::byte> ShaderPack::Find(ShaderIdentity identity) const {
+  const auto entry = std::lower_bound(entries_.begin(), entries_.end(), identity,
+                                      [](const Entry& candidate, const ShaderIdentity& requested) {
+                                        return candidate.identity < requested;
+                                      });
+  if (entry == entries_.end() || entry->identity != identity ||
+      entry->bytecode_offset > file_data_.size() ||
+      entry->bytecode_size > file_data_.size() - entry->bytecode_offset) {
+    return {};
+  }
+  return std::span<const std::byte>(file_data_)
+      .subspan(static_cast<size_t>(entry->bytecode_offset),
+               static_cast<size_t>(entry->bytecode_size));
+}
+
+}  // namespace pinyon_shift::native_renderer

--- a/src/native_renderer/shader_pack.h
+++ b/src/native_renderer/shader_pack.h
@@ -1,0 +1,45 @@
+#pragma once
+
+#include <compare>
+#include <cstddef>
+#include <cstdint>
+#include <filesystem>
+#include <span>
+#include <string>
+#include <vector>
+
+namespace pinyon_shift::native_renderer {
+
+enum class ShaderStage : uint8_t {
+  kVertex = 1,
+  kPixel = 2,
+};
+
+struct ShaderIdentity {
+  ShaderStage stage{};
+  uint64_t guest_hash{};
+  uint64_t specialization_mask{};
+
+  auto operator<=>(const ShaderIdentity&) const = default;
+};
+
+class ShaderPack {
+ public:
+  bool Load(const std::filesystem::path& path, std::string* error = nullptr);
+  void Reset();
+
+  [[nodiscard]] std::span<const std::byte> Find(ShaderIdentity identity) const;
+  [[nodiscard]] size_t entry_count() const { return entries_.size(); }
+
+ private:
+  struct Entry {
+    ShaderIdentity identity;
+    uint64_t bytecode_offset{};
+    uint64_t bytecode_size{};
+  };
+
+  std::vector<std::byte> file_data_;
+  std::vector<Entry> entries_;
+};
+
+}  // namespace pinyon_shift::native_renderer

--- a/tools/create-crash-report.ps1
+++ b/tools/create-crash-report.ps1
@@ -259,6 +259,12 @@ try {
         claimed_frames = [uint64]0
         failure_reason = $null
     }
+    $nativeShaderPack = [ordered]@{
+        status = 'not_configured'
+        backend = 'd3d12'
+        entries = [uint64]0
+        failure_reason = $null
+    }
     if ($null -ne $eventLog) {
         foreach ($line in Get-Content -LiteralPath $eventLog.FullName -ErrorAction SilentlyContinue) {
             try { $event = $line | ConvertFrom-Json -ErrorAction Stop } catch { continue }
@@ -272,6 +278,15 @@ try {
                 'native_renderer.output.failure' {
                     $nativeRenderer.effective = 'xenos'
                     $nativeRenderer.failure_reason = [string]$event.reason
+                }
+                'native_renderer.shader_pack.ready' {
+                    $nativeShaderPack.status = 'ready'
+                    $nativeShaderPack.backend = [string]$event.backend
+                    $nativeShaderPack.entries = [uint64]$event.entries
+                }
+                'native_renderer.shader_pack.failure' {
+                    $nativeShaderPack.status = 'failed'
+                    $nativeShaderPack.failure_reason = [string]$event.reason
                 }
             }
         }
@@ -343,6 +358,7 @@ try {
         }
         graphics = [ordered]@{
             native_renderer = $nativeRenderer
+            native_shader_pack = $nativeShaderPack
             zpd = $zpdCounters
             resolve_readback = $resolveCounters
             presentation = $presentationCounters
@@ -393,7 +409,9 @@ try {
         [Text.UTF8Encoding]::new($false))
 
     foreach ($file in Get-ChildItem -LiteralPath $stagingRoot -Recurse -File) {
-        if ($file.Extension.ToLowerInvariant() -in @('.dmp', '.exe', '.dll', '.iso', '.xex', '.obj', '.lib', '.pdb')) {
+        if ($file.Extension.ToLowerInvariant() -in @(
+                '.dmp', '.exe', '.dll', '.iso', '.xex', '.obj', '.lib', '.pdb',
+                '.dxil', '.pnsp')) {
             throw "Forbidden diagnostic attachment: $($file.Name)"
         }
         $content = Get-Content -LiteralPath $file.FullName -Raw -ErrorAction SilentlyContinue

--- a/tools/native-shader-pack.py
+++ b/tools/native-shader-pack.py
@@ -1,0 +1,324 @@
+#!/usr/bin/env python3
+"""Build and verify deterministic Pinyon Shift native shader packs."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import pathlib
+import re
+import struct
+import sys
+import tempfile
+from dataclasses import dataclass
+
+
+SCHEMA = "pinyon-shift.native-shader-pack.v1"
+MAGIC = b"PNYNSHPK"
+VERSION = 1
+HEADER = struct.Struct("<8sIIIIQQQ32s")
+ENTRY = struct.Struct("<BBHQQQQ32s")
+STAGES = {"vertex": 1, "pixel": 2}
+STAGE_NAMES = {value: key for key, value in STAGES.items()}
+BYTECODE_FORMAT_DXIL = 1
+MAX_ENTRY_COUNT = 65_535
+MAX_BYTECODE_SIZE = 16 * 1024 * 1024
+MAX_PACK_SIZE = 512 * 1024 * 1024
+HEX_64 = re.compile(r"^[0-9A-Fa-f]{16}$")
+HEX_256 = re.compile(r"^[0-9A-Fa-f]{64}$")
+
+
+class PackError(ValueError):
+    """Raised when a shader manifest or pack violates the format contract."""
+
+
+@dataclass(frozen=True, order=True)
+class ShaderIdentity:
+    stage: int
+    guest_hash: int
+    specialization_mask: int
+
+
+@dataclass(frozen=True)
+class ShaderEntry:
+    identity: ShaderIdentity
+    bytecode: bytes
+    bytecode_sha256: bytes
+
+
+def _parse_hex64(value: object, field: str) -> int:
+    if not isinstance(value, str) or not HEX_64.fullmatch(value):
+        raise PackError(f"{field} must contain exactly 16 hexadecimal digits")
+    return int(value, 16)
+
+
+def _parse_sha256(value: object, field: str) -> bytes:
+    if not isinstance(value, str) or not HEX_256.fullmatch(value):
+        raise PackError(f"{field} must contain exactly 64 hexadecimal digits")
+    return bytes.fromhex(value)
+
+
+def _checked_local_file(root: pathlib.Path, relative: object) -> pathlib.Path:
+    if not isinstance(relative, str) or not relative:
+        raise PackError("bytecode must be a non-empty relative path")
+    candidate = pathlib.Path(relative)
+    if candidate.is_absolute():
+        raise PackError("bytecode paths must be relative to the manifest")
+    try:
+        resolved = (root / candidate).resolve(strict=True)
+    except OSError as error:
+        raise PackError(f"bytecode file is unavailable: {relative}") from error
+    try:
+        resolved.relative_to(root)
+    except ValueError as error:
+        raise PackError("bytecode path escapes the manifest directory") from error
+    if not resolved.is_file():
+        raise PackError(f"bytecode path is not a regular file: {relative}")
+    return resolved
+
+
+def load_manifest(path: pathlib.Path) -> list[ShaderEntry]:
+    manifest_path = path.resolve(strict=True)
+    try:
+        document = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as error:
+        raise PackError(f"unable to read shader manifest: {error}") from error
+    if not isinstance(document, dict):
+        raise PackError("shader manifest must be a JSON object")
+    if document.get("schema") != SCHEMA:
+        raise PackError(f"shader manifest schema must be {SCHEMA}")
+    if document.get("backend") != "d3d12":
+        raise PackError("shader manifest backend must be d3d12")
+    raw_entries = document.get("entries")
+    if not isinstance(raw_entries, list) or not raw_entries:
+        raise PackError("shader manifest entries must be a non-empty array")
+    if len(raw_entries) > MAX_ENTRY_COUNT:
+        raise PackError(f"shader manifest exceeds {MAX_ENTRY_COUNT} entries")
+
+    root = manifest_path.parent.resolve(strict=True)
+    entries: list[ShaderEntry] = []
+    identities: set[ShaderIdentity] = set()
+    for index, raw in enumerate(raw_entries):
+        if not isinstance(raw, dict):
+            raise PackError(f"entries[{index}] must be a JSON object")
+        stage_name = raw.get("stage")
+        if stage_name not in STAGES:
+            raise PackError(f"entries[{index}].stage must be vertex or pixel")
+        identity = ShaderIdentity(
+            stage=STAGES[stage_name],
+            guest_hash=_parse_hex64(raw.get("guest_hash"), f"entries[{index}].guest_hash"),
+            specialization_mask=_parse_hex64(
+                raw.get("specialization_mask"),
+                f"entries[{index}].specialization_mask",
+            ),
+        )
+        if identity in identities:
+            raise PackError(f"entries[{index}] duplicates a shader identity")
+        identities.add(identity)
+
+        bytecode_path = _checked_local_file(root, raw.get("bytecode"))
+        bytecode = bytecode_path.read_bytes()
+        if not bytecode:
+            raise PackError(f"entries[{index}] bytecode is empty")
+        if len(bytecode) > MAX_BYTECODE_SIZE:
+            raise PackError(
+                f"entries[{index}] bytecode exceeds {MAX_BYTECODE_SIZE} bytes"
+            )
+        if not bytecode.startswith(b"DXBC"):
+            raise PackError(f"entries[{index}] is not a DXIL container")
+        actual_digest = hashlib.sha256(bytecode).digest()
+        expected_digest = _parse_sha256(
+            raw.get("sha256"), f"entries[{index}].sha256"
+        )
+        if actual_digest != expected_digest:
+            raise PackError(f"entries[{index}] bytecode SHA-256 does not match")
+        entries.append(ShaderEntry(identity, bytecode, actual_digest))
+
+    return sorted(entries, key=lambda entry: entry.identity)
+
+
+def serialize(entries: list[ShaderEntry]) -> bytes:
+    if not entries or len(entries) > MAX_ENTRY_COUNT:
+        raise PackError("shader pack must contain a bounded non-empty entry set")
+    index_offset = HEADER.size
+    data_offset = index_offset + ENTRY.size * len(entries)
+    index = bytearray()
+    data = bytearray()
+    for shader in entries:
+        alignment = (-len(data)) % 16
+        data.extend(b"\0" * alignment)
+        entry_data_offset = len(data)
+        data.extend(shader.bytecode)
+        index.extend(
+            ENTRY.pack(
+                shader.identity.stage,
+                BYTECODE_FORMAT_DXIL,
+                0,
+                shader.identity.guest_hash,
+                shader.identity.specialization_mask,
+                entry_data_offset,
+                len(shader.bytecode),
+                shader.bytecode_sha256,
+            )
+        )
+    content = bytes(index + data)
+    total_size = HEADER.size + len(content)
+    if total_size > MAX_PACK_SIZE:
+        raise PackError(f"shader pack exceeds {MAX_PACK_SIZE} bytes")
+    return HEADER.pack(
+        MAGIC,
+        VERSION,
+        HEADER.size,
+        ENTRY.size,
+        len(entries),
+        index_offset,
+        data_offset,
+        len(data),
+        hashlib.sha256(content).digest(),
+    ) + content
+
+
+def verify_pack(data: bytes) -> dict[str, object]:
+    if len(data) < HEADER.size or len(data) > MAX_PACK_SIZE:
+        raise PackError("shader pack size is outside the supported range")
+    (
+        magic,
+        version,
+        header_size,
+        entry_size,
+        entry_count,
+        index_offset,
+        data_offset,
+        data_size,
+        content_digest,
+    ) = HEADER.unpack_from(data)
+    if magic != MAGIC or version != VERSION:
+        raise PackError("shader pack magic or version is unsupported")
+    if header_size != HEADER.size or entry_size != ENTRY.size:
+        raise PackError("shader pack layout size is invalid")
+    if not 0 < entry_count <= MAX_ENTRY_COUNT:
+        raise PackError("shader pack entry count is invalid")
+    expected_data_offset = index_offset + entry_count * entry_size
+    if index_offset != header_size or data_offset != expected_data_offset:
+        raise PackError("shader pack index offsets are invalid")
+    if data_size > MAX_PACK_SIZE or data_offset + data_size != len(data):
+        raise PackError("shader pack payload range is invalid")
+    if hashlib.sha256(data[index_offset:]).digest() != content_digest:
+        raise PackError("shader pack content SHA-256 does not match")
+
+    identities: list[ShaderIdentity] = []
+    previous_payload_end = 0
+    for index in range(entry_count):
+        offset = index_offset + index * entry_size
+        (
+            stage,
+            bytecode_format,
+            reserved,
+            guest_hash,
+            specialization_mask,
+            entry_data_offset,
+            bytecode_size,
+            bytecode_digest,
+        ) = ENTRY.unpack_from(data, offset)
+        if stage not in STAGE_NAMES or bytecode_format != BYTECODE_FORMAT_DXIL:
+            raise PackError(f"shader pack entry {index} has unsupported identity data")
+        if (
+            reserved != 0
+            or not 0 < bytecode_size <= MAX_BYTECODE_SIZE
+            or entry_data_offset % 16 != 0
+            or entry_data_offset < previous_payload_end
+        ):
+            raise PackError(f"shader pack entry {index} has invalid bounds")
+        bytecode_start = data_offset + entry_data_offset
+        bytecode_end = bytecode_start + bytecode_size
+        if bytecode_start < data_offset or bytecode_end > len(data):
+            raise PackError(f"shader pack entry {index} escapes the payload")
+        bytecode = data[bytecode_start:bytecode_end]
+        if not bytecode.startswith(b"DXBC"):
+            raise PackError(f"shader pack entry {index} is not a DXIL container")
+        if hashlib.sha256(bytecode).digest() != bytecode_digest:
+            raise PackError(f"shader pack entry {index} SHA-256 does not match")
+        padding = data[
+            data_offset + previous_payload_end : data_offset + entry_data_offset
+        ]
+        if any(padding):
+            raise PackError(f"shader pack entry {index} has non-zero padding")
+        identity = ShaderIdentity(stage, guest_hash, specialization_mask)
+        if identities and identity <= identities[-1]:
+            raise PackError("shader pack identities are duplicated or not sorted")
+        identities.append(identity)
+        previous_payload_end = entry_data_offset + bytecode_size
+
+    if previous_payload_end != data_size:
+        raise PackError("shader pack payload contains unreferenced trailing data")
+
+    return {
+        "schema": SCHEMA,
+        "backend": "d3d12",
+        "entry_count": entry_count,
+        "content_sha256": content_digest.hex().upper(),
+        "pack_sha256": hashlib.sha256(data).hexdigest().upper(),
+        "size_bytes": len(data),
+    }
+
+
+def _write_atomic(path: pathlib.Path, data: bytes) -> None:
+    output = path.resolve()
+    output.parent.mkdir(parents=True, exist_ok=True)
+    temporary_name: str | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            dir=output.parent, prefix=f".{output.name}.", suffix=".tmp", delete=False
+        ) as temporary:
+            temporary_name = temporary.name
+            temporary.write(data)
+            temporary.flush()
+            os.fsync(temporary.fileno())
+        os.replace(temporary_name, output)
+    finally:
+        if temporary_name:
+            pathlib.Path(temporary_name).unlink(missing_ok=True)
+
+
+def _build(arguments: argparse.Namespace) -> dict[str, object]:
+    entries = load_manifest(arguments.manifest)
+    data = serialize(entries)
+    verify = verify_pack(data)
+    _write_atomic(arguments.output, data)
+    return {"operation": "build", "output": str(arguments.output), **verify}
+
+
+def _verify(arguments: argparse.Namespace) -> dict[str, object]:
+    try:
+        data = arguments.pack.read_bytes()
+    except OSError as error:
+        raise PackError(f"unable to read shader pack: {error}") from error
+    return {"operation": "verify", "pack": str(arguments.pack), **verify_pack(data)}
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Build or verify deterministic native D3D12 shader packs."
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    build_parser = subparsers.add_parser("build", help="build a pack from a manifest")
+    build_parser.add_argument("manifest", type=pathlib.Path)
+    build_parser.add_argument("--output", required=True, type=pathlib.Path)
+    build_parser.set_defaults(handler=_build)
+    verify_parser = subparsers.add_parser("verify", help="verify a completed pack")
+    verify_parser.add_argument("pack", type=pathlib.Path)
+    verify_parser.set_defaults(handler=_verify)
+    arguments = parser.parse_args(argv)
+    try:
+        result = arguments.handler(arguments)
+    except (PackError, OSError) as error:
+        print(f"native-shader-pack: {error}", file=sys.stderr)
+        return 2
+    print(json.dumps(result, sort_keys=True, separators=(",", ":")))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/package-launcher.ps1
+++ b/tools/package-launcher.ps1
@@ -64,6 +64,7 @@ $include = @(
     'config/rexglue', 'patches/rexglue', 'src',
     'tools/build-preview.ps1', 'tools/create-crash-report.ps1', 'tools/install-build-tools.ps1',
     'tools/launch-preview.ps1', 'tools/prepare-rexglue.ps1',
+    'tools/native-shader-pack.py',
     'tools/provision-toolchain.ps1', 'tools/release-common.ps1',
     'tools/set-graphics-experiment.ps1', 'tools/setup-preview.ps1',
     'tools/verify-codegen-log.ps1', 'tools/verify-game.ps1'
@@ -105,7 +106,7 @@ $sourceProvenancePath = Join-Path $payloadRoot 'config/source-provenance.json'
     [Text.UTF8Encoding]::new($false))
 
 Get-ChildItem -LiteralPath $payloadRoot -Recurse -File | Where-Object {
-    $_.Extension -in @('.exe', '.dll', '.obj', '.lib', '.pdb', '.iso', '.xex')
+    $_.Extension -in @('.exe', '.dll', '.obj', '.lib', '.pdb', '.iso', '.xex', '.dxil', '.pnsp')
 } | ForEach-Object { throw "Forbidden file entered launcher payload: $($_.FullName)" }
 
 New-DeterministicZip -SourceDirectory $payloadRoot -DestinationPath $payloadZip

--- a/tools/tests/test_native_shader_pack.py
+++ b/tools/tests/test_native_shader_pack.py
@@ -1,0 +1,204 @@
+import hashlib
+import importlib.util
+import json
+import pathlib
+import subprocess
+import sys
+import tempfile
+import unittest
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / "tools/native-shader-pack.py"
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("native_shader_pack", SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+PACK = load_module()
+
+
+class NativeShaderPackTests(unittest.TestCase):
+    def make_manifest(self, root: pathlib.Path, entries: list[dict]) -> pathlib.Path:
+        manifest = root / "shader-manifest.json"
+        manifest.write_text(
+            json.dumps(
+                {
+                    "schema": PACK.SCHEMA,
+                    "backend": "d3d12",
+                    "entries": entries,
+                }
+            ),
+            encoding="utf-8",
+        )
+        return manifest
+
+    def make_shader(self, root: pathlib.Path, name: str, payload: bytes) -> dict:
+        path = root / name
+        path.parent.mkdir(parents=True, exist_ok=True)
+        bytecode = b"DXBC" + payload
+        path.write_bytes(bytecode)
+        return {
+            "bytecode": name,
+            "sha256": hashlib.sha256(bytecode).hexdigest(),
+        }
+
+    def test_manifest_order_does_not_change_pack(self):
+        with tempfile.TemporaryDirectory(prefix="pinyon-shader-pack-") as temporary:
+            root = pathlib.Path(temporary)
+            vertex = {
+                "stage": "vertex",
+                "guest_hash": "0000000000000010",
+                "specialization_mask": "0000000000000000",
+                **self.make_shader(root, "vertex.dxil", b"vertex"),
+            }
+            pixel = {
+                "stage": "pixel",
+                "guest_hash": "0000000000000001",
+                "specialization_mask": "0000000000000002",
+                **self.make_shader(root, "pixel.dxil", b"pixel"),
+            }
+            first = PACK.serialize(PACK.load_manifest(self.make_manifest(root, [pixel, vertex])))
+            second = PACK.serialize(PACK.load_manifest(self.make_manifest(root, [vertex, pixel])))
+            self.assertEqual(first, second)
+            metadata = PACK.verify_pack(first)
+            self.assertEqual(metadata["entry_count"], 2)
+            self.assertEqual(metadata["pack_sha256"], hashlib.sha256(first).hexdigest().upper())
+
+    def test_duplicate_identity_and_hash_mismatch_are_rejected(self):
+        with tempfile.TemporaryDirectory(prefix="pinyon-shader-pack-") as temporary:
+            root = pathlib.Path(temporary)
+            shared = self.make_shader(root, "shader.dxil", b"shader")
+            entry = {
+                "stage": "vertex",
+                "guest_hash": "0000000000000001",
+                "specialization_mask": "0000000000000000",
+                **shared,
+            }
+            with self.assertRaisesRegex(PACK.PackError, "duplicates"):
+                PACK.load_manifest(self.make_manifest(root, [entry, dict(entry)]))
+            bad = dict(entry, sha256="00" * 32)
+            with self.assertRaisesRegex(PACK.PackError, "does not match"):
+                PACK.load_manifest(self.make_manifest(root, [bad]))
+
+    def test_path_escape_and_non_dxil_input_are_rejected(self):
+        with tempfile.TemporaryDirectory(prefix="pinyon-shader-pack-") as temporary:
+            root = pathlib.Path(temporary)
+            outside = root.parent / f"{root.name}-outside.dxil"
+            outside.write_bytes(b"DXBCoutside")
+            try:
+                escaped = {
+                    "stage": "pixel",
+                    "guest_hash": "0000000000000001",
+                    "specialization_mask": "0000000000000000",
+                    "bytecode": f"../{outside.name}",
+                    "sha256": hashlib.sha256(outside.read_bytes()).hexdigest(),
+                }
+                with self.assertRaisesRegex(PACK.PackError, "escapes"):
+                    PACK.load_manifest(self.make_manifest(root, [escaped]))
+
+                invalid = root / "invalid.dxil"
+                invalid.write_bytes(b"SPIR-V")
+                non_dxil = dict(
+                    escaped,
+                    bytecode=invalid.name,
+                    sha256=hashlib.sha256(invalid.read_bytes()).hexdigest(),
+                )
+                with self.assertRaisesRegex(PACK.PackError, "not a DXIL"):
+                    PACK.load_manifest(self.make_manifest(root, [non_dxil]))
+            finally:
+                outside.unlink(missing_ok=True)
+
+    def test_content_and_entry_corruption_are_rejected(self):
+        with tempfile.TemporaryDirectory(prefix="pinyon-shader-pack-") as temporary:
+            root = pathlib.Path(temporary)
+            entry = {
+                "stage": "vertex",
+                "guest_hash": "A2347A8A0640CBFA",
+                "specialization_mask": "0000000000000000",
+                **self.make_shader(root, "shader.dxil", b"candidate"),
+            }
+            data = bytearray(PACK.serialize(PACK.load_manifest(self.make_manifest(root, [entry]))))
+            data[-1] ^= 0xFF
+            with self.assertRaisesRegex(PACK.PackError, "content SHA-256"):
+                PACK.verify_pack(bytes(data))
+
+    def test_cli_build_and_verify_round_trip(self):
+        with tempfile.TemporaryDirectory(prefix="pinyon-shader-pack-") as temporary:
+            root = pathlib.Path(temporary)
+            entry = {
+                "stage": "pixel",
+                "guest_hash": "F891D6525E633C08",
+                "specialization_mask": "0000000000000000",
+                **self.make_shader(root, "shader.dxil", b"candidate"),
+            }
+            manifest = self.make_manifest(root, [entry])
+            output = root / "pack.pnsp"
+            build = subprocess.run(
+                [sys.executable, SCRIPT, "build", manifest, "--output", output],
+                cwd=ROOT,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            self.assertEqual(build.returncode, 0, build.stderr)
+            self.assertEqual(json.loads(build.stdout)["entry_count"], 1)
+            verify = subprocess.run(
+                [sys.executable, SCRIPT, "verify", output],
+                cwd=ROOT,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            self.assertEqual(verify.returncode, 0, verify.stderr)
+            self.assertEqual(
+                json.loads(build.stdout)["pack_sha256"],
+                json.loads(verify.stdout)["pack_sha256"],
+            )
+
+    def test_public_format_keeps_xenos_fallback_and_local_payload_boundary(self):
+        document = (
+            ROOT / "docs/native-renderer/SHADER_PACK_FORMAT.md"
+        ).read_text(encoding="utf-8")
+        self.assertIn("Xenos remains authoritative", document)
+        self.assertIn("must remain under `.local`", document)
+        self.assertIn("does not enable guest draw or resolve suppression", document)
+        policy = json.loads(
+            (ROOT / "config/repository-policy.json").read_text(encoding="utf-8")
+        )
+        self.assertIn(".dxil", policy["forbidden_extensions"])
+        self.assertIn(".pnsp", policy["forbidden_extensions"])
+
+    def test_runtime_load_is_restart_scoped_and_never_changes_xenos_authority(self):
+        source = (
+            ROOT / "src/native_renderer/guest_output_renderer.cpp"
+        ).read_text(encoding="utf-8")
+        self.assertIn('pinyon_shift_native_shader_pack, ""', source)
+        self.assertIn("g_shader_pack.Load", source)
+        self.assertIn('"native_renderer.shader_pack.ready"', source)
+        self.assertIn('"native_renderer.shader_pack.failure"', source)
+        self.assertIn('{"fallback", "xenos"}', source)
+        self.assertLess(
+            source.index("g_shader_pack.Load"),
+            source.index('diagnostics::RecordEvent("native_renderer.output.state"'),
+        )
+        report = (ROOT / "tools/create-crash-report.ps1").read_text(
+            encoding="utf-8"
+        )
+        self.assertIn("native_shader_pack = $nativeShaderPack", report)
+        self.assertIn("'native_renderer.shader_pack.ready'", report)
+        self.assertIn("'native_renderer.shader_pack.failure'", report)
+        self.assertNotIn("pinyon_shift_native_shader_pack'", report)
+        package = (ROOT / "tools/package-launcher.ps1").read_text(encoding="utf-8")
+        self.assertIn("'tools/native-shader-pack.py'", package)
+        self.assertIn("'.dxil', '.pnsp'", package)
+        self.assertIn("'.dxil', '.pnsp'", report)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- define stable native shader identity as stage + 64-bit guest hash + 64-bit specialization mask
- add a deterministic bounded D3D12 shader-pack builder and independent verifier with atomic output and SHA-256 integrity
- add a compiled runtime reader with exact lookup, sanitized readiness/failure diagnostics, and fail-closed bounds
- keep `.dxil` and `.pnsp` local and forbidden from Git, launcher payloads, and support bundles
- preserve Xenos as sole output authority; this PR captures no guest payload and suppresses no draw or resolve

## Validation
- clean Release build at `ce28386` with 49 ReXGlue patches
- executable SHA-256 `27163174F2180837FF7BCBDDA7028EA68275F70B2E38B7ED0B9B410E9107BC33`
- 68 repository tests passed
- tracked Markdown links passed
- public-source boundary: zero violations
- ReXGlue: 247 tests passed, 2,282 assertions, 4 documented skips
- deterministic one-entry pack: 212 bytes, SHA-256 `BFB4A386B4F3840048088E186E55CC6AD534F6D3AB109DA2600B7572FD3390EE`
- valid-pack AppData session `20260828T023642Z-p41636`: pack ready, Xenos sole authority, zero native claims/failures, 59.994 Hz presentation, 29.209 Hz simulation, normal exit
- missing-pack recovery `20260828T023747Z-p9136`: one sanitized validation failure, explicit Xenos fallback/authority, zero native claims, normal exit