### PR TITLE
feat(native-renderer): fingerprint candidate textures

### DIFF
--- a/docs/native-renderer/CANDIDATE_DRAW_SELECTION.md
+++ b/docs/native-renderer/CANDIDATE_DRAW_SELECTION.md
@@ -253,3 +253,11 @@ the same 9,300-index payload, range 0–1,616, and hash
 51,744-byte allocation. See [GEOMETRY_CONTRACT.md](GEOMETRY_CONTRACT.md) for
 the scanner contract and safety boundary. The candidate remains pending visual
 identification and static texture-provenance review before any replay work.
+
+The subsequent exact-signature scan established stable 16 KiB fingerprints
+for both texture fetches across two independent AppData-backed processes. The
+bounded scanner, cross-capture gate, crash-hardening result, and remaining
+visual/dependency restrictions are recorded in
+[TEXTURE_PROVENANCE_CONTRACT.md](TEXTURE_PROVENANCE_CONTRACT.md). This is
+source-content evidence only; it does not enable upload, replay, or
+suppression.

--- a/docs/native-renderer/TEXTURE_PROVENANCE_CONTRACT.md
+++ b/docs/native-renderer/TEXTURE_PROVENANCE_CONTRACT.md
@@ -1,0 +1,86 @@
+# Texture provenance contract
+
+NR-02 texture qualification is an opt-in, exact-signature diagnostic. It
+establishes bounded source-content stability for a selected candidate; it does
+not establish visual identity, prove that a resource is never GPU-produced, or
+authorize a native upload, draw, or Xenos suppression.
+
+## Runtime boundary
+
+ReXGlue patch `0056-graphics-texture-layout-observer.patch` adds calculated
+base and mip allocation lengths to the existing bounded draw observation. The
+layout is accepted only while the referenced fetch constant is currently a
+texture. No guest address is dereferenced by ReXGlue, and invalid or stale
+fetch constants leave the layout-valid bit clear.
+
+The title reads texture payload only when
+`PINYON_SHIFT_NATIVE_RENDERER_TEXTURE_SCAN_SIGNATURE` is an exact 16-digit
+candidate signature and a prepared draw matches it. The scanner is
+once-per-process and rejects the complete scan before any read unless every
+resource satisfies all of these constraints:
+
+- one through four texture resources;
+- a valid observed layout and a nonzero base allocation;
+- no resource larger than 16 MiB;
+- no aggregate payload larger than 32 MiB; and
+- every base and mip range contained in the guest physical aperture.
+
+Successful scans hash the bounded base and mip ranges with FNV-1a. They emit
+addresses, byte counts, and hashes to diagnostics, but persist no payload
+bytes. The code does not decode, upload, bind, draw, or suppress anything.
+Xenos renders and presents the frame.
+
+Use the capture wrapper to arm the exact-signature scan:
+
+```powershell
+.\tools\capture-native-renderer-census.ps1 `
+  -StateRoot $stateRoot `
+  -Scene open_world_day `
+  -TextureScanSignature FA45AAFDC22C8625
+```
+
+Summarize at least two independent sessions, then build the cross-capture
+contract:
+
+```powershell
+python .\tools\build-native-texture-provenance.py `
+  .\.local\native-renderer\candidate\run-1-census.json `
+  .\.local\native-renderer\candidate\run-2-census.json `
+  --signature FA45AAFDC22C8625 `
+  --output .\.local\native-renderer\candidate\texture-provenance.json
+```
+
+The builder requires the same successful exact-signature scan, fetch-constant
+set, byte lengths, and hashes in every input. Address relocation is reported
+but is not required: deterministic allocation addresses are not evidence
+against content stability. The resulting `source_texture_candidate` verdict
+still carries `visual_identity_confirmed: false` and
+`dynamic_render_target_exclusion_required: true`.
+
+## Local qualification — 2026-08-28
+
+Two AppData-backed captures of candidate `FA45AAFDC22C8625` produced the same
+bounded texture set:
+
+| Session | Fetch | Base bytes | Base hash |
+| --- | ---: | ---: | --- |
+| `20260828T074051Z-p9108` | 0 | 16,384 | `813168E347A20D13` |
+| `20260828T074051Z-p9108` | 2 | 16,384 | `A1341C9AE209EB41` |
+| `20260828T080034Z-p41528` | 0 | 16,384 | `813168E347A20D13` |
+| `20260828T080034Z-p41528` | 2 | 16,384 | `A1341C9AE209EB41` |
+
+Neither texture has a separate mip allocation. Both captures used the same
+guest addresses, so relocation remains unproven; the content and allocation
+shape are stable across independent processes.
+
+The first run also exposed a stale-fetch safety bug after the successful scan:
+the layout observer passed a fetch constant that was no longer typed as a
+texture into `TextureInfo::Prepare`, causing an integer divide-by-zero. The
+observer now requires `FetchConstantType::kTexture` before layout calculation.
+The rebuilt second run passed the same single-player transition, reached the
+saved festival scene, emitted the matching scan at frame 4,352, and exited
+normally with code zero.
+
+This evidence advances the candidate through static-content fingerprinting
+only. Visual identification and dynamic render-target exclusion remain open,
+and Xenos authority remains mandatory for subsequent isolated replay work.

--- a/patches/rexglue/0056-graphics-texture-layout-observer.patch
+++ b/patches/rexglue/0056-graphics-texture-layout-observer.patch
@@ -1,0 +1,33 @@
+diff --git a/include/rex/system/interfaces/graphics.h b/include/rex/system/interfaces/graphics.h
+--- a/include/rex/system/interfaces/graphics.h
++++ b/include/rex/system/interfaces/graphics.h
+@@ -178,6 +178,9 @@ struct GraphicsDrawObservation {
+   uint32_t pa_su_vtx_cntl = 0;
+   uint32_t texture_fetch_addresses[32] = {};
+   uint32_t texture_fetch_mip_addresses[32] = {};
++  uint32_t texture_fetch_base_lengths[32] = {};
++  uint32_t texture_fetch_mip_lengths[32] = {};
++  uint32_t texture_fetch_layout_valid_mask = 0;
+   uint32_t vertex_float_constant_count = 0;
+   GraphicsFloatConstantObservation vertex_float_constants
+       [kGraphicsFloatConstantObservationLimit] = {};
+diff --git a/src/graphics/command_processor.cpp b/src/graphics/command_processor.cpp
+--- a/src/graphics/command_processor.cpp
++++ b/src/graphics/command_processor.cpp
+@@ -1676,6 +1676,16 @@ bool CommandProcessor::ExecutePacketType3Draw(memory::RingBuffer* reader, uint32
+             observation.texture_fetch_mask |= uint32_t(1) << fetch_index;
+             observation.texture_fetch_addresses[fetch_index] = fetch.base_address << 12;
+             observation.texture_fetch_mip_addresses[fetch_index] = fetch.mip_address << 12;
++            TextureInfo texture_info;
++            if (fetch.type == xenos::FetchConstantType::kTexture &&
++                TextureInfo::Prepare(fetch, &texture_info)) {
++              observation.texture_fetch_base_lengths[fetch_index] =
++                  texture_info.memory.base_size;
++              observation.texture_fetch_mip_lengths[fetch_index] =
++                  texture_info.memory.mip_size;
++              observation.texture_fetch_layout_valid_mask |=
++                  uint32_t(1) << fetch_index;
++            }
+             const uint32_t state_index = observation.texture_state_count++;
+             if (state_index >= system::kGraphicsTextureFetchObservationLimit) {
+               observation.texture_state_overflow = 1;

--- a/src/native_renderer/graphics_hooks.cpp
+++ b/src/native_renderer/graphics_hooks.cpp
@@ -41,6 +41,9 @@ constexpr uint64_t kPhysicalApertureSize = UINT64_C(0x20000000);
 constexpr uint32_t kVertexIndexMask = 0x00FFFFFF;
 constexpr uint32_t kMaximumIndexScanCount = 1 << 20;
 constexpr uint64_t kMaximumIndexScanBytes = UINT64_C(4) << 20;
+constexpr uint32_t kMaximumTextureScanResources = 4;
+constexpr uint64_t kMaximumTextureScanResourceBytes = UINT64_C(16) << 20;
+constexpr uint64_t kMaximumTextureScanTotalBytes = UINT64_C(32) << 20;
 std::atomic<uint64_t> g_frame_sequence{};
 
 std::string CensusSceneMarker() {
@@ -71,31 +74,51 @@ struct IndexScanState {
 
 IndexScanState g_index_scan;
 
-void ConfigureIndexScan() {
-  g_index_scan = {};
+struct TextureScanState {
+  uint64_t target_signature = 0;
+  bool requested = false;
+  bool completed = false;
+  bool valid = true;
+};
+
+TextureScanState g_texture_scan;
+
+void ConfigureSignatureScan(const char *name, uint64_t &target_signature,
+                            bool &requested, bool &valid) {
   char *value = nullptr;
   size_t length = 0;
-  if (_dupenv_s(&value, &length,
-                "PINYON_SHIFT_NATIVE_RENDERER_INDEX_SCAN_SIGNATURE") != 0 ||
-      !value || length <= 1) {
+  if (_dupenv_s(&value, &length, name) != 0 || !value || length <= 1) {
     std::free(value);
     return;
   }
   const std::string setting(value);
   std::free(value);
-  g_index_scan.requested = true;
+  requested = true;
   if (setting.size() != 16) {
-    g_index_scan.valid = false;
+    valid = false;
     return;
   }
   const char *begin = setting.data();
   const char *end = begin + setting.size();
-  const auto parsed =
-      std::from_chars(begin, end, g_index_scan.target_signature, 16);
-  if (parsed.ec != std::errc{} || parsed.ptr != end ||
-      !g_index_scan.target_signature) {
-    g_index_scan.valid = false;
+  const auto parsed = std::from_chars(begin, end, target_signature, 16);
+  if (parsed.ec != std::errc{} || parsed.ptr != end || !target_signature) {
+    valid = false;
   }
+}
+
+void ConfigureIndexScan() {
+  g_index_scan = {};
+  ConfigureSignatureScan("PINYON_SHIFT_NATIVE_RENDERER_INDEX_SCAN_SIGNATURE",
+                         g_index_scan.target_signature,
+                         g_index_scan.requested, g_index_scan.valid);
+}
+
+void ConfigureTextureScan() {
+  g_texture_scan = {};
+  ConfigureSignatureScan(
+      "PINYON_SHIFT_NATIVE_RENDERER_TEXTURE_SCAN_SIGNATURE",
+      g_texture_scan.target_signature, g_texture_scan.requested,
+      g_texture_scan.valid);
 }
 
 struct DrawSignatureEntry {
@@ -219,6 +242,133 @@ void ResetDependencyCensus() {
 uint64_t HashCombine(uint64_t hash, uint64_t value) {
   value += 0x9E3779B97F4A7C15ull + (hash << 6) + (hash >> 2);
   return hash ^ value;
+}
+
+uint64_t HashBytes(const uint8_t *data, uint64_t length) {
+  uint64_t hash = 0xCBF29CE484222325ull;
+  for (uint64_t i = 0; i < length; ++i) {
+    hash ^= data[i];
+    hash *= 0x100000001B3ull;
+  }
+  return hash;
+}
+
+void TryFingerprintCandidateTextures(
+    const rex::system::GraphicsDrawObservation &observation,
+    uint64_t signature) {
+  if (!g_texture_scan.requested || !g_texture_scan.valid ||
+      g_texture_scan.completed ||
+      signature != g_texture_scan.target_signature) {
+    return;
+  }
+  g_texture_scan.completed = true;
+
+  const auto reject = [&](const char *reason) {
+    pinyon_shift::diagnostics::RecordEvent(
+        "native_renderer.census.texture_scan",
+        {{"signature", fmt::format("{:016X}", signature)},
+         {"status", "rejected"},
+         {"reason", reason},
+         {"frame", std::to_string(observation.frame_sequence)},
+         {"draw", std::to_string(observation.draw_sequence)},
+         {"guest_payload_read", "false"},
+         {"native_upload", "false"},
+         {"native_draw", "false"},
+         {"suppression_eligible", "false"}});
+  };
+
+  const uint32_t resource_count = std::popcount(observation.texture_fetch_mask);
+  if (!resource_count || resource_count > kMaximumTextureScanResources ||
+      observation.texture_state_overflow) {
+    reject("texture_resource_count_out_of_bounds");
+    return;
+  }
+  if ((observation.texture_fetch_layout_valid_mask &
+       observation.texture_fetch_mask) != observation.texture_fetch_mask) {
+    reject("texture_layout_unavailable");
+    return;
+  }
+
+  uint64_t total_bytes = 0;
+  for (uint32_t fetch = 0; fetch < 32; ++fetch) {
+    if (!(observation.texture_fetch_mask & (uint32_t(1) << fetch))) {
+      continue;
+    }
+    const uint64_t base_address =
+        observation.texture_fetch_addresses[fetch] & UINT64_C(0x1FFFFFFF);
+    const uint64_t base_length = observation.texture_fetch_base_lengths[fetch];
+    const uint64_t mip_address =
+        observation.texture_fetch_mip_addresses[fetch] & UINT64_C(0x1FFFFFFF);
+    const uint64_t mip_length = observation.texture_fetch_mip_lengths[fetch];
+    if (!base_length || base_length > kMaximumTextureScanResourceBytes ||
+        mip_length > kMaximumTextureScanResourceBytes ||
+        base_address + base_length > kPhysicalApertureSize ||
+        (mip_length && (!mip_address ||
+                        mip_address + mip_length > kPhysicalApertureSize))) {
+      reject("texture_allocation_out_of_bounds");
+      return;
+    }
+    total_bytes += base_length + mip_length;
+    if (total_bytes > kMaximumTextureScanTotalBytes) {
+      reject("texture_scan_total_out_of_bounds");
+      return;
+    }
+  }
+
+  auto *kernel_state = rex::system::kernel_state();
+  if (!kernel_state || !kernel_state->memory()) {
+    reject("guest_memory_unavailable");
+    return;
+  }
+
+  uint32_t resource = 0;
+  for (uint32_t fetch = 0; fetch < 32; ++fetch) {
+    if (!(observation.texture_fetch_mask & (uint32_t(1) << fetch))) {
+      continue;
+    }
+    const uint32_t base_address = observation.texture_fetch_addresses[fetch];
+    const uint32_t base_length =
+        observation.texture_fetch_base_lengths[fetch];
+    const uint32_t mip_address =
+        observation.texture_fetch_mip_addresses[fetch];
+    const uint32_t mip_length = observation.texture_fetch_mip_lengths[fetch];
+    const uint8_t *base =
+        kernel_state->memory()->TranslatePhysical<const uint8_t *>(base_address);
+    const uint64_t base_hash = HashBytes(base, base_length);
+    uint64_t mip_hash = 0;
+    if (mip_length) {
+      const uint8_t *mip =
+          kernel_state->memory()->TranslatePhysical<const uint8_t *>(mip_address);
+      mip_hash = HashBytes(mip, mip_length);
+    }
+    pinyon_shift::diagnostics::RecordEvent(
+        "native_renderer.census.texture_fingerprint",
+        {{"signature", fmt::format("{:016X}", signature)},
+         {"resource", std::to_string(resource++)},
+         {"fetch_constant", std::to_string(fetch)},
+         {"base_address", fmt::format("{:08X}", base_address)},
+         {"base_bytes", std::to_string(base_length)},
+         {"base_hash", fmt::format("{:016X}", base_hash)},
+         {"mip_address", fmt::format("{:08X}", mip_address)},
+         {"mip_bytes", std::to_string(mip_length)},
+         {"mip_hash", mip_length ? fmt::format("{:016X}", mip_hash) : ""},
+         {"guest_payload_read", "bounded_texture_only"},
+         {"native_upload", "false"},
+         {"native_draw", "false"},
+         {"suppression_eligible", "false"}});
+  }
+  pinyon_shift::diagnostics::RecordEvent(
+      "native_renderer.census.texture_scan",
+      {{"signature", fmt::format("{:016X}", signature)},
+       {"status", "scanned"},
+       {"frame", std::to_string(observation.frame_sequence)},
+       {"draw", std::to_string(observation.draw_sequence)},
+       {"resources", std::to_string(resource_count)},
+       {"bytes_read", std::to_string(total_bytes)},
+       {"guest_payload_read", "bounded_texture_only"},
+       {"native_upload", "false"},
+       {"native_draw", "false"},
+       {"suppression_eligible", "false"}});
 }
 
 void TryScanCandidateIndices(
@@ -1311,6 +1461,7 @@ void RecordCandidate(
   const uint64_t signature =
       CandidateSignature(observation, samples_resolved_target, prepared);
   TryScanCandidateIndices(observation, signature);
+  TryFingerprintCandidateTextures(observation, signature);
   size_t index = size_t(signature % kSignatureCapacity);
   for (size_t probe = 0; probe < kSignatureCapacity; ++probe) {
     DrawSignatureEntry &entry = g_candidate_census.entries[index];
@@ -1432,6 +1583,7 @@ void InstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system) {
   ResetPreparedShaderPairs();
   ResetDependencyCensus();
   ConfigureIndexScan();
+  ConfigureTextureScan();
   g_graphics_census_installed = true;
   graphics_system->SetDrawObserver(&ObserveDraw);
   graphics_system->SetCopyObserver(&ObserveCopy);
@@ -1460,6 +1612,22 @@ void InstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system) {
        {"maximum_index_count", std::to_string(kMaximumIndexScanCount)},
        {"maximum_bytes", std::to_string(kMaximumIndexScanBytes)},
        {"mode", "bounded_diagnostic_read"}});
+  diagnostics::RecordEvent(
+      "native_renderer.census.texture_scan_config",
+      {{"status", !g_texture_scan.requested
+                      ? "disabled"
+                      : (g_texture_scan.valid ? "armed" : "invalid_signature")},
+       {"signature", g_texture_scan.valid && g_texture_scan.requested
+                         ? fmt::format("{:016X}",
+                                       g_texture_scan.target_signature)
+                         : ""},
+       {"maximum_resources",
+        std::to_string(kMaximumTextureScanResources)},
+       {"maximum_resource_bytes",
+        std::to_string(kMaximumTextureScanResourceBytes)},
+       {"maximum_total_bytes",
+        std::to_string(kMaximumTextureScanTotalBytes)},
+       {"mode", "bounded_diagnostic_read"}});
 }
 
 void UninstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system) {
@@ -1484,6 +1652,18 @@ void UninstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system) {
     diagnostics::RecordEvent(
         "native_renderer.census.index_scan",
         {{"signature", fmt::format("{:016X}", g_index_scan.target_signature)},
+         {"status", "not_observed"},
+         {"guest_payload_read", "false"},
+         {"native_upload", "false"},
+         {"native_draw", "false"},
+         {"suppression_eligible", "false"}});
+  }
+  if (g_texture_scan.requested && g_texture_scan.valid &&
+      !g_texture_scan.completed) {
+    diagnostics::RecordEvent(
+        "native_renderer.census.texture_scan",
+        {{"signature",
+          fmt::format("{:016X}", g_texture_scan.target_signature)},
          {"status", "not_observed"},
          {"guest_payload_read", "false"},
          {"native_upload", "false"},

--- a/tools/build-native-texture-provenance.py
+++ b/tools/build-native-texture-provenance.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""Build a bounded cross-capture NR-02 texture provenance contract."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+
+SCHEMA = "pinyon-shift.native-texture-provenance.v1"
+CENSUS_SCHEMA = "pinyon-shift.native-renderer-census.v1"
+
+
+def integer(record: dict[str, Any], field: str) -> int:
+    try:
+        return int(record[field])
+    except (KeyError, TypeError, ValueError) as exc:
+        raise ValueError(f"texture fingerprint has invalid {field}") from exc
+
+
+def build(captures: list[dict[str, Any]], signature: str) -> dict[str, Any]:
+    if len(captures) < 2:
+        raise ValueError("texture provenance requires at least two captures")
+    if len(signature) != 16 or any(character not in "0123456789abcdefABCDEF" for character in signature):
+        raise ValueError("texture provenance requires a 16-digit signature")
+    signature = signature.upper()
+
+    normalized: list[dict[int, dict[str, Any]]] = []
+    sessions: list[str] = []
+    for capture in captures:
+        if capture.get("schema") != CENSUS_SCHEMA:
+            raise ValueError("unsupported census schema")
+        sessions.append(str(capture.get("session", "")))
+        scans = [
+            record for record in capture.get("texture_scans", [])
+            if record.get("signature") == signature and record.get("status") == "scanned"
+        ]
+        if len(scans) != 1:
+            raise ValueError("each capture must contain one successful texture scan")
+        expected = integer(scans[0], "resources")
+        records = [
+            record for record in capture.get("texture_fingerprints", [])
+            if record.get("signature") == signature
+        ]
+        if len(records) != expected or not 1 <= expected <= 4:
+            raise ValueError("texture fingerprint count does not match the scan")
+        by_fetch: dict[int, dict[str, Any]] = {}
+        for record in records:
+            fetch = integer(record, "fetch_constant")
+            if fetch in by_fetch or not 0 <= fetch < 32:
+                raise ValueError("texture fingerprints have duplicate or invalid fetch constants")
+            base_bytes = integer(record, "base_bytes")
+            mip_bytes = integer(record, "mip_bytes")
+            base_hash = str(record.get("base_hash", ""))
+            mip_hash = str(record.get("mip_hash", ""))
+            if base_bytes <= 0 or len(base_hash) != 16:
+                raise ValueError("texture fingerprint has invalid base content")
+            if (mip_bytes == 0 and mip_hash) or (mip_bytes > 0 and len(mip_hash) != 16):
+                raise ValueError("texture fingerprint has invalid mip content")
+            by_fetch[fetch] = {
+                "base_address": str(record.get("base_address", "")),
+                "base_bytes": base_bytes,
+                "base_hash": base_hash,
+                "mip_address": str(record.get("mip_address", "")),
+                "mip_bytes": mip_bytes,
+                "mip_hash": mip_hash,
+            }
+        normalized.append(by_fetch)
+
+    fetches = sorted(normalized[0])
+    if any(sorted(capture) != fetches for capture in normalized[1:]):
+        raise ValueError("texture fetch identities differ across captures")
+
+    resources: list[dict[str, Any]] = []
+    for fetch in fetches:
+        observations = [capture[fetch] for capture in normalized]
+        content_keys = {
+            (
+                item["base_bytes"], item["base_hash"],
+                item["mip_bytes"], item["mip_hash"],
+            )
+            for item in observations
+        }
+        if len(content_keys) != 1:
+            raise ValueError(f"texture fetch {fetch} content differs across captures")
+        addresses = {
+            (item["base_address"], item["mip_address"])
+            for item in observations
+        }
+        first = observations[0]
+        resources.append({
+            "fetch_constant": fetch,
+            "base_bytes": first["base_bytes"],
+            "base_hash": first["base_hash"],
+            "mip_bytes": first["mip_bytes"],
+            "mip_hash": first["mip_hash"],
+            "addresses_relocated_across_captures": len(addresses) > 1,
+        })
+
+    return {
+        "schema": SCHEMA,
+        "candidate_signature": signature,
+        "capture_count": len(captures),
+        "sessions": sessions,
+        "resource_count": len(resources),
+        "resources": resources,
+        "qualification": {
+            "content_stable_across_captures": True,
+            "source_texture_candidate": True,
+            "visual_identity_confirmed": False,
+            "dynamic_render_target_exclusion_required": True,
+        },
+        "safety": {
+            "guest_payload_read": "bounded_texture_only",
+            "payload_persisted": False,
+            "native_upload": False,
+            "native_draw": False,
+            "suppression_allowed": False,
+            "xenos_authority": True,
+        },
+    }
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("captures", nargs="+", type=Path)
+    parser.add_argument("--signature", required=True)
+    parser.add_argument("--output", "-o", type=Path)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    captures = [json.loads(path.read_text(encoding="utf-8")) for path in args.captures]
+    result = build(captures, args.signature)
+    rendered = json.dumps(result, indent=2) + "\n"
+    if args.output:
+        args.output.write_text(rendered, encoding="utf-8")
+    else:
+        print(rendered, end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/capture-native-renderer-census.ps1
+++ b/tools/capture-native-renderer-census.ps1
@@ -8,6 +8,8 @@ param(
     [string]$ShaderCaptureDir,
     [ValidatePattern('^[0-9A-Fa-f]{16}$')]
     [string]$IndexScanSignature,
+    [ValidatePattern('^[0-9A-Fa-f]{16}$')]
+    [string]$TextureScanSignature,
     [switch]$Json
 )
 
@@ -46,10 +48,12 @@ if (@(Get-Process -Name 'pinyon_shift' -ErrorAction SilentlyContinue).Count -ne 
 $savedCensus = $env:REX_PINYON_SHIFT_NATIVE_RENDERER_CENSUS
 $savedScene = $env:PINYON_SHIFT_NATIVE_RENDERER_SCENE
 $savedIndexScan = $env:PINYON_SHIFT_NATIVE_RENDERER_INDEX_SCAN_SIGNATURE
+$savedTextureScan = $env:PINYON_SHIFT_NATIVE_RENDERER_TEXTURE_SCAN_SIGNATURE
 try {
     $env:REX_PINYON_SHIFT_NATIVE_RENDERER_CENSUS = 'true'
     $env:PINYON_SHIFT_NATIVE_RENDERER_SCENE = $Scene
     $env:PINYON_SHIFT_NATIVE_RENDERER_INDEX_SCAN_SIGNATURE = $IndexScanSignature
+    $env:PINYON_SHIFT_NATIVE_RENDERER_TEXTURE_SCAN_SIGNATURE = $TextureScanSignature
     & (Join-Path $PSScriptRoot 'launch-preview.ps1') `
         -StateRoot $resolvedStateRoot -ShaderCaptureDir $ShaderCaptureDir `
         -Json:$Json
@@ -58,4 +62,5 @@ finally {
     $env:REX_PINYON_SHIFT_NATIVE_RENDERER_CENSUS = $savedCensus
     $env:PINYON_SHIFT_NATIVE_RENDERER_SCENE = $savedScene
     $env:PINYON_SHIFT_NATIVE_RENDERER_INDEX_SCAN_SIGNATURE = $savedIndexScan
+    $env:PINYON_SHIFT_NATIVE_RENDERER_TEXTURE_SCAN_SIGNATURE = $savedTextureScan
 }

--- a/tools/summarize-native-renderer-census.py
+++ b/tools/summarize-native-renderer-census.py
@@ -137,6 +137,8 @@ def summarize(
     draw_candidates: dict[str, dict[str, Any]] = {}
     prepared_shader_pairs: dict[tuple[str, str, str, str], dict[str, Any]] = {}
     index_scans: list[dict[str, Any]] = []
+    texture_scans: list[dict[str, Any]] = []
+    texture_fingerprints: list[dict[str, Any]] = []
     dependencies: dict[str, dict[str, Any]] = {}
     resolve_targets: dict[str, dict[str, Any]] = {}
     totals = {
@@ -216,6 +218,10 @@ def summarize(
             prepared_shader_pairs.setdefault(key, dict(event))
         elif kind == f"{PREFIX}index_scan":
             index_scans.append(dict(event))
+        elif kind == f"{PREFIX}texture_scan":
+            texture_scans.append(dict(event))
+        elif kind == f"{PREFIX}texture_fingerprint":
+            texture_fingerprints.append(dict(event))
         elif kind == f"{PREFIX}resolve_window":
             for key in (
                 "resolves",
@@ -285,6 +291,8 @@ def summarize(
             clean(record) for _, record in sorted(prepared_shader_pairs.items())
         ],
         "index_scans": [clean(record) for record in index_scans],
+        "texture_scans": [clean(record) for record in texture_scans],
+        "texture_fingerprints": [clean(record) for record in texture_fingerprints],
         "resolve_dependencies": [
             clean(record) for _, record in sorted(dependencies.items())
         ],
@@ -294,10 +302,24 @@ def summarize(
         "safety": {
             "suppression_allowed": False,
             "guest_cpu_reads": (
-                "bounded_index_payload"
+                "bounded_index_and_texture_payload"
                 if any(
                     record.get("guest_payload_read") == "bounded_index_only"
                     for record in index_scans
+                )
+                and any(
+                    record.get("guest_payload_read") == "bounded_texture_only"
+                    for record in texture_scans + texture_fingerprints
+                )
+                else "bounded_index_payload"
+                if any(
+                    record.get("guest_payload_read") == "bounded_index_only"
+                    for record in index_scans
+                )
+                else "bounded_texture_payload"
+                if any(
+                    record.get("guest_payload_read") == "bounded_texture_only"
+                    for record in texture_scans + texture_fingerprints
                 )
                 else "unknown_uninstrumented"
             ),

--- a/tools/tests/test_native_renderer_census.py
+++ b/tools/tests/test_native_renderer_census.py
@@ -131,6 +131,21 @@ class NativeRendererCensusTests(unittest.TestCase):
                 "guest_payload_read": "bounded_index_only",
             },
             {
+                "event": "native_renderer.census.texture_scan",
+                "session": "new",
+                "signature": "CANDIDATE",
+                "status": "scanned",
+                "guest_payload_read": "bounded_texture_only",
+            },
+            {
+                "event": "native_renderer.census.texture_fingerprint",
+                "session": "new",
+                "signature": "CANDIDATE",
+                "fetch_constant": "0",
+                "base_hash": "1111111111111111",
+                "guest_payload_read": "bounded_texture_only",
+            },
+            {
                 "event": "native_renderer.census.resolve_window",
                 "session": "new",
                 "resolves": "7",
@@ -190,7 +205,15 @@ class NativeRendererCensusTests(unittest.TestCase):
             result["prepared_shader_pairs"][0]["vertex_specialization_mask"],
         )
         self.assertEqual("CANDIDATE", result["index_scans"][0]["signature"])
-        self.assertEqual("bounded_index_payload", result["safety"]["guest_cpu_reads"])
+        self.assertEqual("CANDIDATE", result["texture_scans"][0]["signature"])
+        self.assertEqual(
+            "1111111111111111",
+            result["texture_fingerprints"][0]["base_hash"],
+        )
+        self.assertEqual(
+            "bounded_index_and_texture_payload",
+            result["safety"]["guest_cpu_reads"],
+        )
         self.assertEqual("7", result["resolve_dependencies"][0]["resolves"])
         self.assertEqual("00123000", result["resolve_targets"][0]["address"])
         self.assertEqual("4096", result["resolve_targets"][0]["length"])

--- a/tools/tests/test_native_renderer_contract.py
+++ b/tools/tests/test_native_renderer_contract.py
@@ -377,6 +377,15 @@ class NativeRendererContractTests(unittest.TestCase):
         self.assertIn("multi_prim_ib_ena", index_reset_patch)
         self.assertNotIn("TranslatePhysical", index_reset_patch)
 
+        texture_layout_patch = (
+            ROOT / "patches/rexglue/0056-graphics-texture-layout-observer.patch"
+        ).read_text(encoding="utf-8")
+        self.assertIn("TextureInfo::Prepare", texture_layout_patch)
+        self.assertIn("FetchConstantType::kTexture", texture_layout_patch)
+        self.assertIn("texture_fetch_base_lengths", texture_layout_patch)
+        self.assertIn("texture_fetch_layout_valid_mask", texture_layout_patch)
+        self.assertNotIn("TranslatePhysical", texture_layout_patch)
+
         planner = (
             ROOT / "tools/build-native-geometry-contract.py"
         ).read_text(encoding="utf-8")
@@ -395,6 +404,9 @@ class NativeRendererContractTests(unittest.TestCase):
         self.assertIn("kMaximumIndexScanCount", scanner)
         self.assertIn("kMaximumIndexScanBytes", scanner)
         self.assertIn('"bounded_index_only"', scanner)
+        self.assertIn("PINYON_SHIFT_NATIVE_RENDERER_TEXTURE_SCAN_SIGNATURE", scanner)
+        self.assertIn("kMaximumTextureScanTotalBytes", scanner)
+        self.assertIn('"bounded_texture_only"', scanner)
         self.assertNotIn("SetDrawSuppression", scanner)
 
         draw_state_planner = (

--- a/tools/tests/test_native_renderer_texture_provenance.py
+++ b/tools/tests/test_native_renderer_texture_provenance.py
@@ -1,0 +1,66 @@
+import importlib.util
+import pathlib
+import unittest
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+SPEC = importlib.util.spec_from_file_location(
+    "texture_provenance", ROOT / "tools" / "build-native-texture-provenance.py"
+)
+MODULE = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader
+SPEC.loader.exec_module(MODULE)
+
+
+def capture(session="one", address="10000000", second_address="10004000"):
+    signature = "FA45AAFDC22C8625"
+    return {
+        "schema": MODULE.CENSUS_SCHEMA,
+        "session": session,
+        "texture_scans": [{"signature": signature, "status": "scanned", "resources": "2"}],
+        "texture_fingerprints": [
+            {
+                "signature": signature, "fetch_constant": "0",
+                "base_address": address, "base_bytes": "16384",
+                "base_hash": "1111111111111111", "mip_address": "00000000",
+                "mip_bytes": "0", "mip_hash": "",
+            },
+            {
+                "signature": signature, "fetch_constant": "2",
+                "base_address": second_address, "base_bytes": "16384",
+                "base_hash": "2222222222222222", "mip_address": "00000000",
+                "mip_bytes": "0", "mip_hash": "",
+            },
+        ],
+    }
+
+
+class TextureProvenanceTests(unittest.TestCase):
+    def test_accepts_stable_content_at_relocated_addresses(self):
+        result = MODULE.build(
+            [capture(), capture("two", "12000000", "12004000")],
+            "FA45AAFDC22C8625",
+        )
+        self.assertTrue(result["qualification"]["content_stable_across_captures"])
+        self.assertTrue(all(item["addresses_relocated_across_captures"] for item in result["resources"]))
+        self.assertFalse(result["safety"]["native_draw"])
+
+    def test_rejects_changed_content(self):
+        second = capture("two")
+        second["texture_fingerprints"][0]["base_hash"] = "3333333333333333"
+        with self.assertRaisesRegex(ValueError, "content differs"):
+            MODULE.build([capture(), second], "FA45AAFDC22C8625")
+
+    def test_requires_two_captures(self):
+        with self.assertRaisesRegex(ValueError, "at least two"):
+            MODULE.build([capture()], "FA45AAFDC22C8625")
+
+    def test_rejects_missing_successful_scan(self):
+        second = capture("two")
+        second["texture_scans"] = []
+        with self.assertRaisesRegex(ValueError, "successful texture scan"):
+            MODULE.build([capture(), second], "FA45AAFDC22C8625")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/tests/test_release_contract.py
+++ b/tools/tests/test_release_contract.py
@@ -43,10 +43,10 @@ class ReleaseContractTests(unittest.TestCase):
 
     def test_rexglue_patches_have_stable_order_and_no_binary_payload(self):
         patches = sorted((ROOT / "patches/rexglue").glob("*.patch"))
-        self.assertEqual(len(patches), 55)
+        self.assertEqual(len(patches), 56)
         self.assertEqual(
             patches[-1].name,
-            "0055-graphics-index-reset-observer.patch",
+            "0056-graphics-texture-layout-observer.patch",
         )
         self.assertEqual(len(patches), len({path.name[:4] for path in patches}))
         for path in patches:


### PR DESCRIPTION
## Summary
- add exact-signature bounded texture fingerprint capture
- build a two-capture static-content provenance contract
- guard stale non-texture fetch layouts after AppData crash discovery
- keep native upload, draw, and suppression disabled with Xenos authoritative

## Validation
- 102 Python tests
- repository boundary check
- clean 56-patch Release preview build
- two AppData-backed captures; stable 16 KiB hashes for both resources
- rebuilt run reached the saved festival scene and exited normally