### PR TITLE
feat(native-renderer): add render-target provenance bridge

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,7 @@ if(WIN32)
         src/native_renderer/graphics_hooks.cpp
         src/native_renderer/buffer_cache.cpp
         src/native_renderer/guest_output_renderer.cpp
+        src/native_renderer/render_target_bridge.cpp
         src/native_renderer/resource_identity.cpp
         src/native_renderer/shader_capture.cpp
         src/native_renderer/shader_pack.cpp
@@ -40,6 +41,7 @@ else()
         src/native_renderer/graphics_hooks.cpp
         src/native_renderer/buffer_cache.cpp
         src/native_renderer/guest_output_renderer.cpp
+        src/native_renderer/render_target_bridge.cpp
         src/native_renderer/resource_identity.cpp
         src/native_renderer/shader_capture.cpp
         src/native_renderer/shader_pack.cpp
@@ -67,6 +69,13 @@ add_executable(pinyon_shift_texture_cache_tests EXCLUDE_FROM_ALL
     src/native_renderer/texture_cache.cpp
 )
 target_include_directories(pinyon_shift_texture_cache_tests PRIVATE src)
+
+add_executable(pinyon_shift_render_target_bridge_tests EXCLUDE_FROM_ALL
+    tests/native_renderer/render_target_bridge_test.cpp
+    src/native_renderer/render_target_bridge.cpp
+    src/native_renderer/resource_identity.cpp
+)
+target_include_directories(pinyon_shift_render_target_bridge_tests PRIVATE src)
 
 pinyon_shift_attach_rexglue(pinyon_shift)
 

--- a/docs/native-renderer/RENDER_TARGET_BRIDGE.md
+++ b/docs/native-renderer/RENDER_TARGET_BRIDGE.md
@@ -1,0 +1,62 @@
+# Native render-target bridge
+
+NR-03E introduces the backend-neutral ownership and provenance contract for
+native render targets. It does not suppress an Xenos draw or change the
+default renderer. A later backend integration must translate the opaque
+handles to retained host resources and bind a neutral fallback whenever a
+lookup returns `kBridgeRequired`.
+
+## Exact pool identity
+
+`NativeRenderTargetKey` includes the host format, dimensions, sample count,
+and complete usage mask. A checked-in allocation is reusable only when its
+key matches exactly, no resolve mapping pins it, and the completed submission
+has reached every submission that referenced it. Candidate allocations are
+consumed only on a miss; the backend keeps ownership of an unused candidate
+on a hit.
+
+Color and depth attachment identity is mutually exclusive. Resolve producers
+must be single-sampled and shader-readable. The resolve record keeps the
+canonical guest destination, source rectangle, row pitch, mip level, and
+array slice so later backend work does not need to infer subresource identity.
+
+## Producer provenance
+
+Publishing a resolve associates its canonical guest destination with the
+native producer and pins that target against pool reuse. A newer overlapping
+resolve supersedes and unpins the older mapping. A compatible texture request
+returns the producer handle directly; a format, extent, or lifetime mismatch
+returns `kBridgeRequired`.
+
+Known GPU-produced ranges remain recorded after their producer is retired.
+They therefore cannot silently fall through to guest-memory decoding. The
+consumer must bind its neutral fallback until a valid producer is published.
+An overlapping guest write invalidates the old mapping and provenance, after
+which the rewritten resource may follow the normal bounded decode path.
+Physical-heap aliases are canonicalized by `PhysicalRange` before either
+operation.
+
+## Lifetime and telemetry
+
+Targets retired by invalidation, replacement, or shutdown enter the same
+deferred queue. `Collect` returns them to the backend only after the completed
+submission reaches their final-use stamp. The bridge reports pool hits and
+misses, producer hits and refusals, resolve publications, guest invalidations,
+and live and retired allocation counts and bytes.
+
+The standalone semantic test covers exact keys, physical aliases, pinned
+producer non-reuse, superseding resolves, guest-write invalidation, stale
+producer refusal, pool reuse, and fence-safe retirement. This PR establishes
+the resource contract required before the command processor can publish real
+D3D12 render targets into continuous native composition.
+
+## Qualification
+
+Clean build and AppData-backed runtime qualification on 2026-08-28 used
+session `20260828T211430Z-p39104`. The saved game reached the festival scene
+with the default `xenos` renderer and exited normally. The 165.03-second
+capture contained 5,788 samples, 30.715 median FPS, 19.597 one-percent-low
+FPS, 59.993 Hz presentation, 29.654 Hz simulation, and no presentation
+deadline misses. Texture and pipeline hit rates were 99.976 and 100 percent.
+The event stream ended with `process.shutdown` and reported no failure events,
+failed resolve copies, census target overflow, or census page overflow.

--- a/docs/native-renderer/RESOURCE_IDENTITY.md
+++ b/docs/native-renderer/RESOURCE_IDENTITY.md
@@ -77,3 +77,12 @@ returns through a lock-free rejection path unless a texture matches the
 measured 256 by 64 tiled DXN contract. Cache summaries are submission-paced,
 not draw-paced. This keeps the default-off probe bounded even in scenes with
 thousands of draws per frame.
+
+## Render-target provenance
+
+The NR-03E render-target pool and resolve bridge builds on the same canonical
+`PhysicalRange` identity. Its exact allocation, producer lookup, invalidation,
+and deferred-destruction contracts are documented in
+`RENDER_TARGET_BRIDGE.md`. In particular, a known GPU-produced range without a
+compatible live producer returns `kBridgeRequired`; it never falls through to
+stale guest-memory decoding.

--- a/src/native_renderer/render_target_bridge.cpp
+++ b/src/native_renderer/render_target_bridge.cpp
@@ -1,0 +1,319 @@
+#include "native_renderer/render_target_bridge.h"
+
+#include <algorithm>
+#include <functional>
+
+namespace pinyon_shift::native_renderer {
+
+namespace {
+
+size_t HashCombine(size_t seed, uint64_t value) {
+  return seed ^ (std::hash<uint64_t>{}(value) + size_t(0x9E3779B9) +
+                 (seed << 6) + (seed >> 2));
+}
+
+bool Contains(const PhysicalRange &outer, const PhysicalRange &inner) {
+  return outer.valid() && inner.valid() && outer.address <= inner.address &&
+         outer.end_exclusive() >= inner.end_exclusive();
+}
+
+}  // namespace
+
+bool NativeRenderTargetKey::valid() const {
+  const uint32_t usage_bits = RenderTargetUsageBits(usage);
+  const uint32_t known_usage_bits =
+      RenderTargetUsageBits(NativeRenderTargetUsage::kColor) |
+      RenderTargetUsageBits(NativeRenderTargetUsage::kDepth) |
+      RenderTargetUsageBits(NativeRenderTargetUsage::kShaderResource) |
+      RenderTargetUsageBits(NativeRenderTargetUsage::kUnorderedAccess);
+  const bool one_attachment =
+      bool(usage_bits &
+           RenderTargetUsageBits(NativeRenderTargetUsage::kColor)) !=
+      bool(usage_bits & RenderTargetUsageBits(NativeRenderTargetUsage::kDepth));
+  return host_format && width && height && sample_count && one_attachment &&
+         !(usage_bits & ~known_usage_bits);
+}
+
+size_t NativeRenderTargetKeyHash::operator()(
+    const NativeRenderTargetKey &key) const {
+  size_t hash = 0;
+  hash = HashCombine(hash, key.host_format);
+  hash = HashCombine(hash, key.width);
+  hash = HashCombine(hash, key.height);
+  hash = HashCombine(hash, key.sample_count);
+  return HashCombine(hash, RenderTargetUsageBits(key.usage));
+}
+
+bool NativeResolveRegion::valid_for(const NativeRenderTargetKey &key) const {
+  if (!key.valid() || !guest_destination.valid() || !width || !height ||
+      !row_pitch_bytes || mip_level || array_slice || key.sample_count != 1 ||
+      !(RenderTargetUsageBits(key.usage) &
+        RenderTargetUsageBits(NativeRenderTargetUsage::kShaderResource))) {
+    return false;
+  }
+  const uint64_t right = uint64_t(source_x) + width;
+  const uint64_t bottom = uint64_t(source_y) + height;
+  return right <= key.width && bottom <= key.height &&
+         uint64_t(row_pitch_bytes) * height <= guest_destination.length;
+}
+
+std::optional<NativeRenderTargetAcquireResult>
+NativeRenderTargetBridge::Acquire(const NativeRenderTargetKey &key,
+                                  NativeRenderTargetHandle candidate_handle,
+                                  uint64_t allocation_bytes, uint64_t frame,
+                                  uint64_t current_submission,
+                                  uint64_t completed_submission) {
+  if (!key.valid()) {
+    return std::nullopt;
+  }
+  const std::scoped_lock lock(mutex_);
+  auto reusable = std::find_if(
+      targets_.begin(), targets_.end(), [&](const TargetEntry &target) {
+        return target.key == key && !target.checked_out &&
+               !target.mapping_pins &&
+               target.available_after_submission <= completed_submission;
+      });
+  if (reusable != targets_.end()) {
+    reusable->checked_out = true;
+    reusable->last_use_frame = std::max(reusable->last_use_frame, frame);
+    reusable->last_use_submission =
+        std::max(reusable->last_use_submission, current_submission);
+    ++metrics_.pool_hits;
+    return NativeRenderTargetAcquireResult{reusable->handle, true};
+  }
+  if (!candidate_handle || !allocation_bytes ||
+      FindTargetLocked(candidate_handle)) {
+    return std::nullopt;
+  }
+  targets_.push_back({key, candidate_handle, allocation_bytes, frame,
+                      current_submission, current_submission, 0, true});
+  ++metrics_.pool_misses;
+  ++metrics_.live_count;
+  metrics_.live_bytes += allocation_bytes;
+  return NativeRenderTargetAcquireResult{candidate_handle, false};
+}
+
+bool NativeRenderTargetBridge::Release(NativeRenderTargetHandle handle,
+                                       uint64_t current_submission) {
+  const std::scoped_lock lock(mutex_);
+  TargetEntry *target = FindTargetLocked(handle);
+  if (!target || !target->checked_out) {
+    return false;
+  }
+  target->checked_out = false;
+  target->last_use_submission =
+      std::max(target->last_use_submission, current_submission);
+  target->available_after_submission =
+      std::max(target->available_after_submission, current_submission);
+  return true;
+}
+
+bool NativeRenderTargetBridge::PublishResolve(NativeRenderTargetHandle handle,
+                                              const NativeResolveRegion &region,
+                                              uint64_t producer_submission) {
+  const std::scoped_lock lock(mutex_);
+  TargetEntry *target = FindTargetLocked(handle);
+  if (!target || !target->checked_out || !region.valid_for(target->key)) {
+    return false;
+  }
+  for (size_t mapping_index = mappings_.size(); mapping_index-- > 0;) {
+    if (mappings_[mapping_index].region.guest_destination.Overlaps(
+            region.guest_destination)) {
+      RemoveMappingLocked(mapping_index);
+    }
+  }
+  RememberKnownOutputLocked(region.guest_destination);
+  mappings_.push_back({region, handle, producer_submission});
+  ++target->mapping_pins;
+  target->last_use_submission =
+      std::max(target->last_use_submission, producer_submission);
+  target->available_after_submission =
+      std::max(target->available_after_submission, producer_submission);
+  ++metrics_.resolve_publications;
+  return true;
+}
+
+NativeProducerLookup NativeRenderTargetBridge::LookupProducer(
+    const NativeProducerRequest &request, uint64_t frame,
+    uint64_t current_submission) {
+  const std::scoped_lock lock(mutex_);
+  if (!request.guest_source.valid() || !request.host_format || !request.width ||
+      !request.height) {
+    ++metrics_.bridge_refusals;
+    return {NativeProducerLookupState::kBridgeRequired};
+  }
+  const auto mapping = std::find_if(
+      mappings_.begin(), mappings_.end(), [&](const ResolveMapping &candidate) {
+        return Contains(candidate.region.guest_destination,
+                        request.guest_source);
+      });
+  if (mapping != mappings_.end()) {
+    TargetEntry *target = FindTargetLocked(mapping->handle);
+    if (target && target->key.host_format == request.host_format &&
+        mapping->region.width == request.width &&
+        mapping->region.height == request.height) {
+      target->last_use_frame = std::max(target->last_use_frame, frame);
+      target->last_use_submission =
+          std::max(target->last_use_submission, current_submission);
+      target->available_after_submission =
+          std::max(target->available_after_submission, current_submission);
+      ++metrics_.bridge_hits;
+      return {NativeProducerLookupState::kNativeProducer, target->handle,
+              target->key, mapping->region, mapping->producer_submission};
+    }
+    ++metrics_.bridge_refusals;
+    return {NativeProducerLookupState::kBridgeRequired};
+  }
+  const bool known_gpu_output =
+      std::ranges::any_of(known_gpu_outputs_, [&](const PhysicalRange &known) {
+        return known.Overlaps(request.guest_source);
+      });
+  if (known_gpu_output) {
+    ++metrics_.bridge_refusals;
+    return {NativeProducerLookupState::kBridgeRequired};
+  }
+  return {NativeProducerLookupState::kGuestDecodeAllowed};
+}
+
+size_t NativeRenderTargetBridge::InvalidateGuestWrite(
+    const PhysicalRange &written_range, uint64_t current_submission) {
+  if (!written_range.valid()) {
+    return 0;
+  }
+  const std::scoped_lock lock(mutex_);
+  size_t invalidated = 0;
+  for (size_t mapping_index = mappings_.size(); mapping_index-- > 0;) {
+    if (!mappings_[mapping_index].region.guest_destination.Overlaps(
+            written_range)) {
+      continue;
+    }
+    TargetEntry *target = FindTargetLocked(mappings_[mapping_index].handle);
+    if (target) {
+      target->last_use_submission =
+          std::max(target->last_use_submission, current_submission);
+      target->available_after_submission =
+          std::max(target->available_after_submission, current_submission);
+    }
+    RemoveMappingLocked(mapping_index);
+    ++invalidated;
+  }
+  ForgetKnownOutputLocked(written_range);
+  metrics_.guest_invalidations += invalidated;
+  return invalidated;
+}
+
+bool NativeRenderTargetBridge::Retire(NativeRenderTargetHandle handle,
+                                      uint64_t current_submission) {
+  const std::scoped_lock lock(mutex_);
+  auto target = std::find_if(
+      targets_.begin(), targets_.end(),
+      [&](const TargetEntry &candidate) { return candidate.handle == handle; });
+  if (target == targets_.end()) {
+    return false;
+  }
+  RemoveMappingsForHandleLocked(handle, true);
+  retired_.push_back(
+      {target->handle, target->allocation_bytes,
+       std::max(target->last_use_submission, current_submission)});
+  --metrics_.live_count;
+  metrics_.live_bytes -= target->allocation_bytes;
+  ++metrics_.retired_count;
+  metrics_.retired_bytes += target->allocation_bytes;
+  targets_.erase(target);
+  return true;
+}
+
+size_t NativeRenderTargetBridge::RetireAll(uint64_t current_submission) {
+  const std::scoped_lock lock(mutex_);
+  const size_t count = targets_.size();
+  while (!targets_.empty()) {
+    const TargetEntry target = targets_.back();
+    RemoveMappingsForHandleLocked(target.handle, true);
+    retired_.push_back(
+        {target.handle, target.allocation_bytes,
+         std::max(target.last_use_submission, current_submission)});
+    --metrics_.live_count;
+    metrics_.live_bytes -= target.allocation_bytes;
+    ++metrics_.retired_count;
+    metrics_.retired_bytes += target.allocation_bytes;
+    targets_.pop_back();
+  }
+  return count;
+}
+
+std::vector<RetiredRenderTarget> NativeRenderTargetBridge::Collect(
+    uint64_t completed_submission) {
+  const std::scoped_lock lock(mutex_);
+  std::vector<RetiredRenderTarget> ready;
+  auto retained = std::remove_if(
+      retired_.begin(), retired_.end(), [&](const RetiredRenderTarget &target) {
+        if (target.retire_after_submission > completed_submission) {
+          return false;
+        }
+        ready.push_back(target);
+        --metrics_.retired_count;
+        metrics_.retired_bytes -= target.allocation_bytes;
+        return true;
+      });
+  retired_.erase(retained, retired_.end());
+  return ready;
+}
+
+RenderTargetBridgeMetrics NativeRenderTargetBridge::metrics() const {
+  const std::scoped_lock lock(mutex_);
+  return metrics_;
+}
+
+NativeRenderTargetBridge::TargetEntry *
+NativeRenderTargetBridge::FindTargetLocked(NativeRenderTargetHandle handle) {
+  auto target = std::find_if(
+      targets_.begin(), targets_.end(),
+      [&](const TargetEntry &candidate) { return candidate.handle == handle; });
+  return target == targets_.end() ? nullptr : &*target;
+}
+
+void NativeRenderTargetBridge::RemoveMappingsForHandleLocked(
+    NativeRenderTargetHandle handle, bool preserve_known_output) {
+  for (size_t mapping_index = mappings_.size(); mapping_index-- > 0;) {
+    if (mappings_[mapping_index].handle != handle) {
+      continue;
+    }
+    const PhysicalRange destination =
+        mappings_[mapping_index].region.guest_destination;
+    RemoveMappingLocked(mapping_index);
+    if (!preserve_known_output) {
+      ForgetKnownOutputLocked(destination);
+    }
+  }
+}
+
+void NativeRenderTargetBridge::RemoveMappingLocked(size_t mapping_index) {
+  if (mapping_index >= mappings_.size()) {
+    return;
+  }
+  TargetEntry *target = FindTargetLocked(mappings_[mapping_index].handle);
+  if (target && target->mapping_pins) {
+    --target->mapping_pins;
+  }
+  mappings_.erase(mappings_.begin() + mapping_index);
+}
+
+void NativeRenderTargetBridge::RememberKnownOutputLocked(
+    const PhysicalRange &range) {
+  if (std::ranges::none_of(known_gpu_outputs_, [&](const PhysicalRange &known) {
+        return known == range;
+      })) {
+    known_gpu_outputs_.push_back(range);
+  }
+}
+
+void NativeRenderTargetBridge::ForgetKnownOutputLocked(
+    const PhysicalRange &range) {
+  known_gpu_outputs_.erase(
+      std::remove_if(
+          known_gpu_outputs_.begin(), known_gpu_outputs_.end(),
+          [&](const PhysicalRange &known) { return known.Overlaps(range); }),
+      known_gpu_outputs_.end());
+}
+
+}  // namespace pinyon_shift::native_renderer

--- a/src/native_renderer/render_target_bridge.h
+++ b/src/native_renderer/render_target_bridge.h
@@ -1,0 +1,181 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <mutex>
+#include <optional>
+#include <vector>
+
+#include "native_renderer/resource_identity.h"
+
+namespace pinyon_shift::native_renderer {
+
+using NativeRenderTargetHandle = uint64_t;
+
+enum class NativeRenderTargetUsage : uint32_t {
+  kColor = 1u << 0,
+  kDepth = 1u << 1,
+  kShaderResource = 1u << 2,
+  kUnorderedAccess = 1u << 3,
+};
+
+[[nodiscard]] constexpr uint32_t RenderTargetUsageBits(
+    NativeRenderTargetUsage usage) {
+  return static_cast<uint32_t>(usage);
+}
+
+[[nodiscard]] constexpr NativeRenderTargetUsage operator|(
+    NativeRenderTargetUsage left, NativeRenderTargetUsage right) {
+  return static_cast<NativeRenderTargetUsage>(RenderTargetUsageBits(left) |
+                                              RenderTargetUsageBits(right));
+}
+
+struct NativeRenderTargetKey {
+  uint32_t host_format = 0;
+  uint32_t width = 0;
+  uint32_t height = 0;
+  uint32_t sample_count = 0;
+  NativeRenderTargetUsage usage = NativeRenderTargetUsage::kColor;
+
+  [[nodiscard]] bool valid() const;
+  bool operator==(const NativeRenderTargetKey &) const = default;
+};
+
+struct NativeRenderTargetKeyHash {
+  [[nodiscard]] size_t operator()(const NativeRenderTargetKey &key) const;
+};
+
+struct NativeRenderTargetAcquireResult {
+  NativeRenderTargetHandle handle = 0;
+  bool hit = false;
+};
+
+struct NativeResolveRegion {
+  PhysicalRange guest_destination;
+  uint32_t source_x = 0;
+  uint32_t source_y = 0;
+  uint32_t width = 0;
+  uint32_t height = 0;
+  uint32_t row_pitch_bytes = 0;
+  uint32_t mip_level = 0;
+  uint32_t array_slice = 0;
+
+  [[nodiscard]] bool valid_for(const NativeRenderTargetKey &key) const;
+  bool operator==(const NativeResolveRegion &) const = default;
+};
+
+enum class NativeProducerLookupState : uint8_t {
+  kGuestDecodeAllowed,
+  kNativeProducer,
+  kBridgeRequired,
+};
+
+struct NativeProducerRequest {
+  PhysicalRange guest_source;
+  uint32_t host_format = 0;
+  uint32_t width = 0;
+  uint32_t height = 0;
+};
+
+struct NativeProducerLookup {
+  NativeProducerLookupState state =
+      NativeProducerLookupState::kGuestDecodeAllowed;
+  NativeRenderTargetHandle handle = 0;
+  NativeRenderTargetKey key;
+  NativeResolveRegion region;
+  uint64_t producer_submission = 0;
+};
+
+struct RetiredRenderTarget {
+  NativeRenderTargetHandle handle = 0;
+  uint64_t allocation_bytes = 0;
+  uint64_t retire_after_submission = 0;
+};
+
+struct RenderTargetBridgeMetrics {
+  uint64_t pool_hits = 0;
+  uint64_t pool_misses = 0;
+  uint64_t bridge_hits = 0;
+  uint64_t bridge_refusals = 0;
+  uint64_t resolve_publications = 0;
+  uint64_t guest_invalidations = 0;
+  uint64_t live_count = 0;
+  uint64_t live_bytes = 0;
+  uint64_t retired_count = 0;
+  uint64_t retired_bytes = 0;
+};
+
+// Backend-neutral render-target pool and resolve provenance bridge. A target is
+// reusable only when it is checked in, no guest resolve mapping pins it, and
+// every submission that referenced it has completed. Known GPU-produced ranges
+// never fall through to guest-memory decode when their producer is stale or
+// incompatible.
+class NativeRenderTargetBridge {
+ public:
+  // candidate_handle and allocation_bytes are consumed only on a pool miss.
+  // The backend retains ownership of an unused candidate supplied on a hit.
+  [[nodiscard]] std::optional<NativeRenderTargetAcquireResult> Acquire(
+      const NativeRenderTargetKey &key,
+      NativeRenderTargetHandle candidate_handle, uint64_t allocation_bytes,
+      uint64_t frame, uint64_t current_submission,
+      uint64_t completed_submission);
+
+  bool Release(NativeRenderTargetHandle handle, uint64_t current_submission);
+
+  // Publishes a single-sample, shader-readable native producer for the exact
+  // guest resolve destination. Re-publishing an overlapping destination
+  // supersedes and unpins the older producer mapping.
+  bool PublishResolve(NativeRenderTargetHandle handle,
+                      const NativeResolveRegion &region,
+                      uint64_t producer_submission);
+
+  [[nodiscard]] NativeProducerLookup LookupProducer(
+      const NativeProducerRequest &request, uint64_t frame,
+      uint64_t current_submission);
+
+  // A guest write replaces GPU provenance for every overlapping destination.
+  // The target remains pooled, but the written range may be decoded normally.
+  size_t InvalidateGuestWrite(const PhysicalRange &written_range,
+                              uint64_t current_submission);
+
+  bool Retire(NativeRenderTargetHandle handle, uint64_t current_submission);
+  size_t RetireAll(uint64_t current_submission);
+
+  [[nodiscard]] std::vector<RetiredRenderTarget> Collect(
+      uint64_t completed_submission);
+  [[nodiscard]] RenderTargetBridgeMetrics metrics() const;
+
+ private:
+  struct TargetEntry {
+    NativeRenderTargetKey key;
+    NativeRenderTargetHandle handle = 0;
+    uint64_t allocation_bytes = 0;
+    uint64_t last_use_frame = 0;
+    uint64_t last_use_submission = 0;
+    uint64_t available_after_submission = 0;
+    uint64_t mapping_pins = 0;
+    bool checked_out = false;
+  };
+
+  struct ResolveMapping {
+    NativeResolveRegion region;
+    NativeRenderTargetHandle handle = 0;
+    uint64_t producer_submission = 0;
+  };
+
+  [[nodiscard]] TargetEntry *FindTargetLocked(NativeRenderTargetHandle handle);
+  void RemoveMappingsForHandleLocked(NativeRenderTargetHandle handle,
+                                     bool preserve_known_output);
+  void RemoveMappingLocked(size_t mapping_index);
+  void RememberKnownOutputLocked(const PhysicalRange &range);
+  void ForgetKnownOutputLocked(const PhysicalRange &range);
+
+  mutable std::mutex mutex_;
+  std::vector<TargetEntry> targets_;
+  std::vector<ResolveMapping> mappings_;
+  std::vector<PhysicalRange> known_gpu_outputs_;
+  std::vector<RetiredRenderTarget> retired_;
+  RenderTargetBridgeMetrics metrics_;
+};
+
+}  // namespace pinyon_shift::native_renderer

--- a/tests/native_renderer/render_target_bridge_test.cpp
+++ b/tests/native_renderer/render_target_bridge_test.cpp
@@ -1,0 +1,145 @@
+#include "native_renderer/render_target_bridge.h"
+
+#include <cstdlib>
+#include <iostream>
+
+namespace nr = pinyon_shift::native_renderer;
+
+namespace {
+
+void Require(bool condition, const char *message) {
+  if (!condition) {
+    std::cerr << message << '\n';
+    std::exit(EXIT_FAILURE);
+  }
+}
+
+nr::NativeRenderTargetKey ColorTarget(uint32_t format = 10) {
+  return {format, 640, 360, 1,
+          nr::NativeRenderTargetUsage::kColor |
+              nr::NativeRenderTargetUsage::kShaderResource};
+}
+
+nr::NativeResolveRegion ResolveRegion(uint32_t address = 0x11200000) {
+  const auto destination =
+      nr::PhysicalRange::FromGraphicsAddress(address, 640 * 360 * 4);
+  Require(destination.has_value(), "resolve destination must be valid");
+  return {*destination, 0, 0, 640, 360, 640 * 4, 0, 0};
+}
+
+nr::NativeProducerRequest ProducerRequest(uint32_t format = 10,
+                                          uint32_t address = 0x11200000) {
+  const auto source =
+      nr::PhysicalRange::FromGraphicsAddress(address, 640 * 360 * 4);
+  Require(source.has_value(), "producer request must be valid");
+  return {*source, format, 640, 360};
+}
+
+}  // namespace
+
+int main() {
+  const nr::NativeRenderTargetKey color = ColorTarget();
+  Require(color.valid(), "exact color target key must be valid");
+  Require(!nr::NativeRenderTargetKey{10, 640, 360, 1,
+                                     nr::NativeRenderTargetUsage::kColor |
+                                         nr::NativeRenderTargetUsage::kDepth}
+               .valid(),
+          "a target cannot be both color and depth");
+
+  nr::NativeRenderTargetBridge exact_pool;
+  const auto exact_first =
+      exact_pool.Acquire(color, 91, 4 * 1024 * 1024, 1, 1, 0);
+  Require(exact_first && !exact_first->hit && exact_pool.Release(91, 1),
+          "the exact-key probe must check in its first allocation");
+  const auto exact_format_miss =
+      exact_pool.Acquire(ColorTarget(11), 92, 4 * 1024 * 1024, 2, 2, 1);
+  Require(exact_format_miss && !exact_format_miss->hit &&
+              exact_format_miss->handle == 92,
+          "a host-format change must not reuse an incompatible target");
+  nr::NativeRenderTargetKey multisampled = color;
+  multisampled.sample_count = 4;
+  const auto exact_sample_miss =
+      exact_pool.Acquire(multisampled, 93, 4 * 1024 * 1024, 3, 3, 2);
+  Require(exact_sample_miss && !exact_sample_miss->hit &&
+              exact_sample_miss->handle == 93,
+          "a sample-count change must not reuse an incompatible target");
+  Require(!exact_pool.PublishResolve(93, ResolveRegion(), 3),
+          "a multisampled producer must resolve before publication");
+  Require(exact_pool.RetireAll(3) == 3 && exact_pool.Collect(3).size() == 3,
+          "the exact-key probe must retire all allocations safely");
+
+  nr::NativeRenderTargetBridge bridge;
+
+  const auto first = bridge.Acquire(color, 101, 4 * 1024 * 1024, 1, 10, 9);
+  Require(first && !first->hit && first->handle == 101,
+          "a cold target must consume the candidate allocation");
+  Require(bridge.PublishResolve(101, ResolveRegion(), 10),
+          "a checked-out shader-readable target must publish its resolve");
+  Require(bridge.Release(101, 10),
+          "the producer target must check into the pool");
+
+  const auto producer = bridge.LookupProducer(ProducerRequest(), 2, 11);
+  Require(producer.state == nr::NativeProducerLookupState::kNativeProducer &&
+              producer.handle == 101 && producer.producer_submission == 10,
+          "an exact fetch must receive the native producer");
+  Require(bridge.LookupProducer(ProducerRequest(11), 2, 11).state ==
+              nr::NativeProducerLookupState::kBridgeRequired,
+          "format mismatch must refuse guest decode for a GPU output");
+
+  const auto second = bridge.Acquire(color, 102, 4 * 1024 * 1024, 3, 12, 11);
+  Require(second && !second->hit && second->handle == 102,
+          "a mapped producer must remain pinned instead of being reused");
+  Require(bridge.PublishResolve(102, ResolveRegion(), 12),
+          "a newer resolve must supersede the previous producer");
+  Require(bridge.Release(102, 12), "the replacement target must check in");
+
+  const auto reused = bridge.Acquire(color, 103, 4 * 1024 * 1024, 4, 13, 11);
+  Require(reused && reused->hit && reused->handle == 101,
+          "an unpinned target must be reused after its final submission");
+
+  const auto write = nr::PhysicalRange::FromGraphicsAddress(0xB1200080, 64);
+  Require(write.has_value() && bridge.InvalidateGuestWrite(*write, 14) == 1,
+          "an aliased guest write must invalidate overlapping provenance");
+  Require(bridge.LookupProducer(ProducerRequest(), 5, 14).state ==
+              nr::NativeProducerLookupState::kGuestDecodeAllowed,
+          "guest-written content may return to the decode path");
+
+  const auto after_write =
+      bridge.Acquire(color, 104, 4 * 1024 * 1024, 6, 15, 14);
+  Require(after_write && after_write->hit && after_write->handle == 102,
+          "guest invalidation must unpin the superseded producer");
+  Require(bridge.PublishResolve(after_write->handle, ResolveRegion(), 15) &&
+              bridge.Release(after_write->handle, 15),
+          "the recycled target must publish a new producer");
+  Require(bridge.Retire(after_write->handle, 16),
+          "retiring a mapped target must remove it from the live pool");
+  Require(bridge.LookupProducer(ProducerRequest(), 7, 16).state ==
+              nr::NativeProducerLookupState::kBridgeRequired,
+          "a known GPU output with a retired producer must refuse decode");
+  Require(bridge.Collect(15).empty(),
+          "retired producer must remain alive through its final submission");
+  const auto collected = bridge.Collect(16);
+  Require(collected.size() == 1 && collected[0].handle == 102,
+          "retired producer must collect at the fence-safe submission");
+
+  Require(bridge.Release(101, 17),
+          "the independently reused target must check in before shutdown");
+  Require(bridge.RetireAll(17) == 1,
+          "shutdown must retire the remaining pooled target");
+  Require(bridge.Collect(16).empty(),
+          "shutdown retirement must also honor its submission fence");
+  Require(bridge.Collect(17).size() == 1,
+          "shutdown target must collect once the fence completes");
+
+  const nr::RenderTargetBridgeMetrics metrics = bridge.metrics();
+  Require(metrics.pool_hits == 2 && metrics.pool_misses == 2 &&
+              metrics.bridge_hits == 1 && metrics.bridge_refusals == 2 &&
+              metrics.resolve_publications == 3 &&
+              metrics.guest_invalidations == 1 && !metrics.live_count &&
+              !metrics.live_bytes && !metrics.retired_count &&
+              !metrics.retired_bytes,
+          "render-target telemetry must describe the complete lifecycle");
+
+  std::cout << "native renderer render-target bridge tests passed\n";
+  return EXIT_SUCCESS;
+}

--- a/tools/tests/test_native_renderer_render_target_bridge.py
+++ b/tools/tests/test_native_renderer_render_target_bridge.py
@@ -1,0 +1,50 @@
+import pathlib
+import unittest
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+
+
+class NativeRendererRenderTargetBridgeContractTests(unittest.TestCase):
+    def test_preview_and_native_test_compile_bridge(self):
+        cmake = (ROOT / "CMakeLists.txt").read_text(encoding="utf-8")
+        self.assertEqual(
+            cmake.count("src/native_renderer/render_target_bridge.cpp"), 3
+        )
+        self.assertIn("pinyon_shift_render_target_bridge_tests EXCLUDE_FROM_ALL", cmake)
+
+    def test_pool_key_covers_exact_host_allocation_contract(self):
+        header = (
+            ROOT / "src/native_renderer/render_target_bridge.h"
+        ).read_text(encoding="utf-8")
+        for field in ("host_format", "width", "height", "sample_count", "usage"):
+            self.assertIn(field, header)
+        self.assertRegex(
+            header, r"bool operator==\(const NativeRenderTargetKey\s*&\)"
+        )
+
+    def test_gpu_output_never_falls_through_without_a_valid_bridge(self):
+        header = (
+            ROOT / "src/native_renderer/render_target_bridge.h"
+        ).read_text(encoding="utf-8")
+        source = (
+            ROOT / "src/native_renderer/render_target_bridge.cpp"
+        ).read_text(encoding="utf-8")
+        self.assertIn("kBridgeRequired", header)
+        self.assertIn("known_gpu_outputs_", header)
+        self.assertIn("known_gpu_output", source)
+        self.assertIn("NativeProducerLookupState::kBridgeRequired", source)
+
+    def test_pool_reuse_and_retirement_are_submission_safe(self):
+        source = (
+            ROOT / "src/native_renderer/render_target_bridge.cpp"
+        ).read_text(encoding="utf-8")
+        self.assertIn("available_after_submission <=", source)
+        self.assertIn("!target.mapping_pins", source)
+        self.assertIn("retire_after_submission > completed_submission", source)
+        self.assertNotIn("delete ", source)
+        self.assertNotIn("Release()", source)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/tests/test_native_renderer_resource_identity.py
+++ b/tools/tests/test_native_renderer_resource_identity.py
@@ -8,7 +8,7 @@ ROOT = pathlib.Path(__file__).resolve().parents[2]
 class NativeRendererResourceIdentityContractTests(unittest.TestCase):
     def test_preview_compiles_resource_identity(self):
         cmake = (ROOT / "CMakeLists.txt").read_text(encoding="utf-8")
-        self.assertEqual(cmake.count("src/native_renderer/resource_identity.cpp"), 5)
+        self.assertEqual(cmake.count("src/native_renderer/resource_identity.cpp"), 6)
         self.assertIn("pinyon_shift_resource_identity_tests EXCLUDE_FROM_ALL", cmake)
 
     def test_physical_identity_is_canonical_and_generation_aware(self):


### PR DESCRIPTION
## Summary
- add exact-key native render-target pooling and resolve provenance
- refuse stale guest-memory decode for known GPU-produced outputs
- defer target destruction through completed submission fences
- preserve the default Xenos renderer and all no-suppression gates

## Validation
- 145 Python contract tests pass
- native resource identity, buffer cache, texture cache, and render-target bridge tests pass
- clean generated preview build passes with only the three allowlisted codegen warnings
- AppData session `20260828T211430Z-p39104` reaches gameplay and exits normally
- 30.715 median FPS, 19.597 one-percent-low FPS, zero present deadline misses
- no failure events, failed resolve copies, target overflow, or page overflow