### PR TITLE
feat(native-renderer): capture isolated draw readback

### DIFF
--- a/docs/native-renderer/ISOLATED_DRAW_READBACK.md
+++ b/docs/native-renderer/ISOLATED_DRAW_READBACK.md
@@ -1,0 +1,73 @@
+# Asynchronous isolated draw readback
+
+NR-02E extends the one-shot authentic draw replay with an optional D3D12
+readback. The private replay target is copied after the isolated draw and the
+guest render targets are restored before the original Xenos draw is recorded.
+The readback is associated with the submitted command list and completed only
+after its fence has retired; the graphics thread does not wait for all queue
+operations.
+
+## Capture contract
+
+Readback remains disabled unless both an exact draw signature and a new output
+directory below the repository `.local` tree are supplied. The title and the
+capture wrapper reject an existing destination. ReXGlue retains the readback
+buffer through submission completion and invokes the title callback with the
+mapped bytes, dimensions, row pitch, DXGI format, and a structured failure
+status. Multisampled private targets are resolved before the copy.
+
+The title moves the bytes into an asynchronous artifact writer. It creates a
+temporary sibling directory and publishes the completed directory with one
+rename after all three files have been written:
+
+- `isolated.bin`: the full row-pitched GPU readback;
+- `isolated.ppm`: the non-empty target crop converted from
+  `R16G16B16A16_FLOAT` or `R8G8B8A8_UNORM`; and
+- `readback.json`: signature, draw coordinates, layout, crop, hash, and safety
+  metadata.
+
+Captured signature, frame, and draw identifiers are frozen when the request
+is submitted. Later census observations therefore cannot relabel the
+asynchronous completion.
+
+## Safety properties
+
+This diagnostic path does not present the private target and exposes no draw
+suppression API. Allocation, resolve, map, layout, or artifact failures are
+reported as structured events while the original guest draw proceeds. Every
+success and failure record declares Xenos as output authority and suppression
+as ineligible.
+
+## Qualification run
+
+Launch the installed AppData save with a fresh destination:
+
+```powershell
+$stateRoot = Join-Path $env:LOCALAPPDATA `
+    'PinyonShift\source\0.1.0\.local\preview'
+.\tools\capture-native-renderer-census.ps1 `
+  -StateRoot $stateRoot `
+  -Scene open_world_day `
+  -IsolatedDrawSignature 747837906D0BF484 `
+  -IsolatedDrawDir `
+    '.local\qualification\native-renderer-isolated-readback' `
+  -Json
+```
+
+The clean AppData-backed qualification completed on 2026-08-28 as session
+`20260828T105842Z-p39620`. Signature `747837906D0BF484` was replayed at frame
+4593, draw 117. Its 640 by 8192 `R16G16B16A16_FLOAT` target produced a
+41,943,040-byte readback and a non-empty 512 by 280 crop. The raw artifact
+SHA-256 was
+`D2EBD1E257C1033E8D3D133FCBB67DE71DA6679CE87303BD16384C2C17201D40`.
+Visual inspection identified the expected sky, cloud, and horizon/fog layer.
+
+The AppData save reached the festival open world with normal Xenos output.
+The log recorded `armed_with_readback`, `recorded`, and `captured` for the same
+signature, frame, and draw, with no fatal, crash, device-loss, rejected, or
+failed events. The process exited normally with code zero.
+
+This milestone proves asynchronous extraction of a real private native draw
+without disturbing displayed output. It does not yet claim visual equivalence
+with an external reference capture; comparison tooling and broader pass
+coverage remain later NR-02E work.

--- a/patches/rexglue/0059-d3d12-isolated-draw-readback.patch
+++ b/patches/rexglue/0059-d3d12-isolated-draw-readback.patch
@@ -1,0 +1,354 @@
+diff --git a/include/rex/system/interfaces/graphics.h b/include/rex/system/interfaces/graphics.h
+index ab133ca..4c167f4 100644
+--- a/include/rex/system/interfaces/graphics.h
++++ b/include/rex/system/interfaces/graphics.h
+@@ -277,9 +277,34 @@ struct GraphicsIsolatedDrawResult {
+ using GraphicsIsolatedDrawCompletion = void (*)(
+     const GraphicsIsolatedDrawResult& result);
+ 
++enum class GraphicsIsolatedDrawReadbackStatus : uint32_t {
++  kReady = 1,
++  kUnsupportedTarget = 2,
++  kResolveAllocationFailed = 3,
++  kAllocationFailed = 4,
++  kMapFailed = 5,
++};
++
++struct GraphicsIsolatedDrawReadback {
++  GraphicsIsolatedDrawReadbackStatus status =
++      GraphicsIsolatedDrawReadbackStatus::kUnsupportedTarget;
++  uint32_t detail = 0;
++  const uint8_t* data = nullptr;
++  uint64_t data_size = 0;
++  uint32_t width = 0;
++  uint32_t height = 0;
++  uint32_t row_pitch = 0;
++  uint32_t format = 0;
++};
++
++using GraphicsIsolatedDrawReadbackCompletion = void (*)(
++    const GraphicsIsolatedDrawReadback& readback);
++
+ struct GraphicsIsolatedDrawRequest {
+   bool requested = false;
++  bool readback_requested = false;
+   GraphicsIsolatedDrawCompletion completion = nullptr;
++  GraphicsIsolatedDrawReadbackCompletion readback_completion = nullptr;
+ };
+ 
+ // Called after the host pipeline has been prepared. A request duplicates the
+diff --git a/include/rex/graphics/d3d12/deferred_command_list.h b/include/rex/graphics/d3d12/deferred_command_list.h
+index 7a7d488..5f1702e 100644
+--- a/include/rex/graphics/d3d12/deferred_command_list.h
++++ b/include/rex/graphics/d3d12/deferred_command_list.h
+@@ -154,6 +154,20 @@ class DeferredCommandList {
+     }
+   }
+ 
++  void D3DResolveSubresource(ID3D12Resource* dst_resource,
++                             UINT dst_subresource,
++                             ID3D12Resource* src_resource,
++                             UINT src_subresource, DXGI_FORMAT format) {
++    auto& args = *reinterpret_cast<D3DResolveSubresourceArguments*>(
++        WriteCommand(Command::kD3DResolveSubresource,
++                     sizeof(D3DResolveSubresourceArguments)));
++    args.dst_resource = dst_resource;
++    args.dst_subresource = dst_subresource;
++    args.src_resource = src_resource;
++    args.src_subresource = src_subresource;
++    args.format = format;
++  }
++
+   void D3DDispatch(UINT thread_group_count_x, UINT thread_group_count_y,
+                    UINT thread_group_count_z) {
+     auto& args = *reinterpret_cast<D3DDispatchArguments*>(
+@@ -479,6 +493,7 @@ class DeferredCommandList {
+     kD3DCopyResource,
+     kCopyTexture,
+     kD3DCopyTextureRegion,
++    kD3DResolveSubresource,
+     kD3DDispatch,
+     kD3DDrawIndexedInstanced,
+     kD3DDrawInstanced,
+@@ -575,6 +590,14 @@ class DeferredCommandList {
+     bool has_src_box;
+   };
+ 
++  struct D3DResolveSubresourceArguments {
++    ID3D12Resource* dst_resource;
++    UINT dst_subresource;
++    ID3D12Resource* src_resource;
++    UINT src_subresource;
++    DXGI_FORMAT format;
++  };
++
+   struct D3DDispatchArguments {
+     UINT thread_group_count_x;
+     UINT thread_group_count_y;
+diff --git a/src/graphics/d3d12/deferred_command_list.cpp b/src/graphics/d3d12/deferred_command_list.cpp
+index 2c208d1..cde86e6 100644
+--- a/src/graphics/d3d12/deferred_command_list.cpp
++++ b/src/graphics/d3d12/deferred_command_list.cpp
+@@ -86,6 +86,13 @@ void DeferredCommandList::Execute(ID3D12GraphicsCommandList* command_list,
+         command_list->CopyTextureRegion(&args.dst, args.dst_x, args.dst_y, args.dst_z, &args.src,
+                                         args.has_src_box ? &args.src_box : nullptr);
+       } break;
++      case Command::kD3DResolveSubresource: {
++        auto& args =
++            *reinterpret_cast<const D3DResolveSubresourceArguments*>(stream);
++        command_list->ResolveSubresource(
++            args.dst_resource, args.dst_subresource, args.src_resource,
++            args.src_subresource, args.format);
++      } break;
+       case Command::kD3DDispatch: {
+         if (current_pipeline_state != nullptr) {
+           auto& args = *reinterpret_cast<const D3DDispatchArguments*>(stream);
+diff --git a/include/rex/graphics/d3d12/render_target_cache.h b/include/rex/graphics/d3d12/render_target_cache.h
+index 93a3062..e6ed00a 100644
+--- a/include/rex/graphics/d3d12/render_target_cache.h
++++ b/include/rex/graphics/d3d12/render_target_cache.h
+@@ -30,6 +30,7 @@
+ #include <rex/graphics/util/draw.h>
+ #include <rex/graphics/xenos.h>
+ #include <rex/memory.h>
++#include <rex/system/interfaces/graphics.h>
+ #include <rex/ui/d3d12/d3d12_cpu_descriptor_pool.h>
+ #include <rex/ui/d3d12/d3d12_provider.h>
+ #include <rex/ui/d3d12/d3d12_upload_buffer_pool.h>
+@@ -99,6 +100,9 @@ class D3D12RenderTargetCache final : public RenderTargetCache {
+   // EndIsolatedReplayTarget restores the guest targets without changing their
+   // contents or ownership.
+   bool BeginIsolatedReplayTarget(uint32_t& width_out, uint32_t& height_out);
++  system::GraphicsIsolatedDrawReadbackStatus QueueIsolatedReplayReadback(
++      system::GraphicsIsolatedDrawReadbackCompletion completion,
++      uint32_t* failure_detail_out);
+   void EndIsolatedReplayTarget();
+ 
+   DXGI_FORMAT GetColorResourceDXGIFormat(xenos::ColorRenderTargetFormat format) const;
+@@ -673,6 +676,18 @@ class D3D12RenderTargetCache final : public RenderTargetCache {
+   std::shared_ptr<ui::d3d12::D3D12CpuDescriptorPool> descriptor_pool_depth_;
+   std::unique_ptr<RenderTarget> isolated_replay_color_target_;
+   std::unique_ptr<RenderTarget> isolated_replay_depth_target_;
++  struct IsolatedReplayReadback {
++    Microsoft::WRL::ComPtr<ID3D12Resource> buffer;
++    Microsoft::WRL::ComPtr<ID3D12Resource> resolved_target;
++    uint8_t* mapping = nullptr;
++    uint64_t submission = 0;
++    uint64_t data_size = 0;
++    uint32_t width = 0;
++    uint32_t height = 0;
++    uint32_t row_pitch = 0;
++    uint32_t format = 0;
++    system::GraphicsIsolatedDrawReadbackCompletion completion = nullptr;
++  } isolated_replay_readback_;
+   std::shared_ptr<ui::d3d12::D3D12CpuDescriptorPool> descriptor_pool_srv_;
+   ui::d3d12::D3D12CpuDescriptorPool::Descriptor null_rtv_descriptor_ss_;
+   ui::d3d12::D3D12CpuDescriptorPool::Descriptor null_rtv_descriptor_ms_;
+diff --git a/src/graphics/d3d12/render_target_cache.cpp b/src/graphics/d3d12/render_target_cache.cpp
+index 86f8a35..0eed58e 100644
+--- a/src/graphics/d3d12/render_target_cache.cpp
++++ b/src/graphics/d3d12/render_target_cache.cpp
+@@ -1020,6 +1020,11 @@ void D3D12RenderTargetCache::Shutdown(bool from_destructor) {
+   }
+   ui::d3d12::util::ReleaseAndNull(host_depth_store_root_signature_);
+ 
++  if (isolated_replay_readback_.buffer && isolated_replay_readback_.mapping) {
++    D3D12_RANGE write_range = {};
++    isolated_replay_readback_.buffer->Unmap(0, &write_range);
++  }
++  isolated_replay_readback_ = {};
+   isolated_replay_depth_target_.reset();
+   isolated_replay_color_target_.reset();
+   null_rtv_descriptor_ms_.Free();
+@@ -1045,6 +1050,25 @@ void D3D12RenderTargetCache::CompletedSubmissionUpdated() {
+   if (transfer_vertex_buffer_pool_) {
+     transfer_vertex_buffer_pool_->Reclaim(command_processor_.GetCompletedSubmission());
+   }
++  if (isolated_replay_readback_.buffer &&
++      isolated_replay_readback_.submission <=
++          command_processor_.GetCompletedSubmission()) {
++    system::GraphicsIsolatedDrawReadback result;
++    result.status = system::GraphicsIsolatedDrawReadbackStatus::kReady;
++    result.data = isolated_replay_readback_.mapping;
++    result.data_size = isolated_replay_readback_.data_size;
++    result.width = isolated_replay_readback_.width;
++    result.height = isolated_replay_readback_.height;
++    result.row_pitch = isolated_replay_readback_.row_pitch;
++    result.format = isolated_replay_readback_.format;
++    auto completion = isolated_replay_readback_.completion;
++    if (completion) {
++      completion(result);
++    }
++    D3D12_RANGE write_range = {};
++    isolated_replay_readback_.buffer->Unmap(0, &write_range);
++    isolated_replay_readback_ = {};
++  }
+ }
+ 
+ void D3D12RenderTargetCache::BeginSubmission() {
+@@ -1767,6 +1791,139 @@ bool D3D12RenderTargetCache::BeginIsolatedReplayTarget(
+   return true;
+ }
+ 
++system::GraphicsIsolatedDrawReadbackStatus
++D3D12RenderTargetCache::QueueIsolatedReplayReadback(
++    system::GraphicsIsolatedDrawReadbackCompletion completion,
++    uint32_t* failure_detail_out) {
++  if (failure_detail_out) {
++    *failure_detail_out = 0;
++  }
++  if (!completion || isolated_replay_readback_.buffer ||
++      !isolated_replay_color_target_) {
++    return system::GraphicsIsolatedDrawReadbackStatus::kUnsupportedTarget;
++  }
++  auto* isolated_color = static_cast<D3D12RenderTarget*>(
++      isolated_replay_color_target_.get());
++  ID3D12Resource* source = isolated_color->resource();
++  const D3D12_RESOURCE_DESC source_desc = source->GetDesc();
++  if (source_desc.Dimension != D3D12_RESOURCE_DIMENSION_TEXTURE2D ||
++      source_desc.DepthOrArraySize != 1 || source_desc.MipLevels != 1) {
++    return system::GraphicsIsolatedDrawReadbackStatus::kUnsupportedTarget;
++  }
++
++  Microsoft::WRL::ComPtr<ID3D12Resource> resolved_target;
++  D3D12_RESOURCE_DESC copy_desc = source_desc;
++  copy_desc.Alignment = 0;
++  copy_desc.SampleDesc.Count = 1;
++  copy_desc.SampleDesc.Quality = 0;
++  copy_desc.Flags = D3D12_RESOURCE_FLAG_ALLOW_RENDER_TARGET;
++  D3D12_CLEAR_VALUE resolved_clear = {};
++  resolved_clear.Format = source_desc.Format;
++  ID3D12Resource* copy_source = source;
++  ID3D12Device* device = command_processor_.GetD3D12Provider().GetDevice();
++  if (source_desc.SampleDesc.Count > 1) {
++    HRESULT resolve_result = device->CreateCommittedResource(
++        &ui::d3d12::util::kHeapPropertiesDefault, D3D12_HEAP_FLAG_NONE,
++        &copy_desc, D3D12_RESOURCE_STATE_RESOLVE_DEST, &resolved_clear,
++        IID_PPV_ARGS(&resolved_target));
++    if (FAILED(resolve_result)) {
++      if (failure_detail_out) {
++        *failure_detail_out = uint32_t(resolve_result);
++      }
++      REXGPU_ERROR(
++          "D3D12RenderTargetCache: Isolated resolve allocation failed "
++          "(HRESULT 0x{:08X}, {}x{}, format {}, samples {}, alignment {}, "
++          "layout {}, flags 0x{:X})",
++          uint32_t(resolve_result), source_desc.Width, source_desc.Height,
++          uint32_t(source_desc.Format), source_desc.SampleDesc.Count,
++          copy_desc.Alignment, uint32_t(copy_desc.Layout),
++          uint32_t(copy_desc.Flags));
++      return system::GraphicsIsolatedDrawReadbackStatus::
++          kResolveAllocationFailed;
++    }
++    copy_source = resolved_target.Get();
++  }
++
++  D3D12_PLACED_SUBRESOURCE_FOOTPRINT footprint = {};
++  UINT row_count = 0;
++  UINT64 row_size = 0;
++  UINT64 total_size = 0;
++  device->GetCopyableFootprints(&copy_desc, 0, 1, 0, &footprint, &row_count,
++                                &row_size, &total_size);
++  if (!total_size || total_size > UINT32_MAX ||
++      source_desc.Width > UINT32_MAX || !row_count) {
++    return system::GraphicsIsolatedDrawReadbackStatus::kUnsupportedTarget;
++  }
++
++  D3D12_RESOURCE_DESC buffer_desc;
++  ui::d3d12::util::FillBufferResourceDesc(
++      buffer_desc, total_size, D3D12_RESOURCE_FLAG_NONE);
++  Microsoft::WRL::ComPtr<ID3D12Resource> buffer;
++  const auto& provider = command_processor_.GetD3D12Provider();
++  if (FAILED(device->CreateCommittedResource(
++          &ui::d3d12::util::kHeapPropertiesReadback,
++          provider.GetHeapFlagCreateNotZeroed(), &buffer_desc,
++          D3D12_RESOURCE_STATE_COPY_DEST, nullptr, IID_PPV_ARGS(&buffer)))) {
++    return system::GraphicsIsolatedDrawReadbackStatus::kAllocationFailed;
++  }
++  D3D12_RANGE read_range = {0, SIZE_T(total_size)};
++  void* mapping = nullptr;
++  if (FAILED(buffer->Map(0, &read_range, &mapping))) {
++    return system::GraphicsIsolatedDrawReadbackStatus::kMapFailed;
++  }
++
++  D3D12_RESOURCE_STATES old_state =
++      isolated_color->SetResourceState(
++          source_desc.SampleDesc.Count > 1
++              ? D3D12_RESOURCE_STATE_RESOLVE_SOURCE
++              : D3D12_RESOURCE_STATE_COPY_SOURCE);
++  command_processor_.PushTransitionBarrier(
++      source, old_state,
++      source_desc.SampleDesc.Count > 1
++          ? D3D12_RESOURCE_STATE_RESOLVE_SOURCE
++          : D3D12_RESOURCE_STATE_COPY_SOURCE);
++  command_processor_.SubmitBarriers();
++  if (source_desc.SampleDesc.Count > 1) {
++    command_processor_.GetDeferredCommandList().D3DResolveSubresource(
++        copy_source, 0, source, 0, source_desc.Format);
++    command_processor_.PushTransitionBarrier(
++        copy_source, D3D12_RESOURCE_STATE_RESOLVE_DEST,
++        D3D12_RESOURCE_STATE_COPY_SOURCE);
++    isolated_color->SetResourceState(old_state);
++    command_processor_.PushTransitionBarrier(
++        source, D3D12_RESOURCE_STATE_RESOLVE_SOURCE, old_state);
++    command_processor_.SubmitBarriers();
++  }
++  D3D12_TEXTURE_COPY_LOCATION destination = {};
++  destination.pResource = buffer.Get();
++  destination.Type = D3D12_TEXTURE_COPY_TYPE_PLACED_FOOTPRINT;
++  destination.PlacedFootprint = footprint;
++  D3D12_TEXTURE_COPY_LOCATION source_location = {};
++  source_location.pResource = copy_source;
++  source_location.Type = D3D12_TEXTURE_COPY_TYPE_SUBRESOURCE_INDEX;
++  source_location.SubresourceIndex = 0;
++  command_processor_.GetDeferredCommandList().D3DCopyTextureRegion(
++      &destination, 0, 0, 0, &source_location, nullptr);
++  if (source_desc.SampleDesc.Count == 1) {
++    isolated_color->SetResourceState(old_state);
++    command_processor_.PushTransitionBarrier(
++        source, D3D12_RESOURCE_STATE_COPY_SOURCE, old_state);
++  }
++
++  isolated_replay_readback_.buffer = std::move(buffer);
++  isolated_replay_readback_.resolved_target = std::move(resolved_target);
++  isolated_replay_readback_.mapping = static_cast<uint8_t*>(mapping);
++  isolated_replay_readback_.submission =
++      command_processor_.GetCurrentSubmission();
++  isolated_replay_readback_.data_size = total_size;
++  isolated_replay_readback_.width = uint32_t(source_desc.Width);
++  isolated_replay_readback_.height = source_desc.Height;
++  isolated_replay_readback_.row_pitch = footprint.Footprint.RowPitch;
++  isolated_replay_readback_.format = uint32_t(source_desc.Format);
++  isolated_replay_readback_.completion = completion;
++  return system::GraphicsIsolatedDrawReadbackStatus::kReady;
++}
++
+ void D3D12RenderTargetCache::EndIsolatedReplayTarget() {
+   if (GetPath() != Path::kHostRenderTargets) {
+     return;
+diff --git a/src/graphics/d3d12/command_processor.cpp b/src/graphics/d3d12/command_processor.cpp
+index a27f72c..8a2c986 100644
+--- a/src/graphics/d3d12/command_processor.cpp
++++ b/src/graphics/d3d12/command_processor.cpp
+@@ -3069,6 +3069,21 @@ bool D3D12CommandProcessor::IssueDraw(xenos::PrimitiveType primitive_type, uint3
+                      isolated_result.target_height)) {
+         deferred_command_list_.D3DDrawIndexedInstanced(
+             primitive_processing_result.host_draw_vertex_count, 1, 0, 0, 0);
++        if (isolated_draw_request.readback_requested &&
++            isolated_draw_request.readback_completion) {
++          uint32_t readback_detail = 0;
++          auto readback_status =
++              render_target_cache_->QueueIsolatedReplayReadback(
++                  isolated_draw_request.readback_completion,
++                  &readback_detail);
++          if (readback_status !=
++              system::GraphicsIsolatedDrawReadbackStatus::kReady) {
++            system::GraphicsIsolatedDrawReadback readback_result;
++            readback_result.status = readback_status;
++            readback_result.detail = readback_detail;
++            isolated_draw_request.readback_completion(readback_result);
++          }
++        }
+         render_target_cache_->EndIsolatedReplayTarget();
+         isolated_result.status =
+             system::GraphicsIsolatedDrawStatus::kRecorded;

--- a/src/native_renderer/graphics_hooks.cpp
+++ b/src/native_renderer/graphics_hooks.cpp
@@ -3,6 +3,7 @@
 #include <atomic>
 #include <bit>
 #include <charconv>
+#include <cmath>
 #include <cstddef>
 #include <cstdint>
 #include <cstdlib>
@@ -13,6 +14,7 @@
 #include <limits>
 #include <span>
 #include <string>
+#include <thread>
 #include <type_traits>
 #include <vector>
 
@@ -103,7 +105,13 @@ struct IsolatedDrawState {
   uint64_t prepared_signature = 0;
   uint64_t frame = 0;
   uint64_t draw = 0;
+  uint64_t captured_signature = 0;
+  uint64_t captured_frame = 0;
+  uint64_t captured_draw = 0;
+  std::filesystem::path output_root;
+  std::jthread artifact_writer;
   bool requested = false;
+  bool readback_requested = false;
   bool completed = false;
   bool valid = true;
   bool prepared_candidate_valid = false;
@@ -191,6 +199,23 @@ void ConfigureIsolatedDraw() {
       "PINYON_SHIFT_NATIVE_RENDERER_ISOLATED_DRAW_SIGNATURE",
       g_isolated_draw.target_signature, g_isolated_draw.requested,
       g_isolated_draw.valid);
+  const bool signature_requested = g_isolated_draw.requested;
+  char *value = nullptr;
+  size_t length = 0;
+  if (_dupenv_s(&value, &length,
+                "PINYON_SHIFT_NATIVE_RENDERER_ISOLATED_DRAW_DIR") != 0 ||
+      !value || length <= 1) {
+    std::free(value);
+    return;
+  }
+  g_isolated_draw.readback_requested = true;
+  g_isolated_draw.output_root =
+      std::filesystem::absolute(std::filesystem::path(value)).lexically_normal();
+  std::free(value);
+  if (!signature_requested ||
+      !IsLocalArtifactRoot(g_isolated_draw.output_root)) {
+    g_isolated_draw.valid = false;
+  }
 }
 
 struct DrawSignatureEntry {
@@ -1747,6 +1772,212 @@ void EmitCandidateCensusWindow(uint64_t last_frame_value) {
   }
 }
 
+float HalfToFloat(uint16_t value) {
+  const uint32_t sign = uint32_t(value & 0x8000) << 16;
+  const uint32_t exponent = (value >> 10) & 0x1F;
+  uint32_t mantissa = value & 0x03FF;
+  uint32_t bits = 0;
+  if (!exponent) {
+    if (mantissa) {
+      uint32_t normalized_exponent = 113;
+      while (!(mantissa & 0x0400)) {
+        mantissa <<= 1;
+        --normalized_exponent;
+      }
+      bits = sign | (normalized_exponent << 23) |
+             ((mantissa & 0x03FF) << 13);
+    } else {
+      bits = sign;
+    }
+  } else if (exponent == 0x1F) {
+    bits = sign | 0x7F800000 | (mantissa << 13);
+  } else {
+    bits = sign | ((exponent + 112) << 23) | (mantissa << 13);
+  }
+  return std::bit_cast<float>(bits);
+}
+
+void CompleteIsolatedDrawReadback(
+    const rex::system::GraphicsIsolatedDrawReadback &readback) {
+  const auto reject = [&](const char *status) {
+    pinyon_shift::diagnostics::RecordEvent(
+        "native_renderer.isolated_draw.readback",
+        {{"signature",
+          fmt::format("{:016X}", g_isolated_draw.captured_signature)},
+         {"status", status},
+         {"detail", fmt::format("0x{:08X}", readback.detail)},
+         {"frame", std::to_string(g_isolated_draw.captured_frame)},
+         {"draw", std::to_string(g_isolated_draw.captured_draw)},
+         {"output_authority", "xenos"},
+         {"suppression_eligible", "false"}});
+  };
+  if (readback.status !=
+      rex::system::GraphicsIsolatedDrawReadbackStatus::kReady) {
+    if (readback.status ==
+        rex::system::GraphicsIsolatedDrawReadbackStatus::
+            kResolveAllocationFailed) {
+      reject("resolve_allocation_failed");
+    } else if (readback.status ==
+        rex::system::GraphicsIsolatedDrawReadbackStatus::kAllocationFailed) {
+      reject("allocation_failed");
+    } else if (readback.status ==
+               rex::system::GraphicsIsolatedDrawReadbackStatus::kMapFailed) {
+      reject("map_failed");
+    } else {
+      reject("unsupported_target");
+    }
+    return;
+  }
+  constexpr uint32_t kR16G16B16A16Float = 10;
+  constexpr uint32_t kR8G8B8A8Unorm = 28;
+  const uint32_t bytes_per_pixel =
+      readback.format == kR16G16B16A16Float
+          ? 8
+          : (readback.format == kR8G8B8A8Unorm ? 4 : 0);
+  const uint64_t required_size =
+      uint64_t(readback.row_pitch) * readback.height;
+  if (!bytes_per_pixel || !readback.data || !readback.width ||
+      !readback.height ||
+      uint64_t(readback.width) * bytes_per_pixel > readback.row_pitch ||
+      required_size > readback.data_size || required_size > SIZE_MAX) {
+    reject("unsupported_layout");
+    return;
+  }
+
+  std::vector<uint8_t> bytes(readback.data,
+                             readback.data + size_t(required_size));
+  const uint64_t signature = g_isolated_draw.captured_signature;
+  const uint64_t frame = g_isolated_draw.captured_frame;
+  const uint64_t draw = g_isolated_draw.captured_draw;
+  const auto output_root = g_isolated_draw.output_root;
+  const uint32_t width = readback.width;
+  const uint32_t height = readback.height;
+  const uint32_t row_pitch = readback.row_pitch;
+  const uint32_t format = readback.format;
+  g_isolated_draw.artifact_writer = std::jthread(
+      [bytes = std::move(bytes), signature, frame, draw, output_root, width,
+       height, row_pitch, format, bytes_per_pixel]() {
+        uint32_t left = width;
+        uint32_t top = height;
+        uint32_t right = 0;
+        uint32_t bottom = 0;
+        bool nonzero = false;
+        for (uint32_t y = 0; y < height; ++y) {
+          const uint8_t *row = bytes.data() + uint64_t(y) * row_pitch;
+          for (uint32_t x = 0; x < width; ++x) {
+            const uint8_t *pixel = row + uint64_t(x) * bytes_per_pixel;
+            bool pixel_nonzero = false;
+            for (uint32_t i = 0; i < bytes_per_pixel; ++i) {
+              pixel_nonzero |= pixel[i] != 0;
+            }
+            if (pixel_nonzero) {
+              nonzero = true;
+              left = std::min(left, x);
+              top = std::min(top, y);
+              right = std::max(right, x);
+              bottom = std::max(bottom, y);
+            }
+          }
+        }
+        if (!nonzero) {
+          pinyon_shift::diagnostics::RecordEvent(
+              "native_renderer.isolated_draw.readback",
+              {{"signature", fmt::format("{:016X}", signature)},
+               {"status", "empty_target"},
+               {"frame", std::to_string(frame)},
+               {"draw", std::to_string(draw)},
+               {"output_authority", "xenos"},
+               {"suppression_eligible", "false"}});
+          return;
+        }
+
+        const uint32_t crop_width = right - left + 1;
+        const uint32_t crop_height = bottom - top + 1;
+        std::vector<uint8_t> ppm;
+        const std::string header =
+            fmt::format("P6\n{} {}\n255\n", crop_width, crop_height);
+        ppm.insert(ppm.end(), header.begin(), header.end());
+        ppm.reserve(ppm.size() + uint64_t(crop_width) * crop_height * 3);
+        for (uint32_t y = top; y <= bottom; ++y) {
+          const uint8_t *row = bytes.data() + uint64_t(y) * row_pitch;
+          for (uint32_t x = left; x <= right; ++x) {
+            const uint8_t *pixel = row + uint64_t(x) * bytes_per_pixel;
+            if (format == kR16G16B16A16Float) {
+              for (uint32_t component = 0; component < 3; ++component) {
+                uint16_t half = 0;
+                std::memcpy(&half, pixel + component * sizeof(uint16_t),
+                            sizeof(half));
+                const float value =
+                    std::clamp(HalfToFloat(half), 0.0f, 1.0f);
+                ppm.push_back(uint8_t(std::lround(value * 255.0f)));
+              }
+            } else {
+              ppm.insert(ppm.end(), pixel, pixel + 3);
+            }
+          }
+        }
+
+        std::filesystem::path staging = output_root;
+        staging += L".partial";
+        std::error_code error;
+        if (std::filesystem::exists(output_root, error) || error ||
+            std::filesystem::exists(staging, error) || error ||
+            !std::filesystem::create_directories(staging, error) || error) {
+          pinyon_shift::diagnostics::RecordEvent(
+              "native_renderer.isolated_draw.readback",
+              {{"signature", fmt::format("{:016X}", signature)},
+               {"status", "output_directory_unavailable"},
+               {"output_authority", "xenos"},
+               {"suppression_eligible", "false"}});
+          return;
+        }
+        const std::string metadata = fmt::format(
+            "{{\n  \"schema\": \"pinyon-shift.isolated-draw-readback.v1\",\n"
+            "  \"signature\": \"{:016X}\",\n  \"frame\": {},\n"
+            "  \"draw\": {},\n  \"source\": {{\"width\":{},"
+            "\"height\":{},\"row_pitch\":{},\"dxgi_format\":{},"
+            "\"bytes\":{},\"hash\":\"{:016X}\"}},\n"
+            "  \"crop\": {{\"left\":{},\"top\":{},\"right\":{},"
+            "\"bottom\":{},\"width\":{},\"height\":{}}},\n"
+            "  \"image\": {{\"file\":\"isolated.ppm\","
+            "\"encoding\":\"ppm-p6-linear-clamp\"}},\n"
+            "  \"safety\": {{\"output_authority\":\"xenos\","
+            "\"suppression_allowed\":false}}\n}}\n",
+            signature, frame, draw, width, height, row_pitch, format,
+            bytes.size(), HashBytes(bytes.data(), bytes.size()), left, top,
+            right, bottom, crop_width, crop_height);
+        const auto metadata_bytes = std::span(
+            reinterpret_cast<const uint8_t *>(metadata.data()),
+            metadata.size());
+        if (!WriteSnapshotFile(staging / L"isolated.bin", bytes) ||
+            !WriteSnapshotFile(staging / L"isolated.ppm", ppm) ||
+            !WriteSnapshotFile(staging / L"readback.json", metadata_bytes)) {
+          std::filesystem::remove_all(staging, error);
+          pinyon_shift::diagnostics::RecordEvent(
+              "native_renderer.isolated_draw.readback",
+              {{"signature", fmt::format("{:016X}", signature)},
+               {"status", "artifact_write_failed"},
+               {"output_authority", "xenos"},
+               {"suppression_eligible", "false"}});
+          return;
+        }
+        std::filesystem::rename(staging, output_root, error);
+        pinyon_shift::diagnostics::RecordEvent(
+            "native_renderer.isolated_draw.readback",
+            {{"signature", fmt::format("{:016X}", signature)},
+             {"status", error ? "artifact_commit_failed" : "captured"},
+             {"frame", std::to_string(frame)},
+             {"draw", std::to_string(draw)},
+             {"source_width", std::to_string(width)},
+             {"source_height", std::to_string(height)},
+             {"crop_width", std::to_string(crop_width)},
+             {"crop_height", std::to_string(crop_height)},
+             {"readback_bytes", std::to_string(bytes.size())},
+             {"output_authority", "xenos"},
+             {"suppression_eligible", "false"}});
+      });
+}
+
 void CompleteIsolatedDraw(
     const rex::system::GraphicsIsolatedDrawResult &result) {
   const char *status = "unsupported_state";
@@ -1760,10 +1991,10 @@ void CompleteIsolatedDraw(
   pinyon_shift::diagnostics::RecordEvent(
       "native_renderer.isolated_draw.result",
       {{"signature",
-        fmt::format("{:016X}", g_isolated_draw.prepared_signature)},
+        fmt::format("{:016X}", g_isolated_draw.captured_signature)},
        {"status", status},
-       {"frame", std::to_string(g_isolated_draw.frame)},
-       {"draw", std::to_string(g_isolated_draw.draw)},
+       {"frame", std::to_string(g_isolated_draw.captured_frame)},
+       {"draw", std::to_string(g_isolated_draw.captured_draw)},
        {"target_width", std::to_string(result.target_width)},
        {"target_height", std::to_string(result.target_height)},
        {"native_draw", result.status ==
@@ -1799,8 +2030,15 @@ void RequestIsolatedDraw(
          {"suppression_eligible", "false"}});
     return;
   }
+  g_isolated_draw.captured_signature = g_isolated_draw.prepared_signature;
+  g_isolated_draw.captured_frame = g_isolated_draw.frame;
+  g_isolated_draw.captured_draw = g_isolated_draw.draw;
   request.requested = true;
+  request.readback_requested = g_isolated_draw.readback_requested;
   request.completion = &CompleteIsolatedDraw;
+  request.readback_completion = g_isolated_draw.readback_requested
+                                    ? &CompleteIsolatedDrawReadback
+                                    : nullptr;
 }
 
 void EmitDrawCensusWindow(uint64_t last_frame_value) {
@@ -2233,13 +2471,18 @@ void InstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system) {
       "native_renderer.isolated_draw.config",
       {{"status", !g_isolated_draw.requested
                       ? "disabled"
-                      : (g_isolated_draw.valid ? "armed"
+                      : (g_isolated_draw.valid
+                             ? (g_isolated_draw.readback_requested
+                                    ? "armed_with_readback"
+                                    : "armed")
                                                : "invalid_configuration")},
        {"signature",
         g_isolated_draw.valid && g_isolated_draw.requested
             ? fmt::format("{:016X}", g_isolated_draw.target_signature)
             : ""},
        {"native_draw", "isolated_only"},
+       {"readback", g_isolated_draw.readback_requested ? "asynchronous"
+                                                        : "disabled"},
        {"xenos_draw", "preserved"},
        {"output_authority", "xenos"},
        {"suppression_eligible", "false"}});
@@ -2254,6 +2497,9 @@ void UninstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system) {
   }
   if (!g_graphics_census_installed) {
     return;
+  }
+  if (g_isolated_draw.artifact_writer.joinable()) {
+    g_isolated_draw.artifact_writer.join();
   }
   g_graphics_census_installed = false;
   if (g_draw_census.window_first_frame && g_draw_census.window_draw_count) {

--- a/tools/capture-native-renderer-census.ps1
+++ b/tools/capture-native-renderer-census.ps1
@@ -15,6 +15,7 @@ param(
     [string]$ReplaySnapshotDir,
     [ValidatePattern('^[0-9A-Fa-f]{16}$')]
     [string]$IsolatedDrawSignature,
+    [string]$IsolatedDrawDir,
     [switch]$Json
 )
 
@@ -71,6 +72,28 @@ if ($ReplaySnapshotDir) {
     $ReplaySnapshotDir = $resolvedSnapshotDir
 }
 
+if ($IsolatedDrawDir) {
+    if (-not $IsolatedDrawSignature) {
+        throw 'IsolatedDrawDir requires IsolatedDrawSignature'
+    }
+    $repositoryRoot = Split-Path $PSScriptRoot -Parent
+    $localRoot = [IO.Path]::GetFullPath((Join-Path $repositoryRoot '.local'))
+    $resolvedIsolatedDrawDir = [IO.Path]::GetFullPath($IsolatedDrawDir)
+    $localPrefix = $localRoot.TrimEnd([IO.Path]::DirectorySeparatorChar) +
+        [IO.Path]::DirectorySeparatorChar
+    if (-not $resolvedIsolatedDrawDir.StartsWith(
+            $localPrefix, [StringComparison]::OrdinalIgnoreCase)) {
+        throw "IsolatedDrawDir must be below $localRoot"
+    }
+    if (Test-Path -LiteralPath $resolvedIsolatedDrawDir) {
+        throw "IsolatedDrawDir already exists: $resolvedIsolatedDrawDir"
+    }
+    if (Test-Path -LiteralPath "$resolvedIsolatedDrawDir.partial") {
+        throw "Isolated draw staging directory already exists: $resolvedIsolatedDrawDir.partial"
+    }
+    $IsolatedDrawDir = $resolvedIsolatedDrawDir
+}
+
 $savedCensus = $env:REX_PINYON_SHIFT_NATIVE_RENDERER_CENSUS
 $savedScene = $env:PINYON_SHIFT_NATIVE_RENDERER_SCENE
 $savedIndexScan = $env:PINYON_SHIFT_NATIVE_RENDERER_INDEX_SCAN_SIGNATURE
@@ -78,6 +101,7 @@ $savedTextureScan = $env:PINYON_SHIFT_NATIVE_RENDERER_TEXTURE_SCAN_SIGNATURE
 $savedReplaySnapshot = $env:PINYON_SHIFT_NATIVE_RENDERER_SNAPSHOT_SIGNATURE
 $savedReplaySnapshotDir = $env:PINYON_SHIFT_NATIVE_RENDERER_SNAPSHOT_DIR
 $savedIsolatedDraw = $env:PINYON_SHIFT_NATIVE_RENDERER_ISOLATED_DRAW_SIGNATURE
+$savedIsolatedDrawDir = $env:PINYON_SHIFT_NATIVE_RENDERER_ISOLATED_DRAW_DIR
 try {
     $env:REX_PINYON_SHIFT_NATIVE_RENDERER_CENSUS = 'true'
     $env:PINYON_SHIFT_NATIVE_RENDERER_SCENE = $Scene
@@ -86,6 +110,7 @@ try {
     $env:PINYON_SHIFT_NATIVE_RENDERER_SNAPSHOT_SIGNATURE = $ReplaySnapshotSignature
     $env:PINYON_SHIFT_NATIVE_RENDERER_SNAPSHOT_DIR = $ReplaySnapshotDir
     $env:PINYON_SHIFT_NATIVE_RENDERER_ISOLATED_DRAW_SIGNATURE = $IsolatedDrawSignature
+    $env:PINYON_SHIFT_NATIVE_RENDERER_ISOLATED_DRAW_DIR = $IsolatedDrawDir
     & (Join-Path $PSScriptRoot 'launch-preview.ps1') `
         -StateRoot $resolvedStateRoot -ShaderCaptureDir $ShaderCaptureDir `
         -Json:$Json
@@ -98,4 +123,5 @@ finally {
     $env:PINYON_SHIFT_NATIVE_RENDERER_SNAPSHOT_SIGNATURE = $savedReplaySnapshot
     $env:PINYON_SHIFT_NATIVE_RENDERER_SNAPSHOT_DIR = $savedReplaySnapshotDir
     $env:PINYON_SHIFT_NATIVE_RENDERER_ISOLATED_DRAW_SIGNATURE = $savedIsolatedDraw
+    $env:PINYON_SHIFT_NATIVE_RENDERER_ISOLATED_DRAW_DIR = $savedIsolatedDrawDir
 }

--- a/tools/tests/test_native_renderer_contract.py
+++ b/tools/tests/test_native_renderer_contract.py
@@ -442,6 +442,27 @@ class NativeRendererContractTests(unittest.TestCase):
         )
         self.assertLess(isolated_draw_position, guest_draw_position)
 
+        isolated_readback_patch = (
+            ROOT / "patches/rexglue/0059-d3d12-isolated-draw-readback.patch"
+        ).read_text(encoding="utf-8")
+        self.assertIn("QueueIsolatedReplayReadback", isolated_readback_patch)
+        self.assertIn("GetCopyableFootprints", isolated_readback_patch)
+        self.assertIn("D3DCopyTextureRegion", isolated_readback_patch)
+        self.assertIn("D3DResolveSubresource", isolated_readback_patch)
+        self.assertIn("failure_detail_out", isolated_readback_patch)
+        self.assertIn("readback_result.detail", isolated_readback_patch)
+        self.assertIn("GetCompletedSubmission", isolated_readback_patch)
+        self.assertNotIn("AwaitAllQueueOperationsCompletion", isolated_readback_patch)
+        self.assertNotIn("SetDrawSuppression", isolated_readback_patch)
+        copy_position = isolated_readback_patch.index("D3DCopyTextureRegion")
+        guest_draw_position = isolated_readback_patch.index(
+            "render_target_cache_->EndIsolatedReplayTarget", copy_position
+        )
+        self.assertLess(copy_position, guest_draw_position)
+        self.assertIn("captured_signature", scanner)
+        self.assertIn("captured_frame", scanner)
+        self.assertIn("captured_draw", scanner)
+
         draw_state_planner = (
             ROOT / "tools/build-native-draw-state-contract.py"
         ).read_text(encoding="utf-8")

--- a/tools/tests/test_release_contract.py
+++ b/tools/tests/test_release_contract.py
@@ -43,10 +43,10 @@ class ReleaseContractTests(unittest.TestCase):
 
     def test_rexglue_patches_have_stable_order_and_no_binary_payload(self):
         patches = sorted((ROOT / "patches/rexglue").glob("*.patch"))
-        self.assertEqual(len(patches), 58)
+        self.assertEqual(len(patches), 59)
         self.assertEqual(
             patches[-1].name,
-            "0058-d3d12-isolated-draw-replay.patch",
+            "0059-d3d12-isolated-draw-readback.patch",
         )
         self.assertEqual(len(patches), len({path.name[:4] for path in patches}))
         for path in patches:


### PR DESCRIPTION
## Summary
- add asynchronous D3D12 readback for the private authentic-draw replay target
- write raw, cropped image, and metadata artifacts below the local diagnostic boundary
- preserve Xenos output authority and keep suppression unavailable on every path
- freeze request metadata across the asynchronous completion boundary

## Validation
- 114 Python contract tests
- repository boundary check: 186 candidate files
- clean ReXGlue v0.10.0 prepare with all 59 patches
- full release build
- AppData qualification session \20260828T105842Z-p39620\: signature \747837906D0BF484\, 40 MiB readback, 512x280 non-empty sky/fog crop, zero fatal/crash/device/failure events, normal exit