### PR TITLE
feat(native-renderer): add canonical physical resource keys

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,7 @@ if(WIN32)
         src/pinyon_shift_runtime_hooks.cpp
         src/native_renderer/graphics_hooks.cpp
         src/native_renderer/guest_output_renderer.cpp
+        src/native_renderer/resource_identity.cpp
         src/native_renderer/shader_capture.cpp
         src/native_renderer/shader_pack.cpp
     )
@@ -35,10 +36,17 @@ else()
         src/pinyon_shift_runtime_hooks.cpp
         src/native_renderer/graphics_hooks.cpp
         src/native_renderer/guest_output_renderer.cpp
+        src/native_renderer/resource_identity.cpp
         src/native_renderer/shader_capture.cpp
         src/native_renderer/shader_pack.cpp
     )
 endif()
+
+add_executable(pinyon_shift_resource_identity_tests EXCLUDE_FROM_ALL
+    tests/native_renderer/resource_identity_test.cpp
+    src/native_renderer/resource_identity.cpp
+)
+target_include_directories(pinyon_shift_resource_identity_tests PRIVATE src)
 
 pinyon_shift_attach_rexglue(pinyon_shift)
 

--- a/docs/native-renderer/RESOURCE_IDENTITY.md
+++ b/docs/native-renderer/RESOURCE_IDENTITY.md
@@ -1,0 +1,28 @@
+# Native renderer resource identity
+
+NR-03 uses one identity for every guest graphics resource: a half-open byte
+range in the 512 MiB Xenon physical aperture. Physical-heap window bits are
+removed at the capture boundary, so values such as `0xA1234000` and
+`0x01234000` cannot create separate cache entries for the same memory.
+
+`PhysicalRange` rejects empty and aperture-crossing resources and performs
+overflow-safe overlap checks. Buffer keys add the buffer class and descriptor
+signature. Texture keys add the complete fetch signature and optional mip
+range. Both key types carry a content fingerprint from
+`PhysicalResourceTracker`.
+
+The tracker assigns monotonically increasing generations to physical pages
+touched by a guest write. A capture over any touched range therefore produces
+a new key even when the guest object pointer and descriptor are reused. Its
+overlap index reports each affected buffer or texture exactly once.
+
+Invalidation only marks identity stale; it never destroys a host object. The
+buffer and texture caches introduced by later NR-03 pull requests own those
+objects and must retire them behind their final GPU submission. At that point,
+the tracker will be connected to ReXGlue's one-shot physical-memory
+invalidation callback and each cached range will re-arm the callback after a
+successful upload.
+
+The standalone native test covers physical-heap aliases, exact half-open range
+boundaries, aperture bounds, page generations, multi-range textures, resource
+class separation, deduplicated overlap reporting, and unregistration.

--- a/src/native_renderer/graphics_hooks.cpp
+++ b/src/native_renderer/graphics_hooks.cpp
@@ -26,6 +26,7 @@
 #include <rex/system/kernel_state.h>
 
 #include "native_renderer/graphics_hooks.h"
+#include "native_renderer/resource_identity.h"
 #include "pinyon_shift_diagnostics.h"
 
 REXCVAR_DEFINE_BOOL(
@@ -441,10 +442,12 @@ void TryFingerprintCandidateTextures(
       continue;
     }
     const uint64_t base_address =
-        observation.texture_fetch_addresses[fetch] & UINT64_C(0x1FFFFFFF);
+        pinyon_shift::native_renderer::CanonicalPhysicalAddress(
+            observation.texture_fetch_addresses[fetch]);
     const uint64_t base_length = observation.texture_fetch_base_lengths[fetch];
     const uint64_t mip_address =
-        observation.texture_fetch_mip_addresses[fetch] & UINT64_C(0x1FFFFFFF);
+        pinyon_shift::native_renderer::CanonicalPhysicalAddress(
+            observation.texture_fetch_mip_addresses[fetch]);
     const uint64_t mip_length = observation.texture_fetch_mip_lengths[fetch];
     if (!base_length || base_length > kMaximumTextureScanResourceBytes ||
         mip_length > kMaximumTextureScanResourceBytes ||
@@ -569,7 +572,8 @@ void TryScanCandidateIndices(
   const uint64_t required_bytes =
       uint64_t(observation.index_count) * element_bytes;
   const uint64_t physical_address =
-      uint64_t(observation.index_buffer_address & 0x1FFFFFFF);
+      uint64_t(pinyon_shift::native_renderer::CanonicalPhysicalAddress(
+          observation.index_buffer_address));
   if (required_bytes > kMaximumIndexScanBytes ||
       required_bytes > observation.index_buffer_length) {
     reject("index_allocation_too_small");
@@ -783,8 +787,10 @@ void TryCaptureReplaySnapshot(
   const uint64_t vertex_bytes = binding.size;
   constexpr uint64_t kMaximumVertexSnapshotBytes = UINT64_C(64) << 20;
   const uint64_t index_address =
-      uint64_t(observation.index_buffer_address & 0x1FFFFFFF);
-  const uint64_t vertex_address = uint64_t(binding.address & 0x1FFFFFFF);
+      uint64_t(pinyon_shift::native_renderer::CanonicalPhysicalAddress(
+          observation.index_buffer_address));
+  const uint64_t vertex_address =
+      pinyon_shift::native_renderer::CanonicalPhysicalAddress(binding.address);
   if (!vertex_bytes || index_bytes > kMaximumIndexScanBytes ||
       index_bytes > observation.index_buffer_length ||
       vertex_bytes > kMaximumVertexSnapshotBytes ||
@@ -810,9 +816,11 @@ void TryCaptureReplaySnapshot(
         observation.texture_fetch_base_lengths[fetch];
     const uint64_t mip_bytes = observation.texture_fetch_mip_lengths[fetch];
     const uint64_t base_address =
-        observation.texture_fetch_addresses[fetch] & 0x1FFFFFFF;
+        pinyon_shift::native_renderer::CanonicalPhysicalAddress(
+            observation.texture_fetch_addresses[fetch]);
     const uint64_t mip_address =
-        observation.texture_fetch_mip_addresses[fetch] & 0x1FFFFFFF;
+        pinyon_shift::native_renderer::CanonicalPhysicalAddress(
+            observation.texture_fetch_mip_addresses[fetch]);
     if (!base_bytes || base_bytes > kMaximumTextureScanResourceBytes ||
         mip_bytes > kMaximumTextureScanResourceBytes ||
         base_address + base_bytes > kPhysicalApertureSize ||

--- a/src/native_renderer/resource_identity.cpp
+++ b/src/native_renderer/resource_identity.cpp
@@ -1,0 +1,146 @@
+#include "native_renderer/resource_identity.h"
+
+#include <algorithm>
+#include <limits>
+
+namespace pinyon_shift::native_renderer {
+namespace {
+
+constexpr uint64_t kFnvOffsetBasis = UINT64_C(14695981039346656037);
+constexpr uint64_t kFnvPrime = UINT64_C(1099511628211);
+
+void HashValue(uint64_t value, uint64_t& hash) {
+  for (size_t byte = 0; byte < sizeof(value); ++byte) {
+    hash ^= value & 0xFF;
+    hash *= kFnvPrime;
+    value >>= 8;
+  }
+}
+
+}  // namespace
+
+std::optional<PhysicalRange> PhysicalRange::FromGraphicsAddress(
+    uint32_t graphics_address, uint32_t length) {
+  if (!length) {
+    return std::nullopt;
+  }
+  const uint32_t canonical_address = CanonicalPhysicalAddress(graphics_address);
+  if (uint64_t(canonical_address) + length > kGuestPhysicalApertureSize) {
+    return std::nullopt;
+  }
+  return PhysicalRange{canonical_address, length};
+}
+
+uint64_t PhysicalRange::end_exclusive() const {
+  return uint64_t(address) + length;
+}
+
+bool PhysicalRange::Overlaps(const PhysicalRange& other) const {
+  return valid() && other.valid() && address < other.end_exclusive() &&
+         other.address < end_exclusive();
+}
+
+bool PhysicalRange::valid() const {
+  return length && end_exclusive() <= kGuestPhysicalApertureSize;
+}
+
+PhysicalResourceTracker::PhysicalResourceTracker()
+    : page_generations_(kGuestPhysicalApertureSize /
+                        kGuestPhysicalPageSize) {}
+
+ResourceFingerprint PhysicalResourceTracker::Capture(
+    std::span<const PhysicalRange> ranges) const {
+  const std::scoped_lock lock(mutex_);
+  return CaptureLocked(ranges);
+}
+
+ResourceFingerprint PhysicalResourceTracker::Capture(
+    const PhysicalRange& range) const {
+  return Capture(std::span<const PhysicalRange>(&range, 1));
+}
+
+void PhysicalResourceTracker::Track(
+    TrackedResourceId resource, std::span<const PhysicalRange> ranges) {
+  if (ranges.empty() ||
+      std::ranges::any_of(ranges,
+                          [](const PhysicalRange& range) {
+                            return !range.valid();
+                          })) {
+    return;
+  }
+  const std::scoped_lock lock(mutex_);
+  auto existing = std::find_if(
+      entries_.begin(), entries_.end(),
+      [resource](const Entry& entry) { return entry.resource == resource; });
+  if (existing == entries_.end()) {
+    entries_.push_back({resource, {ranges.begin(), ranges.end()}});
+  } else {
+    existing->ranges.assign(ranges.begin(), ranges.end());
+  }
+}
+
+bool PhysicalResourceTracker::Untrack(TrackedResourceId resource) {
+  const std::scoped_lock lock(mutex_);
+  const auto old_size = entries_.size();
+  std::erase_if(entries_,
+                [resource](const Entry& entry) {
+                  return entry.resource == resource;
+                });
+  return entries_.size() != old_size;
+}
+
+std::vector<ResourceInvalidation> PhysicalResourceTracker::Invalidate(
+    const PhysicalRange& written_range) {
+  if (!written_range.valid()) {
+    return {};
+  }
+  const std::scoped_lock lock(mutex_);
+  uint64_t generation = next_generation_++;
+  if (!next_generation_) {
+    // Zero is reserved for never-invalidated content. Saturating is safer than
+    // allowing an ancient cache key to become valid after a wrap.
+    next_generation_ = std::numeric_limits<uint64_t>::max();
+    generation = next_generation_;
+  }
+
+  const uint32_t first_page = written_range.address /
+                              kGuestPhysicalPageSize;
+  const uint32_t last_page =
+      uint32_t((written_range.end_exclusive() - 1) /
+               kGuestPhysicalPageSize);
+  std::fill(page_generations_.begin() + first_page,
+            page_generations_.begin() + last_page + 1, generation);
+
+  std::vector<ResourceInvalidation> invalidations;
+  for (const Entry& entry : entries_) {
+    if (std::ranges::any_of(entry.ranges, [&](const PhysicalRange& range) {
+          return range.Overlaps(written_range);
+        })) {
+      invalidations.push_back({entry.resource, generation});
+    }
+  }
+  return invalidations;
+}
+
+ResourceFingerprint PhysicalResourceTracker::CaptureLocked(
+    std::span<const PhysicalRange> ranges) const {
+  ResourceFingerprint result{0, kFnvOffsetBasis};
+  for (const PhysicalRange& range : ranges) {
+    if (!range.valid()) {
+      return {};
+    }
+    HashValue(range.address, result.fingerprint);
+    HashValue(range.length, result.fingerprint);
+    const uint32_t first_page = range.address / kGuestPhysicalPageSize;
+    const uint32_t last_page =
+        uint32_t((range.end_exclusive() - 1) / kGuestPhysicalPageSize);
+    for (uint32_t page = first_page; page <= last_page; ++page) {
+      const uint64_t page_generation = page_generations_[page];
+      result.generation = std::max(result.generation, page_generation);
+      HashValue(page_generation, result.fingerprint);
+    }
+  }
+  return result;
+}
+
+}  // namespace pinyon_shift::native_renderer

--- a/src/native_renderer/resource_identity.h
+++ b/src/native_renderer/resource_identity.h
@@ -1,0 +1,120 @@
+#pragma once
+
+#include <cstdint>
+#include <mutex>
+#include <optional>
+#include <span>
+#include <vector>
+
+namespace pinyon_shift::native_renderer {
+
+constexpr uint32_t kGuestPhysicalAddressMask = 0x1FFFFFFF;
+constexpr uint64_t kGuestPhysicalApertureSize = UINT64_C(0x20000000);
+constexpr uint32_t kGuestPhysicalPageSize = 4096;
+
+[[nodiscard]] constexpr uint32_t CanonicalPhysicalAddress(
+    uint32_t graphics_address) {
+  return graphics_address & kGuestPhysicalAddressMask;
+}
+
+// Canonical half-open byte range in the 512 MiB Xenon physical aperture.
+// Graphics addresses may retain a physical-heap window in their upper bits;
+// creation masks those aliases before validating the range.
+struct PhysicalRange {
+  uint32_t address = 0;
+  uint32_t length = 0;
+
+  static std::optional<PhysicalRange> FromGraphicsAddress(
+      uint32_t graphics_address, uint32_t length);
+
+  [[nodiscard]] uint64_t end_exclusive() const;
+  [[nodiscard]] bool Overlaps(const PhysicalRange& other) const;
+  [[nodiscard]] bool valid() const;
+
+  bool operator==(const PhysicalRange&) const = default;
+};
+
+struct ResourceFingerprint {
+  uint64_t generation = 0;
+  uint64_t fingerprint = 0;
+
+  bool operator==(const ResourceFingerprint&) const = default;
+};
+
+enum class BufferResourceClass : uint8_t {
+  kVertex,
+  kIndex,
+  kInline,
+};
+
+struct BufferResourceKey {
+  PhysicalRange range;
+  BufferResourceClass resource_class = BufferResourceClass::kVertex;
+  uint32_t descriptor_signature = 0;
+  ResourceFingerprint content;
+
+  bool operator==(const BufferResourceKey&) const = default;
+};
+
+struct TextureResourceKey {
+  PhysicalRange base;
+  std::optional<PhysicalRange> mips;
+  uint64_t fetch_signature = 0;
+  ResourceFingerprint content;
+
+  bool operator==(const TextureResourceKey&) const = default;
+};
+
+enum class TrackedResourceClass : uint8_t {
+  kBuffer,
+  kTexture,
+};
+
+struct TrackedResourceId {
+  TrackedResourceClass resource_class = TrackedResourceClass::kBuffer;
+  uint64_t value = 0;
+
+  bool operator==(const TrackedResourceId&) const = default;
+};
+
+struct ResourceInvalidation {
+  TrackedResourceId resource;
+  uint64_t generation = 0;
+
+  bool operator==(const ResourceInvalidation&) const = default;
+};
+
+// Thread-safe generation and overlap tracker shared by future native caches.
+// Invalidation only marks resources stale. Host objects remain owned by their
+// cache so the cache can retire them behind its submission fence.
+class PhysicalResourceTracker {
+ public:
+  PhysicalResourceTracker();
+
+  [[nodiscard]] ResourceFingerprint Capture(
+      std::span<const PhysicalRange> ranges) const;
+  [[nodiscard]] ResourceFingerprint Capture(const PhysicalRange& range) const;
+
+  void Track(TrackedResourceId resource,
+             std::span<const PhysicalRange> ranges);
+  bool Untrack(TrackedResourceId resource);
+
+  [[nodiscard]] std::vector<ResourceInvalidation> Invalidate(
+      const PhysicalRange& written_range);
+
+ private:
+  struct Entry {
+    TrackedResourceId resource;
+    std::vector<PhysicalRange> ranges;
+  };
+
+  [[nodiscard]] ResourceFingerprint CaptureLocked(
+      std::span<const PhysicalRange> ranges) const;
+
+  mutable std::mutex mutex_;
+  std::vector<uint64_t> page_generations_;
+  std::vector<Entry> entries_;
+  uint64_t next_generation_ = 1;
+};
+
+}  // namespace pinyon_shift::native_renderer

--- a/tests/native_renderer/resource_identity_test.cpp
+++ b/tests/native_renderer/resource_identity_test.cpp
@@ -1,0 +1,93 @@
+#include <cstdlib>
+#include <iostream>
+#include <span>
+
+#include "native_renderer/resource_identity.h"
+
+namespace nr = pinyon_shift::native_renderer;
+
+namespace {
+
+void Require(bool condition, const char* message) {
+  if (!condition) {
+    std::cerr << message << '\n';
+    std::exit(EXIT_FAILURE);
+  }
+}
+
+}  // namespace
+
+int main() {
+  const auto canonical =
+      nr::PhysicalRange::FromGraphicsAddress(0xA1234000, 0x2000);
+  const auto already_physical =
+      nr::PhysicalRange::FromGraphicsAddress(0x01234000, 0x2000);
+  Require(canonical && already_physical,
+          "valid aliased ranges must canonicalize");
+  Require(*canonical == *already_physical,
+          "physical-heap aliases must share one identity");
+  Require(!nr::PhysicalRange::FromGraphicsAddress(0, 0),
+          "empty resources must be rejected");
+  Require(!nr::PhysicalRange::FromGraphicsAddress(0x1FFFFFF0, 0x20),
+          "resources crossing the aperture must be rejected");
+
+  const auto touching =
+      nr::PhysicalRange::FromGraphicsAddress(0x01236000, 0x1000);
+  const auto overlapping =
+      nr::PhysicalRange::FromGraphicsAddress(0x01235FFF, 2);
+  Require(touching && overlapping, "test ranges must be valid");
+  Require(!canonical->Overlaps(*touching),
+          "half-open ranges that only touch must not overlap");
+  Require(canonical->Overlaps(*overlapping),
+          "one-byte intersections must overlap");
+
+  nr::PhysicalResourceTracker tracker;
+  const auto initial = tracker.Capture(*canonical);
+  const nr::TrackedResourceId vertex{nr::TrackedResourceClass::kBuffer, 7};
+  const nr::TrackedResourceId texture{nr::TrackedResourceClass::kTexture, 9};
+  tracker.Track(vertex, std::span<const nr::PhysicalRange>(&*canonical, 1));
+  tracker.Track(texture,
+                std::span<const nr::PhysicalRange>(&*touching, 1));
+
+  const auto write =
+      nr::PhysicalRange::FromGraphicsAddress(0x81234FFF, 2);
+  Require(write.has_value(), "aliased write range must be valid");
+  const auto invalidations = tracker.Invalidate(*write);
+  Require(invalidations.size() == 1 &&
+              invalidations.front().resource == vertex,
+          "only overlapping resources must be invalidated");
+  const auto changed = tracker.Capture(*already_physical);
+  Require(changed.generation > initial.generation &&
+              changed.fingerprint != initial.fingerprint,
+          "a guest write must change the canonical content identity");
+  Require(tracker.Capture(*touching).generation == 0,
+          "adjacent content must retain its generation");
+
+  const nr::PhysicalRange texture_ranges[] = {*canonical, *touching};
+  tracker.Track(texture, texture_ranges);
+  const auto both_hits = tracker.Invalidate(*overlapping);
+  Require(both_hits.size() == 2,
+          "one write must report each overlapping tracked resource once");
+  Require(tracker.Untrack(vertex), "tracked resources must be removable");
+  Require(!tracker.Untrack(vertex), "untracking must be idempotent");
+  Require(tracker.Invalidate(*canonical).size() == 1,
+          "untracked resources must not receive invalidations");
+
+  const nr::BufferResourceKey vertex_key{
+      *canonical, nr::BufferResourceClass::kVertex, 0x1234,
+      tracker.Capture(*canonical)};
+  const nr::BufferResourceKey index_key{
+      *canonical, nr::BufferResourceClass::kIndex, 0x1234,
+      tracker.Capture(*canonical)};
+  Require(vertex_key != index_key,
+          "buffer class must participate in resource identity");
+
+  const nr::TextureResourceKey texture_key{
+      *canonical, *touching, UINT64_C(0xABCDEF),
+      tracker.Capture(texture_ranges)};
+  Require(texture_key.base == *already_physical && texture_key.mips,
+          "texture keys must preserve canonical base and mip identity");
+
+  std::cout << "native renderer resource identity tests passed\n";
+  return EXIT_SUCCESS;
+}

--- a/tools/tests/test_native_renderer_resource_identity.py
+++ b/tools/tests/test_native_renderer_resource_identity.py
@@ -1,0 +1,42 @@
+import pathlib
+import unittest
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+
+
+class NativeRendererResourceIdentityContractTests(unittest.TestCase):
+    def test_preview_compiles_resource_identity(self):
+        cmake = (ROOT / "CMakeLists.txt").read_text(encoding="utf-8")
+        self.assertEqual(cmake.count("src/native_renderer/resource_identity.cpp"), 3)
+        self.assertIn("pinyon_shift_resource_identity_tests EXCLUDE_FROM_ALL", cmake)
+
+    def test_physical_identity_is_canonical_and_generation_aware(self):
+        header = (
+            ROOT / "src/native_renderer/resource_identity.h"
+        ).read_text(encoding="utf-8")
+        source = (
+            ROOT / "src/native_renderer/resource_identity.cpp"
+        ).read_text(encoding="utf-8")
+        self.assertIn("kGuestPhysicalAddressMask = 0x1FFFFFFF", header)
+        self.assertIn("graphics_address & kGuestPhysicalAddressMask", header)
+        self.assertIn("CanonicalPhysicalAddress(graphics_address)", source)
+        self.assertIn("BufferResourceKey", header)
+        self.assertIn("TextureResourceKey", header)
+        self.assertIn("ResourceFingerprint content", header)
+
+    def test_invalidation_marks_overlap_without_owning_destruction(self):
+        header = (
+            ROOT / "src/native_renderer/resource_identity.h"
+        ).read_text(encoding="utf-8")
+        source = (
+            ROOT / "src/native_renderer/resource_identity.cpp"
+        ).read_text(encoding="utf-8")
+        self.assertIn("std::vector<ResourceInvalidation> Invalidate", header)
+        self.assertIn("range.Overlaps(written_range)", source)
+        self.assertNotIn("delete ", source)
+        self.assertNotIn("Release()", source)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- canonicalize graphics aliases into one 512 MiB physical aperture identity
- define generation-aware buffer and texture keys plus overlap invalidation tracking
- route existing native-renderer capture reads through the shared canonicalizer
- document the one-shot callback integration boundary and deferred-destruction ownership

## Validation
- 133 Python tests pass
- native resource identity semantic test passes
- full playable preview build passes
- repository boundary passes

## Safety
- Xenos remains authoritative
- no draw suppression or rendering behavior change
- invalidation only reports stale resources; future caches retain responsibility for fence-safe retirement