### PR TITLE
feat(native-renderer): contract candidate pass follower

### DIFF
--- a/docs/native-renderer/PASS_INVENTORY.md
+++ b/docs/native-renderer/PASS_INVENTORY.md
@@ -45,17 +45,52 @@ draws contain 9,304 indices in total: the qualified candidate contributes
 phase spans RenderDoc draw events 6884 through 6893; the same two-draw shape
 repeats six times.
 
-This closes the pass-boundary ambiguity but does not yet qualify the second
-draw. NR-02F must identify and contract that four-index follower, replay the
-ordered pair into one retained private target, and compare the complete phase
-against Xenos. Until then, Xenos remains authoritative and suppression remains
-forbidden.
+This closes the pass-boundary ambiguity. A bounded runtime scan can contract
+the prepared draw immediately following the anchor without reading guest
+payloads or changing rendering:
+
+```powershell
+.\tools\capture-native-renderer-census.ps1 `
+  -StateRoot "$env:LOCALAPPDATA\PinyonShift\source\0.1.0\.local\preview" `
+  -Scene open_world_day `
+  -PassAnchorSignature 747837906D0BF484
+
+python .\tools\select-native-renderer-pass-follower.py `
+  .local\native-renderer\pass-follower\run-1-census.json `
+  .local\native-renderer\pass-follower\run-2-census.json `
+  --anchor 747837906D0BF484 `
+  --output .local\native-renderer\pass-follower\contract.json
+```
+
+## Qualified follower contract
+
+Two independent AppData-backed `open_world_day` runs on 2026-08-28 observed
+the same draw immediately after the anchor. Its prepared signature is
+`1D253A52B55C9FB3`; both runs placed it at draw 119 after anchor draw 118 in
+the same frame. The frame sequences differed (1,923 and 4,714), demonstrating
+that the contract is not tied to a fixed frame number.
+
+The follower uses vertex shader `21FBB5F33759B350`, pixel shader
+`CF453BD52292E8E8`, prepared pipeline hash `E08F2FEEA79DC6FE`, primitive 13,
+auto-index source selection, four elements, one vertex binding and attribute,
+and one texture fetch. Shader specialization masks, pipeline state, and all
+recorded dependency flags matched across both processes. It is not an isolated
+draw candidate because it uses the auto-index path; that is an expected
+contract property, not drift.
+
+This qualifies the ordered phase shape and its two prepared signatures. NR-02F
+must next replay the ordered pair into one retained private target and compare
+the complete phase against Xenos. Until then, Xenos remains authoritative and
+suppression remains forbidden.
 
 Local evidence hashes:
 
 - pass trace SHA-256:
   `15BA3B6375AED140ADB55FC08D2FCA17927671D16369840C661BDF81BE6DDB37`;
 - derived inventory SHA-256:
-  `9B71679E0971620D192054BC0216CFD3B6EC46668CDB56F224D0C69491CA25D0`.
+  `9B71679E0971620D192054BC0216CFD3B6EC46668CDB56F224D0C69491CA25D0`;
+- two-run follower contract SHA-256:
+  `9F1CC53C8D7989EB3EC113D2215848EDA2D1DFD127D57C4F8BAA73A5DEB7923A`.
 
-The capture and derived reports remain under `.local/qualification`.
+The capture and derived reports remain under `.local/qualification` and
+`.local/native-renderer/pass-follower`.

--- a/src/native_renderer/graphics_hooks.cpp
+++ b/src/native_renderer/graphics_hooks.cpp
@@ -120,6 +120,19 @@ struct IsolatedDrawState {
 
 IsolatedDrawState g_isolated_draw;
 
+struct PassFollowerState {
+  uint64_t target_signature = 0;
+  uint64_t anchor_frame = 0;
+  uint64_t anchor_draw = 0;
+  uint64_t adjacency_mismatches = 0;
+  bool requested = false;
+  bool valid = true;
+  bool awaiting_follower = false;
+  bool completed = false;
+};
+
+PassFollowerState g_pass_follower;
+
 void ConfigureSignatureScan(const char *name, uint64_t &target_signature,
                             bool &requested, bool &valid) {
   char *value = nullptr;
@@ -148,6 +161,14 @@ void ConfigureIndexScan() {
   ConfigureSignatureScan("PINYON_SHIFT_NATIVE_RENDERER_INDEX_SCAN_SIGNATURE",
                          g_index_scan.target_signature,
                          g_index_scan.requested, g_index_scan.valid);
+}
+
+void ConfigurePassFollower() {
+  g_pass_follower = {};
+  ConfigureSignatureScan(
+      "PINYON_SHIFT_NATIVE_RENDERER_PASS_ANCHOR_SIGNATURE",
+      g_pass_follower.target_signature, g_pass_follower.requested,
+      g_pass_follower.valid);
 }
 
 void ConfigureTextureScan() {
@@ -1528,13 +1549,88 @@ void ObservePreparedDraw(
     auto sample = g_pending_candidate.sample;
     sample.vertex_shader_hash = observation.vertex_shader_hash;
     sample.pixel_shader_hash = observation.pixel_shader_hash;
-    g_isolated_draw.prepared_signature = CandidateSignature(
+    const uint64_t prepared_signature = CandidateSignature(
         sample, g_pending_candidate.samples_resolved_target, observation);
+    g_isolated_draw.prepared_signature = prepared_signature;
     g_isolated_draw.frame = sample.frame_sequence;
     g_isolated_draw.draw = sample.draw_sequence;
     g_isolated_draw.prepared_candidate_eligible = IsIsolatedDrawEligible(
         sample, g_pending_candidate.samples_resolved_target, observation);
     g_isolated_draw.prepared_candidate_valid = true;
+    if (g_pass_follower.requested && g_pass_follower.valid &&
+        !g_pass_follower.completed) {
+      if (g_pass_follower.awaiting_follower) {
+        if (sample.frame_sequence == g_pass_follower.anchor_frame &&
+            sample.draw_sequence == g_pass_follower.anchor_draw + 1) {
+          const bool query_draw = sample.viz_query_condition ||
+                                  (sample.pa_sc_viz_query & 1);
+          const std::string pipeline_state = fmt::format(
+              "color_mask={:08X};blend={:08X}:{:08X}:{:08X}:{:08X};"
+              "depth={:08X};raster={:08X};vertex={:08X}",
+              sample.rb_color_mask, sample.rb_blendcontrol[0],
+              sample.rb_blendcontrol[1], sample.rb_blendcontrol[2],
+              sample.rb_blendcontrol[3], sample.rb_depthcontrol,
+              sample.pa_su_sc_mode_cntl, sample.pa_su_vtx_cntl);
+          pinyon_shift::diagnostics::RecordEvent(
+              "native_renderer.census.pass_follower",
+              {{"anchor_signature",
+                fmt::format("{:016X}", g_pass_follower.target_signature)},
+               {"follower_signature",
+                fmt::format("{:016X}", prepared_signature)},
+               {"anchor_frame", std::to_string(g_pass_follower.anchor_frame)},
+               {"anchor_draw", std::to_string(g_pass_follower.anchor_draw)},
+               {"follower_frame", std::to_string(sample.frame_sequence)},
+               {"follower_draw", std::to_string(sample.draw_sequence)},
+               {"vertex_shader",
+                fmt::format("{:016X}", sample.vertex_shader_hash)},
+               {"pixel_shader", fmt::format("{:016X}", sample.pixel_shader_hash)},
+               {"vertex_specialization_mask",
+                fmt::format("{:016X}", observation.vertex_specialization_mask)},
+               {"pixel_specialization_mask",
+                fmt::format("{:016X}", observation.pixel_specialization_mask)},
+               {"prepared_pipeline_hash",
+                fmt::format("{:016X}", PreparedPipelineHash(observation))},
+               {"primitive", std::to_string(sample.primitive_type)},
+               {"source_select", std::to_string(sample.source_select)},
+               {"indexed", sample.indexed ? "true" : "false"},
+               {"index_count", std::to_string(sample.index_count)},
+               {"index_state",
+                fmt::format("format={};endianness={}", sample.index_format,
+                            sample.index_endianness)},
+               {"vertex_binding_count",
+                std::to_string(sample.vertex_binding_count)},
+               {"vertex_attribute_count",
+                std::to_string(sample.vertex_attribute_count)},
+               {"texture_fetch_count",
+                std::to_string(std::popcount(sample.texture_fetch_mask))},
+               {"pipeline_state", pipeline_state},
+               {"query", query_draw ? "true" : "false"},
+               {"memexport", sample.vertex_memexport ? "true" : "false"},
+               {"resolved_input",
+                g_pending_candidate.samples_resolved_target ? "true" : "false"},
+               {"mechanically_eligible",
+                IsIsolatedDrawEligible(
+                    sample, g_pending_candidate.samples_resolved_target,
+                    observation)
+                    ? "true"
+                    : "false"},
+               {"qualification", "metadata_contract_only"},
+               {"xenos_draw", "preserved"},
+               {"native_draw", "false"},
+               {"suppression_eligible", "false"}});
+          g_pass_follower.completed = true;
+        } else {
+          ++g_pass_follower.adjacency_mismatches;
+        }
+        g_pass_follower.awaiting_follower = false;
+      }
+      if (!g_pass_follower.completed &&
+          prepared_signature == g_pass_follower.target_signature) {
+        g_pass_follower.anchor_frame = sample.frame_sequence;
+        g_pass_follower.anchor_draw = sample.draw_sequence;
+        g_pass_follower.awaiting_follower = true;
+      }
+    }
     RecordCandidate(sample, g_pending_candidate.samples_resolved_target,
                     observation);
     g_pending_candidate.valid = false;
@@ -2413,6 +2509,7 @@ void InstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system) {
   ConfigureTextureScan();
   ConfigureReplaySnapshot();
   ConfigureIsolatedDraw();
+  ConfigurePassFollower();
   g_graphics_census_installed = true;
   graphics_system->SetDrawObserver(&ObserveDraw);
   graphics_system->SetCopyObserver(&ObserveCopy);
@@ -2458,6 +2555,20 @@ void InstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system) {
        {"maximum_total_bytes",
         std::to_string(kMaximumTextureScanTotalBytes)},
        {"mode", "bounded_diagnostic_read"}});
+  diagnostics::RecordEvent(
+      "native_renderer.census.pass_follower_config",
+      {{"status", !g_pass_follower.requested
+                      ? "disabled"
+                      : (g_pass_follower.valid ? "armed" : "invalid_signature")},
+       {"anchor_signature",
+        g_pass_follower.valid && g_pass_follower.requested
+            ? fmt::format("{:016X}", g_pass_follower.target_signature)
+            : ""},
+       {"maximum_followers", "1"},
+       {"mode", "bounded_metadata"},
+       {"xenos_draw", "preserved"},
+       {"native_draw", "false"},
+       {"suppression_eligible", "false"}});
   diagnostics::RecordEvent(
       "native_renderer.snapshot.config",
       {{"status", !g_replay_snapshot.requested
@@ -2537,6 +2648,20 @@ void UninstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system) {
          {"status", "not_observed"},
          {"guest_payload_read", "false"},
          {"native_upload", "false"},
+         {"native_draw", "false"},
+         {"suppression_eligible", "false"}});
+  }
+  if (g_pass_follower.requested && g_pass_follower.valid &&
+      !g_pass_follower.completed) {
+    diagnostics::RecordEvent(
+        "native_renderer.census.pass_follower",
+        {{"anchor_signature",
+          fmt::format("{:016X}", g_pass_follower.target_signature)},
+         {"status", "not_observed"},
+         {"adjacency_mismatches",
+          std::to_string(g_pass_follower.adjacency_mismatches)},
+         {"qualification", "metadata_contract_only"},
+         {"xenos_draw", "preserved"},
          {"native_draw", "false"},
          {"suppression_eligible", "false"}});
   }

--- a/tools/capture-native-renderer-census.ps1
+++ b/tools/capture-native-renderer-census.ps1
@@ -16,6 +16,8 @@ param(
     [ValidatePattern('^[0-9A-Fa-f]{16}$')]
     [string]$IsolatedDrawSignature,
     [string]$IsolatedDrawDir,
+    [ValidatePattern('^[0-9A-Fa-f]{16}$')]
+    [string]$PassAnchorSignature,
     [switch]$Json
 )
 
@@ -102,6 +104,7 @@ $savedReplaySnapshot = $env:PINYON_SHIFT_NATIVE_RENDERER_SNAPSHOT_SIGNATURE
 $savedReplaySnapshotDir = $env:PINYON_SHIFT_NATIVE_RENDERER_SNAPSHOT_DIR
 $savedIsolatedDraw = $env:PINYON_SHIFT_NATIVE_RENDERER_ISOLATED_DRAW_SIGNATURE
 $savedIsolatedDrawDir = $env:PINYON_SHIFT_NATIVE_RENDERER_ISOLATED_DRAW_DIR
+$savedPassAnchor = $env:PINYON_SHIFT_NATIVE_RENDERER_PASS_ANCHOR_SIGNATURE
 try {
     $env:REX_PINYON_SHIFT_NATIVE_RENDERER_CENSUS = 'true'
     $env:PINYON_SHIFT_NATIVE_RENDERER_SCENE = $Scene
@@ -111,6 +114,7 @@ try {
     $env:PINYON_SHIFT_NATIVE_RENDERER_SNAPSHOT_DIR = $ReplaySnapshotDir
     $env:PINYON_SHIFT_NATIVE_RENDERER_ISOLATED_DRAW_SIGNATURE = $IsolatedDrawSignature
     $env:PINYON_SHIFT_NATIVE_RENDERER_ISOLATED_DRAW_DIR = $IsolatedDrawDir
+    $env:PINYON_SHIFT_NATIVE_RENDERER_PASS_ANCHOR_SIGNATURE = $PassAnchorSignature
     & (Join-Path $PSScriptRoot 'launch-preview.ps1') `
         -StateRoot $resolvedStateRoot -ShaderCaptureDir $ShaderCaptureDir `
         -Json:$Json
@@ -124,4 +128,5 @@ finally {
     $env:PINYON_SHIFT_NATIVE_RENDERER_SNAPSHOT_DIR = $savedReplaySnapshotDir
     $env:PINYON_SHIFT_NATIVE_RENDERER_ISOLATED_DRAW_SIGNATURE = $savedIsolatedDraw
     $env:PINYON_SHIFT_NATIVE_RENDERER_ISOLATED_DRAW_DIR = $savedIsolatedDrawDir
+    $env:PINYON_SHIFT_NATIVE_RENDERER_PASS_ANCHOR_SIGNATURE = $savedPassAnchor
 }

--- a/tools/select-native-renderer-pass-follower.py
+++ b/tools/select-native-renderer-pass-follower.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""Promote a stable adjacent pass follower from independent census captures."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+
+SCHEMA = "pinyon-shift.native-renderer-pass-follower.v1"
+CONTRACT_FIELDS = (
+    "follower_signature",
+    "vertex_shader",
+    "pixel_shader",
+    "vertex_specialization_mask",
+    "pixel_specialization_mask",
+    "prepared_pipeline_hash",
+    "primitive",
+    "source_select",
+    "indexed",
+    "index_count",
+    "index_state",
+    "vertex_binding_count",
+    "vertex_attribute_count",
+    "texture_fetch_count",
+    "pipeline_state",
+    "query",
+    "memexport",
+    "resolved_input",
+    "mechanically_eligible",
+)
+
+
+def load_capture(path: Path, anchor: str) -> dict[str, Any]:
+    summary = json.loads(path.read_text(encoding="utf-8"))
+    followers = [
+        item
+        for item in summary.get("pass_followers", [])
+        if item.get("anchor_signature") == anchor and item.get("status") != "not_observed"
+    ]
+    if len(followers) != 1:
+        raise ValueError(f"{path}: expected exactly one observed follower, found {len(followers)}")
+    follower = followers[0]
+    if int(follower["follower_frame"]) != int(follower["anchor_frame"]):
+        raise ValueError(f"{path}: follower crosses a frame boundary")
+    if int(follower["follower_draw"]) != int(follower["anchor_draw"]) + 1:
+        raise ValueError(f"{path}: follower is not draw-adjacent")
+    for field in ("query", "memexport", "resolved_input", "suppression_eligible"):
+        if follower.get(field) != "false":
+            raise ValueError(f"{path}: unsafe follower field {field}={follower.get(field)!r}")
+    if follower.get("native_draw") != "false" or follower.get("xenos_draw") != "preserved":
+        raise ValueError(f"{path}: Xenos authority was not preserved")
+    return follower
+
+
+def select(paths: list[Path], anchor: str) -> dict[str, Any]:
+    if len(paths) < 2:
+        raise ValueError("at least two independent captures are required")
+    records = [load_capture(path, anchor) for path in paths]
+    contract = {field: records[0].get(field) for field in CONTRACT_FIELDS}
+    for path, record in zip(paths[1:], records[1:]):
+        drift = [field for field, expected in contract.items() if record.get(field) != expected]
+        if drift:
+            raise ValueError(f"{path}: follower contract drift: {', '.join(drift)}")
+    return {
+        "schema": SCHEMA,
+        "anchor_signature": anchor,
+        "follower_signature": contract["follower_signature"],
+        "captures": len(paths),
+        "contract": contract,
+        "qualification": "stable_adjacent_metadata_contract",
+        "safety": {
+            "guest_payload_read": False,
+            "native_upload": False,
+            "native_draw": False,
+            "suppression_allowed": False,
+            "xenos_authority": True,
+        },
+        "sources": [str(path) for path in paths],
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("captures", nargs="+", type=Path)
+    parser.add_argument("--anchor", required=True)
+    parser.add_argument("--output", required=True, type=Path)
+    args = parser.parse_args()
+    result = select(args.captures, args.anchor.upper())
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(result, indent=2) + "\n", encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/summarize-native-renderer-census.py
+++ b/tools/summarize-native-renderer-census.py
@@ -139,6 +139,7 @@ def summarize(
     index_scans: list[dict[str, Any]] = []
     texture_scans: list[dict[str, Any]] = []
     texture_fingerprints: list[dict[str, Any]] = []
+    pass_followers: list[dict[str, Any]] = []
     dependencies: dict[str, dict[str, Any]] = {}
     resolve_targets: dict[str, dict[str, Any]] = {}
     totals = {
@@ -222,6 +223,8 @@ def summarize(
             texture_scans.append(dict(event))
         elif kind == f"{PREFIX}texture_fingerprint":
             texture_fingerprints.append(dict(event))
+        elif kind == f"{PREFIX}pass_follower":
+            pass_followers.append(dict(event))
         elif kind == f"{PREFIX}resolve_window":
             for key in (
                 "resolves",
@@ -293,6 +296,7 @@ def summarize(
         "index_scans": [clean(record) for record in index_scans],
         "texture_scans": [clean(record) for record in texture_scans],
         "texture_fingerprints": [clean(record) for record in texture_fingerprints],
+        "pass_followers": [clean(record) for record in pass_followers],
         "resolve_dependencies": [
             clean(record) for _, record in sorted(dependencies.items())
         ],

--- a/tools/tests/test_native_renderer_census.py
+++ b/tools/tests/test_native_renderer_census.py
@@ -146,6 +146,15 @@ class NativeRendererCensusTests(unittest.TestCase):
                 "guest_payload_read": "bounded_texture_only",
             },
             {
+                "event": "native_renderer.census.pass_follower",
+                "session": "new",
+                "anchor_signature": "CANDIDATE",
+                "follower_signature": "FOLLOWER",
+                "anchor_draw": "41",
+                "follower_draw": "42",
+                "suppression_eligible": "false",
+            },
+            {
                 "event": "native_renderer.census.resolve_window",
                 "session": "new",
                 "resolves": "7",
@@ -210,6 +219,7 @@ class NativeRendererCensusTests(unittest.TestCase):
             "1111111111111111",
             result["texture_fingerprints"][0]["base_hash"],
         )
+        self.assertEqual("FOLLOWER", result["pass_followers"][0]["follower_signature"])
         self.assertEqual(
             "bounded_index_and_texture_payload",
             result["safety"]["guest_cpu_reads"],

--- a/tools/tests/test_native_renderer_contract.py
+++ b/tools/tests/test_native_renderer_contract.py
@@ -424,6 +424,22 @@ class NativeRendererContractTests(unittest.TestCase):
         self.assertIn('"native_draw", "false"', scanner)
         self.assertIn('"suppression_eligible", "false"', scanner)
         self.assertNotIn("SetDrawSuppression", scanner)
+        self.assertIn("PINYON_SHIFT_NATIVE_RENDERER_PASS_ANCHOR_SIGNATURE", scanner)
+        self.assertIn('"native_renderer.census.pass_follower"', scanner)
+        self.assertIn("sample.draw_sequence == g_pass_follower.anchor_draw + 1", scanner)
+
+        census_capture = (
+            ROOT / "tools/capture-native-renderer-census.ps1"
+        ).read_text(encoding="utf-8")
+        self.assertIn("PassAnchorSignature", census_capture)
+        self.assertIn("PINYON_SHIFT_NATIVE_RENDERER_PASS_ANCHOR_SIGNATURE", census_capture)
+
+        follower_selector = (
+            ROOT / "tools/select-native-renderer-pass-follower.py"
+        ).read_text(encoding="utf-8")
+        self.assertIn("pinyon-shift.native-renderer-pass-follower.v1", follower_selector)
+        self.assertIn('"suppression_allowed": False', follower_selector)
+        self.assertIn('"xenos_authority": True', follower_selector)
 
         isolated_replay_patch = (
             ROOT / "patches/rexglue/0058-d3d12-isolated-draw-replay.patch"

--- a/tools/tests/test_native_renderer_pass_follower.py
+++ b/tools/tests/test_native_renderer_pass_follower.py
@@ -1,0 +1,68 @@
+import importlib.util
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SPEC = importlib.util.spec_from_file_location(
+    "native_renderer_pass_follower",
+    ROOT / "tools/select-native-renderer-pass-follower.py",
+)
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+def follower(signature="FOLLOWER"):
+    return {
+        "anchor_signature": "ANCHOR",
+        "follower_signature": signature,
+        "anchor_frame": "10",
+        "anchor_draw": "20",
+        "follower_frame": "10",
+        "follower_draw": "21",
+        "query": "false",
+        "memexport": "false",
+        "resolved_input": "false",
+        "suppression_eligible": "false",
+        "native_draw": "false",
+        "xenos_draw": "preserved",
+    }
+
+
+class PassFollowerTests(unittest.TestCase):
+    def write(self, root, name, record):
+        path = Path(root) / name
+        path.write_text(json.dumps({"pass_followers": [record]}), encoding="utf-8")
+        return path
+
+    def test_selects_stable_adjacent_follower(self):
+        with tempfile.TemporaryDirectory() as temp:
+            paths = [self.write(temp, f"run-{i}.json", follower()) for i in range(2)]
+            result = MODULE.select(paths, "ANCHOR")
+        self.assertEqual("FOLLOWER", result["follower_signature"])
+        self.assertEqual(2, result["captures"])
+        self.assertTrue(result["safety"]["xenos_authority"])
+        self.assertFalse(result["safety"]["suppression_allowed"])
+
+    def test_rejects_contract_drift(self):
+        with tempfile.TemporaryDirectory() as temp:
+            paths = [
+                self.write(temp, "run-1.json", follower()),
+                self.write(temp, "run-2.json", follower("DRIFT")),
+            ]
+            with self.assertRaisesRegex(ValueError, "contract drift"):
+                MODULE.select(paths, "ANCHOR")
+
+    def test_requires_draw_adjacency(self):
+        record = follower()
+        record["follower_draw"] = "22"
+        with tempfile.TemporaryDirectory() as temp:
+            path = self.write(temp, "run.json", record)
+            with self.assertRaisesRegex(ValueError, "draw-adjacent"):
+                MODULE.load_capture(path, "ANCHOR")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary\n- add a bounded prepared-draw scan for the draw immediately following the qualified anchor\n- require two independent census summaries to match before promoting the follower contract\n- qualify follower 1D253A52B55C9FB3 across two AppData-backed open-world runs\n- keep Xenos authoritative with native draw and suppression disabled\n\n## Validation\n- python -m unittest discover -s tools/tests -p 'test_*.py' (130 passed)\n- .\\tools\\check-repository-boundary.ps1 (201 candidate files)\n- .\\tools\\build-preview.ps1 -Parallel 8 -JsonEvents\n- two AppData-backed open_world_day captures (frame 1923 and frame 4714)\n- stable follower contract SHA-256: 9F1CC53C8D7989EB3EC113D2215848EDA2D1DFD127D57C4F8BAA73A5DEB7923A