### PR TITLE
feat(native-renderer): add dual-path comparison

### DIFF
--- a/docs/native-renderer/CONTINUOUS_COMPOSITION.md
+++ b/docs/native-renderer/CONTINUOUS_COMPOSITION.md
@@ -67,3 +67,7 @@ lasted 238.54 measured seconds and exited normally.
 
 After qualification, the AppData configuration was returned to the default
 `xenos` renderer while preserving the existing graphics settings.
+
+NR-04C builds on this surface with the controlled selector, paired visual
+qualification, and strict capture workflow documented in
+[DUAL_PATH_COMPARISON.md](DUAL_PATH_COMPARISON.md).

--- a/docs/native-renderer/DUAL_PATH_COMPARISON.md
+++ b/docs/native-renderer/DUAL_PATH_COMPARISON.md
@@ -1,0 +1,131 @@
+# Dual-path native/Xenos comparison
+
+NR-04C adds restart-gated `comparison_native` and `comparison_xenos` output
+modes. Both modes preserve the complete Xenos frame and build the exact-frame
+retained native display target in the command processor's existing submission.
+Only the selected path becomes display authority:
+
+- `comparison_native` copies the completed private native display target into
+  guest output after Xenos has finished;
+- `comparison_xenos` leaves guest output untouched after composing the native
+  target privately.
+
+The modes never suppress guest draws, resolves, queries, fences, memexport, or
+other side effects. Missing, stale, unsupported, or failed native work yields
+to the existing Xenos output before any guest-output write. Selection is
+sequential on the command processor's one command list; the two paths cannot
+write guest output concurrently.
+
+## Strict same-frame export
+
+Patch `0069-d3d12-dual-path-comparison.patch` emits two RenderDoc regions only
+in comparison modes:
+
+- `PinyonShift NR-04C native display composition` encloses the compute dispatch
+  that fills the private target;
+- `PinyonShift NR-04C native output selection` encloses the native-to-guest
+  copy and is therefore present only when native output is selected.
+
+The selection copy is the deterministic comparison boundary when the capture
+contains the command-processor submission. Its destination
+contains the completed Xenos frame immediately before the copy and the selected
+native frame immediately afterward. Its source is the private native target.
+All three images therefore come from the same build, guest frame, dimensions,
+and output format.
+
+With the installed AppData save and signed local RenderDoc build, capture a
+native-selected frame using:
+
+```powershell
+$stateRoot = Join-Path $env:LOCALAPPDATA `
+    'PinyonShift\source\0.1.0\.local\preview'
+.\tools\capture-native-renderer-output-comparison.ps1 `
+  -StateRoot $stateRoot `
+  -RenderDocRoot '.local\tools\renderdoc-1.45\RenderDoc_1.45_64' `
+  -IsolatedDrawSignature 1D253A52B55C9FB3 `
+  -PassAnchorSignature 747837906D0BF484 `
+  -IsolatedDrawDir '.local\qualification\nr04c-isolated-pass' `
+  -CaptureDir '.local\qualification\nr04c-capture' `
+  -SelectedOutput native
+```
+
+Load the requested scene, press F12 after the retained native output is visible,
+then close the game. The wrapper changes only the renderer selector and restores
+its original value after the capture process exits.
+
+Export the first complete same-frame pair with:
+
+```powershell
+.\tools\export-native-renderer-output-comparison.ps1 `
+  -Capture '.local\qualification\nr04c-capture\reference_frame1.rdc' `
+  -RenderDocRoot '.local\tools\renderdoc-1.45\RenderDoc_1.45_64' `
+  -OutputDir '.local\qualification\nr04c-output-comparison'
+```
+
+When both NR-04C markers are present, the exporter writes `xenos-output.png`, `native-private.png`,
+`native-selected.png`, and `native-output-comparison.json` below `.local`.
+The report records capture and image hashes, dimensions, marker/event IDs,
+resource IDs, selection authority, and RenderDoc GPU-duration samples for the
+native composition dispatch and selection copy. Export fails if the private
+native image differs from the selected native image, if dimensions differ, if
+resources alias, or if GPU timing is unavailable.
+
+Use `-SelectedOutput xenos` in a separate gameplay run to qualify that the same
+parallel native workload leaves the complete Xenos frame authoritative. That
+mode intentionally has no native selection-copy marker, so it is a fallback and
+visual-safety qualification rather than the paired-image export source.
+
+RenderDoc's F12 boundary can land on either the 30 Hz guest submission or the
+60 Hz presenter frame. In the qualification build, an F12 capture containing
+the guest draws did not include the later command-processor composition and
+selection markers, while adjacent captures contained only presenter work. The
+strict exporter therefore failed closed as designed. Do not interpret a normal
+swapchain thumbnail as proof that the same-frame resource boundary was captured.
+
+## Qualification evidence
+
+The AppData save was exercised in both comparison modes with the same clean
+binary (`81B1BF6A047732CF3A8968E02AB38B1E7C001DC92017DAE20F2353E31CE9E2CE`)
+and the `open_world_day` scene marker. Local, game-derived evidence remains
+below `.local/qualification` and is not committed:
+
+- `comparison_native` session `20260829T004321Z-p43056` displayed the retained
+  native target and logged exact-frame native authority with Xenos draws
+  preserved and suppression disabled. Its 3,837-frame performance capture
+  measured 53.868 median renderer FPS, 19.136 one-percent-low FPS, 29.440 Hz
+  simulation cadence, and one presentation deadline miss.
+- `comparison_xenos` session `20260829T004547Z-p15824` displayed the complete
+  Xenos scene and logged Xenos authority while the same private native workload
+  remained active. Its 3,734-frame capture measured 54.977 median renderer FPS,
+  19.376 one-percent-low FPS, 29.406 Hz simulation cadence, and no presentation
+  deadline misses.
+- The paired thumbnails have SHA-256 values
+  `8C61DF8B76D5F1D2CF3D13A5CF0C377A7F90AB30AA907EFA9F4813F49FC2BD0C`
+  (native) and
+  `EC1CE75B4EA83BB991AD67622EC1AE192EF18459B1843C45F4ADFDE54067860E`
+  (Xenos). A local vertical contact sheet records the difference inventory.
+
+The current native output is deliberately partial: it contains the retained
+pass slice and diagnostic amber border, but not the full vehicle, HUD, crowd,
+transparent scene, or post-processing coverage visible in Xenos. This is useful
+proof that native display authority is real, not a readiness signal for pass
+suppression or default enablement.
+
+Per-pass RenderDoc GPU-duration samples were unavailable from the captured
+boundary. The runtime frame summaries above are the current timing evidence;
+marker-level GPU timing remains an explicit follow-up before suppression work.
+
+## Qualification gates
+
+- Both comparison modes use exact-frame retained state and remain
+  restart-gated and default-off.
+- Native-selected and Xenos-selected gameplay runs remain stable and report the
+  correct `selected_output` and `authority` diagnostics.
+- Xenos draws stay preserved and suppression stays disabled in both modes.
+- When the command-processor submission is captured, the strict export contains
+  distinct Xenos/native resources and identical hashes for the private and
+  selected native output; otherwise it fails closed.
+- Runtime frame timing is recorded for both authorities. Marker-level GPU
+  duration remains required before pass suppression.
+- Unsupported/startup frames yield to Xenos without an output-state fault.
+- Clean exit, relaunch, and renderer restoration remain correct.

--- a/patches/rexglue/0069-d3d12-dual-path-comparison.patch
+++ b/patches/rexglue/0069-d3d12-dual-path-comparison.patch
@@ -1,0 +1,131 @@
+diff --git a/include/rex/system/interfaces/graphics.h b/include/rex/system/interfaces/graphics.h
+index fab4bc0..2975c98 100644
+--- a/include/rex/system/interfaces/graphics.h
++++ b/include/rex/system/interfaces/graphics.h
+@@ -29,12 +29,14 @@ class WindowedAppContext;
+ namespace rex::system {
+ 
+ struct NativeGuestOutputRenderContext;
++enum class NativeGuestOutputRetainedPassMode : uint32_t;
+ using NativeGuestOutputClearColor = bool (*)(
+     const NativeGuestOutputRenderContext& context, const float color[4]);
+ using NativeGuestOutputDrawDiagnosticTriangle = bool (*)(
+     const NativeGuestOutputRenderContext& context, uint32_t phase);
+ using NativeGuestOutputDrawRetainedPass = bool (*)(
+-    const NativeGuestOutputRenderContext& context);
++    const NativeGuestOutputRenderContext& context,
++    NativeGuestOutputRetainedPassMode mode);
+ class KernelState;
+ }
+ 
+@@ -46,6 +48,12 @@ enum class NativeGuestOutputBackend : uint32_t {
+   kVulkan = 2,
+ };
+ 
++enum class NativeGuestOutputRetainedPassMode : uint32_t {
++  kPresentNative = 0,
++  kCompareNative = 1,
++  kCompareXenos = 2,
++};
++
+ struct NativeGuestOutputRenderContext {
+   NativeGuestOutputBackend backend = NativeGuestOutputBackend::kUnsupported;
+   uint32_t guest_output_width = 0;
+diff --git a/include/rex/graphics/d3d12/command_processor.h b/include/rex/graphics/d3d12/command_processor.h
+index d2cf209..a7a3a9b 100644
+--- a/include/rex/graphics/d3d12/command_processor.h
++++ b/include/rex/graphics/d3d12/command_processor.h
+@@ -206,7 +206,8 @@ class D3D12CommandProcessor : public CommandProcessor {
+                                                uint32_t phase);
+   bool DrawNativeGuestOutputRetainedPass(ID3D12Resource* resource,
+                                          uint32_t width,
+-                                         uint32_t height);
++                                         uint32_t height,
++                                         system::NativeGuestOutputRetainedPassMode mode);
+ 
+  protected:
+   bool SetupContext() override;
+diff --git a/src/graphics/d3d12/command_processor.cpp b/src/graphics/d3d12/command_processor.cpp
+index 743baf6..163333e 100644
+--- a/src/graphics/d3d12/command_processor.cpp
++++ b/src/graphics/d3d12/command_processor.cpp
+@@ -2197,10 +2197,15 @@ bool D3D12CommandProcessor::DrawNativeGuestOutputDiagnosticTriangle(
+ }
+ 
+ bool D3D12CommandProcessor::DrawNativeGuestOutputRetainedPass(
+-    ID3D12Resource* resource, uint32_t width, uint32_t height) {
++    ID3D12Resource* resource, uint32_t width, uint32_t height,
++    system::NativeGuestOutputRetainedPassMode mode) {
+   if (!resource || !width || !height || !render_target_cache_) {
+     return false;
+   }
++  const bool comparison =
++      mode != system::NativeGuestOutputRetainedPassMode::kPresentNative;
++  const bool present_native =
++      mode != system::NativeGuestOutputRetainedPassMode::kCompareXenos;
+ 
+   const ui::d3d12::D3D12Provider& provider = GetD3D12Provider();
+   ID3D12Device* device = provider.GetDevice();
+@@ -2383,19 +2388,36 @@ bool D3D12CommandProcessor::DrawNativeGuestOutputRetainedPass(
+       descriptors[1].second);
+   SetExternalPipeline(native_guest_output_retained_pass_pipeline_.Get());
+   SubmitBarriers();
++  if (comparison) {
++    deferred_command_list_.BeginDebugMarker(
++        "PinyonShift NR-04C native display composition");
++  }
+   deferred_command_list_.D3DDispatch((width + 7) / 8, (height + 7) / 8, 1);
+   render_target_cache_->EndIsolatedReplayPreview(preview_source);
+   PushTransitionBarrier(native_guest_output_display_target_.Get(),
+                         D3D12_RESOURCE_STATE_UNORDERED_ACCESS,
+                         D3D12_RESOURCE_STATE_COPY_SOURCE);
+-  PushTransitionBarrier(
+-      resource, ui::d3d12::D3D12Presenter::kGuestOutputInternalState,
+-      D3D12_RESOURCE_STATE_COPY_DEST);
+   SubmitBarriers();
+-  deferred_command_list_.D3DCopyResource(
+-      resource, native_guest_output_display_target_.Get());
+-  PushTransitionBarrier(resource, D3D12_RESOURCE_STATE_COPY_DEST,
+-                        ui::d3d12::D3D12Presenter::kGuestOutputInternalState);
++  if (comparison) {
++    deferred_command_list_.EndDebugMarker();
++  }
++  if (present_native) {
++    if (comparison) {
++      deferred_command_list_.BeginDebugMarker(
++          "PinyonShift NR-04C native output selection");
++    }
++    PushTransitionBarrier(
++        resource, ui::d3d12::D3D12Presenter::kGuestOutputInternalState,
++        D3D12_RESOURCE_STATE_COPY_DEST);
++    SubmitBarriers();
++    deferred_command_list_.D3DCopyResource(
++        resource, native_guest_output_display_target_.Get());
++    PushTransitionBarrier(resource, D3D12_RESOURCE_STATE_COPY_DEST,
++                          ui::d3d12::D3D12Presenter::kGuestOutputInternalState);
++    if (comparison) {
++      deferred_command_list_.EndDebugMarker();
++    }
++  }
+   native_guest_output_display_target_state_ =
+       D3D12_RESOURCE_STATE_COPY_SOURCE;
+   native_guest_output_display_target_submission_ = submission_current_;
+@@ -2414,14 +2436,15 @@ bool InvokeNativeGuestOutputDiagnosticTriangle(
+ }
+ 
+ bool InvokeNativeGuestOutputRetainedPass(
+-    const system::NativeGuestOutputRenderContext& context) {
++    const system::NativeGuestOutputRenderContext& context,
++    system::NativeGuestOutputRetainedPassMode mode) {
+   auto* command_processor =
+       static_cast<D3D12CommandProcessor*>(context.command_context);
+   auto* resource = static_cast<ID3D12Resource*>(context.guest_output);
+   return command_processor &&
+          command_processor->DrawNativeGuestOutputRetainedPass(
+              resource, context.guest_output_width,
+-             context.guest_output_height);
++             context.guest_output_height, mode);
+ }
+ 
+ void D3D12CommandProcessor::IssueSwap(uint32_t frontbuffer_ptr, uint32_t frontbuffer_width,
+

--- a/src/native_renderer/guest_output_renderer.cpp
+++ b/src/native_renderer/guest_output_renderer.cpp
@@ -15,7 +15,8 @@ REXCVAR_DEFINE_BOOL(
     .lifecycle(rex::cvar::Lifecycle::kRequiresRestart);
 REXCVAR_DEFINE_STRING(pinyon_shift_native_renderer, "xenos", "Pinyon Shift",
                       "Guest-output renderer: xenos, diagnostic_clear, "
-                      "diagnostic_triangle, diagnostic_retained_pass")
+                      "diagnostic_triangle, diagnostic_retained_pass, "
+                      "comparison_native, comparison_xenos")
     .lifecycle(rex::cvar::Lifecycle::kRequiresRestart);
 REXCVAR_DEFINE_STRING(
     pinyon_shift_native_shader_pack, "", "Pinyon Shift",
@@ -27,7 +28,13 @@ namespace {
 std::atomic<bool> g_failure_latched{};
 std::atomic<uint64_t> g_callback_count{};
 std::atomic<uint64_t> g_claimed_count{};
-enum class DiagnosticMode : uint32_t { kClear, kTriangle, kRetainedPass };
+enum class DiagnosticMode : uint32_t {
+  kClear,
+  kTriangle,
+  kRetainedPass,
+  kComparisonNative,
+  kComparisonXenos,
+};
 std::atomic<DiagnosticMode> g_mode{DiagnosticMode::kClear};
 pinyon_shift::native_renderer::ShaderPack g_shader_pack;
 
@@ -37,6 +44,10 @@ const char *DiagnosticModeName(DiagnosticMode mode) {
     return "diagnostic_triangle";
   case DiagnosticMode::kRetainedPass:
     return "diagnostic_retained_pass";
+  case DiagnosticMode::kComparisonNative:
+    return "comparison_native";
+  case DiagnosticMode::kComparisonXenos:
+    return "comparison_xenos";
   default:
     return "diagnostic_clear";
   }
@@ -63,11 +74,22 @@ bool RenderDiagnosticOutput(
   if (mode == DiagnosticMode::kTriangle && context.draw_diagnostic_triangle) {
     rendered = context.draw_diagnostic_triangle(
         context, uint32_t((context.submission / 120) & 1));
-  } else if (mode == DiagnosticMode::kRetainedPass &&
+  } else if ((mode == DiagnosticMode::kRetainedPass ||
+              mode == DiagnosticMode::kComparisonNative ||
+              mode == DiagnosticMode::kComparisonXenos) &&
              context.draw_retained_pass) {
     if (context.frame_sequence &&
         context.retained_pass_frame_sequence == context.frame_sequence) {
-      rendered = context.draw_retained_pass(context);
+      auto retained_mode =
+          rex::system::NativeGuestOutputRetainedPassMode::kPresentNative;
+      if (mode == DiagnosticMode::kComparisonNative) {
+        retained_mode =
+            rex::system::NativeGuestOutputRetainedPassMode::kCompareNative;
+      } else if (mode == DiagnosticMode::kComparisonXenos) {
+        retained_mode =
+            rex::system::NativeGuestOutputRetainedPassMode::kCompareXenos;
+      }
+      rendered = context.draw_retained_pass(context, retained_mode);
     }
   } else if (mode == DiagnosticMode::kClear && context.clear_color) {
     const bool alternate = ((context.submission / 120) & 1) != 0;
@@ -76,7 +98,10 @@ bool RenderDiagnosticOutput(
     rendered = context.clear_color(context, color);
   }
   if (!rendered) {
-    if (mode == DiagnosticMode::kRetainedPass && context.draw_retained_pass) {
+    if ((mode == DiagnosticMode::kRetainedPass ||
+         mode == DiagnosticMode::kComparisonNative ||
+         mode == DiagnosticMode::kComparisonXenos) &&
+        context.draw_retained_pass) {
       if (callback == 1 || callback % 300 == 0) {
         pinyon_shift::diagnostics::RecordEvent(
             "native_renderer.output.waiting",
@@ -118,9 +143,16 @@ bool RenderDiagnosticOutput(
          {"display_height", std::to_string(context.display_height)},
          {"format", std::to_string(context.output_format)},
          {"mode", DiagnosticModeName(mode)},
-         {"composition", mode == DiagnosticMode::kRetainedPass
+         {"composition", (mode == DiagnosticMode::kRetainedPass ||
+                           mode == DiagnosticMode::kComparisonNative ||
+                           mode == DiagnosticMode::kComparisonXenos)
                              ? "private_display_target"
                              : "direct_guest_output"},
+         {"selected_output", mode == DiagnosticMode::kComparisonXenos
+                                 ? "xenos"
+                                 : "native"},
+         {"authority", mode == DiagnosticMode::kComparisonXenos ? "xenos"
+                                                                  : "native"},
          {"xenos_draw", "preserved"},
          {"suppression", "disabled"}});
   }
@@ -165,16 +197,23 @@ void InstallGuestOutputRenderer(rex::system::IGraphicsSystem *graphics_system) {
   }
   if (mode != "diagnostic_clear" && mode != "diagnostic_triangle" &&
       mode != "diagnostic_retained_pass" &&
+      mode != "comparison_native" && mode != "comparison_xenos" &&
       !(mode == "xenos" && legacy_clear)) {
     diagnostics::RecordEvent(
         "native_renderer.output.failure",
         {{"reason", "unsupported_mode"}, {"fallback", "xenos"}});
     return;
   }
-  const DiagnosticMode selected_mode =
-      mode == "diagnostic_triangle"        ? DiagnosticMode::kTriangle
-      : mode == "diagnostic_retained_pass" ? DiagnosticMode::kRetainedPass
-                                           : DiagnosticMode::kClear;
+  DiagnosticMode selected_mode = DiagnosticMode::kClear;
+  if (mode == "diagnostic_triangle") {
+    selected_mode = DiagnosticMode::kTriangle;
+  } else if (mode == "diagnostic_retained_pass") {
+    selected_mode = DiagnosticMode::kRetainedPass;
+  } else if (mode == "comparison_native") {
+    selected_mode = DiagnosticMode::kComparisonNative;
+  } else if (mode == "comparison_xenos") {
+    selected_mode = DiagnosticMode::kComparisonXenos;
+  }
   g_mode.store(selected_mode, std::memory_order_release);
   g_failure_latched.store(false, std::memory_order_release);
   g_callback_count.store(0, std::memory_order_release);
@@ -182,6 +221,10 @@ void InstallGuestOutputRenderer(rex::system::IGraphicsSystem *graphics_system) {
   graphics_system->SetNativeGuestOutputRenderer(&RenderDiagnosticOutput);
   diagnostics::RecordEvent("native_renderer.output.installed",
                            {{"mode", DiagnosticModeName(selected_mode)},
+                            {"authority",
+                             selected_mode == DiagnosticMode::kComparisonXenos
+                                 ? "xenos"
+                                 : "native"},
                             {"fallback", "xenos"},
                             {"xenos_draw", "preserved"},
                             {"suppression", "disabled"}});

--- a/tools/capture-native-renderer-output-comparison.ps1
+++ b/tools/capture-native-renderer-output-comparison.ps1
@@ -1,0 +1,50 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)]
+    [string]$StateRoot,
+    [Parameter(Mandatory)]
+    [string]$RenderDocRoot,
+    [Parameter(Mandatory)]
+    [ValidatePattern('^[0-9A-Fa-f]{16}$')]
+    [string]$IsolatedDrawSignature,
+    [Parameter(Mandatory)]
+    [ValidatePattern('^[0-9A-Fa-f]{16}$')]
+    [string]$PassAnchorSignature,
+    [Parameter(Mandatory)]
+    [string]$IsolatedDrawDir,
+    [Parameter(Mandatory)]
+    [string]$CaptureDir,
+    [ValidateSet('native', 'xenos')]
+    [string]$SelectedOutput = 'native',
+    [ValidateSet('open_world_day', 'open_world_night', 'garage', 'race')]
+    [string]$Scene = 'open_world_day'
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$settingsTool = Join-Path $PSScriptRoot 'set-graphics-experiment.ps1'
+$captureTool = Join-Path $PSScriptRoot `
+    'capture-native-renderer-renderdoc.ps1'
+$before = & $settingsTool -Action Get -StateRoot $StateRoot -Json |
+    ConvertFrom-Json
+$originalRenderer = [string]$before.settings.native_renderer
+$comparisonRenderer = if ($SelectedOutput -eq 'native') {
+    'comparison_native'
+} else {
+    'comparison_xenos'
+}
+
+try {
+    [void](& $settingsTool -Action SetRenderer -StateRoot $StateRoot `
+        -NativeRenderer $comparisonRenderer -Json)
+    & $captureTool -StateRoot $StateRoot -RenderDocRoot $RenderDocRoot `
+        -IsolatedDrawSignature $IsolatedDrawSignature `
+        -PassAnchorSignature $PassAnchorSignature `
+        -IsolatedDrawDir $IsolatedDrawDir -CaptureDir $CaptureDir `
+        -Scene $Scene
+}
+finally {
+    [void](& $settingsTool -Action SetRenderer -StateRoot $StateRoot `
+        -NativeRenderer $originalRenderer -Json)
+}

--- a/tools/create-crash-report.ps1
+++ b/tools/create-crash-report.ps1
@@ -257,6 +257,8 @@ try {
         } else { 'xenos' }
         effective = 'unknown'
         composition = $null
+        selected_output = $null
+        authority = $null
         claimed_frames = [uint64]0
         waiting_reason = $null
         failure_reason = $null
@@ -275,7 +277,15 @@ try {
                 'native_renderer.output.installed' { $nativeRenderer.effective = [string]$event.mode }
                 'native_renderer.output.frame' {
                     $nativeRenderer.effective = [string]$event.mode
-                    $nativeRenderer.composition = [string]$event.composition
+                    if ($event.PSObject.Properties['composition']) {
+                        $nativeRenderer.composition = [string]$event.composition
+                    }
+                    if ($event.PSObject.Properties['selected_output']) {
+                        $nativeRenderer.selected_output = [string]$event.selected_output
+                    }
+                    if ($event.PSObject.Properties['authority']) {
+                        $nativeRenderer.authority = [string]$event.authority
+                    }
                     $nativeRenderer.claimed_frames = [uint64]$event.claimed
                     $nativeRenderer.waiting_reason = $null
                 }

--- a/tools/export-native-renderer-output-comparison.ps1
+++ b/tools/export-native-renderer-output-comparison.ps1
@@ -1,0 +1,76 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)]
+    [string]$Capture,
+    [Parameter(Mandatory)]
+    [string]$RenderDocRoot,
+    [Parameter(Mandatory)]
+    [string]$OutputDir,
+    [string]$CompositionMarker =
+        'PinyonShift NR-04C native display composition',
+    [string]$SelectionMarker =
+        'PinyonShift NR-04C native output selection'
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
+$localRoot = [IO.Path]::GetFullPath((Join-Path $repoRoot '.local'))
+$localPrefix = $localRoot.TrimEnd([IO.Path]::DirectorySeparatorChar) +
+    [IO.Path]::DirectorySeparatorChar
+$resolvedCapture = (Resolve-Path -LiteralPath $Capture).Path
+$resolvedOutputDir = [IO.Path]::GetFullPath($OutputDir)
+if (-not $resolvedCapture.StartsWith(
+        $localPrefix, [StringComparison]::OrdinalIgnoreCase)) {
+    throw "Capture must be below $localRoot"
+}
+if (-not $resolvedOutputDir.StartsWith(
+        $localPrefix, [StringComparison]::OrdinalIgnoreCase)) {
+    throw "OutputDir must be below $localRoot"
+}
+if (Test-Path -LiteralPath $resolvedOutputDir) {
+    throw "OutputDir already exists: $resolvedOutputDir"
+}
+
+$qrenderdoc = Join-Path ([IO.Path]::GetFullPath($RenderDocRoot)) 'qrenderdoc.exe'
+if (-not (Test-Path -LiteralPath $qrenderdoc -PathType Leaf)) {
+    throw "qrenderdoc.exe was not found below RenderDocRoot: $RenderDocRoot"
+}
+$signature = Get-AuthenticodeSignature -LiteralPath $qrenderdoc
+if ([string]$signature.Status -ne 'Valid') {
+    throw 'qrenderdoc.exe does not have a valid Authenticode signature'
+}
+
+$script = Join-Path $PSScriptRoot `
+    'export-native-renderer-output-comparison.py'
+[void](New-Item -ItemType Directory -Path $resolvedOutputDir)
+$savedCapture = $env:PINYON_SHIFT_RENDERDOC_CAPTURE
+$savedOutput = $env:PINYON_SHIFT_RENDERDOC_EXPORT_DIR
+$savedCompositionMarker = $env:PINYON_SHIFT_RENDERDOC_COMPOSITION_MARKER
+$savedSelectionMarker = $env:PINYON_SHIFT_RENDERDOC_SELECTION_MARKER
+try {
+    $env:PINYON_SHIFT_RENDERDOC_CAPTURE = $resolvedCapture
+    $env:PINYON_SHIFT_RENDERDOC_EXPORT_DIR = $resolvedOutputDir
+    $env:PINYON_SHIFT_RENDERDOC_COMPOSITION_MARKER = $CompositionMarker
+    $env:PINYON_SHIFT_RENDERDOC_SELECTION_MARKER = $SelectionMarker
+    $process = Start-Process -FilePath $qrenderdoc `
+        -ArgumentList @('--python', $script) -PassThru -Wait `
+        -WindowStyle Hidden
+    if ($process.ExitCode) {
+        throw "qrenderdoc export exited with code $($process.ExitCode)"
+    }
+}
+finally {
+    $env:PINYON_SHIFT_RENDERDOC_CAPTURE = $savedCapture
+    $env:PINYON_SHIFT_RENDERDOC_EXPORT_DIR = $savedOutput
+    $env:PINYON_SHIFT_RENDERDOC_COMPOSITION_MARKER =
+        $savedCompositionMarker
+    $env:PINYON_SHIFT_RENDERDOC_SELECTION_MARKER = $savedSelectionMarker
+}
+
+$report = Join-Path $resolvedOutputDir 'native-output-comparison.json'
+if (-not (Test-Path -LiteralPath $report -PathType Leaf)) {
+    throw 'qrenderdoc exited without producing the comparison report.'
+}
+Get-Content -LiteralPath $report -Raw | ConvertFrom-Json

--- a/tools/export-native-renderer-output-comparison.py
+++ b/tools/export-native-renderer-output-comparison.py
@@ -1,0 +1,292 @@
+"""Export same-frame Xenos/native output and GPU timings from RenderDoc.
+
+This script runs inside qrenderdoc's bundled Python runtime. The PowerShell
+wrapper passes local paths through environment variables so captures and
+game-derived images never enter the public source tree.
+"""
+
+import hashlib
+import json
+import os
+import sys
+import traceback
+
+import renderdoc as rd
+
+
+COMPOSITION_MARKER = os.environ.get(
+    "PINYON_SHIFT_RENDERDOC_COMPOSITION_MARKER",
+    "PinyonShift NR-04C native display composition",
+)
+SELECTION_MARKER = os.environ.get(
+    "PINYON_SHIFT_RENDERDOC_SELECTION_MARKER",
+    "PinyonShift NR-04C native output selection",
+)
+SCHEMA = "pinyon-shift.native-output-comparison.v1"
+
+
+def _flatten(actions):
+    result = []
+    for action in actions:
+        result.append(action)
+        result.extend(_flatten(action.children))
+    return result
+
+
+def _first_action(marker, flag):
+    for action in _flatten(marker.children):
+        if action.flags & flag:
+            return action
+    return None
+
+
+def _action_name(action, structured_file):
+    """Return RenderDoc's displayed action name, including debug markers."""
+    name = action.GetName(structured_file)
+    return name if name else action.customName
+
+
+def _sha256(path):
+    digest = hashlib.sha256()
+    with open(path, "rb") as source:
+        for block in iter(lambda: source.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def _texture_description(controller, resource_id):
+    for texture in controller.GetTextures():
+        if texture.resourceId == resource_id:
+            return texture
+    raise RuntimeError("comparison texture description was not found")
+
+
+def _texture_summary(texture_by_id, resource_id):
+    texture = texture_by_id.get(resource_id)
+    if texture is None:
+        return None
+    return {
+        "resource_id": str(resource_id),
+        "width": texture.width,
+        "height": texture.height,
+    }
+
+
+def _export_resource(controller, resource_id, output_path):
+    if resource_id == rd.ResourceId.Null():
+        raise RuntimeError("comparison action references a null texture")
+    texture = _texture_description(controller, resource_id)
+    save = rd.TextureSave()
+    save.resourceId = resource_id
+    save.destType = rd.FileType.PNG
+    save.alpha = rd.AlphaMapping.Preserve
+    result = controller.SaveTexture(save, output_path)
+    if hasattr(result, "code") and result.code != rd.ResultCode.Succeeded:
+        raise RuntimeError(
+            "RenderDoc failed to save '{}': {}".format(output_path, result)
+        )
+    if not os.path.isfile(output_path):
+        raise RuntimeError("RenderDoc did not create '{}'".format(output_path))
+    return {
+        "resource_id": str(resource_id),
+        "width": texture.width,
+        "height": texture.height,
+        "path": os.path.basename(output_path),
+        "sha256": _sha256(output_path),
+    }
+
+
+def _gpu_durations(controller):
+    available = controller.EnumerateCounters()
+    counter = rd.GPUCounter.EventGPUDuration
+    if counter not in available:
+        raise RuntimeError("RenderDoc replay does not expose GPU duration")
+    results = controller.FetchCounters([counter])
+    return {result.eventId: float(result.value.d) for result in results}
+
+
+def _timing(event_id, durations):
+    if event_id not in durations:
+        raise RuntimeError(
+            "RenderDoc returned no GPU duration for event {}".format(event_id)
+        )
+    seconds = durations[event_id]
+    return {"event_id": event_id, "seconds": seconds, "microseconds": seconds * 1e6}
+
+
+def main():
+    capture_path = os.environ["PINYON_SHIFT_RENDERDOC_CAPTURE"]
+    output_dir = os.environ["PINYON_SHIFT_RENDERDOC_EXPORT_DIR"]
+    report_path = os.path.join(output_dir, "native-output-comparison.json")
+    os.makedirs(output_dir, exist_ok=True)
+
+    capture = rd.OpenCaptureFile()
+    controller = None
+    try:
+        result = capture.OpenFile(capture_path, "", None)
+        if result != rd.ResultCode.Succeeded:
+            raise RuntimeError("could not open capture: {}".format(result))
+        if not capture.LocalReplaySupport():
+            raise RuntimeError("capture does not support local replay")
+        result, controller = capture.OpenCapture(rd.ReplayOptions(), None)
+        if result != rd.ResultCode.Succeeded:
+            raise RuntimeError("could not initialise replay: {}".format(result))
+
+        actions = _flatten(controller.GetRootActions())
+        structured_file = controller.GetStructuredFile()
+        action_names = {
+            action.eventId: _action_name(action, structured_file)
+            for action in actions
+        }
+        texture_by_id = {
+            texture.resourceId: texture for texture in controller.GetTextures()
+        }
+        compositions = [
+            action
+            for action in actions
+            if action_names[action.eventId] == COMPOSITION_MARKER
+        ]
+        selections = [
+            action
+            for action in actions
+            if action_names[action.eventId] == SELECTION_MARKER
+        ]
+        if not compositions or not selections:
+            marker_actions = [
+                action
+                for action in actions
+                if action.flags
+                & (rd.ActionFlags.PushMarker | rd.ActionFlags.SetMarker)
+            ]
+            available_markers = sorted(
+                set(action_names[action.eventId] for action in marker_actions)
+            )
+            copy_actions = [
+                {
+                    "event_id": action.eventId,
+                    "name": action_names[action.eventId],
+                    "source": _texture_summary(texture_by_id, action.copySource),
+                    "destination": _texture_summary(
+                        texture_by_id, action.copyDestination
+                    ),
+                }
+                for action in actions
+                if action.flags & rd.ActionFlags.Copy
+                and "CopyResource" in action_names[action.eventId]
+            ][:64]
+            raise RuntimeError(
+                "NR-04C markers were not found (composition={}, selection={}); "
+                "action_count={}, marker_actions={}, available={}, copies={}, "
+                "sample_actions={}".format(
+                    len(compositions),
+                    len(selections),
+                    len(actions),
+                    len(marker_actions),
+                    available_markers,
+                    copy_actions,
+                    [
+                        (action.eventId, action_names[action.eventId], int(action.flags))
+                        for action in actions[:20] + actions[-20:]
+                    ],
+                )
+            )
+
+        selection = selections[0]
+        composition = next(
+            (a for a in reversed(compositions) if a.eventId < selection.eventId),
+            None,
+        )
+        if composition is None:
+            raise RuntimeError("native selection has no preceding composition marker")
+        dispatch = _first_action(composition, rd.ActionFlags.Dispatch)
+        copy = _first_action(selection, rd.ActionFlags.Copy)
+        if dispatch is None:
+            raise RuntimeError("composition marker contains no dispatch")
+        if copy is None:
+            raise RuntimeError("selection marker contains no copy")
+        if copy.copySource == rd.ResourceId.Null():
+            raise RuntimeError("selection copy has no native source")
+        if copy.copyDestination == rd.ResourceId.Null():
+            raise RuntimeError("selection copy has no guest-output destination")
+        if copy.copySource == copy.copyDestination:
+            raise RuntimeError("native and Xenos outputs alias the same resource")
+
+        controller.SetFrameEvent(copy.eventId - 1, True)
+        xenos = _export_resource(
+            controller,
+            copy.copyDestination,
+            os.path.join(output_dir, "xenos-output.png"),
+        )
+        native_private = _export_resource(
+            controller,
+            copy.copySource,
+            os.path.join(output_dir, "native-private.png"),
+        )
+        controller.SetFrameEvent(copy.eventId, True)
+        native_selected = _export_resource(
+            controller,
+            copy.copyDestination,
+            os.path.join(output_dir, "native-selected.png"),
+        )
+        if native_private["sha256"] != native_selected["sha256"]:
+            raise RuntimeError(
+                "selected native output differs from the private display target"
+            )
+        if (xenos["width"], xenos["height"]) != (
+            native_selected["width"],
+            native_selected["height"],
+        ):
+            raise RuntimeError("paired output dimensions do not match")
+
+        durations = _gpu_durations(controller)
+        report = {
+            "schema": SCHEMA,
+            "capture": {
+                "path": os.path.basename(capture_path),
+                "sha256": _sha256(capture_path),
+            },
+            "marker_counts": {
+                "composition": len(compositions),
+                "selection": len(selections),
+            },
+            "markers": {
+                "composition_event_id": composition.eventId,
+                "selection_event_id": selection.eventId,
+            },
+            "selected_output": "native",
+            "same_frame": True,
+            "sequential_guest_output_writers": True,
+            "xenos_before_selection": xenos,
+            "native_private": native_private,
+            "native_after_selection": native_selected,
+            "gpu_timing": {
+                "native_composition": _timing(dispatch.eventId, durations),
+                "native_selection_copy": _timing(copy.eventId, durations),
+            },
+        }
+        with open(report_path, "w") as output:
+            json.dump(report, output, indent=2, sort_keys=True)
+            output.write("\n")
+        print(report_path)
+        return 0
+    finally:
+        if controller is not None:
+            controller.Shutdown()
+        capture.Shutdown()
+
+
+try:
+    sys.exit(main())
+except Exception as error:
+    message = "native output comparison export failed: {}\n{}".format(
+        error, traceback.format_exc()
+    )
+    output_dir = os.environ.get("PINYON_SHIFT_RENDERDOC_EXPORT_DIR")
+    if output_dir:
+        os.makedirs(output_dir, exist_ok=True)
+        with open(
+            os.path.join(output_dir, "native-output-comparison-error.txt"), "w"
+        ) as output:
+            output.write(message)
+    sys.stderr.write(message)
+    sys.exit(1)

--- a/tools/set-graphics-experiment.ps1
+++ b/tools/set-graphics-experiment.ps1
@@ -1,6 +1,7 @@
 [CmdletBinding()]
 param(
-    [ValidateSet('Get', 'Apply', 'Reset', 'Restore', 'ResetRenderer')]
+    [ValidateSet('Get', 'Apply', 'Reset', 'Restore', 'SetRenderer',
+        'ResetRenderer')]
     [string]$Action = 'Get',
     [ValidateSet(4, 8, 16)]
     [int]$Anisotropy = 4,
@@ -24,7 +25,8 @@ param(
     [string]$DisableMotionBlur = 'false',
     [ValidateSet('true', 'false')]
     [string]$DisableDepthOfField = 'false',
-    [ValidateSet('xenos', 'diagnostic_triangle', 'diagnostic_retained_pass')]
+    [ValidateSet('xenos', 'diagnostic_clear', 'diagnostic_triangle',
+        'diagnostic_retained_pass', 'comparison_native', 'comparison_xenos')]
     [string]$NativeRenderer = 'xenos',
     [string]$StateRoot,
     [switch]$Json
@@ -271,6 +273,19 @@ switch ($Action) {
         }
         $backup = New-ConfigBackup
         $text = Set-TomlValue $text 'pinyon_shift_native_renderer' '"xenos"'
+        Write-Config $text
+    }
+    'SetRenderer' {
+        $text = if (Test-Path -LiteralPath $configPath -PathType Leaf) {
+            Get-Content -LiteralPath $configPath -Raw
+        } else { Get-DefaultConfigText }
+        $schema = Get-SchemaVersion $text
+        if ($schema -notin @(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)) {
+            throw "Unsupported host configuration schema: $schema"
+        }
+        $backup = New-ConfigBackup
+        $text = Set-TomlValue $text 'pinyon_shift_native_renderer' `
+            ('"' + $NativeRenderer + '"')
         Write-Config $text
     }
 }

--- a/tools/tests/test_graphics_settings.py
+++ b/tools/tests/test_graphics_settings.py
@@ -135,6 +135,34 @@ class GraphicsSettingsTests(unittest.TestCase):
             self.assertIn("custom_value = 77", text)
             self.assertTrue(pathlib.Path(result["backup_path"]).is_file())
 
+    def test_set_renderer_selects_comparison_without_changing_other_settings(self):
+        with tempfile.TemporaryDirectory(prefix="pinyon-settings-") as temporary:
+            state = pathlib.Path(temporary)
+            config = state / "config/pinyon_shift.toml"
+            config.parent.mkdir(parents=True)
+            config.write_text(
+                'pinyon_shift_config_schema = 10\n'
+                'pinyon_shift_native_renderer = "xenos"\n'
+                'custom_value = 77\n',
+                encoding="utf-8",
+            )
+            result = self.run_tool(
+                state,
+                "-Action",
+                "SetRenderer",
+                "-NativeRenderer",
+                "comparison_native",
+            )
+            text = config.read_text(encoding="utf-8")
+            self.assertEqual(
+                result["settings"]["native_renderer"], "comparison_native"
+            )
+            self.assertIn(
+                'pinyon_shift_native_renderer = "comparison_native"', text
+            )
+            self.assertIn("custom_value = 77", text)
+            self.assertTrue(pathlib.Path(result["backup_path"]).is_file())
+
     def test_experimental_3x_writes_4k_class_scale_with_fast_readback(self):
         with tempfile.TemporaryDirectory(prefix="pinyon-settings-") as temporary:
             state = pathlib.Path(temporary)

--- a/tools/tests/test_native_renderer_contract.py
+++ b/tools/tests/test_native_renderer_contract.py
@@ -253,7 +253,7 @@ class NativeRendererContractTests(unittest.TestCase):
             ROOT / "src/native_renderer/guest_output_renderer.cpp"
         ).read_text(encoding="utf-8")
         self.assertIn('mode == "diagnostic_retained_pass"', source)
-        self.assertIn("context.draw_retained_pass(context)", source)
+        self.assertIn("context.draw_retained_pass(context, retained_mode)", source)
         self.assertIn('"retained_pass_unavailable"', source)
         self.assertIn('{"suppression", "disabled"}', source)
 
@@ -333,6 +333,74 @@ class NativeRendererContractTests(unittest.TestCase):
         self.assertIn(
             "$nativeRenderer.composition = [string]$event.composition", report
         )
+
+    def test_dual_path_comparison_has_one_controlled_output_authority(self):
+        patch = (
+            ROOT / "patches/rexglue/0069-d3d12-dual-path-comparison.patch"
+        ).read_text(encoding="utf-8")
+        self.assertIn("NativeGuestOutputRetainedPassMode", patch)
+        self.assertIn("kCompareNative", patch)
+        self.assertIn("kCompareXenos", patch)
+        self.assertIn("PinyonShift NR-04C native display composition", patch)
+        self.assertIn("PinyonShift NR-04C native output selection", patch)
+        self.assertIn("if (present_native)", patch)
+        additions = "\n".join(
+            line[1:]
+            for line in patch.splitlines()
+            if line.startswith("+") and not line.startswith("+++")
+        )
+        self.assertEqual(additions.count("D3DCopyResource"), 1)
+        self.assertNotIn("SetDrawSuppression", patch)
+
+        output = (
+            ROOT / "src/native_renderer/guest_output_renderer.cpp"
+        ).read_text(encoding="utf-8")
+        self.assertIn('mode == "comparison_native"', output)
+        self.assertIn('mode == "comparison_xenos"', output)
+        self.assertIn('"selected_output"', output)
+        self.assertIn('"authority"', output)
+        self.assertIn('{"xenos_draw", "preserved"}', output)
+        self.assertIn('{"suppression", "disabled"}', output)
+
+        settings = (ROOT / "tools/set-graphics-experiment.ps1").read_text(
+            encoding="utf-8"
+        )
+        self.assertIn("'SetRenderer'", settings)
+        self.assertIn("'comparison_native'", settings)
+        self.assertIn("'comparison_xenos'", settings)
+
+        capture = (
+            ROOT / "tools/capture-native-renderer-output-comparison.ps1"
+        ).read_text(encoding="utf-8")
+        self.assertIn("Get -StateRoot", capture)
+        self.assertIn("-Action SetRenderer", capture)
+        self.assertIn("finally", capture)
+        self.assertIn("$originalRenderer", capture)
+
+        exporter = (
+            ROOT / "tools/export-native-renderer-output-comparison.py"
+        ).read_text(encoding="utf-8")
+        self.assertIn("pinyon-shift.native-output-comparison.v1", exporter)
+        self.assertIn("copy.copySource", exporter)
+        self.assertIn("copy.copyDestination", exporter)
+        self.assertIn("copy.eventId - 1", exporter)
+        self.assertIn("GPUCounter.EventGPUDuration", exporter)
+        self.assertIn("native-private.png", exporter)
+        self.assertIn("xenos-output.png", exporter)
+
+        wrapper = (
+            ROOT / "tools/export-native-renderer-output-comparison.ps1"
+        ).read_text(encoding="utf-8")
+        self.assertIn("Get-AuthenticodeSignature", wrapper)
+        self.assertIn("Capture must be below", wrapper)
+        self.assertIn("OutputDir must be below", wrapper)
+        self.assertIn("-WindowStyle Hidden", wrapper)
+
+        report = (ROOT / "tools/create-crash-report.ps1").read_text(
+            encoding="utf-8"
+        )
+        self.assertIn("selected_output = $null", report)
+        self.assertIn("authority = $null", report)
 
     def test_shader_capture_is_local_bounded_and_passive(self):
         patch = (

--- a/tools/tests/test_release_contract.py
+++ b/tools/tests/test_release_contract.py
@@ -43,10 +43,10 @@ class ReleaseContractTests(unittest.TestCase):
 
     def test_rexglue_patches_have_stable_order_and_no_binary_payload(self):
         patches = sorted((ROOT / "patches/rexglue").glob("*.patch"))
-        self.assertEqual(len(patches), 68)
+        self.assertEqual(len(patches), 69)
         self.assertEqual(
             patches[-1].name,
-            "0068-d3d12-native-display-target.patch",
+            "0069-d3d12-dual-path-comparison.patch",
         )
         self.assertEqual(len(patches), len({path.name[:4] for path in patches}))
         for path in patches:


### PR DESCRIPTION
## Summary

- add restart-gated `comparison_native` and `comparison_xenos` output modes
- compose the exact-frame retained native pass privately while preserving all Xenos draws and side effects
- select one sequential guest-output authority and report it in runtime/crash diagnostics
- add signed RenderDoc capture/export tooling that fails closed when the command-processor boundary is absent
- document paired AppData visual/performance qualification and the current RenderDoc boundary limitation

## Qualification

- native authority visibly presents the partial retained pass with its amber diagnostic border
- Xenos authority preserves the complete vehicle, HUD, crowd, scene, and post-processing output
- both runs use the same clean executable SHA-256: `81B1BF6A047732CF3A8968E02AB38B1E7C001DC92017DAE20F2353E31CE9E2CE`
- native: 3,837 samples, 53.868 median renderer FPS, 29.440 Hz simulation cadence, one present deadline miss
- Xenos: 3,734 samples, 54.977 median renderer FPS, 29.406 Hz simulation cadence, zero present deadline misses
- renderer configuration restored to `xenos` after qualification

RenderDoc F12 may capture either the guest submission or presenter frame. The strict same-frame exporter correctly rejects captures without the NR-04C command-processor markers. Marker-level GPU timing remains required before any pass suppression; this PR does not enable suppression or change the default renderer.

## Tests

- `python -m unittest discover -s tools/tests -p 'test_*.py'` (156 passed)
- five native renderer test executables (all passed)
- `tools/build-preview.ps1 -CleanGenerated -Parallel 12 -JsonEvents`
- AppData gameplay runs in both comparison modes with clean exit and restoration