### PR TITLE
test(native-renderer): gate pass suppression evidence

### DIFF
--- a/docs/native-renderer/GUEST_VISIBLE_RENDER_DEPENDENCIES.md
+++ b/docs/native-renderer/GUEST_VISIBLE_RENDER_DEPENDENCIES.md
@@ -118,3 +118,8 @@ source log contains machine-specific paths and session identifiers.
 Gate B remains closed after this capture. CPU-read observation, presentation
 provenance, and semantic classification are separate evidence tasks, not facts
 that may be inferred from the absence of a texture-fetch match.
+
+NR-04D evaluates these unknowns per exact pass family with the fail-closed
+admission contract in [SUPPRESSION_ADMISSION.md](SUPPRESSION_ADMISSION.md).
+Neither this aggregate census nor a visually correct native output can bypass
+those family-specific gates.

--- a/docs/native-renderer/SUPPRESSION_ADMISSION.md
+++ b/docs/native-renderer/SUPPRESSION_ADMISSION.md
@@ -1,0 +1,54 @@
+# Pass-suppression admission
+
+NR-04D must not infer safety from a correct-looking frame, a recurring draw
+signature, or a GPU-time measurement. A pass family becomes eligible for a
+suppression implementation only after one local evidence bundle proves every
+required gate for one exact build and scene.
+
+`tools/evaluate-native-renderer-suppression.py` validates that bundle and emits
+a deterministic admission report. The evaluator cannot enable suppression.
+Its output always records `suppression_allowed=false`, Xenos draws preserved,
+and both draw and resolve suppression absent. A fully passing report means only
+that a separate, default-off implementation PR may begin.
+
+## Required gates
+
+| Gate | Required proof |
+| --- | --- |
+| `exact_family_identity` | Exact scene-qualified signatures and stable pass boundaries |
+| `complete_native_coverage` | Every draw in the selected target phase is reproduced |
+| `color_parity` | Complete-pass color comparison passes the documented tolerance |
+| `depth_parity` | Complete-pass depth comparison passes or proves no depth effect |
+| `later_gpu_consumers` | Every later GPU consumer is replaced or proven absent |
+| `guest_cpu_visibility` | CPU reads are preserved/replaced or proven absent |
+| `query_side_effects` | Query behavior is preserved or proven unrelated |
+| `memexport_side_effects` | Memexport behavior is preserved or proven absent |
+| `output_freshness` | Exact-frame publication and stale-frame yield are qualified |
+| `fallback_recovery` | Unsupported/error states yield cleanly to Xenos |
+| `gpu_timing` | Native and preserved-Xenos GPU buckets are available without drops |
+| `rollback_switch` | An independent default-off family switch is specified and tested |
+
+Each gate is `pass`, `fail`, or `unknown` and requires an evidence explanation.
+Unknown is a blocker, not an implicit negative result. Local artifacts may be
+attached by path and uppercase SHA-256. Passing `--artifact-root` verifies that
+every referenced file exists below that root and matches its hash.
+
+Use `--require-ready` in a future suppression implementation workflow; it exits
+with code 2 until every gate passes. A malformed or unsafe bundle exits with
+code 1.
+
+## Current retained sky/horizon family
+
+The exact pair `747837906D0BF484` / `1D253A52B55C9FB3` has stable boundaries,
+one-draw parity, continuous exact-frame output, fallback behavior, and native
+GPU timing. It is not admitted for suppression yet:
+
+- the current RenderDoc parity result covers the anchor draw, not the complete
+  two-draw retained pass;
+- the target's later GPU-consumer graph is not closed;
+- guest CPU visibility remains uninstrumented; and
+- no independently reversible suppression switch exists.
+
+Consequently the next work is evidence collection and complete-pass comparison,
+not draw skipping. The Xenos copy, draw, resolve, query, fence, and memexport
+paths remain unchanged.

--- a/tools/evaluate-native-renderer-suppression.py
+++ b/tools/evaluate-native-renderer-suppression.py
@@ -1,0 +1,206 @@
+#!/usr/bin/env python3
+"""Evaluate a local evidence bundle before implementing pass suppression."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+
+INPUT_SCHEMA = "pinyon-shift.native-renderer-suppression-evidence.v1"
+OUTPUT_SCHEMA = "pinyon-shift.native-renderer-suppression-admission.v1"
+STATUSES = {"pass", "fail", "unknown"}
+REQUIRED_GATES = (
+    "exact_family_identity",
+    "complete_native_coverage",
+    "color_parity",
+    "depth_parity",
+    "later_gpu_consumers",
+    "guest_cpu_visibility",
+    "query_side_effects",
+    "memexport_side_effects",
+    "output_freshness",
+    "fallback_recovery",
+    "gpu_timing",
+    "rollback_switch",
+)
+
+
+def _require(condition: bool, message: str) -> None:
+    if not condition:
+        raise ValueError(message)
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for block in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest().upper()
+
+
+def _validate_sha256(value: Any, label: str) -> str:
+    rendered = str(value)
+    _require(
+        len(rendered) == 64
+        and all(character in "0123456789ABCDEF" for character in rendered),
+        f"{label} must be an uppercase SHA-256",
+    )
+    return rendered
+
+
+def evaluate(
+    evidence: dict[str, Any], *, artifact_root: Path | None = None
+) -> dict[str, Any]:
+    _require(evidence.get("schema") == INPUT_SCHEMA, "unsupported evidence schema")
+    family = str(evidence.get("family", ""))
+    scene = str(evidence.get("scene", ""))
+    _require(bool(family), "family is required")
+    _require(bool(scene), "scene is required")
+    build_sha256 = _validate_sha256(evidence.get("build_sha256"), "build_sha256")
+
+    signatures = evidence.get("signatures")
+    _require(isinstance(signatures, list) and signatures, "signatures are required")
+    normalized_signatures: list[str] = []
+    for index, signature in enumerate(signatures):
+        rendered = str(signature)
+        _require(
+            len(rendered) == 16
+            and all(character in "0123456789ABCDEF" for character in rendered),
+            f"signatures[{index}] must be a 16-digit uppercase hexadecimal value",
+        )
+        _require(rendered not in normalized_signatures, "duplicate signature")
+        normalized_signatures.append(rendered)
+
+    gates = evidence.get("gates")
+    _require(isinstance(gates, dict), "gates must be an object")
+    missing = sorted(set(REQUIRED_GATES) - set(gates))
+    extra = sorted(set(gates) - set(REQUIRED_GATES))
+    _require(not missing, "missing gates: " + ", ".join(missing))
+    _require(not extra, "unknown gates: " + ", ".join(extra))
+
+    verified_root = artifact_root.resolve() if artifact_root else None
+    normalized_gates: dict[str, dict[str, Any]] = {}
+    blockers: list[dict[str, str]] = []
+    for name in REQUIRED_GATES:
+        gate = gates[name]
+        _require(isinstance(gate, dict), f"gate {name} must be an object")
+        status = str(gate.get("status", ""))
+        evidence_text = str(gate.get("evidence", "")).strip()
+        _require(status in STATUSES, f"gate {name} has invalid status")
+        _require(bool(evidence_text), f"gate {name} requires evidence text")
+
+        artifacts = gate.get("artifacts", [])
+        _require(isinstance(artifacts, list), f"gate {name} artifacts must be a list")
+        normalized_artifacts: list[dict[str, Any]] = []
+        for index, artifact in enumerate(artifacts):
+            _require(
+                isinstance(artifact, dict),
+                f"gate {name} artifact {index} must be an object",
+            )
+            path_text = str(artifact.get("path", ""))
+            _require(bool(path_text), f"gate {name} artifact {index} needs a path")
+            expected_hash = _validate_sha256(
+                artifact.get("sha256"), f"gate {name} artifact {index} sha256"
+            )
+            normalized = {"path": path_text, "sha256": expected_hash}
+            if verified_root:
+                path = (verified_root / path_text).resolve()
+                _require(
+                    path == verified_root or verified_root in path.parents,
+                    f"gate {name} artifact escapes artifact root: {path_text}",
+                )
+                _require(path.is_file(), f"gate {name} artifact is missing: {path_text}")
+                _require(
+                    _sha256(path) == expected_hash,
+                    f"gate {name} artifact hash mismatch: {path_text}",
+                )
+                normalized["verified"] = True
+            normalized_artifacts.append(normalized)
+
+        normalized_gates[name] = {
+            "status": status,
+            "evidence": evidence_text,
+            "artifacts": normalized_artifacts,
+        }
+        if status != "pass":
+            blockers.append({"gate": name, "status": status, "reason": evidence_text})
+
+    safety = evidence.get("safety")
+    _require(isinstance(safety, dict), "safety must be an object")
+    required_safety = {
+        "xenos_draws_preserved": True,
+        "draw_suppression_implemented": False,
+        "resolve_suppression_implemented": False,
+    }
+    for name, expected in required_safety.items():
+        _require(
+            safety.get(name) is expected,
+            f"safety.{name} must be {str(expected).lower()}",
+        )
+
+    ready = not blockers
+    return {
+        "schema": OUTPUT_SCHEMA,
+        "family": family,
+        "scene": scene,
+        "build_sha256": build_sha256,
+        "signatures": normalized_signatures,
+        "gates": normalized_gates,
+        "summary": {
+            "passed": len(REQUIRED_GATES) - len(blockers),
+            "required": len(REQUIRED_GATES),
+            "blockers": blockers,
+            "ready_for_suppression_implementation": ready,
+        },
+        "safety": {
+            **required_safety,
+            "suppression_allowed": False,
+            "reason": (
+                "admission evidence complete; implementation remains absent and disabled"
+                if ready
+                else "one or more admission gates are not proven"
+            ),
+        },
+    }
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("evidence", type=Path, help="local evidence bundle JSON")
+    parser.add_argument("--output", "-o", type=Path, help="write admission report")
+    parser.add_argument(
+        "--artifact-root",
+        type=Path,
+        help="verify artifact paths and hashes below this local directory",
+    )
+    parser.add_argument(
+        "--require-ready",
+        action="store_true",
+        help="return exit code 2 while any admission gate is not proven",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    evidence = json.loads(args.evidence.read_text(encoding="utf-8"))
+    result = evaluate(evidence, artifact_root=args.artifact_root)
+    rendered = json.dumps(result, indent=2) + "\n"
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(rendered, encoding="utf-8")
+    else:
+        print(rendered, end="")
+    if args.require_ready and not result["summary"][
+        "ready_for_suppression_implementation"
+    ]:
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/tests/test_native_renderer_contract.py
+++ b/tools/tests/test_native_renderer_contract.py
@@ -424,6 +424,18 @@ class NativeRendererContractTests(unittest.TestCase):
         self.assertIn("NATIVE_GPU_TIMING_COLUMNS", summarizer)
         self.assertIn('"native_renderer_gpu_timing"', summarizer)
 
+    def test_suppression_admission_is_fail_closed_and_non_mutating(self):
+        evaluator = (
+            ROOT / "tools/evaluate-native-renderer-suppression.py"
+        ).read_text(encoding="utf-8")
+        self.assertIn('"guest_cpu_visibility"', evaluator)
+        self.assertIn('"later_gpu_consumers"', evaluator)
+        self.assertIn('"rollback_switch"', evaluator)
+        self.assertIn('"suppression_allowed": False', evaluator)
+        self.assertIn('"draw_suppression_implemented": False', evaluator)
+        self.assertIn('"resolve_suppression_implemented": False', evaluator)
+        self.assertNotIn("SetDrawSuppression", evaluator)
+
     def test_shader_capture_is_local_bounded_and_passive(self):
         patch = (
             ROOT

--- a/tools/tests/test_native_renderer_suppression.py
+++ b/tools/tests/test_native_renderer_suppression.py
@@ -1,0 +1,119 @@
+import copy
+import hashlib
+import importlib.util
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+TOOL = ROOT / "tools" / "evaluate-native-renderer-suppression.py"
+SPEC = importlib.util.spec_from_file_location("native_suppression", TOOL)
+assert SPEC and SPEC.loader
+MODULE = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = MODULE
+SPEC.loader.exec_module(MODULE)
+
+
+def evidence(status="pass"):
+    return {
+        "schema": MODULE.INPUT_SCHEMA,
+        "family": "sky_horizon",
+        "scene": "open_world_day",
+        "build_sha256": "A" * 64,
+        "signatures": ["747837906D0BF484", "1D253A52B55C9FB3"],
+        "gates": {
+            name: {
+                "status": status,
+                "evidence": f"fixture evidence for {name}",
+                "artifacts": [],
+            }
+            for name in MODULE.REQUIRED_GATES
+        },
+        "safety": {
+            "xenos_draws_preserved": True,
+            "draw_suppression_implemented": False,
+            "resolve_suppression_implemented": False,
+        },
+    }
+
+
+class NativeRendererSuppressionAdmissionTests(unittest.TestCase):
+    def test_complete_evidence_is_ready_but_never_enables_suppression(self):
+        result = MODULE.evaluate(evidence())
+        self.assertTrue(result["summary"]["ready_for_suppression_implementation"])
+        self.assertEqual(result["summary"]["passed"], len(MODULE.REQUIRED_GATES))
+        self.assertFalse(result["safety"]["suppression_allowed"])
+        self.assertFalse(result["safety"]["draw_suppression_implemented"])
+        self.assertFalse(result["safety"]["resolve_suppression_implemented"])
+
+    def test_unknown_and_failed_gates_are_explicit_blockers(self):
+        document = evidence()
+        document["gates"]["color_parity"]["status"] = "fail"
+        document["gates"]["guest_cpu_visibility"]["status"] = "unknown"
+        result = MODULE.evaluate(document)
+        self.assertFalse(result["summary"]["ready_for_suppression_implementation"])
+        self.assertEqual(
+            [blocker["gate"] for blocker in result["summary"]["blockers"]],
+            ["color_parity", "guest_cpu_visibility"],
+        )
+        self.assertFalse(result["safety"]["suppression_allowed"])
+
+    def test_rejects_missing_extra_and_malformed_gates(self):
+        missing = evidence()
+        del missing["gates"]["depth_parity"]
+        with self.assertRaisesRegex(ValueError, "missing gates"):
+            MODULE.evaluate(missing)
+
+        extra = evidence()
+        extra["gates"]["looks_good"] = {
+            "status": "pass", "evidence": "subjective", "artifacts": []
+        }
+        with self.assertRaisesRegex(ValueError, "unknown gates"):
+            MODULE.evaluate(extra)
+
+        malformed = evidence()
+        malformed["gates"]["depth_parity"]["status"] = "maybe"
+        with self.assertRaisesRegex(ValueError, "invalid status"):
+            MODULE.evaluate(malformed)
+
+    def test_rejects_any_claim_that_suppression_is_already_implemented(self):
+        for field in (
+            "xenos_draws_preserved",
+            "draw_suppression_implemented",
+            "resolve_suppression_implemented",
+        ):
+            document = evidence()
+            document["safety"][field] = not document["safety"][field]
+            with self.assertRaisesRegex(ValueError, f"safety.{field}"):
+                MODULE.evaluate(document)
+
+    def test_verifies_local_artifact_hash_and_boundary(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            artifact = root / "comparison.json"
+            artifact.write_bytes(b"qualified")
+            digest = hashlib.sha256(b"qualified").hexdigest().upper()
+            document = evidence()
+            document["gates"]["color_parity"]["artifacts"] = [
+                {"path": "comparison.json", "sha256": digest}
+            ]
+            result = MODULE.evaluate(document, artifact_root=root)
+            self.assertTrue(
+                result["gates"]["color_parity"]["artifacts"][0]["verified"]
+            )
+
+            mismatch = copy.deepcopy(document)
+            mismatch["gates"]["color_parity"]["artifacts"][0]["sha256"] = "B" * 64
+            with self.assertRaisesRegex(ValueError, "hash mismatch"):
+                MODULE.evaluate(mismatch, artifact_root=root)
+
+            escape = copy.deepcopy(document)
+            escape["gates"]["color_parity"]["artifacts"][0]["path"] = "../outside"
+            with self.assertRaisesRegex(ValueError, "escapes artifact root"):
+                MODULE.evaluate(escape, artifact_root=root)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add a deterministic NR-04D suppression-admission evaluator
- require twelve family-specific visual, dependency, side-effect, timing, fallback, and rollback gates
- verify optional local evidence artifact hashes inside a bounded root
- keep Xenos draws preserved and report suppression as unavailable in all outputs
- document the five blockers still open for the retained sky/horizon family

## Validation

- 164 Python tests
- five native renderer test executables
- clean preview build with matching manifest hash
- current local evidence evaluates 7/12 gates and --require-ready exits 2