### PR TITLE
feat(native-renderer): capture bounded draw state

### DIFF
--- a/docs/native-renderer/CANDIDATE_DRAW_SELECTION.md
+++ b/docs/native-renderer/CANDIDATE_DRAW_SELECTION.md
@@ -129,3 +129,16 @@ recorded in [GEOMETRY_CONTRACT.md](GEOMETRY_CONTRACT.md). The candidate remains
 `needs_visual_and_dependency_review`; the new selection proves repeatable
 metadata and an exact shader specialization, not visual suitability or static
 texture provenance.
+
+## NR-02C draw-state extension
+
+Patch `0054` adds the used constant registers and raw texture/sampler inputs to
+each candidate summary. Constant or texture-state overflow is an automatic
+rejection. The selector carries the first bounded snapshot from each inventory
+and its draw-state hash. Decoding and the safety boundary are documented in
+[DRAW_STATE_CONTRACT.md](DRAW_STATE_CONTRACT.md).
+
+Two post-`0054` captures selected candidate `08810649442C4213` as the sole
+bounded match. Its draw-state hash was identical in both captures. This is the
+NR-02C subject going forward; earlier provisional signatures remain historical
+because each observer extension intentionally changes the structural identity.

--- a/docs/native-renderer/DRAW_STATE_CONTRACT.md
+++ b/docs/native-renderer/DRAW_STATE_CONTRACT.md
@@ -1,0 +1,79 @@
+# Native draw-state contract
+
+NR-02C captures the immutable shader inputs needed to describe one authentic
+draw without changing the displayed frame. Patch
+`0054-graphics-draw-state-observer.patch` extends the existing synchronous draw
+observer immediately before `IssueDraw`. Xenos remains the only draw authority.
+
+## Captured state
+
+The observer copies only registers referenced by the active shaders:
+
+- up to 64 used vertex float4 constants and 64 used pixel float4 constants,
+  each tagged with its shader-bank index;
+- the used-bit maps and packed values for 256 bool constants;
+- the used loop constants from the 32-register loop bank;
+- up to 16 texture-fetch instruction instances, including stage, fetch index,
+  the raw six-word Xenos texture fetch constant, instruction dimension, filter
+  overrides, LOD bias, half-texel offsets, predication flags, and result
+  swizzle; and
+- an exact hash of the captured state for cross-capture stability reporting.
+
+The bounds are explicit. Any constant or texture instruction overflow makes a
+candidate ineligible. Texture bytes, vertex bytes, index bytes, shader bytecode,
+and render targets are not read by this observer.
+
+## Decoder
+
+`tools/build-native-draw-state-contract.py` accepts an exact candidate-selection
+inventory. The initial contract requires one selected candidate and one texture
+resource, while preserving every observed instruction that references it. It
+validates constant counts and indices, decodes all 64 Xenos
+texture format identities, dimensions stored with minus-one sizing, physical
+base and mip addresses, pitch, tiling, endianness, signs, component swizzle,
+number format, exponent adjustment, clamp modes, effective filtering,
+anisotropy, mip range, fetch and instruction LOD bias, instruction offsets, and
+result routing.
+
+The generated document reports whether the sampled draw-state hash is stable
+across captures. A changing hash is valid for an authentic snapshot, but blocks
+claims that the state is static and must be accounted for by later replay.
+
+## NR-02C qualification
+
+Two post-`0054` AppData-backed `open_world_day` captures selected exactly one
+repeatable candidate:
+
+| Session | Draws | Candidate records | Median FPS | 1% low FPS |
+| --- | ---: | ---: | ---: | ---: |
+| `20260828T055422Z-p40612` | 120,863 | 36 | 60.015 | 28.900 |
+| `20260828T055517Z-p39584` | 129,284 | 39 | 59.948 | 28.370 |
+
+Candidate `08810649442C4213` has the same draw-state hash,
+`6038AE2E348D3441`, in both captures. Its bounded snapshot contains two vertex
+float constants, no pixel float, bool, or loop constants, and one pixel texture
+instruction. The texture is a tiled 1280 by 720
+`2_10_10_10_AS_16_16_16_16` resource with a 1,280-pixel pitch, point base-map
+sampling, and the observed `[2, 1, 0, 5]` component selectors. The geometry
+planner also validates the draw's 24 vertices against its complete 384-byte
+binding.
+
+Both runs exited normally with zero observer overflow and no memexport, XMA, or
+ZPD fallback activity. This closes the metadata and decode gate for NR-02C; the
+half-pixel and output interpretation remain explicitly reserved for the
+isolated visual comparison in NR-02E.
+
+## Safety boundary
+
+This contract deliberately stops before resource payload access. Its safety
+record fixes the following values:
+
+- guest resource payload read: false;
+- native upload: false;
+- native draw: false;
+- suppression allowed: false; and
+- Xenos authority: true.
+
+The next milestone may copy the selected snapshot's bounded resources into an
+isolated native target. It must preserve these gates until visual and dependency
+comparison is complete.

--- a/docs/native-renderer/RENDER_PASS_CENSUS.md
+++ b/docs/native-renderer/RENDER_PASS_CENSUS.md
@@ -111,3 +111,10 @@ minimum index allocation length across census windows. The deterministic
 contract builder independently decodes and validates the captured declaration
 without reading guest payloads. Qualification details are in
 [`GEOMETRY_CONTRACT.md`](GEOMETRY_CONTRACT.md); Xenos remains authoritative.
+
+## NR-02C draw-state extension
+
+Used shader constants plus texture-fetch and sampler state are captured by the
+bounded NR-02C observer and decoded as described in
+[`DRAW_STATE_CONTRACT.md`](DRAW_STATE_CONTRACT.md). This state remains
+register-only; the census still performs no guest resource payload reads.

--- a/patches/rexglue/0054-graphics-draw-state-observer.patch
+++ b/patches/rexglue/0054-graphics-draw-state-observer.patch
@@ -1,0 +1,187 @@
+diff --git a/include/rex/system/interfaces/graphics.h b/include/rex/system/interfaces/graphics.h
+--- a/include/rex/system/interfaces/graphics.h
++++ b/include/rex/system/interfaces/graphics.h
+@@ -110,6 +110,31 @@ struct GraphicsVertexAttributeObservation {
+ 
+ constexpr uint32_t kGraphicsVertexAttributeObservationLimit = 32;
+ 
++struct GraphicsFloatConstantObservation {
++  uint32_t index = 0;
++  uint32_t values[4] = {};
++};
++
++constexpr uint32_t kGraphicsFloatConstantObservationLimit = 64;
++
++struct GraphicsTextureFetchObservation {
++  uint32_t stage = 0;
++  uint32_t fetch_constant = 0;
++  uint32_t dwords[6] = {};
++  uint32_t opcode = 0;
++  uint32_t dimension = 0;
++  uint32_t filters = 0;
++  uint32_t flags = 0;
++  uint32_t lod_bias = 0;
++  uint32_t offsets = 0;
++  uint32_t result_storage_target = 0;
++  uint32_t result_storage_index = 0;
++  uint32_t result_write_mask = 0;
++  uint32_t result_components = 0;
++};
++
++constexpr uint32_t kGraphicsTextureFetchObservationLimit = 16;
++
+ struct GraphicsDrawObservation {
+   uint64_t frame_sequence = 0;
+   uint64_t draw_sequence = 0;
+@@ -151,6 +176,22 @@ struct GraphicsDrawObservation {
+   uint32_t pa_su_vtx_cntl = 0;
+   uint32_t texture_fetch_addresses[32] = {};
+   uint32_t texture_fetch_mip_addresses[32] = {};
++  uint32_t vertex_float_constant_count = 0;
++  GraphicsFloatConstantObservation vertex_float_constants
++      [kGraphicsFloatConstantObservationLimit] = {};
++  uint32_t vertex_float_constant_overflow = 0;
++  uint32_t pixel_float_constant_count = 0;
++  GraphicsFloatConstantObservation pixel_float_constants
++      [kGraphicsFloatConstantObservationLimit] = {};
++  uint32_t pixel_float_constant_overflow = 0;
++  uint32_t bool_constant_bitmap[8] = {};
++  uint32_t bool_constant_values[8] = {};
++  uint32_t loop_constant_bitmap = 0;
++  uint32_t loop_constant_values[32] = {};
++  uint32_t texture_state_count = 0;
++  GraphicsTextureFetchObservation
++      texture_states[kGraphicsTextureFetchObservationLimit] = {};
++  uint32_t texture_state_overflow = 0;
+   bool indexed = false;
+   bool major_mode_explicit = false;
+   bool vertex_memexport = false;
+diff --git a/src/graphics/command_processor.cpp b/src/graphics/command_processor.cpp
+--- a/src/graphics/command_processor.cpp
++++ b/src/graphics/command_processor.cpp
+@@ -1597,7 +1597,66 @@ bool CommandProcessor::ExecutePacketType3Draw(memory::RingBuffer* reader, uint32
+         observation.pa_su_sc_mode_cntl =
+             register_file_->Get<reg::PA_SU_SC_MODE_CNTL>().value;
+         observation.pa_su_vtx_cntl = register_file_->Get<reg::PA_SU_VTX_CNTL>().value;
+-        auto capture_texture_fetches = [&](Shader* shader) {
++        auto capture_float_constants = [&](Shader* shader, uint32_t register_base,
++                                           system::GraphicsFloatConstantObservation* output,
++                                           uint32_t& output_count, uint32_t& overflow) {
++          if (!shader) {
++            return;
++          }
++          const Shader::ConstantRegisterMap& constant_map =
++              shader->constant_register_map();
++          output_count = constant_map.float_count;
++          uint32_t output_index = 0;
++          for (uint32_t block = 0; block < 4; ++block) {
++            uint64_t remaining = constant_map.float_bitmap[block];
++            uint32_t bit;
++            while (rex::bit_scan_forward(remaining, &bit)) {
++              remaining &= ~(uint64_t(1) << bit);
++              if (output_index >=
++                  system::kGraphicsFloatConstantObservationLimit) {
++                overflow = 1;
++                continue;
++              }
++              const uint32_t constant_index = block * 64 + bit;
++              output[output_index].index = constant_index;
++              std::memcpy(output[output_index].values,
++                          &(*register_file_)[register_base + constant_index * 4],
++                          sizeof(output[output_index].values));
++              ++output_index;
++            }
++          }
++        };
++        capture_float_constants(
++            active_vertex_shader_, XE_GPU_REG_SHADER_CONSTANT_000_X,
++            observation.vertex_float_constants,
++            observation.vertex_float_constant_count,
++            observation.vertex_float_constant_overflow);
++        capture_float_constants(
++            active_pixel_shader_, XE_GPU_REG_SHADER_CONSTANT_256_X,
++            observation.pixel_float_constants,
++            observation.pixel_float_constant_count,
++            observation.pixel_float_constant_overflow);
++        auto capture_bool_loop_usage = [&](Shader* shader) {
++          if (!shader) {
++            return;
++          }
++          const Shader::ConstantRegisterMap& constant_map =
++              shader->constant_register_map();
++          for (uint32_t i = 0; i < 8; ++i) {
++            observation.bool_constant_bitmap[i] |= constant_map.bool_bitmap[i];
++          }
++          observation.loop_constant_bitmap |= constant_map.loop_bitmap;
++        };
++        capture_bool_loop_usage(active_vertex_shader_);
++        capture_bool_loop_usage(active_pixel_shader_);
++        std::memcpy(
++            observation.bool_constant_values,
++            &(*register_file_)[XE_GPU_REG_SHADER_CONSTANT_BOOL_000_031],
++            sizeof(observation.bool_constant_values));
++        std::memcpy(observation.loop_constant_values,
++                    &(*register_file_)[XE_GPU_REG_SHADER_CONSTANT_LOOP_00],
++                    sizeof(observation.loop_constant_values));
++        auto capture_texture_fetches = [&](Shader* shader, uint32_t stage) {
+           if (!shader) {
+             return;
+           }
+@@ -1611,10 +1670,55 @@ bool CommandProcessor::ExecutePacketType3Draw(memory::RingBuffer* reader, uint32
+             observation.texture_fetch_mask |= uint32_t(1) << fetch_index;
+             observation.texture_fetch_addresses[fetch_index] = fetch.base_address << 12;
+             observation.texture_fetch_mip_addresses[fetch_index] = fetch.mip_address << 12;
++            const uint32_t state_index = observation.texture_state_count++;
++            if (state_index >= system::kGraphicsTextureFetchObservationLimit) {
++              observation.texture_state_overflow = 1;
++              continue;
++            }
++            const ParsedTextureFetchInstruction& instruction = binding.fetch_instr;
++            auto& state = observation.texture_states[state_index];
++            state.stage = stage;
++            state.fetch_constant = fetch_index;
++            std::memcpy(state.dwords, &fetch, sizeof(state.dwords));
++            state.opcode = uint32_t(instruction.opcode);
++            state.dimension = uint32_t(instruction.dimension);
++            state.filters =
++                uint32_t(instruction.attributes.mag_filter) |
++                (uint32_t(instruction.attributes.min_filter) << 4) |
++                (uint32_t(instruction.attributes.mip_filter) << 8) |
++                (uint32_t(instruction.attributes.aniso_filter) << 12) |
++                (uint32_t(instruction.attributes.vol_mag_filter) << 16) |
++                (uint32_t(instruction.attributes.vol_min_filter) << 20);
++            state.flags =
++                (instruction.is_predicated ? 1u : 0u) |
++                (instruction.predicate_condition ? 2u : 0u) |
++                (instruction.attributes.fetch_valid_only ? 4u : 0u) |
++                (instruction.attributes.unnormalized_coordinates ? 8u : 0u) |
++                (instruction.attributes.use_computed_lod ? 16u : 0u) |
++                (instruction.attributes.use_register_lod ? 32u : 0u) |
++                (instruction.attributes.use_register_gradients ? 64u : 0u);
++            std::memcpy(&state.lod_bias, &instruction.attributes.lod_bias,
++                        sizeof(state.lod_bias));
++            const auto pack_offset = [](float value) {
++              int32_t scaled = int32_t(std::lround(value * 2.0f));
++              return uint32_t(scaled) & 0xFF;
++            };
++            state.offsets = pack_offset(instruction.attributes.offset_x) |
++                            (pack_offset(instruction.attributes.offset_y) << 8) |
++                            (pack_offset(instruction.attributes.offset_z) << 16);
++            state.result_storage_target =
++                uint32_t(instruction.result.storage_target);
++            state.result_storage_index = instruction.result.storage_index;
++            state.result_write_mask = instruction.result.GetUsedWriteMask();
++            for (uint32_t component = 0; component < 4; ++component) {
++              state.result_components |=
++                  uint32_t(instruction.result.components[component])
++                  << (component * 3);
++            }
+           }
+         };
+-        capture_texture_fetches(active_vertex_shader_);
+-        capture_texture_fetches(active_pixel_shader_);
++        capture_texture_fetches(active_vertex_shader_, 1);
++        capture_texture_fetches(active_pixel_shader_, 2);
+         draw_observer(observation);
+       }
+       draw_succeeded = IssueDraw(vgt_draw_initiator.prim_type, vgt_draw_initiator.num_indices,

--- a/src/native_renderer/graphics_hooks.cpp
+++ b/src/native_renderer/graphics_hooks.cpp
@@ -161,6 +161,125 @@ uint64_t HashCombine(uint64_t hash, uint64_t value) {
   return hash ^ value;
 }
 
+uint64_t DrawStateHash(
+    const rex::system::GraphicsDrawObservation &observation) {
+  uint64_t hash = 0xCBF29CE484222325ull;
+  const auto hash_float_constants = [&](const auto *constants, uint32_t count) {
+    const uint32_t bounded_count = std::min(
+        count, rex::system::kGraphicsFloatConstantObservationLimit);
+    for (uint32_t i = 0; i < bounded_count; ++i) {
+      hash = HashCombine(hash, constants[i].index);
+      for (uint32_t value : constants[i].values) {
+        hash = HashCombine(hash, value);
+      }
+    }
+  };
+  hash_float_constants(observation.vertex_float_constants,
+                       observation.vertex_float_constant_count);
+  hash_float_constants(observation.pixel_float_constants,
+                       observation.pixel_float_constant_count);
+  for (uint32_t i = 0; i < 8; ++i) {
+    hash = HashCombine(hash, observation.bool_constant_bitmap[i]);
+    hash = HashCombine(hash, observation.bool_constant_values[i] &
+                                 observation.bool_constant_bitmap[i]);
+  }
+  hash = HashCombine(hash, observation.loop_constant_bitmap);
+  for (uint32_t i = 0; i < 32; ++i) {
+    if (observation.loop_constant_bitmap & (1u << i)) {
+      hash = HashCombine(hash, observation.loop_constant_values[i]);
+    }
+  }
+  const uint32_t texture_count = std::min(
+      observation.texture_state_count,
+      rex::system::kGraphicsTextureFetchObservationLimit);
+  for (uint32_t i = 0; i < texture_count; ++i) {
+    const auto &state = observation.texture_states[i];
+    for (uint32_t value :
+         {state.stage, state.fetch_constant, state.opcode, state.dimension,
+          state.filters, state.flags, state.lod_bias, state.offsets,
+          state.result_storage_target, state.result_storage_index,
+          state.result_write_mask, state.result_components}) {
+      hash = HashCombine(hash, value);
+    }
+    for (uint32_t value : state.dwords) {
+      hash = HashCombine(hash, value);
+    }
+  }
+  return hash ? hash : 1;
+}
+
+std::string SerializeFloatConstants(
+    const rex::system::GraphicsFloatConstantObservation *constants,
+    uint32_t count) {
+  std::string result;
+  const uint32_t bounded_count = std::min(
+      count, rex::system::kGraphicsFloatConstantObservationLimit);
+  for (uint32_t i = 0; i < bounded_count; ++i) {
+    if (!result.empty()) {
+      result += ";";
+    }
+    result += fmt::format("{}:{:08X}:{:08X}:{:08X}:{:08X}",
+                          constants[i].index, constants[i].values[0],
+                          constants[i].values[1], constants[i].values[2],
+                          constants[i].values[3]);
+  }
+  return result;
+}
+
+std::string SerializeWordConstants(const uint32_t *bitmap,
+                                   const uint32_t *values,
+                                   uint32_t word_count) {
+  std::string result;
+  for (uint32_t i = 0; i < word_count; ++i) {
+    if (!bitmap[i]) {
+      continue;
+    }
+    if (!result.empty()) {
+      result += ";";
+    }
+    result += fmt::format("{}:{:08X}:{:08X}", i, bitmap[i], values[i]);
+  }
+  return result;
+}
+
+std::string SerializeLoopConstants(uint32_t bitmap, const uint32_t *values) {
+  std::string result;
+  for (uint32_t i = 0; i < 32; ++i) {
+    if (!(bitmap & (uint32_t(1) << i))) {
+      continue;
+    }
+    if (!result.empty()) {
+      result += ";";
+    }
+    result += fmt::format("{}:{:08X}", i, values[i]);
+  }
+  return result;
+}
+
+std::string SerializeTextureStates(
+    const rex::system::GraphicsDrawObservation &observation) {
+  std::string result;
+  const uint32_t bounded_count = std::min(
+      observation.texture_state_count,
+      rex::system::kGraphicsTextureFetchObservationLimit);
+  for (uint32_t i = 0; i < bounded_count; ++i) {
+    const auto &state = observation.texture_states[i];
+    if (!result.empty()) {
+      result += ";";
+    }
+    result += fmt::format(
+        "{}:{}:{:08X}:{:08X}:{:08X}:{:08X}:{:08X}:{:08X}:{}:{}:{:06X}:"
+        "{:02X}:{:08X}:{:06X}:{}:{}:{:X}:{:X}",
+        state.stage, state.fetch_constant, state.dwords[0], state.dwords[1],
+        state.dwords[2], state.dwords[3], state.dwords[4], state.dwords[5],
+        state.opcode, state.dimension, state.filters, state.flags,
+        state.lod_bias, state.offsets, state.result_storage_target,
+        state.result_storage_index, state.result_write_mask,
+        state.result_components);
+  }
+  return result;
+}
+
 size_t ResolveTargetIndex(uint32_t address) {
   size_t index = size_t(HashCombine(0xCBF29CE484222325ull, address) %
                         kResolveTargetCapacity);
@@ -400,6 +519,12 @@ CandidateSignature(const rex::system::GraphicsDrawObservation &observation,
                          uint64_t(observation.vertex_binding_overflow),
                          uint64_t(observation.vertex_attribute_count),
                          uint64_t(observation.vertex_attribute_overflow),
+                         uint64_t(observation.vertex_float_constant_count),
+                         uint64_t(observation.vertex_float_constant_overflow),
+                         uint64_t(observation.pixel_float_constant_count),
+                         uint64_t(observation.pixel_float_constant_overflow),
+                         uint64_t(observation.texture_state_count),
+                         uint64_t(observation.texture_state_overflow),
                          uint64_t(observation.viz_query_condition),
                          uint64_t(observation.pa_sc_viz_query),
                          uint64_t(samples_resolved_target),
@@ -440,6 +565,23 @@ CandidateSignature(const rex::system::GraphicsDrawObservation &observation,
           uint64_t(attribute.result_storage_index),
           uint64_t(attribute.result_write_mask),
           uint64_t(attribute.result_components), uint64_t(attribute.flags)}) {
+      hash = HashCombine(hash, value);
+    }
+  }
+  for (uint32_t value : observation.bool_constant_bitmap) {
+    hash = HashCombine(hash, value);
+  }
+  hash = HashCombine(hash, observation.loop_constant_bitmap);
+  const uint32_t bounded_texture_count = std::min(
+      observation.texture_state_count,
+      rex::system::kGraphicsTextureFetchObservationLimit);
+  for (uint32_t i = 0; i < bounded_texture_count; ++i) {
+    const auto &state = observation.texture_states[i];
+    for (uint32_t value :
+         {state.stage, state.fetch_constant, state.opcode, state.dimension,
+          state.filters, state.flags, state.lod_bias, state.offsets,
+          state.result_storage_target, state.result_storage_index,
+          state.result_write_mask, state.result_components}) {
       hash = HashCombine(hash, value);
     }
   }
@@ -609,6 +751,25 @@ void EmitCandidateCensusWindow(uint64_t last_frame_value) {
          {"vertex_attributes", vertex_attributes},
          {"texture_fetch_count",
           std::to_string(std::popcount(sample.texture_fetch_mask))},
+         {"draw_state_hash", fmt::format("{:016X}", DrawStateHash(sample))},
+         {"vertex_float_constant_count",
+          std::to_string(sample.vertex_float_constant_count)},
+         {"vertex_float_constants",
+          SerializeFloatConstants(sample.vertex_float_constants,
+                                  sample.vertex_float_constant_count)},
+         {"pixel_float_constant_count",
+          std::to_string(sample.pixel_float_constant_count)},
+         {"pixel_float_constants",
+          SerializeFloatConstants(sample.pixel_float_constants,
+                                  sample.pixel_float_constant_count)},
+         {"bool_constants",
+          SerializeWordConstants(sample.bool_constant_bitmap,
+                                 sample.bool_constant_values, 8)},
+         {"loop_constants",
+          SerializeLoopConstants(sample.loop_constant_bitmap,
+                                 sample.loop_constant_values)},
+         {"texture_state_count", std::to_string(sample.texture_state_count)},
+         {"texture_states", SerializeTextureStates(sample)},
          {"pipeline_state", pipeline_state},
          {"indexed", sample.indexed ? "true" : "false"},
          {"query", query_draw ? "true" : "false"},
@@ -618,6 +779,13 @@ void EmitCandidateCensusWindow(uint64_t last_frame_value) {
          {"vertex_overflow", sample.vertex_binding_overflow ? "true" : "false"},
          {"vertex_attribute_overflow",
           sample.vertex_attribute_overflow ? "true" : "false"},
+         {"constant_overflow",
+          (sample.vertex_float_constant_overflow ||
+           sample.pixel_float_constant_overflow)
+              ? "true"
+              : "false"},
+         {"texture_state_overflow",
+          sample.texture_state_overflow ? "true" : "false"},
          {"qualification", "metadata_shortlist_only"},
          {"suppression_eligible", "false"}});
   }

--- a/tools/build-native-draw-state-contract.py
+++ b/tools/build-native-draw-state-contract.py
@@ -1,0 +1,279 @@
+#!/usr/bin/env python3
+"""Build a bounded NR-02 constant, texture, and sampler contract."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import struct
+from pathlib import Path
+from typing import Any
+
+
+SCHEMA = "pinyon-shift.native-draw-state-contract.v1"
+SELECTION_SCHEMA = "pinyon-shift.native-renderer-candidate-selection.v1"
+PHYSICAL_MASK = 0x1FFFFFFF
+TEXTURE_FORMATS = [
+    "1_REVERSE", "1", "8", "1_5_5_5", "5_6_5", "6_5_5", "8_8_8_8",
+    "2_10_10_10", "8_A", "8_B", "8_8", "Cr_Y1_Cb_Y0_REP",
+    "Y1_Cr_Y0_Cb_REP", "16_16_EDRAM", "8_8_8_8_A", "4_4_4_4",
+    "10_11_11", "11_11_10", "DXT1", "DXT2_3", "DXT4_5",
+    "16_16_16_16_EDRAM", "24_8", "24_8_FLOAT", "16", "16_16",
+    "16_16_16_16", "16_EXPAND", "16_16_EXPAND", "16_16_16_16_EXPAND",
+    "16_FLOAT", "16_16_FLOAT", "16_16_16_16_FLOAT", "32", "32_32",
+    "32_32_32_32", "32_FLOAT", "32_32_FLOAT", "32_32_32_32_FLOAT",
+    "32_AS_8", "32_AS_8_8", "16_MPEG", "16_16_MPEG", "8_INTERLACED",
+    "32_AS_8_INTERLACED", "32_AS_8_8_INTERLACED", "16_INTERLACED",
+    "16_MPEG_INTERLACED", "16_16_MPEG_INTERLACED", "DXN",
+    "8_8_8_8_AS_16_16_16_16", "DXT1_AS_16_16_16_16",
+    "DXT2_3_AS_16_16_16_16", "DXT4_5_AS_16_16_16_16",
+    "2_10_10_10_AS_16_16_16_16", "10_11_11_AS_16_16_16_16",
+    "11_11_10_AS_16_16_16_16", "32_32_32_FLOAT", "DXT3A", "DXT5A",
+    "CTX1", "DXT3A_AS_1_1_1_1", "8_8_8_8_GAMMA_EDRAM",
+    "2_10_10_10_FLOAT_EDRAM",
+]
+DIMENSIONS = ["1d", "2d_or_stacked", "3d", "cube"]
+FETCH_DIMENSIONS = ["1d", "2d", "3d_or_stacked", "cube"]
+ENDIANNESS = ["none", "8in16", "8in32", "16in32"]
+CLAMP = [
+    "repeat", "mirrored_repeat", "clamp_to_edge", "mirror_clamp_to_edge",
+    "clamp_to_halfway", "mirror_clamp_to_halfway", "clamp_to_border",
+    "mirror_clamp_to_border",
+]
+FILTER = ["point", "linear", "base_map", "use_fetch_constant"]
+ANISO = {
+    0: "disabled", 1: "max_1_1", 2: "max_2_1", 3: "max_4_1",
+    4: "max_8_1", 5: "max_16_1", 7: "use_fetch_constant",
+}
+
+
+def parse_hex_words(value: Any, fields: int, label: str) -> list[int]:
+    parts = str(value or "").split(":")
+    if len(parts) != fields:
+        raise ValueError(f"invalid {label}: {value!r}")
+    try:
+        return [int(part, 16) for part in parts]
+    except ValueError as error:
+        raise ValueError(f"invalid {label}: {value!r}") from error
+
+
+def parse_float_constants(value: Any, expected: int) -> list[dict[str, Any]]:
+    if not value and expected == 0:
+        return []
+    result = []
+    for item in str(value).split(";"):
+        fields = item.split(":")
+        if len(fields) != 5:
+            raise ValueError(f"invalid float constant: {item!r}")
+        index = int(fields[0])
+        words = [int(word, 16) for word in fields[1:]]
+        result.append(
+            {
+                "index": index,
+                "words": [f"{word:08X}" for word in words],
+                "values": [struct.unpack("<f", word.to_bytes(4, "little"))[0] for word in words],
+            }
+        )
+    if len(result) != expected or len({item["index"] for item in result}) != expected:
+        raise ValueError("float constant count or indices are inconsistent")
+    if any(item["index"] < 0 or item["index"] >= 256 for item in result):
+        raise ValueError("float constant index is outside the shader bank")
+    return result
+
+
+def parse_bool_constants(value: Any) -> list[dict[str, Any]]:
+    if not value:
+        return []
+    result = []
+    for item in str(value).split(";"):
+        word, bitmap, packed = parse_hex_words(item, 3, "bool constant word")
+        if word >= 8 or not bitmap:
+            raise ValueError("invalid bool constant word")
+        result.append({"word": word, "used_bitmap": f"{bitmap:08X}", "value": f"{packed:08X}"})
+    if len({item["word"] for item in result}) != len(result):
+        raise ValueError("duplicate bool constant word")
+    return result
+
+
+def parse_loop_constants(value: Any) -> list[dict[str, Any]]:
+    if not value:
+        return []
+    result = []
+    for item in str(value).split(";"):
+        fields = item.split(":")
+        if len(fields) != 2:
+            raise ValueError(f"invalid loop constant: {item!r}")
+        index, word = int(fields[0]), int(fields[1], 16)
+        if index < 0 or index >= 32:
+            raise ValueError("loop constant index is outside the register bank")
+        result.append({"index": index, "word": f"{word:08X}"})
+    if len({item["index"] for item in result}) != len(result):
+        raise ValueError("duplicate loop constant")
+    return result
+
+
+def signed(value: int, bits: int) -> int:
+    sign = 1 << (bits - 1)
+    return (value ^ sign) - sign
+
+
+def effective_filter(override: int, fetch: int, names: Any) -> str:
+    value = fetch if override == 3 else override
+    return names[value]
+
+
+def decode_texture(value: Any) -> dict[str, Any]:
+    parts = str(value or "").split(":")
+    if len(parts) != 18:
+        raise ValueError(f"invalid texture state: {value!r}")
+    stage, fetch_constant = int(parts[0]), int(parts[1])
+    words = [int(part, 16) for part in parts[2:8]]
+    opcode, fetch_dimension = int(parts[8]), int(parts[9])
+    overrides, flags = int(parts[10], 16), int(parts[11], 16)
+    instruction_lod_bias, offsets = int(parts[12], 16), int(parts[13], 16)
+    result_target, result_index = int(parts[14]), int(parts[15])
+    result_mask, result_components = int(parts[16], 16), int(parts[17], 16)
+    if stage not in (1, 2) or fetch_constant >= 32 or fetch_dimension >= 4:
+        raise ValueError("invalid texture instruction identity")
+    word0, word1, word2, word3, word4, word5 = words
+    if (word0 & 0x3) not in (2, 3):
+        raise ValueError("texture fetch constant is not a texture")
+    texture_format = word1 & 0x3F
+    dimension = (word5 >> 9) & 0x3
+    base_address = ((word1 >> 12) << 12) & PHYSICAL_MASK
+    mip_address = ((word5 >> 12) << 12) & PHYSICAL_MASK
+    if dimension == 0:
+        size = {"width": (word2 & 0xFFFFFF) + 1, "height": 1, "depth": 1}
+    elif dimension in (1, 3):
+        size = {
+            "width": (word2 & 0x1FFF) + 1,
+            "height": ((word2 >> 13) & 0x1FFF) + 1,
+            "depth": ((word2 >> 26) & 0x3F) + 1 if word0 >> 10 & 1 else 1,
+        }
+    else:
+        size = {
+            "width": (word2 & 0x7FF) + 1,
+            "height": ((word2 >> 11) & 0x7FF) + 1,
+            "depth": ((word2 >> 22) & 0x3FF) + 1,
+        }
+    fetch_filters = [(word3 >> shift) & 0x3 for shift in (19, 21, 23)]
+    override_filters = [(overrides >> shift) & 0xF for shift in (0, 4, 8)]
+    if any(value >= 4 for value in override_filters):
+        raise ValueError("texture instruction filter override is invalid")
+    fetch_aniso, override_aniso = (word3 >> 25) & 0x7, (overrides >> 12) & 0xF
+    if fetch_aniso not in ANISO or override_aniso not in ANISO:
+        raise ValueError("anisotropic filter is invalid")
+    return {
+        "stage": "vertex" if stage == 1 else "pixel",
+        "fetch_constant": fetch_constant,
+        "raw_words": [f"{word:08X}" for word in words],
+        "format": {"code": texture_format, "name": TEXTURE_FORMATS[texture_format]},
+        "dimension": DIMENSIONS[dimension],
+        "fetch_dimension": FETCH_DIMENSIONS[fetch_dimension],
+        "size": size,
+        "base_address": f"{base_address:08X}",
+        "mip_address": f"{mip_address:08X}",
+        "pitch_pixels": ((word0 >> 22) & 0x1FF) << 5,
+        "tiled": bool(word0 >> 31),
+        "stacked": bool((word1 >> 10) & 1),
+        "endianness": ENDIANNESS[(word1 >> 6) & 0x3],
+        "sign": [(word0 >> shift) & 0x3 for shift in (2, 4, 6, 8)],
+        "swizzle": [(word3 >> (1 + component * 3)) & 0x7 for component in range(4)],
+        "number_format": "integer" if word3 & 1 else "fractional",
+        "exponent_adjust": signed((word3 >> 13) & 0x3F, 6),
+        "clamp": [CLAMP[(word0 >> shift) & 0x7] for shift in (10, 13, 16)],
+        "filter": {
+            "mag": effective_filter(override_filters[0], fetch_filters[0], FILTER),
+            "min": effective_filter(override_filters[1], fetch_filters[1], FILTER),
+            "mip": effective_filter(override_filters[2], fetch_filters[2], FILTER),
+            "anisotropic": ANISO[fetch_aniso if override_aniso == 7 else override_aniso],
+        },
+        "mip_range": {"minimum": (word4 >> 2) & 0xF, "maximum": (word4 >> 6) & 0xF},
+        "fetch_lod_bias": signed((word4 >> 12) & 0x3FF, 10) / 32.0,
+        "instruction_lod_bias": struct.unpack("<f", instruction_lod_bias.to_bytes(4, "little"))[0],
+        "instruction_offsets_half_texel": [
+            signed((offsets >> shift) & 0xFF, 8) for shift in (0, 8, 16)
+        ],
+        "instruction_flags": flags,
+        "result": {
+            "storage_target": result_target,
+            "storage_index": result_index,
+            "write_mask": result_mask,
+            "components": result_components,
+        },
+        "opcode": opcode,
+    }
+
+
+def build(selection: dict[str, Any], signature: str | None = None) -> dict[str, Any]:
+    if selection.get("schema") != SELECTION_SCHEMA:
+        raise ValueError("unsupported candidate selection schema")
+    candidates = selection.get("candidates", [])
+    if signature:
+        candidates = [item for item in candidates if item.get("signature") == signature]
+    if len(candidates) != 1:
+        raise ValueError("draw-state contract requires exactly one selected candidate")
+    candidate = candidates[0]
+    texture_count = int(candidate.get("texture_state_count", 0))
+    texture_values = str(candidate.get("texture_states") or "").split(";") if texture_count else []
+    if len(texture_values) != texture_count or texture_count < 1:
+        raise ValueError("draw-state contract requires observed texture states")
+    textures = [decode_texture(value) for value in texture_values]
+    resources = {
+        (texture["fetch_constant"], tuple(texture["raw_words"])) for texture in textures
+    }
+    if len(resources) != 1:
+        raise ValueError("initial draw-state contract requires exactly one texture resource")
+    hashes = candidate.get("draw_state_hashes", [])
+    if not hashes or any(len(str(value)) != 16 for value in hashes):
+        raise ValueError("candidate has invalid draw-state hashes")
+    return {
+        "schema": SCHEMA,
+        "candidate_signature": candidate["signature"],
+        "draw_state_hashes": hashes,
+        "state_stable_across_captures": len(set(hashes)) == 1,
+        "constants": {
+            "vertex_float": parse_float_constants(
+                candidate.get("vertex_float_constants"),
+                int(candidate.get("vertex_float_constant_count", 0)),
+            ),
+            "pixel_float": parse_float_constants(
+                candidate.get("pixel_float_constants"),
+                int(candidate.get("pixel_float_constant_count", 0)),
+            ),
+            "bool": parse_bool_constants(candidate.get("bool_constants")),
+            "loop": parse_loop_constants(candidate.get("loop_constants")),
+        },
+        "texture_resource_count": len(resources),
+        "textures": textures,
+        "half_pixel_behavior": {
+            "pa_su_vtx_cntl": candidate.get("pipeline_state"),
+            "requires_isolated_visual_comparison": True,
+        },
+        "safety": {
+            "guest_resource_payload_read": False,
+            "native_upload": False,
+            "native_draw": False,
+            "suppression_allowed": False,
+            "xenos_authority": True,
+        },
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("selection", type=Path)
+    parser.add_argument("--signature")
+    parser.add_argument("--output", "-o", type=Path)
+    args = parser.parse_args()
+    result = build(json.loads(args.selection.read_text(encoding="utf-8")), args.signature)
+    rendered = json.dumps(result, indent=2, allow_nan=False) + "\n"
+    if args.output:
+        args.output.write_text(rendered, encoding="utf-8")
+    else:
+        print(rendered, end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/select-native-renderer-candidate.py
+++ b/tools/select-native-renderer-candidate.py
@@ -62,6 +62,10 @@ def rejection_reasons(record: dict[str, Any]) -> list[str]:
         reasons.append("vertex_binding_overflow")
     if boolean(record, "vertex_attribute_overflow"):
         reasons.append("vertex_attribute_overflow")
+    if boolean(record, "constant_overflow"):
+        reasons.append("constant_observer_overflow")
+    if boolean(record, "texture_state_overflow"):
+        reasons.append("texture_state_observer_overflow")
     if int(record.get("vertex_binding_count", 0)) != 1:
         reasons.append("vertex_binding_count_not_one")
     if int(record.get("texture_fetch_count", 0)) > 1:
@@ -181,6 +185,22 @@ def select(census_paths: list[Path], shader_manifest_path: Path) -> dict[str, An
                 ),
                 "vertex_attributes": sample.get("vertex_attributes"),
                 "texture_fetch_count": int(sample.get("texture_fetch_count", 0)),
+                "draw_state_hashes": [
+                    str(record.get("draw_state_hash", "")).upper()
+                    for record in records
+                ],
+                "vertex_float_constant_count": int(
+                    sample.get("vertex_float_constant_count", 0)
+                ),
+                "vertex_float_constants": sample.get("vertex_float_constants"),
+                "pixel_float_constant_count": int(
+                    sample.get("pixel_float_constant_count", 0)
+                ),
+                "pixel_float_constants": sample.get("pixel_float_constants"),
+                "bool_constants": sample.get("bool_constants"),
+                "loop_constants": sample.get("loop_constants"),
+                "texture_state_count": int(sample.get("texture_state_count", 0)),
+                "texture_states": sample.get("texture_states"),
                 "pipeline_state": sample.get("pipeline_state"),
                 "qualification": "metadata_shortlist_only",
             }

--- a/tools/tests/test_native_renderer_candidate.py
+++ b/tools/tests/test_native_renderer_candidate.py
@@ -33,6 +33,15 @@ def signature(name: str, **overrides):
         "vertex_attribute_count": "1",
         "vertex_attributes": "0:0:0:8:6:F:0:0:0:0:F:688:0",
         "texture_fetch_count": "1",
+        "draw_state_hash": "3333333333333333",
+        "vertex_float_constant_count": "1",
+        "vertex_float_constants": "0:3F800000:00000000:00000000:3F800000",
+        "pixel_float_constant_count": "1",
+        "pixel_float_constants": "0:3F800000:3F800000:3F800000:3F800000",
+        "bool_constants": "0:00000001:00000001",
+        "loop_constants": "",
+        "texture_state_count": "1",
+        "texture_states": "2:0:0:0:0:0:0:0:0:1:0:1C:0:0:0:0:F:688",
         "pipeline_state": "opaque",
         "indexed": "true",
         "query": "false",
@@ -41,6 +50,8 @@ def signature(name: str, **overrides):
         "opaque": "true",
         "vertex_overflow": "false",
         "vertex_attribute_overflow": "false",
+        "constant_overflow": "false",
+        "texture_state_overflow": "false",
     }
     record.update(overrides)
     return record
@@ -110,6 +121,11 @@ class NativeRendererCandidateTests(unittest.TestCase):
         self.assertEqual(6, result["candidates"][0]["index_buffer_length_min"])
         self.assertFalse(result["candidates"][0]["indexed"])
         self.assertEqual(
+            ["3333333333333333", "3333333333333333"],
+            result["candidates"][0]["draw_state_hashes"],
+        )
+        self.assertEqual(1, result["candidates"][0]["texture_state_count"])
+        self.assertEqual(
             "AAAAAAAAAAAAAAAA",
             result["candidates"][0]["vertex_specialization_mask"],
         )
@@ -125,6 +141,18 @@ class NativeRendererCandidateTests(unittest.TestCase):
             signature("BAD", vertex_attribute_overflow="true")
         )
         self.assertIn("vertex_attribute_overflow", reasons)
+
+    def test_rejects_draw_state_overflow(self):
+        self.assertIn(
+            "constant_observer_overflow",
+            MODULE.rejection_reasons(signature("BAD", constant_overflow="true")),
+        )
+        self.assertIn(
+            "texture_state_observer_overflow",
+            MODULE.rejection_reasons(
+                signature("BAD", texture_state_overflow="true")
+            ),
+        )
 
 
 if __name__ == "__main__":

--- a/tools/tests/test_native_renderer_contract.py
+++ b/tools/tests/test_native_renderer_contract.py
@@ -344,6 +344,22 @@ class NativeRendererContractTests(unittest.TestCase):
         ):
             self.assertNotIn(forbidden, declaration_patch)
 
+        draw_state_patch = (
+            ROOT / "patches/rexglue/0054-graphics-draw-state-observer.patch"
+        ).read_text(encoding="utf-8")
+        self.assertIn("kGraphicsFloatConstantObservationLimit = 64", draw_state_patch)
+        self.assertIn("constant_register_map", draw_state_patch)
+        self.assertIn("XE_GPU_REG_SHADER_CONSTANT_256_X", draw_state_patch)
+        self.assertIn("kGraphicsTextureFetchObservationLimit = 16", draw_state_patch)
+        self.assertIn("instruction.attributes.mag_filter", draw_state_patch)
+        self.assertIn("texture_state_overflow", draw_state_patch)
+        for forbidden in (
+            "TranslatePhysical",
+            "SetDrawSuppression",
+            "native_guest_output",
+        ):
+            self.assertNotIn(forbidden, draw_state_patch)
+
         planner = (
             ROOT / "tools/build-native-geometry-contract.py"
         ).read_text(encoding="utf-8")
@@ -353,6 +369,16 @@ class NativeRendererContractTests(unittest.TestCase):
         self.assertIn('"native_draw": False', planner)
         self.assertIn('"suppression_allowed": False', planner)
         self.assertIn('"xenos_authority": True', planner)
+
+        draw_state_planner = (
+            ROOT / "tools/build-native-draw-state-contract.py"
+        ).read_text(encoding="utf-8")
+        self.assertIn("PHYSICAL_MASK = 0x1FFFFFFF", draw_state_planner)
+        self.assertIn('"guest_resource_payload_read": False', draw_state_planner)
+        self.assertIn('"native_upload": False', draw_state_planner)
+        self.assertIn('"native_draw": False', draw_state_planner)
+        self.assertIn('"suppression_allowed": False', draw_state_planner)
+        self.assertIn('"xenos_authority": True', draw_state_planner)
 
     def test_census_ledger_tracks_exact_starting_baseline(self):
         ledger = (ROOT / "docs/native-renderer/RENDER_PASS_CENSUS.md").read_text(

--- a/tools/tests/test_native_renderer_draw_state.py
+++ b/tools/tests/test_native_renderer_draw_state.py
@@ -1,0 +1,121 @@
+import importlib.util
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SPEC = importlib.util.spec_from_file_location(
+    "native_renderer_draw_state",
+    ROOT / "tools/build-native-draw-state-contract.py",
+)
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+def texture_state(**overrides):
+    fields = {
+        "stage": 2,
+        "fetch": 0,
+        "dwords": [
+            2 | (2 << 10) | (2 << 13) | (2 << 16) | (4 << 22) | (1 << 31),
+            6 | (2 << 6) | (0x12345 << 12),
+            63 | (31 << 13),
+            (0x688 << 1) | (1 << 19) | (1 << 21),
+            0,
+            1 << 9,
+        ],
+        "opcode": 1,
+        "dimension": 1,
+        "filters": 0x7333,
+        "flags": 0x14,
+        "lod": 0,
+        "offsets": 0,
+        "target": 0,
+        "index": 0,
+        "mask": 0xF,
+        "components": 0x688,
+    }
+    fields.update(overrides)
+    return ":".join(
+        [str(fields["stage"]), str(fields["fetch"])]
+        + [f"{word:08X}" for word in fields["dwords"]]
+        + [
+            str(fields["opcode"]),
+            str(fields["dimension"]),
+            f"{fields['filters']:06X}",
+            f"{fields['flags']:02X}",
+            f"{fields['lod']:08X}",
+            f"{fields['offsets']:06X}",
+            str(fields["target"]),
+            str(fields["index"]),
+            f"{fields['mask']:X}",
+            f"{fields['components']:X}",
+        ]
+    )
+
+
+def selection(**overrides):
+    candidate = {
+        "signature": "DRAW",
+        "draw_state_hashes": ["1111111111111111", "1111111111111111"],
+        "vertex_float_constant_count": 1,
+        "vertex_float_constants": "0:3F800000:00000000:00000000:3F800000",
+        "pixel_float_constant_count": 1,
+        "pixel_float_constants": "2:3F000000:3F800000:40000000:40400000",
+        "bool_constants": "0:00000003:00000001",
+        "loop_constants": "1:00000002",
+        "texture_state_count": 1,
+        "texture_states": texture_state(),
+        "pipeline_state": "vertex=00000000",
+    }
+    candidate.update(overrides)
+    return {"schema": MODULE.SELECTION_SCHEMA, "candidates": [candidate]}
+
+
+class NativeRendererDrawStateTests(unittest.TestCase):
+    def test_decodes_bounded_constant_texture_and_sampler_state(self):
+        result = MODULE.build(selection())
+        self.assertEqual(MODULE.SCHEMA, result["schema"])
+        self.assertTrue(result["state_stable_across_captures"])
+        self.assertEqual(1.0, result["constants"]["vertex_float"][0]["values"][0])
+        texture = result["textures"][0]
+        self.assertEqual("8_8_8_8", texture["format"]["name"])
+        self.assertEqual("2d_or_stacked", texture["dimension"])
+        self.assertEqual({"width": 64, "height": 32, "depth": 1}, texture["size"])
+        self.assertEqual("linear", texture["filter"]["mag"])
+        self.assertEqual("linear", texture["filter"]["min"])
+        self.assertEqual("point", texture["filter"]["mip"])
+        self.assertEqual("disabled", texture["filter"]["anisotropic"])
+        self.assertFalse(result["safety"]["guest_resource_payload_read"])
+        self.assertFalse(result["safety"]["native_draw"])
+        self.assertTrue(result["safety"]["xenos_authority"])
+
+    def test_reports_dynamic_draw_state_across_captures(self):
+        result = MODULE.build(
+            selection(draw_state_hashes=["1111111111111111", "2222222222222222"])
+        )
+        self.assertFalse(result["state_stable_across_captures"])
+
+    def test_rejects_constant_count_mismatch(self):
+        with self.assertRaisesRegex(ValueError, "count or indices"):
+            MODULE.build(selection(vertex_float_constant_count=2))
+
+    def test_accepts_multiple_instructions_for_one_texture_resource(self):
+        states = ";".join([texture_state(), texture_state(offsets=1)])
+        result = MODULE.build(selection(texture_state_count=2, texture_states=states))
+        self.assertEqual(1, result["texture_resource_count"])
+        self.assertEqual(2, len(result["textures"]))
+
+    def test_rejects_multiple_texture_resources(self):
+        states = ";".join([texture_state(), texture_state(fetch=1)])
+        with self.assertRaisesRegex(ValueError, "exactly one texture resource"):
+            MODULE.build(selection(texture_state_count=2, texture_states=states))
+
+    def test_rejects_non_texture_fetch_constant(self):
+        state = texture_state(dwords=[0, 0, 0, 0, 0, 0])
+        with self.assertRaisesRegex(ValueError, "not a texture"):
+            MODULE.build(selection(texture_states=state))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/tests/test_release_contract.py
+++ b/tools/tests/test_release_contract.py
@@ -43,10 +43,10 @@ class ReleaseContractTests(unittest.TestCase):
 
     def test_rexglue_patches_have_stable_order_and_no_binary_payload(self):
         patches = sorted((ROOT / "patches/rexglue").glob("*.patch"))
-        self.assertEqual(len(patches), 53)
+        self.assertEqual(len(patches), 54)
         self.assertEqual(
             patches[-1].name,
-            "0053-graphics-vertex-declaration-observer.patch",
+            "0054-graphics-draw-state-observer.patch",
         )
         self.assertEqual(len(patches), len({path.name[:4] for path in patches}))
         for path in patches:


### PR DESCRIPTION
## Summary
- capture only shader-used float, bool, loop, texture, and sampler state before the original Xenos draw
- reject bounded-observer overflow and generate deterministic NR-02C draw-state contracts
- qualify one exact candidate across two AppData-backed captures while preserving pass-through authority

## Validation
- `python -m unittest discover -s tools/tests -p 'test_*.py'` (90 tests)
- `.\tools\build-preview.ps1`
- AppData sessions `20260828T055422Z-p40612` and `20260828T055517Z-p39584` exited normally
- selected candidate `08810649442C4213` had stable state hash `6038AE2E348D3441`

## Safety
- no guest resource payload reads
- no native uploads or draws
- no suppression; Xenos remains authoritative