### PR TITLE
feat(native-renderer): prioritize eligible draw snapshots

### DIFF
--- a/docs/native-renderer/CANDIDATE_DRAW_SELECTION.md
+++ b/docs/native-renderer/CANDIDATE_DRAW_SELECTION.md
@@ -205,3 +205,43 @@ the mechanical gate, but their render-sized planes and conversion constants
 make them inappropriate for the first authentic world draw. No candidate from
 this qualification advances to PSO construction. Xenos remained authoritative
 throughout both runs, and suppression remains disabled.
+
+## Eligible-first candidate windows
+
+Candidate aggregation retains up to 4,096 structural signatures per 300-frame
+window, but only emits 32 detailed state snapshots. Ranking solely by draw
+count allowed high-frequency post-processing, blended, and resolved-input
+signatures to consume those snapshots before the offline selector could reject
+them.
+
+The census now ranks mechanically eligible signatures before other diagnostic
+records. Eligibility mirrors the cheap, synchronous subset of the offline
+contract: opaque color writes, no query, memexport, observed resolved input, or
+observer overflow, exactly one vertex binding, and one through four texture
+resources. Draw count and signature remain deterministic tie-breakers. The
+window event reports eligible signature and draw totals, and the summarizer
+retains those counters. Full resolve-range exclusion, exact prepared-shader
+correlation, cross-capture stability, bounds validation, and visual review
+remain offline requirements; eligible-first ranking is not a safety verdict.
+
+Two AppData-backed open-world captures validate the ranking change:
+
+- `20260828T064806Z-p41300` recorded 25 candidate windows, 2,796
+  mechanically eligible signature observations, and 1,055,186 eligible draws.
+  Its 7,290-frame performance capture measured 30.563 median FPS and a 19.603
+  FPS one-percent low.
+- `20260828T065210Z-p36920` recorded 22 candidate windows, 1,675
+  mechanically eligible signature observations, and 439,557 eligible draws.
+  Its 6,490-frame performance capture measured 30.589 median FPS and a 19.779
+  FPS one-percent low.
+
+Both runs exited normally. Cross-capture selection found 108 repeated detailed
+signatures and retained 33 after the existing offline gates. In particular,
+`FA45AAFDC22C8625` is a repeatable indexed triangle-list draw with one
+32-byte vertex binding, two float4 attributes, 9,300 uint32 indices, and two
+256-by-64 DXN textures. This is materially more suitable for static-world
+qualification than the previously visible quad-list family, but it does not
+advance to native replay yet: its geometry contract still requires a bounded
+guest index scan, its complete draw-state hashes vary between captures, and it
+has not passed isolated visual review. Xenos remained authoritative and no
+suppression path was enabled.

--- a/src/native_renderer/graphics_hooks.cpp
+++ b/src/native_renderer/graphics_hooks.cpp
@@ -622,6 +622,23 @@ bool IsOpaqueColorState(
   return writes_color;
 }
 
+bool IsMechanicallyEligibleCandidate(const DrawSignatureEntry &entry) {
+  const auto &observation = entry.sample;
+  const bool query_draw = observation.viz_query_condition ||
+                          (observation.pa_sc_viz_query & 1);
+  const uint32_t texture_count =
+      std::popcount(observation.texture_fetch_mask);
+  return IsOpaqueColorState(observation) && !query_draw &&
+         !observation.vertex_memexport && !entry.samples_resolved_target &&
+         !observation.vertex_binding_overflow &&
+         !observation.vertex_attribute_overflow &&
+         !observation.vertex_float_constant_overflow &&
+         !observation.pixel_float_constant_overflow &&
+         !observation.texture_state_overflow &&
+         observation.vertex_binding_count == 1 && texture_count >= 1 &&
+         texture_count <= 4;
+}
+
 void RecordCandidate(
     const rex::system::GraphicsDrawObservation &observation,
     bool samples_resolved_target,
@@ -684,12 +701,24 @@ void ObservePreparedDraw(
 
 void EmitCandidateCensusWindow(uint64_t last_frame_value) {
   std::array<size_t, kSignatureCapacity> order{};
+  uint64_t eligible_signatures = 0;
+  uint64_t eligible_draws = 0;
   for (size_t i = 0; i < order.size(); ++i) {
     order[i] = i;
+    const DrawSignatureEntry &entry = g_candidate_census.entries[i];
+    if (entry.draw_count && IsMechanicallyEligibleCandidate(entry)) {
+      ++eligible_signatures;
+      eligible_draws += entry.draw_count;
+    }
   }
   std::sort(order.begin(), order.end(), [](size_t left, size_t right) {
     const DrawSignatureEntry &left_entry = g_candidate_census.entries[left];
     const DrawSignatureEntry &right_entry = g_candidate_census.entries[right];
+    const bool left_eligible = IsMechanicallyEligibleCandidate(left_entry);
+    const bool right_eligible = IsMechanicallyEligibleCandidate(right_entry);
+    if (left_eligible != right_eligible) {
+      return left_eligible;
+    }
     if (left_entry.draw_count != right_entry.draw_count) {
       return left_entry.draw_count > right_entry.draw_count;
     }
@@ -704,6 +733,8 @@ void EmitCandidateCensusWindow(uint64_t last_frame_value) {
         std::to_string(g_candidate_census.unique_signature_count)},
        {"overflow_draws",
         std::to_string(g_candidate_census.overflow_draw_count)},
+       {"eligible_signatures", std::to_string(eligible_signatures)},
+       {"eligible_draws", std::to_string(eligible_draws)},
        {"signature_capacity", std::to_string(kSignatureCapacity)},
        {"summary_limit", std::to_string(kCandidateSummaryLimit)},
        {"mode", "metadata_shortlist_only"}});
@@ -824,6 +855,8 @@ void EmitCandidateCensusWindow(uint64_t last_frame_value) {
               : "false"},
          {"texture_state_overflow",
           sample.texture_state_overflow ? "true" : "false"},
+         {"mechanically_eligible",
+          IsMechanicallyEligibleCandidate(entry) ? "true" : "false"},
          {"qualification", "metadata_shortlist_only"},
          {"suppression_eligible", "false"}});
   }

--- a/tools/summarize-native-renderer-census.py
+++ b/tools/summarize-native-renderer-census.py
@@ -147,6 +147,10 @@ def summarize(
         "query_draws": 0,
         "memexport_draws": 0,
         "draw_overflow": 0,
+        "candidate_windows": 0,
+        "candidate_eligible_signatures": 0,
+        "candidate_eligible_draws": 0,
+        "candidate_overflow": 0,
         "target_overflow": 0,
         "page_overflow": 0,
     }
@@ -156,6 +160,13 @@ def summarize(
         if kind == f"{PREFIX}draw_window":
             totals["draws"] += integer(event, "draws")
             totals["draw_overflow"] += integer(event, "overflow_draws")
+        elif kind == f"{PREFIX}candidate_window":
+            totals["candidate_windows"] += 1
+            totals["candidate_eligible_signatures"] += integer(
+                event, "eligible_signatures"
+            )
+            totals["candidate_eligible_draws"] += integer(event, "eligible_draws")
+            totals["candidate_overflow"] += integer(event, "overflow_draws")
         elif kind == f"{PREFIX}draw_signature":
             key = str(event["signature"])
             record = draw_signatures.get(key)

--- a/tools/tests/test_native_renderer_census.py
+++ b/tools/tests/test_native_renderer_census.py
@@ -109,6 +109,13 @@ class NativeRendererCensusTests(unittest.TestCase):
                 "index_buffer_length_min": "20",
             },
             {
+                "event": "native_renderer.census.candidate_window",
+                "session": "new",
+                "eligible_signatures": "7",
+                "eligible_draws": "30",
+                "overflow_draws": "0",
+            },
+            {
                 "event": "native_renderer.census.prepared_shader_pair",
                 "session": "new",
                 "vertex_shader": "1111111111111111",
@@ -160,6 +167,9 @@ class NativeRendererCensusTests(unittest.TestCase):
 
         self.assertEqual("new", result["session"])
         self.assertEqual(100, result["totals"]["draws"])
+        self.assertEqual(1, result["totals"]["candidate_windows"])
+        self.assertEqual(7, result["totals"]["candidate_eligible_signatures"])
+        self.assertEqual(30, result["totals"]["candidate_eligible_draws"])
         self.assertEqual(7, result["totals"]["resolves"])
         self.assertEqual("CANDIDATE", result["draw_candidates"][0]["signature"])
         self.assertEqual("20", result["draw_candidates"][0]["draws"])


### PR DESCRIPTION
## Summary
- rank mechanically eligible native-renderer candidates before diagnostic-only signatures
- retain eligible window totals in offline census summaries
- document two AppData gameplay captures and the newly surfaced indexed triangle-list candidate

## Safety
- keeps Xenos authoritative
- does not enable suppression or native replay
- leaves resolve exclusion, shader closure, bounds scanning, and visual review as offline gates

## Validation
- python -m unittest discover -s tools/tests -p 'test_*.py' (96 passed)
- cmake --build --preset win-amd64-release --parallel 16
- AppData captures 20260828T064806Z-p41300 and 20260828T065210Z-p36920 exited normally at 30.563/30.589 median FPS