### PR TITLE
perf(native-renderer): bound resource cache residency

### DIFF
--- a/docs/native-renderer/RESOURCE_CACHE_BUDGETS.md
+++ b/docs/native-renderer/RESOURCE_CACHE_BUDGETS.md
@@ -1,0 +1,71 @@
+# Native resource cache budgets
+
+NR-03I adds finite admission and maintenance policies to the backend-neutral
+buffer and texture caches. The policy is independent of D3D12 and Vulkan and
+does not render, suppress, or replace any Xenos work.
+
+## Contract
+
+Every cache policy defines:
+
+- a maximum live byte count;
+- a maximum live resource count;
+- a maximum remembered-state count;
+- a maximum eviction batch;
+- a long normal-operation idle guard; and
+- a shorter explicit-pressure idle guard.
+
+An admission that would exceed the byte or count limit first retires the
+least-recently-used eligible resources, up to one eviction batch. If recent
+resources still occupy the budget, the new resource is refused. Texture
+refusal keeps the previous complete generation or the neutral fallback and
+becomes retryable after the pressure guard; it never silently installs an
+over-budget allocation.
+
+Retirement and destruction remain separate. Evicted resources leave lookup
+immediately, but their opaque backend handles are returned by `Collect` only
+after the final recorded submission completes. Live and retired bytes are
+reported separately so fence lag remains visible.
+
+Idle maintenance is also bounded to one batch. Normal maintenance uses the
+long guard, while an explicit memory-pressure call uses the shorter guard.
+Empty texture decode states are pruned with the same bounded policy, preventing
+streaming churn and permanent failures from growing remembered state without
+limit.
+
+## Current diagnostic integration
+
+The default-off D3D12 texture bridge configures a 128 MiB live texture budget,
+2,048 live resources, 4,096 remembered states, and 16 evictions per pass. It
+performs normal maintenance with a 1,200-submission idle guard and uses a
+120-submission guard when admission is under pressure. Runtime cache age is
+measured from the command processor's submission sequence rather than the much
+faster texture-observer call count.
+
+Periodic and shutdown diagnostics report live and retired bytes, budget
+evictions and refusals, remembered-state count, and state evictions. Xenos
+continues to own every draw, resolve, and presented frame.
+
+## Validation
+
+Native semantic tests cover:
+
+- strict byte and count admission;
+- deterministic least-recently-used selection;
+- one-batch amortized eviction;
+- distinct normal and pressure idle guards;
+- retryable texture budget refusal;
+- remembered-state pruning; and
+- fence-safe collection after budget retirement.
+
+Runtime qualification must confirm bounded live/state telemetry, zero retained
+references at shutdown, no device loss or renderer failure, and unchanged
+Xenos presentation.
+
+The AppData-backed qualification session `20260828T230532Z-p40180` ran for
+179.274 seconds with 5,681 samples. It held two live texture resources at
+131,072 bytes, recorded 32,148 cache hits and two misses, and reported zero
+cache-budget evictions, refusals, state evictions, and retired bytes. Shutdown
+released every live resource and retained reference with no renderer failure,
+fatal event, crash, or device loss. Median performance was 30.211 FPS, host
+presentation remained at 59.986 Hz, and no present deadline was missed.

--- a/src/native_renderer/buffer_cache.cpp
+++ b/src/native_renderer/buffer_cache.cpp
@@ -4,7 +4,11 @@
 
 namespace pinyon_shift::native_renderer {
 
-NativeBufferCache::NativeBufferCache(PhysicalResourceTracker& tracker) : tracker_(tracker) {}
+NativeBufferCache::NativeBufferCache(PhysicalResourceTracker& tracker,
+                                     NativeResourceCacheBudget budget)
+    : tracker_(tracker), budget_(budget) {
+  budget_.Normalize();
+}
 
 std::optional<BufferCacheAcquireResult> NativeBufferCache::Acquire(
     const BufferResourceKey& key, NativeBufferHandle candidate_handle, uint64_t allocation_bytes,
@@ -22,13 +26,27 @@ std::optional<BufferCacheAcquireResult> NativeBufferCache::Acquire(
     return BufferCacheAcquireResult{existing->second, true};
   }
 
+  ++metrics_.misses;
+  if (allocation_bytes > budget_.maximum_live_bytes) {
+    ++metrics_.budget_refusals;
+    return std::nullopt;
+  }
+  if (!HasCapacityLocked(allocation_bytes)) {
+    EvictLocked(frame, submission, budget_.pressure_idle_frames,
+                budget_.maximum_evictions_per_maintenance, true,
+                allocation_bytes);
+  }
+  if (!HasCapacityLocked(allocation_bytes)) {
+    ++metrics_.budget_refusals;
+    return std::nullopt;
+  }
+
   const uint64_t resource_id = next_resource_id_++;
   BufferCacheEntry entry{resource_id, key, candidate_handle, allocation_bytes, frame, submission};
   live_.emplace(key, entry);
   keys_by_id_.emplace(resource_id, key);
   const TrackedResourceId tracked{TrackedResourceClass::kBuffer, resource_id};
   tracker_.Track(tracked, std::span<const PhysicalRange>(&key.range, 1));
-  ++metrics_.misses;
   ++metrics_.live_count;
   metrics_.live_bytes += allocation_bytes;
   return BufferCacheAcquireResult{entry, false};
@@ -81,6 +99,17 @@ size_t NativeBufferCache::RetireAll(uint64_t current_submission) {
   return retired_count;
 }
 
+size_t NativeBufferCache::Trim(uint64_t frame, uint64_t current_submission,
+                               bool under_pressure) {
+  const std::scoped_lock lock(mutex_);
+  ++metrics_.maintenance_passes;
+  return EvictLocked(
+      frame, current_submission,
+      under_pressure ? budget_.pressure_idle_frames
+                     : budget_.normal_idle_frames,
+      budget_.maximum_evictions_per_maintenance, false, 0);
+}
+
 std::vector<RetiredBuffer> NativeBufferCache::Collect(uint64_t completed_submission) {
   const std::scoped_lock lock(mutex_);
   std::vector<RetiredBuffer> ready;
@@ -114,6 +143,45 @@ void NativeBufferCache::RetireLocked(LiveMap::iterator entry, uint64_t current_s
   metrics_.live_bytes -= resource.allocation_bytes;
   ++metrics_.retired_count;
   metrics_.retired_bytes += resource.allocation_bytes;
+}
+
+size_t NativeBufferCache::EvictLocked(uint64_t frame,
+                                      uint64_t current_submission,
+                                      uint64_t idle_frames,
+                                      size_t maximum_count,
+                                      bool only_until_capacity,
+                                      uint64_t incoming_bytes) {
+  size_t evicted = 0;
+  while (evicted < maximum_count && !live_.empty() &&
+         (!only_until_capacity || !HasCapacityLocked(incoming_bytes))) {
+    auto oldest = live_.end();
+    for (auto candidate = live_.begin(); candidate != live_.end();
+         ++candidate) {
+      if (!IsIdleFor(frame, candidate->second.last_use_frame, idle_frames)) {
+        continue;
+      }
+      if (oldest == live_.end() ||
+          candidate->second.last_use_frame < oldest->second.last_use_frame ||
+          (candidate->second.last_use_frame == oldest->second.last_use_frame &&
+           candidate->second.resource_id < oldest->second.resource_id)) {
+        oldest = candidate;
+      }
+    }
+    if (oldest == live_.end()) {
+      break;
+    }
+    RetireLocked(oldest, current_submission);
+    ++evicted;
+    ++metrics_.budget_evictions;
+  }
+  return evicted;
+}
+
+bool NativeBufferCache::HasCapacityLocked(uint64_t incoming_bytes) const {
+  return incoming_bytes <= budget_.maximum_live_bytes &&
+         metrics_.live_count < budget_.maximum_live_count &&
+         metrics_.live_bytes <=
+             budget_.maximum_live_bytes - incoming_bytes;
 }
 
 }  // namespace pinyon_shift::native_renderer

--- a/src/native_renderer/buffer_cache.h
+++ b/src/native_renderer/buffer_cache.h
@@ -7,6 +7,7 @@
 #include <unordered_map>
 #include <vector>
 
+#include "native_renderer/resource_cache_budget.h"
 #include "native_renderer/resource_identity.h"
 
 namespace pinyon_shift::native_renderer {
@@ -42,6 +43,9 @@ struct BufferCacheMetrics {
   uint64_t live_bytes = 0;
   uint64_t retired_count = 0;
   uint64_t retired_bytes = 0;
+  uint64_t budget_evictions = 0;
+  uint64_t budget_refusals = 0;
+  uint64_t maintenance_passes = 0;
 };
 
 // Owns buffer-cache identity and lifetime metadata. The backend creates and
@@ -49,7 +53,8 @@ struct BufferCacheMetrics {
 // handle is not returned for destruction until its final submission completes.
 class NativeBufferCache {
  public:
-  explicit NativeBufferCache(PhysicalResourceTracker& tracker);
+  explicit NativeBufferCache(PhysicalResourceTracker& tracker,
+                             NativeResourceCacheBudget budget = {});
 
   // A zero handle or allocation size is rejected. On a key hit the supplied
   // handle remains caller-owned and the existing allocation is returned.
@@ -68,6 +73,12 @@ class NativeBufferCache {
                            uint64_t current_submission);
   size_t RetireAll(uint64_t current_submission);
 
+  // Retires at most one configured batch of idle resources. Normal
+  // maintenance uses the long idle guard; an explicit pressure signal uses
+  // the shorter guard without weakening fence-safe destruction.
+  size_t Trim(uint64_t frame, uint64_t current_submission,
+              bool under_pressure = false);
+
   [[nodiscard]] std::vector<RetiredBuffer> Collect(uint64_t completed_submission);
   [[nodiscard]] BufferCacheMetrics metrics() const;
 
@@ -75,8 +86,13 @@ class NativeBufferCache {
   using LiveMap = std::unordered_map<BufferResourceKey, BufferCacheEntry, BufferResourceKeyHash>;
 
   void RetireLocked(LiveMap::iterator entry, uint64_t current_submission);
+  size_t EvictLocked(uint64_t frame, uint64_t current_submission,
+                     uint64_t idle_frames, size_t maximum_count,
+                     bool only_until_capacity, uint64_t incoming_bytes);
+  [[nodiscard]] bool HasCapacityLocked(uint64_t incoming_bytes) const;
 
   PhysicalResourceTracker& tracker_;
+  NativeResourceCacheBudget budget_;
   mutable std::mutex mutex_;
   LiveMap live_;
   std::unordered_map<uint64_t, BufferResourceKey> keys_by_id_;

--- a/src/native_renderer/resource_cache_budget.h
+++ b/src/native_renderer/resource_cache_budget.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+
+namespace pinyon_shift::native_renderer {
+
+// Cache limits are intentionally expressed in backend-neutral resource bytes
+// and logical entries. Retired allocations remain separately visible in cache
+// telemetry until their final GPU submission completes.
+struct NativeResourceCacheBudget {
+  uint64_t maximum_live_bytes = 256 * 1024 * 1024;
+  size_t maximum_live_count = 4096;
+  size_t maximum_state_count = 8192;
+  size_t maximum_evictions_per_maintenance = 16;
+  uint64_t normal_idle_frames = 600;
+  uint64_t pressure_idle_frames = 60;
+
+  void Normalize() {
+    maximum_live_bytes = std::max(maximum_live_bytes, uint64_t(1));
+    maximum_live_count = std::max(maximum_live_count, size_t(1));
+    maximum_state_count = std::max(maximum_state_count, maximum_live_count);
+    maximum_evictions_per_maintenance = std::max(maximum_evictions_per_maintenance, size_t(1));
+    normal_idle_frames = std::max(normal_idle_frames, uint64_t(1));
+    pressure_idle_frames = std::clamp(pressure_idle_frames, uint64_t(1), normal_idle_frames);
+  }
+};
+
+[[nodiscard]] inline bool IsIdleFor(uint64_t current_frame, uint64_t last_use_frame,
+                                    uint64_t idle_frames) {
+  return current_frame >= last_use_frame && current_frame - last_use_frame >= idle_frames;
+}
+
+}  // namespace pinyon_shift::native_renderer

--- a/src/native_renderer/texture_cache.cpp
+++ b/src/native_renderer/texture_cache.cpp
@@ -26,14 +26,16 @@ std::optional<NativeTextureDescriptor> NativeTextureDescriptor::FromFetchWords(
 }
 
 NativeTextureCache::NativeTextureCache(PhysicalResourceTracker& tracker,
-                                       TextureRetryPolicy retry_policy)
-    : tracker_(tracker), retry_policy_(retry_policy) {
+                                       TextureRetryPolicy retry_policy,
+                                       NativeResourceCacheBudget budget)
+    : tracker_(tracker), retry_policy_(retry_policy), budget_(budget) {
   retry_policy_.maximum_attempts =
       std::max(retry_policy_.maximum_attempts, uint32_t(1));
   retry_policy_.base_delay_frames =
       std::max(retry_policy_.base_delay_frames, uint32_t(1));
   retry_policy_.maximum_delay_frames = std::max(
       retry_policy_.maximum_delay_frames, retry_policy_.base_delay_frames);
+  budget_.Normalize();
 }
 
 TextureCacheRequest NativeTextureCache::Request(const TextureResourceKey& key,
@@ -45,9 +47,21 @@ TextureCacheRequest NativeTextureCache::Request(const TextureResourceKey& key,
   const std::scoped_lock lock(mutex_);
   Slot* slot = FindSlotLocked(key);
   if (!slot) {
-    slots_.push_back({key.base, key.mips, key.fetch_signature});
+    if (slots_.size() >= budget_.maximum_state_count) {
+      PruneStateLocked(frame, budget_.pressure_idle_frames,
+                       budget_.maximum_evictions_per_maintenance);
+    }
+    if (slots_.size() >= budget_.maximum_state_count) {
+      ++metrics_.budget_refusals;
+      return {TextureRequestState::kRetryPending};
+    }
+    slots_.push_back(
+        {key.base, key.mips, key.fetch_signature, std::nullopt, std::nullopt,
+         0, 0, 0, frame});
     slot = &slots_.back();
+    metrics_.state_count = slots_.size();
   }
+  slot->last_request_frame = std::max(slot->last_request_frame, frame);
   if (slot->live && slot->live->key == key) {
     slot->live->last_use_frame = std::max(slot->live->last_use_frame, frame);
     slot->live->last_use_submission =
@@ -122,6 +136,24 @@ bool NativeTextureCache::Complete(uint64_t decode_ticket,
     return true;
   }
 
+  if (allocation_bytes > budget_.maximum_live_bytes) {
+    slot.decode_ticket = 0;
+    slot.next_retry_frame = frame + budget_.pressure_idle_frames;
+    ++metrics_.budget_refusals;
+    return false;
+  }
+  if (!HasCapacityLocked(&slot, allocation_bytes)) {
+    EvictLiveLocked(&slot, frame, submission, budget_.pressure_idle_frames,
+                    budget_.maximum_evictions_per_maintenance, true,
+                    allocation_bytes);
+  }
+  if (!HasCapacityLocked(&slot, allocation_bytes)) {
+    slot.decode_ticket = 0;
+    slot.next_retry_frame = frame + budget_.pressure_idle_frames;
+    ++metrics_.budget_refusals;
+    return false;
+  }
+
   if (slot.live) {
     RetireLiveLocked(slot, submission);
   }
@@ -188,6 +220,22 @@ size_t NativeTextureCache::RetireAll(uint64_t current_submission) {
   return count;
 }
 
+size_t NativeTextureCache::Trim(uint64_t frame,
+                                uint64_t current_submission,
+                                bool under_pressure) {
+  const std::scoped_lock lock(mutex_);
+  ++metrics_.maintenance_passes;
+  const uint64_t idle_frames =
+      under_pressure ? budget_.pressure_idle_frames
+                     : budget_.normal_idle_frames;
+  const size_t evicted = EvictLiveLocked(
+      nullptr, frame, current_submission, idle_frames,
+      budget_.maximum_evictions_per_maintenance, false, 0);
+  PruneStateLocked(frame, idle_frames,
+                   budget_.maximum_evictions_per_maintenance);
+  return evicted;
+}
+
 std::vector<RetiredTexture> NativeTextureCache::Collect(
     uint64_t completed_submission) {
   const std::scoped_lock lock(mutex_);
@@ -234,6 +282,81 @@ void NativeTextureCache::RetireLiveLocked(Slot& slot,
   metrics_.live_bytes -= texture.allocation_bytes;
   ++metrics_.retired_count;
   metrics_.retired_bytes += texture.allocation_bytes;
+}
+
+size_t NativeTextureCache::EvictLiveLocked(
+    Slot* protected_slot, uint64_t frame, uint64_t current_submission,
+    uint64_t idle_frames, size_t maximum_count, bool only_until_capacity,
+    uint64_t incoming_bytes) {
+  size_t evicted = 0;
+  while (evicted < maximum_count &&
+         (!only_until_capacity ||
+          !HasCapacityLocked(protected_slot, incoming_bytes))) {
+    Slot* oldest = nullptr;
+    for (Slot& candidate : slots_) {
+      if (&candidate == protected_slot || !candidate.live ||
+          !IsIdleFor(frame, candidate.live->last_use_frame, idle_frames)) {
+        continue;
+      }
+      if (!oldest || candidate.live->last_use_frame <
+                         oldest->live->last_use_frame ||
+          (candidate.live->last_use_frame == oldest->live->last_use_frame &&
+           candidate.live->resource_id < oldest->live->resource_id)) {
+        oldest = &candidate;
+      }
+    }
+    if (!oldest) {
+      break;
+    }
+    RetireLiveLocked(*oldest, current_submission);
+    ++evicted;
+    ++metrics_.budget_evictions;
+  }
+  return evicted;
+}
+
+size_t NativeTextureCache::PruneStateLocked(uint64_t frame,
+                                            uint64_t idle_frames,
+                                            size_t maximum_count) {
+  size_t evicted = 0;
+  while (evicted < maximum_count) {
+    auto oldest = slots_.end();
+    for (auto candidate = slots_.begin(); candidate != slots_.end();
+         ++candidate) {
+      if (candidate->live || candidate->decode_in_flight ||
+          !IsIdleFor(frame, candidate->last_request_frame, idle_frames)) {
+        continue;
+      }
+      if (oldest == slots_.end() ||
+          candidate->last_request_frame < oldest->last_request_frame) {
+        oldest = candidate;
+      }
+    }
+    if (oldest == slots_.end()) {
+      break;
+    }
+    slots_.erase(oldest);
+    ++evicted;
+    ++metrics_.state_evictions;
+  }
+  metrics_.state_count = slots_.size();
+  return evicted;
+}
+
+bool NativeTextureCache::HasCapacityLocked(const Slot* replacing,
+                                           uint64_t incoming_bytes) const {
+  uint64_t replaced_bytes = 0;
+  uint64_t replaced_count = 0;
+  if (replacing && replacing->live) {
+    replaced_bytes = replacing->live->allocation_bytes;
+    replaced_count = 1;
+  }
+  if (incoming_bytes > budget_.maximum_live_bytes ||
+      metrics_.live_count - replaced_count >= budget_.maximum_live_count) {
+    return false;
+  }
+  return metrics_.live_bytes - replaced_bytes <=
+         budget_.maximum_live_bytes - incoming_bytes;
 }
 
 uint64_t NativeTextureCache::RetryDelay(uint32_t attempt) const {

--- a/src/native_renderer/texture_cache.h
+++ b/src/native_renderer/texture_cache.h
@@ -7,6 +7,7 @@
 #include <span>
 #include <vector>
 
+#include "native_renderer/resource_cache_budget.h"
 #include "native_renderer/resource_identity.h"
 
 namespace pinyon_shift::native_renderer {
@@ -79,6 +80,11 @@ struct TextureCacheMetrics {
   uint64_t live_bytes = 0;
   uint64_t retired_count = 0;
   uint64_t retired_bytes = 0;
+  uint64_t state_count = 0;
+  uint64_t budget_evictions = 0;
+  uint64_t budget_refusals = 0;
+  uint64_t state_evictions = 0;
+  uint64_t maintenance_passes = 0;
 };
 
 // Backend-neutral texture decode and lifetime state. Decode work is requested
@@ -88,7 +94,8 @@ struct TextureCacheMetrics {
 class NativeTextureCache {
  public:
   explicit NativeTextureCache(PhysicalResourceTracker& tracker,
-                              TextureRetryPolicy retry_policy = {});
+                              TextureRetryPolicy retry_policy = {},
+                              NativeResourceCacheBudget budget = {});
 
   [[nodiscard]] TextureCacheRequest Request(const TextureResourceKey& key,
                                             uint64_t frame,
@@ -101,6 +108,9 @@ class NativeTextureCache {
       std::span<const ResourceInvalidation> invalidations,
       const PhysicalRange& written_range, uint64_t current_submission);
   size_t RetireAll(uint64_t current_submission);
+
+  size_t Trim(uint64_t frame, uint64_t current_submission,
+              bool under_pressure = false);
 
   [[nodiscard]] std::vector<RetiredTexture> Collect(
       uint64_t completed_submission);
@@ -125,16 +135,26 @@ class NativeTextureCache {
     uint64_t decode_ticket = 0;
     uint64_t next_retry_frame = 0;
     uint32_t attempt = 0;
+    uint64_t last_request_frame = 0;
     bool decode_in_flight = false;
     bool permanent_failure = false;
   };
 
   [[nodiscard]] Slot* FindSlotLocked(const TextureResourceKey& key);
   void RetireLiveLocked(Slot& slot, uint64_t current_submission);
+  size_t EvictLiveLocked(Slot* protected_slot, uint64_t frame,
+                         uint64_t current_submission, uint64_t idle_frames,
+                         size_t maximum_count, bool only_until_capacity,
+                         uint64_t incoming_bytes);
+  size_t PruneStateLocked(uint64_t frame, uint64_t idle_frames,
+                          size_t maximum_count);
+  [[nodiscard]] bool HasCapacityLocked(const Slot* replacing,
+                                       uint64_t incoming_bytes) const;
   [[nodiscard]] uint64_t RetryDelay(uint32_t attempt) const;
 
   PhysicalResourceTracker& tracker_;
   TextureRetryPolicy retry_policy_;
+  NativeResourceCacheBudget budget_;
   mutable std::mutex mutex_;
   std::vector<Slot> slots_;
   std::vector<RetiredTexture> retired_;

--- a/src/native_renderer/texture_resource_bridge.cpp
+++ b/src/native_renderer/texture_resource_bridge.cpp
@@ -41,6 +41,9 @@ constexpr size_t kResolveRecordLimit = 4096;
 constexpr size_t kProducerResourceLimit = 64;
 constexpr uint64_t kProducerByteLimit = 128 * 1024 * 1024;
 constexpr uint64_t kProducerStaleSubmissions = 600;
+constexpr uint64_t kTextureCacheByteLimit = 128 * 1024 * 1024;
+constexpr size_t kTextureCacheResourceLimit = 2048;
+constexpr size_t kTextureCacheStateLimit = 4096;
 
 uint64_t HashFetchWords(const uint32_t words[6]) {
   uint64_t hash = UINT64_C(14695981039346656037);
@@ -175,6 +178,9 @@ class TextureResourceBridge {
     if (resource_count_ && (!last_summary_submission_ ||
                             observation.current_submission >= last_summary_submission_ + 300)) {
       last_summary_submission_ = observation.current_submission;
+      cache_.Trim(observation.current_submission,
+                  observation.current_submission, false);
+      ReleaseCollected(cache_.Collect(observation.completed_submission));
       const auto metrics = cache_.metrics();
       const auto target_metrics = render_target_bridge_.metrics();
       const auto worker_metrics = prewarm_worker_.metrics();
@@ -185,8 +191,16 @@ class TextureResourceBridge {
            {"live", std::to_string(metrics.live_count)},
            {"live_bytes", std::to_string(metrics.live_bytes)},
            {"retired", std::to_string(metrics.retired_count)},
+           {"retired_bytes", std::to_string(metrics.retired_bytes)},
            {"hits", std::to_string(metrics.hits)},
            {"misses", std::to_string(metrics.misses)},
+           {"cache_budget_evictions",
+            std::to_string(metrics.budget_evictions)},
+           {"cache_budget_refusals",
+            std::to_string(metrics.budget_refusals)},
+           {"cache_state", std::to_string(metrics.state_count)},
+           {"cache_state_evictions",
+            std::to_string(metrics.state_evictions)},
            {"resolve_observations", std::to_string(resolve_observation_count_)},
            {"producer_publications",
             std::to_string(target_metrics.resolve_publications)},
@@ -239,6 +253,13 @@ class TextureResourceBridge {
          {"prewarm_pending", std::to_string(worker_metrics.pending_count)},
          {"prewarm_prepared", std::to_string(worker_metrics.prepared_count)},
          {"live", std::to_string(metrics.live_count)},
+         {"live_bytes", std::to_string(metrics.live_bytes)},
+         {"retired", std::to_string(metrics.retired_count)},
+         {"retired_bytes", std::to_string(metrics.retired_bytes)},
+         {"cache_budget_evictions",
+          std::to_string(metrics.budget_evictions)},
+         {"cache_budget_refusals",
+          std::to_string(metrics.budget_refusals)},
          {"retained_refs", std::to_string(RetainedReferenceCount())},
          {"xenos_draw", "preserved"}});
   }
@@ -319,18 +340,28 @@ class TextureResourceBridge {
     const uint64_t handle = reinterpret_cast<uint64_t>(resource.resource);
     const pinyon_shift::native_renderer::TextureResourceKey key{
         *base, mips, HashFetchWords(resource.fetch_dwords), {0, handle}};
-    auto request = cache_.Request(key, observation_count_, observation.current_submission);
+    auto request = cache_.Request(key, observation.current_submission,
+                                  observation.current_submission);
     if (request.state != pinyon_shift::native_renderer::TextureRequestState::kDecodeRequired) {
       return;
     }
 
     resource.retain(resource.resource);
+    const uint64_t refusals_before = cache_.metrics().budget_refusals;
     const bool completed = cache_.Complete(
         request.decode_ticket, pinyon_shift::native_renderer::TextureDecodeResult::kReady, handle,
-        resource.host_allocation_bytes, observation_count_, observation.current_submission);
-    const auto confirmed = cache_.Request(key, observation_count_, observation.current_submission);
-    if (!completed ||
-        confirmed.state != pinyon_shift::native_renderer::TextureRequestState::kReady ||
+        resource.host_allocation_bytes, observation.current_submission,
+        observation.current_submission);
+    if (!completed) {
+      resource.release(resource.resource);
+      if (cache_.metrics().budget_refusals == refusals_before) {
+        RecordFailureOnce("cache_commit_failed");
+      }
+      return;
+    }
+    const auto confirmed = cache_.Request(key, observation.current_submission,
+                                          observation.current_submission);
+    if (confirmed.state != pinyon_shift::native_renderer::TextureRequestState::kReady ||
         confirmed.sampled_handle != handle) {
       resource.release(resource.resource);
       RecordFailureOnce("cache_commit_failed");
@@ -581,7 +612,14 @@ class TextureResourceBridge {
 
   std::mutex mutex_;
   pinyon_shift::native_renderer::PhysicalResourceTracker tracker_;
-  pinyon_shift::native_renderer::NativeTextureCache cache_{tracker_};
+  pinyon_shift::native_renderer::NativeTextureCache cache_{
+      tracker_, {},
+      {.maximum_live_bytes = kTextureCacheByteLimit,
+       .maximum_live_count = kTextureCacheResourceLimit,
+       .maximum_state_count = kTextureCacheStateLimit,
+       .maximum_evictions_per_maintenance = 16,
+       .normal_idle_frames = 1200,
+       .pressure_idle_frames = 120}};
   pinyon_shift::native_renderer::NativeResourceWorker prewarm_worker_;
   pinyon_shift::native_renderer::NativeRenderTargetBridge
       render_target_bridge_;

--- a/tests/native_renderer/buffer_cache_test.cpp
+++ b/tests/native_renderer/buffer_cache_test.cpp
@@ -68,6 +68,56 @@ int main() {
               !metrics.retired_count && !metrics.retired_bytes,
           "lifetime telemetry must return to zero after collection");
 
+  nr::PhysicalResourceTracker budget_tracker;
+  nr::NativeBufferCache budget_cache(
+      budget_tracker,
+      {.maximum_live_bytes = 8192,
+       .maximum_live_count = 2,
+       .maximum_state_count = 2,
+       .maximum_evictions_per_maintenance = 1,
+       .normal_idle_frames = 10,
+       .pressure_idle_frames = 3});
+  const auto budget_a =
+      MakeKey(budget_tracker, 0x00110000, nr::BufferResourceClass::kVertex);
+  const auto budget_b =
+      MakeKey(budget_tracker, 0x00112000, nr::BufferResourceClass::kVertex);
+  const auto budget_c =
+      MakeKey(budget_tracker, 0x00114000, nr::BufferResourceClass::kIndex);
+  Require(budget_cache.Acquire(budget_a, 601, 4096, 1, 1).has_value() &&
+              budget_cache.Acquire(budget_b, 602, 4096, 2, 2).has_value(),
+          "resources within byte and count limits must be admitted");
+  Require(budget_cache.Acquire(budget_c, 603, 4096, 5, 3).has_value(),
+          "pressure admission must evict one sufficiently idle resource");
+  Require(!budget_cache.Find(budget_a, 5, 3) &&
+              budget_cache.Find(budget_b, 5, 3).has_value(),
+          "pressure eviction must select the least-recently-used resource");
+  Require(budget_cache.Collect(2).empty() &&
+              budget_cache.Collect(3).size() == 1,
+          "budget eviction must remain fence-safe");
+  Require(budget_cache.Trim(12, 4, false) == 0,
+          "normal maintenance must preserve resources inside the long guard");
+  Require(budget_cache.Trim(15, 5, false) == 1,
+          "normal maintenance must amortize idle eviction to one batch");
+
+  nr::PhysicalResourceTracker refusal_tracker;
+  nr::NativeBufferCache refusal_cache(
+      refusal_tracker,
+      {.maximum_live_bytes = 4096,
+       .maximum_live_count = 1,
+       .maximum_state_count = 1,
+       .maximum_evictions_per_maintenance = 1,
+       .normal_idle_frames = 10,
+       .pressure_idle_frames = 5});
+  const auto recent_a =
+      MakeKey(refusal_tracker, 0x00120000, nr::BufferResourceClass::kVertex);
+  const auto recent_b =
+      MakeKey(refusal_tracker, 0x00122000, nr::BufferResourceClass::kVertex);
+  Require(refusal_cache.Acquire(recent_a, 701, 4096, 10, 10).has_value() &&
+              !refusal_cache.Acquire(recent_b, 702, 4096, 11, 11),
+          "a recent resource must not be evicted merely to exceed the budget");
+  Require(refusal_cache.metrics().budget_refusals == 1,
+          "strict admission refusal must be observable");
+
   std::cout << "native renderer buffer cache tests passed\n";
   return EXIT_SUCCESS;
 }

--- a/tests/native_renderer/texture_cache_test.cpp
+++ b/tests/native_renderer/texture_cache_test.cpp
@@ -15,12 +15,14 @@ void Require(bool condition, const char* message) {
   }
 }
 
-nr::TextureResourceKey MakeKey(nr::PhysicalResourceTracker& tracker) {
+nr::TextureResourceKey MakeKey(nr::PhysicalResourceTracker& tracker,
+                               uint32_t address = 0x94649000,
+                               uint64_t signature =
+                                   UINT64_C(0x747837906D0BF484)) {
   const auto base =
-      nr::PhysicalRange::FromGraphicsAddress(0x94649000, 32768);
+      nr::PhysicalRange::FromGraphicsAddress(address, 32768);
   Require(base.has_value(), "selected DXN range must be valid");
-  return {*base, std::nullopt, UINT64_C(0x747837906D0BF484),
-          tracker.Capture(*base)};
+  return {*base, std::nullopt, signature, tracker.Capture(*base)};
 }
 
 }  // namespace
@@ -130,6 +132,51 @@ int main() {
               !metrics.live_bytes && !metrics.retired_count &&
               !metrics.retired_bytes,
           "texture cache telemetry must describe the complete lifecycle");
+
+  nr::PhysicalResourceTracker budget_tracker;
+  nr::NativeTextureCache budget_cache(
+      budget_tracker, {},
+      {.maximum_live_bytes = 65536,
+       .maximum_live_count = 1,
+       .maximum_state_count = 2,
+       .maximum_evictions_per_maintenance = 1,
+       .normal_idle_frames = 10,
+       .pressure_idle_frames = 3});
+  const auto budget_a = MakeKey(budget_tracker, 0x00130000, 0xA1);
+  const auto budget_b = MakeKey(budget_tracker, 0x00140000, 0xB2);
+  const auto budget_c = MakeKey(budget_tracker, 0x00150000, 0xC3);
+  const auto request_a = budget_cache.Request(budget_a, 1, 1);
+  Require(budget_cache.Complete(request_a.decode_ticket,
+                                nr::TextureDecodeResult::kReady, 601,
+                                65536, 1, 1),
+          "the first texture must fit the configured budget");
+  const auto request_b = budget_cache.Request(budget_b, 5, 2);
+  Require(budget_cache.Complete(request_b.decode_ticket,
+                                nr::TextureDecodeResult::kReady, 602,
+                                65536, 5, 2),
+          "pressure admission must replace an idle texture");
+  Require(budget_cache.Collect(1).empty() &&
+              budget_cache.Collect(2).size() == 1,
+          "evicted texture destruction must wait for its final submission");
+  const auto request_c = budget_cache.Request(budget_c, 6, 3);
+  Require(request_c.state == nr::TextureRequestState::kDecodeRequired &&
+              !budget_cache.Complete(request_c.decode_ticket,
+                                     nr::TextureDecodeResult::kReady, 603,
+                                     65536, 6, 3),
+          "a recent live texture must force strict budget refusal");
+  Require(budget_cache.Request(budget_c, 7, 4).state ==
+              nr::TextureRequestState::kRetryPending,
+          "budget refusal must retry later instead of becoming permanent");
+  Require(budget_cache.Trim(8, 4, false) == 0,
+          "normal maintenance must keep textures within the long idle guard");
+  Require(budget_cache.Trim(9, 5, true) == 1,
+          "pressure maintenance must use the shorter idle guard");
+  const auto budget_metrics = budget_cache.metrics();
+  Require(budget_metrics.budget_evictions == 2 &&
+              budget_metrics.budget_refusals == 1 &&
+              budget_metrics.state_evictions == 2 &&
+              budget_metrics.state_count <= 2,
+          "texture budget, state cap, and eviction telemetry must be bounded");
 
   std::cout << "native renderer texture cache tests passed\n";
   return EXIT_SUCCESS;

--- a/tools/tests/test_native_renderer_buffer_cache.py
+++ b/tools/tests/test_native_renderer_buffer_cache.py
@@ -40,6 +40,26 @@ class NativeRendererBufferCacheContractTests(unittest.TestCase):
         ):
             self.assertIn(f"uint64_t {field}", header)
 
+    def test_cache_enforces_bounded_lru_maintenance(self):
+        header = (ROOT / "src/native_renderer/buffer_cache.h").read_text(
+            encoding="utf-8"
+        )
+        source = (ROOT / "src/native_renderer/buffer_cache.cpp").read_text(
+            encoding="utf-8"
+        )
+        budget = (
+            ROOT / "src/native_renderer/resource_cache_budget.h"
+        ).read_text(encoding="utf-8")
+        self.assertIn("maximum_live_bytes", budget)
+        self.assertIn("maximum_live_count", budget)
+        self.assertIn("maximum_evictions_per_maintenance", budget)
+        self.assertIn("normal_idle_frames", budget)
+        self.assertIn("pressure_idle_frames", budget)
+        self.assertIn("size_t Trim", header)
+        self.assertIn("HasCapacityLocked", source)
+        self.assertIn("budget_evictions", header)
+        self.assertIn("budget_refusals", header)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tools/tests/test_native_renderer_texture_cache.py
+++ b/tools/tests/test_native_renderer_texture_cache.py
@@ -54,6 +54,36 @@ class NativeRendererTextureCacheContractTests(unittest.TestCase):
         self.assertNotIn("delete ", source)
         self.assertNotIn("Release()", source)
 
+    def test_cache_bounds_resources_and_remembered_state(self):
+        header = (ROOT / "src/native_renderer/texture_cache.h").read_text(
+            encoding="utf-8"
+        )
+        source = (ROOT / "src/native_renderer/texture_cache.cpp").read_text(
+            encoding="utf-8"
+        )
+        bridge = (
+            ROOT / "src/native_renderer/texture_resource_bridge.cpp"
+        ).read_text(encoding="utf-8")
+        for token in (
+            "maximum_live_bytes",
+            "maximum_live_count",
+            "maximum_state_count",
+            "maximum_evictions_per_maintenance",
+            "normal_idle_frames",
+            "pressure_idle_frames",
+        ):
+            self.assertIn(token, bridge)
+        self.assertIn("size_t Trim", header)
+        self.assertIn("PruneStateLocked", source)
+        self.assertIn("cache_budget_evictions", bridge)
+        self.assertIn("cache_budget_refusals", bridge)
+        self.assertIn(
+            "cache_.Trim(observation.current_submission,", bridge
+        )
+        self.assertNotIn(
+            "cache_.Request(key, observation_count_", bridge
+        )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- add finite byte, resource-count, and remembered-state budgets to native buffer and texture caches
- retire deterministic idle LRU entries in bounded batches while preserving fence-safe destruction
- expose residency, eviction, refusal, and state telemetry in the default-off texture bridge
- use command submissions as the runtime cache age clock

## Safety
- Xenos remains authoritative for every draw, resolve, and presented frame
- budget refusal remains retryable and preserves the previous complete generation or neutral fallback
- the AppData save was used in place and was not modified

## Validation
- 152 Python contract tests
- five native semantic test executables
- clean preview build plus incremental post-fix build
- AppData session 20260828T230532Z-p40180: 30.211 median FPS, 59.986 Hz host presentation, zero present deadline misses, 99.987% texture-cache hits, zero cache evictions/refusals/state evictions, clean shutdown