### PR TITLE
feat(native-renderer): replay retained candidate pass

### DIFF
--- a/docs/native-renderer/PASS_INVENTORY.md
+++ b/docs/native-renderer/PASS_INVENTORY.md
@@ -87,10 +87,35 @@ contains the expected sky and horizon phase prefix, the process exited normally
 with code zero, and the structured result retained `xenos_draw=preserved`,
 `output_authority=xenos`, and `suppression_eligible=false`.
 
-This qualifies the ordered phase shape, its two prepared signatures, and each
-draw's isolated replay path. NR-02F must next replay the ordered pair into one
-retained private target and compare the complete phase against Xenos. Until
-then, Xenos remains authoritative and suppression remains forbidden.
+## Retained-pass runtime result
+
+NR-02F now replays the ordered pair into one retained private target. The
+indexed anchor seeds and retains the isolated color and depth attachments; the
+immediately adjacent AutoIndex follower resumes those same attachments before
+the private target is released. Each original guest draw still executes.
+
+AppData-backed sessions `20260828T161429Z-p41368` and
+`20260828T162849Z-p8536` both recorded the complete pass. The latter recorded
+anchor draw 117 and follower draw 118 at frame 3,190, produced an asynchronous
+readback from the 640 by 8,192 private target, then recorded a second retained
+pair at draws 126 and 127 in the same frame. Both readback crops have SHA-256
+`AF82E49BAE46AA67B0255BC3B1B5120BA7F69205BB8526F1DB9F8ED151090150`,
+confirming deterministic output across the two runs. The crop contains the
+expected combined sky and horizon phase output. Both processes exited normally
+with code zero.
+
+The structured results report `draw_count=2`, `status=recorded`,
+`xenos_draw=preserved`, `output_authority=xenos`, and
+`suppression_eligible=false`. The one-shot repeat result also reports
+`status=recorded`, proving that the retained target can be recreated after the
+diagnostic readback for later frame-debugger runs.
+
+RenderDoc captures taken after the readback contained only the final 3840 by
+2160 presentation draw and no Pinyon marker regions; the metadata-only trace
+therefore cannot be used as a visual-equivalence result. A complete-pass Xenos
+image comparison remains an explicit gate before any suppression work. The
+runtime replay itself is qualified only as an isolated, default-off diagnostic.
+Xenos remains authoritative and suppression remains forbidden.
 
 Local evidence hashes:
 
@@ -99,7 +124,10 @@ Local evidence hashes:
 - derived inventory SHA-256:
   `9B71679E0971620D192054BC0216CFD3B6EC46668CDB56F224D0C69491CA25D0`;
 - two-run follower contract SHA-256:
-  `9F1CC53C8D7989EB3EC113D2215848EDA2D1DFD127D57C4F8BAA73A5DEB7923A`.
+  `9F1CC53C8D7989EB3EC113D2215848EDA2D1DFD127D57C4F8BAA73A5DEB7923A`;
+- retained-pass readback metadata SHA-256:
+  `B0C6395F5C8BD6294A54837C94E85536BFBEFA99E340DCDA5A8C442829E954CB`.
 
-The capture and derived reports remain under `.local/qualification` and
-`.local/native-renderer/pass-follower`.
+The capture and derived reports remain under `.local/qualification`,
+`.local/native-renderer/pass-follower`, and
+`.local/native-renderer/pass-replay`.

--- a/patches/rexglue/0063-d3d12-retained-isolated-pass-target.patch
+++ b/patches/rexglue/0063-d3d12-retained-isolated-pass-target.patch
@@ -1,0 +1,140 @@
+diff --git a/include/rex/system/interfaces/graphics.h b/include/rex/system/interfaces/graphics.h
+--- a/include/rex/system/interfaces/graphics.h
++++ b/include/rex/system/interfaces/graphics.h
+@@ -303,6 +303,10 @@ struct GraphicsIsolatedDrawRequest {
+   bool requested = false;
+   bool readback_requested = false;
+   bool reference_marker_requested = false;
++  bool retain_target = false;
++  // Rebind the retained private target without copying the guest target. This
++  // is valid only for the immediately following draw of an isolated pass.
++  bool reuse_target = false;
+   GraphicsIsolatedDrawCompletion completion = nullptr;
+   GraphicsIsolatedDrawReadbackCompletion readback_completion = nullptr;
+ };
+diff --git a/include/rex/graphics/d3d12/render_target_cache.h b/include/rex/graphics/d3d12/render_target_cache.h
+--- a/include/rex/graphics/d3d12/render_target_cache.h
++++ b/include/rex/graphics/d3d12/render_target_cache.h
+@@ -99,6 +99,7 @@ class D3D12RenderTargetCache final : public RenderTargetCache {
+   // EndIsolatedReplayTarget restores the guest bindings without changing the
+   // guest attachments or ownership.
+   bool BeginIsolatedReplayTarget(uint32_t& width_out, uint32_t& height_out);
++  bool ResumeIsolatedReplayTarget(uint32_t& width_out, uint32_t& height_out);
+   system::GraphicsIsolatedDrawReadbackStatus QueueIsolatedReplayReadback(
+       system::GraphicsIsolatedDrawReadbackCompletion completion,
+       uint32_t* failure_detail_out);
+diff --git a/src/graphics/d3d12/render_target_cache.cpp b/src/graphics/d3d12/render_target_cache.cpp
+--- a/src/graphics/d3d12/render_target_cache.cpp
++++ b/src/graphics/d3d12/render_target_cache.cpp
+@@ -1818,6 +1818,42 @@ bool D3D12RenderTargetCache::BeginIsolatedReplayTarget(
+   return true;
+ }
+ 
++bool D3D12RenderTargetCache::ResumeIsolatedReplayTarget(
++    uint32_t& width_out, uint32_t& height_out) {
++  width_out = 0;
++  height_out = 0;
++  if (GetPath() != Path::kHostRenderTargets ||
++      !isolated_replay_depth_target_ || !isolated_replay_color_target_) {
++    return false;
++  }
++  RenderTarget* const* guest_targets =
++      last_update_accumulated_render_targets();
++  if (!guest_targets[0] || !guest_targets[1] ||
++      guest_targets[0]->key() != isolated_replay_depth_target_->key() ||
++      guest_targets[1]->key() != isolated_replay_color_target_->key()) {
++    return false;
++  }
++  for (uint32_t i = 2; i <= xenos::kMaxColorRenderTargets; ++i) {
++    if (guest_targets[i]) {
++      return false;
++    }
++  }
++
++  auto* isolated_depth = static_cast<D3D12RenderTarget*>(
++      isolated_replay_depth_target_.get());
++  auto* isolated_color = static_cast<D3D12RenderTarget*>(
++      isolated_replay_color_target_.get());
++  const D3D12_RESOURCE_DESC color_desc = isolated_color->resource()->GetDesc();
++  width_out = uint32_t(color_desc.Width);
++  height_out = color_desc.Height;
++  RenderTarget* isolated_targets[1 + xenos::kMaxColorRenderTargets] = {};
++  isolated_targets[0] = isolated_depth;
++  isolated_targets[1] = isolated_color;
++  SetCommandListRenderTargets(isolated_targets);
++  command_processor_.SubmitBarriers();
++  return true;
++}
++
+ system::GraphicsIsolatedDrawReadbackStatus
+ D3D12RenderTargetCache::QueueIsolatedReplayReadback(
+     system::GraphicsIsolatedDrawReadbackCompletion completion,
+diff --git a/src/graphics/d3d12/command_processor.cpp b/src/graphics/d3d12/command_processor.cpp
+--- a/src/graphics/d3d12/command_processor.cpp
++++ b/src/graphics/d3d12/command_processor.cpp
+@@ -3003,10 +3003,17 @@ bool D3D12CommandProcessor::IssueDraw(xenos::PrimitiveType primitive_type, uint3
+         isolated_result.status =
+             system::GraphicsIsolatedDrawStatus::kUnsupportedState;
+-      } else if (render_target_cache_->BeginIsolatedReplayTarget(
+-                     isolated_result.target_width,
+-                     isolated_result.target_height)) {
++      } else if ((!isolated_draw_request.reuse_target &&
++                  render_target_cache_->BeginIsolatedReplayTarget(
++                      isolated_result.target_width,
++                      isolated_result.target_height)) ||
++                 (isolated_draw_request.reuse_target &&
++                  render_target_cache_->ResumeIsolatedReplayTarget(
++                      isolated_result.target_width,
++                      isolated_result.target_height))) {
+         deferred_command_list_.BeginDebugMarker(
+-            "PinyonShift NR-02F isolated native auto-index draw");
++            isolated_draw_request.reuse_target
++                ? "PinyonShift NR-02F isolated native pass follower"
++                : "PinyonShift NR-02F isolated native auto-index draw");
+         deferred_command_list_.D3DDrawInstanced(
+             primitive_processing_result.host_draw_vertex_count, 1, 0, 0);
+         deferred_command_list_.EndDebugMarker();
+@@ -3039,7 +3047,9 @@ bool D3D12CommandProcessor::IssueDraw(xenos::PrimitiveType primitive_type, uint3
+     }
+     if (isolated_draw_request.reference_marker_requested) {
+       deferred_command_list_.BeginDebugMarker(
+-          "PinyonShift NR-02F authoritative Xenos auto-index draw");
++          isolated_draw_request.reuse_target
++              ? "PinyonShift NR-02F authoritative Xenos pass follower"
++              : "PinyonShift NR-02F authoritative Xenos auto-index draw");
+     }
+     PROFILE_DRAW_CALL();
+     PROFILE_VERTICES(primitive_processing_result.host_draw_vertex_count);
+@@ -3111,10 +3121,17 @@ bool D3D12CommandProcessor::IssueDraw(xenos::PrimitiveType primitive_type, uint3
+         isolated_result.status =
+             system::GraphicsIsolatedDrawStatus::kUnsupportedState;
+-      } else if (render_target_cache_->BeginIsolatedReplayTarget(
+-                     isolated_result.target_width,
+-                     isolated_result.target_height)) {
++      } else if ((!isolated_draw_request.reuse_target &&
++                  render_target_cache_->BeginIsolatedReplayTarget(
++                      isolated_result.target_width,
++                      isolated_result.target_height)) ||
++                 (isolated_draw_request.reuse_target &&
++                  render_target_cache_->ResumeIsolatedReplayTarget(
++                      isolated_result.target_width,
++                      isolated_result.target_height))) {
+         deferred_command_list_.BeginDebugMarker(
+-            "PinyonShift NR-02E isolated native draw");
++            isolated_draw_request.retain_target
++                ? "PinyonShift NR-02F isolated native pass anchor"
++                : "PinyonShift NR-02E isolated native draw");
+         deferred_command_list_.D3DDrawIndexedInstanced(
+             primitive_processing_result.host_draw_vertex_count, 1, 0, 0, 0);
+         deferred_command_list_.EndDebugMarker();
+@@ -3147,7 +3165,9 @@ bool D3D12CommandProcessor::IssueDraw(xenos::PrimitiveType primitive_type, uint3
+     }
+     if (isolated_draw_request.reference_marker_requested) {
+       deferred_command_list_.BeginDebugMarker(
+-          "PinyonShift NR-02E authoritative Xenos draw");
++          isolated_draw_request.retain_target
++              ? "PinyonShift NR-02F authoritative Xenos pass anchor"
++              : "PinyonShift NR-02E authoritative Xenos draw");
+     }
+     PROFILE_DRAW_CALL();
+     PROFILE_VERTICES(primitive_processing_result.host_draw_vertex_count);

--- a/src/native_renderer/graphics_hooks.cpp
+++ b/src/native_renderer/graphics_hooks.cpp
@@ -108,6 +108,8 @@ struct IsolatedDrawState {
   uint64_t captured_signature = 0;
   uint64_t captured_frame = 0;
   uint64_t captured_draw = 0;
+  uint64_t pass_anchor_frame = 0;
+  uint64_t pass_anchor_draw = 0;
   std::filesystem::path output_root;
   std::jthread artifact_writer;
   bool requested = false;
@@ -116,6 +118,9 @@ struct IsolatedDrawState {
   bool valid = true;
   bool prepared_candidate_valid = false;
   bool prepared_candidate_eligible = false;
+  bool awaiting_pass_follower = false;
+  bool pass_anchor_recorded = false;
+  bool pass_repeat_reported = false;
 };
 
 IsolatedDrawState g_isolated_draw;
@@ -2120,12 +2125,153 @@ void CompleteIsolatedDraw(
        {"suppression_eligible", "false"}});
 }
 
+void CompleteIsolatedPassAnchor(
+    const rex::system::GraphicsIsolatedDrawResult &result) {
+  g_isolated_draw.pass_anchor_recorded =
+      result.status == rex::system::GraphicsIsolatedDrawStatus::kRecorded;
+  const char *status = g_isolated_draw.pass_anchor_recorded
+                           ? "recorded"
+                           : (result.status == rex::system::
+                                                   GraphicsIsolatedDrawStatus::
+                                                       kTargetCreationFailed
+                                  ? "target_creation_failed"
+                                  : "unsupported_state");
+  pinyon_shift::diagnostics::RecordEvent(
+      "native_renderer.isolated_pass.stage",
+      {{"anchor_signature",
+        fmt::format("{:016X}", g_pass_follower.target_signature)},
+       {"follower_signature",
+        fmt::format("{:016X}", g_isolated_draw.target_signature)},
+       {"stage", "anchor"},
+       {"status", status},
+       {"frame", std::to_string(g_isolated_draw.pass_anchor_frame)},
+       {"draw", std::to_string(g_isolated_draw.pass_anchor_draw)},
+       {"target_width", std::to_string(result.target_width)},
+       {"target_height", std::to_string(result.target_height)},
+       {"xenos_draw", "preserved"},
+       {"output_authority", "xenos"},
+       {"suppression_eligible", "false"}});
+}
+
+void CompleteIsolatedPassFollower(
+    const rex::system::GraphicsIsolatedDrawResult &result) {
+  const bool recorded =
+      result.status == rex::system::GraphicsIsolatedDrawStatus::kRecorded;
+  if (recorded) {
+    g_isolated_draw.completed = true;
+  }
+  const char *status = recorded
+                           ? "recorded"
+                           : (result.status == rex::system::
+                                                   GraphicsIsolatedDrawStatus::
+                                                       kTargetCreationFailed
+                                  ? "target_creation_failed"
+                                  : "unsupported_state");
+  pinyon_shift::diagnostics::RecordEvent(
+      "native_renderer.isolated_pass.result",
+      {{"anchor_signature",
+        fmt::format("{:016X}", g_pass_follower.target_signature)},
+       {"follower_signature",
+        fmt::format("{:016X}", g_isolated_draw.target_signature)},
+       {"status", status},
+       {"frame", std::to_string(g_isolated_draw.captured_frame)},
+       {"anchor_draw", std::to_string(g_isolated_draw.pass_anchor_draw)},
+       {"follower_draw", std::to_string(g_isolated_draw.captured_draw)},
+       {"draw_count", recorded ? "2" : "0"},
+       {"target_width", std::to_string(result.target_width)},
+       {"target_height", std::to_string(result.target_height)},
+       {"native_draw", recorded ? "isolated_pass" : "false"},
+       {"xenos_draw", "preserved"},
+       {"output_authority", "xenos"},
+       {"suppression_eligible", "false"}});
+}
+
+void CompleteIsolatedPassRepeat(
+    const rex::system::GraphicsIsolatedDrawResult &result) {
+  const bool recorded =
+      result.status == rex::system::GraphicsIsolatedDrawStatus::kRecorded;
+  g_isolated_draw.pass_repeat_reported = true;
+  pinyon_shift::diagnostics::RecordEvent(
+      "native_renderer.isolated_pass.repeat",
+      {{"anchor_signature",
+        fmt::format("{:016X}", g_pass_follower.target_signature)},
+       {"follower_signature",
+        fmt::format("{:016X}", g_isolated_draw.target_signature)},
+       {"status", recorded ? "recorded" : "failed"},
+       {"frame", std::to_string(g_isolated_draw.captured_frame)},
+       {"anchor_draw", std::to_string(g_isolated_draw.pass_anchor_draw)},
+       {"follower_draw", std::to_string(g_isolated_draw.captured_draw)},
+       {"target_width", std::to_string(result.target_width)},
+       {"target_height", std::to_string(result.target_height)},
+       {"xenos_draw", "preserved"},
+       {"output_authority", "xenos"},
+       {"suppression_eligible", "false"}});
+}
+
 void RequestIsolatedDraw(
     const rex::system::GraphicsPreparedDrawObservation &,
     rex::system::GraphicsIsolatedDrawRequest &request) {
   if (!g_isolated_draw.requested || !g_isolated_draw.valid ||
-      !g_isolated_draw.prepared_candidate_valid ||
-      g_isolated_draw.prepared_signature != g_isolated_draw.target_signature) {
+      !g_isolated_draw.prepared_candidate_valid) {
+    return;
+  }
+  const bool pass_mode = g_pass_follower.requested &&
+                         g_pass_follower.valid &&
+                         g_pass_follower.target_signature !=
+                             g_isolated_draw.target_signature;
+  if (pass_mode) {
+    const uint64_t signature = g_isolated_draw.prepared_signature;
+    if (signature == g_pass_follower.target_signature) {
+      g_isolated_draw.awaiting_pass_follower = false;
+      g_isolated_draw.pass_anchor_recorded = false;
+      if (!g_isolated_draw.prepared_candidate_eligible) {
+        return;
+      }
+      g_isolated_draw.pass_anchor_frame = g_isolated_draw.frame;
+      g_isolated_draw.pass_anchor_draw = g_isolated_draw.draw;
+      g_isolated_draw.awaiting_pass_follower = true;
+      g_isolated_draw.pass_anchor_recorded = g_isolated_draw.completed;
+      request.requested = true;
+      request.retain_target = true;
+      request.reference_marker_requested = true;
+      request.completion = g_isolated_draw.completed
+                               ? nullptr
+                               : &CompleteIsolatedPassAnchor;
+      return;
+    }
+    if (!g_isolated_draw.awaiting_pass_follower) {
+      return;
+    }
+    const bool adjacent =
+        signature == g_isolated_draw.target_signature &&
+        g_isolated_draw.frame == g_isolated_draw.pass_anchor_frame &&
+        g_isolated_draw.draw == g_isolated_draw.pass_anchor_draw + 1;
+    g_isolated_draw.awaiting_pass_follower = false;
+    if (!adjacent || !g_isolated_draw.pass_anchor_recorded ||
+        !g_isolated_draw.prepared_candidate_eligible) {
+      return;
+    }
+    request.requested = true;
+    request.reuse_target = true;
+    request.reference_marker_requested = true;
+    if (!g_isolated_draw.completed) {
+      g_isolated_draw.captured_signature = signature;
+      g_isolated_draw.captured_frame = g_isolated_draw.frame;
+      g_isolated_draw.captured_draw = g_isolated_draw.draw;
+      request.readback_requested = g_isolated_draw.readback_requested;
+      request.completion = &CompleteIsolatedPassFollower;
+      request.readback_completion = g_isolated_draw.readback_requested
+                                        ? &CompleteIsolatedDrawReadback
+                                        : nullptr;
+    } else if (!g_isolated_draw.pass_repeat_reported) {
+      g_isolated_draw.captured_frame = g_isolated_draw.frame;
+      g_isolated_draw.captured_draw = g_isolated_draw.draw;
+      request.completion = &CompleteIsolatedPassRepeat;
+    }
+    return;
+  }
+  if (g_isolated_draw.prepared_signature !=
+      g_isolated_draw.target_signature) {
     return;
   }
   request.reference_marker_requested = true;
@@ -2616,6 +2762,14 @@ void InstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system) {
         g_isolated_draw.valid && g_isolated_draw.requested
             ? fmt::format("{:016X}", g_isolated_draw.target_signature)
             : ""},
+       {"anchor_signature",
+        g_isolated_draw.valid && g_isolated_draw.requested &&
+                g_pass_follower.valid && g_pass_follower.requested
+            ? fmt::format("{:016X}", g_pass_follower.target_signature)
+            : ""},
+       {"mode", g_pass_follower.valid && g_pass_follower.requested
+                    ? "retained_pass"
+                    : "single_draw"},
        {"native_draw", "isolated_only"},
        {"readback", g_isolated_draw.readback_requested ? "asynchronous"
                                                         : "disabled"},
@@ -2699,9 +2853,15 @@ void UninstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system) {
   if (g_isolated_draw.requested && g_isolated_draw.valid &&
       !g_isolated_draw.completed) {
     diagnostics::RecordEvent(
-        "native_renderer.isolated_draw.result",
-        {{"signature",
+        g_pass_follower.requested && g_pass_follower.valid
+            ? "native_renderer.isolated_pass.result"
+            : "native_renderer.isolated_draw.result",
+      {{"signature",
           fmt::format("{:016X}", g_isolated_draw.target_signature)},
+         {"anchor_signature",
+          g_pass_follower.requested && g_pass_follower.valid
+              ? fmt::format("{:016X}", g_pass_follower.target_signature)
+              : ""},
          {"status", "not_observed"},
          {"native_draw", "false"},
          {"xenos_draw", "preserved"},

--- a/tools/capture-native-renderer-renderdoc.ps1
+++ b/tools/capture-native-renderer-renderdoc.ps1
@@ -7,6 +7,9 @@ param(
     [Parameter(Mandatory)]
     [ValidatePattern('^[0-9A-Fa-f]{16}$')]
     [string]$IsolatedDrawSignature,
+    [ValidatePattern('^[0-9A-Fa-f]{16}$')]
+    [string]$PassAnchorSignature,
+    [string]$IsolatedDrawDir,
     [Parameter(Mandatory)]
     [string]$CaptureDir,
     [ValidateSet('open_world_day', 'open_world_night', 'garage', 'race')]
@@ -28,6 +31,20 @@ if (-not $resolvedCaptureDir.StartsWith(
 }
 if (Test-Path -LiteralPath $resolvedCaptureDir) {
     throw "CaptureDir already exists: $resolvedCaptureDir"
+}
+if ([bool]$PassAnchorSignature -xor [bool]$IsolatedDrawDir) {
+    throw 'PassAnchorSignature and IsolatedDrawDir must be supplied together.'
+}
+if ($IsolatedDrawDir) {
+    $resolvedIsolatedDrawDir = [IO.Path]::GetFullPath($IsolatedDrawDir)
+    if (-not $resolvedIsolatedDrawDir.StartsWith(
+            $localPrefix, [StringComparison]::OrdinalIgnoreCase)) {
+        throw "IsolatedDrawDir must be below $localRoot"
+    }
+    if (Test-Path -LiteralPath $resolvedIsolatedDrawDir) {
+        throw "IsolatedDrawDir already exists: $resolvedIsolatedDrawDir"
+    }
+    $IsolatedDrawDir = $resolvedIsolatedDrawDir
 }
 
 $profile = Get-ChildItem -LiteralPath (Join-Path $resolvedStateRoot 'user') `
@@ -64,6 +81,8 @@ $saved = @{
     census = $env:REX_PINYON_SHIFT_NATIVE_RENDERER_CENSUS
     scene = $env:PINYON_SHIFT_NATIVE_RENDERER_SCENE
     draw = $env:PINYON_SHIFT_NATIVE_RENDERER_ISOLATED_DRAW_SIGNATURE
+    draw_dir = $env:PINYON_SHIFT_NATIVE_RENDERER_ISOLATED_DRAW_DIR
+    pass_anchor = $env:PINYON_SHIFT_NATIVE_RENDERER_PASS_ANCHOR_SIGNATURE
 }
 try {
     $env:PINYON_SHIFT_STATE_ROOT = $resolvedStateRoot
@@ -73,6 +92,13 @@ try {
     $env:PINYON_SHIFT_NATIVE_RENDERER_SCENE = $Scene
     $env:PINYON_SHIFT_NATIVE_RENDERER_ISOLATED_DRAW_SIGNATURE =
         $IsolatedDrawSignature.ToUpperInvariant()
+    $env:PINYON_SHIFT_NATIVE_RENDERER_ISOLATED_DRAW_DIR = $IsolatedDrawDir
+    $env:PINYON_SHIFT_NATIVE_RENDERER_PASS_ANCHOR_SIGNATURE =
+        if ($PassAnchorSignature) {
+            $PassAnchorSignature.ToUpperInvariant()
+        } else {
+            $null
+        }
     & $renderdoc capture -w `
         -d (Split-Path $executable -Parent) `
         -c (Join-Path $resolvedCaptureDir 'reference') `
@@ -88,6 +114,8 @@ finally {
     $env:REX_PINYON_SHIFT_NATIVE_RENDERER_CENSUS = $saved.census
     $env:PINYON_SHIFT_NATIVE_RENDERER_SCENE = $saved.scene
     $env:PINYON_SHIFT_NATIVE_RENDERER_ISOLATED_DRAW_SIGNATURE = $saved.draw
+    $env:PINYON_SHIFT_NATIVE_RENDERER_ISOLATED_DRAW_DIR = $saved.draw_dir
+    $env:PINYON_SHIFT_NATIVE_RENDERER_PASS_ANCHOR_SIGNATURE = $saved.pass_anchor
 }
 
 $captures = @(Get-ChildItem -LiteralPath $resolvedCaptureDir -File -Filter '*.rdc')

--- a/tools/export-native-renderer-renderdoc.ps1
+++ b/tools/export-native-renderer-renderdoc.ps1
@@ -5,7 +5,9 @@ param(
     [Parameter(Mandatory)]
     [string]$RenderDocRoot,
     [Parameter(Mandatory)]
-    [string]$OutputDir
+    [string]$OutputDir,
+    [string]$NativeMarker = 'PinyonShift NR-02E isolated native draw',
+    [string]$XenosMarker = 'PinyonShift NR-02E authoritative Xenos draw'
 )
 
 Set-StrictMode -Version Latest
@@ -42,9 +44,13 @@ $script = Join-Path $PSScriptRoot 'export-native-renderer-renderdoc.py'
 [void](New-Item -ItemType Directory -Path $resolvedOutputDir)
 $savedCapture = $env:PINYON_SHIFT_RENDERDOC_CAPTURE
 $savedOutput = $env:PINYON_SHIFT_RENDERDOC_EXPORT_DIR
+$savedNativeMarker = $env:PINYON_SHIFT_RENDERDOC_NATIVE_MARKER
+$savedXenosMarker = $env:PINYON_SHIFT_RENDERDOC_XENOS_MARKER
 try {
     $env:PINYON_SHIFT_RENDERDOC_CAPTURE = $resolvedCapture
     $env:PINYON_SHIFT_RENDERDOC_EXPORT_DIR = $resolvedOutputDir
+    $env:PINYON_SHIFT_RENDERDOC_NATIVE_MARKER = $NativeMarker
+    $env:PINYON_SHIFT_RENDERDOC_XENOS_MARKER = $XenosMarker
     $process = Start-Process -FilePath $qrenderdoc `
         -ArgumentList @('--python', $script) -PassThru -Wait
     if ($process.ExitCode) {
@@ -54,6 +60,8 @@ try {
 finally {
     $env:PINYON_SHIFT_RENDERDOC_CAPTURE = $savedCapture
     $env:PINYON_SHIFT_RENDERDOC_EXPORT_DIR = $savedOutput
+    $env:PINYON_SHIFT_RENDERDOC_NATIVE_MARKER = $savedNativeMarker
+    $env:PINYON_SHIFT_RENDERDOC_XENOS_MARKER = $savedXenosMarker
 }
 
 $report = Join-Path $resolvedOutputDir 'renderdoc-export.json'

--- a/tools/export-native-renderer-renderdoc.py
+++ b/tools/export-native-renderer-renderdoc.py
@@ -9,12 +9,19 @@ import hashlib
 import json
 import os
 import sys
+import traceback
 
 import renderdoc as rd
 
 
-ISOLATED_MARKER = "PinyonShift NR-02E isolated native draw"
-XENOS_MARKER = "PinyonShift NR-02E authoritative Xenos draw"
+ISOLATED_MARKER = os.environ.get(
+    "PINYON_SHIFT_RENDERDOC_NATIVE_MARKER",
+    "PinyonShift NR-02E isolated native draw",
+)
+XENOS_MARKER = os.environ.get(
+    "PINYON_SHIFT_RENDERDOC_XENOS_MARKER",
+    "PinyonShift NR-02E authoritative Xenos draw",
+)
 SCHEMA = "pinyon-shift.native-renderer-renderdoc-export.v1"
 
 
@@ -164,9 +171,17 @@ def main():
         isolated = [a for a in actions if a.customName == ISOLATED_MARKER]
         xenos = [a for a in actions if a.customName == XENOS_MARKER]
         if not isolated or not xenos:
+            available_markers = sorted(
+                set(
+                    a.customName
+                    for a in actions
+                    if a.customName and "PinyonShift" in a.customName
+                )
+            )
             raise RuntimeError(
-                "paired markers were not found (isolated={}, xenos={})".format(
-                    len(isolated), len(xenos)
+                "paired markers were not found (isolated={}, xenos={}); "
+                "available PinyonShift markers={}".format(
+                    len(isolated), len(xenos), available_markers
                 )
             )
 
@@ -208,5 +223,13 @@ def main():
 try:
     sys.exit(main())
 except Exception as error:
-    sys.stderr.write("native renderer RenderDoc export failed: {}\n".format(error))
+    message = "native renderer RenderDoc export failed: {}\n{}".format(
+        error, traceback.format_exc()
+    )
+    output_dir = os.environ.get("PINYON_SHIFT_RENDERDOC_EXPORT_DIR")
+    if output_dir:
+        os.makedirs(output_dir, exist_ok=True)
+        with open(os.path.join(output_dir, "renderdoc-export-error.txt"), "w") as output:
+            output.write(message)
+    sys.stderr.write(message)
     sys.exit(1)

--- a/tools/tests/test_native_renderer_contract.py
+++ b/tools/tests/test_native_renderer_contract.py
@@ -488,6 +488,20 @@ class NativeRendererContractTests(unittest.TestCase):
         self.assertNotIn("SetDrawSuppression", auto_index_replay_patch)
         self.assertIn("SourceSelect::kAutoIndex", scanner)
 
+        retained_pass_patch = (
+            ROOT
+            / "patches/rexglue/0063-d3d12-retained-isolated-pass-target.patch"
+        ).read_text(encoding="utf-8")
+        self.assertIn("ResumeIsolatedReplayTarget", retained_pass_patch)
+        self.assertIn("reuse_target", retained_pass_patch)
+        self.assertIn("isolated native pass anchor", retained_pass_patch)
+        self.assertIn("isolated native pass follower", retained_pass_patch)
+        self.assertNotIn("SetDrawSuppression", retained_pass_patch)
+        self.assertIn("request.retain_target = true", scanner)
+        self.assertIn("request.reuse_target = true", scanner)
+        self.assertIn("native_renderer.isolated_pass.result", scanner)
+        self.assertIn("native_renderer.isolated_pass.repeat", scanner)
+
         visual_marker_patch = (
             ROOT / "patches/rexglue/0060-d3d12-isolated-draw-debug-markers.patch"
         ).read_text(encoding="utf-8")
@@ -531,6 +545,8 @@ class NativeRendererContractTests(unittest.TestCase):
         ).read_text(encoding="utf-8")
         self.assertIn("Get-AuthenticodeSignature", renderdoc_wrapper)
         self.assertIn("CaptureDir must be below", renderdoc_wrapper)
+        self.assertIn("PassAnchorSignature and IsolatedDrawDir", renderdoc_wrapper)
+        self.assertIn("PINYON_SHIFT_NATIVE_RENDERER_PASS_ANCHOR_SIGNATURE", renderdoc_wrapper)
         self.assertIn("RenderDoc exited without producing", renderdoc_wrapper)
 
         renderdoc_export = (
@@ -549,12 +565,16 @@ class NativeRendererContractTests(unittest.TestCase):
         self.assertIn('output_dir, "isolated-native"', renderdoc_export)
         self.assertIn('output_dir, "authoritative-xenos"', renderdoc_export)
         self.assertIn("authoritative Xenos marker follows", renderdoc_export)
+        self.assertIn("PINYON_SHIFT_RENDERDOC_NATIVE_MARKER", renderdoc_export)
+        self.assertIn("PINYON_SHIFT_RENDERDOC_XENOS_MARKER", renderdoc_export)
         renderdoc_export_wrapper = (
             ROOT / "tools/export-native-renderer-renderdoc.ps1"
         ).read_text(encoding="utf-8")
         self.assertIn("Get-AuthenticodeSignature", renderdoc_export_wrapper)
         self.assertIn("Capture must be below", renderdoc_export_wrapper)
         self.assertIn("OutputDir must be below", renderdoc_export_wrapper)
+        self.assertIn("PINYON_SHIFT_RENDERDOC_NATIVE_MARKER", renderdoc_export_wrapper)
+        self.assertIn("PINYON_SHIFT_RENDERDOC_XENOS_MARKER", renderdoc_export_wrapper)
         self.assertIn("qrenderdoc exited without producing", renderdoc_export_wrapper)
 
         pass_trace = (

--- a/tools/tests/test_release_contract.py
+++ b/tools/tests/test_release_contract.py
@@ -43,10 +43,10 @@ class ReleaseContractTests(unittest.TestCase):
 
     def test_rexglue_patches_have_stable_order_and_no_binary_payload(self):
         patches = sorted((ROOT / "patches/rexglue").glob("*.patch"))
-        self.assertEqual(len(patches), 62)
+        self.assertEqual(len(patches), 63)
         self.assertEqual(
             patches[-1].name,
-            "0062-d3d12-isolated-auto-index-replay.patch",
+            "0063-d3d12-retained-isolated-pass-target.patch",
         )
         self.assertEqual(len(patches), len({path.name[:4] for path in patches}))
         for path in patches:


### PR DESCRIPTION
## Summary
- retain the isolated render target across the qualified two-draw candidate pass
- replay the indexed anchor and adjacent AutoIndex follower without suppressing Xenos
- add deterministic readback/repeat telemetry and generalized RenderDoc marker tooling
- document two AppData-backed runtime qualifications and the outstanding visual-equivalence gate

## Safety
- default-off diagnostic path only
- every original Xenos draw remains intact and authoritative
- suppression remains explicitly ineligible

## Validation
- 130 Python contract tests passed
- repository boundary check passed (203 candidate files)
- incremental release build passed with 63 ReXGlue patches
- two AppData-backed open-world runs exited normally
- retained pass recorded at draws 117/118 and repeated at 126/127
- deterministic 512x512 readback SHA-256: AF82E49BAE46AA67B0255BC3B1B5120BA7F69205BB8526F1DB9F8ED151090150