### PR TITLE
feat(native-renderer): define bounded geometry contract

### DIFF
--- a/docs/native-renderer/CANDIDATE_DRAW_SELECTION.md
+++ b/docs/native-renderer/CANDIDATE_DRAW_SELECTION.md
@@ -36,6 +36,14 @@ requires one pair to recur in every supplied capture and verifies that exact
 identity exists in the local shader manifest; it never guesses among multiple
 translations of the same guest hash.
 
+Patch `0053-graphics-vertex-declaration-observer.patch` keeps that observer
+passive while adding the bounded declaration needed for NR-02B. It records at
+most 32 vertex attributes plus the VGT index offset/minimum/maximum registers
+and the observed index-count range. Attribute metadata includes the fetch
+constant, word offset and stride, data format, required word mask, result
+mapping, and instruction flags. Overflow is explicit. Neither this patch nor
+the title-side contract builder dereferences a guest address.
+
 ## Repeated-capture shortlist
 
 Capture the same marked scene at least twice while also collecting the local
@@ -64,8 +72,13 @@ input capture. It accepts both indexed and non-indexed authentic draws because
 the NR-02 candidate criteria do not require an index buffer. It rejects missing
 or ambiguous prepared pairs, shader-pack misses, blending, query or memexport
 state, observed resolved-target inputs, more than one vertex binding, more than
-one texture, and bounded-observer overflow. Results are ordered
+one texture, and either bounded-observer overflow. Results are ordered
 deterministically by recurrence and draw count.
+
+The resulting selection can be converted into a metadata-only geometry
+contract as described in [GEOMETRY_CONTRACT.md](GEOMETRY_CONTRACT.md). An
+indexed candidate is retained by the selector, but the initial contract marks
+it as requiring a later bounded index scan rather than reading payload data.
 
 ## Local qualification — 2026-08-28
 
@@ -102,3 +115,17 @@ failure to observe a resolved input does not prove that a texture is static.
 The selected draw still requires visual identification, dependency review,
 guest bounds validation, and isolated comparison before NR-02 can advance to
 native execution.
+
+## NR-02B signature revision
+
+Patch `0053` intentionally adds VGT range and full vertex-declaration metadata
+to the candidate signature. Therefore pre-`0053` signatures, including
+`E184D75768958828`, are historical identities and cannot be compared directly
+with new captures.
+
+Two post-`0053` `open_world_day` captures selected one provisional geometry
+candidate, `6263AD066A342AFE`. Its exact declaration and allocation bounds are
+recorded in [GEOMETRY_CONTRACT.md](GEOMETRY_CONTRACT.md). The candidate remains
+`needs_visual_and_dependency_review`; the new selection proves repeatable
+metadata and an exact shader specialization, not visual suitability or static
+texture provenance.

--- a/docs/native-renderer/GEOMETRY_CONTRACT.md
+++ b/docs/native-renderer/GEOMETRY_CONTRACT.md
@@ -1,0 +1,87 @@
+# Native geometry contract
+
+NR-02B begins with a deterministic metadata contract, not an upload path. The
+contract turns one shortlisted draw into explicit vertex declaration and bounds
+facts while Xenos remains the only renderer.
+
+## Inputs and limits
+
+ReXGlue patch `0053-graphics-vertex-declaration-observer.patch` extends the
+default-off draw observer with:
+
+- VGT vertex index offset, minimum, and maximum registers;
+- the minimum and maximum index count observed for a recurring candidate;
+- up to 32 decoded vertex attributes; and
+- an explicit attribute-overflow marker.
+
+Each attribute reports only shader/fetch metadata: binding and fetch identity,
+word offset and stride, Xenos data format, required fetch-word mask, exponent
+and signed-RF controls, result mapping, and instruction flags. The callback
+does not translate a guest address, read an index or vertex byte, upload data,
+submit a native draw, or suppress Xenos work.
+
+## Deterministic planner
+
+Build a contract from a candidate-selection document:
+
+```powershell
+python .\tools\build-native-geometry-contract.py `
+  .\.local\native-renderer\candidate\selection.json `
+  --output .\.local\native-renderer\candidate\geometry-contract.json
+```
+
+The planner requires exactly one binding for the initial candidate, normalizes
+its physical address with `address & 0x1FFFFFFF`, validates attribute extents
+against the stride, decodes every supported Xenos vertex format, endianness,
+fetch flag, result target and swizzle, independently recomputes the required
+word mask, applies the 24-bit VGT offset and clamp semantics, and
+proves the required non-indexed byte range fits the observed fetch allocation.
+It rejects 24-bit index wrap, negative offsets, empty word masks, stride
+disagreement, unknown formats, aperture crossing, and undersized allocations.
+
+For indexed metadata, the planner also decodes 16/32-bit index format and all
+four Xenos endianness modes, normalizes the DMA base, and proves the allocation
+can contain the requested number of indices before permitting a later scan.
+The VGT DMA base already identifies the draw's start index; VGT index offset is
+the base-vertex term applied after the index value is loaded.
+
+Indexed draws are intentionally reported as `requires_index_scan`; their bounds
+cannot be proven without a later, separately bounded payload-read step. Every
+contract carries explicit false values for guest payload reads, native upload,
+native draw, and suppression, plus true Xenos authority.
+
+## Advancement gate
+
+This slice is ready to merge when a clean build and AppData-backed run confirm
+the selected candidate emits a stable declaration and the planner produces a
+bounded contract. That is evidence for the next isolated upload/replay slice,
+not permission to render or suppress the authentic draw.
+
+## Local qualification — 2026-08-28
+
+The 53-patch Release build completed from a freshly prepared ReXGlue tree. A
+long AppData-backed `open_world_day` run (`20260828T045536Z-p1616`) exited
+through the normal window-close path after 37,608 frames and 4,821,916 observed
+draws. Its performance capture covered 1,221.86 seconds: median frame time was
+33.232 ms (30.091 FPS), presentation cadence was 59.999 Hz, and there were no
+presentation deadline misses. The census reported zero draw, resolve-target,
+or resolve-page overflow and no crash, error, or device-loss event.
+
+After the index-allocation fields were added, the exact final executable
+(SHA-256 `3FF110A72800A6EC0AEF121296F6A3D3A9D8CA53B733FFFCD191AD5B3855C4B5`)
+ran another 2,899-frame AppData confirmation (`20260828T051716Z-p1508`). It
+also exited normally, recorded zero errors and deadline misses, and preserved
+Xenos authority throughout.
+
+The deterministic selector compared both captures and found one provisional
+geometry-contract candidate, signature `6263AD066A342AFE`, with the same exact
+prepared shader pair in both runs. It is a non-indexed rectangle-list draw with
+24 vertices, one 16-byte binding, two `32_32_FLOAT` attributes (the second an
+inherited mini-fetch), and one texture. The planner independently derived a
+384-byte requirement from the declaration and VGT state, exactly matching the
+384-byte observed allocation. Its generated safety record keeps guest payload
+reads, native uploads, native draws, and suppression disabled.
+
+This candidate has only two observations and still needs visual and static
+texture-provenance review. It validates the declaration and bounds machinery;
+it is not yet the approved authentic draw for NR-02E comparison.

--- a/docs/native-renderer/RENDER_PASS_CENSUS.md
+++ b/docs/native-renderer/RENDER_PASS_CENSUS.md
@@ -101,3 +101,13 @@ Candidate-specific index, vertex-layout, blend, depth, and raster metadata is
 documented in [`CANDIDATE_DRAW_SELECTION.md`](CANDIDATE_DRAW_SELECTION.md).
 It is a local NR-02 shortlist only and does not change the NR-00 classifier or
 open Gate B.
+
+## NR-02B declaration extension
+
+Patch `0053-graphics-vertex-declaration-observer.patch` adds a 32-attribute
+bound, VGT index range, exact result mapping, and explicit overflow reporting.
+Title-side candidate aggregation preserves minimum/maximum index counts and
+minimum index allocation length across census windows. The deterministic
+contract builder independently decodes and validates the captured declaration
+without reading guest payloads. Qualification details are in
+[`GEOMETRY_CONTRACT.md`](GEOMETRY_CONTRACT.md); Xenos remains authoritative.

--- a/patches/rexglue/0053-graphics-vertex-declaration-observer.patch
+++ b/patches/rexglue/0053-graphics-vertex-declaration-observer.patch
@@ -1,0 +1,126 @@
+diff --git a/include/rex/system/interfaces/graphics.h b/include/rex/system/interfaces/graphics.h
+index 231e668..33c764b 100644
+--- a/include/rex/system/interfaces/graphics.h
++++ b/include/rex/system/interfaces/graphics.h
+@@ -92,6 +92,24 @@ struct GraphicsVertexBindingObservation {
+ 
+ constexpr uint32_t kGraphicsVertexBindingObservationLimit = 8;
+ 
++struct GraphicsVertexAttributeObservation {
++  uint32_t binding_index = 0;
++  uint32_t fetch_constant = 0;
++  int32_t offset_words = 0;
++  uint32_t stride_words = 0;
++  uint32_t data_format = 0;
++  uint32_t fetch_word_mask = 0;
++  int32_t exp_adjust = 0;
++  uint32_t signed_rf_mode = 0;
++  uint32_t result_storage_target = 0;
++  uint32_t result_storage_index = 0;
++  uint32_t result_write_mask = 0;
++  uint32_t result_components = 0;
++  uint32_t flags = 0;
++};
++
++constexpr uint32_t kGraphicsVertexAttributeObservationLimit = 32;
++
+ struct GraphicsDrawObservation {
+   uint64_t frame_sequence = 0;
+   uint64_t draw_sequence = 0;
+@@ -106,10 +124,17 @@ struct GraphicsDrawObservation {
+   uint32_t index_buffer_length = 0;
+   uint32_t index_format = 0;
+   uint32_t index_endianness = 0;
++  uint32_t vertex_index_offset = 0;
++  uint32_t vertex_index_min = 0;
++  uint32_t vertex_index_max = 0;
+   uint32_t vertex_binding_count = 0;
+   GraphicsVertexBindingObservation
+       vertex_bindings[kGraphicsVertexBindingObservationLimit] = {};
+   uint32_t vertex_binding_overflow = 0;
++  uint32_t vertex_attribute_count = 0;
++  GraphicsVertexAttributeObservation
++      vertex_attributes[kGraphicsVertexAttributeObservationLimit] = {};
++  uint32_t vertex_attribute_overflow = 0;
+   uint32_t surface_info = 0;
+   uint32_t color_info[4] = {};
+   uint32_t depth_info = 0;
+diff --git a/src/graphics/command_processor.cpp b/src/graphics/command_processor.cpp
+index 832f142..6bf3077 100644
+--- a/src/graphics/command_processor.cpp
++++ b/src/graphics/command_processor.cpp
+@@ -1500,9 +1500,20 @@ bool CommandProcessor::ExecutePacketType3Draw(memory::RingBuffer* reader, uint32
+           observation.index_format = uint32_t(index_buffer_info.format);
+           observation.index_endianness = uint32_t(index_buffer_info.endianness);
+         }
++        observation.vertex_index_offset =
++            register_file_->Get<reg::VGT_INDX_OFFSET>().indx_offset;
++        observation.vertex_index_min =
++            register_file_->Get<reg::VGT_MIN_VTX_INDX>().min_indx;
++        observation.vertex_index_max =
++            register_file_->Get<reg::VGT_MAX_VTX_INDX>().max_indx;
+         if (active_vertex_shader_) {
+           const auto& vertex_bindings = active_vertex_shader_->vertex_bindings();
+           observation.vertex_binding_count = uint32_t(vertex_bindings.size());
++          for (const Shader::VertexBinding& binding : vertex_bindings) {
++            observation.vertex_attribute_count +=
++                uint32_t(binding.attributes.size());
++          }
++          uint32_t attribute_index = 0;
+           for (uint32_t i = 0;
+                i < observation.vertex_binding_count &&
+                i < system::kGraphicsVertexBindingObservationLimit;
+@@ -1515,9 +1526,53 @@ bool CommandProcessor::ExecutePacketType3Draw(memory::RingBuffer* reader, uint32
+             observation.vertex_bindings[i].size = fetch.size << 2;
+             observation.vertex_bindings[i].stride_words = binding.stride_words;
+             observation.vertex_bindings[i].endianness = uint32_t(fetch.endian);
++            for (const Shader::VertexBinding::Attribute& attribute :
++                 binding.attributes) {
++              if (attribute_index >=
++                  system::kGraphicsVertexAttributeObservationLimit) {
++                continue;
++              }
++              const ParsedVertexFetchInstruction& fetch_instruction =
++                  attribute.fetch_instr;
++              auto& output = observation.vertex_attributes[attribute_index];
++              output.binding_index = uint32_t(binding.binding_index);
++              output.fetch_constant = binding.fetch_constant;
++              output.offset_words = fetch_instruction.attributes.offset;
++              output.stride_words = fetch_instruction.attributes.stride;
++              output.data_format =
++                  uint32_t(fetch_instruction.attributes.data_format);
++              output.fetch_word_mask = xenos::GetVertexFormatNeededWords(
++                  fetch_instruction.attributes.data_format,
++                  fetch_instruction.result.GetUsedResultComponents());
++              output.exp_adjust = fetch_instruction.attributes.exp_adjust;
++              output.signed_rf_mode =
++                  uint32_t(fetch_instruction.attributes.signed_rf_mode);
++              output.result_storage_target =
++                  uint32_t(fetch_instruction.result.storage_target);
++              output.result_storage_index =
++                  fetch_instruction.result.storage_index;
++              output.result_write_mask =
++                  fetch_instruction.result.GetUsedWriteMask();
++              for (uint32_t component = 0; component < 4; ++component) {
++                output.result_components |=
++                    uint32_t(fetch_instruction.result.components[component])
++                    << (component * 3);
++              }
++              output.flags =
++                  (fetch_instruction.is_mini_fetch ? 1u : 0u) |
++                  (fetch_instruction.is_predicated ? 2u : 0u) |
++                  (fetch_instruction.predicate_condition ? 4u : 0u) |
++                  (fetch_instruction.attributes.is_index_rounded ? 8u : 0u) |
++                  (fetch_instruction.attributes.is_signed ? 16u : 0u) |
++                  (fetch_instruction.attributes.is_integer ? 32u : 0u);
++              ++attribute_index;
++            }
+           }
+           observation.vertex_binding_overflow =
+               observation.vertex_binding_count > system::kGraphicsVertexBindingObservationLimit;
++          observation.vertex_attribute_overflow =
++              observation.vertex_attribute_count >
++              system::kGraphicsVertexAttributeObservationLimit;
+         }
+         observation.surface_info = register_file_->Get<reg::RB_SURFACE_INFO>().value;
+         for (uint32_t i = 0; i < 4; ++i) {

--- a/src/native_renderer/graphics_hooks.cpp
+++ b/src/native_renderer/graphics_hooks.cpp
@@ -58,6 +58,9 @@ struct DrawSignatureEntry {
   uint64_t draw_count = 0;
   uint64_t first_frame = 0;
   uint64_t last_frame = 0;
+  uint32_t min_index_count = 0;
+  uint32_t max_index_count = 0;
+  uint32_t min_index_buffer_length = 0;
   bool samples_resolved_target = false;
   rex::system::GraphicsDrawObservation sample;
 };
@@ -390,8 +393,13 @@ CandidateSignature(const rex::system::GraphicsDrawObservation &observation,
   uint64_t hash = DrawSignature(observation);
   for (uint64_t value : {uint64_t(observation.index_format),
                          uint64_t(observation.index_endianness),
+                         uint64_t(observation.vertex_index_offset),
+                         uint64_t(observation.vertex_index_min),
+                         uint64_t(observation.vertex_index_max),
                          uint64_t(observation.vertex_binding_count),
                          uint64_t(observation.vertex_binding_overflow),
+                         uint64_t(observation.vertex_attribute_count),
+                         uint64_t(observation.vertex_attribute_overflow),
                          uint64_t(observation.viz_query_condition),
                          uint64_t(observation.pa_sc_viz_query),
                          uint64_t(samples_resolved_target),
@@ -415,6 +423,25 @@ CandidateSignature(const rex::system::GraphicsDrawObservation &observation,
     hash = HashCombine(hash, binding.size);
     hash = HashCombine(hash, binding.stride_words);
     hash = HashCombine(hash, binding.endianness);
+  }
+  const uint32_t bounded_attribute_count =
+      std::min(observation.vertex_attribute_count,
+               rex::system::kGraphicsVertexAttributeObservationLimit);
+  for (uint32_t i = 0; i < bounded_attribute_count; ++i) {
+    const auto &attribute = observation.vertex_attributes[i];
+    for (uint64_t value :
+         {uint64_t(attribute.binding_index), uint64_t(attribute.fetch_constant),
+          uint64_t(uint32_t(attribute.offset_words)),
+          uint64_t(attribute.stride_words), uint64_t(attribute.data_format),
+          uint64_t(attribute.fetch_word_mask),
+          uint64_t(uint32_t(attribute.exp_adjust)),
+          uint64_t(attribute.signed_rf_mode),
+          uint64_t(attribute.result_storage_target),
+          uint64_t(attribute.result_storage_index),
+          uint64_t(attribute.result_write_mask),
+          uint64_t(attribute.result_components), uint64_t(attribute.flags)}) {
+      hash = HashCombine(hash, value);
+    }
   }
   return hash ? hash : 1;
 }
@@ -525,6 +552,24 @@ void EmitCandidateCensusWindow(uint64_t last_frame_value) {
           "{}:{:08X}:{}:{}:{}", binding.fetch_constant, binding.address,
           binding.size, binding.stride_words, binding.endianness);
     }
+    std::string vertex_attributes;
+    const uint32_t bounded_attribute_count =
+        std::min(sample.vertex_attribute_count,
+                 rex::system::kGraphicsVertexAttributeObservationLimit);
+    for (uint32_t i = 0; i < bounded_attribute_count; ++i) {
+      const auto &attribute = sample.vertex_attributes[i];
+      if (!vertex_attributes.empty()) {
+        vertex_attributes += ";";
+      }
+      vertex_attributes += fmt::format(
+          "{}:{}:{}:{}:{}:{:X}:{}:{}:{}:{}:{:X}:{:X}:{:X}",
+          attribute.binding_index, attribute.fetch_constant,
+          attribute.offset_words, attribute.stride_words, attribute.data_format,
+          attribute.fetch_word_mask, attribute.exp_adjust,
+          attribute.signed_rf_mode, attribute.result_storage_target,
+          attribute.result_storage_index, attribute.result_write_mask,
+          attribute.result_components, attribute.flags);
+    }
     const bool query_draw =
         sample.viz_query_condition || (sample.pa_sc_viz_query & 1);
     const std::string pipeline_state =
@@ -544,11 +589,24 @@ void EmitCandidateCensusWindow(uint64_t last_frame_value) {
          {"vertex_shader", fmt::format("{:016X}", sample.vertex_shader_hash)},
          {"pixel_shader", fmt::format("{:016X}", sample.pixel_shader_hash)},
          {"primitive", std::to_string(sample.primitive_type)},
+         {"source_select", std::to_string(sample.source_select)},
+         {"index_count_min", std::to_string(entry.min_index_count)},
+         {"index_count_max", std::to_string(entry.max_index_count)},
          {"index_state",
           fmt::format("format={};endianness={}", sample.index_format,
                       sample.index_endianness)},
+         {"index_buffer_address",
+          fmt::format("{:08X}", sample.index_buffer_address)},
+         {"index_buffer_length_min",
+          std::to_string(entry.min_index_buffer_length)},
+         {"vertex_index_range",
+          fmt::format("offset={};min={};max={}", sample.vertex_index_offset,
+                      sample.vertex_index_min, sample.vertex_index_max)},
          {"vertex_binding_count", std::to_string(sample.vertex_binding_count)},
          {"vertex_fetches", vertex_fetches},
+         {"vertex_attribute_count",
+          std::to_string(sample.vertex_attribute_count)},
+         {"vertex_attributes", vertex_attributes},
          {"texture_fetch_count",
           std::to_string(std::popcount(sample.texture_fetch_mask))},
          {"pipeline_state", pipeline_state},
@@ -558,6 +616,8 @@ void EmitCandidateCensusWindow(uint64_t last_frame_value) {
          {"resolved_input", entry.samples_resolved_target ? "true" : "false"},
          {"opaque", IsOpaqueColorState(sample) ? "true" : "false"},
          {"vertex_overflow", sample.vertex_binding_overflow ? "true" : "false"},
+         {"vertex_attribute_overflow",
+          sample.vertex_attribute_overflow ? "true" : "false"},
          {"qualification", "metadata_shortlist_only"},
          {"suppression_eligible", "false"}});
   }
@@ -805,6 +865,9 @@ void RecordCandidate(const rex::system::GraphicsDrawObservation &observation,
       entry.draw_count = 1;
       entry.first_frame = observation.frame_sequence;
       entry.last_frame = observation.frame_sequence;
+      entry.min_index_count = observation.index_count;
+      entry.max_index_count = observation.index_count;
+      entry.min_index_buffer_length = observation.index_buffer_length;
       entry.samples_resolved_target = samples_resolved_target;
       entry.sample = observation;
       ++g_candidate_census.unique_signature_count;
@@ -813,6 +876,14 @@ void RecordCandidate(const rex::system::GraphicsDrawObservation &observation,
     if (entry.signature == signature) {
       ++entry.draw_count;
       entry.last_frame = observation.frame_sequence;
+      entry.min_index_count =
+          std::min(entry.min_index_count, observation.index_count);
+      entry.max_index_count =
+          std::max(entry.max_index_count, observation.index_count);
+      if (observation.indexed) {
+        entry.min_index_buffer_length = std::min(
+            entry.min_index_buffer_length, observation.index_buffer_length);
+      }
       return;
     }
     index = (index + 1) % kSignatureCapacity;

--- a/tools/build-native-geometry-contract.py
+++ b/tools/build-native-geometry-contract.py
@@ -1,0 +1,397 @@
+#!/usr/bin/env python3
+"""Build a bounded NR-02 geometry contract from candidate census metadata."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+
+SELECTION_SCHEMA = "pinyon-shift.native-renderer-candidate-selection.v1"
+SCHEMA = "pinyon-shift.native-geometry-contract.v1"
+PHYSICAL_MASK = 0x1FFFFFFF
+VERTEX_INDEX_MASK = 0xFFFFFF
+
+VERTEX_FORMATS = {
+    6: ("8_8_8_8", 4, 4, "packed_integer"),
+    7: ("2_10_10_10", 4, 4, "packed_integer"),
+    16: ("10_11_11", 3, 4, "packed_integer"),
+    17: ("11_11_10", 3, 4, "packed_integer"),
+    25: ("16_16", 2, 4, "packed_integer"),
+    26: ("16_16_16_16", 4, 8, "packed_integer"),
+    31: ("16_16_FLOAT", 2, 4, "float"),
+    32: ("16_16_16_16_FLOAT", 4, 8, "float"),
+    33: ("32", 1, 4, "integer"),
+    34: ("32_32", 2, 8, "integer"),
+    35: ("32_32_32_32", 4, 16, "integer"),
+    36: ("32_FLOAT", 1, 4, "float"),
+    37: ("32_32_FLOAT", 2, 8, "float"),
+    38: ("32_32_32_32_FLOAT", 4, 16, "float"),
+    57: ("32_32_32_FLOAT", 3, 12, "float"),
+}
+INDEX_FORMATS = {
+    0: ("uint16", 2),
+    1: ("uint32", 4),
+}
+INDEX_ENDIANNESS = {
+    0: "none",
+    1: "8in16",
+    2: "8in32",
+    3: "16in32",
+}
+VERTEX_ENDIANNESS = {
+    **INDEX_ENDIANNESS,
+    4: "8in64",
+    5: "8in128",
+}
+STORAGE_TARGETS = {
+    0: "none",
+    1: "register",
+    2: "interpolator",
+    3: "position",
+    4: "point_size_edge_flag_kill_vertex",
+    5: "export_address",
+    6: "export_data",
+    7: "color",
+    8: "depth",
+}
+SWIZZLE_SOURCES = ("x", "y", "z", "w", "0", "1")
+
+
+def needed_vertex_words(data_format: int, used_components: int) -> int:
+    if data_format in (6, 7):
+        return 0x1 if used_components else 0
+    if data_format in (16, 17):
+        return 0x1 if used_components & 0x7 else 0
+    if data_format in (25, 31):
+        return 0x1 if used_components & 0x3 else 0
+    if data_format in (26, 32):
+        return (0x1 if used_components & 0x3 else 0) | (
+            0x2 if used_components & 0xC else 0
+        )
+    if data_format in (33, 36):
+        return used_components & 0x1
+    if data_format in (34, 37):
+        return used_components & 0x3
+    if data_format in (35, 38):
+        return used_components & 0xF
+    if data_format == 57:
+        return used_components & 0x7
+    raise ValueError(f"unsupported Xenos vertex format {data_format}")
+
+
+def parse_state(value: Any, field: str) -> dict[str, int]:
+    if not isinstance(value, str) or not value:
+        raise ValueError(f"candidate has no {field}")
+    result: dict[str, int] = {}
+    for item in value.split(";"):
+        key, separator, raw = item.partition("=")
+        if not separator or not key or not raw:
+            raise ValueError(f"candidate has invalid {field}: {value!r}")
+        result[key] = int(raw, 0)
+    return result
+
+
+def parse_fetches(value: Any) -> list[dict[str, int]]:
+    if not isinstance(value, str) or not value:
+        raise ValueError("candidate has no vertex fetch metadata")
+    fetches = []
+    for item in value.split(";"):
+        fields = item.split(":")
+        if len(fields) != 5:
+            raise ValueError(f"invalid vertex fetch metadata: {item!r}")
+        fetch_constant, address, size, stride_words, endianness = fields
+        fetches.append(
+            {
+                "fetch_constant": int(fetch_constant),
+                "guest_address": int(address, 16),
+                "size_bytes": int(size),
+                "stride_words": int(stride_words),
+                "endianness": int(endianness),
+            }
+        )
+    return fetches
+
+
+def parse_attributes(value: Any) -> list[dict[str, int]]:
+    if not isinstance(value, str) or not value:
+        raise ValueError("candidate has no vertex attribute metadata")
+    names = (
+        "binding_index",
+        "fetch_constant",
+        "offset_words",
+        "stride_words",
+        "data_format",
+        "fetch_word_mask",
+        "exp_adjust",
+        "signed_rf_mode",
+        "result_storage_target",
+        "result_storage_index",
+        "result_write_mask",
+        "result_components",
+        "flags",
+    )
+    hexadecimal = {
+        "fetch_word_mask",
+        "result_write_mask",
+        "result_components",
+        "flags",
+    }
+    attributes = []
+    for item in value.split(";"):
+        fields = item.split(":")
+        if len(fields) != len(names):
+            raise ValueError(f"invalid vertex attribute metadata: {item!r}")
+        attributes.append(
+            {
+                name: int(raw, 16 if name in hexadecimal else 10)
+                for name, raw in zip(names, fields)
+            }
+        )
+    return attributes
+
+
+def select_candidate(document: dict[str, Any], signature: str | None) -> dict[str, Any]:
+    if document.get("schema") != SELECTION_SCHEMA:
+        raise ValueError(f"unsupported selection schema: {document.get('schema')}")
+    candidates = document.get("candidates", [])
+    if signature is not None:
+        candidates = [item for item in candidates if item.get("signature") == signature]
+    if len(candidates) != 1:
+        raise ValueError("geometry planning requires exactly one selected candidate")
+    return candidates[0]
+
+
+def build(document: dict[str, Any], signature: str | None = None) -> dict[str, Any]:
+    candidate = select_candidate(document, signature)
+    if int(candidate.get("vertex_binding_count", 0)) != 1:
+        raise ValueError("initial geometry contract requires exactly one vertex binding")
+    fetches = parse_fetches(candidate.get("vertex_fetches"))
+    if len(fetches) != 1:
+        raise ValueError("initial geometry contract requires one bounded vertex fetch")
+    attributes = parse_attributes(candidate.get("vertex_attributes"))
+    if len(attributes) != int(candidate.get("vertex_attribute_count", 0)):
+        raise ValueError("vertex attribute metadata count does not match the candidate")
+
+    fetch = fetches[0]
+    if fetch["size_bytes"] <= 0 or fetch["stride_words"] <= 0:
+        raise ValueError("vertex fetch size and stride must be positive")
+    if fetch["endianness"] not in VERTEX_ENDIANNESS:
+        raise ValueError(
+            f"unsupported Xenos vertex endianness {fetch['endianness']}"
+        )
+    stride_bytes = fetch["stride_words"] * 4
+    maximum_extent = 0
+    for attribute in attributes:
+        if attribute["fetch_constant"] != fetch["fetch_constant"]:
+            raise ValueError("vertex attribute references an unbounded fetch constant")
+        if attribute["offset_words"] < 0:
+            raise ValueError("negative vertex attribute offsets are not bounded")
+        if attribute["stride_words"] != fetch["stride_words"]:
+            raise ValueError("vertex attribute and fetch strides disagree")
+        if attribute["fetch_word_mask"] <= 0:
+            raise ValueError("vertex attribute has an empty fetch word mask")
+        format_info = VERTEX_FORMATS.get(attribute["data_format"])
+        if format_info is None:
+            raise ValueError(
+                f"unsupported Xenos vertex format {attribute['data_format']}"
+            )
+        format_name, component_count, storage_bytes, number_class = format_info
+        storage_target = STORAGE_TARGETS.get(attribute["result_storage_target"])
+        if storage_target is None:
+            raise ValueError(
+                "unsupported shader result storage target "
+                f"{attribute['result_storage_target']}"
+            )
+        swizzle_codes = [
+            (attribute["result_components"] >> (component * 3)) & 0x7
+            for component in range(4)
+        ]
+        if any(code >= len(SWIZZLE_SOURCES) for code in swizzle_codes):
+            raise ValueError("vertex attribute has an invalid result swizzle")
+        used_components = 0
+        for output_component, source_component in enumerate(swizzle_codes):
+            if (
+                attribute["result_write_mask"] & (1 << output_component)
+                and source_component < 4
+            ):
+                used_components |= 1 << source_component
+        expected_word_mask = needed_vertex_words(
+            attribute["data_format"], used_components
+        )
+        if attribute["fetch_word_mask"] != expected_word_mask:
+            raise ValueError(
+                "vertex attribute fetch word mask disagrees with its format "
+                "and result swizzle"
+            )
+        extent = (attribute["offset_words"] + attribute["fetch_word_mask"].bit_length()) * 4
+        if extent > stride_bytes:
+            raise ValueError("vertex attribute extends beyond its binding stride")
+        attribute["extent_bytes"] = extent
+        attribute["format_name"] = format_name
+        attribute["component_count"] = component_count
+        attribute["storage_bytes"] = storage_bytes
+        attribute["number_class"] = number_class
+        attribute["result_storage_target_name"] = storage_target
+        attribute["result_write_components"] = "".join(
+            component
+            for index, component in enumerate("xyzw")
+            if attribute["result_write_mask"] & (1 << index)
+        )
+        attribute["result_swizzle"] = "".join(
+            SWIZZLE_SOURCES[code] for code in swizzle_codes
+        )
+        attribute["used_source_components"] = "".join(
+            component
+            for index, component in enumerate("xyzw")
+            if used_components & (1 << index)
+        )
+        attribute["mini_fetch"] = bool(attribute["flags"] & 0x1)
+        attribute["predicated"] = bool(attribute["flags"] & 0x2)
+        attribute["predicate_condition"] = bool(attribute["flags"] & 0x4)
+        attribute["index_rounded"] = bool(attribute["flags"] & 0x8)
+        attribute["signed"] = bool(attribute["flags"] & 0x10)
+        attribute["integer"] = bool(attribute["flags"] & 0x20)
+        maximum_extent = max(maximum_extent, extent)
+
+    normalized_address = fetch["guest_address"] & PHYSICAL_MASK
+    if normalized_address + fetch["size_bytes"] > PHYSICAL_MASK + 1:
+        raise ValueError("normalized vertex fetch crosses the physical aperture")
+
+    index_range = parse_state(candidate.get("vertex_index_range"), "vertex_index_range")
+    index_state = parse_state(candidate.get("index_state"), "index_state")
+    index_format = index_state.get("format")
+    index_endianness = index_state.get("endianness")
+    if index_format not in INDEX_FORMATS:
+        raise ValueError(f"unsupported Xenos index format {index_format}")
+    if index_endianness not in INDEX_ENDIANNESS:
+        raise ValueError(f"unsupported Xenos index endianness {index_endianness}")
+    offset = index_range.get("offset")
+    minimum = index_range.get("min")
+    maximum = index_range.get("max")
+    if offset is None or minimum is None or maximum is None or maximum < minimum:
+        raise ValueError("candidate has an invalid vertex index range")
+
+    indexed = bool(candidate.get("indexed"))
+    index_count_max = int(candidate.get("index_count_max", 0))
+    index_format_name, index_element_bytes = INDEX_FORMATS[index_format]
+    index_buffer: dict[str, Any] | None = None
+    bounds: dict[str, Any]
+    if indexed:
+        index_buffer_length = int(candidate.get("index_buffer_length_min", 0))
+        required_index_bytes = index_count_max * index_element_bytes
+        if index_buffer_length < required_index_bytes:
+            raise ValueError(
+                f"index fetch needs {required_index_bytes} bytes, "
+                f"has {index_buffer_length}"
+            )
+        raw_index_address = candidate.get("index_buffer_address")
+        if not isinstance(raw_index_address, str) or not raw_index_address:
+            raise ValueError("indexed candidate has no index buffer address")
+        guest_index_address = int(raw_index_address, 16)
+        physical_index_address = guest_index_address & PHYSICAL_MASK
+        if physical_index_address + index_buffer_length > PHYSICAL_MASK + 1:
+            raise ValueError("normalized index fetch crosses the physical aperture")
+        index_buffer = {
+            "guest_address": guest_index_address,
+            "physical_address": physical_index_address,
+            "available_bytes": index_buffer_length,
+            "required_bytes_before_scan": required_index_bytes,
+        }
+        bounds = {
+            "status": "requires_index_scan",
+            "validated": False,
+            "reason": "index payload is intentionally outside this metadata-only PR",
+        }
+    else:
+        if index_count_max < 0:
+            raise ValueError("index count must not be negative")
+        raw_last = index_count_max - 1 if index_count_max else None
+        if raw_last is None:
+            maximum_vertex = None
+            required_bytes = 0
+        else:
+            adjusted = raw_last + offset
+            if adjusted > VERTEX_INDEX_MASK:
+                raise ValueError("24-bit vertex index wrap is outside the initial contract")
+            maximum_vertex = min(max(adjusted & VERTEX_INDEX_MASK, minimum), maximum)
+            required_bytes = maximum_vertex * stride_bytes + maximum_extent
+        if required_bytes > fetch["size_bytes"]:
+            raise ValueError(
+                f"vertex fetch needs {required_bytes} bytes, has {fetch['size_bytes']}"
+            )
+        bounds = {
+            "status": "bounded",
+            "validated": True,
+            "raw_last_vertex": raw_last,
+            "maximum_vertex": maximum_vertex,
+            "maximum_attribute_extent_bytes": maximum_extent,
+            "required_bytes": required_bytes,
+            "available_bytes": fetch["size_bytes"],
+        }
+
+    return {
+        "schema": SCHEMA,
+        "candidate_signature": candidate.get("signature"),
+        "primitive": int(candidate.get("primitive", 0)),
+        "indexed": indexed,
+        "source_select": int(candidate.get("source_select", 0)),
+        "index_count": {
+            "minimum_observed": int(candidate.get("index_count_min", 0)),
+            "maximum_observed": index_count_max,
+        },
+        "vertex_index_range": {
+            "offset": offset,
+            "minimum": minimum,
+            "maximum": maximum,
+            "mask": VERTEX_INDEX_MASK,
+        },
+        "index": {
+            "format": index_format,
+            "format_name": index_format_name,
+            "element_bytes": index_element_bytes,
+            "endianness": index_endianness,
+            "endianness_name": INDEX_ENDIANNESS[index_endianness],
+            "buffer": index_buffer,
+        },
+        "binding": {
+            **fetch,
+            "endianness_name": VERTEX_ENDIANNESS[fetch["endianness"]],
+            "physical_address": normalized_address,
+            "stride_bytes": stride_bytes,
+        },
+        "attributes": attributes,
+        "bounds": bounds,
+        "safety": {
+            "guest_payload_read": False,
+            "native_upload": False,
+            "native_draw": False,
+            "suppression_allowed": False,
+            "xenos_authority": True,
+        },
+    }
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("selection", type=Path)
+    parser.add_argument("--signature")
+    parser.add_argument("--output", "-o", type=Path)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    document = json.loads(args.selection.read_text(encoding="utf-8"))
+    rendered = json.dumps(build(document, args.signature), indent=2) + "\n"
+    if args.output:
+        args.output.write_text(rendered, encoding="utf-8")
+    else:
+        print(rendered, end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/select-native-renderer-candidate.py
+++ b/tools/select-native-renderer-candidate.py
@@ -60,6 +60,8 @@ def rejection_reasons(record: dict[str, Any]) -> list[str]:
         reasons.append("dynamic_render_target_input")
     if boolean(record, "vertex_overflow"):
         reasons.append("vertex_binding_overflow")
+    if boolean(record, "vertex_attribute_overflow"):
+        reasons.append("vertex_attribute_overflow")
     if int(record.get("vertex_binding_count", 0)) != 1:
         reasons.append("vertex_binding_count_not_one")
     if int(record.get("texture_fetch_count", 0)) > 1:
@@ -155,8 +157,29 @@ def select(census_paths: list[Path], shader_manifest_path: Path) -> dict[str, An
                 "vertex_specialization_mask": vertex_specialization,
                 "pixel_specialization_mask": pixel_specialization,
                 "primitive": sample.get("primitive"),
+                "indexed": boolean(sample, "indexed"),
+                "source_select": int(sample.get("source_select", 0)),
+                "index_count_min": min(
+                    int(record.get("index_count_min", 0)) for record in records
+                ),
+                "index_count_max": max(
+                    int(record.get("index_count_max", 0)) for record in records
+                ),
                 "index_state": sample.get("index_state"),
+                "index_buffer_address": sample.get("index_buffer_address"),
+                "index_buffer_length_min": min(
+                    int(record.get("index_buffer_length_min", 0))
+                    for record in records
+                ),
+                "vertex_index_range": sample.get("vertex_index_range"),
+                "vertex_binding_count": int(
+                    sample.get("vertex_binding_count", 0)
+                ),
                 "vertex_fetches": sample.get("vertex_fetches"),
+                "vertex_attribute_count": int(
+                    sample.get("vertex_attribute_count", 0)
+                ),
+                "vertex_attributes": sample.get("vertex_attributes"),
                 "texture_fetch_count": int(sample.get("texture_fetch_count", 0)),
                 "pipeline_state": sample.get("pipeline_state"),
                 "qualification": "metadata_shortlist_only",

--- a/tools/summarize-native-renderer-census.py
+++ b/tools/summarize-native-renderer-census.py
@@ -182,6 +182,18 @@ def summarize(
                 record["last_frame"] = str(
                     max(integer(record, "last_frame"), integer(event, "last_frame"))
                 )
+                for field in ("index_count_min", "index_buffer_length_min"):
+                    if field in record and field in event:
+                        record[field] = str(
+                            min(integer(record, field), integer(event, field))
+                        )
+                if "index_count_max" in record and "index_count_max" in event:
+                    record["index_count_max"] = str(
+                        max(
+                            integer(record, "index_count_max"),
+                            integer(event, "index_count_max"),
+                        )
+                    )
         elif kind == f"{PREFIX}prepared_shader_pair":
             key = (
                 str(event["vertex_shader"]),

--- a/tools/tests/test_native_renderer_candidate.py
+++ b/tools/tests/test_native_renderer_candidate.py
@@ -21,9 +21,17 @@ def signature(name: str, **overrides):
         "vertex_shader": "1111111111111111",
         "pixel_shader": "2222222222222222",
         "primitive": "4",
+        "source_select": "2",
+        "index_count_min": "3",
+        "index_count_max": "3",
         "index_state": "format=0;endianness=2",
+        "index_buffer_address": "00180000",
+        "index_buffer_length_min": "6",
+        "vertex_index_range": "offset=0;min=0;max=16777215",
         "vertex_binding_count": "1",
         "vertex_fetches": "0:00100000:4096:8:2",
+        "vertex_attribute_count": "1",
+        "vertex_attributes": "0:0:0:8:6:F:0:0:0:0:F:688:0",
         "texture_fetch_count": "1",
         "pipeline_state": "opaque",
         "indexed": "true",
@@ -32,6 +40,7 @@ def signature(name: str, **overrides):
         "resolved_input": "false",
         "opaque": "true",
         "vertex_overflow": "false",
+        "vertex_attribute_overflow": "false",
     }
     record.update(overrides)
     return record
@@ -96,6 +105,10 @@ class NativeRendererCandidateTests(unittest.TestCase):
         self.assertEqual(1, result["candidate_count"])
         self.assertEqual("GOOD", result["candidates"][0]["signature"])
         self.assertEqual(50, result["candidates"][0]["total_draws"])
+        self.assertEqual(3, result["candidates"][0]["index_count_min"])
+        self.assertEqual(3, result["candidates"][0]["index_count_max"])
+        self.assertEqual(6, result["candidates"][0]["index_buffer_length_min"])
+        self.assertFalse(result["candidates"][0]["indexed"])
         self.assertEqual(
             "AAAAAAAAAAAAAAAA",
             result["candidates"][0]["vertex_specialization_mask"],
@@ -106,6 +119,12 @@ class NativeRendererCandidateTests(unittest.TestCase):
     def test_rejects_dynamic_input(self):
         reasons = MODULE.rejection_reasons(signature("BAD", resolved_input="true"))
         self.assertIn("dynamic_render_target_input", reasons)
+
+    def test_rejects_vertex_attribute_overflow(self):
+        reasons = MODULE.rejection_reasons(
+            signature("BAD", vertex_attribute_overflow="true")
+        )
+        self.assertIn("vertex_attribute_overflow", reasons)
 
 
 if __name__ == "__main__":

--- a/tools/tests/test_native_renderer_census.py
+++ b/tools/tests/test_native_renderer_census.py
@@ -93,6 +93,20 @@ class NativeRendererCensusTests(unittest.TestCase):
                 "draws": "12",
                 "first_frame": "1",
                 "last_frame": "100",
+                "index_count_min": "6",
+                "index_count_max": "12",
+                "index_buffer_length_min": "24",
+            },
+            {
+                "event": "native_renderer.census.draw_candidate",
+                "session": "new",
+                "signature": "CANDIDATE",
+                "draws": "8",
+                "first_frame": "101",
+                "last_frame": "200",
+                "index_count_min": "3",
+                "index_count_max": "18",
+                "index_buffer_length_min": "20",
             },
             {
                 "event": "native_renderer.census.prepared_shader_pair",
@@ -147,6 +161,12 @@ class NativeRendererCensusTests(unittest.TestCase):
         self.assertEqual(100, result["totals"]["draws"])
         self.assertEqual(7, result["totals"]["resolves"])
         self.assertEqual("CANDIDATE", result["draw_candidates"][0]["signature"])
+        self.assertEqual("20", result["draw_candidates"][0]["draws"])
+        self.assertEqual("3", result["draw_candidates"][0]["index_count_min"])
+        self.assertEqual("18", result["draw_candidates"][0]["index_count_max"])
+        self.assertEqual(
+            "20", result["draw_candidates"][0]["index_buffer_length_min"]
+        )
         self.assertEqual(
             "AAAAAAAAAAAAAAAA",
             result["prepared_shader_pairs"][0]["vertex_specialization_mask"],

--- a/tools/tests/test_native_renderer_contract.py
+++ b/tools/tests/test_native_renderer_contract.py
@@ -326,6 +326,34 @@ class NativeRendererContractTests(unittest.TestCase):
         )
         self.assertNotIn("SetDrawSuppression", prepared_patch)
 
+        declaration_patch = (
+            ROOT / "patches/rexglue/0053-graphics-vertex-declaration-observer.patch"
+        ).read_text(encoding="utf-8")
+        self.assertIn("kGraphicsVertexAttributeObservationLimit = 32", declaration_patch)
+        self.assertIn("VGT_INDX_OFFSET", declaration_patch)
+        self.assertIn("VGT_MIN_VTX_INDX", declaration_patch)
+        self.assertIn("VGT_MAX_VTX_INDX", declaration_patch)
+        self.assertIn("fetch_word_mask", declaration_patch)
+        self.assertIn("vertex_attribute_overflow", declaration_patch)
+        for forbidden in (
+            "vertex_data",
+            "index_data",
+            "TranslatePhysical",
+            "SetDrawSuppression",
+            "IssueDraw",
+        ):
+            self.assertNotIn(forbidden, declaration_patch)
+
+        planner = (
+            ROOT / "tools/build-native-geometry-contract.py"
+        ).read_text(encoding="utf-8")
+        self.assertIn("PHYSICAL_MASK = 0x1FFFFFFF", planner)
+        self.assertIn('"guest_payload_read": False', planner)
+        self.assertIn('"native_upload": False', planner)
+        self.assertIn('"native_draw": False', planner)
+        self.assertIn('"suppression_allowed": False', planner)
+        self.assertIn('"xenos_authority": True', planner)
+
     def test_census_ledger_tracks_exact_starting_baseline(self):
         ledger = (ROOT / "docs/native-renderer/RENDER_PASS_CENSUS.md").read_text(
             encoding="utf-8"

--- a/tools/tests/test_native_renderer_geometry.py
+++ b/tools/tests/test_native_renderer_geometry.py
@@ -1,0 +1,141 @@
+import importlib.util
+import unittest
+from copy import deepcopy
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SPEC = importlib.util.spec_from_file_location(
+    "native_renderer_geometry",
+    ROOT / "tools/build-native-geometry-contract.py",
+)
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+def selection(**overrides):
+    candidate = {
+        "signature": "E184D75768958828",
+        "primitive": 13,
+        "indexed": False,
+        "source_select": 2,
+        "index_count_min": 3,
+        "index_count_max": 3,
+        "index_state": "format=0;endianness=2",
+        "index_buffer_address": "E0180000",
+        "index_buffer_length_min": 6,
+        "vertex_index_range": "offset=0;min=0;max=16777215",
+        "vertex_binding_count": 1,
+        "vertex_fetches": "0:E0100000:120:10:2",
+        "vertex_attribute_count": 2,
+        "vertex_attributes": (
+            "0:0:0:10:6:1:0:0:0:0:F:688:0;"
+            "0:0:4:10:37:3:0:0:0:1:3:688:1"
+        ),
+    }
+    candidate.update(overrides)
+    return {"schema": MODULE.SELECTION_SCHEMA, "candidates": [candidate]}
+
+
+class NativeRendererGeometryTests(unittest.TestCase):
+    def test_decodes_every_pinned_xenos_vertex_format_word_shape(self):
+        expected = {
+            6: 0x1,
+            7: 0x1,
+            16: 0x1,
+            17: 0x1,
+            25: 0x1,
+            26: 0x3,
+            31: 0x1,
+            32: 0x3,
+            33: 0x1,
+            34: 0x3,
+            35: 0xF,
+            36: 0x1,
+            37: 0x3,
+            38: 0xF,
+            57: 0x7,
+        }
+        self.assertEqual(set(expected), set(MODULE.VERTEX_FORMATS))
+        for data_format, word_mask in expected.items():
+            self.assertEqual(
+                word_mask,
+                MODULE.needed_vertex_words(data_format, 0xF),
+                data_format,
+            )
+
+    def test_builds_bounded_nonindexed_contract(self):
+        result = MODULE.build(selection())
+
+        self.assertEqual(MODULE.SCHEMA, result["schema"])
+        self.assertEqual(0x00100000, result["binding"]["physical_address"])
+        self.assertEqual(40, result["binding"]["stride_bytes"])
+        self.assertEqual("8in32", result["binding"]["endianness_name"])
+        self.assertEqual(2, result["bounds"]["maximum_vertex"])
+        self.assertEqual(104, result["bounds"]["required_bytes"])
+        self.assertEqual("8_8_8_8", result["attributes"][0]["format_name"])
+        self.assertEqual("none", result["attributes"][0]["result_storage_target_name"])
+        self.assertEqual("xyzw", result["attributes"][0]["result_write_components"])
+        self.assertEqual("xyzw", result["attributes"][0]["result_swizzle"])
+        self.assertEqual("xyzw", result["attributes"][0]["used_source_components"])
+        self.assertTrue(result["attributes"][1]["mini_fetch"])
+        self.assertEqual("uint16", result["index"]["format_name"])
+        self.assertEqual("8in32", result["index"]["endianness_name"])
+        self.assertTrue(result["bounds"]["validated"])
+        self.assertFalse(result["safety"]["guest_payload_read"])
+        self.assertFalse(result["safety"]["native_draw"])
+        self.assertFalse(result["safety"]["suppression_allowed"])
+        self.assertTrue(result["safety"]["xenos_authority"])
+
+    def test_rejects_undersized_vertex_fetch(self):
+        with self.assertRaisesRegex(ValueError, "needs 104 bytes, has 100"):
+            MODULE.build(selection(vertex_fetches="0:E0100000:100:10:2"))
+
+    def test_rejects_attribute_past_stride(self):
+        document = selection(
+            vertex_attribute_count=1,
+            vertex_attributes="0:0:10:10:6:1:0:0:0:0:F:688:0",
+        )
+        with self.assertRaisesRegex(ValueError, "beyond its binding stride"):
+            MODULE.build(document)
+
+    def test_rejects_vertex_index_wrap(self):
+        document = selection(vertex_index_range="offset=16777215;min=0;max=16777215")
+        with self.assertRaisesRegex(ValueError, "24-bit vertex index wrap"):
+            MODULE.build(document)
+
+    def test_rejects_unknown_vertex_format(self):
+        document = selection(
+            vertex_attribute_count=1,
+            vertex_attributes="0:0:0:10:63:F:0:0:0:0:F:688:0",
+        )
+        with self.assertRaisesRegex(ValueError, "unsupported Xenos vertex format 63"):
+            MODULE.build(document)
+
+    def test_rejects_inconsistent_fetch_word_mask(self):
+        document = selection(
+            vertex_attribute_count=1,
+            vertex_attributes="0:0:0:10:6:F:0:0:0:0:F:688:0",
+        )
+        with self.assertRaisesRegex(ValueError, "fetch word mask disagrees"):
+            MODULE.build(document)
+
+    def test_indexed_candidate_requires_future_payload_scan(self):
+        document = deepcopy(selection())
+        document["candidates"][0]["indexed"] = True
+        result = MODULE.build(document)
+        self.assertEqual("requires_index_scan", result["bounds"]["status"])
+        self.assertFalse(result["bounds"]["validated"])
+        self.assertEqual(0x00180000, result["index"]["buffer"]["physical_address"])
+        self.assertEqual(6, result["index"]["buffer"]["required_bytes_before_scan"])
+        self.assertFalse(result["safety"]["guest_payload_read"])
+
+    def test_rejects_undersized_index_fetch_before_scan(self):
+        document = deepcopy(selection(index_buffer_length_min=5))
+        document["candidates"][0]["indexed"] = True
+        with self.assertRaisesRegex(ValueError, "index fetch needs 6 bytes, has 5"):
+            MODULE.build(document)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/tests/test_release_contract.py
+++ b/tools/tests/test_release_contract.py
@@ -43,10 +43,10 @@ class ReleaseContractTests(unittest.TestCase):
 
     def test_rexglue_patches_have_stable_order_and_no_binary_payload(self):
         patches = sorted((ROOT / "patches/rexglue").glob("*.patch"))
-        self.assertEqual(len(patches), 52)
+        self.assertEqual(len(patches), 53)
         self.assertEqual(
             patches[-1].name,
-            "0052-d3d12-prepared-draw-observer.patch",
+            "0053-graphics-vertex-declaration-observer.patch",
         )
         self.assertEqual(len(patches), len({path.name[:4] for path in patches}))
         for path in patches:


### PR DESCRIPTION
## Summary

- observe bounded VGT, vertex declaration, and index allocation metadata without reading guest payloads
- select an exact repeated draw signature and build a deterministic geometry contract
- validate Xenos formats, endian modes, result swizzles, fetch masks, and allocation bounds
- preserve Xenos draw authority with no native upload, native draw, or suppression

## Qualification

- 83 Python contract tests pass
- clean Release build with 53 ReXGlue patches
- executable SHA-256: `3FF110A72800A6EC0AEF121296F6A3D3A9D8CA53B733FFFCD191AD5B3855C4B5`
- AppData-backed captures completed normally with zero observer overflow, crash, device-loss, or deadline-miss events
- long capture: 4,821,916 draws over 1,221.86 seconds; median 30.091 FPS
- final confirmation capture includes the new declaration/index fields

## Tests

- `python -m unittest discover -s tools/tests`
- `tools/build-preview.ps1 -Configuration Release`
- `tools/launch-preview.ps1 -StateRoot C:\Users\neri\AppData\Local\PinyonShift\source\0.1.0\.local\preview`