### PR TITLE
feat(native-renderer): replay one draw in isolated target

### DIFF
--- a/docs/native-renderer/ISOLATED_DRAW_REPLAY.md
+++ b/docs/native-renderer/ISOLATED_DRAW_REPLAY.md
@@ -1,0 +1,59 @@
+# Isolated authentic draw replay
+
+NR-02E begins with a one-shot replay at the synchronous prepared-draw point.
+The D3D12 backend duplicates one exact, title-qualified indexed draw into
+private depth and color targets. It then restores the guest targets and records
+the original draw normally. The isolated target is never presented and Xenos
+remains authoritative for the displayed frame.
+
+## Ownership and safety gates
+
+The path is disabled unless the native-renderer census and an exact 16-digit
+candidate signature are both supplied. Pinyon requests a draw only when the
+live observation still satisfies the qualified candidate boundary:
+
+- direct DMA indexed geometry with supported index format and endianness;
+- one vertex allocation and one through four fully observed textures;
+- no observer overflow, memexport, query, or resolved-target dependency;
+- active host rasterization; and
+- exactly one depth target and the first color target.
+
+ReXGlue independently requires host render targets, rasterization, no
+memexport, and a direct guest DMA index buffer. It creates private clones with
+the same dimensions, formats, and sample count as the live targets, clears
+them, records the duplicate draw with the already prepared PSO and immutable
+bindings, and rebinds the guest targets before the original draw. The API has
+no suppression operation, and failure records an explicit result while the
+guest draw continues.
+
+## Qualification run
+
+Launch the installed AppData save with:
+
+```powershell
+$stateRoot = Join-Path $env:LOCALAPPDATA `
+    'PinyonShift\source\0.1.0\.local\preview'
+.\tools\capture-native-renderer-census.ps1 `
+  -StateRoot $stateRoot `
+  -Scene open_world_day `
+  -IsolatedDrawSignature 747837906D0BF484 `
+  -Json
+```
+
+The expected result is one `native_renderer.isolated_draw.result` event with
+`status=recorded`, non-zero target dimensions, `native_draw=isolated_only`,
+`xenos_draw=preserved`, `output_authority=xenos`, and
+`suppression_eligible=false`. The displayed game must remain visually
+unchanged and the process must exit normally without device-loss, validation,
+or resource-state errors.
+
+The qualifying AppData-backed run completed on 2026-08-28 as session
+`20260828T094158Z-p42200`. The exact signature was recorded once at frame
+3553, draw 116, into a 640 by 8192 private target. The guest output remained
+visually unchanged, census frames continued through frame 5700, and the
+process exited normally with code zero. The structured log contained no fatal,
+device-loss, D3D12 error, exception, access-violation, or crash events.
+
+This milestone proves authentic GPU draw recording and target isolation. A
+later NR-02E pull request must add asynchronous readback and image comparison
+before visual equivalence is claimed.

--- a/patches/rexglue/0058-d3d12-isolated-draw-replay.patch
+++ b/patches/rexglue/0058-d3d12-isolated-draw-replay.patch
@@ -1,0 +1,302 @@
+diff --git a/include/rex/graphics/d3d12/render_target_cache.h b/include/rex/graphics/d3d12/render_target_cache.h
+index cd7693a..93a3062 100644
+--- a/include/rex/graphics/d3d12/render_target_cache.h
++++ b/include/rex/graphics/d3d12/render_target_cache.h
+@@ -95,6 +95,12 @@ class D3D12RenderTargetCache final : public RenderTargetCache {
+     return depth_float24_convert_in_pixel_shader_;
+   }
+ 
++  // Binds cleared private clones of the current depth and first color target.
++  // EndIsolatedReplayTarget restores the guest targets without changing their
++  // contents or ownership.
++  bool BeginIsolatedReplayTarget(uint32_t& width_out, uint32_t& height_out);
++  void EndIsolatedReplayTarget();
++
+   DXGI_FORMAT GetColorResourceDXGIFormat(xenos::ColorRenderTargetFormat format) const;
+   DXGI_FORMAT GetColorDrawDXGIFormat(xenos::ColorRenderTargetFormat format) const;
+   DXGI_FORMAT GetColorOwnershipTransferDXGIFormat(xenos::ColorRenderTargetFormat format,
+@@ -665,6 +671,8 @@ class D3D12RenderTargetCache final : public RenderTargetCache {
+ 
+   std::shared_ptr<ui::d3d12::D3D12CpuDescriptorPool> descriptor_pool_color_;
+   std::shared_ptr<ui::d3d12::D3D12CpuDescriptorPool> descriptor_pool_depth_;
++  std::unique_ptr<RenderTarget> isolated_replay_color_target_;
++  std::unique_ptr<RenderTarget> isolated_replay_depth_target_;
+   std::shared_ptr<ui::d3d12::D3D12CpuDescriptorPool> descriptor_pool_srv_;
+   ui::d3d12::D3D12CpuDescriptorPool::Descriptor null_rtv_descriptor_ss_;
+   ui::d3d12::D3D12CpuDescriptorPool::Descriptor null_rtv_descriptor_ms_;
+diff --git a/include/rex/graphics/graphics_system.h b/include/rex/graphics/graphics_system.h
+index e21660b..682d657 100644
+--- a/include/rex/graphics/graphics_system.h
++++ b/include/rex/graphics/graphics_system.h
+@@ -95,6 +95,15 @@ class GraphicsSystem : public system::IGraphicsSystem {
+   system::GraphicsPreparedDrawObserver prepared_draw_observer() const {
+     return prepared_draw_observer_.load(std::memory_order_acquire);
+   }
++  void SetIsolatedDrawRequestObserver(
++      system::GraphicsIsolatedDrawRequestObserver observer) override {
++    isolated_draw_request_observer_.store(observer,
++                                          std::memory_order_release);
++  }
++  system::GraphicsIsolatedDrawRequestObserver isolated_draw_request_observer()
++      const {
++    return isolated_draw_request_observer_.load(std::memory_order_acquire);
++  }
+   void SetNativeGuestOutputRenderer(
+       system::NativeGuestOutputRenderer renderer) override {
+     native_guest_output_renderer_.Set(renderer);
+@@ -171,6 +180,8 @@ class GraphicsSystem : public system::IGraphicsSystem {
+       shader_translation_observer_{nullptr};
+   std::atomic<system::GraphicsPreparedDrawObserver> prepared_draw_observer_{
+       nullptr};
++  std::atomic<system::GraphicsIsolatedDrawRequestObserver>
++      isolated_draw_request_observer_{nullptr};
+   system::NativeGuestOutputRendererRegistration native_guest_output_renderer_;
+ 
+   std::atomic_flag host_gpu_loss_reported_;
+diff --git a/include/rex/system/interfaces/graphics.h b/include/rex/system/interfaces/graphics.h
+index b157d7d..ab133ca 100644
+--- a/include/rex/system/interfaces/graphics.h
++++ b/include/rex/system/interfaces/graphics.h
+@@ -261,6 +261,33 @@ struct GraphicsPreparedDrawObservation {
+ using GraphicsPreparedDrawObserver = void (*)(
+     const GraphicsPreparedDrawObservation& observation);
+ 
++enum class GraphicsIsolatedDrawStatus : uint32_t {
++  kRecorded = 1,
++  kUnsupportedState = 2,
++  kTargetCreationFailed = 3,
++};
++
++struct GraphicsIsolatedDrawResult {
++  GraphicsIsolatedDrawStatus status =
++      GraphicsIsolatedDrawStatus::kUnsupportedState;
++  uint32_t target_width = 0;
++  uint32_t target_height = 0;
++};
++
++using GraphicsIsolatedDrawCompletion = void (*)(
++    const GraphicsIsolatedDrawResult& result);
++
++struct GraphicsIsolatedDrawRequest {
++  bool requested = false;
++  GraphicsIsolatedDrawCompletion completion = nullptr;
++};
++
++// Called after the host pipeline has been prepared. A request duplicates the
++// current draw into a private backend target and never skips the guest draw.
++using GraphicsIsolatedDrawRequestObserver = void (*)(
++    const GraphicsPreparedDrawObservation& observation,
++    GraphicsIsolatedDrawRequest& request);
++
+ class IGraphicsSystem {
+  public:
+   virtual ~IGraphicsSystem() = default;
+@@ -302,6 +329,10 @@ class IGraphicsSystem {
+   virtual void SetPreparedDrawObserver(GraphicsPreparedDrawObserver observer) {
+     (void)observer;
+   }
++  virtual void SetIsolatedDrawRequestObserver(
++      GraphicsIsolatedDrawRequestObserver observer) {
++    (void)observer;
++  }
+   virtual void SetNativeGuestOutputRenderer(NativeGuestOutputRenderer renderer) {
+     (void)renderer;
+   }
+diff --git a/src/graphics/d3d12/command_processor.cpp b/src/graphics/d3d12/command_processor.cpp
+index 84d04b0..a27f72c 100644
+--- a/src/graphics/d3d12/command_processor.cpp
++++ b/src/graphics/d3d12/command_processor.cpp
+@@ -2729,37 +2729,49 @@ bool D3D12CommandProcessor::IssueDraw(xenos::PrimitiveType primitive_type, uint3
+     return true;
+   }
+   auto prepared_draw_observer = graphics_system_->prepared_draw_observer();
+-  if (prepared_draw_observer) {
+-    system::GraphicsPreparedDrawObservation observation;
+-    observation.vertex_shader_hash = vertex_shader->ucode_data_hash();
+-    observation.pixel_shader_hash =
++  auto isolated_draw_request_observer =
++      graphics_system_->isolated_draw_request_observer();
++  system::GraphicsPreparedDrawObservation prepared_observation;
++  system::GraphicsIsolatedDrawRequest isolated_draw_request;
++  if (prepared_draw_observer || isolated_draw_request_observer) {
++    prepared_observation.vertex_shader_hash = vertex_shader->ucode_data_hash();
++    prepared_observation.pixel_shader_hash =
+         pixel_shader ? pixel_shader->ucode_data_hash() : 0;
+-    observation.vertex_specialization_mask = vertex_shader_modification.value;
+-    observation.pixel_specialization_mask = pixel_shader_modification.value;
+-    observation.guest_primitive_type =
++    prepared_observation.vertex_specialization_mask =
++        vertex_shader_modification.value;
++    prepared_observation.pixel_specialization_mask =
++        pixel_shader_modification.value;
++    prepared_observation.guest_primitive_type =
+         uint32_t(primitive_processing_result.guest_primitive_type);
+-    observation.host_primitive_type =
++    prepared_observation.host_primitive_type =
+         uint32_t(primitive_processing_result.host_primitive_type);
+-    observation.host_vertex_shader_type =
++    prepared_observation.host_vertex_shader_type =
+         uint32_t(primitive_processing_result.host_vertex_shader_type);
+-    observation.tessellation_mode =
++    prepared_observation.tessellation_mode =
+         uint32_t(primitive_processing_result.tessellation_mode);
+-    observation.index_buffer_type =
++    prepared_observation.index_buffer_type =
+         uint32_t(primitive_processing_result.index_buffer_type);
+-    observation.host_index_format =
++    prepared_observation.host_index_format =
+         uint32_t(primitive_processing_result.host_index_format);
+-    observation.host_primitive_reset_enabled =
++    prepared_observation.host_primitive_reset_enabled =
+         primitive_processing_result.host_primitive_reset_enabled;
+-    observation.normalized_depth_control = normalized_depth_control.value;
+-    observation.normalized_color_mask = normalized_color_mask;
+-    observation.bound_render_target_bits =
++    prepared_observation.normalized_depth_control =
++        normalized_depth_control.value;
++    prepared_observation.normalized_color_mask = normalized_color_mask;
++    prepared_observation.bound_render_target_bits =
+         bound_depth_and_color_render_target_bits;
+-    std::memcpy(observation.bound_render_target_formats,
++    std::memcpy(prepared_observation.bound_render_target_formats,
+                 bound_depth_and_color_render_target_formats,
+-                sizeof(observation.bound_render_target_formats));
+-    observation.flags = uint32_t(host_render_targets_used) |
+-                        (uint32_t(is_rasterization_done) << 1);
+-    prepared_draw_observer(observation);
++                sizeof(prepared_observation.bound_render_target_formats));
++    prepared_observation.flags = uint32_t(host_render_targets_used) |
++                                 (uint32_t(is_rasterization_done) << 1);
++    if (prepared_draw_observer) {
++      prepared_draw_observer(prepared_observation);
++    }
++    if (isolated_draw_request_observer) {
++      isolated_draw_request_observer(prepared_observation,
++                                     isolated_draw_request);
++    }
+   }
+ 
+   // Update the textures - this may bind pipelines.
+@@ -3044,6 +3056,30 @@ bool D3D12CommandProcessor::IssueDraw(xenos::PrimitiveType primitive_type, uint3
+       shared_memory_->UseForReading();
+     }
+     SubmitBarriers();
++    if (isolated_draw_request.requested) {
++      system::GraphicsIsolatedDrawResult isolated_result;
++      if (memexport_used || !host_render_targets_used ||
++          !is_rasterization_done ||
++          primitive_processing_result.index_buffer_type !=
++              PrimitiveProcessor::ProcessedIndexBufferType::kGuestDMA) {
++        isolated_result.status =
++            system::GraphicsIsolatedDrawStatus::kUnsupportedState;
++      } else if (render_target_cache_->BeginIsolatedReplayTarget(
++                     isolated_result.target_width,
++                     isolated_result.target_height)) {
++        deferred_command_list_.D3DDrawIndexedInstanced(
++            primitive_processing_result.host_draw_vertex_count, 1, 0, 0, 0);
++        render_target_cache_->EndIsolatedReplayTarget();
++        isolated_result.status =
++            system::GraphicsIsolatedDrawStatus::kRecorded;
++      } else {
++        isolated_result.status =
++            system::GraphicsIsolatedDrawStatus::kTargetCreationFailed;
++      }
++      if (isolated_draw_request.completion) {
++        isolated_draw_request.completion(isolated_result);
++      }
++    }
+     PROFILE_DRAW_CALL();
+     PROFILE_VERTICES(primitive_processing_result.host_draw_vertex_count);
+     deferred_command_list_.D3DDrawIndexedInstanced(
+diff --git a/src/graphics/d3d12/render_target_cache.cpp b/src/graphics/d3d12/render_target_cache.cpp
+index 4dc1d43..86f8a35 100644
+--- a/src/graphics/d3d12/render_target_cache.cpp
++++ b/src/graphics/d3d12/render_target_cache.cpp
+@@ -1020,6 +1020,8 @@ void D3D12RenderTargetCache::Shutdown(bool from_destructor) {
+   }
+   ui::d3d12::util::ReleaseAndNull(host_depth_store_root_signature_);
+ 
++  isolated_replay_depth_target_.reset();
++  isolated_replay_color_target_.reset();
+   null_rtv_descriptor_ms_.Free();
+   null_rtv_descriptor_ss_.Free();
+   descriptor_pool_srv_.reset();
+@@ -1701,6 +1703,78 @@ RenderTargetCache::RenderTarget* D3D12RenderTargetCache::CreateRenderTarget(Rend
+                                std::move(descriptor_srv_stencil), resource_state);
+ }
+ 
++bool D3D12RenderTargetCache::BeginIsolatedReplayTarget(
++    uint32_t& width_out, uint32_t& height_out) {
++  width_out = 0;
++  height_out = 0;
++  if (GetPath() != Path::kHostRenderTargets) {
++    return false;
++  }
++  RenderTarget* const* guest_targets =
++      last_update_accumulated_render_targets();
++  if (!guest_targets[0] || !guest_targets[1]) {
++    return false;
++  }
++  for (uint32_t i = 2; i <= xenos::kMaxColorRenderTargets; ++i) {
++    if (guest_targets[i]) {
++      return false;
++    }
++  }
++
++  const RenderTargetKey depth_key = guest_targets[0]->key();
++  const RenderTargetKey color_key = guest_targets[1]->key();
++  if (!isolated_replay_depth_target_ ||
++      isolated_replay_depth_target_->key() != depth_key) {
++    isolated_replay_depth_target_.reset(CreateRenderTarget(depth_key));
++  }
++  if (!isolated_replay_color_target_ ||
++      isolated_replay_color_target_->key() != color_key) {
++    isolated_replay_color_target_.reset(CreateRenderTarget(color_key));
++  }
++  if (!isolated_replay_depth_target_ || !isolated_replay_color_target_) {
++    isolated_replay_depth_target_.reset();
++    isolated_replay_color_target_.reset();
++    return false;
++  }
++
++  auto* isolated_depth = static_cast<D3D12RenderTarget*>(
++      isolated_replay_depth_target_.get());
++  auto* isolated_color = static_cast<D3D12RenderTarget*>(
++      isolated_replay_color_target_.get());
++  const D3D12_RESOURCE_DESC color_desc = isolated_color->resource()->GetDesc();
++  width_out = uint32_t(color_desc.Width);
++  height_out = color_desc.Height;
++
++  RenderTarget* isolated_targets[1 + xenos::kMaxColorRenderTargets] = {};
++  isolated_targets[0] = isolated_depth;
++  isolated_targets[1] = isolated_color;
++  SetCommandListRenderTargets(isolated_targets);
++  command_processor_.SubmitBarriers();
++
++  DeferredCommandList& command_list =
++      command_processor_.GetDeferredCommandList();
++  const float clear_color[4] = {};
++  command_list.D3DClearRenderTargetView(
++      isolated_color->descriptor_draw().GetHandle(), clear_color, 0, nullptr);
++  const float clear_depth =
++      depth_key.GetDepthFormat() == xenos::DepthRenderTargetFormat::kD24S8
++          ? 1.0f
++          : 0.0f;
++  command_list.D3DClearDepthStencilView(
++      isolated_depth->descriptor_draw().GetHandle(),
++      D3D12_CLEAR_FLAG_DEPTH | D3D12_CLEAR_FLAG_STENCIL, clear_depth, 0, 0,
++      nullptr);
++  return true;
++}
++
++void D3D12RenderTargetCache::EndIsolatedReplayTarget() {
++  if (GetPath() != Path::kHostRenderTargets) {
++    return;
++  }
++  SetCommandListRenderTargets(last_update_accumulated_render_targets());
++  command_processor_.SubmitBarriers();
++}
++
+ bool D3D12RenderTargetCache::IsHostDepthEncodingDifferent(
+     xenos::DepthRenderTargetFormat format) const {
+   if (format == xenos::DepthRenderTargetFormat::kD24FS8) {

--- a/src/native_renderer/graphics_hooks.cpp
+++ b/src/native_renderer/graphics_hooks.cpp
@@ -98,6 +98,20 @@ struct ReplaySnapshotState {
 
 ReplaySnapshotState g_replay_snapshot;
 
+struct IsolatedDrawState {
+  uint64_t target_signature = 0;
+  uint64_t prepared_signature = 0;
+  uint64_t frame = 0;
+  uint64_t draw = 0;
+  bool requested = false;
+  bool completed = false;
+  bool valid = true;
+  bool prepared_candidate_valid = false;
+  bool prepared_candidate_eligible = false;
+};
+
+IsolatedDrawState g_isolated_draw;
+
 void ConfigureSignatureScan(const char *name, uint64_t &target_signature,
                             bool &requested, bool &valid) {
   char *value = nullptr;
@@ -169,6 +183,14 @@ void ConfigureReplaySnapshot() {
       !IsLocalArtifactRoot(g_replay_snapshot.output_root)) {
     g_replay_snapshot.valid = false;
   }
+}
+
+void ConfigureIsolatedDraw() {
+  g_isolated_draw = {};
+  ConfigureSignatureScan(
+      "PINYON_SHIFT_NATIVE_RENDERER_ISOLATED_DRAW_SIGNATURE",
+      g_isolated_draw.target_signature, g_isolated_draw.requested,
+      g_isolated_draw.valid);
 }
 
 struct DrawSignatureEntry {
@@ -1443,6 +1465,30 @@ bool IsMechanicallyEligibleCandidate(const DrawSignatureEntry &entry) {
          texture_count <= 4;
 }
 
+bool IsIsolatedDrawEligible(
+    const rex::system::GraphicsDrawObservation &observation,
+    bool samples_resolved_target,
+    const rex::system::GraphicsPreparedDrawObservation &prepared) {
+  const uint32_t texture_count =
+      std::popcount(observation.texture_fetch_mask);
+  return !samples_resolved_target && observation.indexed &&
+         observation.source_select ==
+             uint32_t(rex::graphics::xenos::SourceSelect::kDMA) &&
+         observation.index_format <= 1 && observation.index_endianness <= 3 &&
+         observation.index_count && observation.vertex_binding_count == 1 &&
+         !observation.vertex_binding_overflow &&
+         !observation.vertex_attribute_overflow &&
+         !observation.vertex_float_constant_overflow &&
+         !observation.pixel_float_constant_overflow &&
+         !observation.texture_state_overflow && !observation.vertex_memexport &&
+         !observation.viz_query_condition && !(observation.pa_sc_viz_query & 1) &&
+         texture_count >= 1 && texture_count <= 4 &&
+         (observation.texture_fetch_layout_valid_mask &
+          observation.texture_fetch_mask) == observation.texture_fetch_mask &&
+         (prepared.flags & 3) == 3 && prepared.bound_render_target_bits == 3 &&
+         prepared.index_buffer_type == 1;
+}
+
 void RecordCandidate(
     const rex::system::GraphicsDrawObservation &observation,
     bool samples_resolved_target,
@@ -1450,12 +1496,20 @@ void RecordCandidate(
 
 void ObservePreparedDraw(
     const rex::system::GraphicsPreparedDrawObservation &observation) {
+  g_isolated_draw.prepared_candidate_valid = false;
   if (!g_pending_candidate.valid) {
     ++g_candidate_prepared_without_observation_count;
   } else {
     auto sample = g_pending_candidate.sample;
     sample.vertex_shader_hash = observation.vertex_shader_hash;
     sample.pixel_shader_hash = observation.pixel_shader_hash;
+    g_isolated_draw.prepared_signature = CandidateSignature(
+        sample, g_pending_candidate.samples_resolved_target, observation);
+    g_isolated_draw.frame = sample.frame_sequence;
+    g_isolated_draw.draw = sample.draw_sequence;
+    g_isolated_draw.prepared_candidate_eligible = IsIsolatedDrawEligible(
+        sample, g_pending_candidate.samples_resolved_target, observation);
+    g_isolated_draw.prepared_candidate_valid = true;
     RecordCandidate(sample, g_pending_candidate.samples_resolved_target,
                     observation);
     g_pending_candidate.valid = false;
@@ -1691,6 +1745,62 @@ void EmitCandidateCensusWindow(uint64_t last_frame_value) {
          {"qualification", "metadata_shortlist_only"},
          {"suppression_eligible", "false"}});
   }
+}
+
+void CompleteIsolatedDraw(
+    const rex::system::GraphicsIsolatedDrawResult &result) {
+  const char *status = "unsupported_state";
+  if (result.status ==
+      rex::system::GraphicsIsolatedDrawStatus::kRecorded) {
+    status = "recorded";
+  } else if (result.status ==
+             rex::system::GraphicsIsolatedDrawStatus::kTargetCreationFailed) {
+    status = "target_creation_failed";
+  }
+  pinyon_shift::diagnostics::RecordEvent(
+      "native_renderer.isolated_draw.result",
+      {{"signature",
+        fmt::format("{:016X}", g_isolated_draw.prepared_signature)},
+       {"status", status},
+       {"frame", std::to_string(g_isolated_draw.frame)},
+       {"draw", std::to_string(g_isolated_draw.draw)},
+       {"target_width", std::to_string(result.target_width)},
+       {"target_height", std::to_string(result.target_height)},
+       {"native_draw", result.status ==
+                                   rex::system::GraphicsIsolatedDrawStatus::kRecorded
+                               ? "isolated_only"
+                               : "false"},
+       {"xenos_draw", "preserved"},
+       {"output_authority", "xenos"},
+       {"suppression_eligible", "false"}});
+}
+
+void RequestIsolatedDraw(
+    const rex::system::GraphicsPreparedDrawObservation &,
+    rex::system::GraphicsIsolatedDrawRequest &request) {
+  if (!g_isolated_draw.requested || !g_isolated_draw.valid ||
+      g_isolated_draw.completed ||
+      !g_isolated_draw.prepared_candidate_valid ||
+      g_isolated_draw.prepared_signature != g_isolated_draw.target_signature) {
+    return;
+  }
+  g_isolated_draw.completed = true;
+  if (!g_isolated_draw.prepared_candidate_eligible) {
+    pinyon_shift::diagnostics::RecordEvent(
+        "native_renderer.isolated_draw.result",
+        {{"signature",
+          fmt::format("{:016X}", g_isolated_draw.prepared_signature)},
+         {"status", "rejected_by_title_gate"},
+         {"frame", std::to_string(g_isolated_draw.frame)},
+         {"draw", std::to_string(g_isolated_draw.draw)},
+         {"native_draw", "false"},
+         {"xenos_draw", "preserved"},
+         {"output_authority", "xenos"},
+         {"suppression_eligible", "false"}});
+    return;
+  }
+  request.requested = true;
+  request.completion = &CompleteIsolatedDraw;
 }
 
 void EmitDrawCensusWindow(uint64_t last_frame_value) {
@@ -2057,10 +2167,12 @@ void InstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system) {
   ConfigureIndexScan();
   ConfigureTextureScan();
   ConfigureReplaySnapshot();
+  ConfigureIsolatedDraw();
   g_graphics_census_installed = true;
   graphics_system->SetDrawObserver(&ObserveDraw);
   graphics_system->SetCopyObserver(&ObserveCopy);
   graphics_system->SetPreparedDrawObserver(&ObservePreparedDraw);
+  graphics_system->SetIsolatedDrawRequestObserver(&RequestIsolatedDraw);
   const std::string capacity = std::to_string(kSignatureCapacity);
   const std::string scene = CensusSceneMarker();
   diagnostics::RecordEvent("native_renderer.census.installed",
@@ -2117,6 +2229,20 @@ void InstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system) {
        {"native_upload", "false"},
        {"native_draw", "false"},
        {"suppression_eligible", "false"}});
+  diagnostics::RecordEvent(
+      "native_renderer.isolated_draw.config",
+      {{"status", !g_isolated_draw.requested
+                      ? "disabled"
+                      : (g_isolated_draw.valid ? "armed"
+                                               : "invalid_configuration")},
+       {"signature",
+        g_isolated_draw.valid && g_isolated_draw.requested
+            ? fmt::format("{:016X}", g_isolated_draw.target_signature)
+            : ""},
+       {"native_draw", "isolated_only"},
+       {"xenos_draw", "preserved"},
+       {"output_authority", "xenos"},
+       {"suppression_eligible", "false"}});
 }
 
 void UninstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system) {
@@ -2124,6 +2250,7 @@ void UninstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system) {
     graphics_system->SetDrawObserver(nullptr);
     graphics_system->SetCopyObserver(nullptr);
     graphics_system->SetPreparedDrawObserver(nullptr);
+    graphics_system->SetIsolatedDrawRequestObserver(nullptr);
   }
   if (!g_graphics_census_installed) {
     return;
@@ -2170,6 +2297,18 @@ void UninstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system) {
          {"payload_persisted", "false"},
          {"native_upload", "false"},
          {"native_draw", "false"},
+         {"suppression_eligible", "false"}});
+  }
+  if (g_isolated_draw.requested && g_isolated_draw.valid &&
+      !g_isolated_draw.completed) {
+    diagnostics::RecordEvent(
+        "native_renderer.isolated_draw.result",
+        {{"signature",
+          fmt::format("{:016X}", g_isolated_draw.target_signature)},
+         {"status", "not_observed"},
+         {"native_draw", "false"},
+         {"xenos_draw", "preserved"},
+         {"output_authority", "xenos"},
          {"suppression_eligible", "false"}});
   }
   diagnostics::RecordEvent(

--- a/tools/capture-native-renderer-census.ps1
+++ b/tools/capture-native-renderer-census.ps1
@@ -13,6 +13,8 @@ param(
     [ValidatePattern('^[0-9A-Fa-f]{16}$')]
     [string]$ReplaySnapshotSignature,
     [string]$ReplaySnapshotDir,
+    [ValidatePattern('^[0-9A-Fa-f]{16}$')]
+    [string]$IsolatedDrawSignature,
     [switch]$Json
 )
 
@@ -75,6 +77,7 @@ $savedIndexScan = $env:PINYON_SHIFT_NATIVE_RENDERER_INDEX_SCAN_SIGNATURE
 $savedTextureScan = $env:PINYON_SHIFT_NATIVE_RENDERER_TEXTURE_SCAN_SIGNATURE
 $savedReplaySnapshot = $env:PINYON_SHIFT_NATIVE_RENDERER_SNAPSHOT_SIGNATURE
 $savedReplaySnapshotDir = $env:PINYON_SHIFT_NATIVE_RENDERER_SNAPSHOT_DIR
+$savedIsolatedDraw = $env:PINYON_SHIFT_NATIVE_RENDERER_ISOLATED_DRAW_SIGNATURE
 try {
     $env:REX_PINYON_SHIFT_NATIVE_RENDERER_CENSUS = 'true'
     $env:PINYON_SHIFT_NATIVE_RENDERER_SCENE = $Scene
@@ -82,6 +85,7 @@ try {
     $env:PINYON_SHIFT_NATIVE_RENDERER_TEXTURE_SCAN_SIGNATURE = $TextureScanSignature
     $env:PINYON_SHIFT_NATIVE_RENDERER_SNAPSHOT_SIGNATURE = $ReplaySnapshotSignature
     $env:PINYON_SHIFT_NATIVE_RENDERER_SNAPSHOT_DIR = $ReplaySnapshotDir
+    $env:PINYON_SHIFT_NATIVE_RENDERER_ISOLATED_DRAW_SIGNATURE = $IsolatedDrawSignature
     & (Join-Path $PSScriptRoot 'launch-preview.ps1') `
         -StateRoot $resolvedStateRoot -ShaderCaptureDir $ShaderCaptureDir `
         -Json:$Json
@@ -93,4 +97,5 @@ finally {
     $env:PINYON_SHIFT_NATIVE_RENDERER_TEXTURE_SCAN_SIGNATURE = $savedTextureScan
     $env:PINYON_SHIFT_NATIVE_RENDERER_SNAPSHOT_SIGNATURE = $savedReplaySnapshot
     $env:PINYON_SHIFT_NATIVE_RENDERER_SNAPSHOT_DIR = $savedReplaySnapshotDir
+    $env:PINYON_SHIFT_NATIVE_RENDERER_ISOLATED_DRAW_SIGNATURE = $savedIsolatedDraw
 }

--- a/tools/tests/test_native_renderer_contract.py
+++ b/tools/tests/test_native_renderer_contract.py
@@ -425,6 +425,23 @@ class NativeRendererContractTests(unittest.TestCase):
         self.assertIn('"suppression_eligible", "false"', scanner)
         self.assertNotIn("SetDrawSuppression", scanner)
 
+        isolated_replay_patch = (
+            ROOT / "patches/rexglue/0058-d3d12-isolated-draw-replay.patch"
+        ).read_text(encoding="utf-8")
+        self.assertIn("GraphicsIsolatedDrawRequest", isolated_replay_patch)
+        self.assertIn("BeginIsolatedReplayTarget", isolated_replay_patch)
+        self.assertIn("EndIsolatedReplayTarget", isolated_replay_patch)
+        self.assertIn("D3DDrawIndexedInstanced", isolated_replay_patch)
+        self.assertIn("isolated_draw_request.completion", isolated_replay_patch)
+        self.assertNotIn("SetDrawSuppression", isolated_replay_patch)
+        isolated_draw_position = isolated_replay_patch.index(
+            "if (isolated_draw_request.requested)"
+        )
+        guest_draw_position = isolated_replay_patch.index(
+            "PROFILE_DRAW_CALL();", isolated_draw_position
+        )
+        self.assertLess(isolated_draw_position, guest_draw_position)
+
         draw_state_planner = (
             ROOT / "tools/build-native-draw-state-contract.py"
         ).read_text(encoding="utf-8")

--- a/tools/tests/test_release_contract.py
+++ b/tools/tests/test_release_contract.py
@@ -43,10 +43,10 @@ class ReleaseContractTests(unittest.TestCase):
 
     def test_rexglue_patches_have_stable_order_and_no_binary_payload(self):
         patches = sorted((ROOT / "patches/rexglue").glob("*.patch"))
-        self.assertEqual(len(patches), 57)
+        self.assertEqual(len(patches), 58)
         self.assertEqual(
             patches[-1].name,
-            "0057-d3d12-prepared-pipeline-observer.patch",
+            "0058-d3d12-isolated-draw-replay.patch",
         )
         self.assertEqual(len(patches), len({path.name[:4] for path in patches}))
         for path in patches:


### PR DESCRIPTION
## Summary
- add a ReXGlue D3D12 hook that duplicates one qualified indexed draw into private depth/color targets
- preserve and execute the original Xenos draw with no suppression surface
- add title-side exact-signature safety gates, structured diagnostics, wrapper support, and contract tests
- document the AppData qualification evidence

## Validation
- clean 58-patch ReXGlue + preview build
- 114 Python contract tests
- repository boundary check (184 candidate files)
- AppData session 20260828T094158Z-p42200: recorded at frame 3553/draw 116, normal visuals, continued through frame 5700, clean exit code 0, no critical GPU/runtime log matches

## Scope
This proves isolated authentic GPU draw recording only. Xenos remains output-authoritative; asynchronous readback and image comparison remain a follow-up milestone.