### PR TITLE
feat(native-renderer): add fence-safe buffer cache

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,7 @@ if(WIN32)
         src/pinyon_shift_diagnostics.cpp
         src/pinyon_shift_runtime_hooks.cpp
         src/native_renderer/graphics_hooks.cpp
+        src/native_renderer/buffer_cache.cpp
         src/native_renderer/guest_output_renderer.cpp
         src/native_renderer/resource_identity.cpp
         src/native_renderer/shader_capture.cpp
@@ -35,6 +36,7 @@ else()
         src/pinyon_shift_diagnostics.cpp
         src/pinyon_shift_runtime_hooks.cpp
         src/native_renderer/graphics_hooks.cpp
+        src/native_renderer/buffer_cache.cpp
         src/native_renderer/guest_output_renderer.cpp
         src/native_renderer/resource_identity.cpp
         src/native_renderer/shader_capture.cpp
@@ -47,6 +49,13 @@ add_executable(pinyon_shift_resource_identity_tests EXCLUDE_FROM_ALL
     src/native_renderer/resource_identity.cpp
 )
 target_include_directories(pinyon_shift_resource_identity_tests PRIVATE src)
+
+add_executable(pinyon_shift_buffer_cache_tests EXCLUDE_FROM_ALL
+    tests/native_renderer/buffer_cache_test.cpp
+    src/native_renderer/buffer_cache.cpp
+    src/native_renderer/resource_identity.cpp
+)
+target_include_directories(pinyon_shift_buffer_cache_tests PRIVATE src)
 
 pinyon_shift_attach_rexglue(pinyon_shift)
 

--- a/docs/native-renderer/RESOURCE_IDENTITY.md
+++ b/docs/native-renderer/RESOURCE_IDENTITY.md
@@ -26,3 +26,12 @@ successful upload.
 The standalone native test covers physical-heap aliases, exact half-open range
 boundaries, aperture bounds, page generations, multi-range textures, resource
 class separation, deduplicated overlap reporting, and unregistration.
+
+## Buffer cache lifetime
+
+`NativeBufferCache` attaches opaque backend allocations to exact buffer keys.
+Hits advance the last-use frame and submission. A physical invalidation removes
+the entry from lookup immediately, but moves its allocation to a retired queue
+stamped with the later of its last use and the current submission. Only
+`Collect(completed_submission)` returns handles that the backend may destroy.
+This makes early invalidation and shutdown use the same fence-safe path.

--- a/src/native_renderer/buffer_cache.cpp
+++ b/src/native_renderer/buffer_cache.cpp
@@ -1,0 +1,119 @@
+#include "native_renderer/buffer_cache.h"
+
+#include <algorithm>
+
+namespace pinyon_shift::native_renderer {
+
+NativeBufferCache::NativeBufferCache(PhysicalResourceTracker& tracker) : tracker_(tracker) {}
+
+std::optional<BufferCacheAcquireResult> NativeBufferCache::Acquire(
+    const BufferResourceKey& key, NativeBufferHandle candidate_handle, uint64_t allocation_bytes,
+    uint64_t frame, uint64_t submission) {
+  if (!key.range.valid() || !candidate_handle || !allocation_bytes) {
+    return std::nullopt;
+  }
+  const std::scoped_lock lock(mutex_);
+  auto existing = live_.find(key);
+  if (existing != live_.end()) {
+    existing->second.last_use_frame = std::max(existing->second.last_use_frame, frame);
+    existing->second.last_use_submission =
+        std::max(existing->second.last_use_submission, submission);
+    ++metrics_.hits;
+    return BufferCacheAcquireResult{existing->second, true};
+  }
+
+  const uint64_t resource_id = next_resource_id_++;
+  BufferCacheEntry entry{resource_id, key, candidate_handle, allocation_bytes, frame, submission};
+  live_.emplace(key, entry);
+  keys_by_id_.emplace(resource_id, key);
+  const TrackedResourceId tracked{TrackedResourceClass::kBuffer, resource_id};
+  tracker_.Track(tracked, std::span<const PhysicalRange>(&key.range, 1));
+  ++metrics_.misses;
+  ++metrics_.live_count;
+  metrics_.live_bytes += allocation_bytes;
+  return BufferCacheAcquireResult{entry, false};
+}
+
+std::optional<BufferCacheEntry> NativeBufferCache::Find(const BufferResourceKey& key,
+                                                        uint64_t frame, uint64_t submission) {
+  const std::scoped_lock lock(mutex_);
+  auto existing = live_.find(key);
+  if (existing == live_.end()) {
+    ++metrics_.misses;
+    return std::nullopt;
+  }
+  existing->second.last_use_frame = std::max(existing->second.last_use_frame, frame);
+  existing->second.last_use_submission = std::max(existing->second.last_use_submission, submission);
+  ++metrics_.hits;
+  return existing->second;
+}
+
+size_t NativeBufferCache::RetireInvalidated(std::span<const ResourceInvalidation> invalidations,
+                                            uint64_t current_submission) {
+  const std::scoped_lock lock(mutex_);
+  size_t retired_count = 0;
+  for (const ResourceInvalidation& invalidation : invalidations) {
+    if (invalidation.resource.resource_class != TrackedResourceClass::kBuffer) {
+      continue;
+    }
+    const auto key = keys_by_id_.find(invalidation.resource.value);
+    if (key == keys_by_id_.end()) {
+      continue;
+    }
+    auto entry = live_.find(key->second);
+    if (entry == live_.end()) {
+      keys_by_id_.erase(key);
+      continue;
+    }
+    RetireLocked(entry, current_submission);
+    ++retired_count;
+  }
+  metrics_.invalidations += retired_count;
+  return retired_count;
+}
+
+size_t NativeBufferCache::RetireAll(uint64_t current_submission) {
+  const std::scoped_lock lock(mutex_);
+  const size_t retired_count = live_.size();
+  while (!live_.empty()) {
+    RetireLocked(live_.begin(), current_submission);
+  }
+  return retired_count;
+}
+
+std::vector<RetiredBuffer> NativeBufferCache::Collect(uint64_t completed_submission) {
+  const std::scoped_lock lock(mutex_);
+  std::vector<RetiredBuffer> ready;
+  auto retained =
+      std::remove_if(retired_.begin(), retired_.end(), [&](const RetiredBuffer& resource) {
+        if (resource.retire_after_submission > completed_submission) {
+          return false;
+        }
+        ready.push_back(resource);
+        metrics_.retired_bytes -= resource.allocation_bytes;
+        --metrics_.retired_count;
+        return true;
+      });
+  retired_.erase(retained, retired_.end());
+  return ready;
+}
+
+BufferCacheMetrics NativeBufferCache::metrics() const {
+  const std::scoped_lock lock(mutex_);
+  return metrics_;
+}
+
+void NativeBufferCache::RetireLocked(LiveMap::iterator entry, uint64_t current_submission) {
+  const BufferCacheEntry resource = entry->second;
+  retired_.push_back({resource.handle, resource.allocation_bytes,
+                      std::max(resource.last_use_submission, current_submission)});
+  tracker_.Untrack({TrackedResourceClass::kBuffer, resource.resource_id});
+  keys_by_id_.erase(resource.resource_id);
+  live_.erase(entry);
+  --metrics_.live_count;
+  metrics_.live_bytes -= resource.allocation_bytes;
+  ++metrics_.retired_count;
+  metrics_.retired_bytes += resource.allocation_bytes;
+}
+
+}  // namespace pinyon_shift::native_renderer

--- a/src/native_renderer/buffer_cache.h
+++ b/src/native_renderer/buffer_cache.h
@@ -1,0 +1,88 @@
+#pragma once
+
+#include <cstdint>
+#include <mutex>
+#include <optional>
+#include <span>
+#include <unordered_map>
+#include <vector>
+
+#include "native_renderer/resource_identity.h"
+
+namespace pinyon_shift::native_renderer {
+
+// Backend-owned allocation identifier. Zero is never a valid allocation.
+using NativeBufferHandle = uint64_t;
+
+struct BufferCacheEntry {
+  uint64_t resource_id = 0;
+  BufferResourceKey key;
+  NativeBufferHandle handle = 0;
+  uint64_t allocation_bytes = 0;
+  uint64_t last_use_frame = 0;
+  uint64_t last_use_submission = 0;
+};
+
+struct BufferCacheAcquireResult {
+  BufferCacheEntry entry;
+  bool hit = false;
+};
+
+struct RetiredBuffer {
+  NativeBufferHandle handle = 0;
+  uint64_t allocation_bytes = 0;
+  uint64_t retire_after_submission = 0;
+};
+
+struct BufferCacheMetrics {
+  uint64_t hits = 0;
+  uint64_t misses = 0;
+  uint64_t invalidations = 0;
+  uint64_t live_count = 0;
+  uint64_t live_bytes = 0;
+  uint64_t retired_count = 0;
+  uint64_t retired_bytes = 0;
+};
+
+// Owns buffer-cache identity and lifetime metadata. The backend creates and
+// destroys the opaque handles; this class guarantees that an invalidated live
+// handle is not returned for destruction until its final submission completes.
+class NativeBufferCache {
+ public:
+  explicit NativeBufferCache(PhysicalResourceTracker& tracker);
+
+  // A zero handle or allocation size is rejected. On a key hit the supplied
+  // handle remains caller-owned and the existing allocation is returned.
+  [[nodiscard]] std::optional<BufferCacheAcquireResult> Acquire(const BufferResourceKey& key,
+                                                                NativeBufferHandle candidate_handle,
+                                                                uint64_t allocation_bytes,
+                                                                uint64_t frame,
+                                                                uint64_t submission);
+
+  [[nodiscard]] std::optional<BufferCacheEntry> Find(const BufferResourceKey& key, uint64_t frame,
+                                                     uint64_t submission);
+
+  // Consumes central tracker notifications. Buffer entries are removed from
+  // lookup immediately but their handles are queued for fence-safe collection.
+  size_t RetireInvalidated(std::span<const ResourceInvalidation> invalidations,
+                           uint64_t current_submission);
+  size_t RetireAll(uint64_t current_submission);
+
+  [[nodiscard]] std::vector<RetiredBuffer> Collect(uint64_t completed_submission);
+  [[nodiscard]] BufferCacheMetrics metrics() const;
+
+ private:
+  using LiveMap = std::unordered_map<BufferResourceKey, BufferCacheEntry, BufferResourceKeyHash>;
+
+  void RetireLocked(LiveMap::iterator entry, uint64_t current_submission);
+
+  PhysicalResourceTracker& tracker_;
+  mutable std::mutex mutex_;
+  LiveMap live_;
+  std::unordered_map<uint64_t, BufferResourceKey> keys_by_id_;
+  std::vector<RetiredBuffer> retired_;
+  BufferCacheMetrics metrics_;
+  uint64_t next_resource_id_ = 1;
+};
+
+}  // namespace pinyon_shift::native_renderer

--- a/src/native_renderer/resource_identity.cpp
+++ b/src/native_renderer/resource_identity.cpp
@@ -44,6 +44,17 @@ bool PhysicalRange::valid() const {
   return length && end_exclusive() <= kGuestPhysicalApertureSize;
 }
 
+size_t BufferResourceKeyHash::operator()(const BufferResourceKey& key) const {
+  uint64_t hash = kFnvOffsetBasis;
+  HashValue(key.range.address, hash);
+  HashValue(key.range.length, hash);
+  HashValue(static_cast<uint8_t>(key.resource_class), hash);
+  HashValue(key.descriptor_signature, hash);
+  HashValue(key.content.generation, hash);
+  HashValue(key.content.fingerprint, hash);
+  return static_cast<size_t>(hash);
+}
+
 PhysicalResourceTracker::PhysicalResourceTracker()
     : page_generations_(kGuestPhysicalApertureSize /
                         kGuestPhysicalPageSize) {}

--- a/src/native_renderer/resource_identity.h
+++ b/src/native_renderer/resource_identity.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstddef>
 #include <cstdint>
 #include <mutex>
 #include <optional>
@@ -54,6 +55,10 @@ struct BufferResourceKey {
   ResourceFingerprint content;
 
   bool operator==(const BufferResourceKey&) const = default;
+};
+
+struct BufferResourceKeyHash {
+  [[nodiscard]] size_t operator()(const BufferResourceKey& key) const;
 };
 
 struct TextureResourceKey {

--- a/tests/native_renderer/buffer_cache_test.cpp
+++ b/tests/native_renderer/buffer_cache_test.cpp
@@ -1,0 +1,73 @@
+#include <cstdlib>
+#include <iostream>
+
+#include "native_renderer/buffer_cache.h"
+
+namespace nr = pinyon_shift::native_renderer;
+
+namespace {
+
+void Require(bool condition, const char* message) {
+  if (!condition) {
+    std::cerr << message << '\n';
+    std::exit(EXIT_FAILURE);
+  }
+}
+
+nr::BufferResourceKey MakeKey(nr::PhysicalResourceTracker& tracker, uint32_t address,
+                              nr::BufferResourceClass resource_class) {
+  const auto range = nr::PhysicalRange::FromGraphicsAddress(address, 4096);
+  Require(range.has_value(), "test range must be valid");
+  return {*range, resource_class, 0x1234, tracker.Capture(*range)};
+}
+
+}  // namespace
+
+int main() {
+  nr::PhysicalResourceTracker tracker;
+  nr::NativeBufferCache cache(tracker);
+  const nr::BufferResourceKey vertex =
+      MakeKey(tracker, 0xA0100000, nr::BufferResourceClass::kVertex);
+
+  const auto inserted = cache.Acquire(vertex, 101, 8192, 4, 10);
+  Require(inserted && !inserted->hit && inserted->entry.handle == 101,
+          "first acquire must insert the candidate allocation");
+  const auto hit = cache.Acquire(vertex, 202, 8192, 5, 12);
+  Require(hit && hit->hit && hit->entry.handle == 101,
+          "same key must reuse the existing allocation");
+  Require(cache.Find(vertex, 6, 13)->last_use_submission == 13,
+          "cache hits must advance the final-use submission");
+  Require(!cache.Acquire(vertex, 0, 8192, 0, 0), "zero backend handles must be rejected");
+
+  const auto write = nr::PhysicalRange::FromGraphicsAddress(0x80100080, 16);
+  Require(write.has_value(), "aliased write must canonicalize");
+  const auto invalidations = tracker.Invalidate(*write);
+  Require(cache.RetireInvalidated(invalidations, 11) == 1,
+          "overlapping writes must retire the live buffer");
+  Require(!cache.Find(vertex, 7, 14), "retired buffers must leave lookup immediately");
+  Require(cache.Collect(12).empty(), "in-flight buffers must survive incomplete submissions");
+  const auto collected = cache.Collect(13);
+  Require(collected.size() == 1 && collected.front().handle == 101,
+          "buffers must become destroyable at their final submission");
+
+  const nr::BufferResourceKey rewritten =
+      MakeKey(tracker, 0x00100000, nr::BufferResourceClass::kVertex);
+  Require(rewritten != vertex, "an in-place write must force a generation-aware cache miss");
+  Require(cache.Acquire(rewritten, 303, 4096, 8, 20).has_value(),
+          "rewritten content must accept a replacement allocation");
+  const nr::BufferResourceKey index = MakeKey(tracker, 0x00102000, nr::BufferResourceClass::kIndex);
+  Require(cache.Acquire(index, 404, 2048, 8, 21).has_value(),
+          "independent index buffers must be cacheable");
+  Require(cache.RetireAll(25) == 2, "shutdown must retire every live allocation");
+  Require(cache.Collect(24).empty(), "shutdown retirement must also respect the fence");
+  Require(cache.Collect(25).size() == 2, "shutdown allocations must collect after completion");
+
+  const nr::BufferCacheMetrics metrics = cache.metrics();
+  Require(metrics.hits == 2 && metrics.misses == 4, "hit and miss telemetry must be deterministic");
+  Require(metrics.invalidations == 1 && !metrics.live_count && !metrics.live_bytes &&
+              !metrics.retired_count && !metrics.retired_bytes,
+          "lifetime telemetry must return to zero after collection");
+
+  std::cout << "native renderer buffer cache tests passed\n";
+  return EXIT_SUCCESS;
+}

--- a/tools/tests/test_native_renderer_buffer_cache.py
+++ b/tools/tests/test_native_renderer_buffer_cache.py
@@ -1,0 +1,45 @@
+import pathlib
+import unittest
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+
+
+class NativeRendererBufferCacheContractTests(unittest.TestCase):
+    def test_preview_and_native_test_compile_cache(self):
+        cmake = (ROOT / "CMakeLists.txt").read_text(encoding="utf-8")
+        self.assertEqual(cmake.count("src/native_renderer/buffer_cache.cpp"), 3)
+        self.assertIn("pinyon_shift_buffer_cache_tests EXCLUDE_FROM_ALL", cmake)
+
+    def test_invalidation_uses_deferred_collection(self):
+        header = (ROOT / "src/native_renderer/buffer_cache.h").read_text(
+            encoding="utf-8"
+        )
+        source = (ROOT / "src/native_renderer/buffer_cache.cpp").read_text(
+            encoding="utf-8"
+        )
+        self.assertIn("RetireInvalidated", header)
+        self.assertIn("retire_after_submission", header)
+        self.assertIn("resource.retire_after_submission > completed_submission", source)
+        self.assertIn("std::max(resource.last_use_submission, current_submission)", source)
+        self.assertNotIn("delete ", source)
+        self.assertNotIn("Release()", source)
+
+    def test_cache_exposes_required_lifetime_telemetry(self):
+        header = (ROOT / "src/native_renderer/buffer_cache.h").read_text(
+            encoding="utf-8"
+        )
+        for field in (
+            "hits",
+            "misses",
+            "invalidations",
+            "live_count",
+            "live_bytes",
+            "retired_count",
+            "retired_bytes",
+        ):
+            self.assertIn(f"uint64_t {field}", header)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/tests/test_native_renderer_resource_identity.py
+++ b/tools/tests/test_native_renderer_resource_identity.py
@@ -8,7 +8,7 @@ ROOT = pathlib.Path(__file__).resolve().parents[2]
 class NativeRendererResourceIdentityContractTests(unittest.TestCase):
     def test_preview_compiles_resource_identity(self):
         cmake = (ROOT / "CMakeLists.txt").read_text(encoding="utf-8")
-        self.assertEqual(cmake.count("src/native_renderer/resource_identity.cpp"), 3)
+        self.assertEqual(cmake.count("src/native_renderer/resource_identity.cpp"), 4)
         self.assertIn("pinyon_shift_resource_identity_tests EXCLUDE_FROM_ALL", cmake)
 
     def test_physical_identity_is_canonical_and_generation_aware(self):
@@ -32,7 +32,7 @@ class NativeRendererResourceIdentityContractTests(unittest.TestCase):
         source = (
             ROOT / "src/native_renderer/resource_identity.cpp"
         ).read_text(encoding="utf-8")
-        self.assertIn("std::vector<ResourceInvalidation> Invalidate", header)
+        self.assertRegex(header, r"Invalidate\(\s+const PhysicalRange&")
         self.assertIn("range.Overlaps(written_range)", source)
         self.assertNotIn("delete ", source)
         self.assertNotIn("Release()", source)


### PR DESCRIPTION
## Summary
- cache opaque native buffer allocations by canonical physical content identity
- track last-use frame and submission for vertex, index, and inline buffers
- remove invalidated entries from lookup immediately while deferring destruction
- collect retired allocations only after their final submission completes
- expose deterministic hit, miss, invalidation, live, and retired telemetry

## Validation
- 136 Python tests pass
- native buffer cache semantic test passes
- full playable preview build passes
- repository boundary passes

## Safety
- Xenos remains authoritative
- no draw suppression or rendering behavior change
- the cache owns identity and lifetime metadata; the backend retains allocation and destruction control