### PR TITLE
feat(native-renderer): capture prepared pso state

### DIFF
--- a/docs/native-renderer/PSO_CONTRACT.md
+++ b/docs/native-renderer/PSO_CONTRACT.md
@@ -1,0 +1,97 @@
+# Native PSO contract
+
+NR-02D begins by describing the exact prepared host pipeline. This milestone
+does not create a D3D12 pipeline, upload a resource, submit a native draw, or
+suppress Xenos work.
+
+## Prepared pipeline observation
+
+ReXGlue patch `0057-d3d12-prepared-pipeline-observer.patch` extends the
+existing synchronous prepared-draw callback after `ConfigurePipeline` has
+succeeded. In addition to the exact translated shader identities, it reports:
+
+- guest and host primitive types;
+- host vertex-shader type and tessellation mode;
+- processed index-buffer type, host index format, and primitive restart;
+- normalized depth control and color mask;
+- the five depth/color render-target format slots and their bound mask; and
+- whether host render targets and rasterization are active.
+
+The callback remains default-null and metadata-only. It does not expose a D3D12
+object or command list. These fields participate in the candidate signature,
+so a change in prepared pipeline shape produces a different candidate rather
+than being merged into one aggregate.
+
+The census emits a deterministic prepared-pipeline hash plus every raw field.
+Raw values are retained because they are the authoritative cache-key inputs;
+later native construction may decode them, but it must never silently ignore
+an unknown value.
+
+## Offline contract
+
+`tools/build-native-pso-contract.py` joins one exact candidate selection with
+its bounded geometry, decoded draw-state, and texture-provenance contracts:
+
+```powershell
+python .\tools\build-native-pso-contract.py `
+  .\.local\native-renderer\candidate\selection.json `
+  .\.local\native-renderer\candidate\geometry.json `
+  .\.local\native-renderer\candidate\draw-state.json `
+  .\.local\native-renderer\candidate\texture-provenance.json `
+  --signature 0000000000000000 `
+  --output .\.local\native-renderer\candidate\pso-contract.json
+```
+
+The builder requires matching signatures, false native-upload, native-draw,
+and suppression gates, and Xenos authority in every input. The initial
+supported shape is a direct
+guest indexed draw with no primitive conversion, active tessellation, special
+host vertex shader, host primitive restart, or unknown prepared-pipeline flag. It
+requires bounded geometry, stable texture content, rasterization, and at least
+one bound color output. Every unsupported condition is named explicitly.
+
+ReXGlue defines the tessellation mode as meaningful only when the prepared
+host vertex-shader type is not the ordinary `kVertex` path. The contract keeps
+the residual register value in the exact key for diagnosis, but does not treat
+it as active tessellation while `host_vertex_shader_type` is zero.
+
+The resulting PSO key contains the exact shader specializations, prepared host
+topology and index state, normalized depth/color state, target formats, and the
+raw guest pipeline-state string. A SHA-256 digest makes the key deterministic
+for later cache work.
+
+`ready_for_pso_creation` means only that the metadata is complete and within
+the initial supported shape. Visual identity and observed-producer exclusion
+remain separate gates, and the contract fixes `native_pso_created`, upload,
+draw, and suppression to false with Xenos authority true.
+
+## Signature revision
+
+Adding the prepared-pipeline hash intentionally revises NR-02 candidate
+signatures. Pre-`0057` identities and their exact-signature payload scans remain
+valid historical evidence, but cannot be reused as post-`0057` scan keys. A
+new repeated capture must select the revised identity before PSO construction
+or isolated comparison proceeds.
+
+## Local qualification — 2026-08-28
+
+Two consecutive `open_world_day` captures against the installed `0.1.0`
+AppData save exited normally. The selector retained 36 recurring candidates.
+The previously chosen shader pair (`E35520B6FDEA8C91`, `676B6C2D37982AD9`)
+recurred in both sessions as revised signature `747837906D0BF484` with prepared
+pipeline hash `464D06471DC459EA`.
+
+| Session | Result |
+| --- | --- |
+| `20260828T081758Z-p38780` | normal exit |
+| `20260828T082430Z-p41780` | normal exit |
+
+The prepared shape was identical in both runs: host primitive 4, ordinary
+host vertex shader, direct guest index buffer, host index format 1, primitive
+restart disabled, depth/color target bits `00000003`, target formats
+`00000001:00000003:00000000:00000000:00000000`, and prepared flags
+`00000003`. The observed tessellation mode was the inactive residual value 1.
+No native PSO, upload, draw, or Xenos suppression path was enabled.
+
+A clean 57-patch Release build succeeded with executable SHA-256
+`8C8556FE675CE6E3A93080A7A420A46A8571AC14B36887F7ED638275B849B6D4`.

--- a/patches/rexglue/0057-d3d12-prepared-pipeline-observer.patch
+++ b/patches/rexglue/0057-d3d12-prepared-pipeline-observer.patch
@@ -1,0 +1,57 @@
+diff --git a/include/rex/system/interfaces/graphics.h b/include/rex/system/interfaces/graphics.h
+index ba5d395..b157d7d 100644
+--- a/include/rex/system/interfaces/graphics.h
++++ b/include/rex/system/interfaces/graphics.h
+@@ -244,6 +244,18 @@ struct GraphicsPreparedDrawObservation {
+   uint64_t pixel_shader_hash = 0;
+   uint64_t vertex_specialization_mask = 0;
+   uint64_t pixel_specialization_mask = 0;
++  uint32_t guest_primitive_type = 0;
++  uint32_t host_primitive_type = 0;
++  uint32_t host_vertex_shader_type = 0;
++  uint32_t tessellation_mode = 0;
++  uint32_t index_buffer_type = 0;
++  uint32_t host_index_format = 0;
++  uint32_t host_primitive_reset_enabled = 0;
++  uint32_t normalized_depth_control = 0;
++  uint32_t normalized_color_mask = 0;
++  uint32_t bound_render_target_bits = 0;
++  uint32_t bound_render_target_formats[5] = {};
++  uint32_t flags = 0;
+ };
+ 
+ using GraphicsPreparedDrawObserver = void (*)(
+diff --git a/src/graphics/d3d12/command_processor.cpp b/src/graphics/d3d12/command_processor.cpp
+index e72b7e5..84d04b0 100644
+--- a/src/graphics/d3d12/command_processor.cpp
++++ b/src/graphics/d3d12/command_processor.cpp
+@@ -2736,6 +2736,29 @@ bool D3D12CommandProcessor::IssueDraw(xenos::PrimitiveType primitive_type, uint3
+         pixel_shader ? pixel_shader->ucode_data_hash() : 0;
+     observation.vertex_specialization_mask = vertex_shader_modification.value;
+     observation.pixel_specialization_mask = pixel_shader_modification.value;
++    observation.guest_primitive_type =
++        uint32_t(primitive_processing_result.guest_primitive_type);
++    observation.host_primitive_type =
++        uint32_t(primitive_processing_result.host_primitive_type);
++    observation.host_vertex_shader_type =
++        uint32_t(primitive_processing_result.host_vertex_shader_type);
++    observation.tessellation_mode =
++        uint32_t(primitive_processing_result.tessellation_mode);
++    observation.index_buffer_type =
++        uint32_t(primitive_processing_result.index_buffer_type);
++    observation.host_index_format =
++        uint32_t(primitive_processing_result.host_index_format);
++    observation.host_primitive_reset_enabled =
++        primitive_processing_result.host_primitive_reset_enabled;
++    observation.normalized_depth_control = normalized_depth_control.value;
++    observation.normalized_color_mask = normalized_color_mask;
++    observation.bound_render_target_bits =
++        bound_depth_and_color_render_target_bits;
++    std::memcpy(observation.bound_render_target_formats,
++                bound_depth_and_color_render_target_formats,
++                sizeof(observation.bound_render_target_formats));
++    observation.flags = uint32_t(host_render_targets_used) |
++                        (uint32_t(is_rasterization_done) << 1);
+     prepared_draw_observer(observation);
+   }
+ 

--- a/src/native_renderer/graphics_hooks.cpp
+++ b/src/native_renderer/graphics_hooks.cpp
@@ -131,6 +131,7 @@ struct DrawSignatureEntry {
   uint32_t min_index_buffer_length = 0;
   uint64_t vertex_specialization_mask = 0;
   uint64_t pixel_specialization_mask = 0;
+  rex::system::GraphicsPreparedDrawObservation prepared_sample;
   bool samples_resolved_target = false;
   rex::system::GraphicsDrawObservation sample;
 };
@@ -242,6 +243,28 @@ void ResetDependencyCensus() {
 uint64_t HashCombine(uint64_t hash, uint64_t value) {
   value += 0x9E3779B97F4A7C15ull + (hash << 6) + (hash >> 2);
   return hash ^ value;
+}
+
+uint64_t PreparedPipelineHash(
+    const rex::system::GraphicsPreparedDrawObservation &prepared) {
+  uint64_t hash = 0xCBF29CE484222325ull;
+  for (uint64_t value :
+       {uint64_t(prepared.guest_primitive_type),
+        uint64_t(prepared.host_primitive_type),
+        uint64_t(prepared.host_vertex_shader_type),
+        uint64_t(prepared.tessellation_mode),
+        uint64_t(prepared.index_buffer_type),
+        uint64_t(prepared.host_index_format),
+        uint64_t(prepared.host_primitive_reset_enabled),
+        uint64_t(prepared.normalized_depth_control),
+        uint64_t(prepared.normalized_color_mask),
+        uint64_t(prepared.bound_render_target_bits), uint64_t(prepared.flags)}) {
+    hash = HashCombine(hash, value);
+  }
+  for (uint32_t format : prepared.bound_render_target_formats) {
+    hash = HashCombine(hash, format);
+  }
+  return hash ? hash : 1;
 }
 
 uint64_t HashBytes(const uint8_t *data, uint64_t length) {
@@ -891,6 +914,7 @@ CandidateSignature(const rex::system::GraphicsDrawObservation &observation,
   uint64_t hash = DrawSignature(observation);
   for (uint64_t value : {prepared.vertex_specialization_mask,
                          prepared.pixel_specialization_mask,
+                         PreparedPipelineHash(prepared),
                          uint64_t(observation.index_format),
                          uint64_t(observation.index_endianness),
                          uint64_t(observation.vertex_index_offset),
@@ -1148,6 +1172,14 @@ void EmitCandidateCensusWindow(uint64_t last_frame_value) {
                     sample.rb_blendcontrol[1], sample.rb_blendcontrol[2],
                     sample.rb_blendcontrol[3], sample.rb_depthcontrol,
                     sample.pa_su_sc_mode_cntl, sample.pa_su_vtx_cntl);
+    const auto &prepared = entry.prepared_sample;
+    const std::string bound_render_target_formats = fmt::format(
+        "{:08X}:{:08X}:{:08X}:{:08X}:{:08X}",
+        prepared.bound_render_target_formats[0],
+        prepared.bound_render_target_formats[1],
+        prepared.bound_render_target_formats[2],
+        prepared.bound_render_target_formats[3],
+        prepared.bound_render_target_formats[4]);
     pinyon_shift::diagnostics::RecordEvent(
         "native_renderer.census.draw_candidate",
         {{"rank", std::to_string(++emitted)},
@@ -1202,6 +1234,25 @@ void EmitCandidateCensusWindow(uint64_t last_frame_value) {
          {"texture_state_count", std::to_string(sample.texture_state_count)},
          {"texture_states", SerializeTextureStates(sample)},
          {"pipeline_state", pipeline_state},
+         {"prepared_pipeline_hash",
+          fmt::format("{:016X}", PreparedPipelineHash(prepared))},
+         {"host_primitive", std::to_string(prepared.host_primitive_type)},
+         {"host_vertex_shader_type",
+          std::to_string(prepared.host_vertex_shader_type)},
+         {"tessellation_mode", std::to_string(prepared.tessellation_mode)},
+         {"host_index_buffer_type",
+          std::to_string(prepared.index_buffer_type)},
+         {"host_index_format", std::to_string(prepared.host_index_format)},
+         {"host_primitive_reset",
+          prepared.host_primitive_reset_enabled ? "true" : "false"},
+         {"normalized_depth_control",
+          fmt::format("{:08X}", prepared.normalized_depth_control)},
+         {"normalized_color_mask",
+          fmt::format("{:08X}", prepared.normalized_color_mask)},
+         {"bound_render_target_bits",
+          fmt::format("{:08X}", prepared.bound_render_target_bits)},
+         {"bound_render_target_formats", bound_render_target_formats},
+         {"prepared_pipeline_flags", fmt::format("{:08X}", prepared.flags)},
          {"indexed", sample.indexed ? "true" : "false"},
          {"query", query_draw ? "true" : "false"},
          {"memexport", sample.vertex_memexport ? "true" : "false"},
@@ -1476,6 +1527,7 @@ void RecordCandidate(
       entry.vertex_specialization_mask =
           prepared.vertex_specialization_mask;
       entry.pixel_specialization_mask = prepared.pixel_specialization_mask;
+      entry.prepared_sample = prepared;
       entry.samples_resolved_target = samples_resolved_target;
       entry.sample = observation;
       ++g_candidate_census.unique_signature_count;

--- a/tools/build-native-pso-contract.py
+++ b/tools/build-native-pso-contract.py
@@ -1,0 +1,226 @@
+#!/usr/bin/env python3
+"""Build the bounded NR-02D pipeline-state contract for one candidate."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+
+SCHEMA = "pinyon-shift.native-pso-contract.v1"
+SELECTION_SCHEMA = "pinyon-shift.native-renderer-candidate-selection.v1"
+GEOMETRY_SCHEMA = "pinyon-shift.native-geometry-contract.v1"
+DRAW_STATE_SCHEMA = "pinyon-shift.native-draw-state-contract.v1"
+TEXTURE_SCHEMA = "pinyon-shift.native-texture-provenance.v1"
+
+
+def integer(value: Any, field: str, base: int = 10) -> int:
+    try:
+        return int(str(value), base)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"invalid {field}") from exc
+
+
+def require_schema(document: dict[str, Any], schema: str) -> None:
+    if document.get("schema") != schema:
+        raise ValueError(f"expected {schema}")
+
+
+def false_gate(document: dict[str, Any], field: str) -> bool:
+    safety = document.get("safety", {})
+    return safety.get(field) is False
+
+
+def true_gate(document: dict[str, Any], field: str) -> bool:
+    safety = document.get("safety", {})
+    return safety.get(field) is True
+
+
+def build(
+    selection: dict[str, Any],
+    geometry: dict[str, Any],
+    draw_state: dict[str, Any],
+    texture: dict[str, Any],
+    signature: str,
+) -> dict[str, Any]:
+    require_schema(selection, SELECTION_SCHEMA)
+    require_schema(geometry, GEOMETRY_SCHEMA)
+    require_schema(draw_state, DRAW_STATE_SCHEMA)
+    require_schema(texture, TEXTURE_SCHEMA)
+    if len(signature) != 16 or any(
+        character not in "0123456789abcdefABCDEF" for character in signature
+    ):
+        raise ValueError("signature must be 16 hexadecimal digits")
+    signature = signature.upper()
+    candidates = [
+        item for item in selection.get("candidates", [])
+        if str(item.get("signature", "")).upper() == signature
+    ]
+    if len(candidates) != 1:
+        raise ValueError("selection must contain the exact candidate once")
+    candidate = candidates[0]
+    for name, document in (
+        ("geometry", geometry), ("draw state", draw_state), ("texture", texture)
+    ):
+        if str(document.get("candidate_signature", "")).upper() != signature:
+            raise ValueError(f"{name} signature does not match")
+
+    pipeline_hash = str(candidate.get("prepared_pipeline_hash", "")).upper()
+    if len(pipeline_hash) != 16 or any(
+        character not in "0123456789ABCDEF" for character in pipeline_hash
+    ):
+        raise ValueError("candidate lacks a prepared pipeline observation")
+    formats_text = str(candidate.get("bound_render_target_formats", ""))
+    format_parts = formats_text.split(":")
+    if len(format_parts) != 5:
+        raise ValueError("prepared render-target format set is malformed")
+    formats = [integer(value, "render-target format", 16) for value in format_parts]
+    bound_bits = integer(candidate.get("bound_render_target_bits"), "bound targets", 16)
+    flags = integer(candidate.get("prepared_pipeline_flags"), "pipeline flags", 16)
+
+    unsupported: list[str] = []
+    host_primitive = integer(candidate.get("host_primitive"), "host primitive")
+    host_vertex_type = integer(
+        candidate.get("host_vertex_shader_type"), "host vertex shader type"
+    )
+    tessellation = integer(candidate.get("tessellation_mode"), "tessellation mode")
+    host_index_buffer = integer(
+        candidate.get("host_index_buffer_type"), "host index buffer type"
+    )
+    host_index_format = integer(candidate.get("host_index_format"), "host index format")
+    host_reset = candidate.get("host_primitive_reset") is True
+    if host_primitive != integer(geometry.get("primitive"), "guest primitive"):
+        unsupported.append("primitive_conversion")
+    if host_vertex_type != 0:
+        unsupported.append("special_host_vertex_shader")
+    # PrimitiveProcessor documents tessellation_mode as meaningful only for a
+    # non-kVertex host shader. Ordinary vertex draws may retain any guest
+    # VGT_HOS_CNTL mode without enabling tessellation.
+    if host_vertex_type != 0:
+        unsupported.append("tessellation")
+    if geometry.get("indexed") is not True or host_index_buffer != 1:
+        unsupported.append("non_direct_guest_index_buffer")
+    if host_index_format != integer(geometry.get("index", {}).get("format"), "index format"):
+        unsupported.append("host_index_format_conversion")
+    if host_reset:
+        unsupported.append("host_primitive_restart")
+    if flags != 3:
+        unsupported.append("unrecognized_prepared_pipeline_flags")
+    if not bound_bits:
+        unsupported.append("no_bound_render_target")
+    normalized_color_mask = integer(
+        candidate.get("normalized_color_mask"), "normalized color mask", 16
+    )
+    if not normalized_color_mask:
+        unsupported.append("no_color_output")
+    if geometry.get("bounds", {}).get("validated") is not True:
+        unsupported.append("geometry_not_bounded")
+    qualification = texture.get("qualification", {})
+    if qualification.get("content_stable_across_captures") is not True:
+        unsupported.append("texture_content_not_stable")
+
+    key = {
+        "vertex_shader": str(candidate.get("vertex_shader", "")).upper(),
+        "pixel_shader": str(candidate.get("pixel_shader", "")).upper(),
+        "vertex_specialization_mask": str(
+            candidate.get("vertex_specialization_mask", "")
+        ).upper(),
+        "pixel_specialization_mask": str(
+            candidate.get("pixel_specialization_mask", "")
+        ).upper(),
+        "prepared_pipeline_hash": pipeline_hash,
+        "host_primitive": host_primitive,
+        "host_vertex_shader_type": host_vertex_type,
+        "tessellation_mode": tessellation,
+        "host_index_buffer_type": host_index_buffer,
+        "host_index_format": host_index_format,
+        "host_primitive_reset": host_reset,
+        "normalized_depth_control": integer(
+            candidate.get("normalized_depth_control"), "normalized depth", 16
+        ),
+        "normalized_color_mask": normalized_color_mask,
+        "bound_render_target_bits": bound_bits,
+        "bound_render_target_formats": [
+            {"slot": slot, "format": value}
+            for slot, value in zip(("depth", "color0", "color1", "color2", "color3"), formats)
+        ],
+        "raw_pipeline_state": candidate.get("pipeline_state"),
+    }
+    key_json = json.dumps(key, sort_keys=True, separators=(",", ":")).encode()
+    contract_hash = hashlib.sha256(key_json).hexdigest().upper()
+    safety_valid = (
+        false_gate(geometry, "native_upload")
+        and false_gate(geometry, "native_draw")
+        and false_gate(geometry, "suppression_allowed")
+        and true_gate(geometry, "xenos_authority")
+        and false_gate(draw_state, "native_upload")
+        and false_gate(draw_state, "native_draw")
+        and false_gate(draw_state, "suppression_allowed")
+        and true_gate(draw_state, "xenos_authority")
+        and false_gate(texture, "native_upload")
+        and false_gate(texture, "native_draw")
+        and false_gate(texture, "suppression_allowed")
+        and true_gate(texture, "xenos_authority")
+    )
+    if not safety_valid:
+        raise ValueError("input contracts do not preserve the isolated safety gates")
+
+    return {
+        "schema": SCHEMA,
+        "candidate_signature": signature,
+        "pso_key_sha256": contract_hash,
+        "pso_key": key,
+        "support": {
+            "ready_for_pso_creation": not unsupported,
+            "unsupported_or_unknown": unsupported,
+            "draw_state_stable_across_captures": bool(
+                draw_state.get("state_stable_across_captures")
+            ),
+            "visual_identity_confirmed": bool(
+                qualification.get("visual_identity_confirmed")
+            ),
+            "dynamic_render_target_exclusion_required": bool(
+                qualification.get("dynamic_render_target_exclusion_required")
+            ),
+        },
+        "safety": {
+            "native_pso_created": False,
+            "native_upload": False,
+            "native_draw": False,
+            "suppression_allowed": False,
+            "xenos_authority": True,
+        },
+    }
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("selection", type=Path)
+    parser.add_argument("geometry", type=Path)
+    parser.add_argument("draw_state", type=Path)
+    parser.add_argument("texture", type=Path)
+    parser.add_argument("--signature", required=True)
+    parser.add_argument("--output", "-o", type=Path)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    documents = [
+        json.loads(path.read_text(encoding="utf-8"))
+        for path in (args.selection, args.geometry, args.draw_state, args.texture)
+    ]
+    result = build(*documents, args.signature)
+    rendered = json.dumps(result, indent=2) + "\n"
+    if args.output:
+        args.output.write_text(rendered, encoding="utf-8")
+    else:
+        print(rendered, end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/select-native-renderer-candidate.py
+++ b/tools/select-native-renderer-candidate.py
@@ -15,6 +15,20 @@ CENSUS_SCHEMA = "pinyon-shift.native-renderer-census.v1"
 SHADER_SCHEMA = "pinyon-shift.native-shader-pack.v1"
 PHYSICAL_MASK = 0x1FFFFFFF
 MAX_TEXTURE_RESOURCES = 4
+PREPARED_PIPELINE_FIELDS = (
+    "prepared_pipeline_hash",
+    "host_primitive",
+    "host_vertex_shader_type",
+    "tessellation_mode",
+    "host_index_buffer_type",
+    "host_index_format",
+    "host_primitive_reset",
+    "normalized_depth_control",
+    "normalized_color_mask",
+    "bound_render_target_bits",
+    "bound_render_target_formats",
+    "prepared_pipeline_flags",
+)
 
 
 def boolean(record: dict[str, Any], key: str) -> bool:
@@ -132,6 +146,20 @@ def prepared_pairs(census: dict[str, Any]) -> dict[tuple[str, str], set[tuple[st
     return result
 
 
+def prepared_pipeline_identity(record: dict[str, Any]) -> tuple[str, ...] | None:
+    if any(record.get(field) is None for field in PREPARED_PIPELINE_FIELDS):
+        return None
+    pipeline_hash = str(record["prepared_pipeline_hash"]).upper()
+    if len(pipeline_hash) != 16:
+        return None
+    return tuple(
+        str(boolean(record, field))
+        if field == "host_primitive_reset"
+        else str(record[field]).upper()
+        for field in PREPARED_PIPELINE_FIELDS
+    )
+
+
 def select(census_paths: list[Path], shader_manifest_path: Path) -> dict[str, Any]:
     if len(census_paths) < 2:
         raise ValueError("at least two census inventories are required")
@@ -189,6 +217,13 @@ def select(census_paths: list[Path], shader_manifest_path: Path) -> dict[str, An
             continue
         if len(set(candidate_specializations)) != 1:
             rejection_counts["specialization_changed_across_captures"] += 1
+            continue
+        prepared_pipelines = [prepared_pipeline_identity(record) for record in records]
+        if any(identity is None for identity in prepared_pipelines):
+            rejection_counts["missing_prepared_pipeline_state"] += 1
+            continue
+        if len(set(prepared_pipelines)) != 1:
+            rejection_counts["prepared_pipeline_changed_across_captures"] += 1
             continue
         vertex_specialization, pixel_specialization = candidate_specializations[0]
         if any(
@@ -259,6 +294,28 @@ def select(census_paths: list[Path], shader_manifest_path: Path) -> dict[str, An
                 "texture_state_count": int(sample.get("texture_state_count", 0)),
                 "texture_states": sample.get("texture_states"),
                 "pipeline_state": sample.get("pipeline_state"),
+                "prepared_pipeline_hash": sample.get("prepared_pipeline_hash"),
+                "host_primitive": sample.get("host_primitive"),
+                "host_vertex_shader_type": sample.get("host_vertex_shader_type"),
+                "tessellation_mode": sample.get("tessellation_mode"),
+                "host_index_buffer_type": sample.get("host_index_buffer_type"),
+                "host_index_format": sample.get("host_index_format"),
+                "host_primitive_reset": (
+                    boolean(sample, "host_primitive_reset")
+                    if "host_primitive_reset" in sample
+                    else None
+                ),
+                "normalized_depth_control": sample.get(
+                    "normalized_depth_control"
+                ),
+                "normalized_color_mask": sample.get("normalized_color_mask"),
+                "bound_render_target_bits": sample.get(
+                    "bound_render_target_bits"
+                ),
+                "bound_render_target_formats": sample.get(
+                    "bound_render_target_formats"
+                ),
+                "prepared_pipeline_flags": sample.get("prepared_pipeline_flags"),
                 "qualification": "metadata_shortlist_only",
             }
         )

--- a/tools/tests/test_native_renderer_candidate.py
+++ b/tools/tests/test_native_renderer_candidate.py
@@ -45,6 +45,20 @@ def signature(name: str, **overrides):
         "texture_state_count": "1",
         "texture_states": "2:0:0:0:0:0:0:0:0:1:0:1C:0:0:0:0:F:688",
         "pipeline_state": "opaque",
+        "prepared_pipeline_hash": "4444444444444444",
+        "host_primitive": "4",
+        "host_vertex_shader_type": "0",
+        "tessellation_mode": "1",
+        "host_index_buffer_type": "1",
+        "host_index_format": "0",
+        "host_primitive_reset": "false",
+        "normalized_depth_control": "087087E3",
+        "normalized_color_mask": "0000000F",
+        "bound_render_target_bits": "00000003",
+        "bound_render_target_formats": (
+            "00000001:00000003:00000000:00000000:00000000"
+        ),
+        "prepared_pipeline_flags": "00000003",
         "indexed": "true",
         "query": "false",
         "memexport": "false",
@@ -141,12 +155,58 @@ class NativeRendererCandidateTests(unittest.TestCase):
             "AAAAAAAAAAAAAAAA",
             result["candidates"][0]["vertex_specialization_mask"],
         )
+        self.assertEqual(
+            "4444444444444444",
+            result["candidates"][0]["prepared_pipeline_hash"],
+        )
+        self.assertEqual("4", result["candidates"][0]["host_primitive"])
+        self.assertFalse(result["candidates"][0]["host_primitive_reset"])
         self.assertFalse(result["safety"]["suppression_allowed"])
         self.assertTrue(result["safety"]["xenos_authority"])
 
     def test_rejects_dynamic_input(self):
         reasons = MODULE.rejection_reasons(signature("BAD", resolved_input="true"))
         self.assertIn("dynamic_render_target_input", reasons)
+
+    def test_requires_stable_prepared_pipeline_state(self):
+        shader_manifest = {
+            "schema": MODULE.SHADER_SCHEMA,
+            "entries": [
+                {
+                    "stage": stage,
+                    "guest_hash": guest_hash,
+                    "specialization_mask": specialization,
+                }
+                for stage, guest_hash, specialization in (
+                    ("vertex", "1111111111111111", "AAAAAAAAAAAAAAAA"),
+                    ("pixel", "2222222222222222", "BBBBBBBBBBBBBBBB"),
+                )
+            ],
+        }
+        prepared = [{
+            "vertex_shader": "1111111111111111",
+            "pixel_shader": "2222222222222222",
+            "vertex_specialization_mask": "AAAAAAAAAAAAAAAA",
+            "pixel_specialization_mask": "BBBBBBBBBBBBBBBB",
+        }]
+        first = {
+            "schema": MODULE.CENSUS_SCHEMA,
+            "classification": {"scene": "open_world_day"},
+            "draw_candidates": [signature("GOOD")],
+            "prepared_shader_pairs": prepared,
+        }
+        second = {
+            "schema": MODULE.CENSUS_SCHEMA,
+            "classification": {"scene": "open_world_day"},
+            "draw_candidates": [signature("GOOD", host_index_format="1")],
+            "prepared_shader_pairs": prepared,
+        }
+        result = select_documents(first, second, shader_manifest)
+        self.assertEqual(0, result["candidate_count"])
+        self.assertIn(
+            {"reason": "prepared_pipeline_changed_across_captures", "signatures": 1},
+            result["rejections"],
+        )
 
     def test_requires_one_to_four_texture_resources(self):
         self.assertIn(

--- a/tools/tests/test_native_renderer_contract.py
+++ b/tools/tests/test_native_renderer_contract.py
@@ -386,6 +386,15 @@ class NativeRendererContractTests(unittest.TestCase):
         self.assertIn("texture_fetch_layout_valid_mask", texture_layout_patch)
         self.assertNotIn("TranslatePhysical", texture_layout_patch)
 
+        prepared_pipeline_patch = (
+            ROOT / "patches/rexglue/0057-d3d12-prepared-pipeline-observer.patch"
+        ).read_text(encoding="utf-8")
+        self.assertIn("normalized_depth_control", prepared_pipeline_patch)
+        self.assertIn("bound_render_target_formats", prepared_pipeline_patch)
+        self.assertIn("host_vertex_shader_type", prepared_pipeline_patch)
+        self.assertNotIn("TranslatePhysical", prepared_pipeline_patch)
+        self.assertNotIn("SetDrawSuppression", prepared_pipeline_patch)
+
         planner = (
             ROOT / "tools/build-native-geometry-contract.py"
         ).read_text(encoding="utf-8")

--- a/tools/tests/test_native_renderer_pso.py
+++ b/tools/tests/test_native_renderer_pso.py
@@ -1,0 +1,136 @@
+import importlib.util
+import pathlib
+import unittest
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+SPEC = importlib.util.spec_from_file_location(
+    "native_pso", ROOT / "tools" / "build-native-pso-contract.py"
+)
+MODULE = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader
+SPEC.loader.exec_module(MODULE)
+
+
+SIGNATURE = "FA45AAFDC22C8625"
+
+
+def documents():
+    candidate = {
+        "signature": SIGNATURE,
+        "vertex_shader": "1111111111111111",
+        "pixel_shader": "2222222222222222",
+        "vertex_specialization_mask": "0000000000000003",
+        "pixel_specialization_mask": "0000400000000003",
+        "prepared_pipeline_hash": "3333333333333333",
+        "host_primitive": "4",
+        "host_vertex_shader_type": "0",
+        "tessellation_mode": "0",
+        "host_index_buffer_type": "1",
+        "host_index_format": "1",
+        "host_primitive_reset": False,
+        "normalized_depth_control": "087087E3",
+        "normalized_color_mask": "0000000F",
+        "bound_render_target_bits": "00000003",
+        "bound_render_target_formats": "0000002D:0000001C:00000000:00000000:00000000",
+        "prepared_pipeline_flags": "00000003",
+        "pipeline_state": "color_mask=0000000F",
+    }
+    selection = {
+        "schema": MODULE.SELECTION_SCHEMA,
+        "candidates": [candidate],
+    }
+    geometry = {
+        "schema": MODULE.GEOMETRY_SCHEMA,
+        "candidate_signature": SIGNATURE,
+        "primitive": 4,
+        "indexed": True,
+        "index": {"format": 1},
+        "bounds": {"validated": True},
+        "safety": {
+            "native_upload": False,
+            "native_draw": False,
+            "suppression_allowed": False,
+            "xenos_authority": True,
+        },
+    }
+    draw_state = {
+        "schema": MODULE.DRAW_STATE_SCHEMA,
+        "candidate_signature": SIGNATURE,
+        "state_stable_across_captures": False,
+        "safety": {
+            "native_upload": False,
+            "native_draw": False,
+            "suppression_allowed": False,
+            "xenos_authority": True,
+        },
+    }
+    texture = {
+        "schema": MODULE.TEXTURE_SCHEMA,
+        "candidate_signature": SIGNATURE,
+        "qualification": {
+            "content_stable_across_captures": True,
+            "visual_identity_confirmed": False,
+            "dynamic_render_target_exclusion_required": True,
+        },
+        "safety": {
+            "native_upload": False,
+            "native_draw": False,
+            "suppression_allowed": False,
+            "xenos_authority": True,
+        },
+    }
+    return selection, geometry, draw_state, texture
+
+
+class NativePsoContractTests(unittest.TestCase):
+    def test_builds_supported_pipeline_key_without_creating_it(self):
+        result = MODULE.build(*documents(), SIGNATURE)
+        self.assertTrue(result["support"]["ready_for_pso_creation"])
+        self.assertEqual([], result["support"]["unsupported_or_unknown"])
+        self.assertEqual(64, len(result["pso_key_sha256"]))
+        self.assertFalse(result["safety"]["native_pso_created"])
+        self.assertTrue(result["safety"]["xenos_authority"])
+
+    def test_reports_unsupported_host_conversion(self):
+        inputs = documents()
+        inputs[0]["candidates"][0]["host_primitive"] = "5"
+        result = MODULE.build(*inputs, SIGNATURE)
+        self.assertFalse(result["support"]["ready_for_pso_creation"])
+        self.assertIn("primitive_conversion", result["support"]["unsupported_or_unknown"])
+
+    def test_ignores_residual_tessellation_mode_for_vertex_shader(self):
+        inputs = documents()
+        inputs[0]["candidates"][0]["tessellation_mode"] = "1"
+        result = MODULE.build(*inputs, SIGNATURE)
+        self.assertTrue(result["support"]["ready_for_pso_creation"])
+
+    def test_rejects_active_tessellation_host_shader(self):
+        inputs = documents()
+        inputs[0]["candidates"][0]["host_vertex_shader_type"] = "1"
+        inputs[0]["candidates"][0]["tessellation_mode"] = "1"
+        result = MODULE.build(*inputs, SIGNATURE)
+        self.assertFalse(result["support"]["ready_for_pso_creation"])
+        self.assertIn("tessellation", result["support"]["unsupported_or_unknown"])
+
+    def test_requires_prepared_pipeline_observation(self):
+        inputs = documents()
+        del inputs[0]["candidates"][0]["prepared_pipeline_hash"]
+        with self.assertRaisesRegex(ValueError, "prepared pipeline"):
+            MODULE.build(*inputs, SIGNATURE)
+
+    def test_rejects_relaxed_input_safety_gate(self):
+        inputs = documents()
+        inputs[2]["safety"]["native_draw"] = True
+        with self.assertRaisesRegex(ValueError, "safety gates"):
+            MODULE.build(*inputs, SIGNATURE)
+
+    def test_requires_xenos_authority_in_every_input(self):
+        inputs = documents()
+        inputs[1]["safety"]["xenos_authority"] = False
+        with self.assertRaisesRegex(ValueError, "safety gates"):
+            MODULE.build(*inputs, SIGNATURE)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/tests/test_release_contract.py
+++ b/tools/tests/test_release_contract.py
@@ -43,10 +43,10 @@ class ReleaseContractTests(unittest.TestCase):
 
     def test_rexglue_patches_have_stable_order_and_no_binary_payload(self):
         patches = sorted((ROOT / "patches/rexglue").glob("*.patch"))
-        self.assertEqual(len(patches), 56)
+        self.assertEqual(len(patches), 57)
         self.assertEqual(
             patches[-1].name,
-            "0056-graphics-texture-layout-observer.patch",
+            "0057-d3d12-prepared-pipeline-observer.patch",
         )
         self.assertEqual(len(patches), len({path.name[:4] for path in patches}))
         for path in patches:


### PR DESCRIPTION
## Summary
- observe exact prepared D3D12 pipeline facts without exposing host objects
- include prepared state in candidate identity and recurring-capture selection
- build a deterministic offline PSO contract with explicit unsupported gates
- preserve native upload, draw, and suppression as disabled with Xenos authoritative

## Validation
- 110 Python tests pass
- repository boundary passes for 179 candidate files
- clean 57-patch Release build succeeds
- two AppData-backed captures exit normally and reproduce signature 747837906D0BF484