### PR TITLE
feat(native-renderer): capture bounded replay snapshot

### DIFF
--- a/docs/native-renderer/REPLAY_SNAPSHOT_FORMAT.md
+++ b/docs/native-renderer/REPLAY_SNAPSHOT_FORMAT.md
@@ -1,0 +1,88 @@
+# Native replay snapshot format
+
+NR-02E starts from an immutable, exact-signature local snapshot. This capture
+freezes the selected draw's bounded payloads and shader inputs at the
+synchronous prepared-draw point; it does not upload them, create a native PSO,
+submit a native draw, or suppress Xenos work.
+
+## Capture boundary
+
+The capture is armed only when both a 16-digit candidate signature and a new
+output directory below the repository's ignored `.local` tree are supplied.
+It attempts the signature once per process and rejects the draw before any
+payload read unless all of these conditions hold:
+
+- direct DMA indexed geometry with supported format and endianness;
+- exactly one bounded vertex allocation, at most 64 MiB;
+- at most 1,048,576 indices and 4 MiB of index payload;
+- one through four textures, at most 16 MiB each and 32 MiB total;
+- every payload range contained in the guest physical aperture;
+- complete constant, texture, vertex, and prepared-pipeline observations;
+- no query, memexport, observer overflow, or observed resolve dependency; and
+- active host rasterization with a bound color target.
+
+After validation, the hook copies every payload into host memory before doing
+file I/O. It then writes a staging directory and renames it to the requested
+destination only after the manifest is complete. Existing output or staging
+directories are never overwritten.
+
+## Local artifact
+
+Arm a capture against the AppData save with:
+
+```powershell
+$stateRoot = Join-Path $env:LOCALAPPDATA `
+    'PinyonShift\source\0.1.0\.local\preview'
+.\tools\capture-native-renderer-census.ps1 `
+  -StateRoot $stateRoot `
+  -Scene open_world_day `
+  -ReplaySnapshotSignature 747837906D0BF484 `
+  -ReplaySnapshotDir .\.local\native-renderer\replay\747837906D0BF484
+```
+
+The resulting `snapshot.json` uses schema
+`pinyon-shift.native-replay-snapshot.v1`. It identifies the exact shader
+specializations and prepared pipeline, records the current constant and
+texture-instruction values, and describes these local payload files:
+
+- `index.bin`: raw guest index data;
+- `vertex.bin`: the complete bounded vertex allocation;
+- `texture_XX_base.bin`: each bounded base texture allocation; and
+- `texture_XX_mip.bin`: an optional separate mip allocation.
+
+Every payload entry includes its byte count and FNV-1a hash. Addresses remain
+diagnostic only and may relocate between processes. The output is local game
+data and must never be committed or uploaded.
+
+## Offline validation
+
+Join the snapshot with the already qualified contracts before isolated upload:
+
+```powershell
+python .\tools\validate-native-replay-snapshot.py `
+  .\.local\native-renderer\replay\747837906D0BF484 `
+  .\.local\native-renderer\candidate\747837906D0BF484-geometry.json `
+  .\.local\native-renderer\candidate\747837906D0BF484-draw-state.json `
+  .\.local\native-renderer\candidate\747837906D0BF484-texture-provenance.json `
+  .\.local\native-renderer\candidate\747837906D0BF484-pso.json
+```
+
+The validator rejects path traversal, missing or changed payloads, signature
+or PSO mismatches, unstable texture content, unbounded geometry, and any input
+that permits native upload, drawing, or suppression. Success means only
+`ready_for_isolated_upload`; Xenos authority remains mandatory.
+
+## Local qualification
+
+The implementation was qualified on 2026-08-28 against the installed 0.1.0
+AppData save and prepared candidate `747837906D0BF484`. Session
+`20260828T090906Z-p43812` captured exactly once at frame 3996, draw 115:
+
+- 37,200 bytes of index data (9,300 32-bit indices);
+- 51,744 bytes of vertex data; and
+- two 16,384-byte texture resources (32,768 bytes total).
+
+The offline validator joined the snapshot to all four candidate contracts and
+reported `ready_for_isolated_upload: true`, `native_draw: false`,
+`suppression_allowed: false`, and `xenos_authority: true`. The preview then
+exited normally with code 0 and no error events in the session log.

--- a/src/native_renderer/graphics_hooks.cpp
+++ b/src/native_renderer/graphics_hooks.cpp
@@ -7,9 +7,14 @@
 #include <cstdint>
 #include <cstdlib>
 #include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <iterator>
 #include <limits>
+#include <span>
 #include <string>
 #include <type_traits>
+#include <vector>
 
 #include <fmt/format.h>
 #include <rex/cvar.h>
@@ -83,6 +88,16 @@ struct TextureScanState {
 
 TextureScanState g_texture_scan;
 
+struct ReplaySnapshotState {
+  uint64_t target_signature = 0;
+  std::filesystem::path output_root;
+  bool requested = false;
+  bool completed = false;
+  bool valid = true;
+};
+
+ReplaySnapshotState g_replay_snapshot;
+
 void ConfigureSignatureScan(const char *name, uint64_t &target_signature,
                             bool &requested, bool &valid) {
   char *value = nullptr;
@@ -119,6 +134,41 @@ void ConfigureTextureScan() {
       "PINYON_SHIFT_NATIVE_RENDERER_TEXTURE_SCAN_SIGNATURE",
       g_texture_scan.target_signature, g_texture_scan.requested,
       g_texture_scan.valid);
+}
+
+bool IsLocalArtifactRoot(const std::filesystem::path &path) {
+  return path.is_absolute() &&
+         std::any_of(path.begin(), path.end(), [](const auto &component) {
+           return component.native() == L".local";
+         });
+}
+
+void ConfigureReplaySnapshot() {
+  g_replay_snapshot = {};
+  ConfigureSignatureScan(
+      "PINYON_SHIFT_NATIVE_RENDERER_SNAPSHOT_SIGNATURE",
+      g_replay_snapshot.target_signature, g_replay_snapshot.requested,
+      g_replay_snapshot.valid);
+  const bool signature_requested = g_replay_snapshot.requested;
+  char *value = nullptr;
+  size_t length = 0;
+  if (_dupenv_s(&value, &length,
+                "PINYON_SHIFT_NATIVE_RENDERER_SNAPSHOT_DIR") != 0 ||
+      !value || length <= 1) {
+    std::free(value);
+    if (g_replay_snapshot.requested) {
+      g_replay_snapshot.valid = false;
+    }
+    return;
+  }
+  g_replay_snapshot.requested = true;
+  g_replay_snapshot.output_root =
+      std::filesystem::absolute(std::filesystem::path(value)).lexically_normal();
+  std::free(value);
+  if (!signature_requested ||
+      !IsLocalArtifactRoot(g_replay_snapshot.output_root)) {
+    g_replay_snapshot.valid = false;
+  }
 }
 
 struct DrawSignatureEntry {
@@ -556,6 +606,374 @@ void TryScanCandidateIndices(
        {"vertex_binding_size",
         std::to_string(observation.vertex_bindings[0].size)},
        {"guest_payload_read", "bounded_index_only"},
+       {"native_upload", "false"},
+       {"native_draw", "false"},
+       {"suppression_eligible", "false"}});
+}
+
+bool WriteSnapshotFile(const std::filesystem::path &path,
+                       std::span<const uint8_t> bytes) {
+  std::ofstream output(path, std::ios::binary | std::ios::trunc);
+  return output.write(reinterpret_cast<const char *>(bytes.data()),
+                      static_cast<std::streamsize>(bytes.size())) &&
+         output.flush();
+}
+
+void AppendFloatConstants(
+    std::string &document, const char *name,
+    const rex::system::GraphicsFloatConstantObservation *constants,
+    uint32_t count) {
+  document += fmt::format("    \"{}\": [", name);
+  const uint32_t bounded_count = std::min(
+      count, rex::system::kGraphicsFloatConstantObservationLimit);
+  for (uint32_t i = 0; i < bounded_count; ++i) {
+    if (i) {
+      document += ",";
+    }
+    document += fmt::format(
+        "\n      {{\"index\":{},\"words\":[\"{:08X}\",\"{:08X}\","
+        "\"{:08X}\",\"{:08X}\"]}}",
+        constants[i].index, constants[i].values[0], constants[i].values[1],
+        constants[i].values[2], constants[i].values[3]);
+  }
+  document += bounded_count ? "\n    ]" : "]";
+}
+
+struct SnapshotTexturePayload {
+  uint32_t fetch_constant = 0;
+  uint32_t base_address = 0;
+  uint32_t mip_address = 0;
+  std::vector<uint8_t> base;
+  std::vector<uint8_t> mip;
+};
+
+void TryCaptureReplaySnapshot(
+    const rex::system::GraphicsDrawObservation &observation,
+    bool samples_resolved_target,
+    const rex::system::GraphicsPreparedDrawObservation &prepared,
+    uint64_t signature) {
+  if (!g_replay_snapshot.requested || !g_replay_snapshot.valid ||
+      g_replay_snapshot.completed ||
+      signature != g_replay_snapshot.target_signature) {
+    return;
+  }
+  g_replay_snapshot.completed = true;
+
+  const auto reject = [&](const char *reason) {
+    pinyon_shift::diagnostics::RecordEvent(
+        "native_renderer.snapshot.capture",
+        {{"signature", fmt::format("{:016X}", signature)},
+         {"status", "rejected"},
+         {"reason", reason},
+         {"frame", std::to_string(observation.frame_sequence)},
+         {"draw", std::to_string(observation.draw_sequence)},
+         {"guest_payload_read", "false"},
+         {"payload_persisted", "false"},
+         {"native_upload", "false"},
+         {"native_draw", "false"},
+         {"suppression_eligible", "false"}});
+  };
+
+  if (samples_resolved_target) {
+    reject("observed_resolve_dependency");
+    return;
+  }
+  if (!observation.indexed ||
+      observation.source_select !=
+          uint32_t(rex::graphics::xenos::SourceSelect::kDMA) ||
+      observation.index_format > 1 || observation.index_endianness > 3 ||
+      !observation.index_count ||
+      observation.index_count > kMaximumIndexScanCount) {
+    reject("unsupported_index_state");
+    return;
+  }
+  if (observation.vertex_binding_count != 1 ||
+      observation.vertex_binding_overflow ||
+      observation.vertex_attribute_overflow ||
+      observation.vertex_float_constant_overflow ||
+      observation.pixel_float_constant_overflow ||
+      observation.texture_state_overflow || observation.vertex_memexport ||
+      observation.viz_query_condition || (observation.pa_sc_viz_query & 1)) {
+    reject("unsupported_draw_state");
+    return;
+  }
+  if ((prepared.flags & 3) != 3 ||
+      !(prepared.bound_render_target_bits & 2)) {
+    reject("inactive_prepared_pipeline");
+    return;
+  }
+
+  const uint32_t index_element_bytes = observation.index_format ? 4 : 2;
+  const uint64_t index_bytes =
+      uint64_t(observation.index_count) * index_element_bytes;
+  const auto &binding = observation.vertex_bindings[0];
+  const uint64_t vertex_bytes = binding.size;
+  constexpr uint64_t kMaximumVertexSnapshotBytes = UINT64_C(64) << 20;
+  const uint64_t index_address =
+      uint64_t(observation.index_buffer_address & 0x1FFFFFFF);
+  const uint64_t vertex_address = uint64_t(binding.address & 0x1FFFFFFF);
+  if (!vertex_bytes || index_bytes > kMaximumIndexScanBytes ||
+      index_bytes > observation.index_buffer_length ||
+      vertex_bytes > kMaximumVertexSnapshotBytes ||
+      index_address + index_bytes > kPhysicalApertureSize ||
+      vertex_address + vertex_bytes > kPhysicalApertureSize) {
+    reject("geometry_range_out_of_bounds");
+    return;
+  }
+
+  const uint32_t texture_count = std::popcount(observation.texture_fetch_mask);
+  if (!texture_count || texture_count > kMaximumTextureScanResources ||
+      (observation.texture_fetch_layout_valid_mask &
+       observation.texture_fetch_mask) != observation.texture_fetch_mask) {
+    reject("texture_layout_unavailable");
+    return;
+  }
+  uint64_t texture_bytes = 0;
+  for (uint32_t fetch = 0; fetch < 32; ++fetch) {
+    if (!(observation.texture_fetch_mask & (uint32_t(1) << fetch))) {
+      continue;
+    }
+    const uint64_t base_bytes =
+        observation.texture_fetch_base_lengths[fetch];
+    const uint64_t mip_bytes = observation.texture_fetch_mip_lengths[fetch];
+    const uint64_t base_address =
+        observation.texture_fetch_addresses[fetch] & 0x1FFFFFFF;
+    const uint64_t mip_address =
+        observation.texture_fetch_mip_addresses[fetch] & 0x1FFFFFFF;
+    if (!base_bytes || base_bytes > kMaximumTextureScanResourceBytes ||
+        mip_bytes > kMaximumTextureScanResourceBytes ||
+        base_address + base_bytes > kPhysicalApertureSize ||
+        (mip_bytes && mip_address + mip_bytes > kPhysicalApertureSize) ||
+        base_bytes + mip_bytes >
+            kMaximumTextureScanTotalBytes - texture_bytes) {
+      reject("texture_range_out_of_bounds");
+      return;
+    }
+    texture_bytes += base_bytes + mip_bytes;
+  }
+
+  auto *kernel_state = rex::system::kernel_state();
+  if (!kernel_state || !kernel_state->memory()) {
+    reject("guest_memory_unavailable");
+    return;
+  }
+  auto *memory = kernel_state->memory();
+  const auto copy_physical = [&](uint32_t address, uint64_t size) {
+    std::vector<uint8_t> result(size);
+    const uint8_t *source =
+        memory->TranslatePhysical<const uint8_t *>(address);
+    std::memcpy(result.data(), source, size);
+    return result;
+  };
+
+  std::vector<uint8_t> index_payload =
+      copy_physical(observation.index_buffer_address, index_bytes);
+  std::vector<uint8_t> vertex_payload =
+      copy_physical(binding.address, vertex_bytes);
+  std::vector<SnapshotTexturePayload> textures;
+  textures.reserve(texture_count);
+  for (uint32_t fetch = 0; fetch < 32; ++fetch) {
+    if (!(observation.texture_fetch_mask & (uint32_t(1) << fetch))) {
+      continue;
+    }
+    SnapshotTexturePayload texture;
+    texture.fetch_constant = fetch;
+    texture.base_address = observation.texture_fetch_addresses[fetch];
+    texture.mip_address = observation.texture_fetch_mip_addresses[fetch];
+    texture.base = copy_physical(
+        texture.base_address, observation.texture_fetch_base_lengths[fetch]);
+    if (observation.texture_fetch_mip_lengths[fetch]) {
+      texture.mip = copy_physical(
+          texture.mip_address, observation.texture_fetch_mip_lengths[fetch]);
+    }
+    textures.push_back(std::move(texture));
+  }
+
+  std::filesystem::path staging = g_replay_snapshot.output_root;
+  staging += L".partial";
+  std::error_code error;
+  if (std::filesystem::exists(g_replay_snapshot.output_root, error) || error ||
+      std::filesystem::exists(staging, error) || error ||
+      !std::filesystem::create_directories(staging, error) || error) {
+    reject("output_directory_unavailable");
+    return;
+  }
+
+  const auto write_payload = [&](const std::filesystem::path &name,
+                                 std::span<const uint8_t> payload) {
+    return WriteSnapshotFile(staging / name, payload);
+  };
+  if (!write_payload(L"index.bin", index_payload) ||
+      !write_payload(L"vertex.bin", vertex_payload)) {
+    reject("geometry_write_failed");
+    return;
+  }
+  for (const auto &texture : textures) {
+    const auto base_name =
+        std::filesystem::path(fmt::format("texture_{:02}_base.bin",
+                                         texture.fetch_constant));
+    if (!write_payload(base_name, texture.base)) {
+      reject("texture_write_failed");
+      return;
+    }
+    if (!texture.mip.empty()) {
+      const auto mip_name =
+          std::filesystem::path(fmt::format("texture_{:02}_mip.bin",
+                                           texture.fetch_constant));
+      if (!write_payload(mip_name, texture.mip)) {
+        reject("texture_write_failed");
+        return;
+      }
+    }
+  }
+
+  std::string document = fmt::format(
+      "{{\n  \"schema\": \"pinyon-shift.native-replay-snapshot.v1\",\n"
+      "  \"candidate_signature\": \"{:016X}\",\n"
+      "  \"frame\": {},\n  \"draw\": {},\n"
+      "  \"shaders\": {{\"vertex\":\"{:016X}\",\"pixel\":\"{:016X}\","
+      "\"vertex_specialization\":\"{:016X}\","
+      "\"pixel_specialization\":\"{:016X}\"}},\n"
+      "  \"prepared_pipeline_hash\": \"{:016X}\",\n"
+      "  \"prepared_pipeline\": {{\"guest_primitive\":{},"
+      "\"host_primitive\":{},\"host_vertex_shader_type\":{},"
+      "\"tessellation_mode\":{},\"index_buffer_type\":{},"
+      "\"host_index_format\":{},\"host_primitive_reset\":{},"
+      "\"depth_control\":\"{:08X}\",\"color_mask\":\"{:08X}\","
+      "\"target_bits\":\"{:08X}\","
+      "\"target_formats\":[{},{},{},{},{}],\"flags\":\"{:08X}\"}},\n"
+      "  \"geometry\": {{\n"
+      "    \"index\": {{\"file\":\"index.bin\",\"bytes\":{},"
+      "\"hash\":\"{:016X}\",\"address\":\"{:08X}\","
+      "\"format\":{},\"endianness\":{},\"count\":{}}},\n"
+      "    \"vertex\": {{\"file\":\"vertex.bin\",\"bytes\":{},"
+      "\"hash\":\"{:016X}\",\"address\":\"{:08X}\","
+      "\"fetch_constant\":{},\"stride_words\":{},"
+      "\"endianness\":{}}}\n  }},\n  \"textures\": [",
+      signature, observation.frame_sequence, observation.draw_sequence,
+      prepared.vertex_shader_hash, prepared.pixel_shader_hash,
+      prepared.vertex_specialization_mask, prepared.pixel_specialization_mask,
+      PreparedPipelineHash(prepared), prepared.guest_primitive_type,
+      prepared.host_primitive_type, prepared.host_vertex_shader_type,
+      prepared.tessellation_mode, prepared.index_buffer_type,
+      prepared.host_index_format, prepared.host_primitive_reset_enabled,
+      prepared.normalized_depth_control, prepared.normalized_color_mask,
+      prepared.bound_render_target_bits, prepared.bound_render_target_formats[0],
+      prepared.bound_render_target_formats[1],
+      prepared.bound_render_target_formats[2],
+      prepared.bound_render_target_formats[3],
+      prepared.bound_render_target_formats[4], prepared.flags,
+      index_payload.size(), HashBytes(index_payload.data(), index_payload.size()),
+      observation.index_buffer_address, observation.index_format,
+      observation.index_endianness, observation.index_count,
+      vertex_payload.size(),
+      HashBytes(vertex_payload.data(), vertex_payload.size()), binding.address,
+      binding.fetch_constant, binding.stride_words, binding.endianness);
+  for (size_t i = 0; i < textures.size(); ++i) {
+    const auto &texture = textures[i];
+    if (i) {
+      document += ",";
+    }
+    document += fmt::format(
+        "\n    {{\"fetch_constant\":{},\"base_file\":"
+        "\"texture_{:02}_base.bin\",\"base_bytes\":{},"
+        "\"base_hash\":\"{:016X}\",\"base_address\":\"{:08X}\","
+        "\"mip_file\":{},\"mip_bytes\":{},\"mip_hash\":{},"
+        "\"mip_address\":\"{:08X}\"}}",
+        texture.fetch_constant, texture.fetch_constant, texture.base.size(),
+        HashBytes(texture.base.data(), texture.base.size()),
+        texture.base_address,
+        texture.mip.empty()
+            ? "null"
+            : fmt::format("\"texture_{:02}_mip.bin\"",
+                          texture.fetch_constant),
+        texture.mip.size(),
+        texture.mip.empty()
+            ? "null"
+            : fmt::format("\"{:016X}\"",
+                          HashBytes(texture.mip.data(), texture.mip.size())),
+        texture.mip_address);
+  }
+  document += "\n  ],\n  \"constants\": {\n";
+  AppendFloatConstants(document, "vertex_float",
+                       observation.vertex_float_constants,
+                       observation.vertex_float_constant_count);
+  document += ",\n";
+  AppendFloatConstants(document, "pixel_float",
+                       observation.pixel_float_constants,
+                       observation.pixel_float_constant_count);
+  document += ",\n    \"bool_bitmap\": [";
+  for (uint32_t i = 0; i < 8; ++i) {
+    document += fmt::format("{}\"{:08X}\"", i ? "," : "",
+                            observation.bool_constant_bitmap[i]);
+  }
+  document += "],\n    \"bool_values\": [";
+  for (uint32_t i = 0; i < 8; ++i) {
+    document += fmt::format("{}\"{:08X}\"", i ? "," : "",
+                            observation.bool_constant_values[i]);
+  }
+  document += fmt::format(
+      "],\n    \"loop_bitmap\": \"{:08X}\",\n"
+      "    \"loop_values\": [",
+      observation.loop_constant_bitmap);
+  for (uint32_t i = 0; i < 32; ++i) {
+    document += fmt::format("{}\"{:08X}\"", i ? "," : "",
+                            observation.loop_constant_values[i]);
+  }
+  document += "],\n    \"texture_states\": [";
+  const uint32_t texture_state_count = std::min(
+      observation.texture_state_count,
+      rex::system::kGraphicsTextureFetchObservationLimit);
+  for (uint32_t i = 0; i < texture_state_count; ++i) {
+    const auto &state = observation.texture_states[i];
+    if (i) {
+      document += ",";
+    }
+    document += fmt::format(
+        "\n      {{\"stage\":{},\"fetch_constant\":{},"
+        "\"dwords\":[\"{:08X}\",\"{:08X}\",\"{:08X}\",\"{:08X}\","
+        "\"{:08X}\",\"{:08X}\"],\"opcode\":{},\"dimension\":{},"
+        "\"filters\":\"{:08X}\",\"flags\":\"{:08X}\","
+        "\"lod_bias\":\"{:08X}\",\"offsets\":\"{:08X}\","
+        "\"result_target\":{},\"result_index\":{},"
+        "\"result_mask\":{},\"result_components\":{}}}",
+        state.stage, state.fetch_constant, state.dwords[0], state.dwords[1],
+        state.dwords[2], state.dwords[3], state.dwords[4], state.dwords[5],
+        state.opcode, state.dimension, state.filters, state.flags,
+        state.lod_bias, state.offsets, state.result_storage_target,
+        state.result_storage_index, state.result_write_mask,
+        state.result_components);
+  }
+  document += texture_state_count ? "\n    ]\n" : "]\n";
+  document +=
+      "  },\n  \"safety\": {\"guest_payload_read\":"
+      "\"bounded_snapshot_only\",\"payload_scope\":\"local_only\","
+      "\"native_upload\":false,\"native_draw\":false,"
+      "\"suppression_allowed\":false,\"xenos_authority\":true}\n}\n";
+  const auto manifest_bytes = std::span(
+      reinterpret_cast<const uint8_t *>(document.data()), document.size());
+  if (!write_payload(L"snapshot.json", manifest_bytes)) {
+    reject("manifest_write_failed");
+    return;
+  }
+  std::filesystem::rename(staging, g_replay_snapshot.output_root, error);
+  if (error) {
+    reject("snapshot_commit_failed");
+    return;
+  }
+
+  pinyon_shift::diagnostics::RecordEvent(
+      "native_renderer.snapshot.capture",
+      {{"signature", fmt::format("{:016X}", signature)},
+       {"status", "captured"},
+       {"frame", std::to_string(observation.frame_sequence)},
+       {"draw", std::to_string(observation.draw_sequence)},
+       {"index_bytes", std::to_string(index_payload.size())},
+       {"vertex_bytes", std::to_string(vertex_payload.size())},
+       {"texture_resources", std::to_string(textures.size())},
+       {"texture_bytes", std::to_string(texture_bytes)},
+       {"guest_payload_read", "bounded_snapshot_only"},
+       {"payload_persisted", "local_only"},
        {"native_upload", "false"},
        {"native_draw", "false"},
        {"suppression_eligible", "false"}});
@@ -1513,6 +1931,8 @@ void RecordCandidate(
       CandidateSignature(observation, samples_resolved_target, prepared);
   TryScanCandidateIndices(observation, signature);
   TryFingerprintCandidateTextures(observation, signature);
+  TryCaptureReplaySnapshot(observation, samples_resolved_target, prepared,
+                           signature);
   size_t index = size_t(signature % kSignatureCapacity);
   for (size_t probe = 0; probe < kSignatureCapacity; ++probe) {
     DrawSignatureEntry &entry = g_candidate_census.entries[index];
@@ -1636,6 +2056,7 @@ void InstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system) {
   ResetDependencyCensus();
   ConfigureIndexScan();
   ConfigureTextureScan();
+  ConfigureReplaySnapshot();
   g_graphics_census_installed = true;
   graphics_system->SetDrawObserver(&ObserveDraw);
   graphics_system->SetCopyObserver(&ObserveCopy);
@@ -1680,6 +2101,22 @@ void InstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system) {
        {"maximum_total_bytes",
         std::to_string(kMaximumTextureScanTotalBytes)},
        {"mode", "bounded_diagnostic_read"}});
+  diagnostics::RecordEvent(
+      "native_renderer.snapshot.config",
+      {{"status", !g_replay_snapshot.requested
+                      ? "disabled"
+                      : (g_replay_snapshot.valid ? "armed"
+                                                 : "invalid_configuration")},
+       {"signature",
+        g_replay_snapshot.valid && g_replay_snapshot.requested
+            ? fmt::format("{:016X}", g_replay_snapshot.target_signature)
+            : ""},
+       {"output",
+        g_replay_snapshot.valid && g_replay_snapshot.requested ? "local_only"
+                                                               : ""},
+       {"native_upload", "false"},
+       {"native_draw", "false"},
+       {"suppression_eligible", "false"}});
 }
 
 void UninstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system) {
@@ -1718,6 +2155,19 @@ void UninstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system) {
           fmt::format("{:016X}", g_texture_scan.target_signature)},
          {"status", "not_observed"},
          {"guest_payload_read", "false"},
+         {"native_upload", "false"},
+         {"native_draw", "false"},
+         {"suppression_eligible", "false"}});
+  }
+  if (g_replay_snapshot.requested && g_replay_snapshot.valid &&
+      !g_replay_snapshot.completed) {
+    diagnostics::RecordEvent(
+        "native_renderer.snapshot.capture",
+        {{"signature",
+          fmt::format("{:016X}", g_replay_snapshot.target_signature)},
+         {"status", "not_observed"},
+         {"guest_payload_read", "false"},
+         {"payload_persisted", "false"},
          {"native_upload", "false"},
          {"native_draw", "false"},
          {"suppression_eligible", "false"}});

--- a/tools/capture-native-renderer-census.ps1
+++ b/tools/capture-native-renderer-census.ps1
@@ -10,6 +10,9 @@ param(
     [string]$IndexScanSignature,
     [ValidatePattern('^[0-9A-Fa-f]{16}$')]
     [string]$TextureScanSignature,
+    [ValidatePattern('^[0-9A-Fa-f]{16}$')]
+    [string]$ReplaySnapshotSignature,
+    [string]$ReplaySnapshotDir,
     [switch]$Json
 )
 
@@ -44,16 +47,41 @@ if ($profiles.Count -eq 0) {
 if (@(Get-Process -Name 'pinyon_shift' -ErrorAction SilentlyContinue).Count -ne 0) {
     throw 'Pinyon Shift is already running.'
 }
+if ([bool]$ReplaySnapshotSignature -xor [bool]$ReplaySnapshotDir) {
+    throw 'ReplaySnapshotSignature and ReplaySnapshotDir must be supplied together.'
+}
+if ($ReplaySnapshotDir) {
+    $repositoryRoot = Split-Path $PSScriptRoot -Parent
+    $localRoot = [IO.Path]::GetFullPath((Join-Path $repositoryRoot '.local'))
+    $resolvedSnapshotDir = [IO.Path]::GetFullPath($ReplaySnapshotDir)
+    $localPrefix = $localRoot.TrimEnd([IO.Path]::DirectorySeparatorChar) +
+        [IO.Path]::DirectorySeparatorChar
+    if (-not $resolvedSnapshotDir.StartsWith(
+            $localPrefix, [StringComparison]::OrdinalIgnoreCase)) {
+        throw "ReplaySnapshotDir must be below $localRoot"
+    }
+    if (Test-Path -LiteralPath $resolvedSnapshotDir) {
+        throw "ReplaySnapshotDir already exists: $resolvedSnapshotDir"
+    }
+    if (Test-Path -LiteralPath "$resolvedSnapshotDir.partial") {
+        throw "Replay snapshot staging directory already exists: $resolvedSnapshotDir.partial"
+    }
+    $ReplaySnapshotDir = $resolvedSnapshotDir
+}
 
 $savedCensus = $env:REX_PINYON_SHIFT_NATIVE_RENDERER_CENSUS
 $savedScene = $env:PINYON_SHIFT_NATIVE_RENDERER_SCENE
 $savedIndexScan = $env:PINYON_SHIFT_NATIVE_RENDERER_INDEX_SCAN_SIGNATURE
 $savedTextureScan = $env:PINYON_SHIFT_NATIVE_RENDERER_TEXTURE_SCAN_SIGNATURE
+$savedReplaySnapshot = $env:PINYON_SHIFT_NATIVE_RENDERER_SNAPSHOT_SIGNATURE
+$savedReplaySnapshotDir = $env:PINYON_SHIFT_NATIVE_RENDERER_SNAPSHOT_DIR
 try {
     $env:REX_PINYON_SHIFT_NATIVE_RENDERER_CENSUS = 'true'
     $env:PINYON_SHIFT_NATIVE_RENDERER_SCENE = $Scene
     $env:PINYON_SHIFT_NATIVE_RENDERER_INDEX_SCAN_SIGNATURE = $IndexScanSignature
     $env:PINYON_SHIFT_NATIVE_RENDERER_TEXTURE_SCAN_SIGNATURE = $TextureScanSignature
+    $env:PINYON_SHIFT_NATIVE_RENDERER_SNAPSHOT_SIGNATURE = $ReplaySnapshotSignature
+    $env:PINYON_SHIFT_NATIVE_RENDERER_SNAPSHOT_DIR = $ReplaySnapshotDir
     & (Join-Path $PSScriptRoot 'launch-preview.ps1') `
         -StateRoot $resolvedStateRoot -ShaderCaptureDir $ShaderCaptureDir `
         -Json:$Json
@@ -63,4 +91,6 @@ finally {
     $env:PINYON_SHIFT_NATIVE_RENDERER_SCENE = $savedScene
     $env:PINYON_SHIFT_NATIVE_RENDERER_INDEX_SCAN_SIGNATURE = $savedIndexScan
     $env:PINYON_SHIFT_NATIVE_RENDERER_TEXTURE_SCAN_SIGNATURE = $savedTextureScan
+    $env:PINYON_SHIFT_NATIVE_RENDERER_SNAPSHOT_SIGNATURE = $savedReplaySnapshot
+    $env:PINYON_SHIFT_NATIVE_RENDERER_SNAPSHOT_DIR = $savedReplaySnapshotDir
 }

--- a/tools/tests/test_native_renderer_contract.py
+++ b/tools/tests/test_native_renderer_contract.py
@@ -416,6 +416,13 @@ class NativeRendererContractTests(unittest.TestCase):
         self.assertIn("PINYON_SHIFT_NATIVE_RENDERER_TEXTURE_SCAN_SIGNATURE", scanner)
         self.assertIn("kMaximumTextureScanTotalBytes", scanner)
         self.assertIn('"bounded_texture_only"', scanner)
+        self.assertIn("PINYON_SHIFT_NATIVE_RENDERER_SNAPSHOT_SIGNATURE", scanner)
+        self.assertIn("PINYON_SHIFT_NATIVE_RENDERER_SNAPSHOT_DIR", scanner)
+        self.assertIn("kMaximumVertexSnapshotBytes", scanner)
+        self.assertIn('"bounded_snapshot_only"', scanner)
+        self.assertIn('"native_upload", "false"', scanner)
+        self.assertIn('"native_draw", "false"', scanner)
+        self.assertIn('"suppression_eligible", "false"', scanner)
         self.assertNotIn("SetDrawSuppression", scanner)
 
         draw_state_planner = (

--- a/tools/tests/test_native_replay_snapshot.py
+++ b/tools/tests/test_native_replay_snapshot.py
@@ -1,0 +1,161 @@
+import importlib.util
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+
+MODULE_PATH = Path(__file__).parents[1] / "validate-native-replay-snapshot.py"
+SPEC = importlib.util.spec_from_file_location("validate_native_replay_snapshot", MODULE_PATH)
+MODULE = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+SPEC.loader.exec_module(MODULE)
+
+
+SIGNATURE = "747837906D0BF484"
+
+
+def safe() -> dict:
+    return {
+        "native_upload": False,
+        "native_draw": False,
+        "suppression_allowed": False,
+        "xenos_authority": True,
+    }
+
+
+class NativeReplaySnapshotTests(unittest.TestCase):
+    def make_fixture(self, root: Path):
+        payloads = {
+            "index.bin": b"index payload",
+            "vertex.bin": b"vertex payload data",
+            "texture_00_base.bin": b"texture zero",
+            "texture_02_base.bin": b"texture two!",
+        }
+        for name, payload in payloads.items():
+            (root / name).write_bytes(payload)
+
+        snapshot = {
+            "schema": "pinyon-shift.native-replay-snapshot.v1",
+            "candidate_signature": SIGNATURE,
+            "frame": 2847,
+            "draw": 116,
+            "shaders": {
+                "vertex": "E35520B6FDEA8C91",
+                "pixel": "676B6C2D37982AD9",
+                "vertex_specialization": "0000000000000003",
+                "pixel_specialization": "0000400000000003",
+            },
+            "prepared_pipeline_hash": "464D06471DC459EA",
+            "geometry": {
+                "index": {
+                    "file": "index.bin",
+                    "bytes": len(payloads["index.bin"]),
+                    "hash": MODULE.fnv1a64(payloads["index.bin"]),
+                    "format": 1,
+                    "endianness": 2,
+                    "count": 9300,
+                },
+                "vertex": {
+                    "file": "vertex.bin",
+                    "bytes": len(payloads["vertex.bin"]),
+                    "hash": MODULE.fnv1a64(payloads["vertex.bin"]),
+                    "stride_words": 8,
+                },
+            },
+            "textures": [
+                {
+                    "fetch_constant": fetch,
+                    "base_file": name,
+                    "base_bytes": len(payloads[name]),
+                    "base_hash": MODULE.fnv1a64(payloads[name]),
+                    "mip_file": None,
+                    "mip_bytes": 0,
+                    "mip_hash": None,
+                }
+                for fetch, name in ((0, "texture_00_base.bin"), (2, "texture_02_base.bin"))
+            ],
+            "constants": {
+                "texture_states": [{"fetch_constant": 0}, {"fetch_constant": 2}]
+            },
+            "safety": {"guest_payload_read": "bounded_snapshot_only", **safe()},
+        }
+        (root / "snapshot.json").write_text(json.dumps(snapshot), encoding="utf-8")
+
+        geometry = {
+            "candidate_signature": SIGNATURE,
+            "index_count": {"maximum_observed": 9300},
+            "index": {"format": 1, "endianness": 2},
+            "binding": {"size_bytes": len(payloads["vertex.bin"]), "stride_bytes": 32},
+            "bounds": {"validated": True},
+            "safety": safe(),
+        }
+        draw_state = {"candidate_signature": SIGNATURE, "safety": safe()}
+        texture = {
+            "candidate_signature": SIGNATURE,
+            "resources": [
+                {
+                    "fetch_constant": fetch,
+                    "base_bytes": len(payloads[name]),
+                    "base_hash": MODULE.fnv1a64(payloads[name]),
+                    "mip_bytes": 0,
+                    "mip_hash": "",
+                }
+                for fetch, name in ((0, "texture_00_base.bin"), (2, "texture_02_base.bin"))
+            ],
+            "qualification": {"content_stable_across_captures": True},
+            "safety": safe(),
+        }
+        pso = {
+            "candidate_signature": SIGNATURE,
+            "pso_key": {
+                "vertex_shader": snapshot["shaders"]["vertex"],
+                "pixel_shader": snapshot["shaders"]["pixel"],
+                "vertex_specialization_mask": snapshot["shaders"]["vertex_specialization"],
+                "pixel_specialization_mask": snapshot["shaders"]["pixel_specialization"],
+                "prepared_pipeline_hash": snapshot["prepared_pipeline_hash"],
+            },
+            "support": {"ready_for_pso_creation": True},
+            "safety": safe(),
+        }
+        return geometry, draw_state, texture, pso
+
+    def test_valid_snapshot_advances_only_to_isolated_upload(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            contracts = self.make_fixture(root)
+            result = MODULE.validate_snapshot(root, *contracts)
+            self.assertTrue(result["ready_for_isolated_upload"])
+            self.assertFalse(result["native_draw"])
+            self.assertFalse(result["suppression_allowed"])
+            self.assertTrue(result["xenos_authority"])
+
+    def test_payload_hash_mismatch_is_rejected(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            contracts = self.make_fixture(root)
+            (root / "index.bin").write_bytes(b"INDEX PAYLOAD")
+            with self.assertRaisesRegex(ValueError, "hash does not match"):
+                MODULE.validate_snapshot(root, *contracts)
+
+    def test_unsafe_contract_is_rejected(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            geometry, draw_state, texture, pso = self.make_fixture(root)
+            pso["safety"]["native_draw"] = True
+            with self.assertRaisesRegex(ValueError, "native drawing disabled"):
+                MODULE.validate_snapshot(root, geometry, draw_state, texture, pso)
+
+    def test_payload_path_traversal_is_rejected(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            contracts = self.make_fixture(root)
+            snapshot = json.loads((root / "snapshot.json").read_text(encoding="utf-8"))
+            snapshot["geometry"]["index"]["file"] = "../index.bin"
+            (root / "snapshot.json").write_text(json.dumps(snapshot), encoding="utf-8")
+            with self.assertRaisesRegex(ValueError, "unsafe snapshot payload path"):
+                MODULE.validate_snapshot(root, *contracts)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/validate-native-replay-snapshot.py
+++ b/tools/validate-native-replay-snapshot.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env python3
+"""Validate one local NR-02 replay snapshot against its offline contracts."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+
+FNV_OFFSET = 0xCBF29CE484222325
+FNV_PRIME = 0x100000001B3
+
+
+def fnv1a64(payload: bytes) -> str:
+    value = FNV_OFFSET
+    for byte in payload:
+        value ^= byte
+        value = (value * FNV_PRIME) & 0xFFFFFFFFFFFFFFFF
+    return f"{value:016X}"
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    document = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(document, dict):
+        raise ValueError(f"{path} must contain a JSON object")
+    return document
+
+
+def require_safety(document: dict[str, Any], name: str) -> None:
+    safety = document.get("safety")
+    if not isinstance(safety, dict):
+        raise ValueError(f"{name} is missing its safety record")
+    if safety.get("native_upload") is not False:
+        raise ValueError(f"{name} does not keep native upload disabled")
+    if safety.get("native_draw") is not False:
+        raise ValueError(f"{name} does not keep native drawing disabled")
+    if safety.get("suppression_allowed") is not False:
+        raise ValueError(f"{name} does not keep suppression disabled")
+    if safety.get("xenos_authority") is not True:
+        raise ValueError(f"{name} does not preserve Xenos authority")
+
+
+def payload_path(root: Path, file_name: object) -> Path:
+    if not isinstance(file_name, str) or not file_name:
+        raise ValueError("snapshot payload has no file name")
+    relative = Path(file_name)
+    if relative.is_absolute() or len(relative.parts) != 1 or relative.name != file_name:
+        raise ValueError(f"unsafe snapshot payload path: {file_name!r}")
+    return root / relative
+
+
+def validate_payload(root: Path, entry: dict[str, Any], prefix: str) -> None:
+    stem = f"{prefix}_" if prefix else ""
+    path = payload_path(root, entry[f"{stem}file"])
+    payload = path.read_bytes()
+    expected_size = entry[f"{stem}bytes"]
+    expected_hash = entry[f"{stem}hash"]
+    if len(payload) != expected_size:
+        raise ValueError(f"{path.name} size does not match the manifest")
+    if fnv1a64(payload) != expected_hash:
+        raise ValueError(f"{path.name} hash does not match the manifest")
+
+
+def validate_snapshot(
+    root: Path,
+    geometry: dict[str, Any],
+    draw_state: dict[str, Any],
+    texture: dict[str, Any],
+    pso: dict[str, Any],
+) -> dict[str, Any]:
+    snapshot = load_json(root / "snapshot.json")
+    if snapshot.get("schema") != "pinyon-shift.native-replay-snapshot.v1":
+        raise ValueError("unsupported replay snapshot schema")
+
+    signature = snapshot.get("candidate_signature")
+    if not isinstance(signature, str) or len(signature) != 16:
+        raise ValueError("snapshot candidate signature is invalid")
+    for name, document in (
+        ("geometry", geometry),
+        ("draw state", draw_state),
+        ("texture provenance", texture),
+        ("PSO", pso),
+    ):
+        if document.get("candidate_signature") != signature:
+            raise ValueError(f"{name} contract signature does not match the snapshot")
+        require_safety(document, name)
+    require_safety(snapshot, "snapshot")
+
+    if geometry.get("bounds", {}).get("validated") is not True:
+        raise ValueError("geometry contract is not bounded")
+    if texture.get("qualification", {}).get("content_stable_across_captures") is not True:
+        raise ValueError("texture content is not stable across captures")
+    if pso.get("support", {}).get("ready_for_pso_creation") is not True:
+        raise ValueError("PSO contract is not ready for isolated creation")
+
+    snapshot_shaders = snapshot.get("shaders", {})
+    pso_key = pso.get("pso_key", {})
+    shader_pairs = (
+        ("vertex", "vertex_shader"),
+        ("pixel", "pixel_shader"),
+        ("vertex_specialization", "vertex_specialization_mask"),
+        ("pixel_specialization", "pixel_specialization_mask"),
+    )
+    for snapshot_name, pso_name in shader_pairs:
+        if snapshot_shaders.get(snapshot_name) != pso_key.get(pso_name):
+            raise ValueError(f"snapshot {snapshot_name} does not match the PSO contract")
+    if snapshot.get("prepared_pipeline_hash") != pso_key.get("prepared_pipeline_hash"):
+        raise ValueError("prepared pipeline hash does not match the PSO contract")
+
+    snapshot_geometry = snapshot.get("geometry", {})
+    index_entry = snapshot_geometry.get("index", {})
+    vertex_entry = snapshot_geometry.get("vertex", {})
+    validate_payload(root, index_entry, "")
+    validate_payload(root, vertex_entry, "")
+    geometry_index = geometry.get("index", {})
+    if index_entry.get("format") != geometry_index.get("format"):
+        raise ValueError("snapshot index format does not match the geometry contract")
+    if index_entry.get("endianness") != geometry_index.get("endianness"):
+        raise ValueError("snapshot index endianness does not match the geometry contract")
+    if index_entry.get("count") != geometry.get("index_count", {}).get("maximum_observed"):
+        raise ValueError("snapshot index count does not match the geometry contract")
+    if vertex_entry.get("bytes") != geometry.get("binding", {}).get("size_bytes"):
+        raise ValueError("snapshot vertex allocation does not match the geometry contract")
+    if vertex_entry.get("stride_words") * 4 != geometry.get("binding", {}).get("stride_bytes"):
+        raise ValueError("snapshot vertex stride does not match the geometry contract")
+
+    provenance = {
+        resource["fetch_constant"]: resource
+        for resource in texture.get("resources", [])
+    }
+    snapshot_textures = snapshot.get("textures")
+    if not isinstance(snapshot_textures, list) or len(snapshot_textures) != len(provenance):
+        raise ValueError("snapshot texture count does not match provenance")
+    for resource in snapshot_textures:
+        fetch = resource.get("fetch_constant")
+        expected = provenance.get(fetch)
+        if expected is None:
+            raise ValueError(f"snapshot texture fetch {fetch!r} has no provenance")
+        validate_payload(root, resource, "base")
+        if resource.get("base_bytes") != expected.get("base_bytes"):
+            raise ValueError(f"texture fetch {fetch} base size is unstable")
+        if resource.get("base_hash") != expected.get("base_hash"):
+            raise ValueError(f"texture fetch {fetch} base hash is unstable")
+        if resource.get("mip_bytes") != expected.get("mip_bytes"):
+            raise ValueError(f"texture fetch {fetch} mip size is unstable")
+        if resource.get("mip_bytes"):
+            validate_payload(root, resource, "mip")
+            if resource.get("mip_hash") != expected.get("mip_hash"):
+                raise ValueError(f"texture fetch {fetch} mip hash is unstable")
+        elif resource.get("mip_file") is not None or resource.get("mip_hash") is not None:
+            raise ValueError(f"texture fetch {fetch} has inconsistent empty mip metadata")
+
+    state_fetches = {
+        item.get("fetch_constant")
+        for item in snapshot.get("constants", {}).get("texture_states", [])
+    }
+    if state_fetches != set(provenance):
+        raise ValueError("snapshot texture instructions do not cover the payload set")
+
+    return {
+        "schema": "pinyon-shift.native-replay-snapshot-validation.v1",
+        "candidate_signature": signature,
+        "frame": snapshot.get("frame"),
+        "draw": snapshot.get("draw"),
+        "index_bytes": index_entry.get("bytes"),
+        "vertex_bytes": vertex_entry.get("bytes"),
+        "texture_resources": len(snapshot_textures),
+        "texture_bytes": sum(resource["base_bytes"] + resource["mip_bytes"] for resource in snapshot_textures),
+        "ready_for_isolated_upload": True,
+        "native_draw": False,
+        "suppression_allowed": False,
+        "xenos_authority": True,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Validate a local exact-signature NR-02 replay snapshot."
+    )
+    parser.add_argument("snapshot_dir", type=Path)
+    parser.add_argument("geometry", type=Path)
+    parser.add_argument("draw_state", type=Path)
+    parser.add_argument("texture", type=Path)
+    parser.add_argument("pso", type=Path)
+    parser.add_argument("--output", "-o", type=Path)
+    args = parser.parse_args()
+
+    result = validate_snapshot(
+        args.snapshot_dir,
+        load_json(args.geometry),
+        load_json(args.draw_state),
+        load_json(args.texture),
+        load_json(args.pso),
+    )
+    text = json.dumps(result, indent=2) + "\n"
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(text, encoding="utf-8")
+    else:
+        print(text, end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- capture one exact-signature bounded replay snapshot into the ignored local artifact tree
- persist geometry, texture, shader, prepared-pipeline, and constant inputs without native upload or draw
- validate the snapshot offline against the qualified geometry, draw-state, texture, and PSO contracts
- preserve Xenos authority and keep suppression unavailable

## Validation
- full Release preview build
- 114 Python tests
- repository boundary check: 182 candidate files
- AppData session 20260828T090906Z-p43812: captured at frame 3996/draw 115, normal exit 0, no error events
- offline validation: ready_for_isolated_upload=true, native_draw=false, suppression_allowed=false