### PR TITLE
feat(native-renderer): preview retained native pass

### DIFF
--- a/cmake/PinyonShiftRexGlue.cmake
+++ b/cmake/PinyonShiftRexGlue.cmake
@@ -204,15 +204,19 @@ function(pinyon_shift_attach_rexglue target_name)
             INCLUDE_DIRECTORIES "${CMAKE_CURRENT_BINARY_DIR}/rexglue-sdk/include")
 
         # ReXGlue's target helper copies runtime DLLs only after the host links.
-        # An incremental SDK-only relink would therefore leave an older DLL next
-        # to an otherwise current host. This target runs on every build (with
-        # copy_if_different) and makes the executable's load-time artifact exact.
+        # An incremental SDK-only relink would therefore leave older runtime or
+        # graphics backend DLLs next to an otherwise current host. This target
+        # runs on every build (with copy_if_different) and makes the executable's
+        # load-time artifacts exact.
         add_custom_target(${target_name}_stage_rexruntime ALL
             COMMAND ${CMAKE_COMMAND} -E copy_if_different
                 $<TARGET_FILE:rexruntime>
                 $<TARGET_FILE_DIR:${target_name}>/$<TARGET_FILE_NAME:rexruntime>
-            DEPENDS ${target_name} rexruntime
-            COMMENT "Staging the current ReXGlue runtime beside ${target_name}"
+            COMMAND ${CMAKE_COMMAND} -E copy_if_different
+                $<TARGET_FILE:rexgpu-xenos>
+                $<TARGET_FILE_DIR:${target_name}>/$<TARGET_FILE_NAME:rexgpu-xenos>
+            DEPENDS ${target_name} rexruntime rexgpu-xenos
+            COMMENT "Staging the current ReXGlue runtime and graphics backend beside ${target_name}"
             VERBATIM)
     endif()
 endfunction()

--- a/docs/native-renderer/GUEST_OUTPUT_OWNERSHIP.md
+++ b/docs/native-renderer/GUEST_OUTPUT_OWNERSHIP.md
@@ -106,3 +106,40 @@ Microsoft Studios sequence, and exited normally. The launcher recovery command
 also created a timestamped configuration backup and reset only
 `pinyon_shift_native_renderer` to `xenos`; all unrelated graphics settings and
 the AppData save remained unchanged.
+
+## Retained authentic-pass preview
+
+Patch `0065-d3d12-retained-pass-preview.patch` adds the first display path for
+authentic native replay pixels. The explicit `diagnostic_retained_pass` mode
+samples the already-qualified top-left 512 by 512 crop of the retained NR-02F
+RGBA16F target and scales it into the guest-output texture with an amber border.
+This is the same private target produced by the indexed anchor and AutoIndex
+follower, not a synthetic triangle or CPU-uploaded screenshot.
+
+The backend accepts only the measured multisampled
+`DXGI_FORMAT_R16G16B16A16_FLOAT` target. It resolves that private target into a
+persistent single-sample texture, transitions the resolved texture to a compute
+SRV, dispatches in the command processor's open submission, and restores the
+source, resolved target, and presenter-owned guest-output states. Until an exact
+retained target exists, the callback returns `false`, records paced waiting
+diagnostics, and leaves the complete Xenos frame visible. The mode is
+default-off, restart-required, and exposed as a developer preview in the
+launcher. It does not suppress any original draw, resolve, query, or
+guest-visible side effect.
+
+## Retained-pass preview qualification
+
+Clean-build AppData-backed session `20260828T205347Z-p35488` first displayed
+the complete Xenos frame while waiting for the qualified anchor/follower pair,
+then switched to the amber-framed native crop after frame 2,656. Visual
+inspection confirmed authentic scene sky, clouds, barriers, Horizon banners,
+and ground geometry in the retained target. A second capture ten seconds later
+remained stable and showed the continuously refreshed pass rather than a
+synthetic or CPU-uploaded image.
+
+The session recorded the isolated two-draw pass, seven paced native-output
+markers, zero native-output failures, zero device-loss/fatal/error markers, and
+a normal shutdown. Its 4,689 measured frames had 31.033 median FPS, 19.161
+one-percent-low FPS, 59.991 Hz host presentation cadence, and zero presentation
+deadline misses. Every original Xenos draw remained enabled and suppression
+remained disabled for the entire qualification.

--- a/launcher/PinyonShift.Launcher/MainWindow.xaml
+++ b/launcher/PinyonShift.Launcher/MainWindow.xaml
@@ -312,6 +312,7 @@
                                   AutomationProperties.Name="Native output renderer">
                             <ComboBoxItem Tag="xenos"><TextBlock Text="Xenos · safe default" Foreground="{StaticResource InkBrush}"/></ComboBoxItem>
                             <ComboBoxItem Tag="diagnostic_triangle"><TextBlock Text="Diagnostic triangle · replaces display output" Foreground="{StaticResource InkBrush}"/></ComboBoxItem>
+                            <ComboBoxItem Tag="diagnostic_retained_pass"><TextBlock Text="Retained native pass · gameplay preview" Foreground="{StaticResource InkBrush}"/></ComboBoxItem>
                         </ComboBox>
                     </StackPanel>
                     <Border Grid.Row="6" x:Name="ShowroomWarning" Background="#241D12"

--- a/patches/rexglue/0065-d3d12-retained-pass-preview.patch
+++ b/patches/rexglue/0065-d3d12-retained-pass-preview.patch
@@ -1,0 +1,973 @@
+diff --git a/include/rex/graphics/d3d12/command_processor.h b/include/rex/graphics/d3d12/command_processor.h
+index e01eac2..d32d5ff 100644
+--- a/include/rex/graphics/d3d12/command_processor.h
++++ b/include/rex/graphics/d3d12/command_processor.h
+@@ -204,6 +204,9 @@ class D3D12CommandProcessor : public CommandProcessor {
+                                                uint32_t width,
+                                                uint32_t height,
+                                                uint32_t phase);
++  bool DrawNativeGuestOutputRetainedPass(ID3D12Resource* resource,
++                                         uint32_t width,
++                                         uint32_t height);
+ 
+  protected:
+   bool SetupContext() override;
+@@ -631,6 +634,22 @@ class D3D12CommandProcessor : public CommandProcessor {
+   Microsoft::WRL::ComPtr<ID3D12PipelineState>
+       native_guest_output_triangle_pipeline_;
+ 
++  struct NativeGuestOutputRetainedPassConstants {
++    uint32_t output_size[2];
++    uint32_t source_size[2];
++    uint32_t crop_size[2];
++  };
++  enum class NativeGuestOutputRetainedPassRootParameter : uint32_t {
++    kConstants,
++    kSource,
++    kOutput,
++    kCount,
++  };
++  Microsoft::WRL::ComPtr<ID3D12RootSignature>
++      native_guest_output_retained_pass_root_signature_;
++  Microsoft::WRL::ComPtr<ID3D12PipelineState>
++      native_guest_output_retained_pass_pipeline_;
++
+   struct ResolveDownscaleConstants {
+     uint32_t scale_x;
+     uint32_t scale_y;
+diff --git a/include/rex/graphics/d3d12/render_target_cache.h b/include/rex/graphics/d3d12/render_target_cache.h
+index 62fca78..7f4bab8 100644
+--- a/include/rex/graphics/d3d12/render_target_cache.h
++++ b/include/rex/graphics/d3d12/render_target_cache.h
+@@ -106,6 +106,18 @@ class D3D12RenderTargetCache final : public RenderTargetCache {
+       uint32_t* failure_detail_out);
+   void EndIsolatedReplayTarget();
+ 
++  struct IsolatedReplayPreviewSource {
++    ID3D12Resource* resource = nullptr;
++    D3D12_RESOURCE_STATES previous_state = D3D12_RESOURCE_STATE_COMMON;
++    DXGI_FORMAT format = DXGI_FORMAT_UNKNOWN;
++    uint32_t width = 0;
++    uint32_t height = 0;
++    bool resolved = false;
++  };
++  bool BeginIsolatedReplayPreview(IsolatedReplayPreviewSource& source_out);
++  void EndIsolatedReplayPreview(
++      const IsolatedReplayPreviewSource& source);
++
+   DXGI_FORMAT GetColorResourceDXGIFormat(xenos::ColorRenderTargetFormat format) const;
+   DXGI_FORMAT GetColorDrawDXGIFormat(xenos::ColorRenderTargetFormat format) const;
+   DXGI_FORMAT GetColorOwnershipTransferDXGIFormat(xenos::ColorRenderTargetFormat format,
+@@ -678,6 +690,10 @@ class D3D12RenderTargetCache final : public RenderTargetCache {
+   std::shared_ptr<ui::d3d12::D3D12CpuDescriptorPool> descriptor_pool_depth_;
+   std::unique_ptr<RenderTarget> isolated_replay_color_target_;
+   std::unique_ptr<RenderTarget> isolated_replay_depth_target_;
++  Microsoft::WRL::ComPtr<ID3D12Resource>
++      isolated_replay_preview_resolved_target_;
++  D3D12_RESOURCE_STATES isolated_replay_preview_resolved_target_state_ =
++      D3D12_RESOURCE_STATE_RESOLVE_DEST;
+   struct IsolatedReplayReadback {
+     Microsoft::WRL::ComPtr<ID3D12Resource> buffer;
+     Microsoft::WRL::ComPtr<ID3D12Resource> resolved_target;
+diff --git a/include/rex/system/interfaces/graphics.h b/include/rex/system/interfaces/graphics.h
+index c54de84..6b7ee36 100644
+--- a/include/rex/system/interfaces/graphics.h
++++ b/include/rex/system/interfaces/graphics.h
+@@ -33,6 +33,8 @@ using NativeGuestOutputClearColor = bool (*)(
+     const NativeGuestOutputRenderContext& context, const float color[4]);
+ using NativeGuestOutputDrawDiagnosticTriangle = bool (*)(
+     const NativeGuestOutputRenderContext& context, uint32_t phase);
++using NativeGuestOutputDrawRetainedPass = bool (*)(
++    const NativeGuestOutputRenderContext& context);
+ class KernelState;
+ }
+ 
+@@ -57,6 +59,7 @@ struct NativeGuestOutputRenderContext {
+   uint64_t submission = 0;
+   NativeGuestOutputClearColor clear_color = nullptr;
+   NativeGuestOutputDrawDiagnosticTriangle draw_diagnostic_triangle = nullptr;
++  NativeGuestOutputDrawRetainedPass draw_retained_pass = nullptr;
+ };
+ 
+ // Returning false yields without modifying guest output. A callback that has
+diff --git a/src/graphics/d3d12/command_processor.cpp b/src/graphics/d3d12/command_processor.cpp
+index d01b57c..0168afc 100644
+--- a/src/graphics/d3d12/command_processor.cpp
++++ b/src/graphics/d3d12/command_processor.cpp
+@@ -58,6 +58,7 @@ namespace shaders {
+ #include "../shaders/bytecode/d3d12_5_1/apply_gamma_table_fxaa_luma_cs.h"
+ #include "../shaders/bytecode/d3d12_5_1/fxaa_cs.h"
+ #include "../shaders/bytecode/d3d12_5_1/fxaa_extreme_cs.h"
++#include "../shaders/bytecode/d3d12_5_1/native_guest_output_retained_pass_cs.h"
+ #include "../shaders/bytecode/d3d12_5_1/native_guest_output_triangle_cs.h"
+ #include "../shaders/bytecode/d3d12_5_1/resolve_downscale_cs.h"
+ }  // namespace shaders
+@@ -2186,6 +2187,145 @@ bool D3D12CommandProcessor::DrawNativeGuestOutputDiagnosticTriangle(
+   return true;
+ }
+ 
++bool D3D12CommandProcessor::DrawNativeGuestOutputRetainedPass(
++    ID3D12Resource* resource, uint32_t width, uint32_t height) {
++  if (!resource || !width || !height || !render_target_cache_) {
++    return false;
++  }
++
++  const ui::d3d12::D3D12Provider& provider = GetD3D12Provider();
++  ID3D12Device* device = provider.GetDevice();
++  if (!device) {
++    return false;
++  }
++
++  if (!native_guest_output_retained_pass_root_signature_) {
++    D3D12_ROOT_PARAMETER root_parameters
++        [uint32_t(NativeGuestOutputRetainedPassRootParameter::kCount)]{};
++    auto& constants = root_parameters[uint32_t(
++        NativeGuestOutputRetainedPassRootParameter::kConstants)];
++    constants.ParameterType = D3D12_ROOT_PARAMETER_TYPE_32BIT_CONSTANTS;
++    constants.Constants.ShaderRegister = 0;
++    constants.Constants.RegisterSpace = 0;
++    constants.Constants.Num32BitValues =
++        sizeof(NativeGuestOutputRetainedPassConstants) / sizeof(uint32_t);
++    constants.ShaderVisibility = D3D12_SHADER_VISIBILITY_ALL;
++
++    D3D12_DESCRIPTOR_RANGE source_range{};
++    source_range.RangeType = D3D12_DESCRIPTOR_RANGE_TYPE_SRV;
++    source_range.NumDescriptors = 1;
++    source_range.BaseShaderRegister = 0;
++    source_range.RegisterSpace = 0;
++    source_range.OffsetInDescriptorsFromTableStart = 0;
++    auto& source = root_parameters[
++        uint32_t(NativeGuestOutputRetainedPassRootParameter::kSource)];
++    source.ParameterType = D3D12_ROOT_PARAMETER_TYPE_DESCRIPTOR_TABLE;
++    source.DescriptorTable.NumDescriptorRanges = 1;
++    source.DescriptorTable.pDescriptorRanges = &source_range;
++    source.ShaderVisibility = D3D12_SHADER_VISIBILITY_ALL;
++
++    D3D12_DESCRIPTOR_RANGE output_range{};
++    output_range.RangeType = D3D12_DESCRIPTOR_RANGE_TYPE_UAV;
++    output_range.NumDescriptors = 1;
++    output_range.BaseShaderRegister = 0;
++    output_range.RegisterSpace = 0;
++    output_range.OffsetInDescriptorsFromTableStart = 0;
++    auto& output = root_parameters[
++        uint32_t(NativeGuestOutputRetainedPassRootParameter::kOutput)];
++    output.ParameterType = D3D12_ROOT_PARAMETER_TYPE_DESCRIPTOR_TABLE;
++    output.DescriptorTable.NumDescriptorRanges = 1;
++    output.DescriptorTable.pDescriptorRanges = &output_range;
++    output.ShaderVisibility = D3D12_SHADER_VISIBILITY_ALL;
++
++    D3D12_ROOT_SIGNATURE_DESC root_signature_desc{};
++    root_signature_desc.NumParameters =
++        uint32_t(NativeGuestOutputRetainedPassRootParameter::kCount);
++    root_signature_desc.pParameters = root_parameters;
++    root_signature_desc.Flags = D3D12_ROOT_SIGNATURE_FLAG_NONE;
++    *native_guest_output_retained_pass_root_signature_
++         .ReleaseAndGetAddressOf() =
++        ui::d3d12::util::CreateRootSignature(provider, root_signature_desc);
++    if (!native_guest_output_retained_pass_root_signature_) {
++      REXGPU_ERROR(
++          "Failed to create the native guest-output retained-pass root "
++          "signature");
++      return false;
++    }
++  }
++
++  if (!native_guest_output_retained_pass_pipeline_) {
++    *native_guest_output_retained_pass_pipeline_.ReleaseAndGetAddressOf() =
++        ui::d3d12::util::CreateComputePipeline(
++            device, shaders::native_guest_output_retained_pass_cs,
++            sizeof(shaders::native_guest_output_retained_pass_cs),
++            native_guest_output_retained_pass_root_signature_.Get());
++    if (!native_guest_output_retained_pass_pipeline_) {
++      REXGPU_ERROR(
++          "Failed to create the native guest-output retained-pass pipeline");
++      return false;
++    }
++  }
++
++  ui::d3d12::util::DescriptorCpuGpuHandlePair descriptors[2];
++  if (!RequestOneUseSingleViewDescriptors(2, descriptors)) {
++    static bool logged_retained_preview_descriptor_failure = false;
++    if (!logged_retained_preview_descriptor_failure) {
++      logged_retained_preview_descriptor_failure = true;
++      REXGPU_WARN(
++          "Native retained-pass preview could not allocate view descriptors");
++    }
++    return false;
++  }
++  D3D12RenderTargetCache::IsolatedReplayPreviewSource preview_source;
++  if (!render_target_cache_->BeginIsolatedReplayPreview(preview_source)) {
++    return false;
++  }
++
++  D3D12_SHADER_RESOURCE_VIEW_DESC source_view_desc{};
++  source_view_desc.Format = preview_source.format;
++  source_view_desc.ViewDimension = D3D12_SRV_DIMENSION_TEXTURE2D;
++  source_view_desc.Shader4ComponentMapping =
++      D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING;
++  source_view_desc.Texture2D.MostDetailedMip = 0;
++  source_view_desc.Texture2D.MipLevels = 1;
++  source_view_desc.Texture2D.PlaneSlice = 0;
++  source_view_desc.Texture2D.ResourceMinLODClamp = 0.0f;
++  device->CreateShaderResourceView(preview_source.resource, &source_view_desc,
++                                   descriptors[0].first);
++  D3D12_UNORDERED_ACCESS_VIEW_DESC output_view_desc{};
++  output_view_desc.Format = ui::d3d12::D3D12Presenter::kGuestOutputFormat;
++  output_view_desc.ViewDimension = D3D12_UAV_DIMENSION_TEXTURE2D;
++  device->CreateUnorderedAccessView(resource, nullptr, &output_view_desc,
++                                    descriptors[1].first);
++
++  NativeGuestOutputRetainedPassConstants preview_constants{
++      {width, height},
++      {preview_source.width, preview_source.height},
++      {std::min(preview_source.width, uint32_t(512)),
++       std::min(preview_source.height, uint32_t(512))}};
++  PushTransitionBarrier(
++      resource, ui::d3d12::D3D12Presenter::kGuestOutputInternalState,
++      D3D12_RESOURCE_STATE_UNORDERED_ACCESS);
++  deferred_command_list_.D3DSetComputeRootSignature(
++      native_guest_output_retained_pass_root_signature_.Get());
++  deferred_command_list_.D3DSetComputeRoot32BitConstants(
++      uint32_t(NativeGuestOutputRetainedPassRootParameter::kConstants),
++      sizeof(preview_constants) / sizeof(uint32_t), &preview_constants, 0);
++  deferred_command_list_.D3DSetComputeRootDescriptorTable(
++      uint32_t(NativeGuestOutputRetainedPassRootParameter::kSource),
++      descriptors[0].second);
++  deferred_command_list_.D3DSetComputeRootDescriptorTable(
++      uint32_t(NativeGuestOutputRetainedPassRootParameter::kOutput),
++      descriptors[1].second);
++  SetExternalPipeline(native_guest_output_retained_pass_pipeline_.Get());
++  SubmitBarriers();
++  deferred_command_list_.D3DDispatch((width + 7) / 8, (height + 7) / 8, 1);
++  render_target_cache_->EndIsolatedReplayPreview(preview_source);
++  PushTransitionBarrier(resource, D3D12_RESOURCE_STATE_UNORDERED_ACCESS,
++                        ui::d3d12::D3D12Presenter::kGuestOutputInternalState);
++  return true;
++}
++
+ bool InvokeNativeGuestOutputDiagnosticTriangle(
+     const system::NativeGuestOutputRenderContext& context, uint32_t phase) {
+   auto* command_processor =
+@@ -2197,6 +2337,17 @@ bool InvokeNativeGuestOutputDiagnosticTriangle(
+              phase);
+ }
+ 
++bool InvokeNativeGuestOutputRetainedPass(
++    const system::NativeGuestOutputRenderContext& context) {
++  auto* command_processor =
++      static_cast<D3D12CommandProcessor*>(context.command_context);
++  auto* resource = static_cast<ID3D12Resource*>(context.guest_output);
++  return command_processor &&
++         command_processor->DrawNativeGuestOutputRetainedPass(
++             resource, context.guest_output_width,
++             context.guest_output_height);
++}
++
+ void D3D12CommandProcessor::IssueSwap(uint32_t frontbuffer_ptr, uint32_t frontbuffer_width,
+                                       uint32_t frontbuffer_height) {
+   SCOPE_profile_cpu_f("gpu");
+@@ -2570,6 +2721,8 @@ void D3D12CommandProcessor::IssueSwap(uint32_t frontbuffer_ptr, uint32_t frontbu
+           native_context.clear_color = &ClearNativeGuestOutput;
+           native_context.draw_diagnostic_triangle =
+               &InvokeNativeGuestOutputDiagnosticTriangle;
++          native_context.draw_retained_pass =
++              &InvokeNativeGuestOutputRetainedPass;
+           renderer(native_context);
+         }
+         SubmitBarriers();
+diff --git a/src/graphics/d3d12/render_target_cache.cpp b/src/graphics/d3d12/render_target_cache.cpp
+index 3a673d8..3423f8f 100644
+--- a/src/graphics/d3d12/render_target_cache.cpp
++++ b/src/graphics/d3d12/render_target_cache.cpp
+@@ -1025,6 +1025,9 @@ void D3D12RenderTargetCache::Shutdown(bool from_destructor) {
+     isolated_replay_readback_.buffer->Unmap(0, &write_range);
+   }
+   isolated_replay_readback_ = {};
++  isolated_replay_preview_resolved_target_.Reset();
++  isolated_replay_preview_resolved_target_state_ =
++      D3D12_RESOURCE_STATE_RESOLVE_DEST;
+   isolated_replay_depth_target_.reset();
+   isolated_replay_color_target_.reset();
+   null_rtv_descriptor_ms_.Free();
+@@ -1995,6 +1998,147 @@ void D3D12RenderTargetCache::EndIsolatedReplayTarget() {
+   command_processor_.SubmitBarriers();
+ }
+ 
++bool D3D12RenderTargetCache::BeginIsolatedReplayPreview(
++    IsolatedReplayPreviewSource& source_out) {
++  source_out = {};
++  if (GetPath() != Path::kHostRenderTargets ||
++      !isolated_replay_color_target_) {
++    return false;
++  }
++  auto* isolated_color = static_cast<D3D12RenderTarget*>(
++      isolated_replay_color_target_.get());
++  ID3D12Resource* resource = isolated_color->resource();
++  const D3D12_RESOURCE_DESC resource_desc = resource->GetDesc();
++  // The first retained Forza pass has an RGBA16F target. Keep this preview
++  // exact rather than guessing how to interpret later targets, but resolve its
++  // host MSAA representation before sampling it from the compute shader.
++  if (resource_desc.Dimension != D3D12_RESOURCE_DIMENSION_TEXTURE2D ||
++      resource_desc.DepthOrArraySize != 1 || resource_desc.MipLevels != 1 ||
++      !resource_desc.SampleDesc.Count ||
++      resource_desc.Format != DXGI_FORMAT_R16G16B16A16_FLOAT ||
++      resource_desc.Width > UINT32_MAX) {
++    static bool logged_unsupported_preview_target = false;
++    if (!logged_unsupported_preview_target) {
++      logged_unsupported_preview_target = true;
++      REXGPU_WARN(
++          "Native retained-pass preview target unsupported: dimension {}, "
++          "{}x{}, array {}, mips {}, format {}, samples {}, quality {}",
++          uint32_t(resource_desc.Dimension), resource_desc.Width,
++          resource_desc.Height, resource_desc.DepthOrArraySize,
++          resource_desc.MipLevels, uint32_t(resource_desc.Format),
++          resource_desc.SampleDesc.Count, resource_desc.SampleDesc.Quality);
++    }
++    return false;
++  }
++
++  source_out.resource = resource;
++  source_out.format = resource_desc.Format;
++  source_out.width = uint32_t(resource_desc.Width);
++  source_out.height = resource_desc.Height;
++  if (resource_desc.SampleDesc.Count > 1) {
++    D3D12_RESOURCE_DESC resolved_desc = resource_desc;
++    resolved_desc.Alignment = 0;
++    resolved_desc.SampleDesc.Count = 1;
++    resolved_desc.SampleDesc.Quality = 0;
++    resolved_desc.Flags = D3D12_RESOURCE_FLAG_ALLOW_RENDER_TARGET;
++    bool recreate_resolved = !isolated_replay_preview_resolved_target_;
++    if (!recreate_resolved) {
++      const D3D12_RESOURCE_DESC current_desc =
++          isolated_replay_preview_resolved_target_->GetDesc();
++      recreate_resolved = current_desc.Width != resolved_desc.Width ||
++                          current_desc.Height != resolved_desc.Height ||
++                          current_desc.Format != resolved_desc.Format;
++    }
++    if (recreate_resolved) {
++      D3D12_CLEAR_VALUE clear_value{};
++      clear_value.Format = resolved_desc.Format;
++      Microsoft::WRL::ComPtr<ID3D12Resource> resolved_target;
++      ID3D12Device* device =
++          command_processor_.GetD3D12Provider().GetDevice();
++      HRESULT create_result = device ? device->CreateCommittedResource(
++                         &ui::d3d12::util::kHeapPropertiesDefault,
++                         D3D12_HEAP_FLAG_NONE, &resolved_desc,
++                         D3D12_RESOURCE_STATE_RESOLVE_DEST, &clear_value,
++                         IID_PPV_ARGS(&resolved_target)) : E_POINTER;
++      if (FAILED(create_result)) {
++        REXGPU_WARN(
++            "Native retained-pass preview resolve allocation failed: "
++            "HRESULT 0x{:08X}, {}x{}, format {}, samples {}",
++            uint32_t(create_result), resolved_desc.Width,
++            resolved_desc.Height, uint32_t(resolved_desc.Format),
++            resource_desc.SampleDesc.Count);
++        return false;
++      }
++      resolved_target->SetName(L"Isolated replay preview resolved target");
++      isolated_replay_preview_resolved_target_ = std::move(resolved_target);
++      isolated_replay_preview_resolved_target_state_ =
++          D3D12_RESOURCE_STATE_RESOLVE_DEST;
++    }
++
++    const D3D12_RESOURCE_STATES source_previous_state =
++        isolated_color->SetResourceState(
++            D3D12_RESOURCE_STATE_RESOLVE_SOURCE);
++    command_processor_.PushTransitionBarrier(
++        resource, source_previous_state,
++        D3D12_RESOURCE_STATE_RESOLVE_SOURCE);
++    command_processor_.PushTransitionBarrier(
++        isolated_replay_preview_resolved_target_.Get(),
++        isolated_replay_preview_resolved_target_state_,
++        D3D12_RESOURCE_STATE_RESOLVE_DEST);
++    command_processor_.SubmitBarriers();
++    command_processor_.GetDeferredCommandList().D3DResolveSubresource(
++        isolated_replay_preview_resolved_target_.Get(), 0, resource, 0,
++        resource_desc.Format);
++    isolated_color->SetResourceState(source_previous_state);
++    command_processor_.PushTransitionBarrier(
++        resource, D3D12_RESOURCE_STATE_RESOLVE_SOURCE,
++        source_previous_state);
++    command_processor_.PushTransitionBarrier(
++        isolated_replay_preview_resolved_target_.Get(),
++        D3D12_RESOURCE_STATE_RESOLVE_DEST,
++        D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE);
++    isolated_replay_preview_resolved_target_state_ =
++        D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE;
++    source_out.resource = isolated_replay_preview_resolved_target_.Get();
++    source_out.previous_state = D3D12_RESOURCE_STATE_RESOLVE_DEST;
++    source_out.resolved = true;
++  } else {
++    source_out.previous_state = isolated_color->SetResourceState(
++        D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE);
++    command_processor_.PushTransitionBarrier(
++        resource, source_out.previous_state,
++        D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE);
++  }
++  command_processor_.SubmitBarriers();
++  return true;
++}
++
++void D3D12RenderTargetCache::EndIsolatedReplayPreview(
++    const IsolatedReplayPreviewSource& source) {
++  if (!source.resource || !isolated_replay_color_target_) {
++    return;
++  }
++  if (source.resolved) {
++    if (isolated_replay_preview_resolved_target_.Get() != source.resource) {
++      return;
++    }
++    command_processor_.PushTransitionBarrier(
++        source.resource, D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE,
++        source.previous_state);
++    isolated_replay_preview_resolved_target_state_ = source.previous_state;
++    return;
++  }
++  auto* isolated_color = static_cast<D3D12RenderTarget*>(
++      isolated_replay_color_target_.get());
++  if (isolated_color->resource() != source.resource) {
++    return;
++  }
++  isolated_color->SetResourceState(source.previous_state);
++  command_processor_.PushTransitionBarrier(
++      source.resource, D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE,
++      source.previous_state);
++}
++
+ bool D3D12RenderTargetCache::IsHostDepthEncodingDifferent(
+     xenos::DepthRenderTargetFormat format) const {
+   if (format == xenos::DepthRenderTargetFormat::kD24FS8) {
+diff --git a/src/graphics/shaders/bytecode/d3d12_5_1/native_guest_output_retained_pass_cs.h b/src/graphics/shaders/bytecode/d3d12_5_1/native_guest_output_retained_pass_cs.h
+new file mode 100644
+index 0000000..8b4c0a0
+--- /dev/null
++++ b/src/graphics/shaders/bytecode/d3d12_5_1/native_guest_output_retained_pass_cs.h
+@@ -0,0 +1,484 @@
++#if 0
++//
++// Generated by Microsoft (R) HLSL Shader Compiler 10.1
++//
++//
++// Buffer Definitions:
++//
++// cbuffer NativeGuestOutputRetainedPassConstants
++// {
++//
++//   uint2 output_size;                 // Offset:    0 Size:     8
++//   uint2 source_size;                 // Offset:    8 Size:     8
++//   uint2 crop_size;                   // Offset:   16 Size:     8
++//
++// }
++//
++//
++// Resource Bindings:
++//
++// Name                                 Type  Format         Dim      ID      HLSL Bind  Count
++// ------------------------------ ---------- ------- ----------- ------- -------------- ------
++// retained_pass                     texture  float4          2d      T0             t0      1
++// output_texture                        UAV  float4          2d      U0             u0      1
++// NativeGuestOutputRetainedPassConstants    cbuffer      NA          NA     CB0            cb0      1
++//
++//
++//
++// Input signature:
++//
++// Name                 Index   Mask Register SysValue  Format   Used
++// -------------------- ----- ------ -------- -------- ------- ------
++// no Input
++//
++// Output signature:
++//
++// Name                 Index   Mask Register SysValue  Format   Used
++// -------------------- ----- ------ -------- -------- ------- ------
++// no Output
++cs_5_1
++dcl_globalFlags refactoringAllowed
++dcl_constantbuffer CB0[0:0][2], immediateIndexed, space=0
++dcl_resource_texture2d (float,float,float,float) T0[0:0], space=0
++dcl_uav_typed_texture2d (float,float,float,float) U0[0:0], space=0
++dcl_input vThreadID.xy
++dcl_temps 3
++dcl_thread_group 8, 8, 1
++uge r0.xy, vThreadID.xyxx, CB0[0][0].xyxx
++or r0.x, r0.y, r0.x
++if_nz r0.x
++  ret
++endif
++umin r0.x, CB0[0][0].y, CB0[0][0].x
++iadd r0.yz, -r0.xxxx, CB0[0][0].xxyx
++ushr r0.yz, r0.yyzy, l(0, 1, 1, 0)
++uge r1.xy, vThreadID.xyxx, r0.yzyy
++and r0.w, r1.y, r1.x
++iadd r1.xy, r0.xxxx, r0.yzyy
++ult r1.xy, vThreadID.xyxx, r1.xyxx
++and r1.x, r1.y, r1.x
++and r0.w, r0.w, r1.x
++not r0.w, r0.w
++ine r1.xy, CB0[0][1].xyxx, l(0, 0, 0, 0)
++and r1.x, r1.y, r1.x
++not r1.x, r1.x
++or r0.w, r0.w, r1.x
++ine r1.xy, CB0[0][0].zwzz, l(0, 0, 0, 0)
++and r1.x, r1.y, r1.x
++not r1.x, r1.x
++or r0.w, r0.w, r1.x
++if_nz r0.w
++  ushr r1.xy, vThreadID.xyxx, l(5, 5, 0, 0)
++  iadd r0.w, r1.y, r1.x
++  and r0.w, r0.w, l(1)
++  movc r1.xyz, r0.wwww, l(0.018000,0.018000,0.018000,0), l(0.010000,0.010000,0.010000,0)
++  mov r1.w, l(1.000000)
++  store_uav_typed U0[0].xyzw, vThreadID.xyyy, r1.xyzw
++  ret
++endif
++iadd r0.yz, -r0.yyzy, vThreadID.xxyx
++imul null, r1.xy, r0.yzyy, CB0[0][1].xyxx
++udiv r1.xy, null, r1.xyxx, r0.xxxx
++iadd r1.zw, CB0[0][1].xxxy, l(0, 0, -1, -1)
++umin r1.xy, r1.zwzz, r1.xyxx
++mov r1.zw, l(0,0,0,0)
++ld r1.xyz, r1.xyzw, T0[0].xyzw
++ult r2.xy, r0.yzyy, l(2, 2, 0, 0)
++or r0.w, r2.y, r2.x
++iadd r0.x, r0.x, l(-2)
++uge r0.xy, r0.yzyy, r0.xxxx
++or r0.x, r0.y, r0.x
++or r0.x, r0.x, r0.w
++mov_sat r1.xyz, r1.xyzx
++movc r0.xyz, r0.xxxx, l(1.000000,0.550000,0.060000,0), r1.xyzx
++mov r0.w, l(1.000000)
++store_uav_typed U0[0].xyzw, vThreadID.xyyy, r0.xyzw
++ret
++// Approximately 50 instruction slots used
++#endif
++
++const BYTE native_guest_output_retained_pass_cs[] =
++{
++     68,  88,  66,  67,   0, 144,
++     77, 172,  96, 176,  62, 158,
++     19,   8,  86,  11, 214, 212,
++      7, 206,   1,   0,   0,   0,
++    240,   8,   0,   0,   5,   0,
++      0,   0,  52,   0,   0,   0,
++     60,   2,   0,   0,  76,   2,
++      0,   0,  92,   2,   0,   0,
++     84,   8,   0,   0,  82,  68,
++     69,  70,   0,   2,   0,   0,
++      1,   0,   0,   0, 248,   0,
++      0,   0,   3,   0,   0,   0,
++     60,   0,   0,   0,   1,   5,
++     83,  67,   0, 141,   0,   0,
++    214,   1,   0,   0,  19,  19,
++     68,  37,  60,   0,   0,   0,
++     24,   0,   0,   0,  40,   0,
++      0,   0,  40,   0,   0,   0,
++     36,   0,   0,   0,  12,   0,
++      0,   0,   0,   0,   0,   0,
++    180,   0,   0,   0,   2,   0,
++      0,   0,   5,   0,   0,   0,
++      4,   0,   0,   0, 255, 255,
++    255, 255,   0,   0,   0,   0,
++      1,   0,   0,   0,  12,   0,
++      0,   0,   0,   0,   0,   0,
++      0,   0,   0,   0, 194,   0,
++      0,   0,   4,   0,   0,   0,
++      5,   0,   0,   0,   4,   0,
++      0,   0, 255, 255, 255, 255,
++      0,   0,   0,   0,   1,   0,
++      0,   0,  12,   0,   0,   0,
++      0,   0,   0,   0,   0,   0,
++      0,   0, 209,   0,   0,   0,
++      0,   0,   0,   0,   0,   0,
++      0,   0,   0,   0,   0,   0,
++      0,   0,   0,   0,   0,   0,
++      0,   0,   1,   0,   0,   0,
++      1,   0,   0,   0,   0,   0,
++      0,   0,   0,   0,   0,   0,
++    114, 101, 116,  97, 105, 110,
++    101, 100,  95, 112,  97, 115,
++    115,   0, 111, 117, 116, 112,
++    117, 116,  95, 116, 101, 120,
++    116, 117, 114, 101,   0,  78,
++     97, 116, 105, 118, 101,  71,
++    117, 101, 115, 116,  79, 117,
++    116, 112, 117, 116,  82, 101,
++    116,  97, 105, 110, 101, 100,
++     80,  97, 115, 115,  67, 111,
++    110, 115, 116,  97, 110, 116,
++    115,   0, 209,   0,   0,   0,
++      3,   0,   0,   0,  16,   1,
++      0,   0,  32,   0,   0,   0,
++      0,   0,   0,   0,   0,   0,
++      0,   0, 136,   1,   0,   0,
++      0,   0,   0,   0,   8,   0,
++      0,   0,   2,   0,   0,   0,
++    156,   1,   0,   0,   0,   0,
++      0,   0, 255, 255, 255, 255,
++      0,   0,   0,   0, 255, 255,
++    255, 255,   0,   0,   0,   0,
++    192,   1,   0,   0,   8,   0,
++      0,   0,   8,   0,   0,   0,
++      2,   0,   0,   0, 156,   1,
++      0,   0,   0,   0,   0,   0,
++    255, 255, 255, 255,   0,   0,
++      0,   0, 255, 255, 255, 255,
++      0,   0,   0,   0, 204,   1,
++      0,   0,  16,   0,   0,   0,
++      8,   0,   0,   0,   2,   0,
++      0,   0, 156,   1,   0,   0,
++      0,   0,   0,   0, 255, 255,
++    255, 255,   0,   0,   0,   0,
++    255, 255, 255, 255,   0,   0,
++      0,   0, 111, 117, 116, 112,
++    117, 116,  95, 115, 105, 122,
++    101,   0, 117, 105, 110, 116,
++     50,   0, 171, 171,   1,   0,
++     19,   0,   1,   0,   2,   0,
++      0,   0,   0,   0,   0,   0,
++      0,   0,   0,   0,   0,   0,
++      0,   0,   0,   0,   0,   0,
++      0,   0,   0,   0,   0,   0,
++    148,   1,   0,   0, 115, 111,
++    117, 114,  99, 101,  95, 115,
++    105, 122, 101,   0,  99, 114,
++    111, 112,  95, 115, 105, 122,
++    101,   0,  77, 105,  99, 114,
++    111, 115, 111, 102, 116,  32,
++     40,  82,  41,  32,  72,  76,
++     83,  76,  32,  83, 104,  97,
++    100, 101, 114,  32,  67, 111,
++    109, 112, 105, 108, 101, 114,
++     32,  49,  48,  46,  49,   0,
++    171, 171,  73,  83,  71,  78,
++      8,   0,   0,   0,   0,   0,
++      0,   0,   8,   0,   0,   0,
++     79,  83,  71,  78,   8,   0,
++      0,   0,   0,   0,   0,   0,
++      8,   0,   0,   0,  83,  72,
++     69,  88, 240,   5,   0,   0,
++     81,   0,   5,   0, 124,   1,
++      0,   0, 106,   8,   0,   1,
++     89,   0,   0,   7,  70, 142,
++     48,   0,   0,   0,   0,   0,
++      0,   0,   0,   0,   0,   0,
++      0,   0,   2,   0,   0,   0,
++      0,   0,   0,   0,  88,  24,
++      0,   7,  70, 126,  48,   0,
++      0,   0,   0,   0,   0,   0,
++      0,   0,   0,   0,   0,   0,
++     85,  85,   0,   0,   0,   0,
++      0,   0, 156,  24,   0,   7,
++     70, 238,  49,   0,   0,   0,
++      0,   0,   0,   0,   0,   0,
++      0,   0,   0,   0,  85,  85,
++      0,   0,   0,   0,   0,   0,
++     95,   0,   0,   2,  50,   0,
++      2,   0, 104,   0,   0,   2,
++      3,   0,   0,   0, 155,   0,
++      0,   4,   8,   0,   0,   0,
++      8,   0,   0,   0,   1,   0,
++      0,   0,  80,   0,   0,   8,
++     50,   0,  16,   0,   0,   0,
++      0,   0,  70,   0,   2,   0,
++     70, 128,  48,   0,   0,   0,
++      0,   0,   0,   0,   0,   0,
++      0,   0,   0,   0,  60,   0,
++      0,   7,  18,   0,  16,   0,
++      0,   0,   0,   0,  26,   0,
++     16,   0,   0,   0,   0,   0,
++     10,   0,  16,   0,   0,   0,
++      0,   0,  31,   0,   4,   3,
++     10,   0,  16,   0,   0,   0,
++      0,   0,  62,   0,   0,   1,
++     21,   0,   0,   1,  84,   0,
++      0,  11,  18,   0,  16,   0,
++      0,   0,   0,   0,  26, 128,
++     48,   0,   0,   0,   0,   0,
++      0,   0,   0,   0,   0,   0,
++      0,   0,  10, 128,  48,   0,
++      0,   0,   0,   0,   0,   0,
++      0,   0,   0,   0,   0,   0,
++     30,   0,   0,  10,  98,   0,
++     16,   0,   0,   0,   0,   0,
++      6,   0,  16, 128,  65,   0,
++      0,   0,   0,   0,   0,   0,
++      6, 129,  48,   0,   0,   0,
++      0,   0,   0,   0,   0,   0,
++      0,   0,   0,   0,  85,   0,
++      0,  10,  98,   0,  16,   0,
++      0,   0,   0,   0,  86,   6,
++     16,   0,   0,   0,   0,   0,
++      2,  64,   0,   0,   0,   0,
++      0,   0,   1,   0,   0,   0,
++      1,   0,   0,   0,   0,   0,
++      0,   0,  80,   0,   0,   6,
++     50,   0,  16,   0,   1,   0,
++      0,   0,  70,   0,   2,   0,
++    150,   5,  16,   0,   0,   0,
++      0,   0,   1,   0,   0,   7,
++    130,   0,  16,   0,   0,   0,
++      0,   0,  26,   0,  16,   0,
++      1,   0,   0,   0,  10,   0,
++     16,   0,   1,   0,   0,   0,
++     30,   0,   0,   7,  50,   0,
++     16,   0,   1,   0,   0,   0,
++      6,   0,  16,   0,   0,   0,
++      0,   0, 150,   5,  16,   0,
++      0,   0,   0,   0,  79,   0,
++      0,   6,  50,   0,  16,   0,
++      1,   0,   0,   0,  70,   0,
++      2,   0,  70,   0,  16,   0,
++      1,   0,   0,   0,   1,   0,
++      0,   7,  18,   0,  16,   0,
++      1,   0,   0,   0,  26,   0,
++     16,   0,   1,   0,   0,   0,
++     10,   0,  16,   0,   1,   0,
++      0,   0,   1,   0,   0,   7,
++    130,   0,  16,   0,   0,   0,
++      0,   0,  58,   0,  16,   0,
++      0,   0,   0,   0,  10,   0,
++     16,   0,   1,   0,   0,   0,
++     59,   0,   0,   5, 130,   0,
++     16,   0,   0,   0,   0,   0,
++     58,   0,  16,   0,   0,   0,
++      0,   0,  39,   0,   0,  12,
++     50,   0,  16,   0,   1,   0,
++      0,   0,  70, 128,  48,   0,
++      0,   0,   0,   0,   0,   0,
++      0,   0,   1,   0,   0,   0,
++      2,  64,   0,   0,   0,   0,
++      0,   0,   0,   0,   0,   0,
++      0,   0,   0,   0,   0,   0,
++      0,   0,   1,   0,   0,   7,
++     18,   0,  16,   0,   1,   0,
++      0,   0,  26,   0,  16,   0,
++      1,   0,   0,   0,  10,   0,
++     16,   0,   1,   0,   0,   0,
++     59,   0,   0,   5,  18,   0,
++     16,   0,   1,   0,   0,   0,
++     10,   0,  16,   0,   1,   0,
++      0,   0,  60,   0,   0,   7,
++    130,   0,  16,   0,   0,   0,
++      0,   0,  58,   0,  16,   0,
++      0,   0,   0,   0,  10,   0,
++     16,   0,   1,   0,   0,   0,
++     39,   0,   0,  12,  50,   0,
++     16,   0,   1,   0,   0,   0,
++    230, 138,  48,   0,   0,   0,
++      0,   0,   0,   0,   0,   0,
++      0,   0,   0,   0,   2,  64,
++      0,   0,   0,   0,   0,   0,
++      0,   0,   0,   0,   0,   0,
++      0,   0,   0,   0,   0,   0,
++      1,   0,   0,   7,  18,   0,
++     16,   0,   1,   0,   0,   0,
++     26,   0,  16,   0,   1,   0,
++      0,   0,  10,   0,  16,   0,
++      1,   0,   0,   0,  59,   0,
++      0,   5,  18,   0,  16,   0,
++      1,   0,   0,   0,  10,   0,
++     16,   0,   1,   0,   0,   0,
++     60,   0,   0,   7, 130,   0,
++     16,   0,   0,   0,   0,   0,
++     58,   0,  16,   0,   0,   0,
++      0,   0,  10,   0,  16,   0,
++      1,   0,   0,   0,  31,   0,
++      4,   3,  58,   0,  16,   0,
++      0,   0,   0,   0,  85,   0,
++      0,   9,  50,   0,  16,   0,
++      1,   0,   0,   0,  70,   0,
++      2,   0,   2,  64,   0,   0,
++      5,   0,   0,   0,   5,   0,
++      0,   0,   0,   0,   0,   0,
++      0,   0,   0,   0,  30,   0,
++      0,   7, 130,   0,  16,   0,
++      0,   0,   0,   0,  26,   0,
++     16,   0,   1,   0,   0,   0,
++     10,   0,  16,   0,   1,   0,
++      0,   0,   1,   0,   0,   7,
++    130,   0,  16,   0,   0,   0,
++      0,   0,  58,   0,  16,   0,
++      0,   0,   0,   0,   1,  64,
++      0,   0,   1,   0,   0,   0,
++     55,   0,   0,  15, 114,   0,
++     16,   0,   1,   0,   0,   0,
++    246,  15,  16,   0,   0,   0,
++      0,   0,   2,  64,   0,   0,
++    188, 116, 147,  60, 188, 116,
++    147,  60, 188, 116, 147,  60,
++      0,   0,   0,   0,   2,  64,
++      0,   0,  10, 215,  35,  60,
++     10, 215,  35,  60,  10, 215,
++     35,  60,   0,   0,   0,   0,
++     54,   0,   0,   5, 130,   0,
++     16,   0,   1,   0,   0,   0,
++      1,  64,   0,   0,   0,   0,
++    128,  63, 164,   0,   0,   7,
++    242, 224,  33,   0,   0,   0,
++      0,   0,   0,   0,   0,   0,
++     70,   5,   2,   0,  70,  14,
++     16,   0,   1,   0,   0,   0,
++     62,   0,   0,   1,  21,   0,
++      0,   1,  30,   0,   0,   7,
++     98,   0,  16,   0,   0,   0,
++      0,   0,  86,   6,  16, 128,
++     65,   0,   0,   0,   0,   0,
++      0,   0,   6,   1,   2,   0,
++     38,   0,   0,  10,   0, 208,
++      0,   0,  50,   0,  16,   0,
++      1,   0,   0,   0, 150,   5,
++     16,   0,   0,   0,   0,   0,
++     70, 128,  48,   0,   0,   0,
++      0,   0,   0,   0,   0,   0,
++      1,   0,   0,   0,  78,   0,
++      0,   8,  50,   0,  16,   0,
++      1,   0,   0,   0,   0, 208,
++      0,   0,  70,   0,  16,   0,
++      1,   0,   0,   0,   6,   0,
++     16,   0,   0,   0,   0,   0,
++     30,   0,   0,  12, 194,   0,
++     16,   0,   1,   0,   0,   0,
++      6, 132,  48,   0,   0,   0,
++      0,   0,   0,   0,   0,   0,
++      1,   0,   0,   0,   2,  64,
++      0,   0,   0,   0,   0,   0,
++      0,   0,   0,   0, 255, 255,
++    255, 255, 255, 255, 255, 255,
++     84,   0,   0,   7,  50,   0,
++     16,   0,   1,   0,   0,   0,
++    230,  10,  16,   0,   1,   0,
++      0,   0,  70,   0,  16,   0,
++      1,   0,   0,   0,  54,   0,
++      0,   8, 194,   0,  16,   0,
++      1,   0,   0,   0,   2,  64,
++      0,   0,   0,   0,   0,   0,
++      0,   0,   0,   0,   0,   0,
++      0,   0,   0,   0,   0,   0,
++     45,   0,   0,   8, 114,   0,
++     16,   0,   1,   0,   0,   0,
++     70,  14,  16,   0,   1,   0,
++      0,   0,  70, 126,  32,   0,
++      0,   0,   0,   0,   0,   0,
++      0,   0,  79,   0,   0,  10,
++     50,   0,  16,   0,   2,   0,
++      0,   0, 150,   5,  16,   0,
++      0,   0,   0,   0,   2,  64,
++      0,   0,   2,   0,   0,   0,
++      2,   0,   0,   0,   0,   0,
++      0,   0,   0,   0,   0,   0,
++     60,   0,   0,   7, 130,   0,
++     16,   0,   0,   0,   0,   0,
++     26,   0,  16,   0,   2,   0,
++      0,   0,  10,   0,  16,   0,
++      2,   0,   0,   0,  30,   0,
++      0,   7,  18,   0,  16,   0,
++      0,   0,   0,   0,  10,   0,
++     16,   0,   0,   0,   0,   0,
++      1,  64,   0,   0, 254, 255,
++    255, 255,  80,   0,   0,   7,
++     50,   0,  16,   0,   0,   0,
++      0,   0, 150,   5,  16,   0,
++      0,   0,   0,   0,   6,   0,
++     16,   0,   0,   0,   0,   0,
++     60,   0,   0,   7,  18,   0,
++     16,   0,   0,   0,   0,   0,
++     26,   0,  16,   0,   0,   0,
++      0,   0,  10,   0,  16,   0,
++      0,   0,   0,   0,  60,   0,
++      0,   7,  18,   0,  16,   0,
++      0,   0,   0,   0,  10,   0,
++     16,   0,   0,   0,   0,   0,
++     58,   0,  16,   0,   0,   0,
++      0,   0,  54,  32,   0,   5,
++    114,   0,  16,   0,   1,   0,
++      0,   0,  70,   2,  16,   0,
++      1,   0,   0,   0,  55,   0,
++      0,  12, 114,   0,  16,   0,
++      0,   0,   0,   0,   6,   0,
++     16,   0,   0,   0,   0,   0,
++      2,  64,   0,   0,   0,   0,
++    128,  63, 205, 204,  12,  63,
++    143, 194, 117,  61,   0,   0,
++      0,   0,  70,   2,  16,   0,
++      1,   0,   0,   0,  54,   0,
++      0,   5, 130,   0,  16,   0,
++      0,   0,   0,   0,   1,  64,
++      0,   0,   0,   0, 128,  63,
++    164,   0,   0,   7, 242, 224,
++     33,   0,   0,   0,   0,   0,
++      0,   0,   0,   0,  70,   5,
++      2,   0,  70,  14,  16,   0,
++      0,   0,   0,   0,  62,   0,
++      0,   1,  83,  84,  65,  84,
++    148,   0,   0,   0,  50,   0,
++      0,   0,   3,   0,   0,   0,
++      0,   0,   0,   0,   1,   0,
++      0,   0,   0,   0,   0,   0,
++      9,   0,   0,   0,  25,   0,
++      0,   0,   3,   0,   0,   0,
++      2,   0,   0,   0,   0,   0,
++      0,   0,   0,   0,   0,   0,
++      0,   0,   0,   0,   0,   0,
++      0,   0,   0,   0,   0,   0,
++      0,   0,   0,   0,   1,   0,
++      0,   0,   0,   0,   0,   0,
++      0,   0,   0,   0,   0,   0,
++      0,   0,   4,   0,   0,   0,
++      2,   0,   0,   0,   0,   0,
++      0,   0,   0,   0,   0,   0,
++      0,   0,   0,   0,   0,   0,
++      0,   0,   0,   0,   0,   0,
++      0,   0,   0,   0,   0,   0,
++      0,   0,   0,   0,   0,   0,
++      0,   0,   0,   0,   0,   0,
++      0,   0,   0,   0,   0,   0,
++      0,   0,   0,   0,   0,   0,
++      0,   0,   0,   0,   0,   0,
++      0,   0,   0,   0,   2,   0,
++      0,   0
++};
+diff --git a/src/graphics/shaders/native_guest_output_retained_pass.cs.hlsl b/src/graphics/shaders/native_guest_output_retained_pass.cs.hlsl
+new file mode 100644
+index 0000000..69b9d4e
+--- /dev/null
++++ b/src/graphics/shaders/native_guest_output_retained_pass.cs.hlsl
+@@ -0,0 +1,38 @@
++cbuffer NativeGuestOutputRetainedPassConstants : register(b0) {
++  uint2 output_size;
++  uint2 source_size;
++  uint2 crop_size;
++};
++
++Texture2D<float4> retained_pass : register(t0);
++RWTexture2D<float4> output_texture : register(u0);
++
++[numthreads(8, 8, 1)]
++void main(uint3 dispatch_thread_id : SV_DispatchThreadID) {
++  uint2 output_position = dispatch_thread_id.xy;
++  if (any(output_position >= output_size)) {
++    return;
++  }
++
++  uint preview_size = min(output_size.x, output_size.y);
++  uint2 preview_origin = (output_size - preview_size) / 2;
++  bool inside = all(output_position >= preview_origin) &&
++                all(output_position < preview_origin + preview_size);
++  if (!inside || !all(crop_size) || !all(source_size)) {
++    float stripe = ((output_position.x / 32 + output_position.y / 32) & 1)
++                       ? 0.018f
++                       : 0.010f;
++    output_texture[output_position] = float4(stripe, stripe, stripe, 1.0f);
++    return;
++  }
++
++  uint2 preview_position = output_position - preview_origin;
++  uint2 source_position = min(
++      preview_position * crop_size / preview_size, crop_size - 1);
++  float4 color = retained_pass.Load(uint3(source_position, 0));
++  bool border = any(preview_position < 2) ||
++                any(preview_position >= preview_size - 2);
++  output_texture[output_position] =
++      border ? float4(1.0f, 0.55f, 0.06f, 1.0f)
++             : float4(saturate(color.rgb), 1.0f);
++}

--- a/src/native_renderer/guest_output_renderer.cpp
+++ b/src/native_renderer/guest_output_renderer.cpp
@@ -9,14 +9,17 @@
 #include "native_renderer/shader_pack.h"
 #include "pinyon_shift_diagnostics.h"
 
-REXCVAR_DEFINE_BOOL(pinyon_shift_native_renderer_diagnostic_clear, false, "Pinyon Shift",
-                    "Replace guest output with a diagnostic clear for native-renderer testing")
+REXCVAR_DEFINE_BOOL(
+    pinyon_shift_native_renderer_diagnostic_clear, false, "Pinyon Shift",
+    "Replace guest output with a diagnostic clear for native-renderer testing")
     .lifecycle(rex::cvar::Lifecycle::kRequiresRestart);
 REXCVAR_DEFINE_STRING(pinyon_shift_native_renderer, "xenos", "Pinyon Shift",
-                      "Guest-output renderer: xenos, diagnostic_clear, diagnostic_triangle")
+                      "Guest-output renderer: xenos, diagnostic_clear, "
+                      "diagnostic_triangle, diagnostic_retained_pass")
     .lifecycle(rex::cvar::Lifecycle::kRequiresRestart);
-REXCVAR_DEFINE_STRING(pinyon_shift_native_shader_pack, "", "Pinyon Shift",
-                      "Local NR-02 D3D12 shader pack path; empty disables pack loading")
+REXCVAR_DEFINE_STRING(
+    pinyon_shift_native_shader_pack, "", "Pinyon Shift",
+    "Local NR-02 D3D12 shader pack path; empty disables pack loading")
     .lifecycle(rex::cvar::Lifecycle::kRequiresRestart);
 
 namespace {
@@ -24,12 +27,25 @@ namespace {
 std::atomic<bool> g_failure_latched{};
 std::atomic<uint64_t> g_callback_count{};
 std::atomic<uint64_t> g_claimed_count{};
-enum class DiagnosticMode : uint32_t { kClear, kTriangle };
+enum class DiagnosticMode : uint32_t { kClear, kTriangle, kRetainedPass };
 std::atomic<DiagnosticMode> g_mode{DiagnosticMode::kClear};
 pinyon_shift::native_renderer::ShaderPack g_shader_pack;
 
-bool RenderDiagnosticOutput(const rex::system::NativeGuestOutputRenderContext& context) {
-  const uint64_t callback = g_callback_count.fetch_add(1, std::memory_order_relaxed) + 1;
+const char *DiagnosticModeName(DiagnosticMode mode) {
+  switch (mode) {
+  case DiagnosticMode::kTriangle:
+    return "diagnostic_triangle";
+  case DiagnosticMode::kRetainedPass:
+    return "diagnostic_retained_pass";
+  default:
+    return "diagnostic_clear";
+  }
+}
+
+bool RenderDiagnosticOutput(
+    const rex::system::NativeGuestOutputRenderContext &context) {
+  const uint64_t callback =
+      g_callback_count.fetch_add(1, std::memory_order_relaxed) + 1;
   if (g_failure_latched.load(std::memory_order_acquire)) {
     return false;
   }
@@ -45,24 +61,40 @@ bool RenderDiagnosticOutput(const rex::system::NativeGuestOutputRenderContext& c
   const DiagnosticMode mode = g_mode.load(std::memory_order_relaxed);
   bool rendered = false;
   if (mode == DiagnosticMode::kTriangle && context.draw_diagnostic_triangle) {
-    rendered = context.draw_diagnostic_triangle(context, uint32_t((context.submission / 120) & 1));
+    rendered = context.draw_diagnostic_triangle(
+        context, uint32_t((context.submission / 120) & 1));
+  } else if (mode == DiagnosticMode::kRetainedPass &&
+             context.draw_retained_pass) {
+    rendered = context.draw_retained_pass(context);
   } else if (mode == DiagnosticMode::kClear && context.clear_color) {
     const bool alternate = ((context.submission / 120) & 1) != 0;
-    const float color[4] = {alternate ? 0.04f : 0.85f, 0.16f, alternate ? 0.55f : 0.03f, 1.0f};
+    const float color[4] = {alternate ? 0.04f : 0.85f, 0.16f,
+                            alternate ? 0.55f : 0.03f, 1.0f};
     rendered = context.clear_color(context, color);
   }
   if (!rendered) {
+    if (mode == DiagnosticMode::kRetainedPass && context.draw_retained_pass) {
+      if (callback == 1 || callback % 300 == 0) {
+        pinyon_shift::diagnostics::RecordEvent(
+            "native_renderer.output.waiting",
+            {{"reason", "retained_pass_unavailable"},
+             {"callback", std::to_string(callback)},
+             {"fallback", "xenos"},
+             {"suppression", "disabled"}});
+      }
+      return false;
+    }
     if (!g_failure_latched.exchange(true, std::memory_order_acq_rel)) {
       pinyon_shift::diagnostics::RecordEvent(
           "native_renderer.output.failure",
-          {{"reason", mode == DiagnosticMode::kTriangle ? "diagnostic_triangle_failed"
-                                                        : "diagnostic_clear_failed"},
+          {{"reason", std::string(DiagnosticModeName(mode)) + "_failed"},
            {"fallback", "xenos"}});
     }
     return false;
   }
 
-  const uint64_t claimed = g_claimed_count.fetch_add(1, std::memory_order_relaxed) + 1;
+  const uint64_t claimed =
+      g_claimed_count.fetch_add(1, std::memory_order_relaxed) + 1;
   if (callback == 1 || callback % 300 == 0) {
     pinyon_shift::diagnostics::RecordEvent(
         "native_renderer.output.frame",
@@ -74,66 +106,79 @@ bool RenderDiagnosticOutput(const rex::system::NativeGuestOutputRenderContext& c
          {"display_width", std::to_string(context.display_width)},
          {"display_height", std::to_string(context.display_height)},
          {"format", std::to_string(context.output_format)},
-         {"mode", mode == DiagnosticMode::kTriangle ? "diagnostic_triangle" : "diagnostic_clear"}});
+         {"mode", DiagnosticModeName(mode)},
+         {"xenos_draw", "preserved"},
+         {"suppression", "disabled"}});
   }
   return true;
 }
 
-}  // namespace
+} // namespace
 
 namespace pinyon_shift::native_renderer {
 
-void InstallGuestOutputRenderer(rex::system::IGraphicsSystem* graphics_system) {
+void InstallGuestOutputRenderer(rex::system::IGraphicsSystem *graphics_system) {
   if (!graphics_system) {
     return;
   }
-  const std::string shader_pack_path = REXCVAR_GET(pinyon_shift_native_shader_pack);
+  const std::string shader_pack_path =
+      REXCVAR_GET(pinyon_shift_native_shader_pack);
   g_shader_pack.Reset();
   if (!shader_pack_path.empty()) {
-    const auto* shader_pack_path_begin = reinterpret_cast<const char8_t*>(shader_pack_path.data());
+    const auto *shader_pack_path_begin =
+        reinterpret_cast<const char8_t *>(shader_pack_path.data());
     const std::filesystem::path local_shader_pack_path(
-        std::u8string(shader_pack_path_begin, shader_pack_path_begin + shader_pack_path.size()));
+        std::u8string(shader_pack_path_begin,
+                      shader_pack_path_begin + shader_pack_path.size()));
     if (g_shader_pack.Load(local_shader_pack_path)) {
       diagnostics::RecordEvent(
           "native_renderer.shader_pack.ready",
-          {{"entries", std::to_string(g_shader_pack.entry_count())}, {"backend", "d3d12"}});
+          {{"entries", std::to_string(g_shader_pack.entry_count())},
+           {"backend", "d3d12"}});
     } else {
-      diagnostics::RecordEvent("native_renderer.shader_pack.failure",
-                               {{"reason", "validation_failed"}, {"fallback", "xenos"}});
+      diagnostics::RecordEvent(
+          "native_renderer.shader_pack.failure",
+          {{"reason", "validation_failed"}, {"fallback", "xenos"}});
     }
   }
   const std::string mode = REXCVAR_GET(pinyon_shift_native_renderer);
-  const bool legacy_clear = REXCVAR_GET(pinyon_shift_native_renderer_diagnostic_clear);
+  const bool legacy_clear =
+      REXCVAR_GET(pinyon_shift_native_renderer_diagnostic_clear);
   if (mode == "xenos" && !legacy_clear) {
     diagnostics::RecordEvent("native_renderer.output.state",
                              {{"mode", "xenos"}, {"authority", "xenos"}});
     return;
   }
   if (mode != "diagnostic_clear" && mode != "diagnostic_triangle" &&
+      mode != "diagnostic_retained_pass" &&
       !(mode == "xenos" && legacy_clear)) {
-    diagnostics::RecordEvent("native_renderer.output.failure",
-                             {{"reason", "unsupported_mode"}, {"fallback", "xenos"}});
+    diagnostics::RecordEvent(
+        "native_renderer.output.failure",
+        {{"reason", "unsupported_mode"}, {"fallback", "xenos"}});
     return;
   }
   const DiagnosticMode selected_mode =
-      mode == "diagnostic_triangle" ? DiagnosticMode::kTriangle : DiagnosticMode::kClear;
+      mode == "diagnostic_triangle"        ? DiagnosticMode::kTriangle
+      : mode == "diagnostic_retained_pass" ? DiagnosticMode::kRetainedPass
+                                           : DiagnosticMode::kClear;
   g_mode.store(selected_mode, std::memory_order_release);
   g_failure_latched.store(false, std::memory_order_release);
   g_callback_count.store(0, std::memory_order_release);
   g_claimed_count.store(0, std::memory_order_release);
   graphics_system->SetNativeGuestOutputRenderer(&RenderDiagnosticOutput);
-  diagnostics::RecordEvent(
-      "native_renderer.output.installed",
-      {{"mode",
-        selected_mode == DiagnosticMode::kTriangle ? "diagnostic_triangle" : "diagnostic_clear"},
-       {"fallback", "xenos"}});
+  diagnostics::RecordEvent("native_renderer.output.installed",
+                           {{"mode", DiagnosticModeName(selected_mode)},
+                            {"fallback", "xenos"},
+                            {"xenos_draw", "preserved"},
+                            {"suppression", "disabled"}});
 }
 
-void UninstallGuestOutputRenderer(rex::system::IGraphicsSystem* graphics_system) {
+void UninstallGuestOutputRenderer(
+    rex::system::IGraphicsSystem *graphics_system) {
   if (graphics_system) {
     graphics_system->SetNativeGuestOutputRenderer(nullptr);
   }
   g_shader_pack.Reset();
 }
 
-}  // namespace pinyon_shift::native_renderer
+} // namespace pinyon_shift::native_renderer

--- a/tools/create-crash-report.ps1
+++ b/tools/create-crash-report.ps1
@@ -257,6 +257,7 @@ try {
         } else { 'xenos' }
         effective = 'unknown'
         claimed_frames = [uint64]0
+        waiting_reason = $null
         failure_reason = $null
     }
     $nativeShaderPack = [ordered]@{
@@ -274,6 +275,11 @@ try {
                 'native_renderer.output.frame' {
                     $nativeRenderer.effective = [string]$event.mode
                     $nativeRenderer.claimed_frames = [uint64]$event.claimed
+                    $nativeRenderer.waiting_reason = $null
+                }
+                'native_renderer.output.waiting' {
+                    $nativeRenderer.effective = 'xenos'
+                    $nativeRenderer.waiting_reason = [string]$event.reason
                 }
                 'native_renderer.output.failure' {
                     $nativeRenderer.effective = 'xenos'

--- a/tools/set-graphics-experiment.ps1
+++ b/tools/set-graphics-experiment.ps1
@@ -24,7 +24,7 @@ param(
     [string]$DisableMotionBlur = 'false',
     [ValidateSet('true', 'false')]
     [string]$DisableDepthOfField = 'false',
-    [ValidateSet('xenos', 'diagnostic_triangle')]
+    [ValidateSet('xenos', 'diagnostic_triangle', 'diagnostic_retained_pass')]
     [string]$NativeRenderer = 'xenos',
     [string]$StateRoot,
     [switch]$Json

--- a/tools/tests/test_native_renderer_contract.py
+++ b/tools/tests/test_native_renderer_contract.py
@@ -232,6 +232,42 @@ class NativeRendererContractTests(unittest.TestCase):
         self.assertIn("claimed_frames", report)
         self.assertIn("failure_reason", report)
 
+    def test_retained_pass_preview_is_explicit_and_preserves_xenos(self):
+        patch = (
+            ROOT / "patches/rexglue/0065-d3d12-retained-pass-preview.patch"
+        ).read_text(encoding="utf-8")
+        self.assertIn("NativeGuestOutputDrawRetainedPass", patch)
+        self.assertIn("BeginIsolatedReplayPreview", patch)
+        self.assertIn("EndIsolatedReplayPreview", patch)
+        self.assertIn("native_guest_output_retained_pass_cs", patch)
+        self.assertIn("DXGI_FORMAT_R16G16B16A16_FLOAT", patch)
+        self.assertIn("isolated_replay_preview_resolved_target_", patch)
+        self.assertIn("D3D12_RESOURCE_STATE_RESOLVE_SOURCE", patch)
+        self.assertIn("D3D12_RESOURCE_STATE_RESOLVE_DEST", patch)
+        self.assertIn("D3DResolveSubresource", patch)
+        self.assertIn("D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE", patch)
+        self.assertIn("kGuestOutputInternalState", patch)
+        self.assertNotIn("SetDrawSuppression", patch)
+
+        source = (
+            ROOT / "src/native_renderer/guest_output_renderer.cpp"
+        ).read_text(encoding="utf-8")
+        self.assertIn('mode == "diagnostic_retained_pass"', source)
+        self.assertIn("context.draw_retained_pass(context)", source)
+        self.assertIn('"retained_pass_unavailable"', source)
+        self.assertIn('{"suppression", "disabled"}', source)
+
+        settings = (ROOT / "tools/set-graphics-experiment.ps1").read_text(
+            encoding="utf-8"
+        )
+        self.assertIn("'diagnostic_retained_pass'", settings)
+
+        report = (ROOT / "tools/create-crash-report.ps1").read_text(
+            encoding="utf-8"
+        )
+        self.assertIn("'native_renderer.output.waiting'", report)
+        self.assertIn("waiting_reason", report)
+
     def test_shader_capture_is_local_bounded_and_passive(self):
         patch = (
             ROOT

--- a/tools/tests/test_release_contract.py
+++ b/tools/tests/test_release_contract.py
@@ -43,10 +43,10 @@ class ReleaseContractTests(unittest.TestCase):
 
     def test_rexglue_patches_have_stable_order_and_no_binary_payload(self):
         patches = sorted((ROOT / "patches/rexglue").glob("*.patch"))
-        self.assertEqual(len(patches), 64)
+        self.assertEqual(len(patches), 65)
         self.assertEqual(
             patches[-1].name,
-            "0064-d3d12-native-texture-resource-observer.patch",
+            "0065-d3d12-retained-pass-preview.patch",
         )
         self.assertEqual(len(patches), len({path.name[:4] for path in patches}))
         for path in patches:
@@ -90,6 +90,9 @@ class ReleaseContractTests(unittest.TestCase):
         self.assertIn("--ignore-stamp", integration)
         self.assertIn("rexglue-sdk EXCLUDE_FROM_ALL", integration)
         self.assertIn("PINYON_SHIFT_REXGLUE_CODEGEN_DEPENDS", integration)
+        self.assertIn("$<TARGET_FILE:rexruntime>", integration)
+        self.assertIn("$<TARGET_FILE:rexgpu-xenos>", integration)
+        self.assertIn("DEPENDS ${target_name} rexruntime rexgpu-xenos", integration)
 
         package_script = (ROOT / "tools/package-launcher.ps1").read_text()
         self.assertIn("$_.Name -ne 'generated'", package_script)


### PR DESCRIPTION
## Summary
- resolve and display the qualified retained RGBA16F pass through the native guest-output path
- preserve complete Xenos fallback while waiting and keep draw suppression disabled
- expose the restart-required developer preview and improve waiting diagnostics
- stage both current ReXGlue runtime DLLs after incremental builds

## Validation
- 141 Python contract tests
- clean 65-patch ReXGlue reconstruction and preview build
- resource identity, buffer cache, and texture cache native tests
- AppData session 20260828T205347Z-p35488: stable live amber crop, normal shutdown, zero failures
- 31.033 median FPS, 19.161 FPS 1% low, 59.991 Hz host presentation, zero deadline misses