### PR TITLE
feat(native-renderer): add bounded prewarm workers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,7 @@ if(WIN32)
         src/native_renderer/buffer_cache.cpp
         src/native_renderer/guest_output_renderer.cpp
         src/native_renderer/render_target_bridge.cpp
+        src/native_renderer/resource_worker.cpp
         src/native_renderer/resource_identity.cpp
         src/native_renderer/shader_capture.cpp
         src/native_renderer/shader_pack.cpp
@@ -42,6 +43,7 @@ else()
         src/native_renderer/buffer_cache.cpp
         src/native_renderer/guest_output_renderer.cpp
         src/native_renderer/render_target_bridge.cpp
+        src/native_renderer/resource_worker.cpp
         src/native_renderer/resource_identity.cpp
         src/native_renderer/shader_capture.cpp
         src/native_renderer/shader_pack.cpp
@@ -76,6 +78,12 @@ add_executable(pinyon_shift_render_target_bridge_tests EXCLUDE_FROM_ALL
     src/native_renderer/resource_identity.cpp
 )
 target_include_directories(pinyon_shift_render_target_bridge_tests PRIVATE src)
+
+add_executable(pinyon_shift_resource_worker_tests EXCLUDE_FROM_ALL
+    tests/native_renderer/resource_worker_test.cpp
+    src/native_renderer/resource_worker.cpp
+)
+target_include_directories(pinyon_shift_resource_worker_tests PRIVATE src)
 
 pinyon_shift_attach_rexglue(pinyon_shift)
 

--- a/docs/native-renderer/RESOURCE_WORKER.md
+++ b/docs/native-renderer/RESOURCE_WORKER.md
@@ -1,0 +1,53 @@
+# Native resource worker and prewarm queue
+
+NR-03G begins with a backend-neutral two-stage worker contract. CPU-only
+preparation runs on a fixed set of `std::jthread` workers. Backend resource,
+view, descriptor, and pipeline creation remains exclusively in the bounded
+`DrainCommits` call made by the renderer thread.
+
+## Scheduling
+
+Work is ordered by four explicit priorities:
+
+1. visible draw misses;
+2. loading-screen prewarm;
+3. streaming-registration prewarm;
+4. speculative preparation.
+
+FIFO order is preserved within a priority. A full pending or prepared queue
+may evict only work with strictly lower priority; equal- or higher-priority
+work is never displaced. Default limits are 256 pending requests and 16 MiB,
+128 prepared results and 16 MiB, two workers, and 4,096 remembered logical
+resources. Completed idle state is retired by least-recently-used order.
+
+Each request carries a resource class, stable identity, and generation. A
+newer generation makes queued, prepared, or in-flight older results stale.
+Stale results are discarded before renderer-thread commit. Repeated requests
+for an outstanding or completed generation are deduplicated. Stop tokens and
+explicit shutdown prevent a worker from outliving the owning renderer bridge.
+
+## Initial texture signal
+
+The default-off D3D12 texture bridge now exercises the worker contract with
+real texture observations. The physical base range and complete fetch
+signature form the metadata identity. Workers validate the copied six-word
+fetch descriptor without accessing guest memory or backend objects. The
+render thread drains at most four results and 64 KiB per observation.
+
+This first integration deliberately prepares metadata rather than performing
+the eventual untile/decode/upload pipeline. It validates scheduling,
+deduplication, stale rejection, and render-thread commit under authentic game
+load while Xenos remains fully authoritative. Later prewarm observers may
+submit the same work before first visibility without changing the queue's
+lifetime contract.
+
+## Qualification
+
+The AppData-backed run `20260828T222703Z-p43172` reached the festival scene
+and ran for 108.45 seconds. It prepared and renderer-committed all 1,151 unique
+texture metadata requests, deduplicated 12,631,781 repeated observations, and
+ended with zero stale results, capacity refusals, pending work, prepared work,
+or retained references. The capture reported 31.057 median FPS, 17.893
+one-percent-low FPS, 59.972 Hz presentation, no presentation deadline misses,
+no renderer failure, fatal, crash, or device-loss event, and a normal
+`process.shutdown`. Xenos draws and resolves remained preserved throughout.

--- a/src/native_renderer/resource_worker.cpp
+++ b/src/native_renderer/resource_worker.cpp
@@ -1,0 +1,390 @@
+#include "native_renderer/resource_worker.h"
+
+#include <algorithm>
+#include <utility>
+
+namespace pinyon_shift::native_renderer {
+namespace {
+
+template <typename T>
+void HashValue(T value, size_t& hash) {
+  hash ^= std::hash<T>{}(value) + size_t{0x9E3779B9} + (hash << 6) +
+          (hash >> 2);
+}
+
+uint8_t PriorityValue(NativeResourceWorkPriority priority) {
+  return static_cast<uint8_t>(priority);
+}
+
+}  // namespace
+
+size_t NativeResourceWorkKeyHash::operator()(
+    const NativeResourceWorkKey& key) const {
+  size_t hash = 0;
+  HashValue(static_cast<uint8_t>(key.resource_class), hash);
+  HashValue(key.identity, hash);
+  HashValue(key.generation, hash);
+  return hash;
+}
+
+size_t NativeResourceWorker::LogicalKeyHash::operator()(
+    const LogicalKey& key) const {
+  size_t hash = 0;
+  HashValue(static_cast<uint8_t>(key.resource_class), hash);
+  HashValue(key.identity, hash);
+  return hash;
+}
+
+NativeResourceWorker::NativeResourceWorker(NativeResourceWorkerLimits limits,
+                                           PrepareFunction prepare)
+    : limits_(limits), prepare_(std::move(prepare)) {}
+
+NativeResourceWorker::~NativeResourceWorker() { Stop(); }
+
+bool NativeResourceWorker::Start() {
+  const std::scoped_lock lock(mutex_);
+  if (started_ || stopping_ || !prepare_ || !limits_.worker_count) {
+    return false;
+  }
+  started_ = true;
+  workers_.reserve(limits_.worker_count);
+  for (size_t worker_index = 0; worker_index < limits_.worker_count;
+       ++worker_index) {
+    workers_.emplace_back(
+        [this](std::stop_token stop_token) { WorkerMain(stop_token); });
+  }
+  wake_.notify_all();
+  return true;
+}
+
+void NativeResourceWorker::Stop() {
+  std::vector<std::jthread> workers;
+  {
+    const std::scoped_lock lock(mutex_);
+    if (stopping_) {
+      return;
+    }
+    stopping_ = true;
+    workers.swap(workers_);
+  }
+  for (auto& worker : workers) {
+    worker.request_stop();
+  }
+  wake_.notify_all();
+  workers.clear();
+  const std::scoped_lock lock(mutex_);
+  for (const auto& queued : pending_) {
+    RemoveOutstandingLocked(queued.request.key);
+  }
+  for (const auto& queued : prepared_) {
+    RemoveOutstandingLocked(queued.resource.key);
+  }
+  pending_.clear();
+  prepared_.clear();
+  metrics_.pending_count = 0;
+  metrics_.pending_bytes = 0;
+  metrics_.prepared_count = 0;
+  metrics_.prepared_bytes = 0;
+  started_ = false;
+}
+
+bool NativeResourceWorker::Submit(NativeResourceWorkRequest request) {
+  if (!request.key.valid()) {
+    return false;
+  }
+  const uint64_t request_bytes = request.payload.size();
+  const LogicalKey logical{request.key.resource_class, request.key.identity};
+  const std::scoped_lock lock(mutex_);
+  if (stopping_ || request_bytes > limits_.pending_bytes) {
+    ++metrics_.capacity_refusals;
+    return false;
+  }
+  const auto latest = latest_generation_.find(logical);
+  if (latest != latest_generation_.end() &&
+      request.key.generation < latest->second) {
+    ++metrics_.stale_results;
+    return false;
+  }
+  const auto committed = committed_generation_.find(logical);
+  if ((committed != committed_generation_.end() &&
+       request.key.generation <= committed->second) ||
+      outstanding_.contains(request.key)) {
+    state_touch_[logical] = next_sequence_++;
+    ++metrics_.deduplications;
+    return true;
+  }
+  if (latest == latest_generation_.end()) {
+    while (latest_generation_.size() >= limits_.state_count) {
+      auto oldest = state_touch_.end();
+      for (auto candidate = state_touch_.begin();
+           candidate != state_touch_.end(); ++candidate) {
+        const bool outstanding = std::ranges::any_of(
+            outstanding_, [&](const NativeResourceWorkKey& key) {
+              return key.resource_class == candidate->first.resource_class &&
+                     key.identity == candidate->first.identity;
+            });
+        if (!outstanding &&
+            (oldest == state_touch_.end() ||
+             candidate->second < oldest->second)) {
+          oldest = candidate;
+        }
+      }
+      if (oldest == state_touch_.end()) {
+        ++metrics_.capacity_refusals;
+        return false;
+      }
+      const LogicalKey oldest_key = oldest->first;
+      state_touch_.erase(oldest);
+      committed_generation_.erase(oldest_key);
+      latest_generation_.erase(oldest_key);
+      ++metrics_.state_evictions;
+    }
+  }
+  latest_generation_[logical] = request.key.generation;
+  state_touch_[logical] = next_sequence_;
+  for (size_t index = pending_.size(); index-- > 0;) {
+    const auto& pending_key = pending_[index].request.key;
+    if (pending_key.resource_class != logical.resource_class ||
+        pending_key.identity != logical.identity ||
+        pending_key.generation >= request.key.generation) {
+      continue;
+    }
+    metrics_.pending_bytes -= pending_[index].request.payload.size();
+    RemoveOutstandingLocked(pending_key);
+    pending_.erase(pending_.begin() + index);
+    ++metrics_.stale_results;
+  }
+  metrics_.pending_count = pending_.size();
+  for (size_t index = prepared_.size(); index-- > 0;) {
+    const auto& prepared_key = prepared_[index].resource.key;
+    if (prepared_key.resource_class != logical.resource_class ||
+        prepared_key.identity != logical.identity ||
+        prepared_key.generation >= request.key.generation) {
+      continue;
+    }
+    metrics_.prepared_bytes -= prepared_[index].resource.payload.size();
+    RemoveOutstandingLocked(prepared_key);
+    prepared_.erase(prepared_.begin() + index);
+    ++metrics_.stale_results;
+  }
+  metrics_.prepared_count = prepared_.size();
+
+  while (pending_.size() >= limits_.pending_count ||
+         metrics_.pending_bytes > limits_.pending_bytes - request_bytes) {
+    if (pending_.empty()) {
+      ++metrics_.capacity_refusals;
+      return false;
+    }
+    const size_t worst_index = SelectWorstPendingLocked();
+    if (PriorityValue(pending_[worst_index].request.priority) <=
+        PriorityValue(request.priority)) {
+      ++metrics_.capacity_refusals;
+      return false;
+    }
+    metrics_.pending_bytes -= pending_[worst_index].request.payload.size();
+    RemoveOutstandingLocked(pending_[worst_index].request.key);
+    pending_.erase(pending_.begin() + worst_index);
+    ++metrics_.pending_evictions;
+  }
+  outstanding_.insert(request.key);
+  metrics_.pending_bytes += request_bytes;
+  pending_.push_back({std::move(request), next_sequence_++});
+  ++metrics_.submissions;
+  metrics_.pending_count = pending_.size();
+  wake_.notify_one();
+  return true;
+}
+
+size_t NativeResourceWorker::DrainCommits(
+    size_t maximum_items, uint64_t maximum_bytes,
+    const CommitFunction& commit) {
+  if (!maximum_items || !maximum_bytes || !commit) {
+    return 0;
+  }
+  size_t committed_count = 0;
+  uint64_t committed_bytes = 0;
+  while (committed_count < maximum_items) {
+    const std::scoped_lock lock(mutex_);
+    if (prepared_.empty()) {
+      break;
+    }
+    const size_t prepared_index = SelectPreparedLocked();
+    const uint64_t resource_bytes =
+        prepared_[prepared_index].resource.payload.size();
+    if (resource_bytes > maximum_bytes - committed_bytes) {
+      break;
+    }
+    NativePreparedResource resource =
+        std::move(prepared_[prepared_index].resource);
+    prepared_.erase(prepared_.begin() + prepared_index);
+    metrics_.prepared_bytes -= resource_bytes;
+    metrics_.prepared_count = prepared_.size();
+    RemoveOutstandingLocked(resource.key);
+    if (!IsCurrentLocked(resource.key)) {
+      ++metrics_.stale_results;
+      continue;
+    }
+    const NativeResourceWorkKey committed_key = resource.key;
+    commit(std::move(resource));
+    const LogicalKey logical{committed_key.resource_class,
+                             committed_key.identity};
+    committed_generation_[logical] = committed_key.generation;
+    state_touch_[logical] = next_sequence_++;
+    ++metrics_.commits;
+    committed_bytes += resource_bytes;
+    ++committed_count;
+  }
+  return committed_count;
+}
+
+NativeResourceWorkerMetrics NativeResourceWorker::metrics() const {
+  const std::scoped_lock lock(mutex_);
+  return metrics_;
+}
+
+void NativeResourceWorker::WorkerMain(std::stop_token stop_token) {
+  while (!stop_token.stop_requested()) {
+    QueuedRequest queued;
+    {
+      std::unique_lock lock(mutex_);
+      wake_.wait(lock, stop_token,
+                 [&] { return !pending_.empty() || stopping_; });
+      if (stop_token.stop_requested() || stopping_) {
+        return;
+      }
+      const size_t pending_index = SelectPendingLocked();
+      queued = std::move(pending_[pending_index]);
+      metrics_.pending_bytes -= queued.request.payload.size();
+      pending_.erase(pending_.begin() + pending_index);
+      metrics_.pending_count = pending_.size();
+      ++metrics_.active_workers;
+    }
+
+    const NativeResourceWorkKey work_key = queued.request.key;
+    std::optional<NativePreparedResource> result =
+        prepare_(std::move(queued.request), stop_token);
+    {
+      const std::scoped_lock lock(mutex_);
+      --metrics_.active_workers;
+      if (!result || result->key != work_key) {
+        RemoveOutstandingLocked(work_key);
+        if (IsCurrentLocked(work_key)) {
+          committed_generation_[{work_key.resource_class,
+                                 work_key.identity}] = work_key.generation;
+          state_touch_[{work_key.resource_class, work_key.identity}] =
+              next_sequence_++;
+        }
+        ++metrics_.prepare_failures;
+        continue;
+      }
+      if (!IsCurrentLocked(result->key)) {
+        RemoveOutstandingLocked(result->key);
+        ++metrics_.stale_results;
+        continue;
+      }
+      const uint64_t result_bytes = result->payload.size();
+      if (result_bytes > limits_.prepared_bytes) {
+        RemoveOutstandingLocked(result->key);
+        ++metrics_.capacity_refusals;
+        continue;
+      }
+      while (prepared_.size() >= limits_.prepared_count ||
+             metrics_.prepared_bytes > limits_.prepared_bytes - result_bytes) {
+        if (prepared_.empty()) {
+          break;
+        }
+        const size_t worst_index = SelectWorstPreparedLocked();
+        if (PriorityValue(prepared_[worst_index].resource.priority) <=
+            PriorityValue(result->priority)) {
+          break;
+        }
+        metrics_.prepared_bytes -=
+            prepared_[worst_index].resource.payload.size();
+        RemoveOutstandingLocked(prepared_[worst_index].resource.key);
+        prepared_.erase(prepared_.begin() + worst_index);
+        ++metrics_.prepared_evictions;
+      }
+      if (prepared_.size() >= limits_.prepared_count ||
+          metrics_.prepared_bytes > limits_.prepared_bytes - result_bytes) {
+        RemoveOutstandingLocked(result->key);
+        ++metrics_.capacity_refusals;
+        continue;
+      }
+      metrics_.prepared_bytes += result_bytes;
+      prepared_.push_back({std::move(*result), queued.sequence});
+      ++metrics_.prepared;
+      metrics_.prepared_count = prepared_.size();
+    }
+  }
+}
+
+size_t NativeResourceWorker::SelectPendingLocked() const {
+  size_t selected = 0;
+  for (size_t index = 1; index < pending_.size(); ++index) {
+    if (PriorityValue(pending_[index].request.priority) <
+            PriorityValue(pending_[selected].request.priority) ||
+        (pending_[index].request.priority ==
+             pending_[selected].request.priority &&
+         pending_[index].sequence < pending_[selected].sequence)) {
+      selected = index;
+    }
+  }
+  return selected;
+}
+
+size_t NativeResourceWorker::SelectPreparedLocked() const {
+  size_t selected = 0;
+  for (size_t index = 1; index < prepared_.size(); ++index) {
+    if (PriorityValue(prepared_[index].resource.priority) <
+            PriorityValue(prepared_[selected].resource.priority) ||
+        (prepared_[index].resource.priority ==
+             prepared_[selected].resource.priority &&
+         prepared_[index].sequence < prepared_[selected].sequence)) {
+      selected = index;
+    }
+  }
+  return selected;
+}
+
+size_t NativeResourceWorker::SelectWorstPendingLocked() const {
+  size_t selected = 0;
+  for (size_t index = 1; index < pending_.size(); ++index) {
+    if (PriorityValue(pending_[index].request.priority) >
+            PriorityValue(pending_[selected].request.priority) ||
+        (pending_[index].request.priority ==
+             pending_[selected].request.priority &&
+         pending_[index].sequence > pending_[selected].sequence)) {
+      selected = index;
+    }
+  }
+  return selected;
+}
+
+size_t NativeResourceWorker::SelectWorstPreparedLocked() const {
+  size_t selected = 0;
+  for (size_t index = 1; index < prepared_.size(); ++index) {
+    if (PriorityValue(prepared_[index].resource.priority) >
+            PriorityValue(prepared_[selected].resource.priority) ||
+        (prepared_[index].resource.priority ==
+             prepared_[selected].resource.priority &&
+         prepared_[index].sequence > prepared_[selected].sequence)) {
+      selected = index;
+    }
+  }
+  return selected;
+}
+
+bool NativeResourceWorker::IsCurrentLocked(
+    const NativeResourceWorkKey& key) const {
+  const auto latest = latest_generation_.find(
+      {key.resource_class, key.identity});
+  return latest != latest_generation_.end() &&
+         latest->second == key.generation;
+}
+
+void NativeResourceWorker::RemoveOutstandingLocked(
+    const NativeResourceWorkKey& key) {
+  outstanding_.erase(key);
+}
+
+}  // namespace pinyon_shift::native_renderer

--- a/src/native_renderer/resource_worker.h
+++ b/src/native_renderer/resource_worker.h
@@ -1,0 +1,161 @@
+#pragma once
+
+#include <condition_variable>
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <mutex>
+#include <optional>
+#include <stop_token>
+#include <thread>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+namespace pinyon_shift::native_renderer {
+
+enum class NativeResourceWorkClass : uint8_t {
+  kTexture,
+  kBuffer,
+  kPipeline,
+};
+
+enum class NativeResourceWorkPriority : uint8_t {
+  kVisibleMiss,
+  kLoadingPrewarm,
+  kStreamingPrewarm,
+  kSpeculative,
+};
+
+struct NativeResourceWorkKey {
+  NativeResourceWorkClass resource_class = NativeResourceWorkClass::kTexture;
+  uint64_t identity = 0;
+  uint64_t generation = 0;
+
+  [[nodiscard]] bool valid() const { return identity != 0; }
+  bool operator==(const NativeResourceWorkKey&) const = default;
+};
+
+struct NativeResourceWorkKeyHash {
+  size_t operator()(const NativeResourceWorkKey& key) const;
+};
+
+struct NativeResourceWorkRequest {
+  NativeResourceWorkKey key;
+  NativeResourceWorkPriority priority =
+      NativeResourceWorkPriority::kSpeculative;
+  std::vector<uint8_t> payload;
+};
+
+struct NativePreparedResource {
+  NativeResourceWorkKey key;
+  NativeResourceWorkPriority priority =
+      NativeResourceWorkPriority::kSpeculative;
+  std::vector<uint8_t> payload;
+};
+
+struct NativeResourceWorkerLimits {
+  size_t worker_count = 2;
+  size_t pending_count = 256;
+  uint64_t pending_bytes = 16 * 1024 * 1024;
+  size_t prepared_count = 128;
+  uint64_t prepared_bytes = 16 * 1024 * 1024;
+  size_t state_count = 4096;
+};
+
+struct NativeResourceWorkerMetrics {
+  uint64_t submissions = 0;
+  uint64_t deduplications = 0;
+  uint64_t pending_evictions = 0;
+  uint64_t capacity_refusals = 0;
+  uint64_t prepared = 0;
+  uint64_t prepare_failures = 0;
+  uint64_t stale_results = 0;
+  uint64_t prepared_evictions = 0;
+  uint64_t state_evictions = 0;
+  uint64_t commits = 0;
+  uint64_t pending_count = 0;
+  uint64_t pending_bytes = 0;
+  uint64_t prepared_count = 0;
+  uint64_t prepared_bytes = 0;
+  uint64_t active_workers = 0;
+};
+
+// CPU-only preparation runs on bounded worker threads. Backend object creation
+// remains in DrainCommits, which must be called by the renderer thread.
+class NativeResourceWorker {
+ public:
+  using PrepareFunction = std::function<std::optional<NativePreparedResource>(
+      NativeResourceWorkRequest, std::stop_token)>;
+  using CommitFunction = std::function<void(NativePreparedResource)>;
+
+  NativeResourceWorker(NativeResourceWorkerLimits limits,
+                       PrepareFunction prepare);
+  ~NativeResourceWorker();
+
+  NativeResourceWorker(const NativeResourceWorker&) = delete;
+  NativeResourceWorker& operator=(const NativeResourceWorker&) = delete;
+
+  bool Start();
+  void Stop();
+  bool Submit(NativeResourceWorkRequest request);
+
+  // Returns the number of commits performed. Both item and byte budgets are
+  // hard limits; zero means no work may be committed in this call. The commit
+  // callback runs while generation publication is serialized and must not
+  // call back into this worker.
+  size_t DrainCommits(size_t maximum_items, uint64_t maximum_bytes,
+                      const CommitFunction& commit);
+
+  [[nodiscard]] NativeResourceWorkerMetrics metrics() const;
+
+ private:
+  struct LogicalKey {
+    NativeResourceWorkClass resource_class =
+        NativeResourceWorkClass::kTexture;
+    uint64_t identity = 0;
+
+    bool operator==(const LogicalKey&) const = default;
+  };
+
+  struct LogicalKeyHash {
+    size_t operator()(const LogicalKey& key) const;
+  };
+
+  struct QueuedRequest {
+    NativeResourceWorkRequest request;
+    uint64_t sequence = 0;
+  };
+
+  struct QueuedPrepared {
+    NativePreparedResource resource;
+    uint64_t sequence = 0;
+  };
+
+  void WorkerMain(std::stop_token stop_token);
+  [[nodiscard]] size_t SelectPendingLocked() const;
+  [[nodiscard]] size_t SelectPreparedLocked() const;
+  [[nodiscard]] size_t SelectWorstPendingLocked() const;
+  [[nodiscard]] size_t SelectWorstPreparedLocked() const;
+  [[nodiscard]] bool IsCurrentLocked(const NativeResourceWorkKey& key) const;
+  void RemoveOutstandingLocked(const NativeResourceWorkKey& key);
+
+  NativeResourceWorkerLimits limits_;
+  PrepareFunction prepare_;
+  mutable std::mutex mutex_;
+  std::condition_variable_any wake_;
+  std::vector<std::jthread> workers_;
+  std::vector<QueuedRequest> pending_;
+  std::vector<QueuedPrepared> prepared_;
+  std::unordered_set<NativeResourceWorkKey, NativeResourceWorkKeyHash>
+      outstanding_;
+  std::unordered_map<LogicalKey, uint64_t, LogicalKeyHash> latest_generation_;
+  std::unordered_map<LogicalKey, uint64_t, LogicalKeyHash> committed_generation_;
+  std::unordered_map<LogicalKey, uint64_t, LogicalKeyHash> state_touch_;
+  NativeResourceWorkerMetrics metrics_;
+  uint64_t next_sequence_ = 1;
+  bool started_ = false;
+  bool stopping_ = false;
+};
+
+}  // namespace pinyon_shift::native_renderer

--- a/src/native_renderer/texture_resource_bridge.cpp
+++ b/src/native_renderer/texture_resource_bridge.cpp
@@ -5,8 +5,10 @@
 
 #include <atomic>
 #include <algorithm>
+#include <array>
 #include <cstddef>
 #include <cstdint>
+#include <cstring>
 #include <memory>
 #include <mutex>
 #include <optional>
@@ -16,6 +18,7 @@
 
 #include "native_renderer/render_target_bridge.h"
 #include "native_renderer/resource_identity.h"
+#include "native_renderer/resource_worker.h"
 #include "native_renderer/texture_cache.h"
 #include "pinyon_shift_diagnostics.h"
 
@@ -58,8 +61,34 @@ bool IsRetainedPassCandidate(const NativeResource& resource) {
          resource.guest_pitch == kRetainedPassTexturePitch && resource.guest_tiled;
 }
 
+std::optional<pinyon_shift::native_renderer::NativePreparedResource>
+PrepareTextureMetadata(
+    pinyon_shift::native_renderer::NativeResourceWorkRequest request,
+    std::stop_token stop_token) {
+  if (stop_token.stop_requested() ||
+      request.payload.size() != sizeof(uint32_t) * 6) {
+    return std::nullopt;
+  }
+  std::array<uint32_t, 6> fetch_words;
+  std::memcpy(fetch_words.data(), request.payload.data(),
+              request.payload.size());
+  if (!pinyon_shift::native_renderer::NativeTextureDescriptor::FromFetchWords(
+          fetch_words)) {
+    return std::nullopt;
+  }
+  return pinyon_shift::native_renderer::NativePreparedResource{
+      request.key, request.priority, std::move(request.payload)};
+}
+
 class TextureResourceBridge {
  public:
+  TextureResourceBridge()
+      : prewarm_worker_({}, &PrepareTextureMetadata) {
+    if (!prewarm_worker_.Start()) {
+      RecordFailureOnce("prewarm_worker_start_failed");
+    }
+  }
+
   void ObserveResolve(const ResolveObservation& observation) {
     if (!observation.succeeded || !observation.written_length) {
       return;
@@ -133,17 +162,22 @@ class TextureResourceBridge {
              {"tiled", resource.guest_tiled ? "1" : "0"},
              {"host_format", std::to_string(resource.host_resource_format)}});
       }
+      SubmitTexturePreparation(resource);
       if (IsRetainedPassCandidate(resource)) {
         Retain(resource, observation);
       }
       ImportResolveProducer(resource, observation);
     }
+    prewarm_worker_.DrainCommits(
+        4, 64 * 1024,
+        [](pinyon_shift::native_renderer::NativePreparedResource) {});
 
     if (resource_count_ && (!last_summary_submission_ ||
                             observation.current_submission >= last_summary_submission_ + 300)) {
       last_summary_submission_ = observation.current_submission;
       const auto metrics = cache_.metrics();
       const auto target_metrics = render_target_bridge_.metrics();
+      const auto worker_metrics = prewarm_worker_.metrics();
       pinyon_shift::diagnostics::RecordEvent(
           "native_renderer.texture_bridge.summary",
           {{"observations", std::to_string(observation_count_)},
@@ -169,6 +203,16 @@ class TextureResourceBridge {
            {"target_live_bytes", std::to_string(target_metrics.live_bytes)},
            {"resolve_record_evictions",
             std::to_string(resolve_record_evictions_)},
+           {"prewarm_submissions",
+            std::to_string(worker_metrics.submissions)},
+           {"prewarm_deduplications",
+            std::to_string(worker_metrics.deduplications)},
+           {"prewarm_prepared", std::to_string(worker_metrics.prepared)},
+           {"prewarm_commits", std::to_string(worker_metrics.commits)},
+           {"prewarm_stale", std::to_string(worker_metrics.stale_results)},
+           {"prewarm_refusals",
+            std::to_string(worker_metrics.capacity_refusals)},
+           {"prewarm_pending", std::to_string(worker_metrics.pending_count)},
            {"submission", std::to_string(observation.current_submission)},
            {"completed_submission", std::to_string(observation.completed_submission)},
            {"xenos_draw", "preserved"}});
@@ -177,17 +221,23 @@ class TextureResourceBridge {
 
   void Shutdown() {
     const std::scoped_lock lock(mutex_);
+    prewarm_worker_.Stop();
     cache_.RetireAll(0);
     render_target_bridge_.RetireAll(0);
     ReleaseCollected(cache_.Collect(UINT64_MAX));
     ReleaseCollected(render_target_bridge_.Collect(UINT64_MAX));
     const auto metrics = cache_.metrics();
+    const auto worker_metrics = prewarm_worker_.metrics();
     pinyon_shift::diagnostics::RecordEvent(
         "native_renderer.texture_bridge.stopped",
         {{"observations", std::to_string(observation_count_)},
          {"resources", std::to_string(resource_count_)},
          {"resolve_observations", std::to_string(resolve_observation_count_)},
          {"producer_resources", std::to_string(producer_resource_count_)},
+         {"prewarm_submissions", std::to_string(worker_metrics.submissions)},
+         {"prewarm_commits", std::to_string(worker_metrics.commits)},
+         {"prewarm_pending", std::to_string(worker_metrics.pending_count)},
+         {"prewarm_prepared", std::to_string(worker_metrics.prepared_count)},
          {"live", std::to_string(metrics.live_count)},
          {"retained_refs", std::to_string(RetainedReferenceCount())},
          {"xenos_draw", "preserved"}});
@@ -212,6 +262,35 @@ class TextureResourceBridge {
     rex::system::GraphicsNativeTextureRelease release = nullptr;
     uint64_t count = 0;
   };
+
+  void SubmitTexturePreparation(const NativeResource& resource) {
+    if (!resource.base_length) {
+      return;
+    }
+    const auto base =
+        pinyon_shift::native_renderer::PhysicalRange::FromGraphicsAddress(
+            resource.base_address, resource.base_length);
+    if (!base) {
+      return;
+    }
+    const uint64_t fetch_signature = HashFetchWords(resource.fetch_dwords);
+    uint64_t identity = base->address;
+    identity ^= base->length + UINT64_C(0x9E3779B97F4A7C15) +
+                (identity << 6) + (identity >> 2);
+    identity ^= fetch_signature + UINT64_C(0x9E3779B97F4A7C15) +
+                (identity << 6) + (identity >> 2);
+    if (!identity) {
+      identity = 1;
+    }
+    std::vector<uint8_t> payload(sizeof(resource.fetch_dwords));
+    std::memcpy(payload.data(), resource.fetch_dwords, payload.size());
+    prewarm_worker_.Submit(
+        {{pinyon_shift::native_renderer::NativeResourceWorkClass::kTexture,
+          identity, 1},
+         pinyon_shift::native_renderer::NativeResourceWorkPriority::
+             kVisibleMiss,
+         std::move(payload)});
+  }
 
   void Retain(const NativeResource& resource, const NativeObservation& observation) {
     if (!resource.resource || !resource.retain || !resource.release ||
@@ -503,6 +582,7 @@ class TextureResourceBridge {
   std::mutex mutex_;
   pinyon_shift::native_renderer::PhysicalResourceTracker tracker_;
   pinyon_shift::native_renderer::NativeTextureCache cache_{tracker_};
+  pinyon_shift::native_renderer::NativeResourceWorker prewarm_worker_;
   pinyon_shift::native_renderer::NativeRenderTargetBridge
       render_target_bridge_;
   std::unordered_map<uint64_t, RetainedReference> retained_;

--- a/tests/native_renderer/resource_worker_test.cpp
+++ b/tests/native_renderer/resource_worker_test.cpp
@@ -1,0 +1,156 @@
+#include <atomic>
+#include <chrono>
+#include <cstdlib>
+#include <iostream>
+#include <thread>
+#include <vector>
+
+#include "native_renderer/resource_worker.h"
+
+namespace nr = pinyon_shift::native_renderer;
+
+namespace {
+
+void Require(bool condition, const char* message) {
+  if (!condition) {
+    std::cerr << message << '\n';
+    std::exit(EXIT_FAILURE);
+  }
+}
+
+nr::NativeResourceWorkRequest Request(
+    uint64_t identity, uint64_t generation,
+    nr::NativeResourceWorkPriority priority, uint8_t payload = 1) {
+  return {{nr::NativeResourceWorkClass::kTexture, identity, generation},
+          priority,
+          {payload}};
+}
+
+bool WaitForPrepared(nr::NativeResourceWorker& worker, uint64_t count) {
+  const auto deadline =
+      std::chrono::steady_clock::now() + std::chrono::seconds(3);
+  while (std::chrono::steady_clock::now() < deadline) {
+    if (worker.metrics().prepared_count >= count) {
+      return true;
+    }
+    std::this_thread::sleep_for(std::chrono::milliseconds(2));
+  }
+  return false;
+}
+
+}  // namespace
+
+int main() {
+  using Priority = nr::NativeResourceWorkPriority;
+  nr::NativeResourceWorkerLimits limits;
+  limits.worker_count = 1;
+  limits.pending_count = 2;
+  limits.pending_bytes = 8;
+  limits.prepared_count = 2;
+  limits.prepared_bytes = 8;
+
+  nr::NativeResourceWorker worker(
+      limits, [](nr::NativeResourceWorkRequest request, std::stop_token) {
+        return std::optional<nr::NativePreparedResource>{{
+            request.key, request.priority, std::move(request.payload)}};
+      });
+  Require(worker.Submit(Request(1, 1, Priority::kSpeculative)),
+          "the first speculative request must queue");
+  Require(worker.Submit(Request(2, 1, Priority::kStreamingPrewarm)),
+          "the second prewarm request must queue");
+  Require(worker.Submit(Request(3, 1, Priority::kVisibleMiss)),
+          "a visible miss must evict lower-priority pending work");
+  Require(!worker.Submit(Request(4, 1, Priority::kSpeculative)),
+          "low-priority work must not displace urgent requests");
+  Require(worker.Start(), "the worker pool must start exactly once");
+  Require(!worker.Start(), "a running worker pool must not start twice");
+  Require(WaitForPrepared(worker, 2), "both retained jobs must prepare");
+
+  std::vector<uint64_t> committed;
+  Require(worker.DrainCommits(
+              1, 8, [&](nr::NativePreparedResource resource) {
+                committed.push_back(resource.key.identity);
+              }) == 1 &&
+              committed.front() == 3,
+          "visible work must commit before streaming prewarm");
+  Require(worker.DrainCommits(
+              1, 8, [&](nr::NativePreparedResource resource) {
+                committed.push_back(resource.key.identity);
+              }) == 1 &&
+              committed.back() == 2,
+          "the remaining prewarm request must commit second");
+  Require(worker.Submit(Request(3, 1, Priority::kVisibleMiss)),
+          "a committed generation must deduplicate successfully");
+  worker.Stop();
+
+  const nr::NativeResourceWorkerMetrics first_metrics = worker.metrics();
+  Require(first_metrics.pending_evictions == 1 &&
+              first_metrics.capacity_refusals == 1 &&
+              first_metrics.deduplications == 1 &&
+              first_metrics.commits == 2 && !first_metrics.pending_count &&
+              !first_metrics.prepared_count && !first_metrics.active_workers,
+          "bounded queue telemetry must match the exercised behavior");
+
+  std::atomic<bool> generation_one_started = false;
+  std::atomic<bool> release_generation_one = false;
+  nr::NativeResourceWorker stale_worker(
+      limits, [&](nr::NativeResourceWorkRequest request, std::stop_token stop) {
+        if (request.key.generation == 1) {
+          generation_one_started.store(true);
+          while (!release_generation_one.load() && !stop.stop_requested()) {
+            std::this_thread::yield();
+          }
+        }
+        return std::optional<nr::NativePreparedResource>{{
+            request.key, request.priority, std::move(request.payload)}};
+      });
+  Require(stale_worker.Submit(Request(9, 1, Priority::kVisibleMiss)) &&
+              stale_worker.Start(),
+          "the first generation must start preparing");
+  const auto start_deadline =
+      std::chrono::steady_clock::now() + std::chrono::seconds(3);
+  while (!generation_one_started.load() &&
+         std::chrono::steady_clock::now() < start_deadline) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(2));
+  }
+  Require(generation_one_started.load(), "generation one must reach the worker");
+  Require(stale_worker.Submit(Request(9, 2, Priority::kVisibleMiss, 2)),
+          "a newer generation must queue while the old one is in flight");
+  release_generation_one.store(true);
+  Require(WaitForPrepared(stale_worker, 1),
+          "the newest generation must become commit-ready");
+  uint64_t committed_generation = 0;
+  Require(stale_worker.DrainCommits(
+              1, 8, [&](nr::NativePreparedResource resource) {
+                committed_generation = resource.key.generation;
+              }) == 1 &&
+              committed_generation == 2,
+          "an obsolete worker result must never reach renderer commit");
+  stale_worker.Stop();
+  Require(stale_worker.metrics().stale_results >= 1,
+          "stale result rejection must be observable");
+
+  limits.state_count = 2;
+  nr::NativeResourceWorker state_worker(
+      limits, [](nr::NativeResourceWorkRequest request, std::stop_token) {
+        return std::optional<nr::NativePreparedResource>{{
+            request.key, request.priority, std::move(request.payload)}};
+      });
+  Require(state_worker.Start(), "the bounded state worker must start");
+  for (uint64_t identity = 20; identity < 23; ++identity) {
+    Require(state_worker.Submit(
+                Request(identity, 1, Priority::kStreamingPrewarm)),
+            "bounded state work must queue");
+    Require(WaitForPrepared(state_worker, 1),
+            "bounded state work must prepare");
+    Require(state_worker.DrainCommits(
+                1, 8, [](nr::NativePreparedResource) {}) == 1,
+            "bounded state work must commit");
+  }
+  state_worker.Stop();
+  Require(state_worker.metrics().state_evictions == 1,
+          "completed logical state must remain bounded by LRU eviction");
+
+  std::cout << "native renderer resource worker tests passed\n";
+  return EXIT_SUCCESS;
+}

--- a/tools/tests/test_native_renderer_resource_worker.py
+++ b/tools/tests/test_native_renderer_resource_worker.py
@@ -1,0 +1,72 @@
+import pathlib
+import unittest
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+
+
+class NativeRendererResourceWorkerContractTests(unittest.TestCase):
+    def test_preview_and_native_test_compile_worker(self):
+        cmake = (ROOT / "CMakeLists.txt").read_text(encoding="utf-8")
+        self.assertEqual(cmake.count("src/native_renderer/resource_worker.cpp"), 3)
+        self.assertIn("pinyon_shift_resource_worker_tests EXCLUDE_FROM_ALL", cmake)
+
+    def test_worker_is_bounded_priority_ordered_and_cpu_only(self):
+        header = (ROOT / "src/native_renderer/resource_worker.h").read_text(
+            encoding="utf-8"
+        )
+        source = (ROOT / "src/native_renderer/resource_worker.cpp").read_text(
+            encoding="utf-8"
+        )
+        for priority in (
+            "kVisibleMiss",
+            "kLoadingPrewarm",
+            "kStreamingPrewarm",
+            "kSpeculative",
+        ):
+            self.assertIn(priority, header)
+        self.assertIn("pending_count", header)
+        self.assertIn("pending_bytes", header)
+        self.assertIn("prepared_count", header)
+        self.assertIn("prepared_bytes", header)
+        self.assertIn("state_count", header)
+        self.assertIn("std::jthread", header)
+        self.assertIn("std::stop_token", header)
+        self.assertIn("DrainCommits", header)
+        self.assertIn("SelectWorstPendingLocked", source)
+        self.assertIn("state_evictions", source)
+        self.assertNotIn("ID3D12", header + source)
+        self.assertNotIn("VkDevice", header + source)
+
+    def test_stale_results_and_lifecycle_are_explicit(self):
+        header = (ROOT / "src/native_renderer/resource_worker.h").read_text(
+            encoding="utf-8"
+        )
+        source = (ROOT / "src/native_renderer/resource_worker.cpp").read_text(
+            encoding="utf-8"
+        )
+        native_test = (
+            ROOT / "tests/native_renderer/resource_worker_test.cpp"
+        ).read_text(encoding="utf-8")
+        self.assertIn("latest_generation_", header)
+        self.assertIn("committed_generation_", header)
+        self.assertIn("stale_results", header)
+        self.assertIn("request_stop", source)
+        self.assertIn("committed_generation == 2", native_test)
+        self.assertIn("active_workers", native_test)
+
+    def test_texture_observer_uses_cpu_prepare_and_bounded_render_commit(self):
+        bridge = (
+            ROOT / "src/native_renderer/texture_resource_bridge.cpp"
+        ).read_text(encoding="utf-8")
+        self.assertIn("PrepareTextureMetadata", bridge)
+        self.assertIn("prewarm_worker_.Submit", bridge)
+        self.assertIn("prewarm_worker_.DrainCommits", bridge)
+        self.assertIn("prewarm_worker_.Stop", bridge)
+        self.assertIn("64 * 1024", bridge)
+        self.assertIn('"prewarm_refusals"', bridge)
+        self.assertNotIn("SetDrawSuppression", bridge)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add a bounded, prioritized CPU resource-preparation worker queue
- serialize renderer-thread commits and reject stale generations
- exercise the queue with passive texture metadata prewarm while preserving Xenos authority
- document lifecycle, budgets, telemetry, and the qualified AppData run

## Safety

- Xenos draws, resolves, and presentation remain authoritative
- no draw or resolve suppression is introduced
- the integration remains default-off and failure falls back to Xenos

## Validation

- 150 Python tests passed
- five native resource semantic test executables passed
- clean preview build passed
- AppData session `20260828T222703Z-p43172` ran for 108.45 seconds
- 1,151 submissions prepared and committed, 0 stale results, 0 refusals
- median 31.057 FPS, 1% low 17.893 FPS, 59.972 Hz presentation
- no deadline miss, renderer failure, fatal, crash, or device-loss event
- normal process shutdown with zero pending/prepared/live resources