### PR TITLE
fix(native-renderer): reject resolved candidate textures

### DIFF
--- a/docs/native-renderer/CANDIDATE_DRAW_SELECTION.md
+++ b/docs/native-renderer/CANDIDATE_DRAW_SELECTION.md
@@ -138,7 +138,14 @@ rejection. The selector carries the first bounded snapshot from each inventory
 and its draw-state hash. Decoding and the safety boundary are documented in
 [DRAW_STATE_CONTRACT.md](DRAW_STATE_CONTRACT.md).
 
-Two post-`0054` captures selected candidate `08810649442C4213` as the sole
-bounded match. Its draw-state hash was identical in both captures. This is the
-NR-02C subject going forward; earlier provisional signatures remain historical
-because each observer extension intentionally changes the structural identity.
+Two post-`0054` captures initially selected candidate `08810649442C4213` as the
+sole bounded metadata match, with an identical draw-state hash in both runs.
+Cross-checking its decoded texture address against the full resolve-target
+inventory then identified `0x1C149000` as a known resolve destination. The
+candidate is therefore rejected as a dynamic render-target consumer and does
+not advance to PSO construction.
+
+The selector now checks every captured base and mip address against every
+emitted resolve range in each input inventory. This is deliberately stricter
+than the draw-window `resolved_input` bit: a missed timing correlation can no
+longer turn absence of a dependency event into static-texture evidence.

--- a/docs/native-renderer/DRAW_STATE_CONTRACT.md
+++ b/docs/native-renderer/DRAW_STATE_CONTRACT.md
@@ -59,9 +59,11 @@ planner also validates the draw's 24 vertices against its complete 384-byte
 binding.
 
 Both runs exited normally with zero observer overflow and no memexport, XMA, or
-ZPD fallback activity. This closes the metadata and decode gate for NR-02C; the
-half-pixel and output interpretation remain explicitly reserved for the
-isolated visual comparison in NR-02E.
+ZPD fallback activity. This qualifies the capture and decode implementation,
+but not this candidate: its texture base `0x1C149000` is also an observed
+resolve destination. The corrected selector rejects it as a dynamic
+render-target consumer. NR-02C therefore needs a new static-source candidate
+before its output can advance to PSO construction or isolated comparison.
 
 ## Safety boundary
 

--- a/docs/native-renderer/GUEST_VISIBLE_RENDER_DEPENDENCIES.md
+++ b/docs/native-renderer/GUEST_VISIBLE_RENDER_DEPENDENCIES.md
@@ -92,8 +92,10 @@ python .\tools\summarize-native-renderer-census.py `
 
 The summarizer selects the latest census-enabled session unless `--session` is
 provided. Its output includes aggregated draw signatures, every emitted
-resolve-to-texture dependency, overflow totals, and an explicit safety object
-that keeps suppression disabled.
+resolve target, every observed resolve-to-texture dependency, overflow totals,
+and an explicit safety object that keeps suppression disabled. Retaining the
+target inventory lets later candidate selection reject a texture address even
+when the draw-window dependency bit did not observe the transition.
 
 ## Qualification status
 

--- a/docs/native-renderer/RENDER_PASS_CENSUS.md
+++ b/docs/native-renderer/RENDER_PASS_CENSUS.md
@@ -118,3 +118,6 @@ Used shader constants plus texture-fetch and sampler state are captured by the
 bounded NR-02C observer and decoded as described in
 [`DRAW_STATE_CONTRACT.md`](DRAW_STATE_CONTRACT.md). This state remains
 register-only; the census still performs no guest resource payload reads.
+The deterministic inventory also retains every emitted resolve target so the
+candidate selector can reject any captured base or mip address inside a known
+resolve range, independently of draw-window timing.

--- a/tools/select-native-renderer-candidate.py
+++ b/tools/select-native-renderer-candidate.py
@@ -13,6 +13,7 @@ from typing import Any
 SCHEMA = "pinyon-shift.native-renderer-candidate-selection.v1"
 CENSUS_SCHEMA = "pinyon-shift.native-renderer-census.v1"
 SHADER_SCHEMA = "pinyon-shift.native-shader-pack.v1"
+PHYSICAL_MASK = 0x1FFFFFFF
 
 
 def boolean(record: dict[str, Any], key: str) -> bool:
@@ -73,6 +74,45 @@ def rejection_reasons(record: dict[str, Any]) -> list[str]:
     return reasons
 
 
+def texture_addresses(record: dict[str, Any]) -> set[int]:
+    count = int(record.get("texture_state_count", 0))
+    values = str(record.get("texture_states") or "").split(";") if count else []
+    if len(values) != count:
+        raise ValueError("candidate texture-state count is inconsistent")
+    addresses: set[int] = set()
+    for value in values:
+        fields = value.split(":")
+        if len(fields) != 18:
+            raise ValueError(f"candidate has invalid texture state: {value!r}")
+        words = [int(field, 16) for field in fields[2:8]]
+        addresses.add(((words[1] >> 12) << 12) & PHYSICAL_MASK)
+        mip_address = ((words[5] >> 12) << 12) & PHYSICAL_MASK
+        if mip_address:
+            addresses.add(mip_address)
+    return addresses
+
+
+def resolve_ranges(census: dict[str, Any]) -> list[tuple[int, int]]:
+    ranges = []
+    for target in census.get("resolve_targets", []):
+        start = int(str(target.get("address", "0")), 16) & PHYSICAL_MASK
+        length = int(target.get("length", 0))
+        if length <= 0 or start + length > PHYSICAL_MASK + 1:
+            raise ValueError("resolve target has an invalid physical range")
+        ranges.append((start, start + length))
+    return ranges
+
+
+def reads_known_resolve_target(
+    record: dict[str, Any], ranges: list[tuple[int, int]]
+) -> bool:
+    return any(
+        start <= address < end
+        for address in texture_addresses(record)
+        for start, end in ranges
+    )
+
+
 def prepared_pairs(census: dict[str, Any]) -> dict[tuple[str, str], set[tuple[str, str]]]:
     result: dict[tuple[str, str], set[tuple[str, str]]] = {}
     for record in census.get("prepared_shader_pairs", []):
@@ -99,6 +139,7 @@ def select(census_paths: list[Path], shader_manifest_path: Path) -> dict[str, An
         raise ValueError("candidate inventories must use the same scene marker")
     shaders = shader_identities(load_json(shader_manifest_path, SHADER_SCHEMA))
     prepared_by_capture = [prepared_pairs(census) for census in censuses]
+    resolve_ranges_by_capture = [resolve_ranges(census) for census in censuses]
 
     by_capture: list[dict[str, dict[str, Any]]] = []
     for census in censuses:
@@ -114,6 +155,11 @@ def select(census_paths: list[Path], shader_manifest_path: Path) -> dict[str, An
     for signature in sorted(repeated):
         records = [capture[signature] for capture in by_capture]
         reasons = rejection_reasons(records[0])
+        if any(
+            reads_known_resolve_target(record, ranges)
+            for record, ranges in zip(records, resolve_ranges_by_capture)
+        ) and "dynamic_render_target_input" not in reasons:
+            reasons.append("dynamic_render_target_input")
         for reason in reasons:
             rejection_counts[reason] += 1
         if reasons:

--- a/tools/summarize-native-renderer-census.py
+++ b/tools/summarize-native-renderer-census.py
@@ -273,6 +273,9 @@ def summarize(
         "resolve_dependencies": [
             clean(record) for _, record in sorted(dependencies.items())
         ],
+        "resolve_targets": [
+            clean(record) for _, record in sorted(resolve_targets.items())
+        ],
         "safety": {
             "suppression_allowed": False,
             "guest_cpu_reads": "unknown_uninstrumented",

--- a/tools/tests/test_native_renderer_candidate.py
+++ b/tools/tests/test_native_renderer_candidate.py
@@ -57,6 +57,25 @@ def signature(name: str, **overrides):
     return record
 
 
+def texture_state(base_address: int) -> str:
+    fields = signature("STATE")["texture_states"].split(":")
+    fields[3] = f"{base_address >> 12 << 12:08X}"
+    return ":".join(fields)
+
+
+def select_documents(first, second, shader_manifest):
+    with tempfile.TemporaryDirectory() as temp:
+        root = Path(temp)
+        paths = []
+        for index, document in enumerate((first, second)):
+            path = root / f"census-{index}.json"
+            path.write_text(json.dumps(document), encoding="utf-8")
+            paths.append(path)
+        manifest = root / "shader-manifest.json"
+        manifest.write_text(json.dumps(shader_manifest), encoding="utf-8")
+        return MODULE.select(paths, manifest)
+
+
 class NativeRendererCandidateTests(unittest.TestCase):
     def test_requires_two_census_inventories(self):
         with self.assertRaisesRegex(ValueError, "at least two"):
@@ -102,16 +121,7 @@ class NativeRendererCandidateTests(unittest.TestCase):
             ],
             "prepared_shader_pairs": first["prepared_shader_pairs"],
         }
-        with tempfile.TemporaryDirectory() as temp:
-            root = Path(temp)
-            paths = []
-            for index, document in enumerate((first, second)):
-                path = root / f"census-{index}.json"
-                path.write_text(json.dumps(document), encoding="utf-8")
-                paths.append(path)
-            manifest = root / "shader-manifest.json"
-            manifest.write_text(json.dumps(shader_manifest), encoding="utf-8")
-            result = MODULE.select(paths, manifest)
+        result = select_documents(first, second, shader_manifest)
 
         self.assertEqual(1, result["candidate_count"])
         self.assertEqual("GOOD", result["candidates"][0]["signature"])
@@ -135,6 +145,67 @@ class NativeRendererCandidateTests(unittest.TestCase):
     def test_rejects_dynamic_input(self):
         reasons = MODULE.rejection_reasons(signature("BAD", resolved_input="true"))
         self.assertIn("dynamic_render_target_input", reasons)
+
+    def test_rejects_texture_inside_any_observed_resolve_range(self):
+        record = signature(
+            "BAD", texture_states=texture_state(0x00124000)
+        )
+        self.assertTrue(
+            MODULE.reads_known_resolve_target(
+                record, MODULE.resolve_ranges({"resolve_targets": [
+                    {"address": "00123000", "length": "8192"}
+                ]})
+            )
+        )
+
+    def test_selector_rejects_candidate_with_known_resolve_provenance(self):
+        shader_manifest = {
+            "schema": MODULE.SHADER_SCHEMA,
+            "entries": [
+                {
+                    "stage": stage,
+                    "guest_hash": guest_hash,
+                    "specialization_mask": specialization,
+                }
+                for stage, guest_hash, specialization in (
+                    ("vertex", "1111111111111111", "AAAAAAAAAAAAAAAA"),
+                    ("pixel", "2222222222222222", "BBBBBBBBBBBBBBBB"),
+                )
+            ],
+        }
+        prepared = [{
+            "vertex_shader": "1111111111111111",
+            "pixel_shader": "2222222222222222",
+            "vertex_specialization_mask": "AAAAAAAAAAAAAAAA",
+            "pixel_specialization_mask": "BBBBBBBBBBBBBBBB",
+        }]
+        census = {
+            "schema": MODULE.CENSUS_SCHEMA,
+            "classification": {"scene": "open_world_day"},
+            "draw_candidates": [signature(
+                "DYNAMIC", texture_states=texture_state(0x00124000)
+            )],
+            "prepared_shader_pairs": prepared,
+            "resolve_targets": [{"address": "00123000", "length": "8192"}],
+        }
+        result = select_documents(census, census, shader_manifest)
+        self.assertEqual(0, result["candidate_count"])
+        self.assertEqual(
+            {"reason": "dynamic_render_target_input", "signatures": 1},
+            next(item for item in result["rejections"]
+                 if item["reason"] == "dynamic_render_target_input"),
+        )
+    def test_ignores_texture_outside_observed_resolve_ranges(self):
+        record = signature(
+            "GOOD", texture_states=texture_state(0x00125000)
+        )
+        self.assertFalse(
+            MODULE.reads_known_resolve_target(
+                record, MODULE.resolve_ranges({"resolve_targets": [
+                    {"address": "00123000", "length": "8192"}
+                ]})
+            )
+        )
 
     def test_rejects_vertex_attribute_overflow(self):
         reasons = MODULE.rejection_reasons(

--- a/tools/tests/test_native_renderer_census.py
+++ b/tools/tests/test_native_renderer_census.py
@@ -139,6 +139,7 @@ class NativeRendererCensusTests(unittest.TestCase):
                 "event": "native_renderer.census.resolve_target",
                 "session": "new",
                 "address": "00123000",
+                "length": "4096",
                 "last_resolve_frame": "42",
                 "resolves": "7",
                 "resolved_bytes": "28672",
@@ -172,6 +173,8 @@ class NativeRendererCensusTests(unittest.TestCase):
             result["prepared_shader_pairs"][0]["vertex_specialization_mask"],
         )
         self.assertEqual("7", result["resolve_dependencies"][0]["resolves"])
+        self.assertEqual("00123000", result["resolve_targets"][0]["address"])
+        self.assertEqual("4096", result["resolve_targets"][0]["length"])
         self.assertFalse(result["safety"]["suppression_allowed"])
 
     def test_summarizer_rejects_missing_session(self):


### PR DESCRIPTION
## Summary
- retain all emitted resolve targets in deterministic census inventories
- reject candidate base and mip addresses inside any observed resolve range
- document that candidate `08810649442C4213` is a dynamic render-target consumer and cannot advance

## Validation
- `python -m unittest discover -s tools/tests -p 'test_*.py'` (93 tests)
- reprocessed both NR-02C AppData captures; corrected selection has zero eligible candidates
- confirmed texture `0x1C149000` overlaps a 3,768,320-byte target resolved 984 times

## Safety
- no runtime behavior changes
- no payload reads, uploads, native draws, or suppression
- Xenos remains authoritative