### PR TITLE
feat(native-renderer): add private display composition

### DIFF
--- a/docs/native-renderer/CONTINUOUS_COMPOSITION.md
+++ b/docs/native-renderer/CONTINUOUS_COMPOSITION.md
@@ -1,0 +1,69 @@
+# Continuous native composition
+
+NR-04B moves the qualified retained-pass preview behind a private, full-size
+native display target. The visible experiment remains default-off and does not
+expand draw coverage or suppress Xenos work.
+
+For each current-frame retained pass, the D3D12 command processor creates or
+reuses one single-sample display texture matching the guest-output dimensions
+and format. The existing native composition shader writes every pixel of that
+private texture. Only after composition has been recorded does the command
+processor transition the completed texture to copy source, transition guest
+output to copy destination, copy the whole texture, and restore the presenter's
+guest-output state.
+
+The texture stays private to the command processor and uses the same open
+submission as the guest swap. There is no second presenter or swapchain. A
+resize allocates a correctly sized replacement and retains the old texture
+until its last recorded submission is complete. Context shutdown waits for GPU
+work before releasing the active display target, pipelines, and root
+signatures.
+
+All failure paths before composition leave guest output untouched. The title
+and backend exact-frame checks from `FRAME_PUBLICATION.md` still run before the
+private target is sampled or copied. Missing, stale, unsupported, or failed
+native work therefore returns `false` and presents the complete Xenos frame.
+Original Xenos draws, resolves, queries, fences, and guest-memory effects remain
+enabled.
+
+This is the composition surface required by the next dual-path milestone. It
+does not yet claim complete native scene coverage or measurable GPU savings;
+those require paired capture followed by separately qualified pass-level
+suppression.
+
+## Qualification gates
+
+- The complete 68-patch ReXGlue stack must apply from the pinned revision.
+- A clean preview build and the repository test suites must pass.
+- Claimed output markers must report `composition=private_display_target`,
+  exact matching frame identifiers, preserved Xenos draws, and disabled
+  suppression.
+- Startup and unsupported frames must continue through Xenos.
+- A sustained AppData-backed run must show no output-state warning, device
+  removal, validation error, fatal event, or crash.
+- Shutdown must be normal and performance must remain within the established
+  retained-preview envelope.
+
+## Qualified checkpoint
+
+Session `20260829T000459Z-p37956` qualified this milestone against the installed
+`0.1.0` AppData save in `open_world_day` on the clean 68-patch build. The run
+lasted 238.54 measured seconds and exited normally.
+
+- All 13 sampled claimed-output markers used
+  `composition=private_display_target` and exact matching `frame` and
+  `retained_frame` identifiers.
+- Every sampled marker reported `xenos_draw=preserved` and
+  `suppression=disabled`.
+- The run reached 3,690 native claims with no output failure, device removal,
+  fatal event, or crash.
+- The native crop remained continuously visible inside the amber diagnostic
+  boundary, with checkerboard fill identifying deliberately unsupported output
+  regions.
+- Across 7,581 performance samples, median frame rate was 30.19 FPS, 1% low was
+  19.20 FPS, and presentation cadence was 59.98 Hz. Two presentation deadline
+  misses and two dropped presents were recorded; no sustained cadence failure
+  or renderer fault accompanied them.
+
+After qualification, the AppData configuration was returned to the default
+`xenos` renderer while preserving the existing graphics settings.

--- a/docs/native-renderer/GUEST_OUTPUT_OWNERSHIP.md
+++ b/docs/native-renderer/GUEST_OUTPUT_OWNERSHIP.md
@@ -148,3 +148,8 @@ NR-04A subsequently tightens this preview with the exact-frame publication
 contract documented in `FRAME_PUBLICATION.md`. A retained pass may now reach
 guest output only when it was reproduced in the same guest frame as the active
 swap; stale targets yield immediately to Xenos.
+
+NR-04B moves composition into the private full-size display target documented
+in `CONTINUOUS_COMPOSITION.md`. The command processor copies that completed
+target into guest output within the existing swap submission, retaining one
+presenter and the same fail-closed Xenos fallback.

--- a/patches/rexglue/0068-d3d12-native-display-target.patch
+++ b/patches/rexglue/0068-d3d12-native-display-target.patch
@@ -1,0 +1,142 @@
+diff --git a/include/rex/graphics/d3d12/command_processor.h b/include/rex/graphics/d3d12/command_processor.h
+index d32d5ff..d2cf209 100644
+--- a/include/rex/graphics/d3d12/command_processor.h
++++ b/include/rex/graphics/d3d12/command_processor.h
+@@ -649,6 +649,11 @@ class D3D12CommandProcessor : public CommandProcessor {
+       native_guest_output_retained_pass_root_signature_;
+   Microsoft::WRL::ComPtr<ID3D12PipelineState>
+       native_guest_output_retained_pass_pipeline_;
++  Microsoft::WRL::ComPtr<ID3D12Resource>
++      native_guest_output_display_target_;
++  D3D12_RESOURCE_STATES native_guest_output_display_target_state_ =
++      D3D12_RESOURCE_STATE_UNORDERED_ACCESS;
++  uint64_t native_guest_output_display_target_submission_ = 0;
+ 
+   struct ResolveDownscaleConstants {
+     uint32_t scale_x;
+diff --git a/src/graphics/d3d12/command_processor.cpp b/src/graphics/d3d12/command_processor.cpp
+index ab7d748..743baf6 100644
+--- a/src/graphics/d3d12/command_processor.cpp
++++ b/src/graphics/d3d12/command_processor.cpp
+@@ -1850,6 +1850,15 @@ void D3D12CommandProcessor::ShutdownContext() {
+   fxaa_source_texture_submission_ = 0;
+   fxaa_source_texture_.Reset();
+ 
++  native_guest_output_display_target_submission_ = 0;
++  native_guest_output_display_target_.Reset();
++  native_guest_output_display_target_state_ =
++      D3D12_RESOURCE_STATE_UNORDERED_ACCESS;
++  native_guest_output_retained_pass_pipeline_.Reset();
++  native_guest_output_retained_pass_root_signature_.Reset();
++  native_guest_output_triangle_pipeline_.Reset();
++  native_guest_output_triangle_root_signature_.Reset();
++
+   fxaa_extreme_pipeline_.Reset();
+   fxaa_pipeline_.Reset();
+   fxaa_root_signature_.Reset();
+@@ -2266,6 +2275,59 @@ bool D3D12CommandProcessor::DrawNativeGuestOutputRetainedPass(
+     }
+   }
+ 
++  bool recreate_display_target = !native_guest_output_display_target_;
++  if (!recreate_display_target) {
++    const D3D12_RESOURCE_DESC display_desc =
++        native_guest_output_display_target_->GetDesc();
++    recreate_display_target =
++        display_desc.Width != width || display_desc.Height != height ||
++        display_desc.Format != ui::d3d12::D3D12Presenter::kGuestOutputFormat;
++  }
++  if (recreate_display_target) {
++    if (native_guest_output_display_target_) {
++      if (submission_completed_ <
++          native_guest_output_display_target_submission_) {
++        native_guest_output_display_target_->AddRef();
++        resources_for_deletion_.emplace_back(
++            native_guest_output_display_target_submission_,
++            native_guest_output_display_target_.Get());
++      }
++      native_guest_output_display_target_.Reset();
++      native_guest_output_display_target_submission_ = 0;
++    }
++    D3D12_RESOURCE_DESC display_desc{};
++    display_desc.Dimension = D3D12_RESOURCE_DIMENSION_TEXTURE2D;
++    display_desc.Width = width;
++    display_desc.Height = height;
++    display_desc.DepthOrArraySize = 1;
++    display_desc.MipLevels = 1;
++    display_desc.Format =
++        ui::d3d12::D3D12Presenter::kGuestOutputFormat;
++    display_desc.SampleDesc.Count = 1;
++    display_desc.Layout = D3D12_TEXTURE_LAYOUT_UNKNOWN;
++    display_desc.Flags = D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS;
++    HRESULT create_result = device->CreateCommittedResource(
++        &ui::d3d12::util::kHeapPropertiesDefault,
++        provider.GetHeapFlagCreateNotZeroed(), &display_desc,
++        D3D12_RESOURCE_STATE_UNORDERED_ACCESS, nullptr,
++        IID_PPV_ARGS(&native_guest_output_display_target_));
++    if (FAILED(create_result)) {
++      static bool logged_display_target_failure = false;
++      if (!logged_display_target_failure) {
++        logged_display_target_failure = true;
++        REXGPU_WARN(
++            "Native guest-output display target allocation failed: "
++            "HRESULT 0x{:08X}, {}x{}",
++            uint32_t(create_result), width, height);
++      }
++      return false;
++    }
++    native_guest_output_display_target_->SetName(
++        L"Native guest-output display target");
++    native_guest_output_display_target_state_ =
++        D3D12_RESOURCE_STATE_UNORDERED_ACCESS;
++  }
++
+   ui::d3d12::util::DescriptorCpuGpuHandlePair descriptors[2];
+   if (!RequestOneUseSingleViewDescriptors(2, descriptors)) {
+     static bool logged_retained_preview_descriptor_failure = false;
+@@ -2296,7 +2358,8 @@ bool D3D12CommandProcessor::DrawNativeGuestOutputRetainedPass(
+   D3D12_UNORDERED_ACCESS_VIEW_DESC output_view_desc{};
+   output_view_desc.Format = ui::d3d12::D3D12Presenter::kGuestOutputFormat;
+   output_view_desc.ViewDimension = D3D12_UAV_DIMENSION_TEXTURE2D;
+-  device->CreateUnorderedAccessView(resource, nullptr, &output_view_desc,
++  device->CreateUnorderedAccessView(native_guest_output_display_target_.Get(),
++                                    nullptr, &output_view_desc,
+                                     descriptors[1].first);
+ 
+   NativeGuestOutputRetainedPassConstants preview_constants{
+@@ -2304,9 +2367,9 @@ bool D3D12CommandProcessor::DrawNativeGuestOutputRetainedPass(
+       {preview_source.width, preview_source.height},
+       {std::min(preview_source.width, uint32_t(512)),
+        std::min(preview_source.height, uint32_t(512))}};
+-  PushTransitionBarrier(
+-      resource, ui::d3d12::D3D12Presenter::kGuestOutputInternalState,
+-      D3D12_RESOURCE_STATE_UNORDERED_ACCESS);
++  PushTransitionBarrier(native_guest_output_display_target_.Get(),
++                        native_guest_output_display_target_state_,
++                        D3D12_RESOURCE_STATE_UNORDERED_ACCESS);
+   deferred_command_list_.D3DSetComputeRootSignature(
+       native_guest_output_retained_pass_root_signature_.Get());
+   deferred_command_list_.D3DSetComputeRoot32BitConstants(
+@@ -2322,8 +2385,20 @@ bool D3D12CommandProcessor::DrawNativeGuestOutputRetainedPass(
+   SubmitBarriers();
+   deferred_command_list_.D3DDispatch((width + 7) / 8, (height + 7) / 8, 1);
+   render_target_cache_->EndIsolatedReplayPreview(preview_source);
+-  PushTransitionBarrier(resource, D3D12_RESOURCE_STATE_UNORDERED_ACCESS,
++  PushTransitionBarrier(native_guest_output_display_target_.Get(),
++                        D3D12_RESOURCE_STATE_UNORDERED_ACCESS,
++                        D3D12_RESOURCE_STATE_COPY_SOURCE);
++  PushTransitionBarrier(
++      resource, ui::d3d12::D3D12Presenter::kGuestOutputInternalState,
++      D3D12_RESOURCE_STATE_COPY_DEST);
++  SubmitBarriers();
++  deferred_command_list_.D3DCopyResource(
++      resource, native_guest_output_display_target_.Get());
++  PushTransitionBarrier(resource, D3D12_RESOURCE_STATE_COPY_DEST,
+                         ui::d3d12::D3D12Presenter::kGuestOutputInternalState);
++  native_guest_output_display_target_state_ =
++      D3D12_RESOURCE_STATE_COPY_SOURCE;
++  native_guest_output_display_target_submission_ = submission_current_;
+   return true;
+ }
+ 
+

--- a/src/native_renderer/guest_output_renderer.cpp
+++ b/src/native_renderer/guest_output_renderer.cpp
@@ -118,6 +118,9 @@ bool RenderDiagnosticOutput(
          {"display_height", std::to_string(context.display_height)},
          {"format", std::to_string(context.output_format)},
          {"mode", DiagnosticModeName(mode)},
+         {"composition", mode == DiagnosticMode::kRetainedPass
+                             ? "private_display_target"
+                             : "direct_guest_output"},
          {"xenos_draw", "preserved"},
          {"suppression", "disabled"}});
   }

--- a/tools/create-crash-report.ps1
+++ b/tools/create-crash-report.ps1
@@ -256,6 +256,7 @@ try {
             ([string]$settings['pinyon_shift_native_renderer']).Trim('"')
         } else { 'xenos' }
         effective = 'unknown'
+        composition = $null
         claimed_frames = [uint64]0
         waiting_reason = $null
         failure_reason = $null
@@ -274,6 +275,7 @@ try {
                 'native_renderer.output.installed' { $nativeRenderer.effective = [string]$event.mode }
                 'native_renderer.output.frame' {
                     $nativeRenderer.effective = [string]$event.mode
+                    $nativeRenderer.composition = [string]$event.composition
                     $nativeRenderer.claimed_frames = [uint64]$event.claimed
                     $nativeRenderer.waiting_reason = $null
                 }

--- a/tools/tests/test_native_renderer_contract.py
+++ b/tools/tests/test_native_renderer_contract.py
@@ -304,6 +304,36 @@ class NativeRendererContractTests(unittest.TestCase):
         self.assertIn('{"fallback", "xenos"}', output)
         self.assertIn('{"suppression", "disabled"}', output)
 
+    def test_continuous_composition_uses_a_private_display_target(self):
+        patch = (
+            ROOT / "patches/rexglue/0068-d3d12-native-display-target.patch"
+        ).read_text(encoding="utf-8")
+        self.assertIn("native_guest_output_display_target_", patch)
+        self.assertIn("D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS", patch)
+        self.assertIn("D3D12_RESOURCE_STATE_COPY_SOURCE", patch)
+        self.assertIn("D3D12_RESOURCE_STATE_COPY_DEST", patch)
+        self.assertIn(
+            "resource, native_guest_output_display_target_.Get()", patch
+        )
+        self.assertIn("resources_for_deletion_.emplace_back", patch)
+        self.assertIn("native_guest_output_display_target_.Reset()", patch)
+        self.assertNotIn("SetDrawSuppression", patch)
+
+        output = (
+            ROOT / "src/native_renderer/guest_output_renderer.cpp"
+        ).read_text(encoding="utf-8")
+        self.assertIn('"private_display_target"', output)
+        self.assertIn('{"xenos_draw", "preserved"}', output)
+        self.assertIn('{"suppression", "disabled"}', output)
+
+        report = (ROOT / "tools/create-crash-report.ps1").read_text(
+            encoding="utf-8"
+        )
+        self.assertIn("composition = $null", report)
+        self.assertIn(
+            "$nativeRenderer.composition = [string]$event.composition", report
+        )
+
     def test_shader_capture_is_local_bounded_and_passive(self):
         patch = (
             ROOT

--- a/tools/tests/test_release_contract.py
+++ b/tools/tests/test_release_contract.py
@@ -43,10 +43,10 @@ class ReleaseContractTests(unittest.TestCase):
 
     def test_rexglue_patches_have_stable_order_and_no_binary_payload(self):
         patches = sorted((ROOT / "patches/rexglue").glob("*.patch"))
-        self.assertEqual(len(patches), 67)
+        self.assertEqual(len(patches), 68)
         self.assertEqual(
             patches[-1].name,
-            "0067-d3d12-retained-pass-frame-freshness.patch",
+            "0068-d3d12-native-display-target.patch",
         )
         self.assertEqual(len(patches), len({path.name[:4] for path in patches}))
         for path in patches:


### PR DESCRIPTION
## Summary

- add a command-processor-owned full-size D3D12 display target
- compose the exact-frame retained native pass privately before copying to guest output
- preserve Xenos draws, guest side effects, fallback, and disabled suppression
- expose composition mode in runtime/crash diagnostics and document qualification

## Validation

- clean preview build with the full 68-patch ReXGlue stack
- 154 Python contract/unit tests
- five native renderer test binaries
- AppData-backed open-world qualification: normal exit, 3,690 native claims, 13 exact-frame markers, zero renderer/device/fatal failures
- 7,581 samples: 30.19 median FPS, 19.20 FPS 1% low, 59.98 Hz presentation

Two isolated presentation deadline misses/dropped presents were recorded; no sustained cadence failure or renderer fault accompanied them.