### PR TITLE
feat(native-renderer): add streaming texture cache

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,7 @@ if(WIN32)
         src/native_renderer/resource_identity.cpp
         src/native_renderer/shader_capture.cpp
         src/native_renderer/shader_pack.cpp
+        src/native_renderer/texture_cache.cpp
     )
 else()
     add_executable(pinyon_shift
@@ -41,6 +42,7 @@ else()
         src/native_renderer/resource_identity.cpp
         src/native_renderer/shader_capture.cpp
         src/native_renderer/shader_pack.cpp
+        src/native_renderer/texture_cache.cpp
     )
 endif()
 
@@ -56,6 +58,13 @@ add_executable(pinyon_shift_buffer_cache_tests EXCLUDE_FROM_ALL
     src/native_renderer/resource_identity.cpp
 )
 target_include_directories(pinyon_shift_buffer_cache_tests PRIVATE src)
+
+add_executable(pinyon_shift_texture_cache_tests EXCLUDE_FROM_ALL
+    tests/native_renderer/texture_cache_test.cpp
+    src/native_renderer/resource_identity.cpp
+    src/native_renderer/texture_cache.cpp
+)
+target_include_directories(pinyon_shift_texture_cache_tests PRIVATE src)
 
 pinyon_shift_attach_rexglue(pinyon_shift)
 

--- a/docs/native-renderer/RESOURCE_IDENTITY.md
+++ b/docs/native-renderer/RESOURCE_IDENTITY.md
@@ -35,3 +35,18 @@ the entry from lookup immediately, but moves its allocation to a retired queue
 stamped with the later of its last use and the current submission. Only
 `Collect(completed_submission)` returns handles that the backend may destroy.
 This makes early invalidation and shutdown use the same fence-safe path.
+
+## Texture streaming state
+
+`NativeTextureCache` uses the same physical content identity for asynchronous
+texture decode and upload work. An incomplete guest payload schedules bounded
+exponential backoff. While a refreshed generation is pending, the cache serves
+the previous complete texture; when no complete generation exists, handle zero
+selects the backend's neutral fallback. Exhausting the configured attempt limit
+stops decode churn until the content identity changes.
+
+The first measured upload contract is taken directly from retained-pass anchor
+`747837906D0BF484`. Its two fetches are tiled 256 by 64 `DXN` (BC5-like)
+resources with 256-pixel pitch and 8-in-16 endianness. The native semantic test
+decodes the captured six-word fetch constant and fixes those values as the
+input contract for the upcoming D3D12 upload bridge.

--- a/src/native_renderer/resource_identity.cpp
+++ b/src/native_renderer/resource_identity.cpp
@@ -55,6 +55,21 @@ size_t BufferResourceKeyHash::operator()(const BufferResourceKey& key) const {
   return static_cast<size_t>(hash);
 }
 
+size_t TextureResourceKeyHash::operator()(const TextureResourceKey& key) const {
+  uint64_t hash = kFnvOffsetBasis;
+  HashValue(key.base.address, hash);
+  HashValue(key.base.length, hash);
+  HashValue(key.mips.has_value(), hash);
+  if (key.mips) {
+    HashValue(key.mips->address, hash);
+    HashValue(key.mips->length, hash);
+  }
+  HashValue(key.fetch_signature, hash);
+  HashValue(key.content.generation, hash);
+  HashValue(key.content.fingerprint, hash);
+  return static_cast<size_t>(hash);
+}
+
 PhysicalResourceTracker::PhysicalResourceTracker()
     : page_generations_(kGuestPhysicalApertureSize /
                         kGuestPhysicalPageSize) {}

--- a/src/native_renderer/resource_identity.h
+++ b/src/native_renderer/resource_identity.h
@@ -70,6 +70,10 @@ struct TextureResourceKey {
   bool operator==(const TextureResourceKey&) const = default;
 };
 
+struct TextureResourceKeyHash {
+  [[nodiscard]] size_t operator()(const TextureResourceKey& key) const;
+};
+
 enum class TrackedResourceClass : uint8_t {
   kBuffer,
   kTexture,

--- a/src/native_renderer/texture_cache.cpp
+++ b/src/native_renderer/texture_cache.cpp
@@ -1,0 +1,245 @@
+#include "native_renderer/texture_cache.h"
+
+#include <algorithm>
+
+namespace pinyon_shift::native_renderer {
+
+std::optional<NativeTextureDescriptor> NativeTextureDescriptor::FromFetchWords(
+    const std::array<uint32_t, 6>& words) {
+  NativeTextureDescriptor descriptor;
+  descriptor.pitch = ((words[0] >> 22) & 0x1FF) * 32;
+  descriptor.tiled = (words[0] >> 31) != 0;
+  descriptor.format = words[1] & 0x3F;
+  descriptor.endianness = (words[1] >> 6) & 0x3;
+  descriptor.width = (words[2] & 0x1FFF) + 1;
+  descriptor.height = ((words[2] >> 13) & 0x1FFF) + 1;
+  descriptor.depth = ((words[2] >> 26) & 0x3F) + 1;
+  descriptor.mip_min_level = (words[4] >> 2) & 0xF;
+  descriptor.mip_max_level = (words[4] >> 6) & 0xF;
+  descriptor.dimension = (words[5] >> 9) & 0x3;
+  descriptor.packed_mips = ((words[5] >> 11) & 1) != 0;
+  if (!descriptor.pitch ||
+      descriptor.mip_min_level > descriptor.mip_max_level) {
+    return std::nullopt;
+  }
+  return descriptor;
+}
+
+NativeTextureCache::NativeTextureCache(PhysicalResourceTracker& tracker,
+                                       TextureRetryPolicy retry_policy)
+    : tracker_(tracker), retry_policy_(retry_policy) {
+  retry_policy_.maximum_attempts =
+      std::max(retry_policy_.maximum_attempts, uint32_t(1));
+  retry_policy_.base_delay_frames =
+      std::max(retry_policy_.base_delay_frames, uint32_t(1));
+  retry_policy_.maximum_delay_frames = std::max(
+      retry_policy_.maximum_delay_frames, retry_policy_.base_delay_frames);
+}
+
+TextureCacheRequest NativeTextureCache::Request(const TextureResourceKey& key,
+                                                uint64_t frame,
+                                                uint64_t submission) {
+  if (!key.base.valid() || (key.mips && !key.mips->valid())) {
+    return {TextureRequestState::kPermanentFailure};
+  }
+  const std::scoped_lock lock(mutex_);
+  Slot* slot = FindSlotLocked(key);
+  if (!slot) {
+    slots_.push_back({key.base, key.mips, key.fetch_signature});
+    slot = &slots_.back();
+  }
+  if (slot->live && slot->live->key == key) {
+    slot->live->last_use_frame = std::max(slot->live->last_use_frame, frame);
+    slot->live->last_use_submission =
+        std::max(slot->live->last_use_submission, submission);
+    ++metrics_.hits;
+    return {TextureRequestState::kReady, 0, slot->live->handle,
+            slot->attempt, false};
+  }
+
+  const bool new_content = !slot->pending || *slot->pending != key;
+  if (new_content) {
+    slot->pending = key;
+    slot->decode_ticket = 0;
+    slot->next_retry_frame = frame;
+    slot->attempt = 0;
+    slot->decode_in_flight = false;
+    slot->permanent_failure = false;
+    ++metrics_.misses;
+  }
+  const NativeTextureHandle fallback = slot->live ? slot->live->handle : 0;
+  if (slot->permanent_failure) {
+    return {TextureRequestState::kPermanentFailure, 0, fallback,
+            slot->attempt, bool(slot->live)};
+  }
+  if (slot->decode_in_flight || frame < slot->next_retry_frame) {
+    return {TextureRequestState::kRetryPending, slot->decode_ticket, fallback,
+            slot->attempt, bool(slot->live)};
+  }
+
+  slot->decode_in_flight = true;
+  slot->decode_ticket = next_decode_ticket_++;
+  ++slot->attempt;
+  ++metrics_.decode_requests;
+  return {TextureRequestState::kDecodeRequired, slot->decode_ticket, fallback,
+          slot->attempt, bool(slot->live)};
+}
+
+bool NativeTextureCache::Complete(uint64_t decode_ticket,
+                                  TextureDecodeResult result,
+                                  NativeTextureHandle handle,
+                                  uint64_t allocation_bytes, uint64_t frame,
+                                  uint64_t submission) {
+  if (!decode_ticket) {
+    return false;
+  }
+  const std::scoped_lock lock(mutex_);
+  auto found = std::find_if(slots_.begin(), slots_.end(),
+                            [&](const Slot& slot) {
+                              return slot.decode_in_flight &&
+                                     slot.decode_ticket == decode_ticket;
+                            });
+  if (found == slots_.end() || !found->pending) {
+    return false;
+  }
+  Slot& slot = *found;
+  slot.decode_in_flight = false;
+  if (result == TextureDecodeResult::kIncompletePayload) {
+    ++metrics_.incomplete_payloads;
+    if (slot.attempt >= retry_policy_.maximum_attempts) {
+      slot.permanent_failure = true;
+      ++metrics_.permanent_failures;
+    } else {
+      slot.next_retry_frame = frame + RetryDelay(slot.attempt);
+      ++metrics_.retries;
+    }
+    return true;
+  }
+  if (result == TextureDecodeResult::kPermanentFailure || !handle ||
+      !allocation_bytes || (slot.live && slot.live->handle == handle)) {
+    slot.permanent_failure = true;
+    ++metrics_.permanent_failures;
+    return true;
+  }
+
+  if (slot.live) {
+    RetireLiveLocked(slot, submission);
+  }
+  const uint64_t resource_id = next_resource_id_++;
+  slot.live = LiveTexture{*slot.pending, resource_id, handle,
+                          allocation_bytes, frame, submission};
+  PhysicalRange ranges[2] = {slot.live->key.base, {}};
+  size_t range_count = 1;
+  if (slot.live->key.mips) {
+    ranges[range_count++] = *slot.live->key.mips;
+  }
+  tracker_.Track({TrackedResourceClass::kTexture, resource_id},
+                 std::span<const PhysicalRange>(ranges, range_count));
+  slot.pending.reset();
+  slot.permanent_failure = false;
+  ++metrics_.live_count;
+  metrics_.live_bytes += allocation_bytes;
+  return true;
+}
+
+size_t NativeTextureCache::RetireInvalidated(
+    std::span<const ResourceInvalidation> invalidations,
+    const PhysicalRange& written_range, uint64_t current_submission) {
+  const std::scoped_lock lock(mutex_);
+  size_t count = 0;
+  for (Slot& slot : slots_) {
+    if (slot.pending &&
+        (slot.pending->base.Overlaps(written_range) ||
+         (slot.pending->mips &&
+          slot.pending->mips->Overlaps(written_range)))) {
+      slot.pending.reset();
+      slot.decode_in_flight = false;
+      slot.permanent_failure = false;
+    }
+    if (!slot.live) {
+      continue;
+    }
+    const bool invalidated = std::ranges::any_of(
+        invalidations, [&](const ResourceInvalidation& invalidation) {
+          return invalidation.resource.resource_class ==
+                     TrackedResourceClass::kTexture &&
+                 invalidation.resource.value == slot.live->resource_id;
+        });
+    if (invalidated) {
+      RetireLiveLocked(slot, current_submission);
+      ++count;
+    }
+  }
+  metrics_.invalidations += count;
+  return count;
+}
+
+size_t NativeTextureCache::RetireAll(uint64_t current_submission) {
+  const std::scoped_lock lock(mutex_);
+  size_t count = 0;
+  for (Slot& slot : slots_) {
+    slot.pending.reset();
+    slot.decode_in_flight = false;
+    if (slot.live) {
+      RetireLiveLocked(slot, current_submission);
+      ++count;
+    }
+  }
+  return count;
+}
+
+std::vector<RetiredTexture> NativeTextureCache::Collect(
+    uint64_t completed_submission) {
+  const std::scoped_lock lock(mutex_);
+  std::vector<RetiredTexture> ready;
+  auto retained = std::remove_if(
+      retired_.begin(), retired_.end(), [&](const RetiredTexture& texture) {
+        if (texture.retire_after_submission > completed_submission) {
+          return false;
+        }
+        ready.push_back(texture);
+        --metrics_.retired_count;
+        metrics_.retired_bytes -= texture.allocation_bytes;
+        return true;
+      });
+  retired_.erase(retained, retired_.end());
+  return ready;
+}
+
+TextureCacheMetrics NativeTextureCache::metrics() const {
+  const std::scoped_lock lock(mutex_);
+  return metrics_;
+}
+
+NativeTextureCache::Slot* NativeTextureCache::FindSlotLocked(
+    const TextureResourceKey& key) {
+  auto found = std::find_if(slots_.begin(), slots_.end(),
+                            [&](const Slot& slot) {
+                              return slot.base == key.base &&
+                                     slot.mips == key.mips &&
+                                     slot.fetch_signature == key.fetch_signature;
+                            });
+  return found == slots_.end() ? nullptr : &*found;
+}
+
+void NativeTextureCache::RetireLiveLocked(Slot& slot,
+                                          uint64_t current_submission) {
+  const LiveTexture texture = *slot.live;
+  retired_.push_back(
+      {texture.handle, texture.allocation_bytes,
+       std::max(texture.last_use_submission, current_submission)});
+  tracker_.Untrack({TrackedResourceClass::kTexture, texture.resource_id});
+  slot.live.reset();
+  --metrics_.live_count;
+  metrics_.live_bytes -= texture.allocation_bytes;
+  ++metrics_.retired_count;
+  metrics_.retired_bytes += texture.allocation_bytes;
+}
+
+uint64_t NativeTextureCache::RetryDelay(uint32_t attempt) const {
+  const uint32_t shift = std::min(attempt - 1, uint32_t(31));
+  const uint64_t delay = uint64_t(retry_policy_.base_delay_frames) << shift;
+  return std::min(delay, uint64_t(retry_policy_.maximum_delay_frames));
+}
+
+}  // namespace pinyon_shift::native_renderer

--- a/src/native_renderer/texture_cache.h
+++ b/src/native_renderer/texture_cache.h
@@ -1,0 +1,146 @@
+#pragma once
+
+#include <array>
+#include <cstdint>
+#include <mutex>
+#include <optional>
+#include <span>
+#include <vector>
+
+#include "native_renderer/resource_identity.h"
+
+namespace pinyon_shift::native_renderer {
+
+constexpr uint32_t kXenosTextureFormatDxn = 49;
+
+struct NativeTextureDescriptor {
+  uint32_t format = 0;
+  uint32_t endianness = 0;
+  uint32_t dimension = 0;
+  uint32_t width = 0;
+  uint32_t height = 0;
+  uint32_t depth = 0;
+  uint32_t pitch = 0;
+  uint32_t mip_min_level = 0;
+  uint32_t mip_max_level = 0;
+  bool tiled = false;
+  bool packed_mips = false;
+
+  static std::optional<NativeTextureDescriptor> FromFetchWords(
+      const std::array<uint32_t, 6>& words);
+
+  bool operator==(const NativeTextureDescriptor&) const = default;
+};
+
+using NativeTextureHandle = uint64_t;
+
+enum class TextureRequestState : uint8_t {
+  kReady,
+  kDecodeRequired,
+  kRetryPending,
+  kPermanentFailure,
+};
+
+struct TextureCacheRequest {
+  TextureRequestState state = TextureRequestState::kRetryPending;
+  uint64_t decode_ticket = 0;
+  NativeTextureHandle sampled_handle = 0;
+  uint32_t attempt = 0;
+  bool serving_previous = false;
+};
+
+enum class TextureDecodeResult : uint8_t {
+  kReady,
+  kIncompletePayload,
+  kPermanentFailure,
+};
+
+struct TextureRetryPolicy {
+  uint32_t maximum_attempts = 4;
+  uint32_t base_delay_frames = 2;
+  uint32_t maximum_delay_frames = 32;
+};
+
+struct RetiredTexture {
+  NativeTextureHandle handle = 0;
+  uint64_t allocation_bytes = 0;
+  uint64_t retire_after_submission = 0;
+};
+
+struct TextureCacheMetrics {
+  uint64_t hits = 0;
+  uint64_t misses = 0;
+  uint64_t decode_requests = 0;
+  uint64_t incomplete_payloads = 0;
+  uint64_t retries = 0;
+  uint64_t permanent_failures = 0;
+  uint64_t invalidations = 0;
+  uint64_t live_count = 0;
+  uint64_t live_bytes = 0;
+  uint64_t retired_count = 0;
+  uint64_t retired_bytes = 0;
+};
+
+// Backend-neutral texture decode and lifetime state. Decode work is requested
+// by ticket and committed later; incomplete streaming data uses bounded
+// exponential backoff while the previous generation (or handle zero as the
+// neutral fallback) remains sampleable.
+class NativeTextureCache {
+ public:
+  explicit NativeTextureCache(PhysicalResourceTracker& tracker,
+                              TextureRetryPolicy retry_policy = {});
+
+  [[nodiscard]] TextureCacheRequest Request(const TextureResourceKey& key,
+                                            uint64_t frame,
+                                            uint64_t submission);
+  bool Complete(uint64_t decode_ticket, TextureDecodeResult result,
+                NativeTextureHandle handle, uint64_t allocation_bytes,
+                uint64_t frame, uint64_t submission);
+
+  size_t RetireInvalidated(
+      std::span<const ResourceInvalidation> invalidations,
+      const PhysicalRange& written_range, uint64_t current_submission);
+  size_t RetireAll(uint64_t current_submission);
+
+  [[nodiscard]] std::vector<RetiredTexture> Collect(
+      uint64_t completed_submission);
+  [[nodiscard]] TextureCacheMetrics metrics() const;
+
+ private:
+  struct LiveTexture {
+    TextureResourceKey key;
+    uint64_t resource_id = 0;
+    NativeTextureHandle handle = 0;
+    uint64_t allocation_bytes = 0;
+    uint64_t last_use_frame = 0;
+    uint64_t last_use_submission = 0;
+  };
+
+  struct Slot {
+    PhysicalRange base;
+    std::optional<PhysicalRange> mips;
+    uint64_t fetch_signature = 0;
+    std::optional<LiveTexture> live;
+    std::optional<TextureResourceKey> pending;
+    uint64_t decode_ticket = 0;
+    uint64_t next_retry_frame = 0;
+    uint32_t attempt = 0;
+    bool decode_in_flight = false;
+    bool permanent_failure = false;
+  };
+
+  [[nodiscard]] Slot* FindSlotLocked(const TextureResourceKey& key);
+  void RetireLiveLocked(Slot& slot, uint64_t current_submission);
+  [[nodiscard]] uint64_t RetryDelay(uint32_t attempt) const;
+
+  PhysicalResourceTracker& tracker_;
+  TextureRetryPolicy retry_policy_;
+  mutable std::mutex mutex_;
+  std::vector<Slot> slots_;
+  std::vector<RetiredTexture> retired_;
+  TextureCacheMetrics metrics_;
+  uint64_t next_resource_id_ = 1;
+  uint64_t next_decode_ticket_ = 1;
+};
+
+}  // namespace pinyon_shift::native_renderer

--- a/tests/native_renderer/texture_cache_test.cpp
+++ b/tests/native_renderer/texture_cache_test.cpp
@@ -1,0 +1,136 @@
+#include <array>
+#include <cstdlib>
+#include <iostream>
+
+#include "native_renderer/texture_cache.h"
+
+namespace nr = pinyon_shift::native_renderer;
+
+namespace {
+
+void Require(bool condition, const char* message) {
+  if (!condition) {
+    std::cerr << message << '\n';
+    std::exit(EXIT_FAILURE);
+  }
+}
+
+nr::TextureResourceKey MakeKey(nr::PhysicalResourceTracker& tracker) {
+  const auto base =
+      nr::PhysicalRange::FromGraphicsAddress(0x94649000, 32768);
+  Require(base.has_value(), "selected DXN range must be valid");
+  return {*base, std::nullopt, UINT64_C(0x747837906D0BF484),
+          tracker.Capture(*base)};
+}
+
+}  // namespace
+
+int main() {
+  constexpr std::array<uint32_t, 6> selected_fetch = {
+      0x82024002, 0x14649071, 0x0007E0FF,
+      0x00A80D10, 0x00000003, 0x00000A00};
+  const auto descriptor =
+      nr::NativeTextureDescriptor::FromFetchWords(selected_fetch);
+  Require(descriptor && descriptor->format == nr::kXenosTextureFormatDxn &&
+              descriptor->width == 256 && descriptor->height == 64 &&
+              descriptor->pitch == 256 && descriptor->tiled &&
+              descriptor->endianness == 1,
+          "the retained-pass fetch must decode as tiled 256x64 DXN");
+
+  nr::PhysicalResourceTracker tracker;
+  nr::NativeTextureCache cache(
+      tracker, {.maximum_attempts = 4,
+                .base_delay_frames = 2,
+                .maximum_delay_frames = 8});
+  const nr::TextureResourceKey key = MakeKey(tracker);
+  const auto first = cache.Request(key, 10, 1);
+  Require(first.state == nr::TextureRequestState::kDecodeRequired &&
+              first.attempt == 1 && !first.sampled_handle,
+          "a cold miss must request decode with the neutral fallback");
+  Require(cache.Complete(first.decode_ticket,
+                         nr::TextureDecodeResult::kIncompletePayload,
+                         0, 0, 10, 1),
+          "an incomplete streaming payload must be accepted");
+  Require(cache.Request(key, 11, 2).state ==
+              nr::TextureRequestState::kRetryPending,
+          "retry must wait for its bounded backoff");
+  const auto second = cache.Request(key, 12, 3);
+  Require(second.state == nr::TextureRequestState::kDecodeRequired &&
+              second.attempt == 2,
+          "retry must become due after two frames");
+  Require(cache.Complete(second.decode_ticket,
+                         nr::TextureDecodeResult::kIncompletePayload,
+                         0, 0, 12, 3),
+          "a second incomplete payload must remain retryable");
+  Require(cache.Request(key, 15, 4).state ==
+              nr::TextureRequestState::kRetryPending,
+          "exponential backoff must grow to four frames");
+  const auto third = cache.Request(key, 16, 5);
+  Require(third.state == nr::TextureRequestState::kDecodeRequired &&
+              third.attempt == 3,
+          "third decode must start at the bounded due frame");
+  Require(cache.Complete(third.decode_ticket, nr::TextureDecodeResult::kReady,
+                         501, 65536, 16, 6),
+          "a complete decode must commit its native allocation");
+  const auto hit = cache.Request(key, 17, 9);
+  Require(hit.state == nr::TextureRequestState::kReady &&
+              hit.sampled_handle == 501,
+          "committed content must produce an exact cache hit");
+
+  nr::TextureResourceKey replacement = key;
+  ++replacement.content.generation;
+  ++replacement.content.fingerprint;
+  const auto refresh = cache.Request(replacement, 18, 10);
+  Require(refresh.state == nr::TextureRequestState::kDecodeRequired &&
+              refresh.sampled_handle == 501 && refresh.serving_previous,
+          "a pending refresh may serve the previous complete texture");
+  Require(cache.Complete(refresh.decode_ticket, nr::TextureDecodeResult::kReady,
+                         502, 65536, 18, 11),
+          "a refreshed generation must atomically replace the old one");
+  Require(cache.Collect(10).empty(),
+          "the replaced allocation must wait for its last submission");
+  Require(cache.Collect(11).size() == 1,
+          "the replaced allocation must collect at its final use");
+
+  const auto write =
+      nr::PhysicalRange::FromGraphicsAddress(0xB4649020, 16);
+  Require(write.has_value(), "aliased texture write must canonicalize");
+  const auto invalidations = tracker.Invalidate(*write);
+  Require(cache.RetireInvalidated(invalidations, *write, 12) == 1,
+          "a guest write must retire the overlapping native texture");
+  Require(cache.Collect(11).empty(),
+          "invalidated allocations must remain live through submission 12");
+  Require(cache.Collect(12).size() == 1,
+          "invalidated allocations must collect after submission 12");
+
+  nr::NativeTextureCache bounded(
+      tracker, {.maximum_attempts = 2,
+                .base_delay_frames = 1,
+                .maximum_delay_frames = 2});
+  const nr::TextureResourceKey rewritten = MakeKey(tracker);
+  const auto bounded_first = bounded.Request(rewritten, 20, 20);
+  Require(bounded.Complete(bounded_first.decode_ticket,
+                           nr::TextureDecodeResult::kIncompletePayload,
+                           0, 0, 20, 20),
+          "bounded retry first failure must complete");
+  const auto bounded_second = bounded.Request(rewritten, 21, 21);
+  Require(bounded.Complete(bounded_second.decode_ticket,
+                           nr::TextureDecodeResult::kIncompletePayload,
+                           0, 0, 21, 21),
+          "bounded retry final failure must complete");
+  Require(bounded.Request(rewritten, 100, 22).state ==
+              nr::TextureRequestState::kPermanentFailure,
+          "retry exhaustion must stop rescheduling decode work");
+
+  const nr::TextureCacheMetrics metrics = cache.metrics();
+  Require(metrics.hits == 1 && metrics.misses == 2 &&
+              metrics.decode_requests == 4 &&
+              metrics.incomplete_payloads == 2 && metrics.retries == 2 &&
+              metrics.invalidations == 1 && !metrics.live_count &&
+              !metrics.live_bytes && !metrics.retired_count &&
+              !metrics.retired_bytes,
+          "texture cache telemetry must describe the complete lifecycle");
+
+  std::cout << "native renderer texture cache tests passed\n";
+  return EXIT_SUCCESS;
+}

--- a/tools/tests/test_native_renderer_resource_identity.py
+++ b/tools/tests/test_native_renderer_resource_identity.py
@@ -8,7 +8,7 @@ ROOT = pathlib.Path(__file__).resolve().parents[2]
 class NativeRendererResourceIdentityContractTests(unittest.TestCase):
     def test_preview_compiles_resource_identity(self):
         cmake = (ROOT / "CMakeLists.txt").read_text(encoding="utf-8")
-        self.assertEqual(cmake.count("src/native_renderer/resource_identity.cpp"), 4)
+        self.assertEqual(cmake.count("src/native_renderer/resource_identity.cpp"), 5)
         self.assertIn("pinyon_shift_resource_identity_tests EXCLUDE_FROM_ALL", cmake)
 
     def test_physical_identity_is_canonical_and_generation_aware(self):

--- a/tools/tests/test_native_renderer_texture_cache.py
+++ b/tools/tests/test_native_renderer_texture_cache.py
@@ -1,0 +1,59 @@
+import pathlib
+import unittest
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+
+
+class NativeRendererTextureCacheContractTests(unittest.TestCase):
+    def test_preview_and_native_test_compile_texture_cache(self):
+        cmake = (ROOT / "CMakeLists.txt").read_text(encoding="utf-8")
+        self.assertEqual(cmake.count("src/native_renderer/texture_cache.cpp"), 3)
+        self.assertIn("pinyon_shift_texture_cache_tests EXCLUDE_FROM_ALL", cmake)
+
+    def test_selected_retained_pass_dxn_contract_is_encoded(self):
+        header = (ROOT / "src/native_renderer/texture_cache.h").read_text(
+            encoding="utf-8"
+        )
+        native_test = (
+            ROOT / "tests/native_renderer/texture_cache_test.cpp"
+        ).read_text(encoding="utf-8")
+        self.assertIn("kXenosTextureFormatDxn = 49", header)
+        for fetch_word in (
+            "0x82024002",
+            "0x14649071",
+            "0x0007E0FF",
+            "0x00A80D10",
+            "0x00000003",
+            "0x00000A00",
+        ):
+            self.assertIn(fetch_word, native_test)
+        self.assertIn("descriptor->width == 256", native_test)
+        self.assertIn("descriptor->height == 64", native_test)
+
+    def test_streaming_retry_is_bounded_and_keeps_a_fallback(self):
+        header = (ROOT / "src/native_renderer/texture_cache.h").read_text(
+            encoding="utf-8"
+        )
+        source = (ROOT / "src/native_renderer/texture_cache.cpp").read_text(
+            encoding="utf-8"
+        )
+        self.assertIn("maximum_attempts", header)
+        self.assertIn("maximum_delay_frames", header)
+        self.assertIn("kIncompletePayload", header)
+        self.assertIn("serving_previous", header)
+        self.assertIn("slot.attempt >= retry_policy_.maximum_attempts", source)
+        self.assertIn("slot->live ? slot->live->handle : 0", source)
+
+    def test_invalidation_and_replacement_use_deferred_destruction(self):
+        source = (ROOT / "src/native_renderer/texture_cache.cpp").read_text(
+            encoding="utf-8"
+        )
+        self.assertIn("RetireInvalidated", source)
+        self.assertIn("std::max(texture.last_use_submission, current_submission)", source)
+        self.assertNotIn("delete ", source)
+        self.assertNotIn("Release()", source)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- decode the retained-pass six-word Xenon fetch contract into native texture metadata
- fix the first upload target as tiled 256x64 DXN with 256-pixel pitch and 8-in-16 endianness
- cache complete generations by canonical physical identity
- retry incomplete streaming payloads with bounded exponential backoff
- serve the previous complete generation or neutral fallback while work is pending
- retire replaced and invalidated textures only after their final submission

## Validation
- 140 Python tests pass
- native texture cache semantic test passes
- full playable preview build passes
- repository boundary passes

## Safety
- Xenos remains authoritative
- no draw suppression or presentation behavior change
- backend allocations remain opaque until the D3D12 upload bridge lands