### PR TITLE
fix(native-renderer): reject stale retained frames

### DIFF
--- a/docs/native-renderer/FRAME_PUBLICATION.md
+++ b/docs/native-renderer/FRAME_PUBLICATION.md
@@ -1,0 +1,55 @@
+# Native retained-frame publication
+
+NR-04A starts with an immutable freshness contract for the existing retained
+authentic-pass preview. It does not expand native visual coverage and does not
+suppress any Xenos work.
+
+Each isolated replay request now carries the guest frame sequence captured with
+its prepared draw. The D3D12 render-target cache publishes that sequence only
+after the private replay commands have been recorded and the original guest
+targets have been restored. The guest-output callback receives both the current
+swap frame and the last successfully published retained-pass frame.
+
+The title and backend independently require an exact frame match before the
+retained target can be sampled. If the pass was not reproduced during the
+current guest frame, the callback records a paced `retained_pass_stale` or
+`retained_pass_unavailable` diagnostic and returns `false` without touching
+guest output. ReXGlue then presents the complete Xenos frame. This prevents a
+loading screen, map transition, menu, or unsupported scene from displaying a
+retained target produced by an older frame.
+
+The frame stamp resets during backend shutdown. Unsupported targets, missing
+callbacks, allocation failures, and all early-return paths retain the existing
+Xenos fallback. No draw, resolve, query, fence, or guest-visible side effect is
+suppressed.
+
+## Qualification gates
+
+- Automated contracts must prove that both the title and D3D12 backend enforce
+  the exact-frame comparison.
+- The complete patch stack must apply from the pinned ReXGlue revision.
+- A clean preview build must pass.
+- An AppData-backed retained-pass run must show matching `frame` and
+  `retained_frame` values whenever native output is claimed.
+- Frames without a current retained pass must report the stale or unavailable
+  reason and continue through Xenos.
+- Shutdown must remain normal, with no renderer failure, device loss, fatal
+  event, or crash.
+
+## Qualification result
+
+Clean-build AppData-backed session `20260828T233352Z-p39060` remained on the
+complete Xenos frame through startup, the title flow, and the period before the
+qualified pass became available. It then displayed the amber-framed authentic
+native crop continuously in the loaded scene.
+
+The session claimed 2,571 callbacks. All nine paced claimed-frame markers had
+identical `frame` and `retained_frame` values. Seventeen pre-publication markers
+reported `retained_pass_unavailable`, `fallback=xenos`, and
+`suppression=disabled`. Every claimed marker reported `xenos_draw=preserved`;
+there were no native-output failures, device-removal events, validation errors,
+fatal events, or crashes, and shutdown was normal.
+
+The 7,781-sample performance capture measured 30.366 median FPS, 19.392
+one-percent-low FPS, 59.988 Hz presentation cadence, and zero presentation
+deadline misses.

--- a/docs/native-renderer/GUEST_OUTPUT_OWNERSHIP.md
+++ b/docs/native-renderer/GUEST_OUTPUT_OWNERSHIP.md
@@ -143,3 +143,8 @@ a normal shutdown. Its 4,689 measured frames had 31.033 median FPS, 19.161
 one-percent-low FPS, 59.991 Hz host presentation cadence, and zero presentation
 deadline misses. Every original Xenos draw remained enabled and suppression
 remained disabled for the entire qualification.
+
+NR-04A subsequently tightens this preview with the exact-frame publication
+contract documented in `FRAME_PUBLICATION.md`. A retained pass may now reach
+guest output only when it was reproduced in the same guest frame as the active
+swap; stale targets yield immediately to Xenos.

--- a/patches/rexglue/0067-d3d12-retained-pass-frame-freshness.patch
+++ b/patches/rexglue/0067-d3d12-retained-pass-frame-freshness.patch
@@ -1,0 +1,150 @@
+diff --git a/include/rex/graphics/d3d12/render_target_cache.h b/include/rex/graphics/d3d12/render_target_cache.h
+index 7f4bab8..afe69ac 100644
+--- a/include/rex/graphics/d3d12/render_target_cache.h
++++ b/include/rex/graphics/d3d12/render_target_cache.h
+@@ -104,7 +104,7 @@ class D3D12RenderTargetCache final : public RenderTargetCache {
+   system::GraphicsIsolatedDrawReadbackStatus QueueIsolatedReplayReadback(
+       system::GraphicsIsolatedDrawReadbackCompletion completion,
+       uint32_t* failure_detail_out);
+-  void EndIsolatedReplayTarget();
++  void EndIsolatedReplayTarget(uint64_t frame_sequence);
+ 
+   struct IsolatedReplayPreviewSource {
+     ID3D12Resource* resource = nullptr;
+@@ -112,11 +112,16 @@ class D3D12RenderTargetCache final : public RenderTargetCache {
+     DXGI_FORMAT format = DXGI_FORMAT_UNKNOWN;
+     uint32_t width = 0;
+     uint32_t height = 0;
++    uint64_t frame_sequence = 0;
+     bool resolved = false;
+   };
+-  bool BeginIsolatedReplayPreview(IsolatedReplayPreviewSource& source_out);
++  bool BeginIsolatedReplayPreview(uint64_t required_frame_sequence,
++                                  IsolatedReplayPreviewSource& source_out);
+   void EndIsolatedReplayPreview(
+       const IsolatedReplayPreviewSource& source);
++  uint64_t GetIsolatedReplayPreviewFrameSequence() const {
++    return isolated_replay_preview_frame_sequence_;
++  }
+ 
+   DXGI_FORMAT GetColorResourceDXGIFormat(xenos::ColorRenderTargetFormat format) const;
+   DXGI_FORMAT GetColorDrawDXGIFormat(xenos::ColorRenderTargetFormat format) const;
+@@ -694,6 +699,7 @@ class D3D12RenderTargetCache final : public RenderTargetCache {
+       isolated_replay_preview_resolved_target_;
+   D3D12_RESOURCE_STATES isolated_replay_preview_resolved_target_state_ =
+       D3D12_RESOURCE_STATE_RESOLVE_DEST;
++  uint64_t isolated_replay_preview_frame_sequence_ = 0;
+   struct IsolatedReplayReadback {
+     Microsoft::WRL::ComPtr<ID3D12Resource> buffer;
+     Microsoft::WRL::ComPtr<ID3D12Resource> resolved_target;
+diff --git a/include/rex/system/interfaces/graphics.h b/include/rex/system/interfaces/graphics.h
+index 08f8947..fab4bc0 100644
+--- a/include/rex/system/interfaces/graphics.h
++++ b/include/rex/system/interfaces/graphics.h
+@@ -57,6 +57,8 @@ struct NativeGuestOutputRenderContext {
+   void* command_context = nullptr;
+   void* guest_output = nullptr;
+   uint64_t submission = 0;
++  uint64_t frame_sequence = 0;
++  uint64_t retained_pass_frame_sequence = 0;
+   NativeGuestOutputClearColor clear_color = nullptr;
+   NativeGuestOutputDrawDiagnosticTriangle draw_diagnostic_triangle = nullptr;
+   NativeGuestOutputDrawRetainedPass draw_retained_pass = nullptr;
+@@ -382,6 +384,7 @@ struct GraphicsIsolatedDrawRequest {
+   // Rebind the retained private target without copying the guest target. This
+   // is valid only for the immediately following draw of an isolated pass.
+   bool reuse_target = false;
++  uint64_t frame_sequence = 0;
+   GraphicsIsolatedDrawCompletion completion = nullptr;
+   GraphicsIsolatedDrawReadbackCompletion readback_completion = nullptr;
+ };
+diff --git a/src/graphics/d3d12/command_processor.cpp b/src/graphics/d3d12/command_processor.cpp
+index de037c2..ab7d748 100644
+--- a/src/graphics/d3d12/command_processor.cpp
++++ b/src/graphics/d3d12/command_processor.cpp
+@@ -2277,7 +2277,8 @@ bool D3D12CommandProcessor::DrawNativeGuestOutputRetainedPass(
+     return false;
+   }
+   D3D12RenderTargetCache::IsolatedReplayPreviewSource preview_source;
+-  if (!render_target_cache_->BeginIsolatedReplayPreview(preview_source)) {
++  if (!render_target_cache_->BeginIsolatedReplayPreview(
++          observation_frame_sequence_, preview_source)) {
+     return false;
+   }
+ 
+@@ -2718,6 +2719,9 @@ void D3D12CommandProcessor::IssueSwap(uint32_t frontbuffer_ptr, uint32_t frontbu
+           native_context.command_context = this;
+           native_context.guest_output = guest_output_resource;
+           native_context.submission = submission_current_;
++          native_context.frame_sequence = observation_frame_sequence_;
++          native_context.retained_pass_frame_sequence =
++              render_target_cache_->GetIsolatedReplayPreviewFrameSequence();
+           native_context.clear_color = &ClearNativeGuestOutput;
+           native_context.draw_diagnostic_triangle =
+               &InvokeNativeGuestOutputDiagnosticTriangle;
+@@ -3195,7 +3199,8 @@ bool D3D12CommandProcessor::IssueDraw(xenos::PrimitiveType primitive_type, uint3
+             isolated_draw_request.readback_completion(readback_result);
+           }
+         }
+-        render_target_cache_->EndIsolatedReplayTarget();
++        render_target_cache_->EndIsolatedReplayTarget(
++            isolated_draw_request.frame_sequence);
+         isolated_result.status =
+             system::GraphicsIsolatedDrawStatus::kRecorded;
+       } else {
+@@ -3312,7 +3317,8 @@ bool D3D12CommandProcessor::IssueDraw(xenos::PrimitiveType primitive_type, uint3
+             isolated_draw_request.readback_completion(readback_result);
+           }
+         }
+-        render_target_cache_->EndIsolatedReplayTarget();
++        render_target_cache_->EndIsolatedReplayTarget(
++            isolated_draw_request.frame_sequence);
+         isolated_result.status =
+             system::GraphicsIsolatedDrawStatus::kRecorded;
+       } else {
+diff --git a/src/graphics/d3d12/render_target_cache.cpp b/src/graphics/d3d12/render_target_cache.cpp
+index 3423f8f..bf2472a 100644
+--- a/src/graphics/d3d12/render_target_cache.cpp
++++ b/src/graphics/d3d12/render_target_cache.cpp
+@@ -1028,6 +1028,7 @@ void D3D12RenderTargetCache::Shutdown(bool from_destructor) {
+   isolated_replay_preview_resolved_target_.Reset();
+   isolated_replay_preview_resolved_target_state_ =
+       D3D12_RESOURCE_STATE_RESOLVE_DEST;
++  isolated_replay_preview_frame_sequence_ = 0;
+   isolated_replay_depth_target_.reset();
+   isolated_replay_color_target_.reset();
+   null_rtv_descriptor_ms_.Free();
+@@ -1990,19 +1991,23 @@ D3D12RenderTargetCache::QueueIsolatedReplayReadback(
+   return system::GraphicsIsolatedDrawReadbackStatus::kReady;
+ }
+ 
+-void D3D12RenderTargetCache::EndIsolatedReplayTarget() {
++void D3D12RenderTargetCache::EndIsolatedReplayTarget(
++    uint64_t frame_sequence) {
+   if (GetPath() != Path::kHostRenderTargets) {
+     return;
+   }
+   SetCommandListRenderTargets(last_update_accumulated_render_targets());
+   command_processor_.SubmitBarriers();
++  isolated_replay_preview_frame_sequence_ = frame_sequence;
+ }
+ 
+ bool D3D12RenderTargetCache::BeginIsolatedReplayPreview(
++    uint64_t required_frame_sequence,
+     IsolatedReplayPreviewSource& source_out) {
+   source_out = {};
+   if (GetPath() != Path::kHostRenderTargets ||
+-      !isolated_replay_color_target_) {
++      !isolated_replay_color_target_ || !required_frame_sequence ||
++      isolated_replay_preview_frame_sequence_ != required_frame_sequence) {
+     return false;
+   }
+   auto* isolated_color = static_cast<D3D12RenderTarget*>(
+@@ -2035,6 +2040,7 @@ bool D3D12RenderTargetCache::BeginIsolatedReplayPreview(
+   source_out.format = resource_desc.Format;
+   source_out.width = uint32_t(resource_desc.Width);
+   source_out.height = resource_desc.Height;
++  source_out.frame_sequence = isolated_replay_preview_frame_sequence_;
+   if (resource_desc.SampleDesc.Count > 1) {
+     D3D12_RESOURCE_DESC resolved_desc = resource_desc;
+     resolved_desc.Alignment = 0;

--- a/src/native_renderer/graphics_hooks.cpp
+++ b/src/native_renderer/graphics_hooks.cpp
@@ -2240,6 +2240,7 @@ void RequestIsolatedDraw(
       g_isolated_draw.awaiting_pass_follower = true;
       g_isolated_draw.pass_anchor_recorded = g_isolated_draw.completed;
       request.requested = true;
+      request.frame_sequence = g_isolated_draw.frame;
       request.retain_target = true;
       request.reference_marker_requested = true;
       request.completion = g_isolated_draw.completed
@@ -2260,6 +2261,7 @@ void RequestIsolatedDraw(
       return;
     }
     request.requested = true;
+    request.frame_sequence = g_isolated_draw.frame;
     request.reuse_target = true;
     request.reference_marker_requested = true;
     if (!g_isolated_draw.completed) {
@@ -2288,6 +2290,7 @@ void RequestIsolatedDraw(
     // result has been recorded. This path has no readback or completion
     // callback, and the authoritative Xenos draw still follows unmodified.
     request.requested = g_isolated_draw.prepared_candidate_eligible;
+    request.frame_sequence = request.requested ? g_isolated_draw.frame : 0;
     return;
   }
   g_isolated_draw.completed = true;
@@ -2309,6 +2312,7 @@ void RequestIsolatedDraw(
   g_isolated_draw.captured_frame = g_isolated_draw.frame;
   g_isolated_draw.captured_draw = g_isolated_draw.draw;
   request.requested = true;
+  request.frame_sequence = g_isolated_draw.frame;
   request.readback_requested = g_isolated_draw.readback_requested;
   request.completion = &CompleteIsolatedDraw;
   request.readback_completion = g_isolated_draw.readback_requested

--- a/src/native_renderer/guest_output_renderer.cpp
+++ b/src/native_renderer/guest_output_renderer.cpp
@@ -65,7 +65,10 @@ bool RenderDiagnosticOutput(
         context, uint32_t((context.submission / 120) & 1));
   } else if (mode == DiagnosticMode::kRetainedPass &&
              context.draw_retained_pass) {
-    rendered = context.draw_retained_pass(context);
+    if (context.frame_sequence &&
+        context.retained_pass_frame_sequence == context.frame_sequence) {
+      rendered = context.draw_retained_pass(context);
+    }
   } else if (mode == DiagnosticMode::kClear && context.clear_color) {
     const bool alternate = ((context.submission / 120) & 1) != 0;
     const float color[4] = {alternate ? 0.04f : 0.85f, 0.16f,
@@ -77,8 +80,13 @@ bool RenderDiagnosticOutput(
       if (callback == 1 || callback % 300 == 0) {
         pinyon_shift::diagnostics::RecordEvent(
             "native_renderer.output.waiting",
-            {{"reason", "retained_pass_unavailable"},
+            {{"reason", context.retained_pass_frame_sequence
+                            ? "retained_pass_stale"
+                            : "retained_pass_unavailable"},
              {"callback", std::to_string(callback)},
+             {"frame", std::to_string(context.frame_sequence)},
+             {"retained_frame",
+              std::to_string(context.retained_pass_frame_sequence)},
              {"fallback", "xenos"},
              {"suppression", "disabled"}});
       }
@@ -101,6 +109,9 @@ bool RenderDiagnosticOutput(
         {{"callback", std::to_string(callback)},
          {"claimed", std::to_string(claimed)},
          {"submission", std::to_string(context.submission)},
+         {"frame", std::to_string(context.frame_sequence)},
+         {"retained_frame",
+          std::to_string(context.retained_pass_frame_sequence)},
          {"guest_width", std::to_string(context.guest_output_width)},
          {"guest_height", std::to_string(context.guest_output_height)},
          {"display_width", std::to_string(context.display_width)},

--- a/tools/tests/test_native_renderer_contract.py
+++ b/tools/tests/test_native_renderer_contract.py
@@ -268,6 +268,42 @@ class NativeRendererContractTests(unittest.TestCase):
         self.assertIn("'native_renderer.output.waiting'", report)
         self.assertIn("waiting_reason", report)
 
+    def test_retained_pass_requires_current_frame_publication(self):
+        patch = (
+            ROOT
+            / "patches/rexglue/0067-d3d12-retained-pass-frame-freshness.patch"
+        ).read_text(encoding="utf-8")
+        self.assertIn("retained_pass_frame_sequence", patch)
+        self.assertIn("isolated_replay_preview_frame_sequence_", patch)
+        self.assertIn("required_frame_sequence", patch)
+        self.assertIn(
+            "isolated_replay_preview_frame_sequence_ != required_frame_sequence",
+            patch,
+        )
+        self.assertIn(
+            "EndIsolatedReplayTarget(\n+            isolated_draw_request.frame_sequence)",
+            patch,
+        )
+        self.assertNotIn("SetDrawSuppression", patch)
+
+        hooks = (ROOT / "src/native_renderer/graphics_hooks.cpp").read_text(
+            encoding="utf-8"
+        )
+        self.assertGreaterEqual(
+            hooks.count("request.frame_sequence = g_isolated_draw.frame"), 3
+        )
+
+        output = (
+            ROOT / "src/native_renderer/guest_output_renderer.cpp"
+        ).read_text(encoding="utf-8")
+        self.assertIn(
+            "context.retained_pass_frame_sequence == context.frame_sequence",
+            output,
+        )
+        self.assertIn('"retained_pass_stale"', output)
+        self.assertIn('{"fallback", "xenos"}', output)
+        self.assertIn('{"suppression", "disabled"}', output)
+
     def test_shader_capture_is_local_bounded_and_passive(self):
         patch = (
             ROOT

--- a/tools/tests/test_release_contract.py
+++ b/tools/tests/test_release_contract.py
@@ -43,10 +43,10 @@ class ReleaseContractTests(unittest.TestCase):
 
     def test_rexglue_patches_have_stable_order_and_no_binary_payload(self):
         patches = sorted((ROOT / "patches/rexglue").glob("*.patch"))
-        self.assertEqual(len(patches), 66)
+        self.assertEqual(len(patches), 67)
         self.assertEqual(
             patches[-1].name,
-            "0066-d3d12-native-resolve-provenance-observer.patch",
+            "0067-d3d12-retained-pass-frame-freshness.patch",
         )
         self.assertEqual(len(patches), len({path.name[:4] for path in patches}))
         for path in patches:


### PR DESCRIPTION
## Summary
- stamp retained native-pass output with its producing guest frame
- require exact current-frame freshness in both title and D3D12 paths
- fall back immediately to the preserved Xenos frame when unavailable or stale
- document the NR-04A publication contract and AppData qualification

## Validation
- clean preview build (1,046 steps)
- 153 Python tests
- 5 native-renderer test binaries
- AppData session \20260828T233352Z-p39060\: 2,571 claimed callbacks, zero frame mismatches, zero renderer failures, normal exit
- 30.366 median FPS, 19.392 1% low, 59.988 Hz presentation, zero deadline misses