### PR TITLE
feat(native-renderer): qualify isolated draw output

### DIFF
--- a/docs/native-renderer/VISUAL_COMPARISON.md
+++ b/docs/native-renderer/VISUAL_COMPARISON.md
@@ -1,0 +1,122 @@
+# Authentic draw visual comparison
+
+NR-02E compares the private native replay with the original ReXGlue/Xenos
+draw. The workflow keeps captures and game-derived images below `.local`; only
+the tooling, thresholds, and result summary belong in the public repository.
+
+## Reference capture
+
+Patch `0060-d3d12-isolated-draw-debug-markers.patch` adds two RenderDoc-visible
+D3D12 regions when an exact isolated-draw signature is configured:
+
+- `PinyonShift NR-02E isolated native draw` marks the private replay. After its
+  one-shot diagnostic result is recorded, the exact-signature debug run repeats
+  the replay without readback or completion callbacks so it remains available
+  to a frame debugger;
+- `PinyonShift NR-02E authoritative Xenos draw` marks the original draw that
+  immediately follows each private replay.
+
+Patch `0061-d3d12-seeded-isolated-replay-targets.patch` copies the current
+guest color and depth attachments into the private clones before replay. This
+preserves the candidate draw's existing depth and target context while keeping
+the guest attachments read-only and restoring their tracked resource states.
+The private replay still never replaces or suppresses the Xenos draw.
+
+The marker path does not skip or suppress either draw. Use an official signed
+RenderDoc portable build and launch the capture with:
+
+```powershell
+$stateRoot = Join-Path $env:LOCALAPPDATA `
+    'PinyonShift\source\0.1.0\.local\preview'
+.\tools\capture-native-renderer-renderdoc.ps1 `
+  -StateRoot $stateRoot `
+  -RenderDocRoot '.local\tools\renderdoc\RenderDoc_64' `
+  -IsolatedDrawSignature 747837906D0BF484 `
+  -CaptureDir '.local\qualification\native-renderer-renderdoc-reference'
+```
+
+Load the saved open world, press F12, and verify the authoritative marker is
+present in the captured frame. Export the first adjacent marker pair with:
+
+```powershell
+.\tools\export-native-renderer-renderdoc.ps1 `
+  -Capture `.local\qualification\native-renderer-renderdoc-reference\reference_frame1.rdc` `
+  -RenderDocRoot '.local\tools\renderdoc\RenderDoc_64' `
+  -OutputDir '.local\qualification\renderdoc-reference-export'
+```
+
+The first qrenderdoc launch may present RenderDoc's own analytics privacy
+choice. Make that choice in the visible official UI; the wrapper neither
+selects nor bypasses it. The export report records marker counts, paired event
+IDs, output dimensions, resource IDs, and hashes. It preserves color alpha in
+the two lossless color PNGs and also exports the bound depth attachment at each
+marked draw as a grayscale PNG. The comparator accepts binary PPM or
+non-interlaced 8-bit PNG, so the lossless exports can be compared directly.
+Keep the RDC and all exports local.
+
+## Deterministic comparison
+
+Run:
+
+```powershell
+python .\tools\compare-native-renderer-images.py `
+  .local\qualification\renderdoc-reference-export\isolated-native.png `
+  .local\qualification\renderdoc-reference-export\authoritative-xenos.png `
+  --native-before `
+    .local\qualification\renderdoc-reference-export\isolated-native-before.png `
+  --reference-before `
+    .local\qualification\renderdoc-reference-export\authoritative-xenos-before.png `
+  --crop 0,0,512,280 `
+  --color-space linear `
+  --difference-output `
+    .local\qualification\visual-comparison\difference.ppm `
+  --output .local\qualification\visual-comparison\report.json
+
+python .\tools\compare-native-renderer-images.py `
+  .local\qualification\renderdoc-reference-export\isolated-native-depth.png `
+  .local\qualification\renderdoc-reference-export\authoritative-xenos-depth.png `
+  --content depth `
+  --crop 0,0,512,280 `
+  --difference-output `
+    .local\qualification\visual-comparison\depth-difference.ppm `
+  --output .local\qualification\visual-comparison\depth-report.json
+```
+
+The report records input hashes, dimensions, color-space declaration,
+per-channel MAE and RMSE, the maximum error, the fraction of pixels outside the
+channel tolerance, and foreground coverage intersection-over-union. A mismatch
+returns exit code 2; malformed or dimensionally incompatible input returns 1.
+The optional difference image amplifies each absolute channel error by 16 for
+direct inspection; this affects visualization only, never the numeric gate.
+
+The default gate is intentionally strict: MAE at most 2, RMSE at most 4, no
+more than 1 percent of pixels beyond a four-value channel tolerance, and
+coverage IoU of at least 0.99.
+
+The color before/after pairs derive draw-only coverage, excluding unrelated
+contents already present in the authoritative Xenos target. The RGBA color
+comparison gates geometry coverage, texture orientation, alpha, and output
+color. The separate post-draw depth comparison gates the seeded mapped depth
+target. The qualified sky candidate does not write depth, so comparing its
+before/after depth delta would produce an empty and therefore meaningless set.
+NR-02E acceptance requires both reports to pass and the paired event IDs in the
+export report to show the isolated native marker immediately followed by the
+authoritative Xenos marker.
+
+## Qualified reference result
+
+The 2026-08-28 `open_world_day` qualification used exact draw signature
+`747837906D0BF484`. RenderDoc exported the isolated native draw at event 6880
+and the immediately following authoritative Xenos draw at event 6884. Six
+paired markers were present in the captured frame.
+
+For the 512 by 280 gameplay crop, both comparisons passed with exact output:
+
+- color draw delta: 122,516 compared pixels, 0 different pixels, MAE 0,
+  RMSE 0, and coverage IoU 1.0;
+- post-draw depth: 143,360 compared pixels, 0 different pixels, MAE 0,
+  RMSE 0, and coverage IoU 1.0.
+
+The isolated and authoritative color PNGs had the same SHA-256, as did their
+pre-draw color PNGs and post-draw depth PNGs. The capture and game-derived
+exports remain local under `.local/qualification`.

--- a/patches/rexglue/0060-d3d12-isolated-draw-debug-markers.patch
+++ b/patches/rexglue/0060-d3d12-isolated-draw-debug-markers.patch
@@ -1,0 +1,44 @@
+diff --git a/src/graphics/d3d12/command_processor.cpp b/src/graphics/d3d12/command_processor.cpp
+--- a/src/graphics/d3d12/command_processor.cpp
++++ b/src/graphics/d3d12/command_processor.cpp
+@@ -3067,8 +3067,11 @@ bool D3D12CommandProcessor::IssueDraw(xenos::PrimitiveType primitive_type,
+       } else if (render_target_cache_->BeginIsolatedReplayTarget(
+                      isolated_result.target_width,
+                      isolated_result.target_height)) {
++        deferred_command_list_.BeginDebugMarker(
++            "PinyonShift NR-02E isolated native draw");
+         deferred_command_list_.D3DDrawIndexedInstanced(
+             primitive_processing_result.host_draw_vertex_count, 1, 0, 0, 0);
++        deferred_command_list_.EndDebugMarker();
+         if (isolated_draw_request.readback_requested &&
+             isolated_draw_request.readback_completion) {
+           uint32_t readback_detail = 0;
+@@ -3098,10 +3101,17 @@ bool D3D12CommandProcessor::IssueDraw(xenos::PrimitiveType primitive_type,
+         isolated_draw_request.completion(isolated_result);
+       }
+     }
++    if (isolated_draw_request.reference_marker_requested) {
++      deferred_command_list_.BeginDebugMarker(
++          "PinyonShift NR-02E authoritative Xenos draw");
++    }
+     PROFILE_DRAW_CALL();
+     PROFILE_VERTICES(primitive_processing_result.host_draw_vertex_count);
+     deferred_command_list_.D3DDrawIndexedInstanced(
+         primitive_processing_result.host_draw_vertex_count, 1, 0, 0, 0);
++    if (isolated_draw_request.reference_marker_requested) {
++      deferred_command_list_.EndDebugMarker();
++    }
+     if (scratch_index_buffer != nullptr) {
+       ReleaseScratchGPUBuffer(scratch_index_buffer, D3D12_RESOURCE_STATE_INDEX_BUFFER);
+     }
+diff --git a/include/rex/system/interfaces/graphics.h b/include/rex/system/interfaces/graphics.h
+--- a/include/rex/system/interfaces/graphics.h
++++ b/include/rex/system/interfaces/graphics.h
+@@ -303,6 +303,7 @@ using GraphicsIsolatedDrawReadbackCompletion = void (*)(
+ struct GraphicsIsolatedDrawRequest {
+   bool requested = false;
+   bool readback_requested = false;
++  bool reference_marker_requested = false;
+   GraphicsIsolatedDrawCompletion completion = nullptr;
+   GraphicsIsolatedDrawReadbackCompletion readback_completion = nullptr;
+ };

--- a/patches/rexglue/0061-d3d12-seeded-isolated-replay-targets.patch
+++ b/patches/rexglue/0061-d3d12-seeded-isolated-replay-targets.patch
@@ -1,0 +1,89 @@
+diff --git a/include/rex/graphics/d3d12/render_target_cache.h b/include/rex/graphics/d3d12/render_target_cache.h
+--- a/include/rex/graphics/d3d12/render_target_cache.h
++++ b/include/rex/graphics/d3d12/render_target_cache.h
+@@ -96,9 +96,9 @@ class D3D12RenderTargetCache final : public RenderTargetCache {
+     return depth_float24_convert_in_pixel_shader_;
+   }
+ 
+-  // Binds cleared private clones of the current depth and first color target.
+-  // EndIsolatedReplayTarget restores the guest targets without changing their
+-  // contents or ownership.
++  // Seeds and binds private clones of the current depth and first color target.
++  // EndIsolatedReplayTarget restores the guest bindings without changing the
++  // guest attachments or ownership.
+   bool BeginIsolatedReplayTarget(uint32_t& width_out, uint32_t& height_out);
+   system::GraphicsIsolatedDrawReadbackStatus QueueIsolatedReplayReadback(
+       system::GraphicsIsolatedDrawReadbackCompletion completion,
+diff --git a/src/graphics/d3d12/render_target_cache.cpp b/src/graphics/d3d12/render_target_cache.cpp
+--- a/src/graphics/d3d12/render_target_cache.cpp
++++ b/src/graphics/d3d12/render_target_cache.cpp
+@@ -1748,10 +1748,50 @@ bool D3D12RenderTargetCache::BeginIsolatedReplayTarget(
+       isolated_replay_depth_target_.get());
+   auto* isolated_color = static_cast<D3D12RenderTarget*>(
+       isolated_replay_color_target_.get());
++  auto* guest_depth = static_cast<D3D12RenderTarget*>(guest_targets[0]);
++  auto* guest_color = static_cast<D3D12RenderTarget*>(guest_targets[1]);
+   const D3D12_RESOURCE_DESC color_desc = isolated_color->resource()->GetDesc();
+   width_out = uint32_t(color_desc.Width);
+   height_out = color_desc.Height;
+ 
++  const D3D12_RESOURCE_STATES guest_depth_state =
++      guest_depth->SetResourceState(D3D12_RESOURCE_STATE_COPY_SOURCE);
++  const D3D12_RESOURCE_STATES guest_color_state =
++      guest_color->SetResourceState(D3D12_RESOURCE_STATE_COPY_SOURCE);
++  const D3D12_RESOURCE_STATES isolated_depth_state =
++      isolated_depth->SetResourceState(D3D12_RESOURCE_STATE_COPY_DEST);
++  const D3D12_RESOURCE_STATES isolated_color_state =
++      isolated_color->SetResourceState(D3D12_RESOURCE_STATE_COPY_DEST);
++  command_processor_.PushTransitionBarrier(
++      guest_depth->resource(), guest_depth_state,
++      D3D12_RESOURCE_STATE_COPY_SOURCE);
++  command_processor_.PushTransitionBarrier(
++      guest_color->resource(), guest_color_state,
++      D3D12_RESOURCE_STATE_COPY_SOURCE);
++  command_processor_.PushTransitionBarrier(
++      isolated_depth->resource(), isolated_depth_state,
++      D3D12_RESOURCE_STATE_COPY_DEST);
++  command_processor_.PushTransitionBarrier(
++      isolated_color->resource(), isolated_color_state,
++      D3D12_RESOURCE_STATE_COPY_DEST);
++  command_processor_.SubmitBarriers();
++
++  DeferredCommandList& command_list =
++      command_processor_.GetDeferredCommandList();
++  command_list.D3DCopyResource(isolated_depth->resource(),
++                               guest_depth->resource());
++  command_list.D3DCopyResource(isolated_color->resource(),
++                               guest_color->resource());
++
++  guest_depth->SetResourceState(guest_depth_state);
++  guest_color->SetResourceState(guest_color_state);
++  command_processor_.PushTransitionBarrier(
++      guest_depth->resource(), D3D12_RESOURCE_STATE_COPY_SOURCE,
++      guest_depth_state);
++  command_processor_.PushTransitionBarrier(
++      guest_color->resource(), D3D12_RESOURCE_STATE_COPY_SOURCE,
++      guest_color_state);
++
+   RenderTarget* isolated_targets[1 + xenos::kMaxColorRenderTargets] = {};
+   isolated_targets[0] = isolated_depth;
+   isolated_targets[1] = isolated_color;
+@@ -1759,18 +1799,5 @@ bool D3D12RenderTargetCache::BeginIsolatedReplayTarget(
+   SetCommandListRenderTargets(isolated_targets);
+   command_processor_.SubmitBarriers();
+ 
+-  DeferredCommandList& command_list =
+-      command_processor_.GetDeferredCommandList();
+-  const float clear_color[4] = {};
+-  command_list.D3DClearRenderTargetView(
+-      isolated_color->descriptor_draw().GetHandle(), clear_color, 0, nullptr);
+-  const float clear_depth =
+-      depth_key.GetDepthFormat() == xenos::DepthRenderTargetFormat::kD24S8
+-          ? 1.0f
+-          : 0.0f;
+-  command_list.D3DClearDepthStencilView(
+-      isolated_depth->descriptor_draw().GetHandle(),
+-      D3D12_CLEAR_FLAG_DEPTH | D3D12_CLEAR_FLAG_STENCIL, clear_depth, 0, 0,
+-      nullptr);
+   return true;
+ }

--- a/src/native_renderer/graphics_hooks.cpp
+++ b/src/native_renderer/graphics_hooks.cpp
@@ -2010,9 +2010,16 @@ void RequestIsolatedDraw(
     const rex::system::GraphicsPreparedDrawObservation &,
     rex::system::GraphicsIsolatedDrawRequest &request) {
   if (!g_isolated_draw.requested || !g_isolated_draw.valid ||
-      g_isolated_draw.completed ||
       !g_isolated_draw.prepared_candidate_valid ||
       g_isolated_draw.prepared_signature != g_isolated_draw.target_signature) {
+    return;
+  }
+  request.reference_marker_requested = true;
+  if (g_isolated_draw.completed) {
+    // Keep the private replay visible to frame debuggers after the one-shot
+    // result has been recorded. This path has no readback or completion
+    // callback, and the authoritative Xenos draw still follows unmodified.
+    request.requested = g_isolated_draw.prepared_candidate_eligible;
     return;
   }
   g_isolated_draw.completed = true;
@@ -2483,6 +2490,7 @@ void InstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system) {
        {"native_draw", "isolated_only"},
        {"readback", g_isolated_draw.readback_requested ? "asynchronous"
                                                         : "disabled"},
+       {"reference_marker", "exact_signature"},
        {"xenos_draw", "preserved"},
        {"output_authority", "xenos"},
        {"suppression_eligible", "false"}});

--- a/tools/capture-native-renderer-renderdoc.ps1
+++ b/tools/capture-native-renderer-renderdoc.ps1
@@ -1,0 +1,97 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)]
+    [string]$StateRoot,
+    [Parameter(Mandatory)]
+    [string]$RenderDocRoot,
+    [Parameter(Mandatory)]
+    [ValidatePattern('^[0-9A-Fa-f]{16}$')]
+    [string]$IsolatedDrawSignature,
+    [Parameter(Mandatory)]
+    [string]$CaptureDir,
+    [ValidateSet('open_world_day', 'open_world_night', 'garage', 'race')]
+    [string]$Scene = 'open_world_day'
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
+$localRoot = [IO.Path]::GetFullPath((Join-Path $repoRoot '.local'))
+$resolvedStateRoot = [IO.Path]::GetFullPath($StateRoot)
+$resolvedCaptureDir = [IO.Path]::GetFullPath($CaptureDir)
+$localPrefix = $localRoot.TrimEnd([IO.Path]::DirectorySeparatorChar) +
+    [IO.Path]::DirectorySeparatorChar
+if (-not $resolvedCaptureDir.StartsWith(
+        $localPrefix, [StringComparison]::OrdinalIgnoreCase)) {
+    throw "CaptureDir must be below $localRoot"
+}
+if (Test-Path -LiteralPath $resolvedCaptureDir) {
+    throw "CaptureDir already exists: $resolvedCaptureDir"
+}
+
+$profile = Get-ChildItem -LiteralPath (Join-Path $resolvedStateRoot 'user') `
+    -Recurse -File -Filter ForzaProfile -ErrorAction SilentlyContinue |
+    Where-Object { $_.FullName -match 'ForzaProfile\\ForzaProfile$' } |
+    Select-Object -First 1
+if (-not $profile) {
+    throw "StateRoot does not contain an AppData ForzaProfile: $resolvedStateRoot"
+}
+if (@(Get-Process -Name pinyon_shift -ErrorAction SilentlyContinue).Count) {
+    throw 'Pinyon Shift is already running.'
+}
+
+$renderdoc = Join-Path ([IO.Path]::GetFullPath($RenderDocRoot)) 'renderdoccmd.exe'
+if (-not (Test-Path -LiteralPath $renderdoc -PathType Leaf)) {
+    throw "renderdoccmd.exe was not found below RenderDocRoot: $RenderDocRoot"
+}
+$signature = Get-AuthenticodeSignature -LiteralPath $renderdoc
+if ([string]$signature.Status -ne 'Valid') {
+    throw "renderdoccmd.exe does not have a valid Authenticode signature"
+}
+
+$executable = Join-Path $repoRoot 'out\build\win-amd64-release\pinyon_shift.exe'
+$gameRoot = (Resolve-Path (Join-Path $repoRoot '.local\game\base')).Path
+if (-not (Test-Path -LiteralPath $executable -PathType Leaf)) {
+    throw 'The preview has not been built.'
+}
+[void](New-Item -ItemType Directory -Path $resolvedCaptureDir)
+
+$saved = @{
+    state = $env:PINYON_SHIFT_STATE_ROOT
+    game = $env:PINYON_SHIFT_GAME_ROOT
+    tearing = $env:REX_D3D12_ALLOW_VARIABLE_REFRESH_RATE_AND_TEARING
+    census = $env:REX_PINYON_SHIFT_NATIVE_RENDERER_CENSUS
+    scene = $env:PINYON_SHIFT_NATIVE_RENDERER_SCENE
+    draw = $env:PINYON_SHIFT_NATIVE_RENDERER_ISOLATED_DRAW_SIGNATURE
+}
+try {
+    $env:PINYON_SHIFT_STATE_ROOT = $resolvedStateRoot
+    $env:PINYON_SHIFT_GAME_ROOT = $gameRoot
+    $env:REX_D3D12_ALLOW_VARIABLE_REFRESH_RATE_AND_TEARING = 'false'
+    $env:REX_PINYON_SHIFT_NATIVE_RENDERER_CENSUS = 'true'
+    $env:PINYON_SHIFT_NATIVE_RENDERER_SCENE = $Scene
+    $env:PINYON_SHIFT_NATIVE_RENDERER_ISOLATED_DRAW_SIGNATURE =
+        $IsolatedDrawSignature.ToUpperInvariant()
+    & $renderdoc capture -w `
+        -d (Split-Path $executable -Parent) `
+        -c (Join-Path $resolvedCaptureDir 'reference') `
+        $executable
+    if ($LASTEXITCODE) {
+        throw "RenderDoc capture exited with code $LASTEXITCODE"
+    }
+}
+finally {
+    $env:PINYON_SHIFT_STATE_ROOT = $saved.state
+    $env:PINYON_SHIFT_GAME_ROOT = $saved.game
+    $env:REX_D3D12_ALLOW_VARIABLE_REFRESH_RATE_AND_TEARING = $saved.tearing
+    $env:REX_PINYON_SHIFT_NATIVE_RENDERER_CENSUS = $saved.census
+    $env:PINYON_SHIFT_NATIVE_RENDERER_SCENE = $saved.scene
+    $env:PINYON_SHIFT_NATIVE_RENDERER_ISOLATED_DRAW_SIGNATURE = $saved.draw
+}
+
+$captures = @(Get-ChildItem -LiteralPath $resolvedCaptureDir -File -Filter '*.rdc')
+if (-not $captures.Count) {
+    throw 'RenderDoc exited without producing an RDC capture.'
+}
+$captures

--- a/tools/compare-native-renderer-images.py
+++ b/tools/compare-native-renderer-images.py
@@ -1,0 +1,514 @@
+#!/usr/bin/env python3
+"""Compare an isolated native draw with an exported reference image."""
+
+from __future__ import annotations
+
+import argparse
+import functools
+import hashlib
+import json
+import math
+import struct
+import sys
+import zlib
+from dataclasses import dataclass
+from pathlib import Path
+
+
+SCHEMA = "pinyon-shift.native-renderer-image-comparison.v1"
+
+
+@dataclass(frozen=True)
+class PpmImage:
+    width: int
+    height: int
+    pixels: bytes
+    channels: int = 3
+    encoding: str = "ppm-p6-8bit"
+
+
+def _token(data: bytes, offset: int) -> tuple[bytes, int]:
+    while offset < len(data):
+        if data[offset] == ord("#"):
+            newline = data.find(b"\n", offset)
+            if newline < 0:
+                raise ValueError("unterminated PPM comment")
+            offset = newline + 1
+        elif chr(data[offset]).isspace():
+            offset += 1
+        else:
+            break
+    end = offset
+    while end < len(data) and not chr(data[end]).isspace():
+        end += 1
+    if end == offset:
+        raise ValueError("missing PPM header token")
+    return data[offset:end], end
+
+
+def read_ppm(path: Path) -> PpmImage:
+    data = path.read_bytes()
+    offset = 0
+    values: list[bytes] = []
+    for _ in range(4):
+        value, offset = _token(data, offset)
+        values.append(value)
+    if values[0] != b"P6":
+        raise ValueError(f"{path}: expected binary PPM P6")
+    try:
+        width, height, maximum = (int(value) for value in values[1:])
+    except ValueError as error:
+        raise ValueError(f"{path}: invalid PPM dimensions") from error
+    if width <= 0 or height <= 0 or maximum != 255:
+        raise ValueError(f"{path}: unsupported PPM dimensions or maximum")
+    if offset >= len(data) or not chr(data[offset]).isspace():
+        raise ValueError(f"{path}: missing PPM pixel separator")
+    offset += 2 if data[offset : offset + 2] == b"\r\n" else 1
+    pixels = data[offset:]
+    expected = width * height * 3
+    if len(pixels) != expected:
+        raise ValueError(
+            f"{path}: expected {expected} pixel bytes, found {len(pixels)}"
+        )
+    return PpmImage(width, height, pixels)
+
+
+def _paeth(left: int, above: int, upper_left: int) -> int:
+    estimate = left + above - upper_left
+    left_distance = abs(estimate - left)
+    above_distance = abs(estimate - above)
+    diagonal_distance = abs(estimate - upper_left)
+    if left_distance <= above_distance and left_distance <= diagonal_distance:
+        return left
+    return above if above_distance <= diagonal_distance else upper_left
+
+
+def read_png(path: Path) -> PpmImage:
+    data = path.read_bytes()
+    if not data.startswith(b"\x89PNG\r\n\x1a\n"):
+        raise ValueError(f"{path}: invalid PNG signature")
+    offset = 8
+    header = None
+    compressed = bytearray()
+    while offset < len(data):
+        if offset + 12 > len(data):
+            raise ValueError(f"{path}: truncated PNG chunk")
+        length = struct.unpack_from(">I", data, offset)[0]
+        chunk_type = data[offset + 4 : offset + 8]
+        chunk_start = offset + 8
+        chunk_end = chunk_start + length
+        if chunk_end + 4 > len(data):
+            raise ValueError(f"{path}: truncated PNG chunk payload")
+        payload = data[chunk_start:chunk_end]
+        expected_crc = struct.unpack_from(">I", data, chunk_end)[0]
+        if zlib.crc32(chunk_type + payload) & 0xFFFFFFFF != expected_crc:
+            raise ValueError(f"{path}: PNG chunk CRC mismatch")
+        if chunk_type == b"IHDR":
+            header = struct.unpack(">IIBBBBB", payload)
+        elif chunk_type == b"IDAT":
+            compressed.extend(payload)
+        elif chunk_type == b"IEND":
+            break
+        offset = chunk_end + 4
+    if header is None:
+        raise ValueError(f"{path}: PNG has no IHDR")
+    width, height, bit_depth, color_type, compression, filtering, interlace = header
+    channels_by_type = {0: 1, 2: 3, 4: 2, 6: 4}
+    if (
+        width <= 0
+        or height <= 0
+        or bit_depth != 8
+        or color_type not in channels_by_type
+        or compression != 0
+        or filtering != 0
+        or interlace != 0
+    ):
+        raise ValueError(f"{path}: unsupported PNG encoding")
+    channels = channels_by_type[color_type]
+    row_bytes = width * channels
+    try:
+        scanlines = zlib.decompress(bytes(compressed))
+    except zlib.error as error:
+        raise ValueError(f"{path}: invalid PNG image data") from error
+    expected = height * (row_bytes + 1)
+    if len(scanlines) != expected:
+        raise ValueError(
+            f"{path}: expected {expected} decoded bytes, found {len(scanlines)}"
+        )
+    pixels = bytearray(width * height * channels)
+    previous = bytearray(row_bytes)
+    for row in range(height):
+        source_offset = row * (row_bytes + 1)
+        filter_type = scanlines[source_offset]
+        encoded = scanlines[source_offset + 1 : source_offset + 1 + row_bytes]
+        decoded = bytearray(row_bytes)
+        for index, value in enumerate(encoded):
+            left = decoded[index - channels] if index >= channels else 0
+            above = previous[index]
+            upper_left = previous[index - channels] if index >= channels else 0
+            if filter_type == 0:
+                predictor = 0
+            elif filter_type == 1:
+                predictor = left
+            elif filter_type == 2:
+                predictor = above
+            elif filter_type == 3:
+                predictor = (left + above) // 2
+            elif filter_type == 4:
+                predictor = _paeth(left, above, upper_left)
+            else:
+                raise ValueError(f"{path}: unsupported PNG filter {filter_type}")
+            decoded[index] = (value + predictor) & 0xFF
+        start = row * row_bytes
+        pixels[start : start + row_bytes] = decoded
+        previous = decoded
+    return PpmImage(width, height, bytes(pixels), channels, "png-8bit")
+
+
+@functools.lru_cache(maxsize=4)
+def read_image(path: Path) -> PpmImage:
+    return read_png(path) if path.suffix.lower() == ".png" else read_ppm(path)
+
+
+def crop_image(image: PpmImage, crop: tuple[int, int, int, int] | None) -> PpmImage:
+    if crop is None:
+        return image
+    left, top, width, height = crop
+    if (
+        left < 0
+        or top < 0
+        or width <= 0
+        or height <= 0
+        or left + width > image.width
+        or top + height > image.height
+    ):
+        raise ValueError(
+            f"crop {left},{top},{width},{height} exceeds "
+            f"{image.width}x{image.height} image"
+        )
+    row_bytes = image.width * image.channels
+    crop_row_bytes = width * image.channels
+    pixels = bytearray(crop_row_bytes * height)
+    for row in range(height):
+        source = (top + row) * row_bytes + left * image.channels
+        destination = row * crop_row_bytes
+        pixels[destination : destination + crop_row_bytes] = image.pixels[
+            source : source + crop_row_bytes
+        ]
+    return PpmImage(width, height, bytes(pixels), image.channels, image.encoding)
+
+
+def compare_images(
+    native: PpmImage,
+    reference: PpmImage,
+    *,
+    channel_tolerance: int,
+    coverage_threshold: int,
+    native_before: PpmImage | None = None,
+    reference_before: PpmImage | None = None,
+) -> dict[str, float | int]:
+    if (native.width, native.height) != (reference.width, reference.height):
+        raise ValueError(
+            "image dimensions differ: "
+            f"native={native.width}x{native.height}, "
+            f"reference={reference.width}x{reference.height}"
+        )
+    if native.channels != reference.channels:
+        raise ValueError(
+            "image channel counts differ: "
+            f"native={native.channels}, reference={reference.channels}"
+        )
+    if (native_before is None) != (reference_before is None):
+        raise ValueError("both before-draw images are required for delta comparison")
+    for label, before in (
+        ("native", native_before),
+        ("reference", reference_before),
+    ):
+        if before is not None and (
+            before.width != native.width
+            or before.height != native.height
+            or before.channels != native.channels
+        ):
+            raise ValueError(f"{label} before-draw image layout differs")
+
+    pixel_count = native.width * native.height
+    channel_errors: list[int] = []
+    different_pixels = 0
+    compared_pixels = 0
+    native_coverage = 0
+    reference_coverage = 0
+    coverage_intersection = 0
+    coverage_union = 0
+    for index in range(pixel_count):
+        start = index * native.channels
+        end = start + native.channels
+        native_pixel = native.pixels[start:end]
+        reference_pixel = reference.pixels[start:end]
+        if native_before is None:
+            coverage_channels = 3 if native.channels >= 3 else 1
+            native_present = any(
+                value > coverage_threshold for value in native_pixel[:coverage_channels]
+            )
+            reference_present = any(
+                value > coverage_threshold
+                for value in reference_pixel[:coverage_channels]
+            )
+        else:
+            native_before_pixel = native_before.pixels[start:end]
+            reference_before_pixel = reference_before.pixels[start:end]
+            native_present = any(
+                abs(after - before) > coverage_threshold
+                for after, before in zip(native_pixel, native_before_pixel, strict=True)
+            )
+            reference_present = any(
+                abs(after - before) > coverage_threshold
+                for after, before in zip(
+                    reference_pixel, reference_before_pixel, strict=True
+                )
+            )
+        native_coverage += native_present
+        reference_coverage += reference_present
+        coverage_intersection += native_present and reference_present
+        coverage_union += native_present or reference_present
+        if native_before is None or native_present or reference_present:
+            errors = [
+                abs(left - right)
+                for left, right in zip(native_pixel, reference_pixel, strict=True)
+            ]
+            channel_errors.extend(errors)
+            compared_pixels += 1
+            if any(error > channel_tolerance for error in errors):
+                different_pixels += 1
+    squared = sum(error * error for error in channel_errors)
+    return {
+        "mean_absolute_error": (
+            sum(channel_errors) / len(channel_errors) if channel_errors else 0.0
+        ),
+        "root_mean_square_error": (
+            math.sqrt(squared / len(channel_errors)) if channel_errors else 0.0
+        ),
+        "maximum_channel_error": max(channel_errors, default=0),
+        "compared_pixels": compared_pixels,
+        "different_pixels": different_pixels,
+        "different_pixel_ratio": (
+            different_pixels / compared_pixels if compared_pixels else 0.0
+        ),
+        "native_coverage_pixels": native_coverage,
+        "reference_coverage_pixels": reference_coverage,
+        "coverage_intersection_pixels": coverage_intersection,
+        "coverage_union_pixels": coverage_union,
+        "coverage_iou": (
+            coverage_intersection / coverage_union if coverage_union else 1.0
+        ),
+    }
+
+
+def write_difference_ppm(
+    path: Path, native: PpmImage, reference: PpmImage, amplification: int
+) -> None:
+    if (native.width, native.height) != (reference.width, reference.height):
+        raise ValueError("cannot write a difference image for mismatched dimensions")
+    if native.channels != reference.channels:
+        raise ValueError("cannot write a difference image for mismatched channels")
+    difference = bytearray()
+    for index in range(native.width * native.height):
+        start = index * native.channels
+        errors = [
+            min(
+                255,
+                abs(native.pixels[start + channel] - reference.pixels[start + channel])
+                * amplification,
+            )
+            for channel in range(native.channels)
+        ]
+        if native.channels == 1:
+            difference.extend(errors * 3)
+        elif native.channels == 2:
+            difference.extend((max(errors), errors[0], errors[0]))
+        else:
+            rgb = errors[:3]
+            if native.channels == 4:
+                rgb[0] = max(rgb[0], errors[3])
+            difference.extend(rgb)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(
+        f"P6\n{native.width} {native.height}\n255\n".encode("ascii") + bytes(difference)
+    )
+
+
+def build_report(args: argparse.Namespace) -> dict[str, object]:
+    native_path = args.native.resolve()
+    reference_path = args.reference.resolve()
+    native_source = read_image(native_path)
+    reference_source = read_image(reference_path)
+    native = crop_image(native_source, args.crop)
+    reference = crop_image(reference_source, args.crop)
+    native_before_path = args.native_before.resolve() if args.native_before else None
+    reference_before_path = (
+        args.reference_before.resolve() if args.reference_before else None
+    )
+    native_before = (
+        crop_image(read_image(native_before_path), args.crop)
+        if native_before_path
+        else None
+    )
+    reference_before = (
+        crop_image(read_image(reference_before_path), args.crop)
+        if reference_before_path
+        else None
+    )
+    metrics = compare_images(
+        native,
+        reference,
+        channel_tolerance=args.channel_tolerance,
+        coverage_threshold=args.coverage_threshold,
+        native_before=native_before,
+        reference_before=reference_before,
+    )
+    checks = {
+        "mean_absolute_error": metrics["mean_absolute_error"]
+        <= args.mean_absolute_error_max,
+        "root_mean_square_error": metrics["root_mean_square_error"]
+        <= args.root_mean_square_error_max,
+        "different_pixel_ratio": metrics["different_pixel_ratio"]
+        <= args.different_pixel_ratio_max,
+        "coverage_iou": metrics["coverage_iou"] >= args.coverage_iou_min,
+    }
+    return {
+        "schema": SCHEMA,
+        "result": "pass" if all(checks.values()) else "fail",
+        "inputs": {
+            "native": {
+                "path": str(native_path),
+                "sha256": hashlib.sha256(native_path.read_bytes()).hexdigest().upper(),
+            },
+            "reference": {
+                "path": str(reference_path),
+                "sha256": hashlib.sha256(reference_path.read_bytes()).hexdigest().upper(),
+            },
+            "native_before": (
+                {
+                    "path": str(native_before_path),
+                    "sha256": hashlib.sha256(
+                        native_before_path.read_bytes()
+                    ).hexdigest().upper(),
+                }
+                if native_before_path
+                else None
+            ),
+            "reference_before": (
+                {
+                    "path": str(reference_before_path),
+                    "sha256": hashlib.sha256(
+                        reference_before_path.read_bytes()
+                    ).hexdigest().upper(),
+                }
+                if reference_before_path
+                else None
+            ),
+            "width": native.width,
+            "height": native.height,
+            "source_width": native_source.width,
+            "source_height": native_source.height,
+            "crop": (
+                dict(zip(("left", "top", "width", "height"), args.crop))
+                if args.crop is not None
+                else None
+            ),
+            "encoding": native.encoding,
+            "channels": native.channels,
+            "color_space": args.color_space,
+            "comparison_mode": "draw_delta" if native_before else "post_draw",
+        },
+        "thresholds": {
+            "channel_tolerance": args.channel_tolerance,
+            "coverage_threshold": args.coverage_threshold,
+            "mean_absolute_error_max": args.mean_absolute_error_max,
+            "root_mean_square_error_max": args.root_mean_square_error_max,
+            "different_pixel_ratio_max": args.different_pixel_ratio_max,
+            "coverage_iou_min": args.coverage_iou_min,
+        },
+        "metrics": metrics,
+        "checks": checks,
+        "scope": {
+            "geometry_coverage": args.content == "color",
+            "output_color": args.content == "color",
+            "depth": args.content == "depth",
+            "alpha": args.content == "color" and native.channels in (2, 4),
+            "texture_orientation": args.content == "color",
+        },
+    }
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("native", type=Path)
+    parser.add_argument("reference", type=Path)
+    parser.add_argument("--native-before", type=Path)
+    parser.add_argument("--reference-before", type=Path)
+    parser.add_argument("--output", type=Path)
+    parser.add_argument("--difference-output", type=Path)
+    parser.add_argument("--difference-amplification", type=int, default=16)
+    parser.add_argument("--channel-tolerance", type=int, default=4)
+    parser.add_argument("--coverage-threshold", type=int, default=1)
+    parser.add_argument("--mean-absolute-error-max", type=float, default=2.0)
+    parser.add_argument("--root-mean-square-error-max", type=float, default=4.0)
+    parser.add_argument("--different-pixel-ratio-max", type=float, default=0.01)
+    parser.add_argument("--coverage-iou-min", type=float, default=0.99)
+    parser.add_argument("--color-space", choices=("linear", "srgb"), default="linear")
+    parser.add_argument("--content", choices=("color", "depth"), default="color")
+    parser.add_argument(
+        "--crop",
+        type=lambda value: tuple(int(part) for part in value.split(",")),
+        metavar="LEFT,TOP,WIDTH,HEIGHT",
+    )
+    args = parser.parse_args(argv)
+    if not 0 <= args.channel_tolerance <= 255:
+        parser.error("--channel-tolerance must be between 0 and 255")
+    if not 0 <= args.coverage_threshold <= 255:
+        parser.error("--coverage-threshold must be between 0 and 255")
+    if not 0 <= args.different_pixel_ratio_max <= 1:
+        parser.error("--different-pixel-ratio-max must be between 0 and 1")
+    if not 0 <= args.coverage_iou_min <= 1:
+        parser.error("--coverage-iou-min must be between 0 and 1")
+    if args.mean_absolute_error_max < 0 or args.root_mean_square_error_max < 0:
+        parser.error("error thresholds must be non-negative")
+    if args.difference_amplification < 1:
+        parser.error("--difference-amplification must be at least 1")
+    if args.crop is not None and len(args.crop) != 4:
+        parser.error("--crop must contain left,top,width,height")
+    if (args.native_before is None) != (args.reference_before is None):
+        parser.error("--native-before and --reference-before must be used together")
+    return args
+
+
+def main(argv: list[str] | None = None) -> int:
+    read_image.cache_clear()
+    args = parse_args(argv)
+    try:
+        report = build_report(args)
+        if args.difference_output:
+            write_difference_ppm(
+                args.difference_output,
+                crop_image(read_image(args.native.resolve()), args.crop),
+                crop_image(read_image(args.reference.resolve()), args.crop),
+                args.difference_amplification,
+            )
+            report["difference"] = {
+                "path": str(args.difference_output.resolve()),
+                "amplification": args.difference_amplification,
+            }
+        payload = json.dumps(report, indent=2, sort_keys=True) + "\n"
+        if args.output:
+            args.output.parent.mkdir(parents=True, exist_ok=True)
+            args.output.write_text(payload, encoding="utf-8")
+        else:
+            sys.stdout.write(payload)
+        return 0 if report["result"] == "pass" else 2
+    except (OSError, ValueError) as error:
+        print(f"error: {error}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/export-native-renderer-renderdoc.ps1
+++ b/tools/export-native-renderer-renderdoc.ps1
@@ -1,0 +1,63 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)]
+    [string]$Capture,
+    [Parameter(Mandatory)]
+    [string]$RenderDocRoot,
+    [Parameter(Mandatory)]
+    [string]$OutputDir
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
+$localRoot = [IO.Path]::GetFullPath((Join-Path $repoRoot '.local'))
+$localPrefix = $localRoot.TrimEnd([IO.Path]::DirectorySeparatorChar) +
+    [IO.Path]::DirectorySeparatorChar
+$resolvedCapture = (Resolve-Path -LiteralPath $Capture).Path
+$resolvedOutputDir = [IO.Path]::GetFullPath($OutputDir)
+if (-not $resolvedCapture.StartsWith(
+        $localPrefix, [StringComparison]::OrdinalIgnoreCase)) {
+    throw "Capture must be below $localRoot"
+}
+if (-not $resolvedOutputDir.StartsWith(
+        $localPrefix, [StringComparison]::OrdinalIgnoreCase)) {
+    throw "OutputDir must be below $localRoot"
+}
+if (Test-Path -LiteralPath $resolvedOutputDir) {
+    throw "OutputDir already exists: $resolvedOutputDir"
+}
+
+$qrenderdoc = Join-Path ([IO.Path]::GetFullPath($RenderDocRoot)) 'qrenderdoc.exe'
+if (-not (Test-Path -LiteralPath $qrenderdoc -PathType Leaf)) {
+    throw "qrenderdoc.exe was not found below RenderDocRoot: $RenderDocRoot"
+}
+$signature = Get-AuthenticodeSignature -LiteralPath $qrenderdoc
+if ([string]$signature.Status -ne 'Valid') {
+    throw 'qrenderdoc.exe does not have a valid Authenticode signature'
+}
+
+$script = Join-Path $PSScriptRoot 'export-native-renderer-renderdoc.py'
+[void](New-Item -ItemType Directory -Path $resolvedOutputDir)
+$savedCapture = $env:PINYON_SHIFT_RENDERDOC_CAPTURE
+$savedOutput = $env:PINYON_SHIFT_RENDERDOC_EXPORT_DIR
+try {
+    $env:PINYON_SHIFT_RENDERDOC_CAPTURE = $resolvedCapture
+    $env:PINYON_SHIFT_RENDERDOC_EXPORT_DIR = $resolvedOutputDir
+    $process = Start-Process -FilePath $qrenderdoc `
+        -ArgumentList @('--python', $script) -PassThru -Wait
+    if ($process.ExitCode) {
+        throw "qrenderdoc export exited with code $($process.ExitCode)"
+    }
+}
+finally {
+    $env:PINYON_SHIFT_RENDERDOC_CAPTURE = $savedCapture
+    $env:PINYON_SHIFT_RENDERDOC_EXPORT_DIR = $savedOutput
+}
+
+$report = Join-Path $resolvedOutputDir 'renderdoc-export.json'
+if (-not (Test-Path -LiteralPath $report -PathType Leaf)) {
+    throw 'qrenderdoc exited without producing the export report.'
+}
+Get-Content -LiteralPath $report -Raw | ConvertFrom-Json

--- a/tools/export-native-renderer-renderdoc.py
+++ b/tools/export-native-renderer-renderdoc.py
@@ -1,0 +1,212 @@
+"""Export the paired NR-02E RenderDoc marker outputs.
+
+This script is executed by qrenderdoc's bundled Python runtime. Inputs are
+passed through environment variables by export-native-renderer-renderdoc.ps1
+so RenderDoc's command-line parser never needs to understand tool arguments.
+"""
+
+import hashlib
+import json
+import os
+import sys
+
+import renderdoc as rd
+
+
+ISOLATED_MARKER = "PinyonShift NR-02E isolated native draw"
+XENOS_MARKER = "PinyonShift NR-02E authoritative Xenos draw"
+SCHEMA = "pinyon-shift.native-renderer-renderdoc-export.v1"
+
+
+def _flatten(actions):
+    result = []
+    for action in actions:
+        result.append(action)
+        result.extend(_flatten(action.children))
+    return result
+
+
+def _first_draw(action):
+    if action.flags & rd.ActionFlags.Drawcall:
+        return action
+    for child in action.children:
+        draw = _first_draw(child)
+        if draw is not None:
+            return draw
+    return None
+
+
+def _sha256(path):
+    digest = hashlib.sha256()
+    with open(path, "rb") as source:
+        for block in iter(lambda: source.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def _texture_description(controller, resource_id):
+    for texture in controller.GetTextures():
+        if texture.resourceId == resource_id:
+            return texture
+    raise RuntimeError("output target texture description was not found")
+
+
+def _export_texture(controller, target, output_path, channel_extract=-1):
+    texture = _texture_description(controller, target.resource)
+    save = rd.TextureSave()
+    save.resourceId = target.resource
+    save.destType = rd.FileType.PNG
+    save.alpha = rd.AlphaMapping.Preserve
+    save.mip = getattr(target, "firstMip", 0)
+    save.slice.sliceIndex = getattr(target, "firstSlice", 0)
+    save.channelExtract = channel_extract
+    result = controller.SaveTexture(save, output_path)
+    if hasattr(result, "code") and result.code != rd.ResultCode.Succeeded:
+        raise RuntimeError(
+            "RenderDoc failed to save '{}': {}".format(output_path, result)
+        )
+    if not os.path.isfile(output_path):
+        raise RuntimeError("RenderDoc did not create '{}'".format(output_path))
+
+    return {
+        "resource_id": str(target.resource),
+        "width": texture.width,
+        "height": texture.height,
+        "mip": save.mip,
+        "slice": save.slice.sliceIndex,
+        "channel_extract": channel_extract,
+        "path": os.path.basename(output_path),
+        "sha256": _sha256(output_path),
+    }
+
+
+def _bound_targets(controller):
+    pipeline = controller.GetPipelineState()
+    colors = [
+        target
+        for target in pipeline.GetOutputTargets()
+        if target.resource != rd.ResourceId.Null()
+    ]
+    depth = pipeline.GetDepthTarget()
+    return colors, depth
+
+
+def _export_marker(controller, marker, output_dir, basename):
+    draw = _first_draw(marker)
+    if draw is None:
+        raise RuntimeError("marker '{}' contains no draw".format(marker.customName))
+
+    controller.SetFrameEvent(marker.eventId, True)
+    before_colors, before_depth = _bound_targets(controller)
+    if not before_colors:
+        raise RuntimeError(
+            "marker '{}' has no pre-draw color output".format(marker.customName)
+        )
+    before_color_path = os.path.join(output_dir, basename + "-before.png")
+    before_depth_path = os.path.join(output_dir, basename + "-depth-before.png")
+    before = {
+        "color": _export_texture(
+            controller, before_colors[0], before_color_path
+        ),
+        "depth": (
+            _export_texture(
+                controller, before_depth, before_depth_path, channel_extract=0
+            )
+            if before_depth.resource != rd.ResourceId.Null()
+            else None
+        ),
+    }
+
+    controller.SetFrameEvent(draw.eventId, True)
+    targets, depth = _bound_targets(controller)
+    if not targets:
+        raise RuntimeError(
+            "marker '{}' draw has no color output".format(marker.customName)
+        )
+    color_path = os.path.join(output_dir, basename + ".png")
+    depth_path = os.path.join(output_dir, basename + "-depth.png")
+    result = {
+        "marker": marker.customName,
+        "marker_event_id": marker.eventId,
+        "draw_event_id": draw.eventId,
+        "before": before,
+        "color": _export_texture(controller, targets[0], color_path),
+    }
+    if depth.resource != rd.ResourceId.Null():
+        result["depth"] = _export_texture(
+            controller, depth, depth_path, channel_extract=0
+        )
+    else:
+        result["depth"] = None
+    return result
+
+
+def main():
+    capture_path = os.environ["PINYON_SHIFT_RENDERDOC_CAPTURE"]
+    output_dir = os.environ["PINYON_SHIFT_RENDERDOC_EXPORT_DIR"]
+    report_path = os.path.join(output_dir, "renderdoc-export.json")
+    os.makedirs(output_dir, exist_ok=True)
+
+    capture = rd.OpenCaptureFile()
+    controller = None
+    try:
+        result = capture.OpenFile(capture_path, "", None)
+        if result != rd.ResultCode.Succeeded:
+            raise RuntimeError("could not open capture: {}".format(result))
+        if not capture.LocalReplaySupport():
+            raise RuntimeError("capture does not support local replay")
+
+        result, controller = capture.OpenCapture(rd.ReplayOptions(), None)
+        if result != rd.ResultCode.Succeeded:
+            raise RuntimeError("could not initialise replay: {}".format(result))
+
+        actions = _flatten(controller.GetRootActions())
+        isolated = [a for a in actions if a.customName == ISOLATED_MARKER]
+        xenos = [a for a in actions if a.customName == XENOS_MARKER]
+        if not isolated or not xenos:
+            raise RuntimeError(
+                "paired markers were not found (isolated={}, xenos={})".format(
+                    len(isolated), len(xenos)
+                )
+            )
+
+        isolated_marker = isolated[0]
+        paired_xenos = next(
+            (a for a in xenos if a.eventId > isolated_marker.eventId), None
+        )
+        if paired_xenos is None:
+            raise RuntimeError("no authoritative Xenos marker follows the native marker")
+
+        report = {
+            "schema": SCHEMA,
+            "capture": {
+                "path": os.path.basename(capture_path),
+                "sha256": _sha256(capture_path),
+            },
+            "marker_counts": {
+                "isolated_native": len(isolated),
+                "authoritative_xenos": len(xenos),
+            },
+            "isolated_native": _export_marker(
+                controller, isolated_marker, output_dir, "isolated-native"
+            ),
+            "authoritative_xenos": _export_marker(
+                controller, paired_xenos, output_dir, "authoritative-xenos"
+            ),
+        }
+        with open(report_path, "w") as output:
+            json.dump(report, output, indent=2, sort_keys=True)
+            output.write("\n")
+        print(report_path)
+        return 0
+    finally:
+        if controller is not None:
+            controller.Shutdown()
+        capture.Shutdown()
+
+
+try:
+    sys.exit(main())
+except Exception as error:
+    sys.stderr.write("native renderer RenderDoc export failed: {}\n".format(error))
+    sys.exit(1)

--- a/tools/tests/test_native_renderer_contract.py
+++ b/tools/tests/test_native_renderer_contract.py
@@ -463,6 +463,75 @@ class NativeRendererContractTests(unittest.TestCase):
         self.assertIn("captured_frame", scanner)
         self.assertIn("captured_draw", scanner)
 
+        visual_marker_patch = (
+            ROOT / "patches/rexglue/0060-d3d12-isolated-draw-debug-markers.patch"
+        ).read_text(encoding="utf-8")
+        self.assertIn("PinyonShift NR-02E isolated native draw", visual_marker_patch)
+        self.assertIn("PinyonShift NR-02E authoritative Xenos draw", visual_marker_patch)
+        self.assertEqual(visual_marker_patch.count("BeginDebugMarker"), 2)
+        self.assertEqual(visual_marker_patch.count("EndDebugMarker"), 2)
+        self.assertIn("reference_marker_requested", visual_marker_patch)
+        self.assertNotIn("SetDrawSuppression", visual_marker_patch)
+        self.assertIn("request.reference_marker_requested = true", scanner)
+        self.assertIn(
+            "request.requested = g_isolated_draw.prepared_candidate_eligible", scanner
+        )
+        self.assertIn("authoritative Xenos draw still follows unmodified", scanner)
+
+        seeded_target_patch = (
+            ROOT / "patches/rexglue/0061-d3d12-seeded-isolated-replay-targets.patch"
+        ).read_text(encoding="utf-8")
+        seeded_target_additions = "\n".join(
+            line[1:]
+            for line in seeded_target_patch.splitlines()
+            if line.startswith("+") and not line.startswith("+++")
+        )
+        self.assertEqual(seeded_target_additions.count("D3DCopyResource"), 2)
+        self.assertIn("guest_depth_state", seeded_target_additions)
+        self.assertIn("guest_color_state", seeded_target_additions)
+        self.assertNotIn("D3DClearRenderTargetView", seeded_target_additions)
+        self.assertNotIn("D3DClearDepthStencilView", seeded_target_additions)
+        self.assertNotIn("SetDrawSuppression", seeded_target_additions)
+
+        visual_compare = (
+            ROOT / "tools/compare-native-renderer-images.py"
+        ).read_text(encoding="utf-8")
+        self.assertIn(
+            "pinyon-shift.native-renderer-image-comparison.v1", visual_compare
+        )
+        self.assertIn('args.content == "depth"', visual_compare)
+        self.assertIn("native.channels in (2, 4)", visual_compare)
+        renderdoc_wrapper = (
+            ROOT / "tools/capture-native-renderer-renderdoc.ps1"
+        ).read_text(encoding="utf-8")
+        self.assertIn("Get-AuthenticodeSignature", renderdoc_wrapper)
+        self.assertIn("CaptureDir must be below", renderdoc_wrapper)
+        self.assertIn("RenderDoc exited without producing", renderdoc_wrapper)
+
+        renderdoc_export = (
+            ROOT / "tools/export-native-renderer-renderdoc.py"
+        ).read_text(encoding="utf-8")
+        self.assertIn(
+            "pinyon-shift.native-renderer-renderdoc-export.v1",
+            renderdoc_export,
+        )
+        self.assertIn("GetRootActions", renderdoc_export)
+        self.assertIn("SetFrameEvent", renderdoc_export)
+        self.assertIn("SaveTexture", renderdoc_export)
+        self.assertIn("GetDepthTarget", renderdoc_export)
+        self.assertIn('basename + "-before.png"', renderdoc_export)
+        self.assertIn('basename + "-depth-before.png"', renderdoc_export)
+        self.assertIn('output_dir, "isolated-native"', renderdoc_export)
+        self.assertIn('output_dir, "authoritative-xenos"', renderdoc_export)
+        self.assertIn("authoritative Xenos marker follows", renderdoc_export)
+        renderdoc_export_wrapper = (
+            ROOT / "tools/export-native-renderer-renderdoc.ps1"
+        ).read_text(encoding="utf-8")
+        self.assertIn("Get-AuthenticodeSignature", renderdoc_export_wrapper)
+        self.assertIn("Capture must be below", renderdoc_export_wrapper)
+        self.assertIn("OutputDir must be below", renderdoc_export_wrapper)
+        self.assertIn("qrenderdoc exited without producing", renderdoc_export_wrapper)
+
         draw_state_planner = (
             ROOT / "tools/build-native-draw-state-contract.py"
         ).read_text(encoding="utf-8")

--- a/tools/tests/test_native_renderer_visual_compare.py
+++ b/tools/tests/test_native_renderer_visual_compare.py
@@ -1,0 +1,171 @@
+import importlib.util
+import contextlib
+import io
+import sys
+import tempfile
+import unittest
+import struct
+import zlib
+from argparse import Namespace
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+TOOL = ROOT / "tools" / "compare-native-renderer-images.py"
+SPEC = importlib.util.spec_from_file_location("native_visual_compare", TOOL)
+assert SPEC and SPEC.loader
+MODULE = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = MODULE
+SPEC.loader.exec_module(MODULE)
+
+
+def write_ppm(path: Path, width: int, height: int, pixels: bytes) -> None:
+    path.write_bytes(f"P6\n# fixture\n{width} {height}\n255\n".encode() + pixels)
+
+
+def write_png(path: Path, width: int, height: int, channels: int, pixels: bytes) -> None:
+    color_type = {1: 0, 3: 2, 4: 6}[channels]
+
+    def chunk(kind: bytes, payload: bytes) -> bytes:
+        body = kind + payload
+        return struct.pack(">I", len(payload)) + body + struct.pack(">I", zlib.crc32(body))
+
+    rows = b"".join(
+        b"\0" + pixels[row * width * channels : (row + 1) * width * channels]
+        for row in range(height)
+    )
+    path.write_bytes(
+        b"\x89PNG\r\n\x1a\n"
+        + chunk(b"IHDR", struct.pack(">IIBBBBB", width, height, 8, color_type, 0, 0, 0))
+        + chunk(b"IDAT", zlib.compress(rows))
+        + chunk(b"IEND", b"")
+    )
+
+
+class NativeRendererVisualCompareTests(unittest.TestCase):
+    def test_exact_images_pass_all_checks(self):
+        image = MODULE.PpmImage(2, 2, bytes([0, 0, 0, 20, 30, 40] * 2))
+        metrics = MODULE.compare_images(
+            image, image, channel_tolerance=0, coverage_threshold=1
+        )
+        self.assertEqual(metrics["mean_absolute_error"], 0)
+        self.assertEqual(metrics["different_pixel_ratio"], 0)
+        self.assertEqual(metrics["coverage_iou"], 1)
+
+    def test_channel_and_coverage_differences_are_independent(self):
+        native = MODULE.PpmImage(2, 1, bytes([8, 8, 8, 0, 0, 0]))
+        reference = MODULE.PpmImage(2, 1, bytes([10, 10, 10, 9, 0, 0]))
+        metrics = MODULE.compare_images(
+            native, reference, channel_tolerance=2, coverage_threshold=1
+        )
+        self.assertEqual(metrics["different_pixels"], 1)
+        self.assertEqual(metrics["different_pixel_ratio"], 0.5)
+        self.assertEqual(metrics["coverage_iou"], 0.5)
+
+    def test_dimension_mismatch_is_rejected(self):
+        with self.assertRaisesRegex(ValueError, "dimensions differ"):
+            MODULE.compare_images(
+                MODULE.PpmImage(1, 1, b"\0\0\0"),
+                MODULE.PpmImage(2, 1, b"\0" * 6),
+                channel_tolerance=0,
+                coverage_threshold=0,
+            )
+
+    def test_difference_image_amplifies_channel_error(self):
+        with tempfile.TemporaryDirectory() as directory:
+            output = Path(directory) / "difference.ppm"
+            MODULE.write_difference_ppm(
+                output,
+                MODULE.PpmImage(1, 1, bytes([10, 20, 30])),
+                MODULE.PpmImage(1, 1, bytes([12, 18, 40])),
+                4,
+            )
+            self.assertEqual(MODULE.read_ppm(output).pixels, bytes([8, 8, 40]))
+
+    def test_report_exit_code_distinguishes_pass_and_mismatch(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            native = root / "native.ppm"
+            reference = root / "reference.ppm"
+            output = root / "report.json"
+            write_ppm(native, 1, 1, bytes([1, 2, 3]))
+            write_ppm(reference, 1, 1, bytes([1, 2, 3]))
+            self.assertEqual(
+                MODULE.main([str(native), str(reference), "--output", str(output)]),
+                0,
+            )
+            write_ppm(reference, 1, 1, bytes([255, 255, 255]))
+            with contextlib.redirect_stdout(io.StringIO()):
+                self.assertEqual(MODULE.main([str(native), str(reference)]), 2)
+
+    def test_rgba_png_comparison_includes_alpha(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            native = root / "native.png"
+            reference = root / "reference.png"
+            write_png(native, 1, 1, 4, bytes([10, 20, 30, 40]))
+            write_png(reference, 1, 1, 4, bytes([10, 20, 30, 50]))
+            left = MODULE.read_image(native)
+            right = MODULE.read_image(reference)
+            self.assertEqual(left.channels, 4)
+            metrics = MODULE.compare_images(
+                left, right, channel_tolerance=0, coverage_threshold=1
+            )
+            self.assertEqual(metrics["maximum_channel_error"], 10)
+            self.assertEqual(metrics["different_pixels"], 1)
+
+    def test_depth_png_report_declares_depth_scope(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            native = root / "native-depth.png"
+            reference = root / "reference-depth.png"
+            write_png(native, 1, 1, 1, bytes([128]))
+            write_png(reference, 1, 1, 1, bytes([128]))
+            args = MODULE.parse_args(
+                [str(native), str(reference), "--content", "depth"]
+            )
+            report = MODULE.build_report(args)
+            self.assertTrue(report["scope"]["depth"])
+            self.assertFalse(report["scope"]["output_color"])
+
+    def test_crop_selects_identical_region_and_is_reported(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            native = root / "native.ppm"
+            reference = root / "reference.ppm"
+            write_ppm(native, 2, 1, bytes([255, 0, 0, 1, 2, 3]))
+            write_ppm(reference, 2, 1, bytes([0, 255, 0, 1, 2, 3]))
+            args = MODULE.parse_args(
+                [str(native), str(reference), "--crop", "1,0,1,1"]
+            )
+            report = MODULE.build_report(args)
+            self.assertEqual(report["result"], "pass")
+            self.assertEqual(
+                report["inputs"]["crop"],
+                {"left": 1, "top": 0, "width": 1, "height": 1},
+            )
+
+    def test_draw_delta_ignores_unchanged_background(self):
+        native_before = MODULE.PpmImage(2, 1, bytes([0, 0, 0, 0, 0, 0]))
+        native_after = MODULE.PpmImage(2, 1, bytes([10, 20, 30, 0, 0, 0]))
+        reference_before = MODULE.PpmImage(
+            2, 1, bytes([100, 100, 100, 200, 200, 200])
+        )
+        reference_after = MODULE.PpmImage(
+            2, 1, bytes([10, 20, 30, 200, 200, 200])
+        )
+        metrics = MODULE.compare_images(
+            native_after,
+            reference_after,
+            channel_tolerance=0,
+            coverage_threshold=0,
+            native_before=native_before,
+            reference_before=reference_before,
+        )
+        self.assertEqual(metrics["compared_pixels"], 1)
+        self.assertEqual(metrics["coverage_iou"], 1)
+        self.assertEqual(metrics["mean_absolute_error"], 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/tests/test_release_contract.py
+++ b/tools/tests/test_release_contract.py
@@ -43,10 +43,10 @@ class ReleaseContractTests(unittest.TestCase):
 
     def test_rexglue_patches_have_stable_order_and_no_binary_payload(self):
         patches = sorted((ROOT / "patches/rexglue").glob("*.patch"))
-        self.assertEqual(len(patches), 59)
+        self.assertEqual(len(patches), 61)
         self.assertEqual(
             patches[-1].name,
-            "0059-d3d12-isolated-draw-readback.patch",
+            "0061-d3d12-seeded-isolated-replay-targets.patch",
         )
         self.assertEqual(len(patches), len({path.name[:4] for path in patches}))
         for path in patches:


### PR DESCRIPTION
## Summary
- add paired RenderDoc markers around the isolated native replay and authoritative Xenos draw
- seed private replay color/depth targets from live guest attachments while keeping Xenos authoritative and unsuppressed
- add signed-RenderDoc capture/export wrappers, deterministic PNG/PPM comparison, tests, and the NR-02E qualification record

## Qualification
- exact draw signature: 747837906D0BF484
- paired events: native 6880, Xenos 6884; six marker pairs captured
- color draw delta: 122,516 pixels, 0 different, MAE 0, RMSE 0, coverage IoU 1.0
- post-draw depth: 143,360 pixels, 0 different, MAE 0, RMSE 0, coverage IoU 1.0
- Xenos draw preserved; output authority remains Xenos; suppression remains false

## Tests
- python -m unittest discover -s tools/tests -v (123 passed)
- .\tools\check-repository-boundary.ps1 (194 candidate files passed)
- .\tools\build-preview.ps1 -Parallel 8 -JsonEvents
- clean ReXGlue application: 61 patches
- final patch-set SHA-256: A64E7733453625FDECD69D85CD1757E641ACB23B3F3C66EC7DD86760B63EC04A
- final executable SHA-256: F48CB5A43E184DAA780498AAB54844337521ABFF2BBDD2B7364B1CF8C64991CC