### PR TITLE
fix(native-renderer): correlate prepared specialization

### DIFF
--- a/docs/native-renderer/CANDIDATE_DRAW_SELECTION.md
+++ b/docs/native-renderer/CANDIDATE_DRAW_SELECTION.md
@@ -149,3 +149,28 @@ The selector now checks every captured base and mip address against every
 emitted resolve range in each input inventory. This is deliberately stricter
 than the draw-window `resolved_input` bit: a missed timing correlation can no
 longer turn absence of a dependency event into static-texture evidence.
+
+## Prepared-specialization correlation
+
+Candidate aggregation is deferred from the generic pre-draw observation until
+the synchronous D3D12 prepared-draw callback. The callback supplies the exact
+effective vertex and pixel shader identities plus their specialization masks.
+This matters when an active guest pixel shader is omitted from the prepared
+pipeline because rasterization is disabled, and when one guest shader pair has
+multiple render-target specializations.
+
+The specialization masks are part of the candidate signature and are emitted
+with every candidate record. Selection now requires the exact pair to repeat in
+every capture, appear in each prepared-draw inventory, and exist in the local
+shader manifest. It no longer guesses from all specializations seen for a guest
+shader pair.
+
+AppData-backed sessions `20260828T061406Z-p33972` and
+`20260828T061541Z-p41620` reached more than 2,100 frames and exited normally.
+Both reported zero prepared callbacks without a corresponding generic draw
+observation, zero observer overflow, and 22 prepared shader pairs. Exact
+correlation recovered four repeatable candidates under the existing
+zero-or-one-texture gate; all four are textureless. Two additional opaque,
+one-binding candidates have three non-resolved texture inputs and remain
+rejected by the current bounded-complexity gate pending an explicit scope
+decision.

--- a/docs/native-renderer/RENDER_PASS_CENSUS.md
+++ b/docs/native-renderer/RENDER_PASS_CENSUS.md
@@ -121,3 +121,9 @@ register-only; the census still performs no guest resource payload reads.
 The deterministic inventory also retains every emitted resolve target so the
 candidate selector can reject any captured base or mip address inside a known
 resolve range, independently of draw-window timing.
+
+Candidate records are finalized only by the synchronous D3D12 prepared-draw
+callback. Their signature includes the exact effective shader specialization,
+preventing a global guest-shader pair with multiple prepared variants from
+producing an ambiguous or guessed candidate identity. Draws that never reach a
+prepared pipeline are counted and excluded; Xenos remains authoritative.

--- a/src/native_renderer/graphics_hooks.cpp
+++ b/src/native_renderer/graphics_hooks.cpp
@@ -61,6 +61,8 @@ struct DrawSignatureEntry {
   uint32_t min_index_count = 0;
   uint32_t max_index_count = 0;
   uint32_t min_index_buffer_length = 0;
+  uint64_t vertex_specialization_mask = 0;
+  uint64_t pixel_specialization_mask = 0;
   bool samples_resolved_target = false;
   rex::system::GraphicsDrawObservation sample;
 };
@@ -86,7 +88,17 @@ std::array<PreparedShaderPairEntry, kPreparedShaderPairCapacity>
     g_prepared_shader_pairs{};
 uint64_t g_prepared_shader_pair_count = 0;
 uint64_t g_prepared_shader_pair_overflow = 0;
+uint64_t g_candidate_unprepared_draw_count = 0;
+uint64_t g_candidate_prepared_without_observation_count = 0;
 bool g_graphics_census_installed = false;
+
+struct PendingCandidateObservation {
+  rex::system::GraphicsDrawObservation sample;
+  bool samples_resolved_target = false;
+  bool valid = false;
+};
+
+thread_local PendingCandidateObservation g_pending_candidate;
 
 struct ResolveTargetEntry {
   uint32_t address = 0;
@@ -150,6 +162,9 @@ void ResetPreparedShaderPairs() {
               sizeof(g_prepared_shader_pairs));
   g_prepared_shader_pair_count = 0;
   g_prepared_shader_pair_overflow = 0;
+  g_candidate_unprepared_draw_count = 0;
+  g_candidate_prepared_without_observation_count = 0;
+  g_pending_candidate.valid = false;
 }
 
 void ResetDependencyCensus() {
@@ -508,9 +523,13 @@ DrawSignature(const rex::system::GraphicsDrawObservation &observation) {
 
 uint64_t
 CandidateSignature(const rex::system::GraphicsDrawObservation &observation,
-                   bool samples_resolved_target) {
+                   bool samples_resolved_target,
+                   const rex::system::GraphicsPreparedDrawObservation
+                       &prepared) {
   uint64_t hash = DrawSignature(observation);
-  for (uint64_t value : {uint64_t(observation.index_format),
+  for (uint64_t value : {prepared.vertex_specialization_mask,
+                         prepared.pixel_specialization_mask,
+                         uint64_t(observation.index_format),
                          uint64_t(observation.index_endianness),
                          uint64_t(observation.vertex_index_offset),
                          uint64_t(observation.vertex_index_min),
@@ -603,8 +622,23 @@ bool IsOpaqueColorState(
   return writes_color;
 }
 
+void RecordCandidate(
+    const rex::system::GraphicsDrawObservation &observation,
+    bool samples_resolved_target,
+    const rex::system::GraphicsPreparedDrawObservation &prepared);
+
 void ObservePreparedDraw(
     const rex::system::GraphicsPreparedDrawObservation &observation) {
+  if (!g_pending_candidate.valid) {
+    ++g_candidate_prepared_without_observation_count;
+  } else {
+    auto sample = g_pending_candidate.sample;
+    sample.vertex_shader_hash = observation.vertex_shader_hash;
+    sample.pixel_shader_hash = observation.pixel_shader_hash;
+    RecordCandidate(sample, g_pending_candidate.samples_resolved_target,
+                    observation);
+    g_pending_candidate.valid = false;
+  }
   uint64_t identity = 0xCBF29CE484222325ull;
   for (uint64_t value :
        {observation.vertex_shader_hash, observation.pixel_shader_hash,
@@ -730,6 +764,10 @@ void EmitCandidateCensusWindow(uint64_t last_frame_value) {
          {"last_frame", std::to_string(entry.last_frame)},
          {"vertex_shader", fmt::format("{:016X}", sample.vertex_shader_hash)},
          {"pixel_shader", fmt::format("{:016X}", sample.pixel_shader_hash)},
+         {"vertex_specialization_mask",
+          fmt::format("{:016X}", entry.vertex_specialization_mask)},
+         {"pixel_specialization_mask",
+          fmt::format("{:016X}", entry.pixel_specialization_mask)},
          {"primitive", std::to_string(sample.primitive_type)},
          {"source_select", std::to_string(sample.source_select)},
          {"index_count_min", std::to_string(entry.min_index_count)},
@@ -1020,11 +1058,13 @@ void ObserveResolvedFetch(
   }
 }
 
-void RecordCandidate(const rex::system::GraphicsDrawObservation &observation,
-                     bool samples_resolved_target) {
+void RecordCandidate(
+    const rex::system::GraphicsDrawObservation &observation,
+    bool samples_resolved_target,
+    const rex::system::GraphicsPreparedDrawObservation &prepared) {
   ++g_candidate_census.window_draw_count;
   const uint64_t signature =
-      CandidateSignature(observation, samples_resolved_target);
+      CandidateSignature(observation, samples_resolved_target, prepared);
   size_t index = size_t(signature % kSignatureCapacity);
   for (size_t probe = 0; probe < kSignatureCapacity; ++probe) {
     DrawSignatureEntry &entry = g_candidate_census.entries[index];
@@ -1036,6 +1076,9 @@ void RecordCandidate(const rex::system::GraphicsDrawObservation &observation,
       entry.min_index_count = observation.index_count;
       entry.max_index_count = observation.index_count;
       entry.min_index_buffer_length = observation.index_buffer_length;
+      entry.vertex_specialization_mask =
+          prepared.vertex_specialization_mask;
+      entry.pixel_specialization_mask = prepared.pixel_specialization_mask;
       entry.samples_resolved_target = samples_resolved_target;
       entry.sample = observation;
       ++g_candidate_census.unique_signature_count;
@@ -1101,7 +1144,12 @@ void ObserveDraw(const rex::system::GraphicsDrawObservation &observation) {
 
   ++g_draw_census.window_draw_count;
   const bool samples_resolved_target = sampled_target_count != 0;
-  RecordCandidate(observation, samples_resolved_target);
+  if (g_pending_candidate.valid) {
+    ++g_candidate_unprepared_draw_count;
+  }
+  g_pending_candidate.sample = observation;
+  g_pending_candidate.samples_resolved_target = samples_resolved_target;
+  g_pending_candidate.valid = true;
   const uint64_t signature = DrawSignature(observation);
   size_t index = size_t(signature % kSignatureCapacity);
   for (size_t probe = 0; probe < kSignatureCapacity; ++probe) {
@@ -1169,11 +1217,19 @@ void UninstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system) {
   if (g_draw_census.window_first_frame && g_draw_census.window_draw_count) {
     EmitDrawCensusWindow(g_draw_census.window_last_frame);
   }
+  if (g_pending_candidate.valid) {
+    ++g_candidate_unprepared_draw_count;
+    g_pending_candidate.valid = false;
+  }
   EmitDependencyCensusWindow();
   diagnostics::RecordEvent(
       "native_renderer.census.prepared_shader_pair_summary",
       {{"pairs", std::to_string(g_prepared_shader_pair_count)},
        {"overflow", std::to_string(g_prepared_shader_pair_overflow)},
+       {"candidate_unprepared_draws",
+        std::to_string(g_candidate_unprepared_draw_count)},
+       {"candidate_prepared_without_observation",
+        std::to_string(g_candidate_prepared_without_observation_count)},
        {"capacity", std::to_string(kPreparedShaderPairCapacity)},
        {"mode", "pass_through"}});
 }

--- a/tools/select-native-renderer-candidate.py
+++ b/tools/select-native-renderer-candidate.py
@@ -171,22 +171,31 @@ def select(census_paths: list[Path], shader_manifest_path: Path) -> dict[str, An
             str(records[0].get("vertex_shader", "")).upper(),
             str(records[0].get("pixel_shader", "")).upper(),
         )
-        repeated_specializations = set(
-            prepared_by_capture[0].get(shader_pair, set())
-        )
-        for prepared in prepared_by_capture[1:]:
-            repeated_specializations.intersection_update(
-                prepared.get(shader_pair, set())
+        candidate_specializations = [
+            (
+                str(record.get("vertex_specialization_mask", "")).upper(),
+                str(record.get("pixel_specialization_mask", "")).upper(),
             )
-        if not repeated_specializations:
+            for record in records
+        ]
+        if any(
+            len(value) != 16
+            for specialization in candidate_specializations
+            for value in specialization
+        ):
+            rejection_counts["missing_candidate_specialization"] += 1
+            continue
+        if len(set(candidate_specializations)) != 1:
+            rejection_counts["specialization_changed_across_captures"] += 1
+            continue
+        vertex_specialization, pixel_specialization = candidate_specializations[0]
+        if any(
+            candidate_specializations[index]
+            not in prepared_by_capture[index].get(shader_pair, set())
+            for index in range(len(censuses))
+        ):
             rejection_counts["missing_prepared_shader_pair"] += 1
             continue
-        if len(repeated_specializations) != 1:
-            rejection_counts["ambiguous_prepared_shader_pair"] += 1
-            continue
-        vertex_specialization, pixel_specialization = next(
-            iter(repeated_specializations)
-        )
         if ("vertex", shader_pair[0], vertex_specialization) not in shaders:
             rejection_counts["missing_vertex_shader_specialization"] += 1
             continue

--- a/tools/tests/test_native_renderer_candidate.py
+++ b/tools/tests/test_native_renderer_candidate.py
@@ -20,6 +20,8 @@ def signature(name: str, **overrides):
         "draws": "20",
         "vertex_shader": "1111111111111111",
         "pixel_shader": "2222222222222222",
+        "vertex_specialization_mask": "AAAAAAAAAAAAAAAA",
+        "pixel_specialization_mask": "BBBBBBBBBBBBBBBB",
         "primitive": "4",
         "source_select": "2",
         "index_count_min": "3",

--- a/tools/tests/test_native_renderer_contract.py
+++ b/tools/tests/test_native_renderer_contract.py
@@ -325,6 +325,16 @@ class NativeRendererContractTests(unittest.TestCase):
             prepared_patch.index("// Update the textures"),
         )
         self.assertNotIn("SetDrawSuppression", prepared_patch)
+        self.assertIn("g_pending_candidate.sample = observation;", source)
+        self.assertIn(
+            "sample.vertex_shader_hash = observation.vertex_shader_hash;",
+            source,
+        )
+        self.assertIn(
+            'fmt::format("{:016X}", entry.vertex_specialization_mask)',
+            source,
+        )
+        self.assertIn("candidate_prepared_without_observation", source)
 
         declaration_patch = (
             ROOT / "patches/rexglue/0053-graphics-vertex-declaration-observer.patch"


### PR DESCRIPTION
## Summary
- finalize candidate records only when the synchronous D3D12 prepared-draw callback supplies the effective shaders
- include exact vertex and pixel specialization masks in candidate signatures and output
- require the exact prepared specialization to repeat across captures and exist in the local shader manifest

## Validation
- `python -m unittest discover -s tools/tests -p 'test_*.py'` (93 tests)
- `.\tools\build-preview.ps1`
- AppData sessions `20260828T061406Z-p33972` and `20260828T061541Z-p41620` exceeded 2,100 frames and exited normally
- zero prepared callbacks without a generic observation in both runs

## Safety
- observation only; no payload reads, uploads, native draws, or suppression
- draws that never prepare a D3D12 pipeline are explicitly excluded
- Xenos remains authoritative