### PR TITLE
feat(native-renderer): bridge gpu-ready textures

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,7 @@ if(WIN32)
         src/native_renderer/shader_capture.cpp
         src/native_renderer/shader_pack.cpp
         src/native_renderer/texture_cache.cpp
+        src/native_renderer/texture_resource_bridge.cpp
     )
 else()
     add_executable(pinyon_shift
@@ -43,6 +44,7 @@ else()
         src/native_renderer/shader_capture.cpp
         src/native_renderer/shader_pack.cpp
         src/native_renderer/texture_cache.cpp
+        src/native_renderer/texture_resource_bridge.cpp
     )
 endif()
 

--- a/docs/native-renderer/RESOURCE_IDENTITY.md
+++ b/docs/native-renderer/RESOURCE_IDENTITY.md
@@ -50,3 +50,30 @@ The first measured upload contract is taken directly from retained-pass anchor
 resources with 256-pixel pitch and 8-in-16 endianness. The native semantic test
 decodes the captured six-word fetch constant and fixes those values as the
 input contract for the upcoming D3D12 upload bridge.
+
+## GPU-ready texture handoff
+
+Patch `0064-d3d12-native-texture-resource-observer.patch` adds a read-only
+observer immediately after ReXGlue finishes `RequestTextures`. The D3D12
+backend exports the exact guest fetch words, canonical base and mip ranges,
+host resource and view formats, component swizzle, allocation size, and the
+current and completed submission indices. The observer receives borrowed
+resources. Keeping one beyond the callback requires the backend-provided
+retain function, and releasing it is deferred through the native texture
+cache's completed-submission gate.
+
+Pinyon's bridge is controlled by the restart-required
+`pinyon_shift_native_renderer_texture_bridge` setting and defaults to `false`.
+When enabled, it imports the already-untilled GPU resource into
+`NativeTextureCache`, records bounded ownership and cache diagnostics, and
+leaves the authoritative Xenos draw untouched. This is a producer-resource
+handoff, not an independent upload and not a suppression point. The next
+milestone may build a native descriptor from the exported host view metadata
+and bind it to the retained isolated pass without changing that fallback
+policy.
+
+The bridge records only the first 16 observed layouts for discovery, then
+returns through a lock-free rejection path unless a texture matches the
+measured 256 by 64 tiled DXN contract. Cache summaries are submission-paced,
+not draw-paced. This keeps the default-off probe bounded even in scenes with
+thousands of draws per frame.

--- a/patches/rexglue/0064-d3d12-native-texture-resource-observer.patch
+++ b/patches/rexglue/0064-d3d12-native-texture-resource-observer.patch
@@ -1,0 +1,245 @@
+diff --git a/include/rex/system/interfaces/graphics.h b/include/rex/system/interfaces/graphics.h
+index 154d2b8..51d7941 100644
+--- a/include/rex/system/interfaces/graphics.h
++++ b/include/rex/system/interfaces/graphics.h
+@@ -82,6 +82,67 @@ class NativeGuestOutputRendererRegistration {
+   std::atomic<NativeGuestOutputRenderer> renderer_{nullptr};
+ };
+ 
++enum class GraphicsNativeTextureBackend : uint32_t {
++  kUnsupported = 0,
++  kD3D12 = 1,
++  kVulkan = 2,
++};
++
++using GraphicsNativeTextureRetain = void (*)(void* resource);
++using GraphicsNativeTextureRelease = void (*)(void* resource);
++
++// A GPU-ready texture resource borrowed for the duration of the observer. An
++// observer that stores resource must call retain before returning and release
++// it only after its own submission-safe retirement gate has passed.
++struct GraphicsNativeTextureResourceObservation {
++  uint32_t fetch_constant = 0;
++  uint32_t fetch_dwords[6] = {};
++  uint32_t base_address = 0;
++  uint32_t base_length = 0;
++  uint32_t mip_address = 0;
++  uint32_t mip_length = 0;
++  uint32_t guest_format = 0;
++  uint32_t guest_dimension = 0;
++  uint32_t guest_width = 0;
++  uint32_t guest_height = 0;
++  uint32_t guest_depth_or_array_size = 0;
++  uint32_t guest_pitch = 0;
++  uint32_t guest_endianness = 0;
++  uint32_t guest_mip_max_level = 0;
++  uint32_t guest_tiled = 0;
++  uint32_t guest_packed_mips = 0;
++  uint32_t host_resource_format = 0;
++  uint32_t host_view_format = 0;
++  uint32_t host_swizzle = 0;
++  uint32_t host_swizzled_signs = 0;
++  uint32_t host_dimension = 0;
++  uint32_t host_mip_levels = 0;
++  uint32_t host_depth_or_array_size = 0;
++  uint64_t host_width = 0;
++  uint32_t host_height = 0;
++  uint64_t host_allocation_bytes = 0;
++  void* resource = nullptr;
++  GraphicsNativeTextureRetain retain = nullptr;
++  GraphicsNativeTextureRelease release = nullptr;
++};
++
++constexpr uint32_t kGraphicsNativeTextureResourceObservationLimit = 32;
++
++struct GraphicsNativeTextureSetObservation {
++  GraphicsNativeTextureBackend backend =
++      GraphicsNativeTextureBackend::kUnsupported;
++  uint32_t used_texture_mask = 0;
++  uint32_t resource_count = 0;
++  uint32_t resource_overflow = 0;
++  uint64_t current_submission = 0;
++  uint64_t completed_submission = 0;
++  GraphicsNativeTextureResourceObservation
++      resources[kGraphicsNativeTextureResourceObservationLimit] = {};
++};
++
++using GraphicsNativeTextureSetObserver = void (*)(
++    const GraphicsNativeTextureSetObservation& observation);
++
+ struct GraphicsVertexBindingObservation {
+   uint32_t fetch_constant = 0;
+   uint32_t address = 0;
+@@ -363,6 +422,10 @@ class IGraphicsSystem {
+       GraphicsIsolatedDrawRequestObserver observer) {
+     (void)observer;
+   }
++  virtual void SetNativeTextureSetObserver(
++      GraphicsNativeTextureSetObserver observer) {
++    (void)observer;
++  }
+   virtual void SetNativeGuestOutputRenderer(NativeGuestOutputRenderer renderer) {
+     (void)renderer;
+   }
+diff --git a/include/rex/graphics/graphics_system.h b/include/rex/graphics/graphics_system.h
+index 682d657..70b0a0d 100644
+--- a/include/rex/graphics/graphics_system.h
++++ b/include/rex/graphics/graphics_system.h
+@@ -104,6 +104,13 @@ class GraphicsSystem : public system::IGraphicsSystem {
+       const {
+     return isolated_draw_request_observer_.load(std::memory_order_acquire);
+   }
++  void SetNativeTextureSetObserver(
++      system::GraphicsNativeTextureSetObserver observer) override {
++    native_texture_set_observer_.store(observer, std::memory_order_release);
++  }
++  system::GraphicsNativeTextureSetObserver native_texture_set_observer() const {
++    return native_texture_set_observer_.load(std::memory_order_acquire);
++  }
+   void SetNativeGuestOutputRenderer(
+       system::NativeGuestOutputRenderer renderer) override {
+     native_guest_output_renderer_.Set(renderer);
+@@ -182,6 +189,8 @@ class GraphicsSystem : public system::IGraphicsSystem {
+       nullptr};
+   std::atomic<system::GraphicsIsolatedDrawRequestObserver>
+       isolated_draw_request_observer_{nullptr};
++  std::atomic<system::GraphicsNativeTextureSetObserver>
++      native_texture_set_observer_{nullptr};
+   system::NativeGuestOutputRendererRegistration native_guest_output_renderer_;
+ 
+   std::atomic_flag host_gpu_loss_reported_;
+diff --git a/include/rex/graphics/d3d12/texture_cache.h b/include/rex/graphics/d3d12/texture_cache.h
+index 4d845c7..262ec6f 100644
+--- a/include/rex/graphics/d3d12/texture_cache.h
++++ b/include/rex/graphics/d3d12/texture_cache.h
+@@ -25,6 +25,7 @@
+ #include <rex/graphics/pipeline/texture/util.h>
+ #include <rex/graphics/register_file.h>
+ #include <rex/graphics/xenos.h>
++#include <rex/system/interfaces/graphics.h>
+ #include <rex/ui/d3d12/d3d12_api.h>
+ #include <rex/ui/d3d12/d3d12_provider.h>
+ 
+@@ -96,6 +97,12 @@ class D3D12TextureCache final : public TextureCache {
+   // binding the actual drawing pipeline.
+   void RequestTextures(uint32_t used_texture_mask) override;
+ 
++  // Exports borrowed GPU-ready resources after RequestTextures has completed.
++  // Callers retaining a resource must use the supplied lifetime callbacks.
++  void ObserveNativeTextures(
++      uint32_t used_texture_mask,
++      system::GraphicsNativeTextureSetObservation& observation) const;
++
+   // Returns whether texture SRV keys stored externally are still valid for the
+   // current bindings and host shader binding layout. Both keys and
+   // host_shader_bindings must have host_shader_binding_count elements
+diff --git a/src/graphics/d3d12/texture_cache.cpp b/src/graphics/d3d12/texture_cache.cpp
+index 2be0e8e..52b50f2 100644
+--- a/src/graphics/d3d12/texture_cache.cpp
++++ b/src/graphics/d3d12/texture_cache.cpp
+@@ -34,6 +34,14 @@
+ 
+ namespace rex::graphics::d3d12 {
+ 
++static void RetainNativeTextureResource(void* resource) {
++  static_cast<ID3D12Resource*>(resource)->AddRef();
++}
++
++static void ReleaseNativeTextureResource(void* resource) {
++  static_cast<ID3D12Resource*>(resource)->Release();
++}
++
+ // Generated with `xb buildshaders`.
+ namespace shaders {
+ #include "../shaders/bytecode/d3d12_5_1/texture_load_128bpb_cs.h"
+@@ -766,6 +774,70 @@ void D3D12TextureCache::RequestTextures(uint32_t used_texture_mask) {
+   }
+ }
+ 
++void D3D12TextureCache::ObserveNativeTextures(
++    uint32_t used_texture_mask,
++    system::GraphicsNativeTextureSetObservation& observation) const {
++  observation.backend = system::GraphicsNativeTextureBackend::kD3D12;
++  observation.used_texture_mask = used_texture_mask;
++  uint32_t textures_remaining = used_texture_mask;
++  uint32_t index;
++  while (rex::bit_scan_forward(textures_remaining, &index)) {
++    textures_remaining &= ~(uint32_t(1) << index);
++    const TextureBinding* binding = GetValidTextureBinding(index);
++    if (!binding) {
++      continue;
++    }
++    const D3D12Texture* texture =
++        static_cast<const D3D12Texture*>(binding->texture);
++    if (!texture) {
++      texture = static_cast<const D3D12Texture*>(binding->texture_signed);
++    }
++    if (!texture || !texture->resource()) {
++      continue;
++    }
++    if (observation.resource_count >=
++        system::kGraphicsNativeTextureResourceObservationLimit) {
++      ++observation.resource_overflow;
++      continue;
++    }
++    system::GraphicsNativeTextureResourceObservation& resource =
++        observation.resources[observation.resource_count++];
++    const TextureKey& key = texture->key();
++    const xenos::xe_gpu_texture_fetch_t fetch =
++        register_file().GetTextureFetch(index);
++    std::memcpy(resource.fetch_dwords, &fetch, sizeof(resource.fetch_dwords));
++    resource.fetch_constant = index;
++    resource.base_address = key.base_page << 12;
++    resource.base_length = texture->GetGuestBaseSize();
++    resource.mip_address = key.mip_page << 12;
++    resource.mip_length = texture->GetGuestMipsSize();
++    resource.guest_format = uint32_t(key.format);
++    resource.guest_dimension = uint32_t(key.dimension);
++    resource.guest_width = key.GetWidth();
++    resource.guest_height = key.GetHeight();
++    resource.guest_depth_or_array_size = key.GetDepthOrArraySize();
++    resource.guest_pitch = key.pitch << 5;
++    resource.guest_endianness = uint32_t(key.endianness);
++    resource.guest_mip_max_level = key.mip_max_level;
++    resource.guest_tiled = key.tiled;
++    resource.guest_packed_mips = key.packed_mips;
++    const D3D12_RESOURCE_DESC host_desc = texture->resource()->GetDesc();
++    resource.host_resource_format = uint32_t(host_desc.Format);
++    resource.host_view_format = uint32_t(GetDXGIUnormFormat(key));
++    resource.host_swizzle = binding->host_swizzle;
++    resource.host_swizzled_signs = binding->swizzled_signs;
++    resource.host_dimension = uint32_t(host_desc.Dimension);
++    resource.host_mip_levels = host_desc.MipLevels;
++    resource.host_depth_or_array_size = host_desc.DepthOrArraySize;
++    resource.host_width = host_desc.Width;
++    resource.host_height = host_desc.Height;
++    resource.host_allocation_bytes = texture->GetHostMemoryUsage();
++    resource.resource = texture->resource();
++    resource.retain = &RetainNativeTextureResource;
++    resource.release = &ReleaseNativeTextureResource;
++  }
++}
++
+ bool D3D12TextureCache::AreActiveTextureSRVKeysUpToDate(
+     const TextureSRVKey* keys, const D3D12Shader::TextureBinding* host_shader_bindings,
+     size_t host_shader_binding_count) const {
+diff --git a/src/graphics/d3d12/command_processor.cpp b/src/graphics/d3d12/command_processor.cpp
+index 133fbd4..d01b57c 100644
+--- a/src/graphics/d3d12/command_processor.cpp
++++ b/src/graphics/d3d12/command_processor.cpp
+@@ -2779,6 +2779,15 @@ bool D3D12CommandProcessor::IssueDraw(xenos::PrimitiveType primitive_type, uint3
+       vertex_shader->GetUsedTextureMaskAfterTranslation() |
+       (pixel_shader != nullptr ? pixel_shader->GetUsedTextureMaskAfterTranslation() : 0);
+   texture_cache_->RequestTextures(used_texture_mask);
++  if (auto native_texture_set_observer =
++          graphics_system_->native_texture_set_observer()) {
++    system::GraphicsNativeTextureSetObservation texture_observation;
++    texture_observation.current_submission = submission_current_;
++    texture_observation.completed_submission = submission_completed_;
++    texture_cache_->ObserveNativeTextures(used_texture_mask,
++                                           texture_observation);
++    native_texture_set_observer(texture_observation);
++  }
+ 
+   // Bind the pipeline after configuring it and doing everything that may bind
+   // other pipelines.

--- a/src/native_renderer/texture_resource_bridge.cpp
+++ b/src/native_renderer/texture_resource_bridge.cpp
@@ -1,0 +1,279 @@
+#include "native_renderer/texture_resource_bridge.h"
+
+#include <rex/cvar.h>
+#include <rex/system/interfaces/graphics.h>
+
+#include <atomic>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "native_renderer/resource_identity.h"
+#include "native_renderer/texture_cache.h"
+#include "pinyon_shift_diagnostics.h"
+
+REXCVAR_DEFINE_BOOL(pinyon_shift_native_renderer_texture_bridge, false, "Pinyon Shift",
+                    "Retain GPU-ready textures for native-renderer replay diagnostics")
+    .lifecycle(rex::cvar::Lifecycle::kRequiresRestart);
+
+namespace {
+
+using NativeObservation = rex::system::GraphicsNativeTextureSetObservation;
+using NativeResource = rex::system::GraphicsNativeTextureResourceObservation;
+
+constexpr uint32_t kRetainedPassTextureFormat =
+    pinyon_shift::native_renderer::kXenosTextureFormatDxn;
+constexpr uint32_t kRetainedPassTextureWidth = 256;
+constexpr uint32_t kRetainedPassTextureHeight = 64;
+constexpr uint32_t kRetainedPassTexturePitch = 256;
+
+uint64_t HashFetchWords(const uint32_t words[6]) {
+  uint64_t hash = UINT64_C(14695981039346656037);
+  for (size_t word_index = 0; word_index < 6; ++word_index) {
+    uint32_t word = words[word_index];
+    for (size_t byte_index = 0; byte_index < sizeof(word); ++byte_index) {
+      hash ^= uint8_t(word >> (byte_index * 8));
+      hash *= UINT64_C(1099511628211);
+    }
+  }
+  return hash;
+}
+
+bool IsRetainedPassCandidate(const NativeResource& resource) {
+  return resource.guest_format == kRetainedPassTextureFormat &&
+         resource.guest_width == kRetainedPassTextureWidth &&
+         resource.guest_height == kRetainedPassTextureHeight &&
+         resource.guest_pitch == kRetainedPassTexturePitch && resource.guest_tiled;
+}
+
+class TextureResourceBridge {
+ public:
+  void Observe(const NativeObservation& observation) {
+    bool has_candidate = false;
+    for (uint32_t resource_index = 0; resource_index < observation.resource_count;
+         ++resource_index) {
+      has_candidate |= IsRetainedPassCandidate(observation.resources[resource_index]);
+    }
+    if (!has_candidate && observed_resource_count_.load(std::memory_order_relaxed) >= 16) {
+      return;
+    }
+    const std::scoped_lock lock(mutex_);
+    ++observation_count_;
+    if (observation.backend != rex::system::GraphicsNativeTextureBackend::kD3D12) {
+      RecordFailureOnce("unsupported_backend");
+      return;
+    }
+
+    ReleaseCollected(cache_.Collect(observation.completed_submission));
+    for (uint32_t resource_index = 0; resource_index < observation.resource_count;
+         ++resource_index) {
+      const NativeResource& resource = observation.resources[resource_index];
+      const uint64_t observed = observed_resource_count_.fetch_add(1, std::memory_order_relaxed);
+      if (observed < 16) {
+        pinyon_shift::diagnostics::RecordEvent(
+            "native_renderer.texture_bridge.observed",
+            {{"fetch", std::to_string(resource.fetch_constant)},
+             {"guest_format", std::to_string(resource.guest_format)},
+             {"width", std::to_string(resource.guest_width)},
+             {"height", std::to_string(resource.guest_height)},
+             {"pitch", std::to_string(resource.guest_pitch)},
+             {"tiled", resource.guest_tiled ? "1" : "0"},
+             {"host_format", std::to_string(resource.host_resource_format)}});
+      }
+      if (IsRetainedPassCandidate(resource)) {
+        Retain(resource, observation);
+      }
+    }
+
+    if (resource_count_ && (!last_summary_submission_ ||
+                            observation.current_submission >= last_summary_submission_ + 300)) {
+      last_summary_submission_ = observation.current_submission;
+      const auto metrics = cache_.metrics();
+      pinyon_shift::diagnostics::RecordEvent(
+          "native_renderer.texture_bridge.summary",
+          {{"observations", std::to_string(observation_count_)},
+           {"resources", std::to_string(resource_count_)},
+           {"live", std::to_string(metrics.live_count)},
+           {"live_bytes", std::to_string(metrics.live_bytes)},
+           {"retired", std::to_string(metrics.retired_count)},
+           {"hits", std::to_string(metrics.hits)},
+           {"misses", std::to_string(metrics.misses)},
+           {"submission", std::to_string(observation.current_submission)},
+           {"completed_submission", std::to_string(observation.completed_submission)},
+           {"xenos_draw", "preserved"}});
+    }
+  }
+
+  void Shutdown() {
+    const std::scoped_lock lock(mutex_);
+    cache_.RetireAll(0);
+    ReleaseCollected(cache_.Collect(UINT64_MAX));
+    const auto metrics = cache_.metrics();
+    pinyon_shift::diagnostics::RecordEvent(
+        "native_renderer.texture_bridge.stopped",
+        {{"observations", std::to_string(observation_count_)},
+         {"resources", std::to_string(resource_count_)},
+         {"live", std::to_string(metrics.live_count)},
+         {"retained_refs", std::to_string(RetainedReferenceCount())},
+         {"xenos_draw", "preserved"}});
+  }
+
+ private:
+  struct RetainedReference {
+    rex::system::GraphicsNativeTextureRelease release = nullptr;
+    uint64_t count = 0;
+  };
+
+  void Retain(const NativeResource& resource, const NativeObservation& observation) {
+    if (!resource.resource || !resource.retain || !resource.release ||
+        !resource.host_allocation_bytes || !resource.base_length) {
+      return;
+    }
+    // This diagnostic bridge deliberately imports only the first measured
+    // retained-pass contract. Expanding format coverage belongs to later
+    // budgeted NR-03 work, not an unbounded observer-side cache.
+    const auto base = pinyon_shift::native_renderer::PhysicalRange::FromGraphicsAddress(
+        resource.base_address, resource.base_length);
+    if (!base) {
+      RecordFailureOnce("invalid_base_range");
+      return;
+    }
+    std::optional<pinyon_shift::native_renderer::PhysicalRange> mips;
+    if (resource.mip_length) {
+      mips = pinyon_shift::native_renderer::PhysicalRange::FromGraphicsAddress(resource.mip_address,
+                                                                               resource.mip_length);
+      if (!mips) {
+        RecordFailureOnce("invalid_mip_range");
+        return;
+      }
+    }
+
+    const uint64_t handle = reinterpret_cast<uint64_t>(resource.resource);
+    const pinyon_shift::native_renderer::TextureResourceKey key{
+        *base, mips, HashFetchWords(resource.fetch_dwords), {0, handle}};
+    auto request = cache_.Request(key, observation_count_, observation.current_submission);
+    if (request.state != pinyon_shift::native_renderer::TextureRequestState::kDecodeRequired) {
+      return;
+    }
+
+    resource.retain(resource.resource);
+    const bool completed = cache_.Complete(
+        request.decode_ticket, pinyon_shift::native_renderer::TextureDecodeResult::kReady, handle,
+        resource.host_allocation_bytes, observation_count_, observation.current_submission);
+    const auto confirmed = cache_.Request(key, observation_count_, observation.current_submission);
+    if (!completed ||
+        confirmed.state != pinyon_shift::native_renderer::TextureRequestState::kReady ||
+        confirmed.sampled_handle != handle) {
+      resource.release(resource.resource);
+      RecordFailureOnce("cache_commit_failed");
+      return;
+    }
+    auto& retained = retained_[handle];
+    retained.release = resource.release;
+    ++retained.count;
+    ++resource_count_;
+
+    if (resource_count_ <= 16) {
+      pinyon_shift::diagnostics::RecordEvent(
+          "native_renderer.texture_bridge.resource",
+          {{"fetch", std::to_string(resource.fetch_constant)},
+           {"fetch_signature", std::to_string(key.fetch_signature)},
+           {"guest_format", std::to_string(resource.guest_format)},
+           {"width", std::to_string(resource.guest_width)},
+           {"height", std::to_string(resource.guest_height)},
+           {"base_address", std::to_string(base->address)},
+           {"base_bytes", std::to_string(base->length)},
+           {"host_format", std::to_string(resource.host_resource_format)},
+           {"host_view_format", std::to_string(resource.host_view_format)},
+           {"host_bytes", std::to_string(resource.host_allocation_bytes)},
+           {"ownership", "retained"},
+           {"native_upload", "rexglue_reuse"},
+           {"xenos_draw", "preserved"}});
+    }
+  }
+
+  void ReleaseCollected(
+      const std::vector<pinyon_shift::native_renderer::RetiredTexture>& collected) {
+    for (const auto& texture : collected) {
+      auto retained = retained_.find(texture.handle);
+      if (retained == retained_.end() || !retained->second.count) {
+        RecordFailureOnce("missing_retained_reference");
+        continue;
+      }
+      retained->second.release(reinterpret_cast<void*>(texture.handle));
+      if (!--retained->second.count) {
+        retained_.erase(retained);
+      }
+    }
+  }
+
+  uint64_t RetainedReferenceCount() const {
+    uint64_t count = 0;
+    for (const auto& [handle, retained] : retained_) {
+      (void)handle;
+      count += retained.count;
+    }
+    return count;
+  }
+
+  void RecordFailureOnce(const char* reason) {
+    if (failure_recorded_) {
+      return;
+    }
+    failure_recorded_ = true;
+    pinyon_shift::diagnostics::RecordEvent("native_renderer.texture_bridge.failure",
+                                           {{"reason", reason}, {"fallback", "xenos"}});
+  }
+
+  std::mutex mutex_;
+  pinyon_shift::native_renderer::PhysicalResourceTracker tracker_;
+  pinyon_shift::native_renderer::NativeTextureCache cache_{tracker_};
+  std::unordered_map<uint64_t, RetainedReference> retained_;
+  std::atomic<uint64_t> observed_resource_count_{};
+  uint64_t observation_count_ = 0;
+  uint64_t resource_count_ = 0;
+  uint64_t last_summary_submission_ = 0;
+  bool failure_recorded_ = false;
+};
+
+std::unique_ptr<TextureResourceBridge> g_texture_resource_bridge;
+
+void ObserveNativeTextures(const NativeObservation& observation) {
+  if (g_texture_resource_bridge) {
+    g_texture_resource_bridge->Observe(observation);
+  }
+}
+
+}  // namespace
+
+namespace pinyon_shift::native_renderer {
+
+void InstallTextureResourceBridge(rex::system::IGraphicsSystem* graphics_system) {
+  if (!graphics_system || !REXCVAR_GET(pinyon_shift_native_renderer_texture_bridge)) {
+    return;
+  }
+  g_texture_resource_bridge = std::make_unique<TextureResourceBridge>();
+  graphics_system->SetNativeTextureSetObserver(&ObserveNativeTextures);
+  diagnostics::RecordEvent("native_renderer.texture_bridge.installed",
+                           {{"backend", "d3d12"},
+                            {"ownership", "explicit_retain_release"},
+                            {"xenos_draw", "preserved"},
+                            {"suppression", "disabled"}});
+}
+
+void UninstallTextureResourceBridge(rex::system::IGraphicsSystem* graphics_system) {
+  if (graphics_system) {
+    graphics_system->SetNativeTextureSetObserver(nullptr);
+  }
+  if (g_texture_resource_bridge) {
+    g_texture_resource_bridge->Shutdown();
+    g_texture_resource_bridge.reset();
+  }
+}
+
+}  // namespace pinyon_shift::native_renderer

--- a/src/native_renderer/texture_resource_bridge.h
+++ b/src/native_renderer/texture_resource_bridge.h
@@ -1,0 +1,12 @@
+#pragma once
+
+namespace rex::system {
+class IGraphicsSystem;
+}
+
+namespace pinyon_shift::native_renderer {
+
+void InstallTextureResourceBridge(rex::system::IGraphicsSystem* graphics_system);
+void UninstallTextureResourceBridge(rex::system::IGraphicsSystem* graphics_system);
+
+}  // namespace pinyon_shift::native_renderer

--- a/src/pinyon_shift_app.cpp
+++ b/src/pinyon_shift_app.cpp
@@ -21,6 +21,7 @@
 #include "native_renderer/graphics_hooks.h"
 #include "native_renderer/guest_output_renderer.h"
 #include "native_renderer/shader_capture.h"
+#include "native_renderer/texture_resource_bridge.h"
 #include "pinyon_shift_diagnostics.h"
 
 #include <cstdio>
@@ -307,6 +308,9 @@ void PinyonShiftApp::OnPostInitLogging() {
                         {"native_renderer_census",
                          rex::cvar::GetFlagByName(
                              "pinyon_shift_native_renderer_census")},
+                        {"native_renderer_texture_bridge",
+                         rex::cvar::GetFlagByName(
+                             "pinyon_shift_native_renderer_texture_bridge")},
                         {"native_renderer",
                          rex::cvar::GetFlagByName(
                              "pinyon_shift_native_renderer")},
@@ -347,6 +351,8 @@ void PinyonShiftApp::OnPostSetup() {
       runtime() ? runtime()->graphics_system() : nullptr);
   pinyon_shift::native_renderer::InstallGraphicsCensus(
       runtime() ? runtime()->graphics_system() : nullptr);
+  pinyon_shift::native_renderer::InstallTextureResourceBridge(
+      runtime() ? runtime()->graphics_system() : nullptr);
   pinyon_shift::native_renderer::InstallShaderCapture(
       runtime() ? runtime()->graphics_system() : nullptr);
   pinyon_shift::diagnostics::RecordEvent(
@@ -382,6 +388,8 @@ bool PinyonShiftApp::OnWindowCloseRequested() {
       runtime() ? runtime()->graphics_system() : nullptr);
   pinyon_shift::native_renderer::UninstallGraphicsCensus(
       runtime() ? runtime()->graphics_system() : nullptr);
+  pinyon_shift::native_renderer::UninstallTextureResourceBridge(
+      runtime() ? runtime()->graphics_system() : nullptr);
   RecordShutdownOnce();
   return true;
 }
@@ -392,6 +400,8 @@ void PinyonShiftApp::OnShutdown() {
   pinyon_shift::native_renderer::UninstallGuestOutputRenderer(
       runtime() ? runtime()->graphics_system() : nullptr);
   pinyon_shift::native_renderer::UninstallGraphicsCensus(
+      runtime() ? runtime()->graphics_system() : nullptr);
+  pinyon_shift::native_renderer::UninstallTextureResourceBridge(
       runtime() ? runtime()->graphics_system() : nullptr);
   RecordShutdownOnce();
 }

--- a/tools/tests/test_native_renderer_contract.py
+++ b/tools/tests/test_native_renderer_contract.py
@@ -502,6 +502,32 @@ class NativeRendererContractTests(unittest.TestCase):
         self.assertIn("native_renderer.isolated_pass.result", scanner)
         self.assertIn("native_renderer.isolated_pass.repeat", scanner)
 
+        texture_resource_patch = (
+            ROOT
+            / "patches/rexglue/0064-d3d12-native-texture-resource-observer.patch"
+        ).read_text(encoding="utf-8")
+        self.assertIn("GraphicsNativeTextureSetObservation", texture_resource_patch)
+        self.assertIn("GraphicsNativeTextureRetain", texture_resource_patch)
+        self.assertIn("GraphicsNativeTextureRelease", texture_resource_patch)
+        self.assertIn("ObserveNativeTextures", texture_resource_patch)
+        self.assertIn("texture_cache_->RequestTextures", texture_resource_patch)
+        self.assertIn("completed_submission", texture_resource_patch)
+        self.assertNotIn("SetDrawSuppression", texture_resource_patch)
+        texture_bridge = (
+            ROOT / "src/native_renderer/texture_resource_bridge.cpp"
+        ).read_text(encoding="utf-8")
+        self.assertIn(
+            "pinyon_shift_native_renderer_texture_bridge, false", texture_bridge
+        )
+        self.assertIn('"xenos_draw", "preserved"', texture_bridge)
+        self.assertIn('"suppression", "disabled"', texture_bridge)
+        self.assertIn("resource.retain(resource.resource)", texture_bridge)
+        self.assertIn("retained->second.release", texture_bridge)
+        self.assertIn("IsRetainedPassCandidate", texture_bridge)
+        self.assertIn("observed_resource_count_", texture_bridge)
+        self.assertIn("observed < 16", texture_bridge)
+        self.assertIn("last_summary_submission_ + 300", texture_bridge)
+
         visual_marker_patch = (
             ROOT / "patches/rexglue/0060-d3d12-isolated-draw-debug-markers.patch"
         ).read_text(encoding="utf-8")

--- a/tools/tests/test_release_contract.py
+++ b/tools/tests/test_release_contract.py
@@ -43,10 +43,10 @@ class ReleaseContractTests(unittest.TestCase):
 
     def test_rexglue_patches_have_stable_order_and_no_binary_payload(self):
         patches = sorted((ROOT / "patches/rexglue").glob("*.patch"))
-        self.assertEqual(len(patches), 63)
+        self.assertEqual(len(patches), 64)
         self.assertEqual(
             patches[-1].name,
-            "0063-d3d12-retained-isolated-pass-target.patch",
+            "0064-d3d12-native-texture-resource-observer.patch",
         )
         self.assertEqual(len(patches), len({path.name[:4] for path in patches}))
         for path in patches:


### PR DESCRIPTION
## Summary
- expose backend-neutral GPU-ready texture observations after ReXGlue texture preparation
- retain the measured pass texture through Pinyon's fence-safe native texture cache
- keep the experiment default-off with Xenos draws and resolves fully preserved
- document resource ownership and bounded diagnostic behavior

## Validation
- 140 Python contract tests passed
- native resource identity, buffer cache, and texture cache semantic tests passed
- clean preview build passed with all 64 ReXGlue patches
- AppData runtime observer exercised without device loss or suppression
- measured Xenos runtime remained at approximately 30 FPS

## Safety
This PR does not bind a native descriptor, publish native pixels, or suppress emulated work. Unknown and unsupported states continue through the authoritative Xenos path.