### PR TITLE
feat(renderer): qualify repeatable native draw candidate

### DIFF
--- a/docs/native-renderer/CANDIDATE_DRAW_SELECTION.md
+++ b/docs/native-renderer/CANDIDATE_DRAW_SELECTION.md
@@ -1,0 +1,104 @@
+# Candidate draw selection
+
+NR-02 candidate selection is a local, evidence-producing workflow. It does not
+read guest buffer contents, submit native work, or make a draw eligible for
+suppression. Xenos remains authoritative.
+
+## Bounded draw state
+
+ReXGlue patch `0051-graphics-draw-candidate-state.patch` extends the existing
+default-off observer with the metadata needed to reject unsuitable first
+draws:
+
+- index format and endianness;
+- at most eight vertex bindings, with fetch identity, address, byte range,
+  stride, and endianness;
+- color write masks and four blend-control registers;
+- depth, rasterizer, and vertex convention registers; and
+- an explicit overflow bit when a shader exceeds the vertex-binding bound.
+
+The observer still runs immediately before the unmodified `IssueDraw` call.
+It borrows no bytecode and serializes no vertex, index, texture, constant, or
+render-target contents. The disabled path remains one null callback check.
+
+The existing NR-00 pass signature remains byte-for-byte stable. A separate
+candidate signature includes layout shape, index interpretation, query and
+memexport state, resolved-input observation, and the captured pipeline state.
+The census emits at most 32 candidate records per 300-frame window. Buffer
+addresses are reported in the local sample but deliberately do not identify
+the recurring candidate signature.
+
+Patch `0052-d3d12-prepared-draw-observer.patch` adds a second default-null,
+metadata-only callback after successful D3D12 pipeline configuration. It joins
+the guest vertex/pixel hashes to the exact ReXGlue specialization masks used by
+that prepared draw. The title records at most 1,024 unique pairs. The selector
+requires one pair to recur in every supplied capture and verifies that exact
+identity exists in the local shader manifest; it never guesses among multiple
+translations of the same guest hash.
+
+## Repeated-capture shortlist
+
+Capture the same marked scene at least twice while also collecting the local
+shader manifest:
+
+```powershell
+$capture = '.\.local\native-renderer\candidate\run-1'
+.\tools\capture-native-renderer-census.ps1 `
+  -Scene open_world_day -ShaderCaptureDir $capture
+```
+
+After each normal exit, summarize the corresponding diagnostic session with
+`summarize-native-renderer-census.py`. Then produce the shortlist:
+
+```powershell
+python .\tools\select-native-renderer-candidate.py `
+  .\.local\native-renderer\candidate\run-1-census.json `
+  .\.local\native-renderer\candidate\run-2-census.json `
+  --shader-manifest `
+  .\.local\native-renderer\candidate\run-1\shader-manifest.json `
+  --output .\.local\native-renderer\candidate\selection.json
+```
+
+The selector requires a signature and exact prepared shader pair in every
+input capture. It accepts both indexed and non-indexed authentic draws because
+the NR-02 candidate criteria do not require an index buffer. It rejects missing
+or ambiguous prepared pairs, shader-pack misses, blending, query or memexport
+state, observed resolved-target inputs, more than one vertex binding, more than
+one texture, and bounded-observer overflow. Results are ordered
+deterministically by recurrence and draw count.
+
+## Local qualification — 2026-08-28
+
+The clean 52-patch Release build produced executable SHA-256
+`AE63C436A34B56AD4775FE5B5669F6D1E8A63F50B96203DB0B8D246CFD191083`.
+Two consecutive `open_world_day` captures against the installed `0.1.0`
+AppData save exited normally:
+
+| Session | Draws | Candidate records | Prepared shader pairs |
+| --- | ---: | ---: | ---: |
+| `20260828T040945Z-p40816` | 2,070,384 | 75 | 274 |
+| `20260828T041037Z-p40152` | 2,783,339 | 85 | 286 |
+
+The selector found one repeatable candidate, signature
+`E184D75768958828`, across 6,183 observed draws. It uses vertex shader
+`3BC346726C1C2535` with specialization `000000000000000F` and pixel shader
+`9584B309533EF6C9` with specialization `00000000000E000F`. Its bounded sample
+is an opaque, non-indexed primitive with one 40-byte vertex binding and one
+texture fetch. The exact shader identities exist in the first capture's local
+manifest.
+
+This result selects the subject for visual identification and NR-02B data
+validation; it does not establish static-texture provenance, visual parity, or
+suppression safety. Xenos rendered and presented both qualification runs.
+
+The final close-path build produced executable SHA-256
+`C2A49BAFBEAFFB1B0B414F224718F05F3BA0DA6C1E13AECA46A3A289CF4BE903`.
+Session `20260828T041356Z-p41140` verified that a normal window close flushes
+four candidate windows and a 231-pair prepared-shader summary with zero
+overflow. It exited normally with no error event and Xenos authority intact.
+
+`metadata_shortlist_only` is not a rendering-safety verdict. In particular,
+failure to observe a resolved input does not prove that a texture is static.
+The selected draw still requires visual identification, dependency review,
+guest bounds validation, and isolated comparison before NR-02 can advance to
+native execution.

--- a/docs/native-renderer/CANDIDATE_SHADER_CAPTURE.md
+++ b/docs/native-renderer/CANDIDATE_SHADER_CAPTURE.md
@@ -83,3 +83,5 @@ copied the AppData save.
 This closes the local extraction/translation prerequisite for NR-02. Selecting
 one stable candidate shader pair still depends on a scene-specific draw census;
 geometry, constants, resources, and PSO state remain NR-02B through NR-02D.
+The bounded repeated-capture workflow is defined in
+[`CANDIDATE_DRAW_SELECTION.md`](CANDIDATE_DRAW_SELECTION.md).

--- a/docs/native-renderer/RENDER_PASS_CENSUS.md
+++ b/docs/native-renderer/RENDER_PASS_CENSUS.md
@@ -96,3 +96,8 @@ CPU-read observation, and presentation provenance remain subsequent NR-00
 work.
 
 Unknown work stays on Xenos.
+
+Candidate-specific index, vertex-layout, blend, depth, and raster metadata is
+documented in [`CANDIDATE_DRAW_SELECTION.md`](CANDIDATE_DRAW_SELECTION.md).
+It is a local NR-02 shortlist only and does not change the NR-00 classifier or
+open Gate B.

--- a/patches/rexglue/0051-graphics-draw-candidate-state.patch
+++ b/patches/rexglue/0051-graphics-draw-candidate-state.patch
@@ -1,0 +1,93 @@
+diff --git a/include/rex/system/interfaces/graphics.h b/include/rex/system/interfaces/graphics.h
+index 8ced0d1..c2561b8 100644
+--- a/include/rex/system/interfaces/graphics.h
++++ b/include/rex/system/interfaces/graphics.h
+@@ -85,3 +85,13 @@ class NativeGuestOutputRendererRegistration {
++struct GraphicsVertexBindingObservation {
++  uint32_t fetch_constant = 0;
++  uint32_t address = 0;
++  uint32_t size = 0;
++  uint32_t stride_words = 0;
++  uint32_t endianness = 0;
++};
++
++constexpr uint32_t kGraphicsVertexBindingObservationLimit = 8;
++
+ struct GraphicsDrawObservation {
+   uint64_t frame_sequence = 0;
+   uint64_t draw_sequence = 0;
+@@ -45,6 +54,12 @@ struct GraphicsDrawObservation {
+   uint32_t source_select = 0;
+   uint32_t index_buffer_address = 0;
+   uint32_t index_buffer_length = 0;
++  uint32_t index_format = 0;
++  uint32_t index_endianness = 0;
++  uint32_t vertex_binding_count = 0;
++  GraphicsVertexBindingObservation
++      vertex_bindings[kGraphicsVertexBindingObservationLimit] = {};
++  uint32_t vertex_binding_overflow = 0;
+   uint32_t surface_info = 0;
+   uint32_t color_info[4] = {};
+   uint32_t depth_info = 0;
+@@ -54,6 +69,11 @@ struct GraphicsDrawObservation {
+   uint32_t viz_query_condition = 0;
+   uint32_t pa_sc_viz_query = 0;
+   uint32_t texture_fetch_mask = 0;
++  uint32_t rb_color_mask = 0;
++  uint32_t rb_blendcontrol[4] = {};
++  uint32_t rb_depthcontrol = 0;
++  uint32_t pa_su_sc_mode_cntl = 0;
++  uint32_t pa_su_vtx_cntl = 0;
+   uint32_t texture_fetch_addresses[32] = {};
+   uint32_t texture_fetch_mip_addresses[32] = {};
+   bool indexed = false;
+diff --git a/src/graphics/command_processor.cpp b/src/graphics/command_processor.cpp
+index 795d5ed..86f7141 100644
+--- a/src/graphics/command_processor.cpp
++++ b/src/graphics/command_processor.cpp
+@@ -1495,6 +1495,27 @@ bool CommandProcessor::ExecutePacketType3Draw(memory::RingBuffer* reader, uint32
+         if (is_indexed) {
+           observation.index_buffer_address = index_buffer_info.guest_base;
+           observation.index_buffer_length = uint32_t(index_buffer_info.length);
++          observation.index_format = uint32_t(index_buffer_info.format);
++          observation.index_endianness = uint32_t(index_buffer_info.endianness);
++        }
++        if (active_vertex_shader_) {
++          const auto& vertex_bindings = active_vertex_shader_->vertex_bindings();
++          observation.vertex_binding_count = uint32_t(vertex_bindings.size());
++          for (uint32_t i = 0;
++               i < observation.vertex_binding_count &&
++               i < system::kGraphicsVertexBindingObservationLimit;
++               ++i) {
++            const Shader::VertexBinding& binding = vertex_bindings[i];
++            const xenos::xe_gpu_vertex_fetch_t fetch =
++                register_file_->GetVertexFetch(binding.fetch_constant);
++            observation.vertex_bindings[i].fetch_constant = binding.fetch_constant;
++            observation.vertex_bindings[i].address = fetch.address << 2;
++            observation.vertex_bindings[i].size = fetch.size << 2;
++            observation.vertex_bindings[i].stride_words = binding.stride_words;
++            observation.vertex_bindings[i].endianness = uint32_t(fetch.endian);
++          }
++          observation.vertex_binding_overflow =
++              observation.vertex_binding_count > system::kGraphicsVertexBindingObservationLimit;
+         }
+         observation.surface_info = register_file_->Get<reg::RB_SURFACE_INFO>().value;
+         for (uint32_t i = 0; i < 4; ++i) {
+@@ -1508,6 +1529,16 @@ bool CommandProcessor::ExecutePacketType3Draw(memory::RingBuffer* reader, uint32
+             register_file_->Get<reg::PA_SC_WINDOW_SCISSOR_BR>().value;
+         observation.rb_modecontrol = register_file_->Get<reg::RB_MODECONTROL>().value;
+         observation.viz_query_condition = viz_query_condition;
+         observation.pa_sc_viz_query = viz_query.value;
++        observation.rb_color_mask = register_file_->Get<reg::RB_COLOR_MASK>().value;
++        for (uint32_t i = 0; i < 4; ++i) {
++          observation.rb_blendcontrol[i] =
++              (*register_file_)[reg::RB_BLENDCONTROL::rt_register_indices[i]];
++        }
++        observation.rb_depthcontrol =
++            register_file_->Get<reg::RB_DEPTHCONTROL>().value;
++        observation.pa_su_sc_mode_cntl =
++            register_file_->Get<reg::PA_SU_SC_MODE_CNTL>().value;
++        observation.pa_su_vtx_cntl = register_file_->Get<reg::PA_SU_VTX_CNTL>().value;
+         auto capture_texture_fetches = [&](Shader* shader) {
+           if (!shader) {
+             return;

--- a/patches/rexglue/0052-d3d12-prepared-draw-observer.patch
+++ b/patches/rexglue/0052-d3d12-prepared-draw-observer.patch
@@ -1,0 +1,79 @@
+diff --git a/include/rex/graphics/graphics_system.h b/include/rex/graphics/graphics_system.h
+index f24e4b7..b63fc2a 100644
+--- a/include/rex/graphics/graphics_system.h
++++ b/include/rex/graphics/graphics_system.h
+@@ -89,6 +89,12 @@ class GraphicsSystem : public system::IGraphicsSystem {
+   system::GraphicsShaderTranslationObserver shader_translation_observer() const {
+     return shader_translation_observer_.load(std::memory_order_acquire);
+   }
++  void SetPreparedDrawObserver(system::GraphicsPreparedDrawObserver observer) override {
++    prepared_draw_observer_.store(observer, std::memory_order_release);
++  }
++  system::GraphicsPreparedDrawObserver prepared_draw_observer() const {
++    return prepared_draw_observer_.load(std::memory_order_acquire);
++  }
+   void SetNativeGuestOutputRenderer(
+       system::NativeGuestOutputRenderer renderer) override {
+     native_guest_output_renderer_.Set(renderer);
+@@ -163,6 +170,8 @@ class GraphicsSystem : public system::IGraphicsSystem {
+   std::atomic<system::GraphicsCopyObserver> copy_observer_{nullptr};
+   std::atomic<system::GraphicsShaderTranslationObserver>
+       shader_translation_observer_{nullptr};
++  std::atomic<system::GraphicsPreparedDrawObserver> prepared_draw_observer_{
++      nullptr};
+   system::NativeGuestOutputRendererRegistration native_guest_output_renderer_;
+ 
+   std::atomic_flag host_gpu_loss_reported_;
+diff --git a/include/rex/system/interfaces/graphics.h b/include/rex/system/interfaces/graphics.h
+index c2561b8..322c4a8 100644
+--- a/include/rex/system/interfaces/graphics.h
++++ b/include/rex/system/interfaces/graphics.h
+@@ -168,5 +168,15 @@ using GraphicsShaderTranslationObserver = void (*)(
+     const GraphicsShaderTranslationObservation& observation);
+ 
++struct GraphicsPreparedDrawObservation {
++  uint64_t vertex_shader_hash = 0;
++  uint64_t pixel_shader_hash = 0;
++  uint64_t vertex_specialization_mask = 0;
++  uint64_t pixel_specialization_mask = 0;
++};
++
++using GraphicsPreparedDrawObserver = void (*)(
++    const GraphicsPreparedDrawObservation& observation);
++
+ class IGraphicsSystem {
+  public:
+   virtual ~IGraphicsSystem() = default;
+@@ -205,7 +215,10 @@ class IGraphicsSystem {
+   virtual void SetShaderTranslationObserver(
+       GraphicsShaderTranslationObserver observer) {
+     (void)observer;
+   }
++  virtual void SetPreparedDrawObserver(GraphicsPreparedDrawObserver observer) {
++    (void)observer;
++  }
+   virtual void SetNativeGuestOutputRenderer(NativeGuestOutputRenderer renderer) {
+     (void)renderer;
+   }
+diff --git a/src/graphics/d3d12/command_processor.cpp b/src/graphics/d3d12/command_processor.cpp
+index ea0f1cc..f72fe8b 100644
+--- a/src/graphics/d3d12/command_processor.cpp
++++ b/src/graphics/d3d12/command_processor.cpp
+@@ -2727,7 +2727,17 @@ bool D3D12CommandProcessor::IssueDraw(xenos::PrimitiveType primitive_type, uint3
+   if (REXCVAR_GET(async_shader_compilation) &&
+       pipeline_cache_->GetD3D12PipelineByHandle(pipeline_handle) == nullptr) {
+     return true;
+   }
++  auto prepared_draw_observer = graphics_system_->prepared_draw_observer();
++  if (prepared_draw_observer) {
++    system::GraphicsPreparedDrawObservation observation;
++    observation.vertex_shader_hash = vertex_shader->ucode_data_hash();
++    observation.pixel_shader_hash =
++        pixel_shader ? pixel_shader->ucode_data_hash() : 0;
++    observation.vertex_specialization_mask = vertex_shader_modification.value;
++    observation.pixel_specialization_mask = pixel_shader_modification.value;
++    prepared_draw_observer(observation);
++  }
+ 
+   // Update the textures - this may bind pipelines.
+   uint32_t used_texture_mask =

--- a/src/native_renderer/graphics_hooks.cpp
+++ b/src/native_renderer/graphics_hooks.cpp
@@ -1,6 +1,7 @@
 #include <algorithm>
 #include <array>
 #include <atomic>
+#include <bit>
 #include <cstddef>
 #include <cstdint>
 #include <cstdlib>
@@ -25,6 +26,8 @@ namespace {
 constexpr uint64_t kFrameSummaryInterval = 300;
 constexpr size_t kSignatureCapacity = 4096;
 constexpr size_t kSummaryLimit = 16;
+constexpr size_t kCandidateSummaryLimit = 32;
+constexpr size_t kPreparedShaderPairCapacity = 1024;
 constexpr size_t kResolveTargetCapacity = 4096;
 constexpr size_t kResolvePageCapacity = 32768;
 constexpr size_t kResolveSummaryLimit = 32;
@@ -32,7 +35,7 @@ constexpr uint64_t kGuestPageSize = 4096;
 std::atomic<uint64_t> g_frame_sequence{};
 
 std::string CensusSceneMarker() {
-  char* value = nullptr;
+  char *value = nullptr;
   size_t length = 0;
   if (_dupenv_s(&value, &length, "PINYON_SHIFT_NATIVE_RENDERER_SCENE") != 0 ||
       !value || length <= 1) {
@@ -55,6 +58,7 @@ struct DrawSignatureEntry {
   uint64_t draw_count = 0;
   uint64_t first_frame = 0;
   uint64_t last_frame = 0;
+  bool samples_resolved_target = false;
   rex::system::GraphicsDrawObservation sample;
 };
 
@@ -68,6 +72,18 @@ struct DrawCensus {
 };
 
 DrawCensus g_draw_census;
+DrawCensus g_candidate_census;
+
+struct PreparedShaderPairEntry {
+  uint64_t identity = 0;
+  rex::system::GraphicsPreparedDrawObservation sample;
+};
+
+std::array<PreparedShaderPairEntry, kPreparedShaderPairCapacity>
+    g_prepared_shader_pairs{};
+uint64_t g_prepared_shader_pair_count = 0;
+uint64_t g_prepared_shader_pair_overflow = 0;
+bool g_graphics_census_installed = false;
 
 struct ResolveTargetEntry {
   uint32_t address = 0;
@@ -123,6 +139,14 @@ static_assert(std::is_trivially_copyable_v<DependencyCensus>);
 
 void ResetDrawCensus() {
   std::memset(&g_draw_census, 0, sizeof(g_draw_census));
+  std::memset(&g_candidate_census, 0, sizeof(g_candidate_census));
+}
+
+void ResetPreparedShaderPairs() {
+  std::memset(g_prepared_shader_pairs.data(), 0,
+              sizeof(g_prepared_shader_pairs));
+  g_prepared_shader_pair_count = 0;
+  g_prepared_shader_pair_overflow = 0;
 }
 
 void ResetDependencyCensus() {
@@ -138,7 +162,7 @@ size_t ResolveTargetIndex(uint32_t address) {
   size_t index = size_t(HashCombine(0xCBF29CE484222325ull, address) %
                         kResolveTargetCapacity);
   for (size_t probe = 0; probe < kResolveTargetCapacity; ++probe) {
-    const ResolveTargetEntry& entry = g_dependency_census.targets[index];
+    const ResolveTargetEntry &entry = g_dependency_census.targets[index];
     if (!entry.resolve_count || entry.address == address) {
       return index;
     }
@@ -148,10 +172,10 @@ size_t ResolveTargetIndex(uint32_t address) {
 }
 
 void MapResolvePage(uint32_t page, size_t target_index) {
-  size_t index = size_t(HashCombine(0x9E3779B97F4A7C15ull, page) %
-                        kResolvePageCapacity);
+  size_t index =
+      size_t(HashCombine(0x9E3779B97F4A7C15ull, page) % kResolvePageCapacity);
   for (size_t probe = 0; probe < kResolvePageCapacity; ++probe) {
-    ResolvePageEntry& entry = g_dependency_census.pages[index];
+    ResolvePageEntry &entry = g_dependency_census.pages[index];
     if (!entry.target_index_plus_one) {
       entry.page = page;
       entry.target_index_plus_one = uint32_t(target_index + 1);
@@ -178,23 +202,22 @@ void MapResolveRange(size_t target_index, uint32_t address, uint32_t length) {
     MapResolvePage(uint32_t(first_page + offset), target_index);
   }
   if (page_count > bounded_page_count) {
-    g_dependency_census.page_overflow_count +=
-        page_count - bounded_page_count;
+    g_dependency_census.page_overflow_count += page_count - bounded_page_count;
   }
 }
 
 size_t FindResolveTarget(uint32_t address) {
   const uint32_t page = uint32_t(uint64_t(address) / kGuestPageSize);
-  size_t index = size_t(HashCombine(0x9E3779B97F4A7C15ull, page) %
-                        kResolvePageCapacity);
+  size_t index =
+      size_t(HashCombine(0x9E3779B97F4A7C15ull, page) % kResolvePageCapacity);
   for (size_t probe = 0; probe < kResolvePageCapacity; ++probe) {
-    const ResolvePageEntry& page_entry = g_dependency_census.pages[index];
+    const ResolvePageEntry &page_entry = g_dependency_census.pages[index];
     if (!page_entry.target_index_plus_one) {
       return kResolveTargetCapacity;
     }
     if (page_entry.page == page) {
       const size_t target_index = page_entry.target_index_plus_one - 1;
-      const ResolveTargetEntry& target =
+      const ResolveTargetEntry &target =
           g_dependency_census.targets[target_index];
       const uint64_t target_end =
           uint64_t(target.address) + uint64_t(target.length);
@@ -227,7 +250,7 @@ void ResetDependencyWindow() {
   g_dependency_census.window_sampled_target_count = 0;
   g_dependency_census.window_query_draw_count = 0;
   g_dependency_census.window_memexport_draw_count = 0;
-  for (ResolveTargetEntry& target : g_dependency_census.targets) {
+  for (ResolveTargetEntry &target : g_dependency_census.targets) {
     target.window_resolve_count = 0;
     target.window_sampled_draw_count = 0;
   }
@@ -248,8 +271,7 @@ void EmitDependencyCensusWindow() {
        {"failed_copies", number(g_dependency_census.window_failed_copy_count)},
        {"zero_length_copies",
         number(g_dependency_census.window_zero_length_copy_count)},
-       {"sampled_draws",
-        number(g_dependency_census.window_sampled_draw_count)},
+       {"sampled_draws", number(g_dependency_census.window_sampled_draw_count)},
        {"sample_references",
         number(g_dependency_census.window_sample_reference_count)},
        {"sampled_targets",
@@ -270,12 +292,10 @@ void EmitDependencyCensusWindow() {
     order[i] = i;
   }
   std::sort(order.begin(), order.end(), [](size_t left, size_t right) {
-    const ResolveTargetEntry& left_entry =
-        g_dependency_census.targets[left];
-    const ResolveTargetEntry& right_entry =
-        g_dependency_census.targets[right];
-    const uint64_t left_activity = left_entry.window_resolve_count +
-                                   left_entry.window_sampled_draw_count;
+    const ResolveTargetEntry &left_entry = g_dependency_census.targets[left];
+    const ResolveTargetEntry &right_entry = g_dependency_census.targets[right];
+    const uint64_t left_activity =
+        left_entry.window_resolve_count + left_entry.window_sampled_draw_count;
     const uint64_t right_activity = right_entry.window_resolve_count +
                                     right_entry.window_sampled_draw_count;
     if (left_activity != right_activity) {
@@ -286,7 +306,7 @@ void EmitDependencyCensusWindow() {
 
   size_t emitted = 0;
   for (size_t target_index : order) {
-    const ResolveTargetEntry& target =
+    const ResolveTargetEntry &target =
         g_dependency_census.targets[target_index];
     if ((!target.window_resolve_count && !target.window_sampled_draw_count) ||
         emitted == kResolveSummaryLimit) {
@@ -317,16 +337,14 @@ void EmitDependencyCensusWindow() {
           number(target.conditional_sample_draw_count)},
          {"query_state_sample_draws",
           number(target.query_state_sample_draw_count)},
-         {"memexport_sample_draws",
-          number(target.memexport_sample_draw_count)},
+         {"memexport_sample_draws", number(target.memexport_sample_draw_count)},
          {"last_fetch_index", number(target.last_fetch_index)},
          {"last_fetch_kind", target.last_fetch_was_mip ? "mip" : "base"},
-         {"copy_state",
-          fmt::format("{:08X}:{:08X}:{:08X}:{:08X}",
-                      target.sample.rb_copy_control,
-                      target.sample.rb_copy_dest_info,
-                      target.sample.rb_copy_dest_pitch,
-                      target.sample.surface_info)},
+         {"copy_state", fmt::format("{:08X}:{:08X}:{:08X}:{:08X}",
+                                    target.sample.rb_copy_control,
+                                    target.sample.rb_copy_dest_info,
+                                    target.sample.rb_copy_dest_pitch,
+                                    target.sample.surface_info)},
          {"presentation_only", "unknown_uninstrumented"},
          {"guest_cpu_read", "unknown_uninstrumented"},
          {"query_dependency", query_relation},
@@ -339,14 +357,14 @@ void EmitDependencyCensusWindow() {
 
 void AdvanceDependencyWindow(uint64_t frame) {
   if (g_dependency_census.window_first_frame &&
-      frame >= g_dependency_census.window_first_frame +
-                   kFrameSummaryInterval) {
+      frame >= g_dependency_census.window_first_frame + kFrameSummaryInterval) {
     EmitDependencyCensusWindow();
   }
   BeginDependencyWindow(frame);
 }
 
-uint64_t DrawSignature(const rex::system::GraphicsDrawObservation& observation) {
+uint64_t
+DrawSignature(const rex::system::GraphicsDrawObservation &observation) {
   uint64_t hash = 0xCBF29CE484222325ull;
   for (uint64_t value :
        {observation.vertex_shader_hash, observation.pixel_shader_hash,
@@ -354,8 +372,7 @@ uint64_t DrawSignature(const rex::system::GraphicsDrawObservation& observation) 
         uint64_t(observation.source_select), uint64_t(observation.indexed),
         uint64_t(observation.major_mode_explicit),
         uint64_t(observation.vertex_memexport),
-        uint64_t(observation.surface_info),
-        uint64_t(observation.color_info[0]),
+        uint64_t(observation.surface_info), uint64_t(observation.color_info[0]),
         uint64_t(observation.color_info[1]),
         uint64_t(observation.color_info[2]),
         uint64_t(observation.color_info[3]), uint64_t(observation.depth_info),
@@ -367,14 +384,193 @@ uint64_t DrawSignature(const rex::system::GraphicsDrawObservation& observation) 
   return hash ? hash : 1;
 }
 
+uint64_t
+CandidateSignature(const rex::system::GraphicsDrawObservation &observation,
+                   bool samples_resolved_target) {
+  uint64_t hash = DrawSignature(observation);
+  for (uint64_t value : {uint64_t(observation.index_format),
+                         uint64_t(observation.index_endianness),
+                         uint64_t(observation.vertex_binding_count),
+                         uint64_t(observation.vertex_binding_overflow),
+                         uint64_t(observation.viz_query_condition),
+                         uint64_t(observation.pa_sc_viz_query),
+                         uint64_t(samples_resolved_target),
+                         uint64_t(observation.texture_fetch_mask),
+                         uint64_t(observation.rb_color_mask),
+                         uint64_t(observation.rb_blendcontrol[0]),
+                         uint64_t(observation.rb_blendcontrol[1]),
+                         uint64_t(observation.rb_blendcontrol[2]),
+                         uint64_t(observation.rb_blendcontrol[3]),
+                         uint64_t(observation.rb_depthcontrol),
+                         uint64_t(observation.pa_su_sc_mode_cntl),
+                         uint64_t(observation.pa_su_vtx_cntl)}) {
+    hash = HashCombine(hash, value);
+  }
+  const uint32_t bounded_binding_count =
+      std::min(observation.vertex_binding_count,
+               rex::system::kGraphicsVertexBindingObservationLimit);
+  for (uint32_t i = 0; i < bounded_binding_count; ++i) {
+    const auto &binding = observation.vertex_bindings[i];
+    hash = HashCombine(hash, binding.fetch_constant);
+    hash = HashCombine(hash, binding.size);
+    hash = HashCombine(hash, binding.stride_words);
+    hash = HashCombine(hash, binding.endianness);
+  }
+  return hash ? hash : 1;
+}
+
+bool IsOpaqueColorState(
+    const rex::system::GraphicsDrawObservation &observation) {
+  bool writes_color = false;
+  for (uint32_t i = 0; i < 4; ++i) {
+    if (!(observation.rb_color_mask & (uint32_t(0xF) << (i * 4)))) {
+      continue;
+    }
+    writes_color = true;
+    if (observation.rb_blendcontrol[i] != 0x00010001) {
+      return false;
+    }
+  }
+  return writes_color;
+}
+
+void ObservePreparedDraw(
+    const rex::system::GraphicsPreparedDrawObservation &observation) {
+  uint64_t identity = 0xCBF29CE484222325ull;
+  for (uint64_t value :
+       {observation.vertex_shader_hash, observation.pixel_shader_hash,
+        observation.vertex_specialization_mask,
+        observation.pixel_specialization_mask}) {
+    identity = HashCombine(identity, value);
+  }
+  identity = identity ? identity : 1;
+  size_t index = size_t(identity % kPreparedShaderPairCapacity);
+  for (size_t probe = 0; probe < kPreparedShaderPairCapacity; ++probe) {
+    PreparedShaderPairEntry &entry = g_prepared_shader_pairs[index];
+    if (!entry.identity) {
+      entry.identity = identity;
+      entry.sample = observation;
+      ++g_prepared_shader_pair_count;
+      pinyon_shift::diagnostics::RecordEvent(
+          "native_renderer.census.prepared_shader_pair",
+          {{"vertex_shader",
+            fmt::format("{:016X}", observation.vertex_shader_hash)},
+           {"pixel_shader",
+            fmt::format("{:016X}", observation.pixel_shader_hash)},
+           {"vertex_specialization_mask",
+            fmt::format("{:016X}", observation.vertex_specialization_mask)},
+           {"pixel_specialization_mask",
+            fmt::format("{:016X}", observation.pixel_specialization_mask)},
+           {"mode", "pass_through"},
+           {"suppression_eligible", "false"}});
+      return;
+    }
+    if (entry.identity == identity &&
+        entry.sample.vertex_shader_hash == observation.vertex_shader_hash &&
+        entry.sample.pixel_shader_hash == observation.pixel_shader_hash &&
+        entry.sample.vertex_specialization_mask ==
+            observation.vertex_specialization_mask &&
+        entry.sample.pixel_specialization_mask ==
+            observation.pixel_specialization_mask) {
+      return;
+    }
+    index = (index + 1) % kPreparedShaderPairCapacity;
+  }
+  ++g_prepared_shader_pair_overflow;
+}
+
+void EmitCandidateCensusWindow(uint64_t last_frame_value) {
+  std::array<size_t, kSignatureCapacity> order{};
+  for (size_t i = 0; i < order.size(); ++i) {
+    order[i] = i;
+  }
+  std::sort(order.begin(), order.end(), [](size_t left, size_t right) {
+    const DrawSignatureEntry &left_entry = g_candidate_census.entries[left];
+    const DrawSignatureEntry &right_entry = g_candidate_census.entries[right];
+    if (left_entry.draw_count != right_entry.draw_count) {
+      return left_entry.draw_count > right_entry.draw_count;
+    }
+    return left_entry.signature < right_entry.signature;
+  });
+  pinyon_shift::diagnostics::RecordEvent(
+      "native_renderer.census.candidate_window",
+      {{"first_frame", std::to_string(g_candidate_census.window_first_frame)},
+       {"last_frame", std::to_string(last_frame_value)},
+       {"draws", std::to_string(g_candidate_census.window_draw_count)},
+       {"unique_signatures",
+        std::to_string(g_candidate_census.unique_signature_count)},
+       {"overflow_draws",
+        std::to_string(g_candidate_census.overflow_draw_count)},
+       {"signature_capacity", std::to_string(kSignatureCapacity)},
+       {"summary_limit", std::to_string(kCandidateSummaryLimit)},
+       {"mode", "metadata_shortlist_only"}});
+
+  size_t emitted = 0;
+  for (size_t index : order) {
+    const DrawSignatureEntry &entry = g_candidate_census.entries[index];
+    if (!entry.draw_count || emitted == kCandidateSummaryLimit) {
+      break;
+    }
+    const auto &sample = entry.sample;
+    std::string vertex_fetches;
+    const uint32_t bounded_binding_count =
+        std::min(sample.vertex_binding_count,
+                 rex::system::kGraphicsVertexBindingObservationLimit);
+    for (uint32_t i = 0; i < bounded_binding_count; ++i) {
+      const auto &binding = sample.vertex_bindings[i];
+      if (!vertex_fetches.empty()) {
+        vertex_fetches += ";";
+      }
+      vertex_fetches += fmt::format(
+          "{}:{:08X}:{}:{}:{}", binding.fetch_constant, binding.address,
+          binding.size, binding.stride_words, binding.endianness);
+    }
+    const bool query_draw =
+        sample.viz_query_condition || (sample.pa_sc_viz_query & 1);
+    const std::string pipeline_state =
+        fmt::format("color_mask={:08X};blend={:08X}:{:08X}:{:08X}:{:08X};"
+                    "depth={:08X};raster={:08X};vertex={:08X}",
+                    sample.rb_color_mask, sample.rb_blendcontrol[0],
+                    sample.rb_blendcontrol[1], sample.rb_blendcontrol[2],
+                    sample.rb_blendcontrol[3], sample.rb_depthcontrol,
+                    sample.pa_su_sc_mode_cntl, sample.pa_su_vtx_cntl);
+    pinyon_shift::diagnostics::RecordEvent(
+        "native_renderer.census.draw_candidate",
+        {{"rank", std::to_string(++emitted)},
+         {"signature", fmt::format("{:016X}", entry.signature)},
+         {"draws", std::to_string(entry.draw_count)},
+         {"first_frame", std::to_string(entry.first_frame)},
+         {"last_frame", std::to_string(entry.last_frame)},
+         {"vertex_shader", fmt::format("{:016X}", sample.vertex_shader_hash)},
+         {"pixel_shader", fmt::format("{:016X}", sample.pixel_shader_hash)},
+         {"primitive", std::to_string(sample.primitive_type)},
+         {"index_state",
+          fmt::format("format={};endianness={}", sample.index_format,
+                      sample.index_endianness)},
+         {"vertex_binding_count", std::to_string(sample.vertex_binding_count)},
+         {"vertex_fetches", vertex_fetches},
+         {"texture_fetch_count",
+          std::to_string(std::popcount(sample.texture_fetch_mask))},
+         {"pipeline_state", pipeline_state},
+         {"indexed", sample.indexed ? "true" : "false"},
+         {"query", query_draw ? "true" : "false"},
+         {"memexport", sample.vertex_memexport ? "true" : "false"},
+         {"resolved_input", entry.samples_resolved_target ? "true" : "false"},
+         {"opaque", IsOpaqueColorState(sample) ? "true" : "false"},
+         {"vertex_overflow", sample.vertex_binding_overflow ? "true" : "false"},
+         {"qualification", "metadata_shortlist_only"},
+         {"suppression_eligible", "false"}});
+  }
+}
+
 void EmitDrawCensusWindow(uint64_t last_frame_value) {
   std::array<size_t, kSignatureCapacity> order{};
   for (size_t i = 0; i < order.size(); ++i) {
     order[i] = i;
   }
   std::sort(order.begin(), order.end(), [](size_t left, size_t right) {
-    const DrawSignatureEntry& left_entry = g_draw_census.entries[left];
-    const DrawSignatureEntry& right_entry = g_draw_census.entries[right];
+    const DrawSignatureEntry &left_entry = g_draw_census.entries[left];
+    const DrawSignatureEntry &right_entry = g_draw_census.entries[right];
     if (left_entry.draw_count != right_entry.draw_count) {
       return left_entry.draw_count > right_entry.draw_count;
     }
@@ -401,11 +597,11 @@ void EmitDrawCensusWindow(uint64_t last_frame_value) {
 
   size_t emitted = 0;
   for (size_t index : order) {
-    const DrawSignatureEntry& entry = g_draw_census.entries[index];
+    const DrawSignatureEntry &entry = g_draw_census.entries[index];
     if (!entry.draw_count || emitted == kSummaryLimit) {
       break;
     }
-    const auto& sample = entry.sample;
+    const auto &sample = entry.sample;
     const std::string rank = std::to_string(++emitted);
     const std::string count = std::to_string(entry.draw_count);
     const std::string first = std::to_string(entry.first_frame);
@@ -425,9 +621,37 @@ void EmitDrawCensusWindow(uint64_t last_frame_value) {
         "{:08X}:{:08X}", sample.window_scissor_tl, sample.window_scissor_br);
     const std::string index_buffer = fmt::format(
         "{:08X}:{}", sample.index_buffer_address, sample.index_buffer_length);
-    const std::string flags =
-        fmt::format("indexed={};explicit_major={};memexport={}", sample.indexed,
-                    sample.major_mode_explicit, sample.vertex_memexport);
+    const std::string index_state =
+        fmt::format("format={};endianness={}", sample.index_format,
+                    sample.index_endianness);
+    std::string vertex_fetches;
+    const uint32_t bounded_binding_count =
+        std::min(sample.vertex_binding_count,
+                 rex::system::kGraphicsVertexBindingObservationLimit);
+    for (uint32_t i = 0; i < bounded_binding_count; ++i) {
+      const auto &binding = sample.vertex_bindings[i];
+      if (!vertex_fetches.empty()) {
+        vertex_fetches += ";";
+      }
+      vertex_fetches += fmt::format(
+          "{}:{:08X}:{}:{}:{}", binding.fetch_constant, binding.address,
+          binding.size, binding.stride_words, binding.endianness);
+    }
+    const bool query_draw =
+        sample.viz_query_condition || (sample.pa_sc_viz_query & 1);
+    const std::string pipeline_state =
+        fmt::format("color_mask={:08X};blend={:08X}:{:08X}:{:08X}:{:08X};"
+                    "depth={:08X};raster={:08X};vertex={:08X}",
+                    sample.rb_color_mask, sample.rb_blendcontrol[0],
+                    sample.rb_blendcontrol[1], sample.rb_blendcontrol[2],
+                    sample.rb_blendcontrol[3], sample.rb_depthcontrol,
+                    sample.pa_su_sc_mode_cntl, sample.pa_su_vtx_cntl);
+    const std::string flags = fmt::format(
+        "indexed={};explicit_major={};memexport={};query={};"
+        "resolved_input={};opaque={};vertex_overflow={}",
+        sample.indexed, sample.major_mode_explicit, sample.vertex_memexport,
+        query_draw, entry.samples_resolved_target, IsOpaqueColorState(sample),
+        bool(sample.vertex_binding_overflow));
     pinyon_shift::diagnostics::RecordEvent(
         "native_renderer.census.draw_signature",
         {{"rank", rank},
@@ -442,13 +666,26 @@ void EmitDrawCensusWindow(uint64_t last_frame_value) {
          {"target_state", target_state},
          {"scissor", scissor},
          {"index_buffer", index_buffer},
+         {"index_state", index_state},
+         {"vertex_binding_count", std::to_string(sample.vertex_binding_count)},
+         {"vertex_fetches", vertex_fetches},
+         {"texture_fetch_count",
+          std::to_string(std::popcount(sample.texture_fetch_mask))},
+         {"pipeline_state", pipeline_state},
+         {"indexed", sample.indexed ? "true" : "false"},
+         {"query", query_draw ? "true" : "false"},
+         {"memexport", sample.vertex_memexport ? "true" : "false"},
+         {"resolved_input", entry.samples_resolved_target ? "true" : "false"},
+         {"opaque", IsOpaqueColorState(sample) ? "true" : "false"},
+         {"vertex_overflow", sample.vertex_binding_overflow ? "true" : "false"},
          {"flags", flags}});
   }
 
+  EmitCandidateCensusWindow(last_frame_value);
   ResetDrawCensus();
 }
 
-void ObserveCopy(const rex::system::GraphicsCopyObservation& observation) {
+void ObserveCopy(const rex::system::GraphicsCopyObservation &observation) {
   AdvanceDependencyWindow(observation.frame_sequence);
   if (!observation.succeeded) {
     ++g_dependency_census.window_failed_copy_count;
@@ -467,7 +704,7 @@ void ObserveCopy(const rex::system::GraphicsCopyObservation& observation) {
     return;
   }
 
-  ResolveTargetEntry& target = g_dependency_census.targets[target_index];
+  ResolveTargetEntry &target = g_dependency_census.targets[target_index];
   if (!target.resolve_count) {
     target.address = observation.written_address;
     target.first_resolve_frame = observation.frame_sequence;
@@ -486,8 +723,8 @@ void ObserveCopy(const rex::system::GraphicsCopyObservation& observation) {
 }
 
 void EmitResolvedTextureDependency(
-    const rex::system::GraphicsDrawObservation& observation,
-    const ResolveTargetEntry& target, uint32_t fetch_index, bool is_mip) {
+    const rex::system::GraphicsDrawObservation &observation,
+    const ResolveTargetEntry &target, uint32_t fetch_index, bool is_mip) {
   pinyon_shift::diagnostics::RecordEvent(
       "native_renderer.census.resolve_dependency",
       {{"address", fmt::format("{:08X}", target.address)},
@@ -497,8 +734,7 @@ void EmitResolvedTextureDependency(
        {"sample_draw", std::to_string(observation.draw_sequence)},
        {"fetch_index", std::to_string(fetch_index)},
        {"fetch_kind", is_mip ? "mip" : "base"},
-       {"conditional_draw",
-        observation.viz_query_condition ? "true" : "false"},
+       {"conditional_draw", observation.viz_query_condition ? "true" : "false"},
        {"query_state", (observation.pa_sc_viz_query & 1) ? "true" : "false"},
        {"memexport_draw", observation.vertex_memexport ? "true" : "false"},
        {"presentation_only", "unknown_uninstrumented"},
@@ -509,9 +745,9 @@ void EmitResolvedTextureDependency(
 }
 
 void ObserveResolvedFetch(
-    const rex::system::GraphicsDrawObservation& observation,
+    const rex::system::GraphicsDrawObservation &observation,
     uint32_t fetch_index, uint32_t address, bool is_mip,
-    std::array<size_t, 64>& sampled_targets, size_t& sampled_target_count) {
+    std::array<size_t, 64> &sampled_targets, size_t &sampled_target_count) {
   if (!address) {
     return;
   }
@@ -520,7 +756,7 @@ void ObserveResolvedFetch(
     return;
   }
 
-  ResolveTargetEntry& target = g_dependency_census.targets[target_index];
+  ResolveTargetEntry &target = g_dependency_census.targets[target_index];
   ++target.sample_reference_count;
   ++g_dependency_census.window_sample_reference_count;
   target.last_fetch_index = fetch_index;
@@ -556,10 +792,38 @@ void ObserveResolvedFetch(
   }
 }
 
-void ObserveDraw(const rex::system::GraphicsDrawObservation& observation) {
+void RecordCandidate(const rex::system::GraphicsDrawObservation &observation,
+                     bool samples_resolved_target) {
+  ++g_candidate_census.window_draw_count;
+  const uint64_t signature =
+      CandidateSignature(observation, samples_resolved_target);
+  size_t index = size_t(signature % kSignatureCapacity);
+  for (size_t probe = 0; probe < kSignatureCapacity; ++probe) {
+    DrawSignatureEntry &entry = g_candidate_census.entries[index];
+    if (!entry.draw_count) {
+      entry.signature = signature;
+      entry.draw_count = 1;
+      entry.first_frame = observation.frame_sequence;
+      entry.last_frame = observation.frame_sequence;
+      entry.samples_resolved_target = samples_resolved_target;
+      entry.sample = observation;
+      ++g_candidate_census.unique_signature_count;
+      return;
+    }
+    if (entry.signature == signature) {
+      ++entry.draw_count;
+      entry.last_frame = observation.frame_sequence;
+      return;
+    }
+    index = (index + 1) % kSignatureCapacity;
+  }
+  ++g_candidate_census.overflow_draw_count;
+}
+
+void ObserveDraw(const rex::system::GraphicsDrawObservation &observation) {
   AdvanceDependencyWindow(observation.frame_sequence);
-  const bool query_draw = observation.viz_query_condition ||
-                          (observation.pa_sc_viz_query & 1);
+  const bool query_draw =
+      observation.viz_query_condition || (observation.pa_sc_viz_query & 1);
   if (query_draw) {
     ++g_dependency_census.window_query_draw_count;
   }
@@ -574,12 +838,11 @@ void ObserveDraw(const rex::system::GraphicsDrawObservation& observation) {
       continue;
     }
     ObserveResolvedFetch(observation, fetch_index,
-                         observation.texture_fetch_addresses[fetch_index], false,
-                         sampled_targets, sampled_target_count);
-    ObserveResolvedFetch(
-        observation, fetch_index,
-        observation.texture_fetch_mip_addresses[fetch_index], true,
-        sampled_targets, sampled_target_count);
+                         observation.texture_fetch_addresses[fetch_index],
+                         false, sampled_targets, sampled_target_count);
+    ObserveResolvedFetch(observation, fetch_index,
+                         observation.texture_fetch_mip_addresses[fetch_index],
+                         true, sampled_targets, sampled_target_count);
   }
   if (sampled_target_count) {
     ++g_dependency_census.window_sampled_draw_count;
@@ -587,23 +850,29 @@ void ObserveDraw(const rex::system::GraphicsDrawObservation& observation) {
 
   if (!g_draw_census.window_first_frame) {
     g_draw_census.window_first_frame = observation.frame_sequence;
+    g_candidate_census.window_first_frame = observation.frame_sequence;
   } else if (observation.frame_sequence >=
              g_draw_census.window_first_frame + kFrameSummaryInterval) {
     EmitDrawCensusWindow(observation.frame_sequence - 1);
     g_draw_census.window_first_frame = observation.frame_sequence;
+    g_candidate_census.window_first_frame = observation.frame_sequence;
   }
   g_draw_census.window_last_frame = observation.frame_sequence;
+  g_candidate_census.window_last_frame = observation.frame_sequence;
 
   ++g_draw_census.window_draw_count;
+  const bool samples_resolved_target = sampled_target_count != 0;
+  RecordCandidate(observation, samples_resolved_target);
   const uint64_t signature = DrawSignature(observation);
   size_t index = size_t(signature % kSignatureCapacity);
   for (size_t probe = 0; probe < kSignatureCapacity; ++probe) {
-    DrawSignatureEntry& entry = g_draw_census.entries[index];
+    DrawSignatureEntry &entry = g_draw_census.entries[index];
     if (!entry.draw_count) {
       entry.signature = signature;
       entry.draw_count = 1;
       entry.first_frame = observation.frame_sequence;
       entry.last_frame = observation.frame_sequence;
+      entry.samples_resolved_target = samples_resolved_target;
       entry.sample = observation;
       ++g_draw_census.unique_signature_count;
       return;
@@ -618,18 +887,21 @@ void ObserveDraw(const rex::system::GraphicsDrawObservation& observation) {
   ++g_draw_census.overflow_draw_count;
 }
 
-}  // namespace
+} // namespace
 
 namespace pinyon_shift::native_renderer {
 
-void InstallGraphicsCensus(rex::system::IGraphicsSystem* graphics_system) {
+void InstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system) {
   if (!graphics_system || !REXCVAR_GET(pinyon_shift_native_renderer_census)) {
     return;
   }
   ResetDrawCensus();
+  ResetPreparedShaderPairs();
   ResetDependencyCensus();
+  g_graphics_census_installed = true;
   graphics_system->SetDrawObserver(&ObserveDraw);
   graphics_system->SetCopyObserver(&ObserveCopy);
+  graphics_system->SetPreparedDrawObserver(&ObservePreparedDraw);
   const std::string capacity = std::to_string(kSignatureCapacity);
   const std::string scene = CensusSceneMarker();
   diagnostics::RecordEvent("native_renderer.census.installed",
@@ -638,24 +910,36 @@ void InstallGraphicsCensus(rex::system::IGraphicsSystem* graphics_system) {
                             {"resolve_target_capacity", "4096"},
                             {"resolve_page_capacity", "32768"},
                             {"resolve_summary_limit", "32"},
+                            {"prepared_shader_pair_capacity", "1024"},
                             {"scene", scene},
                             {"mode", "pass_through"}});
   diagnostics::RecordEvent("native_renderer.census.scene_marker",
                            {{"scene", scene}, {"source", "operator"}});
 }
 
-void UninstallGraphicsCensus(rex::system::IGraphicsSystem* graphics_system) {
+void UninstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system) {
   if (graphics_system) {
     graphics_system->SetDrawObserver(nullptr);
     graphics_system->SetCopyObserver(nullptr);
+    graphics_system->SetPreparedDrawObserver(nullptr);
   }
+  if (!g_graphics_census_installed) {
+    return;
+  }
+  g_graphics_census_installed = false;
   if (g_draw_census.window_first_frame && g_draw_census.window_draw_count) {
     EmitDrawCensusWindow(g_draw_census.window_last_frame);
   }
   EmitDependencyCensusWindow();
+  diagnostics::RecordEvent(
+      "native_renderer.census.prepared_shader_pair_summary",
+      {{"pairs", std::to_string(g_prepared_shader_pair_count)},
+       {"overflow", std::to_string(g_prepared_shader_pair_overflow)},
+       {"capacity", std::to_string(kPreparedShaderPairCapacity)},
+       {"mode", "pass_through"}});
 }
 
-}  // namespace pinyon_shift::native_renderer
+} // namespace pinyon_shift::native_renderer
 
 // This translation unit is the single owner for title-side graphics hooks.
 // The hook runs immediately before FH1's sole VdSwap import and intentionally
@@ -674,9 +958,8 @@ void PinyonShiftObserveGraphicsFrame() {
   }
 
   const std::string frame = std::to_string(frame_sequence);
-  pinyon_shift::diagnostics::RecordEvent(
-      "native_renderer.census.frame",
-      {{"frame_sequence", frame},
-       {"guest_address", "829EFEB8"},
-       {"mode", "pass_through"}});
+  pinyon_shift::diagnostics::RecordEvent("native_renderer.census.frame",
+                                         {{"frame_sequence", frame},
+                                          {"guest_address", "829EFEB8"},
+                                          {"mode", "pass_through"}});
 }

--- a/src/pinyon_shift_app.cpp
+++ b/src/pinyon_shift_app.cpp
@@ -380,6 +380,8 @@ bool PinyonShiftApp::OnWindowCloseRequested() {
   // clean qualification boundary before allowing the SDK to terminate.
   pinyon_shift::native_renderer::UninstallShaderCapture(
       runtime() ? runtime()->graphics_system() : nullptr);
+  pinyon_shift::native_renderer::UninstallGraphicsCensus(
+      runtime() ? runtime()->graphics_system() : nullptr);
   RecordShutdownOnce();
   return true;
 }

--- a/tools/capture-native-renderer-census.ps1
+++ b/tools/capture-native-renderer-census.ps1
@@ -5,6 +5,7 @@ param(
         'open_world_night', 'traffic', 'race', 'rewind', 'pause',
         'save_reload')]
     [string]$Scene = 'unmarked',
+    [string]$ShaderCaptureDir,
     [switch]$Json
 )
 
@@ -46,7 +47,8 @@ try {
     $env:REX_PINYON_SHIFT_NATIVE_RENDERER_CENSUS = 'true'
     $env:PINYON_SHIFT_NATIVE_RENDERER_SCENE = $Scene
     & (Join-Path $PSScriptRoot 'launch-preview.ps1') `
-        -StateRoot $resolvedStateRoot -Json:$Json
+        -StateRoot $resolvedStateRoot -ShaderCaptureDir $ShaderCaptureDir `
+        -Json:$Json
 }
 finally {
     $env:REX_PINYON_SHIFT_NATIVE_RENDERER_CENSUS = $savedCensus

--- a/tools/select-native-renderer-candidate.py
+++ b/tools/select-native-renderer-candidate.py
@@ -1,0 +1,206 @@
+#!/usr/bin/env python3
+"""Shortlist repeatable NR-02 draw candidates from local census inventories."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections import Counter
+from pathlib import Path
+from typing import Any
+
+
+SCHEMA = "pinyon-shift.native-renderer-candidate-selection.v1"
+CENSUS_SCHEMA = "pinyon-shift.native-renderer-census.v1"
+SHADER_SCHEMA = "pinyon-shift.native-shader-pack.v1"
+
+
+def boolean(record: dict[str, Any], key: str) -> bool:
+    value = record.get(key)
+    if value not in ("true", "false", True, False):
+        raise ValueError(f"draw signature has invalid {key}: {value!r}")
+    return value in ("true", True)
+
+
+def load_json(path: Path, schema: str) -> dict[str, Any]:
+    document = json.loads(path.read_text(encoding="utf-8"))
+    if document.get("schema") != schema:
+        raise ValueError(f"unsupported schema in {path}: {document.get('schema')}")
+    return document
+
+
+def shader_identities(manifest: dict[str, Any]) -> set[tuple[str, str, str]]:
+    identities: set[tuple[str, str, str]] = set()
+    for entry in manifest.get("entries", []):
+        stage = str(entry.get("stage", ""))
+        guest_hash = str(entry.get("guest_hash", "")).upper()
+        specialization = str(entry.get("specialization_mask", "")).upper()
+        if (
+            stage not in ("vertex", "pixel")
+            or len(guest_hash) != 16
+            or len(specialization) != 16
+        ):
+            raise ValueError("shader manifest contains an invalid identity")
+        identity = (stage, guest_hash, specialization)
+        if identity in identities:
+            raise ValueError("shader manifest contains a duplicate identity")
+        identities.add(identity)
+    return identities
+
+
+def rejection_reasons(record: dict[str, Any]) -> list[str]:
+    reasons: list[str] = []
+    if not boolean(record, "opaque"):
+        reasons.append("non_opaque")
+    if boolean(record, "query"):
+        reasons.append("query_state")
+    if boolean(record, "memexport"):
+        reasons.append("memexport")
+    if boolean(record, "resolved_input"):
+        reasons.append("dynamic_render_target_input")
+    if boolean(record, "vertex_overflow"):
+        reasons.append("vertex_binding_overflow")
+    if int(record.get("vertex_binding_count", 0)) != 1:
+        reasons.append("vertex_binding_count_not_one")
+    if int(record.get("texture_fetch_count", 0)) > 1:
+        reasons.append("multiple_textures")
+    return reasons
+
+
+def prepared_pairs(census: dict[str, Any]) -> dict[tuple[str, str], set[tuple[str, str]]]:
+    result: dict[tuple[str, str], set[tuple[str, str]]] = {}
+    for record in census.get("prepared_shader_pairs", []):
+        shader_pair = (
+            str(record.get("vertex_shader", "")).upper(),
+            str(record.get("pixel_shader", "")).upper(),
+        )
+        specialization_pair = (
+            str(record.get("vertex_specialization_mask", "")).upper(),
+            str(record.get("pixel_specialization_mask", "")).upper(),
+        )
+        if any(len(value) != 16 for value in shader_pair + specialization_pair):
+            raise ValueError("prepared shader pair contains an invalid identity")
+        result.setdefault(shader_pair, set()).add(specialization_pair)
+    return result
+
+
+def select(census_paths: list[Path], shader_manifest_path: Path) -> dict[str, Any]:
+    if len(census_paths) < 2:
+        raise ValueError("at least two census inventories are required")
+    censuses = [load_json(path, CENSUS_SCHEMA) for path in census_paths]
+    scenes = {str(item.get("classification", {}).get("scene", "unmarked")) for item in censuses}
+    if len(scenes) != 1:
+        raise ValueError("candidate inventories must use the same scene marker")
+    shaders = shader_identities(load_json(shader_manifest_path, SHADER_SCHEMA))
+    prepared_by_capture = [prepared_pairs(census) for census in censuses]
+
+    by_capture: list[dict[str, dict[str, Any]]] = []
+    for census in censuses:
+        by_capture.append(
+            {str(record["signature"]): record for record in census.get("draw_candidates", [])}
+        )
+    repeated = set(by_capture[0])
+    for capture in by_capture[1:]:
+        repeated.intersection_update(capture)
+
+    candidates: list[dict[str, Any]] = []
+    rejection_counts: Counter[str] = Counter()
+    for signature in sorted(repeated):
+        records = [capture[signature] for capture in by_capture]
+        reasons = rejection_reasons(records[0])
+        for reason in reasons:
+            rejection_counts[reason] += 1
+        if reasons:
+            continue
+        if any(rejection_reasons(record) for record in records[1:]):
+            rejection_counts["state_changed_across_captures"] += 1
+            continue
+        shader_pair = (
+            str(records[0].get("vertex_shader", "")).upper(),
+            str(records[0].get("pixel_shader", "")).upper(),
+        )
+        repeated_specializations = set(
+            prepared_by_capture[0].get(shader_pair, set())
+        )
+        for prepared in prepared_by_capture[1:]:
+            repeated_specializations.intersection_update(
+                prepared.get(shader_pair, set())
+            )
+        if not repeated_specializations:
+            rejection_counts["missing_prepared_shader_pair"] += 1
+            continue
+        if len(repeated_specializations) != 1:
+            rejection_counts["ambiguous_prepared_shader_pair"] += 1
+            continue
+        vertex_specialization, pixel_specialization = next(
+            iter(repeated_specializations)
+        )
+        if ("vertex", shader_pair[0], vertex_specialization) not in shaders:
+            rejection_counts["missing_vertex_shader_specialization"] += 1
+            continue
+        if shader_pair[1] != "0000000000000000" and (
+            "pixel", shader_pair[1], pixel_specialization
+        ) not in shaders:
+            rejection_counts["missing_pixel_shader_specialization"] += 1
+            continue
+        total_draws = sum(int(record.get("draws", 0)) for record in records)
+        sample = records[0]
+        candidates.append(
+            {
+                "signature": signature,
+                "captures": len(records),
+                "total_draws": total_draws,
+                "vertex_shader": sample["vertex_shader"],
+                "pixel_shader": sample["pixel_shader"],
+                "vertex_specialization_mask": vertex_specialization,
+                "pixel_specialization_mask": pixel_specialization,
+                "primitive": sample.get("primitive"),
+                "index_state": sample.get("index_state"),
+                "vertex_fetches": sample.get("vertex_fetches"),
+                "texture_fetch_count": int(sample.get("texture_fetch_count", 0)),
+                "pipeline_state": sample.get("pipeline_state"),
+                "qualification": "metadata_shortlist_only",
+            }
+        )
+    candidates.sort(key=lambda item: (-item["captures"], -item["total_draws"], item["signature"]))
+    return {
+        "schema": SCHEMA,
+        "scene": next(iter(scenes)),
+        "capture_count": len(censuses),
+        "repeated_signature_count": len(repeated),
+        "candidate_count": len(candidates),
+        "candidates": candidates,
+        "rejections": [
+            {"reason": reason, "signatures": count}
+            for reason, count in sorted(rejection_counts.items())
+        ],
+        "safety": {
+            "selection_status": "needs_visual_and_dependency_review",
+            "suppression_allowed": False,
+            "xenos_authority": True,
+            "absence_of_resolved_input_is_not_static_texture_proof": True,
+        },
+    }
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("census", nargs="+", type=Path)
+    parser.add_argument("--shader-manifest", required=True, type=Path)
+    parser.add_argument("--output", "-o", type=Path)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    result = select(args.census, args.shader_manifest)
+    rendered = json.dumps(result, indent=2) + "\n"
+    if args.output:
+        args.output.write_text(rendered, encoding="utf-8")
+    else:
+        print(rendered, end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/summarize-native-renderer-census.py
+++ b/tools/summarize-native-renderer-census.py
@@ -134,6 +134,8 @@ def summarize(
     scene = str(marker_events[-1].get("scene", "unmarked")) if marker_events else "unmarked"
 
     draw_signatures: dict[str, dict[str, Any]] = {}
+    draw_candidates: dict[str, dict[str, Any]] = {}
+    prepared_shader_pairs: dict[tuple[str, str, str, str], dict[str, Any]] = {}
     dependencies: dict[str, dict[str, Any]] = {}
     resolve_targets: dict[str, dict[str, Any]] = {}
     totals = {
@@ -167,6 +169,27 @@ def summarize(
                 record["last_frame"] = str(
                     max(integer(record, "last_frame"), integer(event, "last_frame"))
                 )
+        elif kind == f"{PREFIX}draw_candidate":
+            key = str(event["signature"])
+            record = draw_candidates.get(key)
+            if record is None:
+                draw_candidates[key] = dict(event)
+            else:
+                record["draws"] = str(integer(record, "draws") + integer(event, "draws"))
+                record["first_frame"] = str(
+                    min(integer(record, "first_frame"), integer(event, "first_frame"))
+                )
+                record["last_frame"] = str(
+                    max(integer(record, "last_frame"), integer(event, "last_frame"))
+                )
+        elif kind == f"{PREFIX}prepared_shader_pair":
+            key = (
+                str(event["vertex_shader"]),
+                str(event["pixel_shader"]),
+                str(event["vertex_specialization_mask"]),
+                str(event["pixel_specialization_mask"]),
+            )
+            prepared_shader_pairs.setdefault(key, dict(event))
         elif kind == f"{PREFIX}resolve_window":
             for key in (
                 "resolves",
@@ -225,6 +248,16 @@ def summarize(
         "totals": totals,
         "classification": classification,
         "draw_signatures": cleaned_signatures,
+        "draw_candidates": [
+            clean(record)
+            for _, record in sorted(
+                draw_candidates.items(),
+                key=lambda item: (-integer(item[1], "draws"), item[0]),
+            )
+        ],
+        "prepared_shader_pairs": [
+            clean(record) for _, record in sorted(prepared_shader_pairs.items())
+        ],
         "resolve_dependencies": [
             clean(record) for _, record in sorted(dependencies.items())
         ],

--- a/tools/tests/test_native_renderer_candidate.py
+++ b/tools/tests/test_native_renderer_candidate.py
@@ -1,0 +1,112 @@
+import importlib.util
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SPEC = importlib.util.spec_from_file_location(
+    "native_renderer_candidate",
+    ROOT / "tools/select-native-renderer-candidate.py",
+)
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+def signature(name: str, **overrides):
+    record = {
+        "signature": name,
+        "draws": "20",
+        "vertex_shader": "1111111111111111",
+        "pixel_shader": "2222222222222222",
+        "primitive": "4",
+        "index_state": "format=0;endianness=2",
+        "vertex_binding_count": "1",
+        "vertex_fetches": "0:00100000:4096:8:2",
+        "texture_fetch_count": "1",
+        "pipeline_state": "opaque",
+        "indexed": "true",
+        "query": "false",
+        "memexport": "false",
+        "resolved_input": "false",
+        "opaque": "true",
+        "vertex_overflow": "false",
+    }
+    record.update(overrides)
+    return record
+
+
+class NativeRendererCandidateTests(unittest.TestCase):
+    def test_requires_two_census_inventories(self):
+        with self.assertRaisesRegex(ValueError, "at least two"):
+            MODULE.select([], Path("unused.json"))
+
+    def test_selects_only_repeatable_bounded_opaque_draw(self):
+        shader_manifest = {
+            "schema": MODULE.SHADER_SCHEMA,
+            "entries": [
+                {
+                    "stage": "vertex",
+                    "guest_hash": "1111111111111111",
+                    "specialization_mask": "AAAAAAAAAAAAAAAA",
+                },
+                {
+                    "stage": "pixel",
+                    "guest_hash": "2222222222222222",
+                    "specialization_mask": "BBBBBBBBBBBBBBBB",
+                },
+            ],
+        }
+        first = {
+            "schema": MODULE.CENSUS_SCHEMA,
+            "classification": {"scene": "open_world_day"},
+            "draw_candidates": [
+                signature("GOOD", indexed="false"),
+                signature("QUERY", query="true"),
+            ],
+            "prepared_shader_pairs": [
+                {
+                    "vertex_shader": "1111111111111111",
+                    "pixel_shader": "2222222222222222",
+                    "vertex_specialization_mask": "AAAAAAAAAAAAAAAA",
+                    "pixel_specialization_mask": "BBBBBBBBBBBBBBBB",
+                }
+            ],
+        }
+        second = {
+            "schema": MODULE.CENSUS_SCHEMA,
+            "classification": {"scene": "open_world_day"},
+            "draw_candidates": [
+                signature("GOOD", draws="30", indexed="false")
+            ],
+            "prepared_shader_pairs": first["prepared_shader_pairs"],
+        }
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            paths = []
+            for index, document in enumerate((first, second)):
+                path = root / f"census-{index}.json"
+                path.write_text(json.dumps(document), encoding="utf-8")
+                paths.append(path)
+            manifest = root / "shader-manifest.json"
+            manifest.write_text(json.dumps(shader_manifest), encoding="utf-8")
+            result = MODULE.select(paths, manifest)
+
+        self.assertEqual(1, result["candidate_count"])
+        self.assertEqual("GOOD", result["candidates"][0]["signature"])
+        self.assertEqual(50, result["candidates"][0]["total_draws"])
+        self.assertEqual(
+            "AAAAAAAAAAAAAAAA",
+            result["candidates"][0]["vertex_specialization_mask"],
+        )
+        self.assertFalse(result["safety"]["suppression_allowed"])
+        self.assertTrue(result["safety"]["xenos_authority"])
+
+    def test_rejects_dynamic_input(self):
+        reasons = MODULE.rejection_reasons(signature("BAD", resolved_input="true"))
+        self.assertIn("dynamic_render_target_input", reasons)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/tests/test_native_renderer_census.py
+++ b/tools/tests/test_native_renderer_census.py
@@ -87,6 +87,22 @@ class NativeRendererCensusTests(unittest.TestCase):
                 "overflow_draws": "0",
             },
             {
+                "event": "native_renderer.census.draw_candidate",
+                "session": "new",
+                "signature": "CANDIDATE",
+                "draws": "12",
+                "first_frame": "1",
+                "last_frame": "100",
+            },
+            {
+                "event": "native_renderer.census.prepared_shader_pair",
+                "session": "new",
+                "vertex_shader": "1111111111111111",
+                "pixel_shader": "2222222222222222",
+                "vertex_specialization_mask": "AAAAAAAAAAAAAAAA",
+                "pixel_specialization_mask": "BBBBBBBBBBBBBBBB",
+            },
+            {
                 "event": "native_renderer.census.resolve_window",
                 "session": "new",
                 "resolves": "7",
@@ -130,6 +146,11 @@ class NativeRendererCensusTests(unittest.TestCase):
         self.assertEqual("new", result["session"])
         self.assertEqual(100, result["totals"]["draws"])
         self.assertEqual(7, result["totals"]["resolves"])
+        self.assertEqual("CANDIDATE", result["draw_candidates"][0]["signature"])
+        self.assertEqual(
+            "AAAAAAAAAAAAAAAA",
+            result["prepared_shader_pairs"][0]["vertex_specialization_mask"],
+        )
         self.assertEqual("7", result["resolve_dependencies"][0]["resolves"])
         self.assertFalse(result["safety"]["suppression_allowed"])
 

--- a/tools/tests/test_native_renderer_contract.py
+++ b/tools/tests/test_native_renderer_contract.py
@@ -143,11 +143,13 @@ class NativeRendererContractTests(unittest.TestCase):
             encoding="utf-8"
         )
         signature = source.split("DrawSignature(", 1)[1].split(
-            "EmitDrawCensusWindow", 1
+            "CandidateSignature", 1
         )[0]
         self.assertIn("observation.primitive_type", signature)
         self.assertIn("observation.source_select", signature)
         self.assertNotIn("observation.initiator", signature)
+        self.assertNotIn("observation.rb_blendcontrol", signature)
+        self.assertNotIn("samples_resolved_target", signature)
 
     def test_census_has_no_native_renderer_or_suppression_api(self):
         source = (ROOT / "src/native_renderer/graphics_hooks.cpp").read_text(
@@ -267,6 +269,62 @@ class NativeRendererContractTests(unittest.TestCase):
         self.assertIn("-StateRoot $resolvedStateRoot", capture)
         self.assertIn("ForzaProfile", capture)
         self.assertIn("repository .local directory", capture)
+
+    def test_candidate_state_is_bounded_metadata_before_draw(self):
+        patch = (
+            ROOT / "patches/rexglue/0051-graphics-draw-candidate-state.patch"
+        ).read_text(encoding="utf-8")
+        self.assertIn("kGraphicsVertexBindingObservationLimit = 8", patch)
+        self.assertIn("index_format", patch)
+        self.assertIn("index_endianness", patch)
+        self.assertIn("vertex_binding_overflow", patch)
+        self.assertIn("rb_blendcontrol", patch)
+        self.assertIn("rb_depthcontrol", patch)
+        self.assertIn("pa_su_sc_mode_cntl", patch)
+        for forbidden in (
+            "vertex_data",
+            "index_data",
+            "texture_data",
+            "constant_data",
+            "SetDrawSuppression",
+        ):
+            self.assertNotIn(forbidden, patch)
+
+        source = (ROOT / "src/native_renderer/graphics_hooks.cpp").read_text(
+            encoding="utf-8"
+        )
+        self.assertIn('"suppression_allowed": False', (
+            ROOT / "tools/select-native-renderer-candidate.py"
+        ).read_text(encoding="utf-8"))
+        self.assertIn("IsOpaqueColorState", source)
+        self.assertIn("samples_resolved_target", source)
+        reset_window = source.split("void ResetDrawCensus()", 1)[1].split(
+            "void ResetPreparedShaderPairs()", 1
+        )[0]
+        self.assertNotIn("g_prepared_shader_pairs", reset_window)
+        self.assertIn("ResetPreparedShaderPairs();", source)
+
+        app = (ROOT / "src/pinyon_shift_app.cpp").read_text(encoding="utf-8")
+        close_path = app.split("bool PinyonShiftApp::OnWindowCloseRequested()", 1)[
+            1
+        ].split("void PinyonShiftApp::OnShutdown()", 1)[0]
+        self.assertIn("UninstallGraphicsCensus", close_path)
+
+        prepared_patch = (
+            ROOT / "patches/rexglue/0052-d3d12-prepared-draw-observer.patch"
+        ).read_text(encoding="utf-8")
+        self.assertIn("GraphicsPreparedDrawObservation", prepared_patch)
+        self.assertIn("vertex_specialization_mask", prepared_patch)
+        self.assertIn("pixel_specialization_mask", prepared_patch)
+        self.assertLess(
+            prepared_patch.index("GetD3D12PipelineByHandle"),
+            prepared_patch.index("prepared_draw_observer(observation);"),
+        )
+        self.assertLess(
+            prepared_patch.index("prepared_draw_observer(observation);"),
+            prepared_patch.index("// Update the textures"),
+        )
+        self.assertNotIn("SetDrawSuppression", prepared_patch)
 
     def test_census_ledger_tracks_exact_starting_baseline(self):
         ledger = (ROOT / "docs/native-renderer/RENDER_PASS_CENSUS.md").read_text(

--- a/tools/tests/test_release_contract.py
+++ b/tools/tests/test_release_contract.py
@@ -43,10 +43,10 @@ class ReleaseContractTests(unittest.TestCase):
 
     def test_rexglue_patches_have_stable_order_and_no_binary_payload(self):
         patches = sorted((ROOT / "patches/rexglue").glob("*.patch"))
-        self.assertEqual(len(patches), 50)
+        self.assertEqual(len(patches), 52)
         self.assertEqual(
             patches[-1].name,
-            "0050-d3d12-shader-translation-observer.patch",
+            "0052-d3d12-prepared-draw-observer.patch",
         )
         self.assertEqual(len(patches), len({path.name[:4] for path in patches}))
         for path in patches:


### PR DESCRIPTION
## Summary
- extend the passive ReXGlue draw observer with bounded candidate state and exact prepared D3D12 shader specialization pairs
- add deterministic two-capture candidate selection while preserving the original NR-00 signature and Xenos authority
- flush census evidence on normal window close and document the qualified NR-02 candidate

## Safety
- no guest payload is serialized by census diagnostics
- no native draw is submitted
- no draw or resolve suppression is enabled
- unsupported and unqualified work remains on Xenos

## Validation
- 73 repository tests pass
- repository boundary check passes for 162 candidate files
- all 52 ReXGlue patches apply cleanly from pinned v0.10.0
- clean Release build succeeds (`C2A49BAFBEAFFB1B0B414F224718F05F3BA0DA6C1E13AECA46A3A289CF4BE903`)
- two AppData-backed captures select one repeated draw candidate with an exact local shader pair
- final AppData-backed close-path session exits normally, reports zero prepared-pair overflow and no errors, and retains Xenos authority