### PR TITLE
feat(native-renderer): inventory candidate pass phases

### DIFF
--- a/docs/native-renderer/PASS_INVENTORY.md
+++ b/docs/native-renderer/PASS_INVENTORY.md
@@ -1,0 +1,61 @@
+# Candidate pass inventory
+
+NR-02F must replay a complete target phase, not merely every occurrence of an
+already-qualified draw signature. The pass inventory derives those boundaries
+from a RenderDoc capture before any multi-draw runtime path is enabled.
+
+## Safety boundary
+
+`tools/export-native-renderer-pass-trace.ps1` runs the bundled Python script
+through an official, Authenticode-valid qrenderdoc executable. Both the input
+capture and output report must remain below `.local`. The trace contains only
+event IDs, draw counts, target resource IDs and descriptions, and boundary
+kinds. It does not export images, buffers, textures, shaders, or other game
+payloads.
+
+The offline builder ignores native isolated-replay draws and groups only the
+authoritative Xenos draws. A new phase begins after a clear, copy, resolve,
+present, or dispatch boundary, or when the bound color/depth target tuple
+changes. Every phase is metadata-only and explicitly suppression-ineligible.
+
+Run:
+
+```powershell
+.\tools\export-native-renderer-pass-trace.ps1 `
+  -Capture '.local\qualification\renderdoc-reference\reference_frame1.rdc' `
+  -RenderDocRoot '.local\tools\renderdoc\RenderDoc_64' `
+  -Output '.local\qualification\native-renderer-pass-trace.json'
+
+python .\tools\build-native-renderer-pass-inventory.py `
+  .local\qualification\native-renderer-pass-trace.json `
+  --output .local\qualification\native-renderer-pass-inventory.json
+```
+
+## Qualified discovery result
+
+The 2026-08-28 `open_world_day` RenderDoc frame used for the NR-02E exact
+comparison contains 1,582 authoritative Xenos draws across 412 target phases.
+The builder ignored six injected native replay draws and found all six marked
+authoritative occurrences of candidate `747837906D0BF484`.
+
+Each occurrence begins a two-draw phase on the same 640 by 8,192
+`R16G16B16A16_FLOAT` color target and `D32S8_TYPELESS` depth target. The two
+draws contain 9,304 indices in total: the qualified candidate contributes
+9,300, and one immediately following draw contributes four. The first observed
+phase spans RenderDoc draw events 6884 through 6893; the same two-draw shape
+repeats six times.
+
+This closes the pass-boundary ambiguity but does not yet qualify the second
+draw. NR-02F must identify and contract that four-index follower, replay the
+ordered pair into one retained private target, and compare the complete phase
+against Xenos. Until then, Xenos remains authoritative and suppression remains
+forbidden.
+
+Local evidence hashes:
+
+- pass trace SHA-256:
+  `15BA3B6375AED140ADB55FC08D2FCA17927671D16369840C661BDF81BE6DDB37`;
+- derived inventory SHA-256:
+  `9B71679E0971620D192054BC0216CFD3B6EC46668CDB56F224D0C69491CA25D0`.
+
+The capture and derived reports remain under `.local/qualification`.

--- a/docs/native-renderer/VISUAL_COMPARISON.md
+++ b/docs/native-renderer/VISUAL_COMPARISON.md
@@ -40,7 +40,7 @@ present in the captured frame. Export the first adjacent marker pair with:
 
 ```powershell
 .\tools\export-native-renderer-renderdoc.ps1 `
-  -Capture `.local\qualification\native-renderer-renderdoc-reference\reference_frame1.rdc` `
+  -Capture '.local\qualification\native-renderer-renderdoc-reference\reference_frame1.rdc' `
   -RenderDocRoot '.local\tools\renderdoc\RenderDoc_64' `
   -OutputDir '.local\qualification\renderdoc-reference-export'
 ```
@@ -120,3 +120,7 @@ For the 512 by 280 gameplay crop, both comparisons passed with exact output:
 The isolated and authoritative color PNGs had the same SHA-256, as did their
 pre-draw color PNGs and post-draw depth PNGs. The capture and game-derived
 exports remain local under `.local/qualification`.
+
+The six exact-signature occurrences do not by themselves define the complete
+pass. Their target-phase correlation and the remaining four-index follower are
+documented in [PASS_INVENTORY.md](PASS_INVENTORY.md).

--- a/tools/build-native-renderer-pass-inventory.py
+++ b/tools/build-native-renderer-pass-inventory.py
@@ -1,0 +1,128 @@
+"""Build deterministic target phases from a payload-free RenderDoc trace."""
+
+import argparse
+import hashlib
+import json
+import pathlib
+import sys
+
+
+TRACE_SCHEMA = "pinyon-shift.native-renderer-renderdoc-pass-trace.v1"
+SCHEMA = "pinyon-shift.native-renderer-pass-inventory.v1"
+
+
+def target_key(draw):
+    colors = tuple(
+        (item["resource_id"], item["mip"], item["slice"])
+        for item in draw.get("color_targets", [])
+    )
+    depth = draw.get("depth_target")
+    depth_key = None if depth is None else (
+        depth["resource_id"], depth["mip"], depth["slice"]
+    )
+    return colors, depth_key
+
+
+def build_inventory(trace):
+    if trace.get("schema") != TRACE_SCHEMA:
+        raise ValueError("unsupported pass trace schema")
+    safety = trace.get("safety", {})
+    if safety.get("resource_payload_exported") is not False:
+        raise ValueError("pass trace does not prove its payload-free boundary")
+    events = trace.get("events")
+    if not isinstance(events, list):
+        raise ValueError("pass trace events must be a list")
+
+    phases = []
+    current = None
+    pending_boundaries = []
+    last_event = -1
+    ignored_native_draws = 0
+    authoritative_candidates = 0
+    for event in events:
+        event_id = event.get("event_id")
+        if not isinstance(event_id, int) or event_id < last_event:
+            raise ValueError("pass trace events are not monotonically ordered")
+        last_event = event_id
+        kind = event.get("kind")
+        if kind == "boundary":
+            pending_boundaries.extend(event.get("boundary_kinds", []))
+            continue
+        if kind != "draw":
+            raise ValueError("pass trace contains an unknown event kind")
+        if event.get("isolated_native") is True:
+            ignored_native_draws += 1
+            continue
+
+        key = target_key(event)
+        must_split = current is None or key != current["_key"] or bool(pending_boundaries)
+        if must_split:
+            current = {
+                "ordinal": len(phases) + 1,
+                "first_draw_event": event_id,
+                "last_draw_event": event_id,
+                "draw_count": 0,
+                "index_count_total": 0,
+                "candidate_draw_count": 0,
+                "boundary_before": sorted(set(pending_boundaries)),
+                "color_targets": event.get("color_targets", []),
+                "depth_target": event.get("depth_target"),
+                "_key": key,
+            }
+            phases.append(current)
+        current["last_draw_event"] = event_id
+        current["draw_count"] += 1
+        current["index_count_total"] += int(event.get("index_count", 0))
+        if event.get("authoritative_candidate") is True:
+            current["candidate_draw_count"] += 1
+            authoritative_candidates += 1
+        pending_boundaries = []
+
+    for phase in phases:
+        phase.pop("_key")
+        phase["qualification"] = (
+            "candidate_phase"
+            if phase["candidate_draw_count"]
+            else "metadata_inventory_only"
+        )
+        phase["suppression_eligible"] = False
+    return {
+        "schema": SCHEMA,
+        "capture": trace.get("capture"),
+        "totals": {
+            "phases": len(phases),
+            "draws": sum(phase["draw_count"] for phase in phases),
+            "isolated_native_draws_ignored": ignored_native_draws,
+            "authoritative_candidate_draws": authoritative_candidates,
+        },
+        "phases": phases,
+        "safety": {
+            "metadata_only": True,
+            "xenos_authority": True,
+            "suppression_allowed": False,
+        },
+    }
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser()
+    parser.add_argument("trace", type=pathlib.Path)
+    parser.add_argument("--output", required=True, type=pathlib.Path)
+    args = parser.parse_args(argv)
+    try:
+        trace_bytes = args.trace.read_bytes()
+        trace = json.loads(trace_bytes)
+        inventory = build_inventory(trace)
+        inventory["trace_sha256"] = hashlib.sha256(trace_bytes).hexdigest().upper()
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(
+            json.dumps(inventory, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+        )
+        return 0
+    except (OSError, ValueError, KeyError, TypeError, json.JSONDecodeError) as error:
+        print("native renderer pass inventory failed: {}".format(error), file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/export-native-renderer-pass-trace.ps1
+++ b/tools/export-native-renderer-pass-trace.ps1
@@ -1,0 +1,63 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)]
+    [string]$Capture,
+    [Parameter(Mandatory)]
+    [string]$RenderDocRoot,
+    [Parameter(Mandatory)]
+    [string]$Output
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
+$localRoot = [IO.Path]::GetFullPath((Join-Path $repoRoot '.local'))
+$localPrefix = $localRoot.TrimEnd([IO.Path]::DirectorySeparatorChar) +
+    [IO.Path]::DirectorySeparatorChar
+$resolvedCapture = (Resolve-Path -LiteralPath $Capture).Path
+$resolvedOutput = [IO.Path]::GetFullPath($Output)
+foreach ($item in @(
+        @{ Name = 'Capture'; Value = $resolvedCapture },
+        @{ Name = 'Output'; Value = $resolvedOutput }
+    )) {
+    if (-not $item.Value.StartsWith(
+            $localPrefix, [StringComparison]::OrdinalIgnoreCase)) {
+        throw "$($item.Name) must be below $localRoot"
+    }
+}
+if (Test-Path -LiteralPath $resolvedOutput) {
+    throw "Output already exists: $resolvedOutput"
+}
+
+$qrenderdoc = Join-Path ([IO.Path]::GetFullPath($RenderDocRoot)) 'qrenderdoc.exe'
+if (-not (Test-Path -LiteralPath $qrenderdoc -PathType Leaf)) {
+    throw "qrenderdoc.exe was not found below RenderDocRoot: $RenderDocRoot"
+}
+$signature = Get-AuthenticodeSignature -LiteralPath $qrenderdoc
+if ([string]$signature.Status -ne 'Valid') {
+    throw 'qrenderdoc.exe does not have a valid Authenticode signature'
+}
+
+$script = Join-Path $PSScriptRoot 'export-native-renderer-pass-trace.py'
+$parent = Split-Path $resolvedOutput -Parent
+[void](New-Item -ItemType Directory -Path $parent -Force)
+$savedCapture = $env:PINYON_SHIFT_RENDERDOC_CAPTURE
+$savedOutput = $env:PINYON_SHIFT_RENDERDOC_PASS_TRACE
+try {
+    $env:PINYON_SHIFT_RENDERDOC_CAPTURE = $resolvedCapture
+    $env:PINYON_SHIFT_RENDERDOC_PASS_TRACE = $resolvedOutput
+    $process = Start-Process -FilePath $qrenderdoc `
+        -ArgumentList @('--python', $script) -PassThru -Wait
+    if ($process.ExitCode) {
+        throw "qrenderdoc pass trace exited with code $($process.ExitCode)"
+    }
+}
+finally {
+    $env:PINYON_SHIFT_RENDERDOC_CAPTURE = $savedCapture
+    $env:PINYON_SHIFT_RENDERDOC_PASS_TRACE = $savedOutput
+}
+if (-not (Test-Path -LiteralPath $resolvedOutput -PathType Leaf)) {
+    throw 'qrenderdoc exited without producing the pass trace.'
+}
+Get-Content -LiteralPath $resolvedOutput -Raw | ConvertFrom-Json

--- a/tools/export-native-renderer-pass-trace.py
+++ b/tools/export-native-renderer-pass-trace.py
@@ -1,0 +1,160 @@
+"""Export a payload-free draw/target trace from a RenderDoc capture.
+
+Executed by qrenderdoc's bundled Python runtime. The resulting trace contains
+only event metadata and resource descriptions; it never exports game images or
+resource bytes.
+"""
+
+import hashlib
+import json
+import os
+import sys
+
+import renderdoc as rd
+
+
+ISOLATED_MARKER = "PinyonShift NR-02E isolated native draw"
+XENOS_MARKER = "PinyonShift NR-02E authoritative Xenos draw"
+SCHEMA = "pinyon-shift.native-renderer-renderdoc-pass-trace.v1"
+
+
+def flatten(actions):
+    result = []
+    for action in actions:
+        result.append(action)
+        result.extend(flatten(action.children))
+    return result
+
+
+def descendants(action):
+    result = []
+    for child in action.children:
+        result.append(child)
+        result.extend(descendants(child))
+    return result
+
+
+def sha256(path):
+    digest = hashlib.sha256()
+    with open(path, "rb") as source:
+        for block in iter(lambda: source.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def texture_map(controller):
+    return {str(texture.resourceId): texture for texture in controller.GetTextures()}
+
+
+def target_description(target, textures):
+    if target.resource == rd.ResourceId.Null():
+        return None
+    resource_id = str(target.resource)
+    texture = textures.get(resource_id)
+    if texture is None:
+        raise RuntimeError("target texture description was not found: " + resource_id)
+    return {
+        "resource_id": resource_id,
+        "width": texture.width,
+        "height": texture.height,
+        "mip": getattr(target, "firstMip", 0),
+        "slice": getattr(target, "firstSlice", 0),
+        "format": texture.format.Name(),
+    }
+
+
+def boundary_kinds(action):
+    kinds = []
+    for name in ("Clear", "Copy", "Resolve", "Present", "Dispatch"):
+        flag = getattr(rd.ActionFlags, name, None)
+        if flag is not None and action.flags & flag:
+            kinds.append(name.lower())
+    return kinds
+
+
+def main():
+    capture_path = os.environ["PINYON_SHIFT_RENDERDOC_CAPTURE"]
+    report_path = os.environ["PINYON_SHIFT_RENDERDOC_PASS_TRACE"]
+    capture = rd.OpenCaptureFile()
+    controller = None
+    try:
+        result = capture.OpenFile(capture_path, "", None)
+        if result != rd.ResultCode.Succeeded:
+            raise RuntimeError("could not open capture: {}".format(result))
+        if not capture.LocalReplaySupport():
+            raise RuntimeError("capture does not support local replay")
+        result, controller = capture.OpenCapture(rd.ReplayOptions(), None)
+        if result != rd.ResultCode.Succeeded:
+            raise RuntimeError("could not initialise replay: {}".format(result))
+
+        actions = flatten(controller.GetRootActions())
+        isolated_events = set()
+        authoritative_events = set()
+        for action in actions:
+            if action.customName == ISOLATED_MARKER:
+                isolated_events.update(child.eventId for child in descendants(action))
+            elif action.customName == XENOS_MARKER:
+                authoritative_events.update(child.eventId for child in descendants(action))
+
+        textures = texture_map(controller)
+        events = []
+        for action in actions:
+            kinds = boundary_kinds(action)
+            if kinds:
+                events.append({
+                    "event_id": action.eventId,
+                    "kind": "boundary",
+                    "boundary_kinds": kinds,
+                })
+            if not action.flags & rd.ActionFlags.Drawcall:
+                continue
+            controller.SetFrameEvent(action.eventId, True)
+            pipeline = controller.GetPipelineState()
+            colors = [
+                target_description(target, textures)
+                for target in pipeline.GetOutputTargets()
+                if target.resource != rd.ResourceId.Null()
+            ]
+            events.append({
+                "event_id": action.eventId,
+                "kind": "draw",
+                "index_count": action.numIndices,
+                "instance_count": action.numInstances,
+                "color_targets": colors,
+                "depth_target": target_description(
+                    pipeline.GetDepthTarget(), textures
+                ),
+                "isolated_native": action.eventId in isolated_events,
+                "authoritative_candidate": action.eventId in authoritative_events,
+            })
+
+        events.sort(key=lambda event: (event["event_id"], event["kind"] != "boundary"))
+        report = {
+            "schema": SCHEMA,
+            "capture": {
+                "path": os.path.basename(capture_path),
+                "sha256": sha256(capture_path),
+            },
+            "events": events,
+            "safety": {
+                "resource_payload_exported": False,
+                "xenos_authority": True,
+                "suppression_allowed": False,
+            },
+        }
+        with open(report_path, "w") as output:
+            json.dump(report, output, indent=2, sort_keys=True)
+            output.write("\n")
+        print(report_path)
+        return 0
+    finally:
+        if controller is not None:
+            controller.Shutdown()
+        capture.Shutdown()
+
+
+try:
+    sys.exit(main())
+except Exception as error:
+    sys.stderr.write("native renderer pass trace failed: {}\n".format(error))
+    sys.exit(1)

--- a/tools/tests/test_native_renderer_contract.py
+++ b/tools/tests/test_native_renderer_contract.py
@@ -532,6 +532,28 @@ class NativeRendererContractTests(unittest.TestCase):
         self.assertIn("OutputDir must be below", renderdoc_export_wrapper)
         self.assertIn("qrenderdoc exited without producing", renderdoc_export_wrapper)
 
+        pass_trace = (
+            ROOT / "tools/export-native-renderer-pass-trace.py"
+        ).read_text(encoding="utf-8")
+        self.assertIn(
+            "pinyon-shift.native-renderer-renderdoc-pass-trace.v1", pass_trace
+        )
+        self.assertIn("resource_payload_exported", pass_trace)
+        self.assertIn("authoritative_candidate", pass_trace)
+        self.assertNotIn("SaveTexture", pass_trace)
+        pass_trace_wrapper = (
+            ROOT / "tools/export-native-renderer-pass-trace.ps1"
+        ).read_text(encoding="utf-8")
+        self.assertIn("Get-AuthenticodeSignature", pass_trace_wrapper)
+        self.assertIn("@{ Name = 'Capture'", pass_trace_wrapper)
+        self.assertIn("@{ Name = 'Output'", pass_trace_wrapper)
+        self.assertIn('$($item.Name) must be below', pass_trace_wrapper)
+        pass_inventory = (
+            ROOT / "tools/build-native-renderer-pass-inventory.py"
+        ).read_text(encoding="utf-8")
+        self.assertIn("isolated_native_draws_ignored", pass_inventory)
+        self.assertIn('"suppression_eligible"] = False', pass_inventory)
+
         draw_state_planner = (
             ROOT / "tools/build-native-draw-state-contract.py"
         ).read_text(encoding="utf-8")

--- a/tools/tests/test_native_renderer_pass_inventory.py
+++ b/tools/tests/test_native_renderer_pass_inventory.py
@@ -1,0 +1,93 @@
+import importlib.util
+import sys
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+TOOL = ROOT / "tools" / "build-native-renderer-pass-inventory.py"
+SPEC = importlib.util.spec_from_file_location("native_pass_inventory", TOOL)
+assert SPEC and SPEC.loader
+MODULE = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = MODULE
+SPEC.loader.exec_module(MODULE)
+
+
+def target(resource_id, width=640, height=8192):
+    return {
+        "resource_id": resource_id,
+        "width": width,
+        "height": height,
+        "mip": 0,
+        "slice": 0,
+        "format": "R8G8B8A8_UNORM",
+    }
+
+
+def draw(event_id, color="ResourceId::1", **fields):
+    event = {
+        "event_id": event_id,
+        "kind": "draw",
+        "index_count": 3,
+        "instance_count": 1,
+        "color_targets": [target(color)],
+        "depth_target": target("ResourceId::2"),
+        "isolated_native": False,
+        "authoritative_candidate": False,
+    }
+    event.update(fields)
+    return event
+
+
+def trace(events, payload_exported=False):
+    return {
+        "schema": MODULE.TRACE_SCHEMA,
+        "capture": {"path": "fixture.rdc", "sha256": "A" * 64},
+        "events": events,
+        "safety": {"resource_payload_exported": payload_exported},
+    }
+
+
+class NativeRendererPassInventoryTests(unittest.TestCase):
+    def test_groups_contiguous_xenos_draws_and_ignores_native_replay(self):
+        inventory = MODULE.build_inventory(trace([
+            draw(10),
+            draw(11, isolated_native=True),
+            draw(12, authoritative_candidate=True),
+            draw(13),
+        ]))
+        self.assertEqual(inventory["totals"]["phases"], 1)
+        self.assertEqual(inventory["totals"]["draws"], 3)
+        self.assertEqual(inventory["totals"]["isolated_native_draws_ignored"], 1)
+        self.assertEqual(inventory["totals"]["authoritative_candidate_draws"], 1)
+        self.assertEqual(inventory["phases"][0]["candidate_draw_count"], 1)
+        self.assertFalse(inventory["phases"][0]["suppression_eligible"])
+
+    def test_splits_on_explicit_boundary_and_target_change(self):
+        inventory = MODULE.build_inventory(trace([
+            draw(1),
+            {"event_id": 2, "kind": "boundary", "boundary_kinds": ["clear"]},
+            draw(3),
+            draw(4, color="ResourceId::9"),
+        ]))
+        self.assertEqual(inventory["totals"]["phases"], 3)
+        self.assertEqual(inventory["phases"][1]["boundary_before"], ["clear"])
+        self.assertEqual(inventory["phases"][2]["boundary_before"], [])
+
+    def test_rejects_payload_export_and_unordered_events(self):
+        with self.assertRaisesRegex(ValueError, "payload-free"):
+            MODULE.build_inventory(trace([], payload_exported=True))
+        with self.assertRaisesRegex(ValueError, "monotonically"):
+            MODULE.build_inventory(trace([draw(2), draw(1)]))
+
+    def test_rejects_unknown_schema_and_event_kind(self):
+        document = trace([])
+        document["schema"] = "unknown"
+        with self.assertRaisesRegex(ValueError, "unsupported"):
+            MODULE.build_inventory(document)
+        with self.assertRaisesRegex(ValueError, "unknown event"):
+            MODULE.build_inventory(trace([{"event_id": 1, "kind": "mystery"}]))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- export a payload-free RenderDoc draw/target trace through an Authenticode-valid qrenderdoc
- deterministically group authoritative Xenos draws into target phases while ignoring injected native replay draws
- record the NR-02F discovery result and keep every phase explicitly suppression-ineligible

## Qualified result
- 1,582 authoritative Xenos draws across 412 phases
- six injected native replay draws ignored
- all six authoritative occurrences of 747837906D0BF484 found
- each candidate occurrence begins a two-draw phase on one 640x8192 R16G16B16A16_FLOAT color target and D32S8_TYPELESS depth target
- each phase contains 9,304 indices: the qualified 9,300-index draw plus one four-index follower
- Xenos authority preserved; no resource payload exported; suppression remains forbidden

## Tests
- python -m unittest discover -s tools/tests -v (127 passed)
- .\tools\check-repository-boundary.ps1 (199 candidate files passed)
- qualified RenderDoc pass trace and deterministic inventory generated from reference_frame8134.rdc