### PR TITLE
feat(native-renderer): capture local shader candidates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 *.pirs
 *.stfs
 *.dxil
+*.dxbc
 *.pnsp
 TU_*
 assets/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,7 @@ if(WIN32)
         src/pinyon_shift_runtime_hooks.cpp
         src/native_renderer/graphics_hooks.cpp
         src/native_renderer/guest_output_renderer.cpp
+        src/native_renderer/shader_capture.cpp
         src/native_renderer/shader_pack.cpp
     )
 else()
@@ -34,6 +35,7 @@ else()
         src/pinyon_shift_runtime_hooks.cpp
         src/native_renderer/graphics_hooks.cpp
         src/native_renderer/guest_output_renderer.cpp
+        src/native_renderer/shader_capture.cpp
         src/native_renderer/shader_pack.cpp
     )
 endif()

--- a/config/repository-policy.json
+++ b/config/repository-policy.json
@@ -8,6 +8,7 @@
     ".pirs",
     ".stfs",
     ".dxil",
+    ".dxbc",
     ".pnsp",
     ".exe",
     ".dll",

--- a/docs/native-renderer/CANDIDATE_SHADER_CAPTURE.md
+++ b/docs/native-renderer/CANDIDATE_SHADER_CAPTURE.md
@@ -1,0 +1,85 @@
+# Candidate shader capture
+
+NR-02 now has a bounded, process-scoped path from an authentic ReXGlue D3D12
+translation to the deterministic local shader-pack format. This is capture
+tooling only. It does not replay a draw, suppress guest work, or change the
+authoritative Xenos output.
+
+## Capture seam
+
+ReXGlue patch `0050-d3d12-shader-translation-observer.patch` adds a default-null
+observer after `TranslateAnalyzedShader` has produced a valid host container.
+The borrowed callback view contains only:
+
+- vertex or pixel stage;
+- the 64-bit guest shader hash;
+- the exact 64-bit ReXGlue modification key; and
+- the validated host bytecode container.
+
+Invalid translations never reach the observer. With no observer registered,
+the path performs one null callback check per newly translated shader. The
+observer cannot change translation results, pipeline state, draw submission,
+resolve behavior, or presentation.
+
+## Local-only capture contract
+
+Capture is enabled only when the process receives an explicit
+`PINYON_SHIFT_NATIVE_SHADER_CAPTURE_DIR`. The title-side writer rejects paths
+that are not absolute or do not contain a `.local` component. Each capture is
+limited to 256 unique identities, 16 MiB per container, and 128 MiB total.
+Inputs must begin with the D3D container magic `DXBC`; all writes use temporary
+files followed by replacement.
+
+The writer produces `shader-manifest.json` and an `dxil/` directory. The
+manifest uses `pinyon-shift.native-shader-pack.v1`, records SHA-256 for every
+container, and is directly consumable by `tools/native-shader-pack.py`. Guest
+hashes, specialization masks, file paths, and bytecode never enter diagnostic
+logs or support bundles. `.dxil`, `.dxbc`, and `.pnsp` remain forbidden public
+repository extensions.
+
+Run an AppData-backed capture with:
+
+```powershell
+.\tools\capture-native-renderer-shaders.ps1
+```
+
+The helper verifies the installed `ForzaProfile` save, refuses to launch over
+an existing Pinyon Shift process, creates a timestamped directory below
+`.local/native-renderer/captures`, and delegates gameplay to
+`tools/launch-preview.ps1` with the exact installed preview state root. It does
+not copy, move, reset, or overwrite the save.
+
+After closing the game, build and verify the captured pack locally:
+
+```powershell
+$capture = '.\.local\native-renderer\captures\<timestamp>'
+python .\tools\native-shader-pack.py build `
+  "$capture\shader-manifest.json" --output "$capture\captured.pnsp"
+python .\tools\native-shader-pack.py verify "$capture\captured.pnsp"
+```
+
+## Qualification
+
+The clean 50-patch build produced executable SHA-256
+`C32EFE369AD59DCED9BD151BE90B3ECDC272D4C96A90F49D4865593F46191A44`.
+All 69 repository tests passed, tracked Markdown links were valid, and the
+public-source boundary reported zero violations. The ReXGlue unit suite passed
+2,282 assertions across 247 test cases with four documented skips; the PPC
+suite passed 6,549 assertions across 1,480 test cases.
+AppData-backed session `20260828T030228Z-p10520` exited normally after capturing
+34 authentic front-end translations: 14 vertex and 20 pixel containers,
+407,148 bytecode bytes total. No callback was duplicated or rejected. The
+generated 34-entry pack verified independently at 409,736 bytes with SHA-256
+`259982B4F4D966A08041B699468A2CC66744E54606D9D98809B8829A746BEC1B`.
+
+Xenos remained the sole output authority. The session recorded no capture
+failure, device removal, TDR, resource-state warning, validation warning, or
+presentation deadline miss. Presentation cadence was 60.005 Hz and simulation
+cadence was 29.437 Hz. A separate default session
+`20260828T030355Z-p41808` emitted zero shader-capture events, retained Xenos
+authority, and exited normally with no error event. Neither run modified or
+copied the AppData save.
+
+This closes the local extraction/translation prerequisite for NR-02. Selecting
+one stable candidate shader pair still depends on a scene-specific draw census;
+geometry, constants, resources, and PSO state remain NR-02B through NR-02D.

--- a/docs/native-renderer/SHADER_PACK_FORMAT.md
+++ b/docs/native-renderer/SHADER_PACK_FORMAT.md
@@ -118,3 +118,8 @@ exactly one sanitized `validation_failed` event with `fallback=xenos`, then
 recorded Xenos as output authority, claimed no native frame, and exited
 normally without another error signal. Neither qualification run changed or
 copied the AppData save.
+
+Authentic local capture is documented in
+[`CANDIDATE_SHADER_CAPTURE.md`](CANDIDATE_SHADER_CAPTURE.md). The capture writer
+emits this manifest schema directly from validated ReXGlue translations while
+keeping all shader identity and bytecode data under `.local`.

--- a/patches/rexglue/0050-d3d12-shader-translation-observer.patch
+++ b/patches/rexglue/0050-d3d12-shader-translation-observer.patch
@@ -1,0 +1,112 @@
+diff --git a/include/rex/system/interfaces/graphics.h b/include/rex/system/interfaces/graphics.h
+index 608436a..594564d 100644
+--- a/include/rex/system/interfaces/graphics.h
++++ b/include/rex/system/interfaces/graphics.h
+@@ -129,6 +129,24 @@ struct GraphicsCopyObservation {
+ 
+ using GraphicsCopyObserver = void (*)(const GraphicsCopyObservation& observation);
+ 
++enum class GraphicsShaderStage : uint32_t {
++  kVertex = 1,
++  kPixel = 2,
++};
++
++// The bytecode view is borrowed for the duration of the callback only. The
++// observer is diagnostic and cannot alter shader translation or draw state.
++struct GraphicsShaderTranslationObservation {
++  GraphicsShaderStage stage = GraphicsShaderStage::kVertex;
++  uint64_t guest_hash = 0;
++  uint64_t specialization_mask = 0;
++  const uint8_t* bytecode = nullptr;
++  size_t bytecode_size = 0;
++};
++
++using GraphicsShaderTranslationObserver = void (*)(
++    const GraphicsShaderTranslationObservation& observation);
++
+ class IGraphicsSystem {
+  public:
+   virtual ~IGraphicsSystem() = default;
+@@ -163,6 +181,10 @@ class IGraphicsSystem {
+   virtual void SetCopyObserver(GraphicsCopyObserver observer) {
+     (void)observer;
+   }
++  virtual void SetShaderTranslationObserver(
++      GraphicsShaderTranslationObserver observer) {
++    (void)observer;
++  }
+   virtual void SetNativeGuestOutputRenderer(NativeGuestOutputRenderer renderer) {
+     (void)renderer;
+   }
+diff --git a/include/rex/graphics/graphics_system.h b/include/rex/graphics/graphics_system.h
+index 5406fd0..f7f84c4 100644
+--- a/include/rex/graphics/graphics_system.h
++++ b/include/rex/graphics/graphics_system.h
+@@ -82,6 +82,13 @@ class GraphicsSystem : public system::IGraphicsSystem {
+   system::GraphicsCopyObserver copy_observer() const {
+     return copy_observer_.load(std::memory_order_acquire);
+   }
++  void SetShaderTranslationObserver(
++      system::GraphicsShaderTranslationObserver observer) override {
++    shader_translation_observer_.store(observer, std::memory_order_release);
++  }
++  system::GraphicsShaderTranslationObserver shader_translation_observer() const {
++    return shader_translation_observer_.load(std::memory_order_acquire);
++  }
+   void SetNativeGuestOutputRenderer(
+       system::NativeGuestOutputRenderer renderer) override {
+     native_guest_output_renderer_.Set(renderer);
+@@ -154,6 +161,8 @@ class GraphicsSystem : public system::IGraphicsSystem {
+ 
+   std::atomic<system::GraphicsDrawObserver> draw_observer_{nullptr};
+   std::atomic<system::GraphicsCopyObserver> copy_observer_{nullptr};
++  std::atomic<system::GraphicsShaderTranslationObserver>
++      shader_translation_observer_{nullptr};
+   system::NativeGuestOutputRendererRegistration native_guest_output_renderer_;
+ 
+   std::atomic_flag host_gpu_loss_reported_;
+diff --git a/include/rex/graphics/d3d12/command_processor.h b/include/rex/graphics/d3d12/command_processor.h
+index 8ae9f12..e01eac2 100644
+--- a/include/rex/graphics/d3d12/command_processor.h
++++ b/include/rex/graphics/d3d12/command_processor.h
+@@ -61,6 +61,10 @@ class D3D12CommandProcessor : public CommandProcessor {
+     return *static_cast<ui::d3d12::D3D12Provider*>(graphics_system_->provider());
+   }
+ 
++  system::GraphicsShaderTranslationObserver GetShaderTranslationObserver() const {
++    return graphics_system_->shader_translation_observer();
++  }
++
+   // Returns the deferred drawing command list for the currently open
+   // submission.
+   DeferredCommandList& GetDeferredCommandList() {
+diff --git a/src/graphics/d3d12/pipeline_cache.cpp b/src/graphics/d3d12/pipeline_cache.cpp
+index 8e6b854..cd09ea2 100644
+--- a/src/graphics/d3d12/pipeline_cache.cpp
++++ b/src/graphics/d3d12/pipeline_cache.cpp
+@@ -1229,7 +1229,24 @@ bool PipelineCache::TranslateAnalyzedShader(DxbcShaderTranslator& translator,
+                                                     : "d3d12");
+   }
+ 
+-  return translation.is_valid();
++  if (!translation.is_valid()) {
++    return false;
++  }
++
++  auto shader_translation_observer =
++      command_processor_.GetShaderTranslationObserver();
++  if (shader_translation_observer) {
++    system::GraphicsShaderTranslationObservation observation;
++    observation.stage = shader.type() == xenos::ShaderType::kVertex
++                            ? system::GraphicsShaderStage::kVertex
++                            : system::GraphicsShaderStage::kPixel;
++    observation.guest_hash = shader.ucode_data_hash();
++    observation.specialization_mask = translation.modification();
++    observation.bytecode = translation.translated_binary().data();
++    observation.bytecode_size = translation.translated_binary().size();
++    shader_translation_observer(observation);
++  }
++  return true;
+ }
+ 
+ bool PipelineCache::GetCurrentStateDescription(

--- a/src/native_renderer/shader_capture.cpp
+++ b/src/native_renderer/shader_capture.cpp
@@ -1,0 +1,341 @@
+#include "native_renderer/shader_capture.h"
+
+#include <algorithm>
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <iterator>
+#include <limits>
+#include <mutex>
+#include <span>
+#include <string>
+#include <vector>
+
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#include <Windows.h>
+#include <bcrypt.h>
+
+#include <fmt/format.h>
+#include <rex/system/interfaces/graphics.h>
+
+#include "pinyon_shift_diagnostics.h"
+
+namespace {
+
+constexpr size_t kMaximumEntries = 256;
+constexpr size_t kMaximumBytecodeBytes = 16 * 1024 * 1024;
+constexpr size_t kMaximumCaptureBytes = 128 * 1024 * 1024;
+
+struct CaptureEntry {
+  rex::system::GraphicsShaderStage stage{};
+  uint64_t guest_hash = 0;
+  uint64_t specialization_mask = 0;
+  size_t bytecode_size = 0;
+  std::array<std::byte, 32> digest{};
+  std::string file_name;
+};
+
+struct CaptureState {
+  std::mutex mutex;
+  std::filesystem::path root;
+  std::vector<CaptureEntry> entries;
+  size_t bytecode_bytes = 0;
+  size_t duplicate_callbacks = 0;
+  size_t rejected_callbacks = 0;
+  bool active = false;
+};
+
+CaptureState g_capture;
+
+bool ComputeSha256(std::span<const std::byte> source,
+                   std::array<std::byte, 32> *digest) {
+  if (!digest || source.size() > std::numeric_limits<ULONG>::max()) {
+    return false;
+  }
+  BCRYPT_ALG_HANDLE algorithm = nullptr;
+  BCRYPT_HASH_HANDLE hash = nullptr;
+  DWORD object_size = 0;
+  DWORD returned_size = 0;
+  std::vector<UCHAR> object;
+  bool succeeded = false;
+  if (!BCRYPT_SUCCESS(BCryptOpenAlgorithmProvider(
+          &algorithm, BCRYPT_SHA256_ALGORITHM, nullptr, 0)) ||
+      !BCRYPT_SUCCESS(BCryptGetProperty(algorithm, BCRYPT_OBJECT_LENGTH,
+                                        reinterpret_cast<PUCHAR>(&object_size),
+                                        sizeof(object_size), &returned_size,
+                                        0))) {
+    goto cleanup;
+  }
+  object.resize(object_size);
+  if (!BCRYPT_SUCCESS(BCryptCreateHash(algorithm, &hash, object.data(),
+                                       object_size, nullptr, 0, 0)) ||
+      !BCRYPT_SUCCESS(BCryptHashData(
+          hash,
+          const_cast<PUCHAR>(reinterpret_cast<const UCHAR *>(source.data())),
+          static_cast<ULONG>(source.size()), 0)) ||
+      !BCRYPT_SUCCESS(
+          BCryptFinishHash(hash, reinterpret_cast<PUCHAR>(digest->data()),
+                           static_cast<ULONG>(digest->size()), 0))) {
+    goto cleanup;
+  }
+  succeeded = true;
+
+cleanup:
+  if (hash) {
+    BCryptDestroyHash(hash);
+  }
+  if (algorithm) {
+    BCryptCloseAlgorithmProvider(algorithm, 0);
+  }
+  return succeeded;
+}
+
+std::string DigestHex(const std::array<std::byte, 32> &digest) {
+  std::string result;
+  result.reserve(digest.size() * 2);
+  for (std::byte value : digest) {
+    fmt::format_to(std::back_inserter(result), "{:02x}",
+                   std::to_integer<uint8_t>(value));
+  }
+  return result;
+}
+
+bool IsCaptureRoot(const std::filesystem::path &path) {
+  if (!path.is_absolute()) {
+    return false;
+  }
+  return std::any_of(path.begin(), path.end(), [](const auto &component) {
+    return component.native() == L".local";
+  });
+}
+
+bool ReplaceFile(const std::filesystem::path &temporary,
+                 const std::filesystem::path &destination) {
+  return MoveFileExW(temporary.c_str(), destination.c_str(),
+                     MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH) != 0;
+}
+
+bool WriteFileAtomically(const std::filesystem::path &destination,
+                         std::span<const std::byte> bytes) {
+  std::filesystem::path temporary = destination;
+  temporary += L".tmp";
+  std::error_code error;
+  std::filesystem::remove(temporary, error);
+  std::ofstream output(temporary, std::ios::binary | std::ios::trunc);
+  if (!output.write(reinterpret_cast<const char *>(bytes.data()),
+                    static_cast<std::streamsize>(bytes.size())) ||
+      !output.flush()) {
+    output.close();
+    std::filesystem::remove(temporary, error);
+    return false;
+  }
+  output.close();
+  if (!ReplaceFile(temporary, destination)) {
+    std::filesystem::remove(temporary, error);
+    return false;
+  }
+  return true;
+}
+
+bool ExistingFileMatches(const std::filesystem::path &path,
+                         std::span<const std::byte> expected) {
+  std::error_code error;
+  if (std::filesystem::file_size(path, error) != expected.size() || error) {
+    return false;
+  }
+  std::vector<std::byte> actual(expected.size());
+  std::ifstream input(path, std::ios::binary);
+  return input.read(reinterpret_cast<char *>(actual.data()),
+                    static_cast<std::streamsize>(actual.size())) &&
+         input.peek() == std::char_traits<char>::eof() &&
+         std::equal(actual.begin(), actual.end(), expected.begin());
+}
+
+bool WriteManifestLocked(const CaptureEntry &pending) {
+  std::vector<CaptureEntry> entries = g_capture.entries;
+  entries.push_back(pending);
+  std::sort(entries.begin(), entries.end(),
+            [](const auto &left, const auto &right) {
+              if (left.stage != right.stage) {
+                return left.stage < right.stage;
+              }
+              if (left.guest_hash != right.guest_hash) {
+                return left.guest_hash < right.guest_hash;
+              }
+              return left.specialization_mask < right.specialization_mask;
+            });
+
+  std::string document =
+      "{\n  \"schema\": \"pinyon-shift.native-shader-pack.v1\",\n"
+      "  \"backend\": \"d3d12\",\n  \"entries\": [\n";
+  for (size_t index = 0; index < entries.size(); ++index) {
+    const CaptureEntry &entry = entries[index];
+    const char *stage = entry.stage == rex::system::GraphicsShaderStage::kVertex
+                            ? "vertex"
+                            : "pixel";
+    document += fmt::format("    {{\n      \"stage\": \"{}\",\n"
+                            "      \"guest_hash\": \"{:016X}\",\n"
+                            "      \"specialization_mask\": \"{:016X}\",\n"
+                            "      \"bytecode\": \"dxil/{}\",\n"
+                            "      \"sha256\": \"{}\"\n    }}{}\n",
+                            stage, entry.guest_hash, entry.specialization_mask,
+                            entry.file_name, DigestHex(entry.digest),
+                            index + 1 == entries.size() ? "" : ",");
+  }
+  document += "  ]\n}\n";
+  return WriteFileAtomically(
+      g_capture.root / L"shader-manifest.json",
+      std::as_bytes(std::span<const char>(document.data(), document.size())));
+}
+
+void ObserveShaderTranslation(
+    const rex::system::GraphicsShaderTranslationObservation &observation) {
+  const auto bytecode =
+      std::as_bytes(std::span(observation.bytecode, observation.bytecode_size));
+  std::lock_guard lock(g_capture.mutex);
+  if (!g_capture.active) {
+    return;
+  }
+  if ((observation.stage != rex::system::GraphicsShaderStage::kVertex &&
+       observation.stage != rex::system::GraphicsShaderStage::kPixel) ||
+      observation.guest_hash == 0 || bytecode.size() < 4 ||
+      bytecode.size() > kMaximumBytecodeBytes ||
+      std::memcmp(bytecode.data(), "DXBC", 4) != 0) {
+    ++g_capture.rejected_callbacks;
+    return;
+  }
+
+  auto existing = std::find_if(
+      g_capture.entries.begin(), g_capture.entries.end(),
+      [&](const CaptureEntry &entry) {
+        return entry.stage == observation.stage &&
+               entry.guest_hash == observation.guest_hash &&
+               entry.specialization_mask == observation.specialization_mask;
+      });
+  if (existing != g_capture.entries.end()) {
+    ++g_capture.duplicate_callbacks;
+    return;
+  }
+  if (g_capture.entries.size() >= kMaximumEntries ||
+      bytecode.size() > kMaximumCaptureBytes - g_capture.bytecode_bytes) {
+    ++g_capture.rejected_callbacks;
+    return;
+  }
+
+  CaptureEntry entry;
+  entry.stage = observation.stage;
+  entry.guest_hash = observation.guest_hash;
+  entry.specialization_mask = observation.specialization_mask;
+  entry.bytecode_size = bytecode.size();
+  if (!ComputeSha256(bytecode, &entry.digest)) {
+    ++g_capture.rejected_callbacks;
+    return;
+  }
+  entry.file_name = fmt::format(
+      "{}_{:016X}_{:016X}.dxil",
+      entry.stage == rex::system::GraphicsShaderStage::kVertex ? "vertex"
+                                                               : "pixel",
+      entry.guest_hash, entry.specialization_mask);
+  const std::filesystem::path destination =
+      g_capture.root / L"dxil" / entry.file_name;
+  std::error_code error;
+  if (std::filesystem::exists(destination, error)) {
+    if (error || !ExistingFileMatches(destination, bytecode)) {
+      ++g_capture.rejected_callbacks;
+      return;
+    }
+  } else if (!WriteFileAtomically(destination, bytecode)) {
+    ++g_capture.rejected_callbacks;
+    return;
+  }
+  if (!WriteManifestLocked(entry)) {
+    ++g_capture.rejected_callbacks;
+    return;
+  }
+  g_capture.bytecode_bytes += bytecode.size();
+  g_capture.entries.push_back(std::move(entry));
+}
+
+} // namespace
+
+namespace pinyon_shift::native_renderer {
+
+void InstallShaderCapture(rex::system::IGraphicsSystem *graphics_system) {
+  char *raw_path = nullptr;
+  size_t raw_path_length = 0;
+  if (_dupenv_s(&raw_path, &raw_path_length,
+                "PINYON_SHIFT_NATIVE_SHADER_CAPTURE_DIR") != 0 ||
+      !raw_path || raw_path_length <= 1) {
+    std::free(raw_path);
+    return;
+  }
+  const std::filesystem::path root =
+      std::filesystem::absolute(std::filesystem::path(raw_path))
+          .lexically_normal();
+  std::free(raw_path);
+  if (!graphics_system || !IsCaptureRoot(root)) {
+    diagnostics::RecordEvent(
+        "native_renderer.shader_capture.failure",
+        {{"reason", "invalid_local_root"}, {"fallback", "xenos"}});
+    return;
+  }
+  std::error_code error;
+  std::filesystem::create_directories(root / L"dxil", error);
+  if (error) {
+    diagnostics::RecordEvent(
+        "native_renderer.shader_capture.failure",
+        {{"reason", "create_directory_failed"}, {"fallback", "xenos"}});
+    return;
+  }
+  {
+    std::lock_guard lock(g_capture.mutex);
+    g_capture.root = root;
+    g_capture.entries.clear();
+    g_capture.bytecode_bytes = 0;
+    g_capture.duplicate_callbacks = 0;
+    g_capture.rejected_callbacks = 0;
+    g_capture.active = true;
+  }
+  graphics_system->SetShaderTranslationObserver(&ObserveShaderTranslation);
+  diagnostics::RecordEvent("native_renderer.shader_capture.installed",
+                           {{"entry_limit", "256"},
+                            {"byte_limit", "134217728"},
+                            {"output", "local_only"},
+                            {"mode", "pass_through"}});
+}
+
+void UninstallShaderCapture(rex::system::IGraphicsSystem *graphics_system) {
+  if (graphics_system) {
+    graphics_system->SetShaderTranslationObserver(nullptr);
+  }
+  size_t entries = 0;
+  size_t bytes = 0;
+  size_t duplicates = 0;
+  size_t rejected = 0;
+  {
+    std::lock_guard lock(g_capture.mutex);
+    if (!g_capture.active) {
+      return;
+    }
+    g_capture.active = false;
+    entries = g_capture.entries.size();
+    bytes = g_capture.bytecode_bytes;
+    duplicates = g_capture.duplicate_callbacks;
+    rejected = g_capture.rejected_callbacks;
+  }
+  diagnostics::RecordEvent("native_renderer.shader_capture.summary",
+                           {{"entries", std::to_string(entries)},
+                            {"bytes", std::to_string(bytes)},
+                            {"duplicate_callbacks", std::to_string(duplicates)},
+                            {"rejected_callbacks", std::to_string(rejected)},
+                            {"output", "local_only"},
+                            {"mode", "pass_through"}});
+}
+
+} // namespace pinyon_shift::native_renderer

--- a/src/native_renderer/shader_capture.h
+++ b/src/native_renderer/shader_capture.h
@@ -1,0 +1,12 @@
+#pragma once
+
+namespace rex::system {
+class IGraphicsSystem;
+}
+
+namespace pinyon_shift::native_renderer {
+
+void InstallShaderCapture(rex::system::IGraphicsSystem *graphics_system);
+void UninstallShaderCapture(rex::system::IGraphicsSystem *graphics_system);
+
+} // namespace pinyon_shift::native_renderer

--- a/src/pinyon_shift_app.cpp
+++ b/src/pinyon_shift_app.cpp
@@ -20,6 +20,7 @@
 
 #include "native_renderer/graphics_hooks.h"
 #include "native_renderer/guest_output_renderer.h"
+#include "native_renderer/shader_capture.h"
 #include "pinyon_shift_diagnostics.h"
 
 #include <cstdio>
@@ -346,6 +347,8 @@ void PinyonShiftApp::OnPostSetup() {
       runtime() ? runtime()->graphics_system() : nullptr);
   pinyon_shift::native_renderer::InstallGraphicsCensus(
       runtime() ? runtime()->graphics_system() : nullptr);
+  pinyon_shift::native_renderer::InstallShaderCapture(
+      runtime() ? runtime()->graphics_system() : nullptr);
   pinyon_shift::diagnostics::RecordEvent(
       "runtime.setup.complete",
       {{"memory", runtime() && runtime()->memory() ? "1" : "0"},
@@ -375,11 +378,15 @@ bool PinyonShiftApp::OnWindowCloseRequested() {
   // ReXGlue 0.9 deliberately hard-exits after accepting a window-close
   // request, so OnDestroy/OnShutdown are not reached on that path. Record the
   // clean qualification boundary before allowing the SDK to terminate.
+  pinyon_shift::native_renderer::UninstallShaderCapture(
+      runtime() ? runtime()->graphics_system() : nullptr);
   RecordShutdownOnce();
   return true;
 }
 
 void PinyonShiftApp::OnShutdown() {
+  pinyon_shift::native_renderer::UninstallShaderCapture(
+      runtime() ? runtime()->graphics_system() : nullptr);
   pinyon_shift::native_renderer::UninstallGuestOutputRenderer(
       runtime() ? runtime()->graphics_system() : nullptr);
   pinyon_shift::native_renderer::UninstallGraphicsCensus(

--- a/tools/capture-native-renderer-shaders.ps1
+++ b/tools/capture-native-renderer-shaders.ps1
@@ -1,0 +1,57 @@
+[CmdletBinding()]
+param(
+    [string]$StateRoot,
+    [string]$OutputRoot,
+    [switch]$Json
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
+$resolvedStateRoot = if ($StateRoot) {
+    [IO.Path]::GetFullPath($StateRoot)
+} else {
+    Join-Path $env:LOCALAPPDATA 'PinyonShift\source\0.1.0\.local\preview'
+}
+$captureRoot = if ($OutputRoot) {
+    [IO.Path]::GetFullPath($OutputRoot)
+} else {
+    $stamp = [DateTime]::UtcNow.ToString('yyyyMMddTHHmmssfffZ')
+    Join-Path $repoRoot ".local\native-renderer\captures\$stamp"
+}
+
+$profile = Get-ChildItem -LiteralPath (Join-Path $resolvedStateRoot 'user') `
+    -Filter 'ForzaProfile' -File -Recurse -ErrorAction SilentlyContinue |
+    Where-Object { $_.Directory.Name -eq 'ForzaProfile' } |
+    Select-Object -First 1
+if ($null -eq $profile) {
+    throw "The selected state root has no ForzaProfile save: $resolvedStateRoot"
+}
+if (@(Get-Process -Name 'pinyon_shift' -ErrorAction SilentlyContinue).Count -ne 0) {
+    throw 'Pinyon Shift is already running.'
+}
+$localRoot = [IO.Path]::GetFullPath((Join-Path $repoRoot '.local'))
+$localPrefix = $localRoot.TrimEnd([IO.Path]::DirectorySeparatorChar,
+    [IO.Path]::AltDirectorySeparatorChar) + [IO.Path]::DirectorySeparatorChar
+if ($captureRoot -ne $localRoot -and
+    -not $captureRoot.StartsWith($localPrefix,
+        [StringComparison]::OrdinalIgnoreCase)) {
+    throw 'Shader capture output must remain under the repository .local directory.'
+}
+
+[void](New-Item -ItemType Directory -Force -Path $captureRoot)
+$result = [ordered]@{
+    capture_root = $captureRoot
+    manifest = Join-Path $captureRoot 'shader-manifest.json'
+    state_root = $resolvedStateRoot
+    save_verified = $true
+}
+if ($Json) {
+    $result | ConvertTo-Json -Compress
+} else {
+    $result
+}
+
+& (Join-Path $PSScriptRoot 'launch-preview.ps1') `
+    -StateRoot $resolvedStateRoot -ShaderCaptureDir $captureRoot

--- a/tools/launch-preview.ps1
+++ b/tools/launch-preview.ps1
@@ -4,6 +4,7 @@ param(
     [string]$Configuration = 'Release',
     [string]$GameRoot,
     [string]$StateRoot,
+    [string]$ShaderCaptureDir,
     [switch]$Json,
     [switch]$CrashSelfTest
 )
@@ -47,6 +48,7 @@ $savedStateRoot = $env:PINYON_SHIFT_STATE_ROOT
 $savedGameRoot = $env:PINYON_SHIFT_GAME_ROOT
 $savedTearing = $env:REX_D3D12_ALLOW_VARIABLE_REFRESH_RATE_AND_TEARING
 $savedCrashTest = $env:PINYON_SHIFT_CRASH_SELF_TEST
+$savedShaderCaptureDir = $env:PINYON_SHIFT_NATIVE_SHADER_CAPTURE_DIR
 $startedUtc = [DateTime]::UtcNow
 $process = $null
 try {
@@ -54,6 +56,11 @@ try {
     $env:PINYON_SHIFT_GAME_ROOT = $resolvedGameRoot
     $env:REX_D3D12_ALLOW_VARIABLE_REFRESH_RATE_AND_TEARING = 'false'
     $env:PINYON_SHIFT_CRASH_SELF_TEST = if ($CrashSelfTest) { '1' } else { $null }
+    $env:PINYON_SHIFT_NATIVE_SHADER_CAPTURE_DIR = if ($ShaderCaptureDir) {
+        [IO.Path]::GetFullPath($ShaderCaptureDir)
+    } else {
+        $null
+    }
     $process = Start-Process -FilePath $executable `
         -WorkingDirectory (Split-Path $executable -Parent) -PassThru
     $process.WaitForExit()
@@ -64,6 +71,7 @@ finally {
     $env:PINYON_SHIFT_GAME_ROOT = $savedGameRoot
     $env:REX_D3D12_ALLOW_VARIABLE_REFRESH_RATE_AND_TEARING = $savedTearing
     $env:PINYON_SHIFT_CRASH_SELF_TEST = $savedCrashTest
+    $env:PINYON_SHIFT_NATIVE_SHADER_CAPTURE_DIR = $savedShaderCaptureDir
 }
 
 if ($null -eq $process) { throw 'Windows did not start Pinyon Shift.' }

--- a/tools/tests/test_native_renderer_contract.py
+++ b/tools/tests/test_native_renderer_contract.py
@@ -230,6 +230,44 @@ class NativeRendererContractTests(unittest.TestCase):
         self.assertIn("claimed_frames", report)
         self.assertIn("failure_reason", report)
 
+    def test_shader_capture_is_local_bounded_and_passive(self):
+        patch = (
+            ROOT
+            / "patches/rexglue/0050-d3d12-shader-translation-observer.patch"
+        ).read_text(encoding="utf-8")
+        self.assertIn("GraphicsShaderTranslationObservation", patch)
+        self.assertIn("translation.translated_binary().data()", patch)
+        self.assertIn("translation.modification()", patch)
+        self.assertIn("if (!translation.is_valid())", patch)
+        self.assertNotIn("SetDrawSuppression", patch)
+        self.assertNotIn("SetCopySuppression", patch)
+
+        source = (
+            ROOT / "src/native_renderer/shader_capture.cpp"
+        ).read_text(encoding="utf-8")
+        self.assertIn("PINYON_SHIFT_NATIVE_SHADER_CAPTURE_DIR", source)
+        self.assertIn("kMaximumEntries = 256", source)
+        self.assertIn("kMaximumBytecodeBytes = 16 * 1024 * 1024", source)
+        self.assertIn("kMaximumCaptureBytes = 128 * 1024 * 1024", source)
+        self.assertIn('component.native() == L".local"', source)
+        self.assertIn('std::memcmp(bytecode.data(), "DXBC", 4)', source)
+        self.assertIn("pinyon-shift.native-shader-pack.v1", source)
+        self.assertIn('{"fallback", "xenos"}', source)
+        self.assertNotIn("guest_hash", source.split(
+            'diagnostics::RecordEvent("native_renderer.shader_capture.installed"', 1
+        )[1])
+
+        launcher = (ROOT / "tools/launch-preview.ps1").read_text(
+            encoding="utf-8"
+        )
+        capture = (
+            ROOT / "tools/capture-native-renderer-shaders.ps1"
+        ).read_text(encoding="utf-8")
+        self.assertIn("PINYON_SHIFT_NATIVE_SHADER_CAPTURE_DIR", launcher)
+        self.assertIn("-StateRoot $resolvedStateRoot", capture)
+        self.assertIn("ForzaProfile", capture)
+        self.assertIn("repository .local directory", capture)
+
     def test_census_ledger_tracks_exact_starting_baseline(self):
         ledger = (ROOT / "docs/native-renderer/RENDER_PASS_CENSUS.md").read_text(
             encoding="utf-8"

--- a/tools/tests/test_native_shader_pack.py
+++ b/tools/tests/test_native_shader_pack.py
@@ -172,6 +172,7 @@ class NativeShaderPackTests(unittest.TestCase):
             (ROOT / "config/repository-policy.json").read_text(encoding="utf-8")
         )
         self.assertIn(".dxil", policy["forbidden_extensions"])
+        self.assertIn(".dxbc", policy["forbidden_extensions"])
         self.assertIn(".pnsp", policy["forbidden_extensions"])
 
     def test_runtime_load_is_restart_scoped_and_never_changes_xenos_authority(self):

--- a/tools/tests/test_release_contract.py
+++ b/tools/tests/test_release_contract.py
@@ -43,10 +43,10 @@ class ReleaseContractTests(unittest.TestCase):
 
     def test_rexglue_patches_have_stable_order_and_no_binary_payload(self):
         patches = sorted((ROOT / "patches/rexglue").glob("*.patch"))
-        self.assertEqual(len(patches), 49)
+        self.assertEqual(len(patches), 50)
         self.assertEqual(
             patches[-1].name,
-            "0049-native-guest-output-diagnostic-triangle.patch",
+            "0050-d3d12-shader-translation-observer.patch",
         )
         self.assertEqual(len(patches), len({path.name[:4] for path in patches}))
         for path in patches:


### PR DESCRIPTION
## Summary
- add a default-null ReXGlue observer after successful D3D12 shader translation
- capture bounded local-only candidate bytecode in the deterministic pack format
- add an AppData-safe capture helper and document the capture boundary
- preserve Xenos as sole output authority; no draw suppression or native replay

## Validation
- clean 50-patch preview build and 69 repository tests
- ReXGlue: 2,282 assertions; PPC: 6,549 assertions
- repository boundary: 0 violations
- enabled AppData run: 34 translations, 0 rejected, verified pack, normal shutdown
- default AppData run: zero capture events, Xenos authority, normal shutdown
- no TDR, device removal, validation warning, or presentation deadline miss

Closes the local extraction/translation prerequisite for NR-02. Geometry, resources, PSO state, and isolated native draw execution remain follow-up work.