### PR TITLE
docs(native-renderer): refresh candidate contracts

### DIFF
--- a/docs/native-renderer/CANDIDATE_DRAW_SELECTION.md
+++ b/docs/native-renderer/CANDIDATE_DRAW_SELECTION.md
@@ -261,3 +261,12 @@ visual/dependency restrictions are recorded in
 [TEXTURE_PROVENANCE_CONTRACT.md](TEXTURE_PROVENANCE_CONTRACT.md). This is
 source-content evidence only; it does not enable upload, replay, or
 suppression.
+
+Prepared-pipeline observation revised this identity to `747837906D0BF484`.
+Two fresh exact-signature AppData scans independently reproduced its 9,300
+indices, decoded range 0–1,616, 51,744-byte vertex bound, and both 16 KiB DXN
+texture hashes. The guest allocations relocated between processes, while all
+bounded content facts remained stable. Its prepared pipeline is within the
+initial supported PSO shape and the joined offline contract is ready for
+isolated PSO creation. Visual identity and observed-producer exclusion remain
+open, so native drawing and Xenos suppression are still forbidden.

--- a/docs/native-renderer/DRAW_STATE_CONTRACT.md
+++ b/docs/native-renderer/DRAW_STATE_CONTRACT.md
@@ -79,3 +79,18 @@ record fixes the following values:
 The next milestone may copy the selected snapshot's bounded resources into an
 isolated native target. It must preserve these gates until visual and dependency
 comparison is complete.
+
+## Selected authentic-draw state — 2026-08-28
+
+Revised candidate `747837906D0BF484` carries 15 vertex float4 constants, four
+pixel float4 constants, and two pixel texture instructions. The texture
+instructions describe tiled 256 by 64 DXN resources with 256-pixel pitch,
+8-in-16 endianness, linear filtering, and distinct result routes. The two
+selection captures produced different draw-state hashes, as expected for a
+world draw whose transform and lighting values evolve over time.
+
+This variability is not a PSO-key failure. It proves that replay must consume
+the immutable per-draw snapshot and must not reread mutable guest constants on
+the render thread. The contract therefore reports
+`state_stable_across_captures: false` while retaining the same decoded resource
+shape and all no-upload, no-draw, no-suppression safety gates.

--- a/docs/native-renderer/GEOMETRY_CONTRACT.md
+++ b/docs/native-renderer/GEOMETRY_CONTRACT.md
@@ -148,3 +148,21 @@ The captures contained 4,134 and 4,364 performance samples, measured 31.885
 and 31.653 median FPS, reported zero presentation deadline misses, and emitted
 no crash, error, or device-loss event. The one-time 37,200-byte diagnostic read
 did not alter Xenos rendering authority.
+
+## Prepared-signature refresh — 2026-08-28
+
+The prepared-pipeline observer intentionally changed the candidate identity.
+Two new AppData-backed captures therefore rescanned revised signature
+`747837906D0BF484` rather than reusing the historical payload result:
+
+| Session | Frame | Index address | Vertex address | Decoded range | Hash |
+| --- | ---: | ---: | ---: | ---: | --- |
+| `20260828T084949Z-p36548` | 2,847 | `1426B30C` | `1425E8EC` | 0–1,616 | `76F4D9C9DFE1E128` |
+| `20260828T085323Z-p43944` | 2,953 | `1428730C` | `1427A8EC` | 0–1,616 | `76F4D9C9DFE1E128` |
+
+Both scans decoded 9,300 uint32 indices from 37,200 bytes, observed no
+primitive-reset marker, and independently reproduced the exact 51,744-byte
+vertex bound. The relocated index and vertex allocations demonstrate that the
+contract is content- and layout-bound rather than tied to one process address.
+Both processes exited normally with no error, crash, or device-loss event.
+Native upload, native drawing, and suppression remained disabled.

--- a/docs/native-renderer/PSO_CONTRACT.md
+++ b/docs/native-renderer/PSO_CONTRACT.md
@@ -95,3 +95,20 @@ No native PSO, upload, draw, or Xenos suppression path was enabled.
 
 A clean 57-patch Release build succeeded with executable SHA-256
 `8C8556FE675CE6E3A93080A7A420A46A8571AC14B36887F7ED638275B849B6D4`.
+
+## Joined contract qualification — 2026-08-28
+
+Fresh exact-signature scans in sessions `20260828T084949Z-p36548` and
+`20260828T085323Z-p43944` reproduced the bounded geometry and texture
+contracts under revised signature `747837906D0BF484`. The joined PSO contract
+is now `ready_for_pso_creation: true` and has deterministic key SHA-256
+`A4E07C14394100E280810B52BDB72D93CAF348AC3A79AE70EDA6F933DDFC4E64`.
+
+The two runs measured 30.560 and 31.032 median FPS over 6,682 and 4,893 frame
+samples. Presentation cadence was 59.993 and 59.994 Hz, with zero deadline
+misses. Both exited normally and emitted no error, crash, or device-loss event.
+
+The joined result is permission to attempt isolated PSO creation only. Visual
+identity remains unconfirmed and observed-producer exclusion is still
+required. The contract therefore keeps native PSO creation, native upload,
+native drawing, and suppression false, with Xenos authoritative.

--- a/docs/native-renderer/TEXTURE_PROVENANCE_CONTRACT.md
+++ b/docs/native-renderer/TEXTURE_PROVENANCE_CONTRACT.md
@@ -84,3 +84,21 @@ normally with code zero.
 This evidence advances the candidate through static-content fingerprinting
 only. Visual identification and dynamic render-target exclusion remain open,
 and Xenos authority remains mandatory for subsequent isolated replay work.
+
+## Prepared-signature refresh — 2026-08-28
+
+The revised prepared-pipeline signature `747837906D0BF484` was fingerprinted
+again in two independent AppData-backed processes:
+
+| Session | Fetch | Address | Base bytes | Base hash |
+| --- | ---: | ---: | ---: | --- |
+| `20260828T084949Z-p36548` | 0 | `1464A000` | 16,384 | `813168E347A20D13` |
+| `20260828T084949Z-p36548` | 2 | `14752000` | 16,384 | `A1341C9AE209EB41` |
+| `20260828T085323Z-p43944` | 0 | `14666000` | 16,384 | `813168E347A20D13` |
+| `20260828T085323Z-p43944` | 2 | `1476E000` | 16,384 | `A1341C9AE209EB41` |
+
+Both resources relocated while their allocation shapes and hashes remained
+identical. This closes the earlier relocation caveat and confirms that the
+fingerprints describe stable source content rather than one deterministic
+allocation. It still does not prove visual identity or exclude an unobserved
+GPU producer; those remain explicit gates before replay or suppression.


### PR DESCRIPTION
## Summary
- record fresh post-prepared-pipeline index and texture scans for candidate 747837906D0BF484
- confirm stable content across relocated guest allocations and join the complete PSO contract
- retain explicit visual-identity, producer-exclusion, no-native-draw, and no-suppression gates

## Validation
- python -m unittest discover -s tools/tests -p 'test_*.py' (110 passed)
- tools/check-repository-boundary.ps1 (179 candidate files)
- AppData sessions 20260828T084949Z-p36548 and 20260828T085323Z-p43944 exited normally with zero deadline misses