### PR TITLE
feat(native-renderer): bound candidate texture sets

### DIFF
--- a/docs/native-renderer/CANDIDATE_DRAW_SELECTION.md
+++ b/docs/native-renderer/CANDIDATE_DRAW_SELECTION.md
@@ -72,8 +72,8 @@ input capture. It accepts both indexed and non-indexed authentic draws because
 the NR-02 candidate criteria do not require an index buffer. It rejects missing
 or ambiguous prepared pairs, shader-pack misses, blending, query or memexport
 state, observed resolved-target inputs, more than one vertex binding, more than
-one texture, and either bounded-observer overflow. Results are ordered
-deterministically by recurrence and draw count.
+four or fewer than one texture resource, and either bounded-observer overflow.
+Results are ordered deterministically by recurrence and draw count.
 
 The resulting selection can be converted into a metadata-only geometry
 contract as described in [GEOMETRY_CONTRACT.md](GEOMETRY_CONTRACT.md). An
@@ -174,3 +174,34 @@ zero-or-one-texture gate; all four are textureless. Two additional opaque,
 one-binding candidates have three non-resolved texture inputs and remain
 rejected by the current bounded-complexity gate pending an explicit scope
 decision.
+
+## Bounded texture-set qualification
+
+The NR-02 static-source requirement makes a textureless draw unsuitable for the
+first isolated replay even when its shader and geometry metadata are otherwise
+simple. The selector now requires one through four texture resources. This
+keeps the first replay bounded while admitting common material sets without
+weakening the resolve-range exclusion or any Xenos-authority gate.
+
+Two AppData-backed `gameplay_candidate` captures navigated through the title
+screen into the same open-world save and exited normally:
+
+| Session | Frames | Draws | Candidate records | Median FPS | 1% low FPS |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| `20260828T062404Z-p40136` | 9,191 | 18,294,006 | 117 | 30.333 | 19.602 |
+| `20260828T062956Z-p33312` | 6,573 | 14,902,074 | 115 | 30.570 | 19.443 |
+
+Exact cross-capture selection produced five bounded candidates. Three use the
+same opaque quad-list shader pair, one 40-byte binding, and one non-resolved
+512 by 512 tiled `DXT4_5` texture. They are better static-source leads than the
+front-end candidates, but the geometry planner correctly rejects their current
+snapshots: a four-vertex quad needs 160 bytes while the observed fetch exposes
+one 40-byte record. Quad expansion or instancing semantics must be understood
+before any guest payload read.
+
+The remaining two candidates are the previously observed three-texture,
+full-screen YUV-style compositor family. Their non-resolved addresses satisfy
+the mechanical gate, but their render-sized planes and conversion constants
+make them inappropriate for the first authentic world draw. No candidate from
+this qualification advances to PSO construction. Xenos remained authoritative
+throughout both runs, and suppression remains disabled.

--- a/docs/native-renderer/DRAW_STATE_CONTRACT.md
+++ b/docs/native-renderer/DRAW_STATE_CONTRACT.md
@@ -26,9 +26,9 @@ and render targets are not read by this observer.
 ## Decoder
 
 `tools/build-native-draw-state-contract.py` accepts an exact candidate-selection
-inventory. The initial contract requires one selected candidate and one texture
-resource, while preserving every observed instruction that references it. It
-validates constant counts and indices, decodes all 64 Xenos
+inventory. The initial contract requires one selected candidate and one through
+four texture resources, while preserving every observed instruction that
+references them. It validates constant counts and indices, decodes all 64 Xenos
 texture format identities, dimensions stored with minus-one sizing, physical
 base and mip addresses, pitch, tiling, endianness, signs, component swizzle,
 number format, exponent adjustment, clamp modes, effective filtering,

--- a/tools/build-native-draw-state-contract.py
+++ b/tools/build-native-draw-state-contract.py
@@ -13,6 +13,7 @@ from typing import Any
 SCHEMA = "pinyon-shift.native-draw-state-contract.v1"
 SELECTION_SCHEMA = "pinyon-shift.native-renderer-candidate-selection.v1"
 PHYSICAL_MASK = 0x1FFFFFFF
+MAX_TEXTURE_RESOURCES = 4
 TEXTURE_FORMATS = [
     "1_REVERSE", "1", "8", "1_5_5_5", "5_6_5", "6_5_5", "8_8_8_8",
     "2_10_10_10", "8_A", "8_B", "8_8", "Cr_Y1_Cb_Y0_REP",
@@ -222,8 +223,8 @@ def build(selection: dict[str, Any], signature: str | None = None) -> dict[str, 
     resources = {
         (texture["fetch_constant"], tuple(texture["raw_words"])) for texture in textures
     }
-    if len(resources) != 1:
-        raise ValueError("initial draw-state contract requires exactly one texture resource")
+    if not 1 <= len(resources) <= MAX_TEXTURE_RESOURCES:
+        raise ValueError("draw-state contract requires one to four texture resources")
     hashes = candidate.get("draw_state_hashes", [])
     if not hashes or any(len(str(value)) != 16 for value in hashes):
         raise ValueError("candidate has invalid draw-state hashes")

--- a/tools/select-native-renderer-candidate.py
+++ b/tools/select-native-renderer-candidate.py
@@ -14,6 +14,7 @@ SCHEMA = "pinyon-shift.native-renderer-candidate-selection.v1"
 CENSUS_SCHEMA = "pinyon-shift.native-renderer-census.v1"
 SHADER_SCHEMA = "pinyon-shift.native-shader-pack.v1"
 PHYSICAL_MASK = 0x1FFFFFFF
+MAX_TEXTURE_RESOURCES = 4
 
 
 def boolean(record: dict[str, Any], key: str) -> bool:
@@ -69,8 +70,9 @@ def rejection_reasons(record: dict[str, Any]) -> list[str]:
         reasons.append("texture_state_observer_overflow")
     if int(record.get("vertex_binding_count", 0)) != 1:
         reasons.append("vertex_binding_count_not_one")
-    if int(record.get("texture_fetch_count", 0)) > 1:
-        reasons.append("multiple_textures")
+    texture_count = int(record.get("texture_fetch_count", 0))
+    if texture_count < 1 or texture_count > MAX_TEXTURE_RESOURCES:
+        reasons.append("texture_count_outside_1_to_4")
     return reasons
 
 

--- a/tools/tests/test_native_renderer_candidate.py
+++ b/tools/tests/test_native_renderer_candidate.py
@@ -148,6 +148,20 @@ class NativeRendererCandidateTests(unittest.TestCase):
         reasons = MODULE.rejection_reasons(signature("BAD", resolved_input="true"))
         self.assertIn("dynamic_render_target_input", reasons)
 
+    def test_requires_one_to_four_texture_resources(self):
+        self.assertIn(
+            "texture_count_outside_1_to_4",
+            MODULE.rejection_reasons(signature("NONE", texture_fetch_count="0")),
+        )
+        self.assertNotIn(
+            "texture_count_outside_1_to_4",
+            MODULE.rejection_reasons(signature("FOUR", texture_fetch_count="4")),
+        )
+        self.assertIn(
+            "texture_count_outside_1_to_4",
+            MODULE.rejection_reasons(signature("FIVE", texture_fetch_count="5")),
+        )
+
     def test_rejects_texture_inside_any_observed_resolve_range(self):
         record = signature(
             "BAD", texture_states=texture_state(0x00124000)

--- a/tools/tests/test_native_renderer_draw_state.py
+++ b/tools/tests/test_native_renderer_draw_state.py
@@ -106,10 +106,19 @@ class NativeRendererDrawStateTests(unittest.TestCase):
         self.assertEqual(1, result["texture_resource_count"])
         self.assertEqual(2, len(result["textures"]))
 
-    def test_rejects_multiple_texture_resources(self):
+    def test_accepts_multiple_texture_resources_within_bound(self):
         states = ";".join([texture_state(), texture_state(fetch=1)])
-        with self.assertRaisesRegex(ValueError, "exactly one texture resource"):
-            MODULE.build(selection(texture_state_count=2, texture_states=states))
+        result = MODULE.build(selection(texture_state_count=2, texture_states=states))
+        self.assertEqual(2, result["texture_resource_count"])
+
+    def test_rejects_missing_texture_resource(self):
+        with self.assertRaisesRegex(ValueError, "observed texture states"):
+            MODULE.build(selection(texture_state_count=0, texture_states=""))
+
+    def test_rejects_more_than_four_texture_resources(self):
+        states = ";".join(texture_state(fetch=index) for index in range(5))
+        with self.assertRaisesRegex(ValueError, "one to four"):
+            MODULE.build(selection(texture_state_count=5, texture_states=states))
 
     def test_rejects_non_texture_fetch_constant(self):
         state = texture_state(dwords=[0, 0, 0, 0, 0, 0])


### PR DESCRIPTION
## Summary
- require one through four texture resources for NR-02 candidate selection
- preserve every bounded texture instruction in draw-state contracts
- record two AppData-backed gameplay captures and the remaining quad-list/YUV qualification boundaries

## Validation
- python -m unittest discover -s tools/tests -p 'test_*.py' (96 tests)
- AppData gameplay sessions 20260828T062404Z-p40136 and 20260828T062956Z-p33312 exited normally
- Xenos remained authoritative and suppression stayed disabled