### PR TITLE
perf(native-renderer): add gpu timing buckets

### DIFF
--- a/docs/native-renderer/DUAL_PATH_COMPARISON.md
+++ b/docs/native-renderer/DUAL_PATH_COMPARISON.md
@@ -112,8 +112,18 @@ proof that native display authority is real, not a readiness signal for pass
 suppression or default enablement.
 
 Per-pass RenderDoc GPU-duration samples were unavailable from the captured
-boundary. The runtime frame summaries above are the current timing evidence;
-marker-level GPU timing remains an explicit follow-up before suppression work.
+boundary. Engine-owned asynchronous D3D12 timestamp queries now close that
+instrumentation gap. The same clean timing build and AppData scene produced:
+
+- `comparison_native` session `20260829T015610Z-p25896`: 32,604.962 us mean
+  guest-frame GPU time, 90.184 us native composition, 20.682 us native
+  selection, and zero dropped samples;
+- `comparison_xenos` session `20260829T015923Z-p23056`: 34,848.473 us mean
+  guest-frame GPU time, 73.845 us native composition, no selection samples as
+  expected, and zero dropped samples.
+
+See [GPU_TIMING.md](GPU_TIMING.md) for the query lifecycle, counter schema,
+full build identity, and safety boundary.
 
 ## Qualification gates
 
@@ -125,7 +135,7 @@ marker-level GPU timing remains an explicit follow-up before suppression work.
 - When the command-processor submission is captured, the strict export contains
   distinct Xenos/native resources and identical hashes for the private and
   selected native output; otherwise it fails closed.
-- Runtime frame timing is recorded for both authorities. Marker-level GPU
-  duration remains required before pass suppression.
+- Runtime frame timing and native GPU buckets are recorded for both authorities
+  with no CPU wait and no dropped samples in qualification.
 - Unsupported/startup frames yield to Xenos without an output-state fault.
 - Clean exit, relaunch, and renderer restoration remain correct.

--- a/docs/native-renderer/GPU_TIMING.md
+++ b/docs/native-renderer/GPU_TIMING.md
@@ -1,0 +1,77 @@
+# Native renderer GPU timing
+
+NR-04C requires separate GPU evidence for the preserved guest frame, private
+native composition, and native output selection. RenderDoc remains useful for
+resource and image inspection, but its F12 capture boundary did not reliably
+contain the command-processor markers. Patch
+`0070-d3d12-native-gpu-timing.patch` therefore records these buckets directly
+with D3D12 timestamp queries.
+
+## Collection model
+
+The command processor owns a bounded three-frame timing ring. Each active slot
+uses five timestamp queries:
+
+1. guest-frame start;
+2. guest-frame end and native-composition start;
+3. native-composition end;
+4. native-selection start; and
+5. native-selection end.
+
+The queries are resolved to a persistently mapped readback buffer on the same
+command list as the measured work. A slot is consumed only after the existing
+submission fence retires it. Collection never waits for the GPU; if every slot
+is still in flight, the frame increments `native_gpu_timing_drops` and proceeds
+without a timing sample.
+
+The buckets mean:
+
+- `guest_frame_gpu_time_ns`: preserved Xenos command-processor work before the
+  native callback;
+- `native_composition_gpu_time_ns`: construction of the private native display
+  target;
+- `native_selection_gpu_time_ns`: the native-to-guest output copy and barriers.
+
+Selection samples are intentionally absent in `comparison_xenos`, because that
+mode never writes the private target into guest output.
+
+## Performance capture schema
+
+The runtime CSV includes cumulative time and sample counters for all three
+buckets plus the dropped-sample counter. `tools/summarize-performance.py`
+accepts the timing fields only as a complete set and reports per-sample mean
+microseconds. Older captures without any of the fields remain supported;
+partially populated schemas fail closed.
+
+## AppData qualification
+
+Both comparison modes used the same clean binary
+`B4F823DB76742FB8A95A877AE8A34F58BD1F0BD4820EC4E6B898A7FEECBBEE8D`,
+the installed AppData save, the `open_world_day` marker, isolated draw
+`1D253A52B55C9FB3`, and pass anchor `747837906D0BF484`.
+
+| Mode | Session | Guest frame | Native composition | Native selection | Drops |
+| --- | --- | ---: | ---: | ---: | ---: |
+| `comparison_native` | `20260829T015610Z-p25896` | 32,604.962 us | 90.184 us | 20.682 us | 0 |
+| `comparison_xenos` | `20260829T015923Z-p23056` | 34,848.473 us | 73.845 us | n/a | 0 |
+
+The native-selected run collected 1,984 guest samples and 1,985 composition
+and selection samples over 5,548 measured frames. It displayed the partial
+retained native target and continuously reported native output authority. The
+Xenos-selected run collected 1,892 guest samples and 1,893 composition samples
+over 5,243 measured frames. It displayed the complete Xenos scene and correctly
+recorded zero selection samples. Both runs reported zero presentation deadline
+misses, no timing drops, and no device removal, TDR, or output-state fault.
+
+Local machine-readable summaries are retained below `.local/qualification` as
+`nr04c-gpu-timing-native-summary.json` and
+`nr04c-gpu-timing-xenos-summary.json`.
+
+## Safety boundary
+
+Timing changes observation only. Renderer selection remains restart-gated and
+default-off, Xenos draws and guest side effects remain preserved, and no draw
+or resolve suppression API is introduced. Startup, stale, unsupported, or
+failed native frames continue to yield to Xenos. These measurements close the
+NR-04C timing-evidence gap; they do not establish visual coverage or authorize
+NR-04D suppression by themselves.

--- a/patches/rexglue/0070-d3d12-native-gpu-timing.patch
+++ b/patches/rexglue/0070-d3d12-native-gpu-timing.patch
@@ -1,0 +1,397 @@
+diff --git a/include/rex/graphics/d3d12/command_processor.h b/include/rex/graphics/d3d12/command_processor.h
+index a7a3a9b..e6a8075 100644
+--- a/include/rex/graphics/d3d12/command_processor.h
++++ b/include/rex/graphics/d3d12/command_processor.h
+@@ -384,6 +384,11 @@ class D3D12CommandProcessor : public CommandProcessor {
+   bool IssueDraw_MemexportReadbackFullPath(uint32_t total_size);
+   bool IssueDraw_MemexportReadbackFastPath(uint32_t total_size);
+ 
++  bool InitializeNativeGuestOutputGpuTiming();
++  void ShutdownNativeGuestOutputGpuTiming();
++  void BeginNativeGuestOutputGpuTimingFrame();
++  void RetireNativeGuestOutputGpuTimings();
++
+   // Returns a buffer for reading GPU data back to the CPU. Assuming
+   // synchronizing immediately after use. Always in COPY_DEST state.
+   ID3D12Resource* RequestReadbackBuffer(uint32_t size);
+@@ -656,6 +661,23 @@ class D3D12CommandProcessor : public CommandProcessor {
+       D3D12_RESOURCE_STATE_UNORDERED_ACCESS;
+   uint64_t native_guest_output_display_target_submission_ = 0;
+ 
++  static constexpr uint32_t kNativeGuestOutputGpuQueriesPerFrame = 5;
++  struct NativeGuestOutputGpuTimingSlot {
++    uint64_t submission = 0;
++    bool frame_started = false;
++    bool guest_timed = false;
++    bool selection_timed = false;
++  };
++  Microsoft::WRL::ComPtr<ID3D12QueryHeap>
++      native_guest_output_gpu_query_heap_;
++  Microsoft::WRL::ComPtr<ID3D12Resource>
++      native_guest_output_gpu_query_readback_;
++  uint64_t* native_guest_output_gpu_query_mapping_ = nullptr;
++  uint64_t native_guest_output_gpu_timestamp_frequency_ = 0;
++  std::array<NativeGuestOutputGpuTimingSlot, kQueueFrames>
++      native_guest_output_gpu_timing_slots_{};
++  bool native_guest_output_gpu_timing_active_ = false;
++
+   struct ResolveDownscaleConstants {
+     uint32_t scale_x;
+     uint32_t scale_y;
+diff --git a/include/rex/perf/counter.h b/include/rex/perf/counter.h
+index 97b1683..be36e8c 100644
+--- a/include/rex/perf/counter.h
++++ b/include/rex/perf/counter.h
+@@ -28,6 +28,13 @@ enum class CounterId : uint16_t {
+   kDrawCalls,
+   kCommandBufferStalls,
+   kVerticesProcessed,
++  kGuestFrameGpuTimeNs,
++  kNativeCompositionGpuTimeNs,
++  kNativeSelectionGpuTimeNs,
++  kGuestFrameGpuTimingSamples,
++  kNativeCompositionGpuTimingSamples,
++  kNativeSelectionGpuTimingSamples,
++  kNativeGpuTimingDrops,
+ 
+   // Audio
+   kXmaFramesDecoded,
+@@ -200,6 +207,18 @@ class Profiler {
+ #define PROFILE_DRAW_CALL() PERF_counter_inc(kDrawCalls)
+ #define PROFILE_VERTICES(n) PERF_counter_add(kVerticesProcessed, n)
+ #define PROFILE_CMD_BUFFER_STALL() PERF_counter_inc(kCommandBufferStalls)
++#define PROFILE_GUEST_FRAME_GPU_TIME_NS(n) PERF_counter_add(kGuestFrameGpuTimeNs, n)
++#define PROFILE_NATIVE_COMPOSITION_GPU_TIME_NS(n) \
++  PERF_counter_add(kNativeCompositionGpuTimeNs, n)
++#define PROFILE_NATIVE_SELECTION_GPU_TIME_NS(n) \
++  PERF_counter_add(kNativeSelectionGpuTimeNs, n)
++#define PROFILE_GUEST_FRAME_GPU_TIMING_SAMPLE() \
++  PERF_counter_inc(kGuestFrameGpuTimingSamples)
++#define PROFILE_NATIVE_COMPOSITION_GPU_TIMING_SAMPLE() \
++  PERF_counter_inc(kNativeCompositionGpuTimingSamples)
++#define PROFILE_NATIVE_SELECTION_GPU_TIMING_SAMPLE() \
++  PERF_counter_inc(kNativeSelectionGpuTimingSamples)
++#define PROFILE_NATIVE_GPU_TIMING_DROP() PERF_counter_inc(kNativeGpuTimingDrops)
+ #define PROFILE_AUDIO_LATENCY_US(value) PERF_counter_set(kAudioFrameLatencyUs, value)
+ #define PROFILE_BUFFER_QUEUE_DEPTH(value) PERF_counter_set(kBufferQueueDepth, value)
+ #define PROFILE_THREAD_CREATED() PERF_counter_inc(kActiveThreads)
+@@ -248,6 +267,13 @@ class Profiler {
+ #define PROFILE_DRAW_CALL()
+ #define PROFILE_VERTICES(n)
+ #define PROFILE_CMD_BUFFER_STALL()
++#define PROFILE_GUEST_FRAME_GPU_TIME_NS(n)
++#define PROFILE_NATIVE_COMPOSITION_GPU_TIME_NS(n)
++#define PROFILE_NATIVE_SELECTION_GPU_TIME_NS(n)
++#define PROFILE_GUEST_FRAME_GPU_TIMING_SAMPLE()
++#define PROFILE_NATIVE_COMPOSITION_GPU_TIMING_SAMPLE()
++#define PROFILE_NATIVE_SELECTION_GPU_TIMING_SAMPLE()
++#define PROFILE_NATIVE_GPU_TIMING_DROP()
+ #define PROFILE_AUDIO_LATENCY_US(value)
+ #define PROFILE_BUFFER_QUEUE_DEPTH(value)
+ #define PROFILE_THREAD_CREATED()
+diff --git a/src/core/perf/counter.cpp b/src/core/perf/counter.cpp
+index 11f57cf..5a4c6b2 100644
+--- a/src/core/perf/counter.cpp
++++ b/src/core/perf/counter.cpp
+@@ -37,6 +37,13 @@ constexpr const char* kCounterNames[] = {
+     "draw_calls",
+     "command_buffer_stalls",
+     "vertices_processed",
++    "guest_frame_gpu_time_ns",
++    "native_composition_gpu_time_ns",
++    "native_selection_gpu_time_ns",
++    "guest_frame_gpu_timing_samples",
++    "native_composition_gpu_timing_samples",
++    "native_selection_gpu_timing_samples",
++    "native_gpu_timing_drops",
+     "xma_frames_decoded",
+     "xma_no_space_stalls",
+     "xma_no_progress_stalls",
+@@ -100,6 +107,13 @@ constexpr bool kIsGauge[] = {
+     false,  // kDrawCalls
+     false,  // kCommandBufferStalls
+     false,  // kVerticesProcessed
++    false,  // kGuestFrameGpuTimeNs
++    false,  // kNativeCompositionGpuTimeNs
++    false,  // kNativeSelectionGpuTimeNs
++    false,  // kGuestFrameGpuTimingSamples
++    false,  // kNativeCompositionGpuTimingSamples
++    false,  // kNativeSelectionGpuTimingSamples
++    false,  // kNativeGpuTimingDrops
+     false,  // kXmaFramesDecoded
+     false,  // kXmaNoSpaceStalls
+     false,  // kXmaNoProgressStalls
+diff --git a/src/graphics/d3d12/command_processor.cpp b/src/graphics/d3d12/command_processor.cpp
+index 163333e..95e917a 100644
+--- a/src/graphics/d3d12/command_processor.cpp
++++ b/src/graphics/d3d12/command_processor.cpp
+@@ -1787,6 +1787,7 @@ bool D3D12CommandProcessor::SetupContext() {
+   }
+ 
+   occlusion_query_resources_available_ = InitializeOcclusionQueryResources();
++  InitializeNativeGuestOutputGpuTiming();
+ 
+   // Just not to expose uninitialized memory.
+   std::memset(&system_constants_, 0, sizeof(system_constants_));
+@@ -1797,6 +1798,7 @@ bool D3D12CommandProcessor::SetupContext() {
+ void D3D12CommandProcessor::ShutdownContext() {
+   AwaitAllQueueOperationsCompletion();
+   InvalidateAllVertexBufferResidency();
++  ShutdownNativeGuestOutputGpuTiming();
+   ShutdownOcclusionQueryResources();
+ 
+   ui::d3d12::util::ReleaseAndNull(readback_buffer_);
+@@ -2333,6 +2335,32 @@ bool D3D12CommandProcessor::DrawNativeGuestOutputRetainedPass(
+         D3D12_RESOURCE_STATE_UNORDERED_ACCESS;
+   }
+ 
++  NativeGuestOutputGpuTimingSlot* timing_slot = nullptr;
++  uint32_t timing_query_base = 0;
++  if (comparison) {
++    native_guest_output_gpu_timing_active_ = true;
++    if (native_guest_output_gpu_query_heap_ &&
++        native_guest_output_gpu_query_readback_) {
++      const uint32_t slot_index =
++          uint32_t(frame_current_ % kQueueFrames);
++      auto& candidate_slot =
++          native_guest_output_gpu_timing_slots_[slot_index];
++      if (!candidate_slot.submission) {
++        timing_slot = &candidate_slot;
++        timing_slot->guest_timed = timing_slot->frame_started;
++        timing_query_base =
++            slot_index * kNativeGuestOutputGpuQueriesPerFrame;
++        deferred_command_list_.D3DEndQuery(
++            native_guest_output_gpu_query_heap_.Get(),
++            D3D12_QUERY_TYPE_TIMESTAMP, timing_query_base + 1);
++      } else {
++        PROFILE_NATIVE_GPU_TIMING_DROP();
++      }
++    } else {
++      PROFILE_NATIVE_GPU_TIMING_DROP();
++    }
++  }
++
+   ui::d3d12::util::DescriptorCpuGpuHandlePair descriptors[2];
+   if (!RequestOneUseSingleViewDescriptors(2, descriptors)) {
+     static bool logged_retained_preview_descriptor_failure = false;
+@@ -2401,11 +2429,22 @@ bool D3D12CommandProcessor::DrawNativeGuestOutputRetainedPass(
+   if (comparison) {
+     deferred_command_list_.EndDebugMarker();
+   }
++  if (timing_slot) {
++    deferred_command_list_.D3DEndQuery(
++        native_guest_output_gpu_query_heap_.Get(),
++        D3D12_QUERY_TYPE_TIMESTAMP, timing_query_base + 2);
++  }
+   if (present_native) {
+     if (comparison) {
+       deferred_command_list_.BeginDebugMarker(
+           "PinyonShift NR-04C native output selection");
+     }
++    if (timing_slot) {
++      timing_slot->selection_timed = true;
++      deferred_command_list_.D3DEndQuery(
++          native_guest_output_gpu_query_heap_.Get(),
++          D3D12_QUERY_TYPE_TIMESTAMP, timing_query_base + 3);
++    }
+     PushTransitionBarrier(
+         resource, ui::d3d12::D3D12Presenter::kGuestOutputInternalState,
+         D3D12_RESOURCE_STATE_COPY_DEST);
+@@ -2414,10 +2453,29 @@ bool D3D12CommandProcessor::DrawNativeGuestOutputRetainedPass(
+         resource, native_guest_output_display_target_.Get());
+     PushTransitionBarrier(resource, D3D12_RESOURCE_STATE_COPY_DEST,
+                           ui::d3d12::D3D12Presenter::kGuestOutputInternalState);
++    SubmitBarriers();
++    if (timing_slot) {
++      deferred_command_list_.D3DEndQuery(
++          native_guest_output_gpu_query_heap_.Get(),
++          D3D12_QUERY_TYPE_TIMESTAMP, timing_query_base + 4);
++    }
+     if (comparison) {
+       deferred_command_list_.EndDebugMarker();
+     }
+   }
++  if (timing_slot) {
++    const uint32_t first_query =
++        timing_query_base + (timing_slot->guest_timed ? 0 : 1);
++    const uint32_t last_query = timing_query_base +
++        (timing_slot->selection_timed ? 4 : 2);
++    deferred_command_list_.D3DResolveQueryData(
++        native_guest_output_gpu_query_heap_.Get(),
++        D3D12_QUERY_TYPE_TIMESTAMP, first_query,
++        last_query - first_query + 1,
++        native_guest_output_gpu_query_readback_.Get(),
++        uint64_t(first_query) * sizeof(uint64_t));
++    timing_slot->submission = submission_current_;
++  }
+   native_guest_output_display_target_state_ =
+       D3D12_RESOURCE_STATE_COPY_SOURCE;
+   native_guest_output_display_target_submission_ = submission_current_;
+@@ -3954,6 +4012,7 @@ void D3D12CommandProcessor::CheckSubmissionFence(uint64_t await_submission) {
+     REXGPU_ERROR("Failed to await a submission completion Direct3D 12 fence");
+   }
+   RetireModernZPDQueries();
++  RetireNativeGuestOutputGpuTimings();
+   if (submission_completed_ <= submission_completed_before) {
+     // Not updated - no need to reclaim or download things.
+     return;
+@@ -4112,6 +4171,9 @@ bool D3D12CommandProcessor::BeginSubmission(bool is_guest_command) {
+     // end of the submission (when async pipeline creation requests are
+     // fulfilled).
+     deferred_command_list_.Reset();
++    if (is_opening_frame) {
++      BeginNativeGuestOutputGpuTimingFrame();
++    }
+ 
+     // Reset cached state of the command list.
+     ff_viewport_update_needed_ = true;
+@@ -5628,6 +5690,149 @@ ID3D12Resource* D3D12CommandProcessor::RequestReadbackBuffer(uint32_t size) {
+   return readback_buffer_;
+ }
+ 
++bool D3D12CommandProcessor::InitializeNativeGuestOutputGpuTiming() {
++  native_guest_output_gpu_query_heap_.Reset();
++  native_guest_output_gpu_query_readback_.Reset();
++  native_guest_output_gpu_query_mapping_ = nullptr;
++  native_guest_output_gpu_timestamp_frequency_ = 0;
++  native_guest_output_gpu_timing_slots_ = {};
++  native_guest_output_gpu_timing_active_ = false;
++
++  ID3D12Device* device = GetD3D12Provider().GetDevice();
++  ID3D12CommandQueue* direct_queue = GetD3D12Provider().GetDirectQueue();
++  if (!device || !direct_queue ||
++      FAILED(direct_queue->GetTimestampFrequency(
++          &native_guest_output_gpu_timestamp_frequency_)) ||
++      !native_guest_output_gpu_timestamp_frequency_) {
++    REXGPU_WARN("Native guest-output GPU timestamps are unavailable");
++    return false;
++  }
++
++  D3D12_QUERY_HEAP_DESC heap_desc{};
++  heap_desc.Type = D3D12_QUERY_HEAP_TYPE_TIMESTAMP;
++  heap_desc.Count =
++      kQueueFrames * kNativeGuestOutputGpuQueriesPerFrame;
++  if (FAILED(device->CreateQueryHeap(
++          &heap_desc,
++          IID_PPV_ARGS(&native_guest_output_gpu_query_heap_)))) {
++    REXGPU_WARN("Failed to create native guest-output GPU timestamp heap");
++    return false;
++  }
++
++  const uint64_t readback_size =
++      sizeof(uint64_t) * heap_desc.Count;
++  D3D12_RESOURCE_DESC buffer_desc;
++  ui::d3d12::util::FillBufferResourceDesc(
++      buffer_desc, readback_size, D3D12_RESOURCE_FLAG_NONE);
++  if (FAILED(device->CreateCommittedResource(
++          &ui::d3d12::util::kHeapPropertiesReadback,
++          GetD3D12Provider().GetHeapFlagCreateNotZeroed(), &buffer_desc,
++          D3D12_RESOURCE_STATE_COPY_DEST, nullptr,
++          IID_PPV_ARGS(&native_guest_output_gpu_query_readback_)))) {
++    REXGPU_WARN(
++        "Failed to allocate native guest-output GPU timestamp readback");
++    native_guest_output_gpu_query_heap_.Reset();
++    return false;
++  }
++
++  D3D12_RANGE read_range{0, SIZE_T(readback_size)};
++  void* mapping = nullptr;
++  if (FAILED(native_guest_output_gpu_query_readback_->Map(
++          0, &read_range, &mapping))) {
++    REXGPU_WARN("Failed to map native guest-output GPU timestamps");
++    native_guest_output_gpu_query_readback_.Reset();
++    native_guest_output_gpu_query_heap_.Reset();
++    return false;
++  }
++  native_guest_output_gpu_query_mapping_ =
++      static_cast<uint64_t*>(mapping);
++  return true;
++}
++
++void D3D12CommandProcessor::ShutdownNativeGuestOutputGpuTiming() {
++  RetireNativeGuestOutputGpuTimings();
++  if (native_guest_output_gpu_query_readback_ &&
++      native_guest_output_gpu_query_mapping_) {
++    native_guest_output_gpu_query_readback_->Unmap(0, nullptr);
++  }
++  native_guest_output_gpu_query_mapping_ = nullptr;
++  native_guest_output_gpu_query_readback_.Reset();
++  native_guest_output_gpu_query_heap_.Reset();
++  native_guest_output_gpu_timestamp_frequency_ = 0;
++  native_guest_output_gpu_timing_slots_ = {};
++  native_guest_output_gpu_timing_active_ = false;
++}
++
++void D3D12CommandProcessor::BeginNativeGuestOutputGpuTimingFrame() {
++  if (!native_guest_output_gpu_timing_active_ ||
++      !native_guest_output_gpu_query_heap_) {
++    return;
++  }
++  const uint32_t slot_index = uint32_t(frame_current_ % kQueueFrames);
++  auto& slot = native_guest_output_gpu_timing_slots_[slot_index];
++  if (slot.submission) {
++    PROFILE_NATIVE_GPU_TIMING_DROP();
++    return;
++  }
++  slot = {};
++  slot.frame_started = true;
++  const uint32_t query_base =
++      slot_index * kNativeGuestOutputGpuQueriesPerFrame;
++  deferred_command_list_.D3DEndQuery(
++      native_guest_output_gpu_query_heap_.Get(),
++      D3D12_QUERY_TYPE_TIMESTAMP, query_base);
++}
++
++void D3D12CommandProcessor::RetireNativeGuestOutputGpuTimings() {
++  if (!native_guest_output_gpu_query_mapping_ ||
++      !native_guest_output_gpu_timestamp_frequency_) {
++    return;
++  }
++  auto ticks_to_ns = [this](uint64_t ticks) -> int64_t {
++    const long double nanoseconds =
++        static_cast<long double>(ticks) * 1000000000.0L /
++        static_cast<long double>(
++            native_guest_output_gpu_timestamp_frequency_);
++    return static_cast<int64_t>(nanoseconds);
++  };
++  for (uint32_t slot_index = 0; slot_index < kQueueFrames;
++       ++slot_index) {
++    auto& slot = native_guest_output_gpu_timing_slots_[slot_index];
++    if (!slot.submission || slot.submission > submission_completed_) {
++      continue;
++    }
++    const uint32_t query_base =
++        slot_index * kNativeGuestOutputGpuQueriesPerFrame;
++    const uint64_t* timestamps =
++        native_guest_output_gpu_query_mapping_ + query_base;
++    bool valid = timestamps[2] >= timestamps[1];
++    if (slot.guest_timed) {
++      valid &= timestamps[1] >= timestamps[0];
++    }
++    if (slot.selection_timed) {
++      valid &= timestamps[4] >= timestamps[3];
++    }
++    if (valid) {
++      if (slot.guest_timed) {
++        PROFILE_GUEST_FRAME_GPU_TIME_NS(
++            ticks_to_ns(timestamps[1] - timestamps[0]));
++        PROFILE_GUEST_FRAME_GPU_TIMING_SAMPLE();
++      }
++      PROFILE_NATIVE_COMPOSITION_GPU_TIME_NS(
++          ticks_to_ns(timestamps[2] - timestamps[1]));
++      PROFILE_NATIVE_COMPOSITION_GPU_TIMING_SAMPLE();
++      if (slot.selection_timed) {
++        PROFILE_NATIVE_SELECTION_GPU_TIME_NS(
++            ticks_to_ns(timestamps[4] - timestamps[3]));
++        PROFILE_NATIVE_SELECTION_GPU_TIMING_SAMPLE();
++      }
++    } else {
++      PROFILE_NATIVE_GPU_TIMING_DROP();
++    }
++    slot = {};
++  }
++}
++
+ bool D3D12CommandProcessor::InitializeOcclusionQueryResources() {
+   active_occlusion_query_ = {};
+   occlusion_query_cursor_ = 0;

--- a/tools/summarize-performance.py
+++ b/tools/summarize-performance.py
@@ -81,6 +81,15 @@ PRESENTATION_COLUMNS = (
     "duplicate_present_count",
     "dropped_present_count",
 )
+NATIVE_GPU_TIMING_COLUMNS = (
+    "guest_frame_gpu_time_ns",
+    "native_composition_gpu_time_ns",
+    "native_selection_gpu_time_ns",
+    "guest_frame_gpu_timing_samples",
+    "native_composition_gpu_timing_samples",
+    "native_selection_gpu_timing_samples",
+    "native_gpu_timing_drops",
+)
 
 
 class CaptureError(ValueError):
@@ -147,6 +156,20 @@ def summarize(path: pathlib.Path) -> dict[str, Any]:
                 "capture has an incomplete presentation counter set: "
                 + ", ".join(missing_presentation)
             )
+        available_native_gpu_timing = columns.intersection(
+            NATIVE_GPU_TIMING_COLUMNS
+        )
+        if (
+            available_native_gpu_timing
+            and available_native_gpu_timing != set(NATIVE_GPU_TIMING_COLUMNS)
+        ):
+            missing_native_gpu_timing = sorted(
+                set(NATIVE_GPU_TIMING_COLUMNS) - available_native_gpu_timing
+            )
+            raise CaptureError(
+                "capture has an incomplete native GPU timing counter set: "
+                + ", ".join(missing_native_gpu_timing)
+            )
 
         frame_times: list[float] = []
         totals = {name: 0.0 for name in TOTAL_COLUMNS}
@@ -158,6 +181,11 @@ def summarize(path: pathlib.Path) -> dict[str, Any]:
         presentation_totals = (
             {name: 0.0 for name in PRESENTATION_COLUMNS}
             if available_presentation else None
+        )
+        native_gpu_timing_totals = (
+            {name: 0.0 for name in NATIVE_GPU_TIMING_COLUMNS}
+            if available_native_gpu_timing
+            else None
         )
         presentation_delta_samples = {
             "guest_vblank_delta_ns": 0,
@@ -183,6 +211,10 @@ def summarize(path: pathlib.Path) -> dict[str, Any]:
                 name: finite_number(row[name], column=name, row_number=row_number)
                 for name in PRESENTATION_COLUMNS
             } if presentation_totals is not None else {})
+            row_native_gpu_timing = ({
+                name: finite_number(row[name], column=name, row_number=row_number)
+                for name in NATIVE_GPU_TIMING_COLUMNS
+            } if native_gpu_timing_totals is not None else {})
             # The runtime writes one initialization row with frame_time_us == 0.
             # It is valid CSV, but not a displayed frame and must not skew latency.
             if frame_time == 0:
@@ -202,6 +234,8 @@ def summarize(path: pathlib.Path) -> dict[str, Any]:
                 presentation_totals[name] += value
                 if name in presentation_delta_samples and value > 0:
                     presentation_delta_samples[name] += 1
+            for name, value in row_native_gpu_timing.items():
+                native_gpu_timing_totals[name] += value
 
     if rows_seen == 0:
         raise CaptureError("capture contains a header but no rows")
@@ -282,6 +316,35 @@ def summarize(path: pathlib.Path) -> dict[str, Any]:
                 ),
             },
         }
+    if native_gpu_timing_totals is not None:
+        counters = {
+            name: int(value) if value.is_integer() else value
+            for name, value in native_gpu_timing_totals.items()
+        }
+
+        def mean_microseconds(time_name: str, sample_name: str) -> float | None:
+            samples = counters[sample_name]
+            if not samples:
+                return None
+            return round(counters[time_name] / samples / 1000.0, 3)
+
+        result["native_renderer_gpu_timing"] = {
+            "counters": counters,
+            "mean_microseconds": {
+                "guest_frame": mean_microseconds(
+                    "guest_frame_gpu_time_ns",
+                    "guest_frame_gpu_timing_samples",
+                ),
+                "native_composition": mean_microseconds(
+                    "native_composition_gpu_time_ns",
+                    "native_composition_gpu_timing_samples",
+                ),
+                "native_selection": mean_microseconds(
+                    "native_selection_gpu_time_ns",
+                    "native_selection_gpu_timing_samples",
+                ),
+            },
+        }
     return result
 
 
@@ -354,6 +417,18 @@ def markdown(summary: dict[str, Any]) -> str:
             f"- Present deadline misses: {pacing['counters']['present_deadline_misses']}",
             f"- Duplicate presents: {pacing['counters']['duplicate_present_count']}",
             f"- Dropped presents: {pacing['counters']['dropped_present_count']}",
+        ])
+    if "native_renderer_gpu_timing" in summary:
+        timing = summary["native_renderer_gpu_timing"]
+        means = timing["mean_microseconds"]
+        lines.extend([
+            "",
+            "## Native renderer GPU timing",
+            "",
+            f"- Guest frame bucket: {means['guest_frame'] if means['guest_frame'] is not None else 'n/a'} us",
+            f"- Native composition: {means['native_composition'] if means['native_composition'] is not None else 'n/a'} us",
+            f"- Native selection: {means['native_selection'] if means['native_selection'] is not None else 'n/a'} us",
+            f"- Dropped samples: {timing['counters']['native_gpu_timing_drops']}",
         ])
     return "\n".join(lines) + "\n"
 

--- a/tools/tests/test_native_renderer_contract.py
+++ b/tools/tests/test_native_renderer_contract.py
@@ -402,6 +402,28 @@ class NativeRendererContractTests(unittest.TestCase):
         self.assertIn("selected_output = $null", report)
         self.assertIn("authority = $null", report)
 
+    def test_native_gpu_timing_is_async_bounded_and_non_suppressing(self):
+        patch = (
+            ROOT / "patches/rexglue/0070-d3d12-native-gpu-timing.patch"
+        ).read_text(encoding="utf-8")
+        self.assertIn("D3D12_QUERY_HEAP_TYPE_TIMESTAMP", patch)
+        self.assertIn("kNativeGuestOutputGpuQueriesPerFrame = 5", patch)
+        self.assertIn("std::array<NativeGuestOutputGpuTimingSlot", patch)
+        self.assertIn("slot.submission > submission_completed_", patch)
+        self.assertIn("D3DResolveQueryData", patch)
+        self.assertIn("PROFILE_GUEST_FRAME_GPU_TIME_NS", patch)
+        self.assertIn("PROFILE_NATIVE_COMPOSITION_GPU_TIME_NS", patch)
+        self.assertIn("PROFILE_NATIVE_SELECTION_GPU_TIME_NS", patch)
+        self.assertIn("PROFILE_NATIVE_GPU_TIMING_DROP", patch)
+        self.assertNotIn("WaitForSingleObject", patch)
+        self.assertNotIn("SetDrawSuppression", patch)
+
+        summarizer = (ROOT / "tools/summarize-performance.py").read_text(
+            encoding="utf-8"
+        )
+        self.assertIn("NATIVE_GPU_TIMING_COLUMNS", summarizer)
+        self.assertIn('"native_renderer_gpu_timing"', summarizer)
+
     def test_shader_capture_is_local_bounded_and_passive(self):
         patch = (
             ROOT

--- a/tools/tests/test_performance_summary.py
+++ b/tools/tests/test_performance_summary.py
@@ -24,6 +24,46 @@ FIELDS = [
 
 
 class PerformanceSummaryTests(unittest.TestCase):
+    def test_emits_native_renderer_gpu_timing_buckets(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            capture = pathlib.Path(temporary) / "capture.csv"
+            timing_columns = list(MODULE.NATIVE_GPU_TIMING_COLUMNS)
+            fields = FIELDS + timing_columns
+            with capture.open("w", encoding="utf-8", newline="") as stream:
+                writer = csv.DictWriter(stream, fieldnames=fields)
+                writer.writeheader()
+                base = dict.fromkeys(fields, 0)
+                writer.writerow(base | {
+                    "frame_time_us": 20_000,
+                    "guest_frame_gpu_time_ns": 10_000_000,
+                    "native_composition_gpu_time_ns": 200_000,
+                    "native_selection_gpu_time_ns": 40_000,
+                    "guest_frame_gpu_timing_samples": 1,
+                    "native_composition_gpu_timing_samples": 1,
+                    "native_selection_gpu_timing_samples": 1,
+                })
+                writer.writerow(base | {
+                    "frame_time_us": 20_000,
+                    "guest_frame_gpu_time_ns": 12_000_000,
+                    "native_composition_gpu_time_ns": 300_000,
+                    "native_selection_gpu_time_ns": 60_000,
+                    "guest_frame_gpu_timing_samples": 1,
+                    "native_composition_gpu_timing_samples": 1,
+                    "native_selection_gpu_timing_samples": 1,
+                    "native_gpu_timing_drops": 1,
+                })
+            timing = MODULE.summarize(capture)[
+                "native_renderer_gpu_timing"
+            ]
+            self.assertEqual(timing["mean_microseconds"]["guest_frame"], 11_000)
+            self.assertEqual(
+                timing["mean_microseconds"]["native_composition"], 250
+            )
+            self.assertEqual(
+                timing["mean_microseconds"]["native_selection"], 50
+            )
+            self.assertEqual(timing["counters"]["native_gpu_timing_drops"], 1)
+
     def test_emits_presentation_cadence_and_totals(self):
         with tempfile.TemporaryDirectory() as temporary:
             capture = pathlib.Path(temporary) / "capture.csv"

--- a/tools/tests/test_release_contract.py
+++ b/tools/tests/test_release_contract.py
@@ -43,10 +43,10 @@ class ReleaseContractTests(unittest.TestCase):
 
     def test_rexglue_patches_have_stable_order_and_no_binary_payload(self):
         patches = sorted((ROOT / "patches/rexglue").glob("*.patch"))
-        self.assertEqual(len(patches), 69)
+        self.assertEqual(len(patches), 70)
         self.assertEqual(
             patches[-1].name,
-            "0069-d3d12-dual-path-comparison.patch",
+            "0070-d3d12-native-gpu-timing.patch",
         )
         self.assertEqual(len(patches), len({path.name[:4] for path in patches}))
         for path in patches:


### PR DESCRIPTION
## Summary

- add bounded asynchronous D3D12 timestamp queries for guest, native composition, and native selection work
- export complete timing counters through performance CSV summaries
- document paired AppData comparison evidence with zero timing drops
- preserve Xenos fallback and keep all draw/resolve suppression disabled

## Validation

- 158 Python contract tests
- five native renderer test executables
- clean preview build (SHA-256 B4F823DB76742FB8A95A877AE8A34F58BD1F0BD4820EC4E6B898A7FEECBBEE8D)
- AppData comparison_native and comparison_xenos gameplay qualification