### PR TITLE
feat(native-renderer): validate indexed candidate bounds

### DIFF
--- a/docs/native-renderer/CANDIDATE_DRAW_SELECTION.md
+++ b/docs/native-renderer/CANDIDATE_DRAW_SELECTION.md
@@ -245,3 +245,11 @@ advance to native replay yet: its geometry contract still requires a bounded
 guest index scan, its complete draw-state hashes vary between captures, and it
 has not passed isolated visual review. Xenos remained authoritative and no
 suppression path was enabled.
+
+The subsequent bounded scan qualified this candidate's geometry across
+sessions `20260828T070848Z-p13800` and `20260828T071104Z-p37760`. Both decoded
+the same 9,300-index payload, range 0–1,616, and hash
+`76F4D9C9DFE1E128`; the derived vertex requirement is exactly the observed
+51,744-byte allocation. See [GEOMETRY_CONTRACT.md](GEOMETRY_CONTRACT.md) for
+the scanner contract and safety boundary. The candidate remains pending visual
+identification and static texture-provenance review before any replay work.

--- a/docs/native-renderer/GEOMETRY_CONTRACT.md
+++ b/docs/native-renderer/GEOMETRY_CONTRACT.md
@@ -50,6 +50,43 @@ cannot be proven without a later, separately bounded payload-read step. Every
 contract carries explicit false values for guest payload reads, native upload,
 native draw, and suppression, plus true Xenos authority.
 
+## Bounded index-scan qualification
+
+The later payload-read step is now available as an exact-signature diagnostic:
+
+```powershell
+.\tools\capture-native-renderer-census.ps1 `
+  -StateRoot $stateRoot `
+  -Scene open_world_day `
+  -IndexScanSignature FA45AAFDC22C8625
+```
+
+The scanner is disabled unless a 16-digit signature is supplied. It attempts
+that signature once per process, accepts only DMA-indexed draws with one vertex
+binding, and rejects unknown formats, invalid clamp state, undersized
+allocations, physical-aperture crossings, more than 1,048,576 indices, or more
+than 4 MiB. It reads no vertex or texture payload. Index decoding matches the
+Xenos 16/32-bit endianness rules, masks values to 24 bits, excludes enabled
+primitive-reset markers, and applies the VGT base offset and min/max clamp.
+Only decoded bounds and a hash are logged; payload bytes remain local.
+
+Two summarized scan captures may be supplied to the planner:
+
+```powershell
+python .\tools\build-native-geometry-contract.py `
+  .\.local\native-renderer\candidate\selection.json `
+  --signature FA45AAFDC22C8625 `
+  --index-census `
+    .\.local\native-renderer\candidate\scan-1-census.json `
+    .\.local\native-renderer\candidate\scan-2-census.json `
+  --output .\.local\native-renderer\candidate\geometry-contract.json
+```
+
+The planner requires one successful scan in each of at least two captures,
+stable decoded payload hash, bounds, and reset state, matching index format and
+endianness, and a vertex byte range that fits the signature-bound allocation.
+It still emits false native-upload, native-draw, and suppression gates.
+
 ## Advancement gate
 
 This slice is ready to merge when a clean build and AppData-backed run confirm
@@ -85,3 +122,29 @@ reads, native uploads, native draws, and suppression disabled.
 This candidate has only two observations and still needs visual and static
 texture-provenance review. It validates the declaration and bounds machinery;
 it is not yet the approved authentic draw for NR-02E comparison.
+
+## Indexed candidate qualification — 2026-08-28
+
+Patch `0055-graphics-index-reset-observer.patch` adds the reset index and enable
+state needed to scan indexed geometry precisely. Two AppData-backed
+`open_world_day` sessions scanned candidate `FA45AAFDC22C8625` and exited
+normally:
+
+| Session | Frame | Indices | Bytes | Decoded range | Hash |
+| --- | ---: | ---: | ---: | ---: | --- |
+| `20260828T070848Z-p13800` | 3,004 | 9,300 | 37,200 | 0–1,616 | `76F4D9C9DFE1E128` |
+| `20260828T071104Z-p37760` | 3,127 | 9,300 | 37,200 | 0–1,616 | `76F4D9C9DFE1E128` |
+
+Both captures observed reset index `0000FFFF` enabled with zero reset markers.
+The guest index and vertex addresses relocated between processes, while the
+decoded payload and bounds remained identical. With a 32-byte stride and
+32-byte maximum attribute extent, vertex 1,616 requires exactly 51,744 bytes,
+matching the observed allocation exactly. The generated contract is therefore
+`bounded_index_scan` and validated across two captures. This closes the guest
+index/vertex bounds gate only; texture provenance, visual identification,
+native upload, native drawing, and suppression remain unapproved.
+
+The captures contained 4,134 and 4,364 performance samples, measured 31.885
+and 31.653 median FPS, reported zero presentation deadline misses, and emitted
+no crash, error, or device-loss event. The one-time 37,200-byte diagnostic read
+did not alter Xenos rendering authority.

--- a/patches/rexglue/0055-graphics-index-reset-observer.patch
+++ b/patches/rexglue/0055-graphics-index-reset-observer.patch
@@ -1,0 +1,28 @@
+diff --git a/include/rex/system/interfaces/graphics.h b/include/rex/system/interfaces/graphics.h
+--- a/include/rex/system/interfaces/graphics.h
++++ b/include/rex/system/interfaces/graphics.h
+@@ -148,6 +148,8 @@ struct GraphicsDrawObservation {
+   uint32_t index_buffer_length = 0;
+   uint32_t index_format = 0;
+   uint32_t index_endianness = 0;
++  uint32_t index_reset = 0;
++  bool index_reset_enabled = false;
+   uint32_t vertex_index_offset = 0;
+   uint32_t vertex_index_min = 0;
+   uint32_t vertex_index_max = 0;
+diff --git a/src/graphics/command_processor.cpp b/src/graphics/command_processor.cpp
+--- a/src/graphics/command_processor.cpp
++++ b/src/graphics/command_processor.cpp
+@@ -1499,6 +1499,12 @@ bool CommandProcessor::ExecutePacketType3Draw(memory::RingBuffer* reader, uint32
+           observation.index_buffer_length = uint32_t(index_buffer_info.length);
+           observation.index_format = uint32_t(index_buffer_info.format);
+           observation.index_endianness = uint32_t(index_buffer_info.endianness);
++          observation.index_reset =
++              register_file_->Get<reg::VGT_MULTI_PRIM_IB_RESET_INDX>()
++                  .reset_indx;
++          observation.index_reset_enabled =
++              register_file_->Get<reg::PA_SU_SC_MODE_CNTL>()
++                  .multi_prim_ib_ena;
+         }
+         observation.vertex_index_offset =
+             register_file_->Get<reg::VGT_INDX_OFFSET>().indx_offset;

--- a/src/native_renderer/graphics_hooks.cpp
+++ b/src/native_renderer/graphics_hooks.cpp
@@ -2,16 +2,21 @@
 #include <array>
 #include <atomic>
 #include <bit>
+#include <charconv>
 #include <cstddef>
 #include <cstdint>
 #include <cstdlib>
 #include <cstring>
+#include <limits>
 #include <string>
 #include <type_traits>
 
 #include <fmt/format.h>
 #include <rex/cvar.h>
+#include <rex/graphics/xenos.h>
+#include <rex/memory.h>
 #include <rex/system/interfaces/graphics.h>
+#include <rex/system/kernel_state.h>
 
 #include "native_renderer/graphics_hooks.h"
 #include "pinyon_shift_diagnostics.h"
@@ -32,6 +37,10 @@ constexpr size_t kResolveTargetCapacity = 4096;
 constexpr size_t kResolvePageCapacity = 32768;
 constexpr size_t kResolveSummaryLimit = 32;
 constexpr uint64_t kGuestPageSize = 4096;
+constexpr uint64_t kPhysicalApertureSize = UINT64_C(0x20000000);
+constexpr uint32_t kVertexIndexMask = 0x00FFFFFF;
+constexpr uint32_t kMaximumIndexScanCount = 1 << 20;
+constexpr uint64_t kMaximumIndexScanBytes = UINT64_C(4) << 20;
 std::atomic<uint64_t> g_frame_sequence{};
 
 std::string CensusSceneMarker() {
@@ -51,6 +60,42 @@ std::string CensusSceneMarker() {
     return "invalid";
   }
   return marker;
+}
+
+struct IndexScanState {
+  uint64_t target_signature = 0;
+  bool requested = false;
+  bool completed = false;
+  bool valid = true;
+};
+
+IndexScanState g_index_scan;
+
+void ConfigureIndexScan() {
+  g_index_scan = {};
+  char *value = nullptr;
+  size_t length = 0;
+  if (_dupenv_s(&value, &length,
+                "PINYON_SHIFT_NATIVE_RENDERER_INDEX_SCAN_SIGNATURE") != 0 ||
+      !value || length <= 1) {
+    std::free(value);
+    return;
+  }
+  const std::string setting(value);
+  std::free(value);
+  g_index_scan.requested = true;
+  if (setting.size() != 16) {
+    g_index_scan.valid = false;
+    return;
+  }
+  const char *begin = setting.data();
+  const char *end = begin + setting.size();
+  const auto parsed =
+      std::from_chars(begin, end, g_index_scan.target_signature, 16);
+  if (parsed.ec != std::errc{} || parsed.ptr != end ||
+      !g_index_scan.target_signature) {
+    g_index_scan.valid = false;
+  }
 }
 
 struct DrawSignatureEntry {
@@ -174,6 +219,173 @@ void ResetDependencyCensus() {
 uint64_t HashCombine(uint64_t hash, uint64_t value) {
   value += 0x9E3779B97F4A7C15ull + (hash << 6) + (hash >> 2);
   return hash ^ value;
+}
+
+void TryScanCandidateIndices(
+    const rex::system::GraphicsDrawObservation &observation,
+    uint64_t signature) {
+  if (!g_index_scan.requested || !g_index_scan.valid ||
+      g_index_scan.completed || signature != g_index_scan.target_signature) {
+    return;
+  }
+  g_index_scan.completed = true;
+
+  const auto reject = [&](const char *reason) {
+    pinyon_shift::diagnostics::RecordEvent(
+        "native_renderer.census.index_scan",
+        {{"signature", fmt::format("{:016X}", signature)},
+         {"status", "rejected"},
+         {"reason", reason},
+         {"frame", std::to_string(observation.frame_sequence)},
+         {"draw", std::to_string(observation.draw_sequence)},
+         {"guest_payload_read", "false"},
+         {"native_upload", "false"},
+         {"native_draw", "false"},
+         {"suppression_eligible", "false"}});
+  };
+
+  if (!observation.indexed ||
+      observation.source_select !=
+          uint32_t(rex::graphics::xenos::SourceSelect::kDMA)) {
+    reject("not_dma_indexed");
+    return;
+  }
+  if (observation.index_format > 1 || observation.index_endianness > 3) {
+    reject("unsupported_index_state");
+    return;
+  }
+  if (!observation.index_count ||
+      observation.index_count > kMaximumIndexScanCount) {
+    reject("index_count_out_of_bounds");
+    return;
+  }
+  if (observation.vertex_index_min > observation.vertex_index_max) {
+    reject("invalid_vertex_index_clamp");
+    return;
+  }
+  if (observation.vertex_binding_count != 1 ||
+      observation.vertex_binding_overflow) {
+    reject("unsupported_vertex_bindings");
+    return;
+  }
+
+  const uint32_t element_bytes = observation.index_format ? 4 : 2;
+  const uint64_t required_bytes =
+      uint64_t(observation.index_count) * element_bytes;
+  const uint64_t physical_address =
+      uint64_t(observation.index_buffer_address & 0x1FFFFFFF);
+  if (required_bytes > kMaximumIndexScanBytes ||
+      required_bytes > observation.index_buffer_length) {
+    reject("index_allocation_too_small");
+    return;
+  }
+  if (physical_address + required_bytes > kPhysicalApertureSize) {
+    reject("index_range_crosses_aperture");
+    return;
+  }
+  auto *kernel_state = rex::system::kernel_state();
+  if (!kernel_state || !kernel_state->memory()) {
+    reject("guest_memory_unavailable");
+    return;
+  }
+
+  const uint8_t *payload =
+      kernel_state->memory()->TranslatePhysical<const uint8_t *>(
+          observation.index_buffer_address);
+  auto endianness =
+      static_cast<rex::graphics::xenos::Endian>(observation.index_endianness);
+  if (!observation.index_format) {
+    if (endianness == rex::graphics::xenos::Endian::k8in32) {
+      endianness = rex::graphics::xenos::Endian::k8in16;
+    } else if (endianness == rex::graphics::xenos::Endian::k16in32) {
+      endianness = rex::graphics::xenos::Endian::kNone;
+    }
+  }
+
+  uint32_t decoded_minimum = std::numeric_limits<uint32_t>::max();
+  uint32_t decoded_maximum = 0;
+  uint32_t effective_minimum = std::numeric_limits<uint32_t>::max();
+  uint32_t effective_maximum = 0;
+  uint32_t non_reset_count = 0;
+  uint32_t reset_count = 0;
+  uint64_t decoded_hash = 0xCBF29CE484222325ull;
+  for (uint32_t i = 0; i < observation.index_count; ++i) {
+    uint32_t decoded = 0;
+    if (observation.index_format) {
+      std::memcpy(&decoded, payload + uint64_t(i) * element_bytes,
+                  sizeof(decoded));
+      decoded = rex::graphics::xenos::GpuSwap(decoded, endianness);
+    } else {
+      uint16_t decoded16 = 0;
+      std::memcpy(&decoded16, payload + uint64_t(i) * element_bytes,
+                  sizeof(decoded16));
+      decoded = rex::graphics::xenos::GpuSwap(decoded16, endianness);
+    }
+    decoded &= kVertexIndexMask;
+    decoded_hash = HashCombine(decoded_hash, decoded);
+    if (observation.index_reset_enabled &&
+        decoded == (observation.index_reset & kVertexIndexMask)) {
+      ++reset_count;
+      continue;
+    }
+    decoded_minimum = std::min(decoded_minimum, decoded);
+    decoded_maximum = std::max(decoded_maximum, decoded);
+    const uint32_t adjusted =
+        (decoded + observation.vertex_index_offset) & kVertexIndexMask;
+    const uint32_t effective = std::clamp(
+        adjusted, observation.vertex_index_min, observation.vertex_index_max);
+    effective_minimum = std::min(effective_minimum, effective);
+    effective_maximum = std::max(effective_maximum, effective);
+    ++non_reset_count;
+  }
+  if (!non_reset_count) {
+    pinyon_shift::diagnostics::RecordEvent(
+        "native_renderer.census.index_scan",
+        {{"signature", fmt::format("{:016X}", signature)},
+         {"status", "empty_after_reset"},
+         {"frame", std::to_string(observation.frame_sequence)},
+         {"draw", std::to_string(observation.draw_sequence)},
+         {"index_count", std::to_string(observation.index_count)},
+         {"bytes_read", std::to_string(required_bytes)},
+         {"reset_count", std::to_string(reset_count)},
+         {"guest_payload_read", "bounded_index_only"},
+         {"native_upload", "false"},
+         {"native_draw", "false"},
+         {"suppression_eligible", "false"}});
+    return;
+  }
+
+  pinyon_shift::diagnostics::RecordEvent(
+      "native_renderer.census.index_scan",
+      {{"signature", fmt::format("{:016X}", signature)},
+       {"status", "scanned"},
+       {"frame", std::to_string(observation.frame_sequence)},
+       {"draw", std::to_string(observation.draw_sequence)},
+       {"index_count", std::to_string(observation.index_count)},
+       {"bytes_read", std::to_string(required_bytes)},
+       {"index_buffer_address",
+        fmt::format("{:08X}", observation.index_buffer_address)},
+       {"index_buffer_length", std::to_string(observation.index_buffer_length)},
+       {"index_format", std::to_string(observation.index_format)},
+       {"index_endianness", std::to_string(observation.index_endianness)},
+       {"index_reset_enabled",
+        observation.index_reset_enabled ? "true" : "false"},
+       {"index_reset", fmt::format("{:08X}", observation.index_reset)},
+       {"decoded_minimum", std::to_string(decoded_minimum)},
+       {"decoded_maximum", std::to_string(decoded_maximum)},
+       {"effective_minimum", std::to_string(effective_minimum)},
+       {"effective_maximum", std::to_string(effective_maximum)},
+       {"non_reset_count", std::to_string(non_reset_count)},
+       {"reset_count", std::to_string(reset_count)},
+       {"decoded_hash", fmt::format("{:016X}", decoded_hash)},
+       {"vertex_binding_address",
+        fmt::format("{:08X}", observation.vertex_bindings[0].address)},
+       {"vertex_binding_size",
+        std::to_string(observation.vertex_bindings[0].size)},
+       {"guest_payload_read", "bounded_index_only"},
+       {"native_upload", "false"},
+       {"native_draw", "false"},
+       {"suppression_eligible", "false"}});
 }
 
 uint64_t DrawStateHash(
@@ -1098,6 +1310,7 @@ void RecordCandidate(
   ++g_candidate_census.window_draw_count;
   const uint64_t signature =
       CandidateSignature(observation, samples_resolved_target, prepared);
+  TryScanCandidateIndices(observation, signature);
   size_t index = size_t(signature % kSignatureCapacity);
   for (size_t probe = 0; probe < kSignatureCapacity; ++probe) {
     DrawSignatureEntry &entry = g_candidate_census.entries[index];
@@ -1218,6 +1431,7 @@ void InstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system) {
   ResetDrawCensus();
   ResetPreparedShaderPairs();
   ResetDependencyCensus();
+  ConfigureIndexScan();
   g_graphics_census_installed = true;
   graphics_system->SetDrawObserver(&ObserveDraw);
   graphics_system->SetCopyObserver(&ObserveCopy);
@@ -1235,6 +1449,17 @@ void InstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system) {
                             {"mode", "pass_through"}});
   diagnostics::RecordEvent("native_renderer.census.scene_marker",
                            {{"scene", scene}, {"source", "operator"}});
+  diagnostics::RecordEvent(
+      "native_renderer.census.index_scan_config",
+      {{"status", !g_index_scan.requested
+                      ? "disabled"
+                      : (g_index_scan.valid ? "armed" : "invalid_signature")},
+       {"signature", g_index_scan.valid && g_index_scan.requested
+                         ? fmt::format("{:016X}", g_index_scan.target_signature)
+                         : ""},
+       {"maximum_index_count", std::to_string(kMaximumIndexScanCount)},
+       {"maximum_bytes", std::to_string(kMaximumIndexScanBytes)},
+       {"mode", "bounded_diagnostic_read"}});
 }
 
 void UninstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system) {
@@ -1255,6 +1480,16 @@ void UninstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system) {
     g_pending_candidate.valid = false;
   }
   EmitDependencyCensusWindow();
+  if (g_index_scan.requested && g_index_scan.valid && !g_index_scan.completed) {
+    diagnostics::RecordEvent(
+        "native_renderer.census.index_scan",
+        {{"signature", fmt::format("{:016X}", g_index_scan.target_signature)},
+         {"status", "not_observed"},
+         {"guest_payload_read", "false"},
+         {"native_upload", "false"},
+         {"native_draw", "false"},
+         {"suppression_eligible", "false"}});
+  }
   diagnostics::RecordEvent(
       "native_renderer.census.prepared_shader_pair_summary",
       {{"pairs", std::to_string(g_prepared_shader_pair_count)},

--- a/tools/build-native-geometry-contract.py
+++ b/tools/build-native-geometry-contract.py
@@ -10,6 +10,7 @@ from typing import Any
 
 
 SELECTION_SCHEMA = "pinyon-shift.native-renderer-candidate-selection.v1"
+CENSUS_SCHEMA = "pinyon-shift.native-renderer-census.v1"
 SCHEMA = "pinyon-shift.native-geometry-contract.v1"
 PHYSICAL_MASK = 0x1FFFFFFF
 VERTEX_INDEX_MASK = 0xFFFFFF
@@ -164,7 +165,11 @@ def select_candidate(document: dict[str, Any], signature: str | None) -> dict[st
     return candidates[0]
 
 
-def build(document: dict[str, Any], signature: str | None = None) -> dict[str, Any]:
+def build(
+    document: dict[str, Any],
+    signature: str | None = None,
+    index_censuses: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
     candidate = select_candidate(document, signature)
     if int(candidate.get("vertex_binding_count", 0)) != 1:
         raise ValueError("initial geometry contract requires exactly one vertex binding")
@@ -300,11 +305,100 @@ def build(document: dict[str, Any], signature: str | None = None) -> dict[str, A
             "available_bytes": index_buffer_length,
             "required_bytes_before_scan": required_index_bytes,
         }
-        bounds = {
-            "status": "requires_index_scan",
-            "validated": False,
-            "reason": "index payload is intentionally outside this metadata-only PR",
-        }
+        if not index_censuses:
+            bounds = {
+                "status": "requires_index_scan",
+                "validated": False,
+                "reason": "no bounded index-scan evidence was supplied",
+            }
+        else:
+            if len(index_censuses) < 2:
+                raise ValueError("indexed qualification requires two scan captures")
+            scans = []
+            for census in index_censuses:
+                if census.get("schema") != CENSUS_SCHEMA:
+                    raise ValueError("unsupported index census schema")
+                matching = [
+                    scan
+                    for scan in census.get("index_scans", [])
+                    if scan.get("signature") == candidate.get("signature")
+                    and scan.get("status") == "scanned"
+                ]
+                if len(matching) != 1:
+                    raise ValueError(
+                        "each index census must contain one successful candidate scan"
+                    )
+                scans.append(matching[0])
+            for scan in scans:
+                scan_count = int(scan.get("index_count", 0))
+                scan_bytes = int(scan.get("bytes_read", 0))
+                scan_length = int(scan.get("index_buffer_length", 0))
+                scan_address = int(str(scan.get("index_buffer_address", "0")), 16)
+                if scan_count < int(candidate.get("index_count_min", 0)) or (
+                    scan_count > index_count_max
+                ):
+                    raise ValueError("index scan count is outside candidate observations")
+                if int(scan.get("index_format", -1)) != index_format or int(
+                    scan.get("index_endianness", -1)
+                ) != index_endianness:
+                    raise ValueError("index scan state disagrees with the candidate")
+                if scan_bytes != scan_count * index_element_bytes:
+                    raise ValueError("index scan byte count is inconsistent")
+                if scan_bytes > scan_length:
+                    raise ValueError("index scan exceeded its observed allocation")
+                scan_physical_address = scan_address & PHYSICAL_MASK
+                if scan_physical_address + scan_bytes > PHYSICAL_MASK + 1:
+                    raise ValueError("index scan crosses the physical aperture")
+                effective_minimum = int(scan.get("effective_minimum", -1))
+                effective_maximum = int(scan.get("effective_maximum", -1))
+                if (
+                    int(scan.get("non_reset_count", 0)) <= 0
+                    or effective_minimum < minimum
+                    or effective_maximum > maximum
+                    or effective_maximum < effective_minimum
+                ):
+                    raise ValueError("index scan has invalid effective bounds")
+                if int(scan.get("vertex_binding_size", 0)) != fetch["size_bytes"]:
+                    raise ValueError("index scan vertex allocation changed")
+            stable_fields = (
+                "decoded_minimum",
+                "decoded_maximum",
+                "effective_minimum",
+                "effective_maximum",
+                "non_reset_count",
+                "reset_count",
+                "decoded_hash",
+                "index_reset_enabled",
+                "index_reset",
+            )
+            if any(
+                scan.get(field) != scans[0].get(field)
+                for scan in scans[1:]
+                for field in stable_fields
+            ):
+                raise ValueError("index payload or reset state changed across captures")
+            maximum_vertex = int(scans[0]["effective_maximum"])
+            required_vertex_bytes = maximum_vertex * stride_bytes + maximum_extent
+            if required_vertex_bytes > fetch["size_bytes"]:
+                raise ValueError(
+                    f"scanned vertex fetch needs {required_vertex_bytes} bytes, "
+                    f"has {fetch['size_bytes']}"
+                )
+            bounds = {
+                "status": "bounded_index_scan",
+                "validated": True,
+                "scan_captures": len(scans),
+                "decoded_minimum": int(scans[0]["decoded_minimum"]),
+                "decoded_maximum": int(scans[0]["decoded_maximum"]),
+                "effective_minimum": int(scans[0]["effective_minimum"]),
+                "effective_maximum": maximum_vertex,
+                "non_reset_count": int(scans[0]["non_reset_count"]),
+                "reset_count": int(scans[0]["reset_count"]),
+                "decoded_hash": scans[0]["decoded_hash"],
+                "maximum_attribute_extent_bytes": maximum_extent,
+                "required_vertex_bytes": required_vertex_bytes,
+                "available_vertex_bytes": fetch["size_bytes"],
+            }
     else:
         if index_count_max < 0:
             raise ValueError("index count must not be negative")
@@ -365,7 +459,10 @@ def build(document: dict[str, Any], signature: str | None = None) -> dict[str, A
         "attributes": attributes,
         "bounds": bounds,
         "safety": {
-            "guest_payload_read": False,
+            "guest_payload_read": indexed and bool(index_censuses),
+            "guest_payload_scope": (
+                "bounded_index_only" if indexed and index_censuses else "none"
+            ),
             "native_upload": False,
             "native_draw": False,
             "suppression_allowed": False,
@@ -378,6 +475,7 @@ def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("selection", type=Path)
     parser.add_argument("--signature")
+    parser.add_argument("--index-census", nargs="+", type=Path)
     parser.add_argument("--output", "-o", type=Path)
     return parser.parse_args()
 
@@ -385,7 +483,14 @@ def parse_args() -> argparse.Namespace:
 def main() -> int:
     args = parse_args()
     document = json.loads(args.selection.read_text(encoding="utf-8"))
-    rendered = json.dumps(build(document, args.signature), indent=2) + "\n"
+    index_censuses = (
+        [json.loads(path.read_text(encoding="utf-8")) for path in args.index_census]
+        if args.index_census
+        else None
+    )
+    rendered = json.dumps(
+        build(document, args.signature, index_censuses), indent=2
+    ) + "\n"
     if args.output:
         args.output.write_text(rendered, encoding="utf-8")
     else:

--- a/tools/capture-native-renderer-census.ps1
+++ b/tools/capture-native-renderer-census.ps1
@@ -6,6 +6,8 @@ param(
         'save_reload')]
     [string]$Scene = 'unmarked',
     [string]$ShaderCaptureDir,
+    [ValidatePattern('^[0-9A-Fa-f]{16}$')]
+    [string]$IndexScanSignature,
     [switch]$Json
 )
 
@@ -43,9 +45,11 @@ if (@(Get-Process -Name 'pinyon_shift' -ErrorAction SilentlyContinue).Count -ne 
 
 $savedCensus = $env:REX_PINYON_SHIFT_NATIVE_RENDERER_CENSUS
 $savedScene = $env:PINYON_SHIFT_NATIVE_RENDERER_SCENE
+$savedIndexScan = $env:PINYON_SHIFT_NATIVE_RENDERER_INDEX_SCAN_SIGNATURE
 try {
     $env:REX_PINYON_SHIFT_NATIVE_RENDERER_CENSUS = 'true'
     $env:PINYON_SHIFT_NATIVE_RENDERER_SCENE = $Scene
+    $env:PINYON_SHIFT_NATIVE_RENDERER_INDEX_SCAN_SIGNATURE = $IndexScanSignature
     & (Join-Path $PSScriptRoot 'launch-preview.ps1') `
         -StateRoot $resolvedStateRoot -ShaderCaptureDir $ShaderCaptureDir `
         -Json:$Json
@@ -53,4 +57,5 @@ try {
 finally {
     $env:REX_PINYON_SHIFT_NATIVE_RENDERER_CENSUS = $savedCensus
     $env:PINYON_SHIFT_NATIVE_RENDERER_SCENE = $savedScene
+    $env:PINYON_SHIFT_NATIVE_RENDERER_INDEX_SCAN_SIGNATURE = $savedIndexScan
 }

--- a/tools/summarize-native-renderer-census.py
+++ b/tools/summarize-native-renderer-census.py
@@ -136,6 +136,7 @@ def summarize(
     draw_signatures: dict[str, dict[str, Any]] = {}
     draw_candidates: dict[str, dict[str, Any]] = {}
     prepared_shader_pairs: dict[tuple[str, str, str, str], dict[str, Any]] = {}
+    index_scans: list[dict[str, Any]] = []
     dependencies: dict[str, dict[str, Any]] = {}
     resolve_targets: dict[str, dict[str, Any]] = {}
     totals = {
@@ -213,6 +214,8 @@ def summarize(
                 str(event["pixel_specialization_mask"]),
             )
             prepared_shader_pairs.setdefault(key, dict(event))
+        elif kind == f"{PREFIX}index_scan":
+            index_scans.append(dict(event))
         elif kind == f"{PREFIX}resolve_window":
             for key in (
                 "resolves",
@@ -281,6 +284,7 @@ def summarize(
         "prepared_shader_pairs": [
             clean(record) for _, record in sorted(prepared_shader_pairs.items())
         ],
+        "index_scans": [clean(record) for record in index_scans],
         "resolve_dependencies": [
             clean(record) for _, record in sorted(dependencies.items())
         ],
@@ -289,7 +293,14 @@ def summarize(
         ],
         "safety": {
             "suppression_allowed": False,
-            "guest_cpu_reads": "unknown_uninstrumented",
+            "guest_cpu_reads": (
+                "bounded_index_payload"
+                if any(
+                    record.get("guest_payload_read") == "bounded_index_only"
+                    for record in index_scans
+                )
+                else "unknown_uninstrumented"
+            ),
             "presentation_only": "unknown_uninstrumented",
             "semantic_roles": "unknown_unclassified",
         },

--- a/tools/tests/test_native_renderer_census.py
+++ b/tools/tests/test_native_renderer_census.py
@@ -124,6 +124,13 @@ class NativeRendererCensusTests(unittest.TestCase):
                 "pixel_specialization_mask": "BBBBBBBBBBBBBBBB",
             },
             {
+                "event": "native_renderer.census.index_scan",
+                "session": "new",
+                "signature": "CANDIDATE",
+                "status": "scanned",
+                "guest_payload_read": "bounded_index_only",
+            },
+            {
                 "event": "native_renderer.census.resolve_window",
                 "session": "new",
                 "resolves": "7",
@@ -182,6 +189,8 @@ class NativeRendererCensusTests(unittest.TestCase):
             "AAAAAAAAAAAAAAAA",
             result["prepared_shader_pairs"][0]["vertex_specialization_mask"],
         )
+        self.assertEqual("CANDIDATE", result["index_scans"][0]["signature"])
+        self.assertEqual("bounded_index_payload", result["safety"]["guest_cpu_reads"])
         self.assertEqual("7", result["resolve_dependencies"][0]["resolves"])
         self.assertEqual("00123000", result["resolve_targets"][0]["address"])
         self.assertEqual("4096", result["resolve_targets"][0]["length"])

--- a/tools/tests/test_native_renderer_contract.py
+++ b/tools/tests/test_native_renderer_contract.py
@@ -370,15 +370,32 @@ class NativeRendererContractTests(unittest.TestCase):
         ):
             self.assertNotIn(forbidden, draw_state_patch)
 
+        index_reset_patch = (
+            ROOT / "patches/rexglue/0055-graphics-index-reset-observer.patch"
+        ).read_text(encoding="utf-8")
+        self.assertIn("index_reset", index_reset_patch)
+        self.assertIn("multi_prim_ib_ena", index_reset_patch)
+        self.assertNotIn("TranslatePhysical", index_reset_patch)
+
         planner = (
             ROOT / "tools/build-native-geometry-contract.py"
         ).read_text(encoding="utf-8")
         self.assertIn("PHYSICAL_MASK = 0x1FFFFFFF", planner)
-        self.assertIn('"guest_payload_read": False', planner)
+        self.assertIn('"guest_payload_scope"', planner)
+        self.assertIn('"bounded_index_only"', planner)
         self.assertIn('"native_upload": False', planner)
         self.assertIn('"native_draw": False', planner)
         self.assertIn('"suppression_allowed": False', planner)
         self.assertIn('"xenos_authority": True', planner)
+
+        scanner = (
+            ROOT / "src/native_renderer/graphics_hooks.cpp"
+        ).read_text(encoding="utf-8")
+        self.assertIn("PINYON_SHIFT_NATIVE_RENDERER_INDEX_SCAN_SIGNATURE", scanner)
+        self.assertIn("kMaximumIndexScanCount", scanner)
+        self.assertIn("kMaximumIndexScanBytes", scanner)
+        self.assertIn('"bounded_index_only"', scanner)
+        self.assertNotIn("SetDrawSuppression", scanner)
 
         draw_state_planner = (
             ROOT / "tools/build-native-draw-state-contract.py"

--- a/tools/tests/test_native_renderer_geometry.py
+++ b/tools/tests/test_native_renderer_geometry.py
@@ -37,6 +37,34 @@ def selection(**overrides):
     return {"schema": MODULE.SELECTION_SCHEMA, "candidates": [candidate]}
 
 
+def index_census(decoded_hash="0123456789ABCDEF"):
+    return {
+        "schema": MODULE.CENSUS_SCHEMA,
+        "index_scans": [
+            {
+                "signature": "E184D75768958828",
+                "status": "scanned",
+                "index_count": "3",
+                "bytes_read": "6",
+                "index_buffer_address": "E0180000",
+                "index_buffer_length": "6",
+                "index_format": "0",
+                "index_endianness": "2",
+                "index_reset_enabled": "false",
+                "index_reset": "0000FFFF",
+                "decoded_minimum": "0",
+                "decoded_maximum": "2",
+                "effective_minimum": "0",
+                "effective_maximum": "2",
+                "non_reset_count": "3",
+                "reset_count": "0",
+                "decoded_hash": decoded_hash,
+                "vertex_binding_size": "120",
+            }
+        ],
+    }
+
+
 class NativeRendererGeometryTests(unittest.TestCase):
     def test_decodes_every_pinned_xenos_vertex_format_word_shape(self):
         expected = {
@@ -135,6 +163,29 @@ class NativeRendererGeometryTests(unittest.TestCase):
         document["candidates"][0]["indexed"] = True
         with self.assertRaisesRegex(ValueError, "index fetch needs 6 bytes, has 5"):
             MODULE.build(document)
+
+    def test_validates_repeatable_bounded_index_scan(self):
+        document = deepcopy(selection())
+        document["candidates"][0]["indexed"] = True
+
+        result = MODULE.build(document, index_censuses=[index_census(), index_census()])
+
+        self.assertEqual("bounded_index_scan", result["bounds"]["status"])
+        self.assertTrue(result["bounds"]["validated"])
+        self.assertEqual(2, result["bounds"]["scan_captures"])
+        self.assertEqual(104, result["bounds"]["required_vertex_bytes"])
+        self.assertTrue(result["safety"]["guest_payload_read"])
+        self.assertEqual("bounded_index_only", result["safety"]["guest_payload_scope"])
+        self.assertFalse(result["safety"]["native_draw"])
+
+    def test_rejects_index_payload_drift(self):
+        document = deepcopy(selection())
+        document["candidates"][0]["indexed"] = True
+        with self.assertRaisesRegex(ValueError, "changed across captures"):
+            MODULE.build(
+                document,
+                index_censuses=[index_census(), index_census("FEDCBA9876543210")],
+            )
 
 
 if __name__ == "__main__":

--- a/tools/tests/test_release_contract.py
+++ b/tools/tests/test_release_contract.py
@@ -43,10 +43,10 @@ class ReleaseContractTests(unittest.TestCase):
 
     def test_rexglue_patches_have_stable_order_and_no_binary_payload(self):
         patches = sorted((ROOT / "patches/rexglue").glob("*.patch"))
-        self.assertEqual(len(patches), 54)
+        self.assertEqual(len(patches), 55)
         self.assertEqual(
             patches[-1].name,
-            "0054-graphics-draw-state-observer.patch",
+            "0055-graphics-index-reset-observer.patch",
         )
         self.assertEqual(len(patches), len({path.name[:4] for path in patches}))
         for path in patches:


### PR DESCRIPTION
## Summary
- add a default-off exact-signature index scanner with hard 1,048,576-index / 4 MiB limits
- capture Xenos primitive-reset state and apply index endianness, 24-bit offset, and clamp semantics
- require two stable scan captures before the geometry planner validates indexed vertex bounds
- document the exact FA45AAFDC22C8625 allocation proof

## Evidence
- sessions 20260828T070848Z-p13800 and 20260828T071104Z-p37760 exited normally
- both decoded 9,300 indices, range 0–1,616, hash 76F4D9C9DFE1E128
- derived vertex requirement is exactly 51,744 / 51,744 bytes
- zero crash, error, device-loss, or presentation-deadline-miss events

## Safety
- payload logging is hashes and bounds only; no bytes leave the local machine
- scanner reads only the configured signature once per process
- no vertex/texture payload read, native upload, native draw, or suppression path
- Xenos remains authoritative

## Validation
- python -m unittest discover -s tools/tests -p 'test_*.py' (98 passed)
- cmake --build --preset win-amd64-release --parallel 16
- all 55 ReXGlue patches apply cleanly from the pinned base