### PR TITLE
feat(native-renderer): import d3d12 resolve producers

### DIFF
--- a/docs/native-renderer/RENDER_TARGET_BRIDGE.md
+++ b/docs/native-renderer/RENDER_TARGET_BRIDGE.md
@@ -50,6 +50,38 @@ producer refusal, pool reuse, and fence-safe retirement. This PR establishes
 the resource contract required before the command processor can publish real
 D3D12 render targets into continuous native composition.
 
+## D3D12 producer handoff
+
+The NR-03E milestone installs a dedicated passive resolve
+observer alongside the existing diagnostic copy observer. Successful copies
+carry their current and completed submission IDs and immediately mark the
+canonical destination as GPU-produced, invalidating any older overlapping
+producer. This ensures that a consumer cannot decode stale guest memory while
+the concrete host allocation is still being discovered.
+
+Later texture bindings expose the backend-owned D3D12 resource, exact guest
+row pitch, host format, dimensions, and allocation size. A bounded correlation
+table matches only a texture whose complete base range is covered by a known
+resolve. The title retains that COM resource on the bridge's first import,
+publishes the exact mip-zero producer region, and releases it only after the
+backend's completed submission reaches the retirement fence. Re-observing the
+same handle is continued use, not pool alias reuse, and an incompatible key is
+refused.
+
+Resolve correlation is capped at 4,096 records. Old correlation metadata may
+be evicted, but GPU provenance is independently retained by the bridge. If the
+provenance table itself reaches its bound, it enters a conservative overflow
+state where unmatched requests return `kBridgeRequired` rather than falling
+through to guest decode. All observers are default-off, preserve the original
+Xenos copies and draws, and expose no suppression operation.
+
+Repeated draw bindings of the same resource and resolve submission are
+deduplicated before bridge checkout. Imported backend allocations are limited
+to 64 live resources and 128 MiB, with least-recently-observed and 600-
+submission-stale producers retired through the submission fence. A resource
+that cannot fit those limits remains Xenos-backed; the bridge never weakens
+its GPU-provenance refusal to make room.
+
 ## Qualification
 
 Clean build and AppData-backed runtime qualification on 2026-08-28 used
@@ -60,3 +92,22 @@ FPS, 59.993 Hz presentation, 29.654 Hz simulation, and no presentation
 deadline misses. Texture and pipeline hit rates were 99.976 and 100 percent.
 The event stream ended with `process.shutdown` and reported no failure events,
 failed resolve copies, census target overflow, or census page overflow.
+
+The concrete D3D12 producer handoff was qualified with the same AppData save
+in session `20260828T215636Z-p11712`. The 276.83-second capture contained
+8,986 samples, 30.346 median FPS, 19.464 one-percent-low FPS, 59.993 Hz
+presentation, 29.801 Hz simulation, and no presentation deadline misses.
+During 321,521 successful resolve observations, repeated bindings were
+deduplicated 3,863,185 times. The producer pool remained at or below 64 live
+targets and 108,003,328 bytes in the final steady-state sample, below both
+configured limits, with zero budget refusals and zero bridge refusals. The
+event stream reported no renderer failure, fatal, crash, or device-loss event,
+released every retained reference, preserved Xenos draws, and ended with
+`process.shutdown` after a normal exit.
+
+After hardening handle reuse across different guest destinations, the exact
+final binary was regression-tested in session `20260828T221140Z-p38016`.
+The saved game again reached the festival scene, presented at 59.974 Hz with
+no deadline misses, kept 64 live producers to 74,776,576 bytes, recorded zero
+budget or bridge refusals and zero failure events, released all retained
+references, and exited through `process.shutdown`.

--- a/patches/rexglue/0066-d3d12-native-resolve-provenance-observer.patch
+++ b/patches/rexglue/0066-d3d12-native-resolve-provenance-observer.patch
@@ -1,0 +1,119 @@
+diff --git a/include/rex/graphics/graphics_system.h b/include/rex/graphics/graphics_system.h
+index 70b0a0d..5014049 100644
+--- a/include/rex/graphics/graphics_system.h
++++ b/include/rex/graphics/graphics_system.h
+@@ -111,6 +111,13 @@ class GraphicsSystem : public system::IGraphicsSystem {
+   system::GraphicsNativeTextureSetObserver native_texture_set_observer() const {
+     return native_texture_set_observer_.load(std::memory_order_acquire);
+   }
++  void SetNativeResolveObserver(
++      system::GraphicsNativeResolveObserver observer) override {
++    native_resolve_observer_.store(observer, std::memory_order_release);
++  }
++  system::GraphicsNativeResolveObserver native_resolve_observer() const {
++    return native_resolve_observer_.load(std::memory_order_acquire);
++  }
+   void SetNativeGuestOutputRenderer(
+       system::NativeGuestOutputRenderer renderer) override {
+     native_guest_output_renderer_.Set(renderer);
+@@ -191,6 +198,8 @@ class GraphicsSystem : public system::IGraphicsSystem {
+       isolated_draw_request_observer_{nullptr};
+   std::atomic<system::GraphicsNativeTextureSetObserver>
+       native_texture_set_observer_{nullptr};
++  std::atomic<system::GraphicsNativeResolveObserver> native_resolve_observer_{
++      nullptr};
+   system::NativeGuestOutputRendererRegistration native_guest_output_renderer_;
+ 
+   std::atomic_flag host_gpu_loss_reported_;
+diff --git a/include/rex/system/interfaces/graphics.h b/include/rex/system/interfaces/graphics.h
+index 6b7ee36..08f8947 100644
+--- a/include/rex/system/interfaces/graphics.h
++++ b/include/rex/system/interfaces/graphics.h
+@@ -110,6 +110,7 @@ struct GraphicsNativeTextureResourceObservation {
+   uint32_t guest_height = 0;
+   uint32_t guest_depth_or_array_size = 0;
+   uint32_t guest_pitch = 0;
++  uint32_t guest_row_pitch_bytes = 0;
+   uint32_t guest_endianness = 0;
+   uint32_t guest_mip_max_level = 0;
+   uint32_t guest_tiled = 0;
+@@ -146,6 +147,13 @@ struct GraphicsNativeTextureSetObservation {
+ using GraphicsNativeTextureSetObserver = void (*)(
+     const GraphicsNativeTextureSetObservation& observation);
+ 
++// Dedicated resolve-provenance channel for native-renderer resource bridges.
++// This is separate from the diagnostic copy observer so both may be installed
++// without either observer replacing the other.
++struct GraphicsCopyObservation;
++using GraphicsNativeResolveObserver = void (*)(
++    const GraphicsCopyObservation& observation);
++
+ struct GraphicsVertexBindingObservation {
+   uint32_t fetch_constant = 0;
+   uint32_t address = 0;
+@@ -271,6 +279,8 @@ using GraphicsDrawObserver = void (*)(const GraphicsDrawObservation& observation
+ struct GraphicsCopyObservation {
+   uint64_t frame_sequence = 0;
+   uint64_t copy_sequence = 0;
++  uint64_t current_submission = 0;
++  uint64_t completed_submission = 0;
+   uint32_t written_address = 0;
+   uint32_t written_length = 0;
+   uint32_t rb_copy_control = 0;
+@@ -431,6 +441,10 @@ class IGraphicsSystem {
+       GraphicsNativeTextureSetObserver observer) {
+     (void)observer;
+   }
++  virtual void SetNativeResolveObserver(
++      GraphicsNativeResolveObserver observer) {
++    (void)observer;
++  }
+   virtual void SetNativeGuestOutputRenderer(NativeGuestOutputRenderer renderer) {
+     (void)renderer;
+   }
+diff --git a/src/graphics/d3d12/command_processor.cpp b/src/graphics/d3d12/command_processor.cpp
+index 0168afc..de037c2 100644
+--- a/src/graphics/d3d12/command_processor.cpp
++++ b/src/graphics/d3d12/command_processor.cpp
+@@ -3542,10 +3542,13 @@ bool D3D12CommandProcessor::IssueCopy() {
+   }
+ 
+   auto copy_observer = graphics_system_->copy_observer();
+-  if (copy_observer) {
++  auto native_resolve_observer = graphics_system_->native_resolve_observer();
++  if (copy_observer || native_resolve_observer) {
+     system::GraphicsCopyObservation observation;
+     observation.frame_sequence = observation_frame_sequence_;
+     observation.copy_sequence = ++observation_copy_sequence_;
++    observation.current_submission = GetCurrentSubmission();
++    observation.completed_submission = submission_completed_;
+     observation.written_address = written_address;
+     observation.written_length = written_length;
+     observation.rb_copy_control = register_file_->Get<reg::RB_COPY_CONTROL>().value;
+@@ -3559,7 +3562,12 @@ bool D3D12CommandProcessor::IssueCopy() {
+     }
+     observation.depth_info = register_file_->Get<reg::RB_DEPTH_INFO>().value;
+     observation.succeeded = copy_succeeded;
+-    copy_observer(observation);
++    if (copy_observer) {
++      copy_observer(observation);
++    }
++    if (native_resolve_observer) {
++      native_resolve_observer(observation);
++    }
+   }
+   return copy_succeeded;
+ }
+diff --git a/src/graphics/d3d12/texture_cache.cpp b/src/graphics/d3d12/texture_cache.cpp
+index ce1fe40..ac34178 100644
+--- a/src/graphics/d3d12/texture_cache.cpp
++++ b/src/graphics/d3d12/texture_cache.cpp
+@@ -817,6 +817,8 @@ void D3D12TextureCache::ObserveNativeTextures(
+     resource.guest_height = key.GetHeight();
+     resource.guest_depth_or_array_size = key.GetDepthOrArraySize();
+     resource.guest_pitch = key.pitch << 5;
++    resource.guest_row_pitch_bytes =
++        texture->guest_layout().base.row_pitch_bytes;
+     resource.guest_endianness = uint32_t(key.endianness);
+     resource.guest_mip_max_level = key.mip_max_level;
+     resource.guest_tiled = key.tiled;

--- a/src/native_renderer/render_target_bridge.cpp
+++ b/src/native_renderer/render_target_bridge.cpp
@@ -93,6 +93,36 @@ NativeRenderTargetBridge::Acquire(const NativeRenderTargetKey &key,
   return NativeRenderTargetAcquireResult{candidate_handle, false};
 }
 
+std::optional<NativeRenderTargetAcquireResult>
+NativeRenderTargetBridge::ImportObserved(
+    const NativeRenderTargetKey &key,
+    NativeRenderTargetHandle observed_handle, uint64_t allocation_bytes,
+    uint64_t frame, uint64_t current_submission) {
+  if (!key.valid() || !observed_handle || !allocation_bytes) {
+    return std::nullopt;
+  }
+  const std::scoped_lock lock(mutex_);
+  TargetEntry *target = FindTargetLocked(observed_handle);
+  if (target) {
+    if (target->checked_out || target->key != key ||
+        target->allocation_bytes != allocation_bytes) {
+      return std::nullopt;
+    }
+    target->checked_out = true;
+    target->last_use_frame = std::max(target->last_use_frame, frame);
+    target->last_use_submission =
+        std::max(target->last_use_submission, current_submission);
+    ++metrics_.pool_hits;
+    return NativeRenderTargetAcquireResult{observed_handle, true};
+  }
+  targets_.push_back({key, observed_handle, allocation_bytes, frame,
+                      current_submission, current_submission, 0, true});
+  ++metrics_.pool_misses;
+  ++metrics_.live_count;
+  metrics_.live_bytes += allocation_bytes;
+  return NativeRenderTargetAcquireResult{observed_handle, false};
+}
+
 bool NativeRenderTargetBridge::Release(NativeRenderTargetHandle handle,
                                        uint64_t current_submission) {
   const std::scoped_lock lock(mutex_);
@@ -133,6 +163,29 @@ bool NativeRenderTargetBridge::PublishResolve(NativeRenderTargetHandle handle,
   return true;
 }
 
+bool NativeRenderTargetBridge::RecordGpuOutput(
+    const PhysicalRange &range, uint64_t producer_submission) {
+  if (!range.valid()) {
+    return false;
+  }
+  const std::scoped_lock lock(mutex_);
+  for (size_t mapping_index = mappings_.size(); mapping_index-- > 0;) {
+    if (!mappings_[mapping_index].region.guest_destination.Overlaps(range)) {
+      continue;
+    }
+    TargetEntry *target = FindTargetLocked(mappings_[mapping_index].handle);
+    if (target) {
+      target->last_use_submission =
+          std::max(target->last_use_submission, producer_submission);
+      target->available_after_submission =
+          std::max(target->available_after_submission, producer_submission);
+    }
+    RemoveMappingLocked(mapping_index);
+  }
+  ++metrics_.gpu_output_records;
+  return RememberKnownOutputLocked(range);
+}
+
 NativeProducerLookup NativeRenderTargetBridge::LookupProducer(
     const NativeProducerRequest &request, uint64_t frame,
     uint64_t current_submission) {
@@ -165,6 +218,7 @@ NativeProducerLookup NativeRenderTargetBridge::LookupProducer(
     return {NativeProducerLookupState::kBridgeRequired};
   }
   const bool known_gpu_output =
+      known_output_overflow_ ||
       std::ranges::any_of(known_gpu_outputs_, [&](const PhysicalRange &known) {
         return known.Overlaps(request.guest_source);
       });
@@ -298,13 +352,20 @@ void NativeRenderTargetBridge::RemoveMappingLocked(size_t mapping_index) {
   mappings_.erase(mappings_.begin() + mapping_index);
 }
 
-void NativeRenderTargetBridge::RememberKnownOutputLocked(
+bool NativeRenderTargetBridge::RememberKnownOutputLocked(
     const PhysicalRange &range) {
-  if (std::ranges::none_of(known_gpu_outputs_, [&](const PhysicalRange &known) {
+  if (std::ranges::any_of(known_gpu_outputs_, [&](const PhysicalRange &known) {
         return known == range;
       })) {
-    known_gpu_outputs_.push_back(range);
+    return true;
   }
+  if (known_gpu_outputs_.size() >= kKnownGpuOutputLimit) {
+    known_output_overflow_ = true;
+    ++metrics_.known_output_overflows;
+    return false;
+  }
+  known_gpu_outputs_.push_back(range);
+  return true;
 }
 
 void NativeRenderTargetBridge::ForgetKnownOutputLocked(

--- a/src/native_renderer/render_target_bridge.h
+++ b/src/native_renderer/render_target_bridge.h
@@ -98,6 +98,8 @@ struct RenderTargetBridgeMetrics {
   uint64_t bridge_hits = 0;
   uint64_t bridge_refusals = 0;
   uint64_t resolve_publications = 0;
+  uint64_t gpu_output_records = 0;
+  uint64_t known_output_overflows = 0;
   uint64_t guest_invalidations = 0;
   uint64_t live_count = 0;
   uint64_t live_bytes = 0;
@@ -112,6 +114,8 @@ struct RenderTargetBridgeMetrics {
 // incompatible.
 class NativeRenderTargetBridge {
  public:
+  static constexpr size_t kKnownGpuOutputLimit = 4096;
+
   // candidate_handle and allocation_bytes are consumed only on a pool miss.
   // The backend retains ownership of an unused candidate supplied on a hit.
   [[nodiscard]] std::optional<NativeRenderTargetAcquireResult> Acquire(
@@ -119,6 +123,15 @@ class NativeRenderTargetBridge {
       NativeRenderTargetHandle candidate_handle, uint64_t allocation_bytes,
       uint64_t frame, uint64_t current_submission,
       uint64_t completed_submission);
+
+  // Imports an exact backend-owned allocation. Re-observing the same handle
+  // may check it out again even while an existing mapping pins it because this
+  // is continued use of that allocation, never pool alias reuse. The caller
+  // retains the backend resource only when this returns a miss.
+  [[nodiscard]] std::optional<NativeRenderTargetAcquireResult> ImportObserved(
+      const NativeRenderTargetKey &key,
+      NativeRenderTargetHandle observed_handle, uint64_t allocation_bytes,
+      uint64_t frame, uint64_t current_submission);
 
   bool Release(NativeRenderTargetHandle handle, uint64_t current_submission);
 
@@ -128,6 +141,11 @@ class NativeRenderTargetBridge {
   bool PublishResolve(NativeRenderTargetHandle handle,
                       const NativeResolveRegion &region,
                       uint64_t producer_submission);
+
+  // Records a successful GPU write before its concrete sampled allocation is
+  // observed. Any older overlapping producer becomes stale immediately.
+  bool RecordGpuOutput(const PhysicalRange &range,
+                       uint64_t producer_submission);
 
   [[nodiscard]] NativeProducerLookup LookupProducer(
       const NativeProducerRequest &request, uint64_t frame,
@@ -167,13 +185,14 @@ class NativeRenderTargetBridge {
   void RemoveMappingsForHandleLocked(NativeRenderTargetHandle handle,
                                      bool preserve_known_output);
   void RemoveMappingLocked(size_t mapping_index);
-  void RememberKnownOutputLocked(const PhysicalRange &range);
+  bool RememberKnownOutputLocked(const PhysicalRange &range);
   void ForgetKnownOutputLocked(const PhysicalRange &range);
 
   mutable std::mutex mutex_;
   std::vector<TargetEntry> targets_;
   std::vector<ResolveMapping> mappings_;
   std::vector<PhysicalRange> known_gpu_outputs_;
+  bool known_output_overflow_ = false;
   std::vector<RetiredRenderTarget> retired_;
   RenderTargetBridgeMetrics metrics_;
 };

--- a/src/native_renderer/texture_resource_bridge.cpp
+++ b/src/native_renderer/texture_resource_bridge.cpp
@@ -4,6 +4,7 @@
 #include <rex/system/interfaces/graphics.h>
 
 #include <atomic>
+#include <algorithm>
 #include <cstddef>
 #include <cstdint>
 #include <memory>
@@ -13,6 +14,7 @@
 #include <unordered_map>
 #include <vector>
 
+#include "native_renderer/render_target_bridge.h"
 #include "native_renderer/resource_identity.h"
 #include "native_renderer/texture_cache.h"
 #include "pinyon_shift_diagnostics.h"
@@ -25,12 +27,17 @@ namespace {
 
 using NativeObservation = rex::system::GraphicsNativeTextureSetObservation;
 using NativeResource = rex::system::GraphicsNativeTextureResourceObservation;
+using ResolveObservation = rex::system::GraphicsCopyObservation;
 
 constexpr uint32_t kRetainedPassTextureFormat =
     pinyon_shift::native_renderer::kXenosTextureFormatDxn;
 constexpr uint32_t kRetainedPassTextureWidth = 256;
 constexpr uint32_t kRetainedPassTextureHeight = 64;
 constexpr uint32_t kRetainedPassTexturePitch = 256;
+constexpr size_t kResolveRecordLimit = 4096;
+constexpr size_t kProducerResourceLimit = 64;
+constexpr uint64_t kProducerByteLimit = 128 * 1024 * 1024;
+constexpr uint64_t kProducerStaleSubmissions = 600;
 
 uint64_t HashFetchWords(const uint32_t words[6]) {
   uint64_t hash = UINT64_C(14695981039346656037);
@@ -53,15 +60,54 @@ bool IsRetainedPassCandidate(const NativeResource& resource) {
 
 class TextureResourceBridge {
  public:
-  void Observe(const NativeObservation& observation) {
-    bool has_candidate = false;
-    for (uint32_t resource_index = 0; resource_index < observation.resource_count;
-         ++resource_index) {
-      has_candidate |= IsRetainedPassCandidate(observation.resources[resource_index]);
-    }
-    if (!has_candidate && observed_resource_count_.load(std::memory_order_relaxed) >= 16) {
+  void ObserveResolve(const ResolveObservation& observation) {
+    if (!observation.succeeded || !observation.written_length) {
       return;
     }
+    const auto destination =
+        pinyon_shift::native_renderer::PhysicalRange::FromGraphicsAddress(
+            observation.written_address, observation.written_length);
+    if (!destination) {
+      RecordFailureOnce("invalid_resolve_range");
+      return;
+    }
+
+    const std::scoped_lock lock(mutex_);
+    ReleaseCollected(render_target_bridge_.Collect(
+        observation.completed_submission));
+    render_target_bridge_.RecordGpuOutput(*destination,
+                                          observation.current_submission);
+
+    const bool is_depth = (observation.rb_copy_control & 0x7u) >= 4u;
+    auto record = std::find_if(
+        resolve_records_.begin(), resolve_records_.end(),
+        [&](const ResolveRecord& candidate) {
+          return candidate.destination == *destination;
+        });
+    if (record == resolve_records_.end()) {
+      if (resolve_records_.size() >= kResolveRecordLimit) {
+        resolve_records_.erase(resolve_records_.begin());
+        ++resolve_record_evictions_;
+      }
+      resolve_records_.push_back(
+          {*destination, observation.current_submission, is_depth});
+    } else {
+      *record = {*destination, observation.current_submission, is_depth};
+    }
+    ++resolve_observation_count_;
+
+    if (resolve_observation_count_ <= 16) {
+      pinyon_shift::diagnostics::RecordEvent(
+          "native_renderer.resolve_bridge.observed",
+          {{"address", std::to_string(destination->address)},
+           {"bytes", std::to_string(destination->length)},
+           {"attachment", is_depth ? "depth" : "color"},
+           {"submission", std::to_string(observation.current_submission)},
+           {"xenos_resolve", "preserved"}});
+    }
+  }
+
+  void Observe(const NativeObservation& observation) {
     const std::scoped_lock lock(mutex_);
     ++observation_count_;
     if (observation.backend != rex::system::GraphicsNativeTextureBackend::kD3D12) {
@@ -70,6 +116,8 @@ class TextureResourceBridge {
     }
 
     ReleaseCollected(cache_.Collect(observation.completed_submission));
+    ReleaseCollected(
+        render_target_bridge_.Collect(observation.completed_submission));
     for (uint32_t resource_index = 0; resource_index < observation.resource_count;
          ++resource_index) {
       const NativeResource& resource = observation.resources[resource_index];
@@ -88,12 +136,14 @@ class TextureResourceBridge {
       if (IsRetainedPassCandidate(resource)) {
         Retain(resource, observation);
       }
+      ImportResolveProducer(resource, observation);
     }
 
     if (resource_count_ && (!last_summary_submission_ ||
                             observation.current_submission >= last_summary_submission_ + 300)) {
       last_summary_submission_ = observation.current_submission;
       const auto metrics = cache_.metrics();
+      const auto target_metrics = render_target_bridge_.metrics();
       pinyon_shift::diagnostics::RecordEvent(
           "native_renderer.texture_bridge.summary",
           {{"observations", std::to_string(observation_count_)},
@@ -103,6 +153,22 @@ class TextureResourceBridge {
            {"retired", std::to_string(metrics.retired_count)},
            {"hits", std::to_string(metrics.hits)},
            {"misses", std::to_string(metrics.misses)},
+           {"resolve_observations", std::to_string(resolve_observation_count_)},
+           {"producer_publications",
+            std::to_string(target_metrics.resolve_publications)},
+           {"producer_deduplications",
+            std::to_string(producer_deduplications_)},
+           {"producer_budget_evictions",
+            std::to_string(producer_budget_evictions_)},
+           {"producer_budget_refusals",
+            std::to_string(producer_budget_refusals_)},
+           {"producer_hits", std::to_string(target_metrics.bridge_hits)},
+           {"producer_refusals",
+            std::to_string(target_metrics.bridge_refusals)},
+           {"target_live", std::to_string(target_metrics.live_count)},
+           {"target_live_bytes", std::to_string(target_metrics.live_bytes)},
+           {"resolve_record_evictions",
+            std::to_string(resolve_record_evictions_)},
            {"submission", std::to_string(observation.current_submission)},
            {"completed_submission", std::to_string(observation.completed_submission)},
            {"xenos_draw", "preserved"}});
@@ -112,18 +178,36 @@ class TextureResourceBridge {
   void Shutdown() {
     const std::scoped_lock lock(mutex_);
     cache_.RetireAll(0);
+    render_target_bridge_.RetireAll(0);
     ReleaseCollected(cache_.Collect(UINT64_MAX));
+    ReleaseCollected(render_target_bridge_.Collect(UINT64_MAX));
     const auto metrics = cache_.metrics();
     pinyon_shift::diagnostics::RecordEvent(
         "native_renderer.texture_bridge.stopped",
         {{"observations", std::to_string(observation_count_)},
          {"resources", std::to_string(resource_count_)},
+         {"resolve_observations", std::to_string(resolve_observation_count_)},
+         {"producer_resources", std::to_string(producer_resource_count_)},
          {"live", std::to_string(metrics.live_count)},
          {"retained_refs", std::to_string(RetainedReferenceCount())},
          {"xenos_draw", "preserved"}});
   }
 
  private:
+  struct ResolveRecord {
+    pinyon_shift::native_renderer::PhysicalRange destination;
+    uint64_t submission = 0;
+    bool is_depth = false;
+  };
+
+  struct ProducerResource {
+    pinyon_shift::native_renderer::NativeRenderTargetKey key;
+    pinyon_shift::native_renderer::PhysicalRange destination;
+    uint64_t last_resolve_submission = 0;
+    uint64_t last_seen_submission = 0;
+    uint64_t allocation_bytes = 0;
+  };
+
   struct RetainedReference {
     rex::system::GraphicsNativeTextureRelease release = nullptr;
     uint64_t count = 0;
@@ -197,6 +281,176 @@ class TextureResourceBridge {
     }
   }
 
+  void ImportResolveProducer(const NativeResource& resource,
+                             const NativeObservation& observation) {
+    if (!resource.resource || !resource.retain || !resource.release ||
+        !resource.host_resource_format || !resource.host_allocation_bytes ||
+        !resource.base_length || !resource.guest_row_pitch_bytes ||
+        !resource.guest_width || !resource.guest_height ||
+        !resource.host_width || resource.host_width > UINT32_MAX ||
+        !resource.host_height || resource.host_depth_or_array_size != 1 ||
+        !resource.host_mip_levels) {
+      return;
+    }
+    const auto base =
+        pinyon_shift::native_renderer::PhysicalRange::FromGraphicsAddress(
+            resource.base_address, resource.base_length);
+    if (!base) {
+      return;
+    }
+    const auto resolve = std::find_if(
+        resolve_records_.rbegin(), resolve_records_.rend(),
+        [&](const ResolveRecord& candidate) {
+          return candidate.destination.address <= base->address &&
+                 candidate.destination.end_exclusive() >=
+                     base->end_exclusive();
+        });
+    if (resolve == resolve_records_.rend()) {
+      return;
+    }
+
+    using pinyon_shift::native_renderer::NativeRenderTargetUsage;
+    const NativeRenderTargetUsage attachment =
+        resolve->is_depth ? NativeRenderTargetUsage::kDepth
+                          : NativeRenderTargetUsage::kColor;
+    const pinyon_shift::native_renderer::NativeRenderTargetKey key{
+        resource.host_resource_format, uint32_t(resource.host_width),
+        resource.host_height, 1,
+        attachment | NativeRenderTargetUsage::kShaderResource};
+    const uint64_t handle = reinterpret_cast<uint64_t>(resource.resource);
+    auto existing = producer_resources_.find(handle);
+    if (existing != producer_resources_.end() && existing->second.key == key &&
+        existing->second.allocation_bytes ==
+            resource.host_allocation_bytes &&
+        existing->second.destination == *base &&
+        existing->second.last_resolve_submission >= resolve->submission) {
+      existing->second.last_seen_submission = observation.current_submission;
+      ++producer_deduplications_;
+      return;
+    }
+    if (existing != producer_resources_.end() &&
+        (existing->second.key != key ||
+         existing->second.allocation_bytes !=
+             resource.host_allocation_bytes ||
+         existing->second.destination != *base)) {
+      RetireProducer(handle, observation.current_submission);
+    }
+    PruneProducers(observation.completed_submission,
+                   observation.current_submission, handle,
+                   resource.host_allocation_bytes);
+    existing = producer_resources_.find(handle);
+    if (existing == producer_resources_.end() &&
+        (producer_resources_.size() >= kProducerResourceLimit ||
+         resource.host_allocation_bytes > kProducerByteLimit ||
+         producer_live_bytes_ >
+             kProducerByteLimit - resource.host_allocation_bytes)) {
+      ++producer_budget_refusals_;
+      return;
+    }
+    const auto imported = render_target_bridge_.ImportObserved(
+        key, handle, resource.host_allocation_bytes, observation_count_,
+        observation.current_submission);
+    if (!imported) {
+      RecordFailureOnce("producer_import_failed");
+      return;
+    }
+    if (!imported->hit) {
+      resource.retain(resource.resource);
+      auto& retained = retained_[handle];
+      retained.release = resource.release;
+      ++retained.count;
+      producer_resources_[handle] =
+          {key, *base, 0, observation.current_submission,
+           resource.host_allocation_bytes};
+      producer_live_bytes_ += resource.host_allocation_bytes;
+    }
+
+    const pinyon_shift::native_renderer::NativeResolveRegion region{
+        *base, 0, 0, resource.guest_width, resource.guest_height,
+        resource.guest_row_pitch_bytes, 0, 0};
+    if (!render_target_bridge_.PublishResolve(handle, region,
+                                               resolve->submission) ||
+        !render_target_bridge_.Release(handle,
+                                       observation.current_submission)) {
+      RetireProducer(handle, observation.current_submission);
+      ReleaseCollected(render_target_bridge_.Collect(
+          observation.completed_submission));
+      RecordFailureOnce("producer_publish_failed");
+      return;
+    }
+    ++producer_resource_count_;
+    auto& tracked = producer_resources_[handle];
+    tracked.key = key;
+    tracked.destination = *base;
+    tracked.last_resolve_submission = resolve->submission;
+    tracked.last_seen_submission = observation.current_submission;
+    if (producer_resource_count_ <= 16) {
+      pinyon_shift::diagnostics::RecordEvent(
+          "native_renderer.resolve_bridge.producer",
+          {{"address", std::to_string(base->address)},
+           {"bytes", std::to_string(base->length)},
+           {"host_format", std::to_string(resource.host_resource_format)},
+           {"width", std::to_string(resource.guest_width)},
+           {"height", std::to_string(resource.guest_height)},
+           {"row_pitch", std::to_string(resource.guest_row_pitch_bytes)},
+           {"pool", imported->hit ? "hit" : "miss"},
+           {"ownership", "retained"},
+           {"xenos_draw", "preserved"}});
+    }
+  }
+
+  void PruneProducers(uint64_t completed_submission,
+                      uint64_t current_submission,
+                      uint64_t protected_handle,
+                      uint64_t incoming_bytes) {
+    std::vector<uint64_t> stale;
+    for (const auto& [handle, producer] : producer_resources_) {
+      if (handle != protected_handle &&
+          producer.last_seen_submission + kProducerStaleSubmissions <=
+              completed_submission) {
+        stale.push_back(handle);
+      }
+    }
+    for (uint64_t handle : stale) {
+      RetireProducer(handle, current_submission);
+    }
+    while (!producer_resources_.empty() &&
+           (producer_resources_.size() >= kProducerResourceLimit ||
+            incoming_bytes > kProducerByteLimit ||
+            producer_live_bytes_ > kProducerByteLimit - incoming_bytes)) {
+      auto oldest = producer_resources_.end();
+      for (auto candidate = producer_resources_.begin();
+           candidate != producer_resources_.end(); ++candidate) {
+        if (candidate->first == protected_handle) {
+          continue;
+        }
+        if (oldest == producer_resources_.end() ||
+            candidate->second.last_seen_submission <
+                oldest->second.last_seen_submission) {
+          oldest = candidate;
+        }
+      }
+      if (oldest == producer_resources_.end()) {
+        break;
+      }
+      const uint64_t handle = oldest->first;
+      RetireProducer(handle, current_submission);
+      ++producer_budget_evictions_;
+    }
+  }
+
+  void RetireProducer(uint64_t handle, uint64_t current_submission) {
+    auto producer = producer_resources_.find(handle);
+    if (producer == producer_resources_.end()) {
+      return;
+    }
+    if (!render_target_bridge_.Retire(handle, current_submission)) {
+      RecordFailureOnce("producer_retire_failed");
+    }
+    producer_live_bytes_ -= producer->second.allocation_bytes;
+    producer_resources_.erase(producer);
+  }
+
   void ReleaseCollected(
       const std::vector<pinyon_shift::native_renderer::RetiredTexture>& collected) {
     for (const auto& texture : collected) {
@@ -206,6 +460,22 @@ class TextureResourceBridge {
         continue;
       }
       retained->second.release(reinterpret_cast<void*>(texture.handle));
+      if (!--retained->second.count) {
+        retained_.erase(retained);
+      }
+    }
+  }
+
+  void ReleaseCollected(const std::vector<
+                        pinyon_shift::native_renderer::RetiredRenderTarget>&
+                            collected) {
+    for (const auto& target : collected) {
+      auto retained = retained_.find(target.handle);
+      if (retained == retained_.end() || !retained->second.count) {
+        RecordFailureOnce("missing_target_reference");
+        continue;
+      }
+      retained->second.release(reinterpret_cast<void*>(target.handle));
       if (!--retained->second.count) {
         retained_.erase(retained);
       }
@@ -233,10 +503,21 @@ class TextureResourceBridge {
   std::mutex mutex_;
   pinyon_shift::native_renderer::PhysicalResourceTracker tracker_;
   pinyon_shift::native_renderer::NativeTextureCache cache_{tracker_};
+  pinyon_shift::native_renderer::NativeRenderTargetBridge
+      render_target_bridge_;
   std::unordered_map<uint64_t, RetainedReference> retained_;
+  std::unordered_map<uint64_t, ProducerResource> producer_resources_;
+  std::vector<ResolveRecord> resolve_records_;
   std::atomic<uint64_t> observed_resource_count_{};
   uint64_t observation_count_ = 0;
   uint64_t resource_count_ = 0;
+  uint64_t resolve_observation_count_ = 0;
+  uint64_t producer_resource_count_ = 0;
+  uint64_t producer_live_bytes_ = 0;
+  uint64_t producer_deduplications_ = 0;
+  uint64_t producer_budget_evictions_ = 0;
+  uint64_t producer_budget_refusals_ = 0;
+  uint64_t resolve_record_evictions_ = 0;
   uint64_t last_summary_submission_ = 0;
   bool failure_recorded_ = false;
 };
@@ -246,6 +527,12 @@ std::unique_ptr<TextureResourceBridge> g_texture_resource_bridge;
 void ObserveNativeTextures(const NativeObservation& observation) {
   if (g_texture_resource_bridge) {
     g_texture_resource_bridge->Observe(observation);
+  }
+}
+
+void ObserveNativeResolve(const ResolveObservation& observation) {
+  if (g_texture_resource_bridge) {
+    g_texture_resource_bridge->ObserveResolve(observation);
   }
 }
 
@@ -259,6 +546,7 @@ void InstallTextureResourceBridge(rex::system::IGraphicsSystem* graphics_system)
   }
   g_texture_resource_bridge = std::make_unique<TextureResourceBridge>();
   graphics_system->SetNativeTextureSetObserver(&ObserveNativeTextures);
+  graphics_system->SetNativeResolveObserver(&ObserveNativeResolve);
   diagnostics::RecordEvent("native_renderer.texture_bridge.installed",
                            {{"backend", "d3d12"},
                             {"ownership", "explicit_retain_release"},
@@ -269,6 +557,7 @@ void InstallTextureResourceBridge(rex::system::IGraphicsSystem* graphics_system)
 void UninstallTextureResourceBridge(rex::system::IGraphicsSystem* graphics_system) {
   if (graphics_system) {
     graphics_system->SetNativeTextureSetObserver(nullptr);
+    graphics_system->SetNativeResolveObserver(nullptr);
   }
   if (g_texture_resource_bridge) {
     g_texture_resource_bridge->Shutdown();

--- a/tests/native_renderer/render_target_bridge_test.cpp
+++ b/tests/native_renderer/render_target_bridge_test.cpp
@@ -70,13 +70,30 @@ int main() {
 
   nr::NativeRenderTargetBridge bridge;
 
-  const auto first = bridge.Acquire(color, 101, 4 * 1024 * 1024, 1, 10, 9);
+  const auto recorded = nr::PhysicalRange::FromGraphicsAddress(
+      0xB1200000, 640 * 360 * 4);
+  Require(recorded && bridge.RecordGpuOutput(*recorded, 9),
+          "a successful backend resolve must record GPU provenance");
+  Require(bridge.LookupProducer(ProducerRequest(), 1, 9).state ==
+              nr::NativeProducerLookupState::kBridgeRequired,
+          "a recorded GPU output must refuse decode before import");
+
+  const auto first = bridge.ImportObserved(color, 101, 4 * 1024 * 1024, 1, 10);
   Require(first && !first->hit && first->handle == 101,
           "a cold target must consume the candidate allocation");
   Require(bridge.PublishResolve(101, ResolveRegion(), 10),
           "a checked-out shader-readable target must publish its resolve");
   Require(bridge.Release(101, 10),
           "the producer target must check into the pool");
+
+  const auto same_observed =
+      bridge.ImportObserved(color, 101, 4 * 1024 * 1024, 2, 11);
+  Require(same_observed && same_observed->hit &&
+              same_observed->handle == 101 && bridge.Release(101, 11),
+          "the same externally owned producer may be observed again");
+  Require(!bridge.ImportObserved(ColorTarget(11), 101,
+                                 4 * 1024 * 1024, 2, 11),
+          "an observed handle must never change its exact allocation key");
 
   const auto producer = bridge.LookupProducer(ProducerRequest(), 2, 11);
   Require(producer.state == nr::NativeProducerLookupState::kNativeProducer &&
@@ -132,9 +149,11 @@ int main() {
           "shutdown target must collect once the fence completes");
 
   const nr::RenderTargetBridgeMetrics metrics = bridge.metrics();
-  Require(metrics.pool_hits == 2 && metrics.pool_misses == 2 &&
-              metrics.bridge_hits == 1 && metrics.bridge_refusals == 2 &&
+  Require(metrics.pool_hits == 3 && metrics.pool_misses == 2 &&
+              metrics.bridge_hits == 1 && metrics.bridge_refusals == 3 &&
               metrics.resolve_publications == 3 &&
+              metrics.gpu_output_records == 1 &&
+              metrics.known_output_overflows == 0 &&
               metrics.guest_invalidations == 1 && !metrics.live_count &&
               !metrics.live_bytes && !metrics.retired_count &&
               !metrics.retired_bytes,

--- a/tools/tests/test_native_renderer_contract.py
+++ b/tools/tests/test_native_renderer_contract.py
@@ -564,6 +564,19 @@ class NativeRendererContractTests(unittest.TestCase):
         self.assertIn("observed < 16", texture_bridge)
         self.assertIn("last_summary_submission_ + 300", texture_bridge)
 
+        resolve_resource_patch = (
+            ROOT
+            / "patches/rexglue/0066-d3d12-native-resolve-provenance-observer.patch"
+        ).read_text(encoding="utf-8")
+        self.assertIn("GraphicsNativeResolveObserver", resolve_resource_patch)
+        self.assertIn("SetNativeResolveObserver", resolve_resource_patch)
+        self.assertIn("native_resolve_observer", resolve_resource_patch)
+        self.assertIn("guest_row_pitch_bytes", resolve_resource_patch)
+        self.assertIn("copy_observer || native_resolve_observer", resolve_resource_patch)
+        self.assertIn("current_submission", resolve_resource_patch)
+        self.assertIn("completed_submission", resolve_resource_patch)
+        self.assertNotIn("SetDrawSuppression", resolve_resource_patch)
+
         visual_marker_patch = (
             ROOT / "patches/rexglue/0060-d3d12-isolated-draw-debug-markers.patch"
         ).read_text(encoding="utf-8")

--- a/tools/tests/test_native_renderer_render_target_bridge.py
+++ b/tools/tests/test_native_renderer_render_target_bridge.py
@@ -34,6 +34,31 @@ class NativeRendererRenderTargetBridgeContractTests(unittest.TestCase):
         self.assertIn("known_gpu_outputs_", header)
         self.assertIn("known_gpu_output", source)
         self.assertIn("NativeProducerLookupState::kBridgeRequired", source)
+        self.assertIn("RecordGpuOutput", header)
+        self.assertIn("known_output_overflow_", header)
+        self.assertIn("kKnownGpuOutputLimit", header)
+
+    def test_observed_backend_resources_have_explicit_import_ownership(self):
+        header = (
+            ROOT / "src/native_renderer/render_target_bridge.h"
+        ).read_text(encoding="utf-8")
+        source = (
+            ROOT / "src/native_renderer/texture_resource_bridge.cpp"
+        ).read_text(encoding="utf-8")
+        self.assertIn("ImportObserved", header)
+        self.assertIn("SetNativeResolveObserver(&ObserveNativeResolve)", source)
+        self.assertIn("render_target_bridge_.RecordGpuOutput", source)
+        self.assertIn("render_target_bridge_.PublishResolve", source)
+        self.assertIn("guest_row_pitch_bytes", source)
+        self.assertIn("kProducerResourceLimit", source)
+        self.assertIn("kProducerByteLimit", source)
+        self.assertIn("producer_deduplications_", source)
+        self.assertIn("PruneProducers", source)
+        self.assertIn("RetireProducer", source)
+        self.assertIn("existing->second.destination != *base", source)
+        self.assertIn('RecordFailureOnce("producer_retire_failed")', source)
+        self.assertIn('"xenos_resolve", "preserved"', source)
+        self.assertNotIn("SetDrawSuppression", source)
 
     def test_pool_reuse_and_retirement_are_submission_safe(self):
         source = (

--- a/tools/tests/test_release_contract.py
+++ b/tools/tests/test_release_contract.py
@@ -43,10 +43,10 @@ class ReleaseContractTests(unittest.TestCase):
 
     def test_rexglue_patches_have_stable_order_and_no_binary_payload(self):
         patches = sorted((ROOT / "patches/rexglue").glob("*.patch"))
-        self.assertEqual(len(patches), 65)
+        self.assertEqual(len(patches), 66)
         self.assertEqual(
             patches[-1].name,
-            "0065-d3d12-retained-pass-preview.patch",
+            "0066-d3d12-native-resolve-provenance-observer.patch",
         )
         self.assertEqual(len(patches), len({path.name[:4] for path in patches}))
         for path in patches:


### PR DESCRIPTION
## Summary
- add a dedicated submission-aware D3D12 resolve provenance observer
- import exact backend-owned resolve resources into the neutral render-target bridge
- bound producer correlation to 64 resources / 128 MiB with fence-safe retirement
- preserve all Xenos copies and draws with conservative fallback on unknown GPU output

## Validation
- 146 Python contract tests
- four native semantic test executables
- clean generated-source Release preview build
- AppData gameplay session `20260828T221140Z-p38016`
  - festival scene reached and rendered correctly
  - 59.974 Hz presentation, zero deadline misses
  - zero renderer failures, bridge refusals, or budget refusals
  - 64 live producers / 74,776,576 bytes at steady-state sample
  - normal exit through `process.shutdown`