### PR TITLE
test(native-renderer): prove complete pass color parity

### DIFF
--- a/docs/native-renderer/SUPPRESSION_ADMISSION.md
+++ b/docs/native-renderer/SUPPRESSION_ADMISSION.md
@@ -52,3 +52,15 @@ GPU timing. It is not admitted for suppression yet:
 Consequently the next work is evidence collection and complete-pass comparison,
 not draw skipping. The Xenos copy, draw, resolve, query, fence, and memexport
 paths remain unchanged.
+
+The complete-pass color gate may use the paired asynchronous readback described
+in [VISUAL_COMPARISON.md](VISUAL_COMPARISON.md). It captures private-native and
+authoritative-Xenos color after the same follower draw, checks exact active
+texel bytes, adds no GPU wait, and preserves the original draw. It does not
+prove the independent depth gate.
+
+The 2026-08-28 same-frame qualification passed exact complete-pass color parity
+across 41,943,040 active bytes. This promotes `color_parity` to `pass`. The
+admission result is now 8/12; `depth_parity`, `later_gpu_consumers`,
+`guest_cpu_visibility`, and `rollback_switch` remain `unknown`, so suppression
+is still prohibited.

--- a/docs/native-renderer/VISUAL_COMPARISON.md
+++ b/docs/native-renderer/VISUAL_COMPARISON.md
@@ -124,3 +124,68 @@ exports remain local under `.local/qualification`.
 The six exact-signature occurrences do not by themselves define the complete
 pass. Their target-phase correlation and the remaining four-index follower are
 documented in [PASS_INVENTORY.md](PASS_INVENTORY.md).
+
+## Complete-pass comparison
+
+NR-04D admission compares the entire two-draw family rather than promoting the
+anchor result above. The preferred color path is a same-frame paired asynchronous
+readback. Launch the pass with the existing isolated readback directory set. The
+native artifact is committed at that path and the authoritative guest artifact
+is committed beside it with `.xenos` appended. Compare active texel bytes while
+excluding D3D12 row padding:
+
+```powershell
+python .\tools\compare-native-renderer-pass-readbacks.py `
+  '.local\qualification\nr04d-pass-readback' `
+  --output '.local\qualification\nr04d-pass-color-report.json'
+```
+
+Both copies are inserted into the same command list: native after the private
+follower, and Xenos after the original authoritative follower. They retire by
+submission fence without a CPU/GPU wait. The comparison rejects mismatched
+signature, frame, follower draw, dimensions, row pitch, format, role, or safety
+metadata, and requires exact active color bytes. Xenos remains the displayed
+and authoritative output throughout.
+
+RenderDoc remains the strict color-and-depth path. Capture with both the anchor
+and follower configured, then export their native/Xenos spans:
+
+```powershell
+.\tools\export-native-renderer-renderdoc.ps1 `
+  -Capture '.local\qualification\nr04d-pass\reference_frame1.rdc' `
+  -RenderDocRoot '.local\tools\renderdoc-1.45\RenderDoc_1.45_64' `
+  -OutputDir '.local\qualification\nr04d-pass-export' `
+  -CompletePass
+```
+
+The exporter requires this exact marker order: native anchor, Xenos anchor,
+native follower, Xenos follower. It saves each target before its anchor and
+after its follower, verifies stable resources and dimensions within each span,
+and rejects aliasing between native and Xenos output. The resulting image names
+remain compatible with the color and depth comparator commands above.
+
+The complete-pass report records
+`pinyon-shift.native-renderer-pass-renderdoc-export.v1`, two draws per path,
+all marker/event IDs, capture and image hashes, and an explicit safety object.
+It never enables draw or resolve suppression. A passing paired readback can
+promote `color_parity`; `depth_parity` still requires the RenderDoc depth export
+or a future same-frame depth capture. Both gates must pass before suppression
+admission can complete.
+
+### Qualified complete-pass color result
+
+The 2026-08-28 AppData-backed `open_world_day` run used clean-build executable
+SHA-256 `9965749C430F0011A691BEEF851F08170089F2F1EEB1B3F5647E9AAF12A261B2`.
+Frame 2800 replayed anchor `747837906D0BF484` at draw 115 and follower
+`1D253A52B55C9FB3` at draw 116. Both native and authoritative Xenos readbacks
+were 640 by 8192 `R16G16B16A16_FLOAT` resources with 41,943,040 active bytes.
+
+The comparison passed exactly: zero differing bytes, zero maximum error, and
+identical binary SHA-256
+`E238DB4ED42A27EF04386C7F196EF2EB5C9F1182E750F91A95453E8356888660`.
+Runtime diagnostics recorded both roles as captured, preserved both Xenos
+draws, reported no error/fatal/device-loss events, and exited normally. GPU
+timing recorded zero drops; native composition averaged 77.223 microseconds
+and native selection averaged 19.245 microseconds. The admission report now
+passes 8 of 12 gates, with depth parity, later GPU consumers, guest CPU
+visibility, and a rollback switch still deliberately blocking suppression.

--- a/patches/rexglue/0071-d3d12-paired-pass-color-readback.patch
+++ b/patches/rexglue/0071-d3d12-paired-pass-color-readback.patch
@@ -1,0 +1,266 @@
+diff --git a/include/rex/graphics/d3d12/render_target_cache.h b/include/rex/graphics/d3d12/render_target_cache.h
+index afe69ac..d328cc1 100644
+--- a/include/rex/graphics/d3d12/render_target_cache.h
++++ b/include/rex/graphics/d3d12/render_target_cache.h
+@@ -104,6 +104,9 @@ class D3D12RenderTargetCache final : public RenderTargetCache {
+   system::GraphicsIsolatedDrawReadbackStatus QueueIsolatedReplayReadback(
+       system::GraphicsIsolatedDrawReadbackCompletion completion,
+       uint32_t* failure_detail_out);
++  system::GraphicsIsolatedDrawReadbackStatus QueueGuestColorReadback(
++      system::GraphicsIsolatedDrawReadbackCompletion completion,
++      uint32_t* failure_detail_out);
+   void EndIsolatedReplayTarget(uint64_t frame_sequence);
+ 
+   struct IsolatedReplayPreviewSource {
+@@ -712,6 +715,11 @@ class D3D12RenderTargetCache final : public RenderTargetCache {
+     uint32_t format = 0;
+     system::GraphicsIsolatedDrawReadbackCompletion completion = nullptr;
+   } isolated_replay_readback_;
++  IsolatedReplayReadback guest_reference_readback_;
++  system::GraphicsIsolatedDrawReadbackStatus QueueRenderTargetReadback(
++      D3D12RenderTarget* target, IsolatedReplayReadback& pending_readback,
++      system::GraphicsIsolatedDrawReadbackCompletion completion,
++      uint32_t* failure_detail_out);
+   std::shared_ptr<ui::d3d12::D3D12CpuDescriptorPool> descriptor_pool_srv_;
+   ui::d3d12::D3D12CpuDescriptorPool::Descriptor null_rtv_descriptor_ss_;
+   ui::d3d12::D3D12CpuDescriptorPool::Descriptor null_rtv_descriptor_ms_;
+diff --git a/include/rex/system/interfaces/graphics.h b/include/rex/system/interfaces/graphics.h
+index 2975c98..b6385ee 100644
+--- a/include/rex/system/interfaces/graphics.h
++++ b/include/rex/system/interfaces/graphics.h
+@@ -387,6 +387,10 @@ using GraphicsIsolatedDrawReadbackCompletion = void (*)(
+ struct GraphicsIsolatedDrawRequest {
+   bool requested = false;
+   bool readback_requested = false;
++  // Capture the authoritative guest color target after the original draw.
++  // This is independent of the private replay readback and never suppresses
++  // or redirects the guest draw.
++  bool reference_readback_requested = false;
+   bool reference_marker_requested = false;
+   bool retain_target = false;
+   // Rebind the retained private target without copying the guest target. This
+@@ -395,6 +399,8 @@ struct GraphicsIsolatedDrawRequest {
+   uint64_t frame_sequence = 0;
+   GraphicsIsolatedDrawCompletion completion = nullptr;
+   GraphicsIsolatedDrawReadbackCompletion readback_completion = nullptr;
++  GraphicsIsolatedDrawReadbackCompletion reference_readback_completion =
++      nullptr;
+ };
+ 
+ // Called after the host pipeline has been prepared. A request duplicates the
+diff --git a/src/graphics/d3d12/command_processor.cpp b/src/graphics/d3d12/command_processor.cpp
+index 95e917a..0885b89 100644
+--- a/src/graphics/d3d12/command_processor.cpp
++++ b/src/graphics/d3d12/command_processor.cpp
+@@ -3380,6 +3380,20 @@ bool D3D12CommandProcessor::IssueDraw(xenos::PrimitiveType primitive_type, uint3
+     if (isolated_draw_request.reference_marker_requested) {
+       deferred_command_list_.EndDebugMarker();
+     }
++    if (isolated_draw_request.reference_readback_requested &&
++        isolated_draw_request.reference_readback_completion) {
++      uint32_t readback_detail = 0;
++      auto readback_status = render_target_cache_->QueueGuestColorReadback(
++          isolated_draw_request.reference_readback_completion,
++          &readback_detail);
++      if (readback_status !=
++          system::GraphicsIsolatedDrawReadbackStatus::kReady) {
++        system::GraphicsIsolatedDrawReadback readback_result;
++        readback_result.status = readback_status;
++        readback_result.detail = readback_detail;
++        isolated_draw_request.reference_readback_completion(readback_result);
++      }
++    }
+   } else {
+     D3D12_INDEX_BUFFER_VIEW index_buffer_view;
+     index_buffer_view.SizeInBytes = primitive_processing_result.host_draw_vertex_count;
+@@ -3498,6 +3512,20 @@ bool D3D12CommandProcessor::IssueDraw(xenos::PrimitiveType primitive_type, uint3
+     if (isolated_draw_request.reference_marker_requested) {
+       deferred_command_list_.EndDebugMarker();
+     }
++    if (isolated_draw_request.reference_readback_requested &&
++        isolated_draw_request.reference_readback_completion) {
++      uint32_t readback_detail = 0;
++      auto readback_status = render_target_cache_->QueueGuestColorReadback(
++          isolated_draw_request.reference_readback_completion,
++          &readback_detail);
++      if (readback_status !=
++          system::GraphicsIsolatedDrawReadbackStatus::kReady) {
++        system::GraphicsIsolatedDrawReadback readback_result;
++        readback_result.status = readback_status;
++        readback_result.detail = readback_detail;
++        isolated_draw_request.reference_readback_completion(readback_result);
++      }
++    }
+     if (scratch_index_buffer != nullptr) {
+       ReleaseScratchGPUBuffer(scratch_index_buffer, D3D12_RESOURCE_STATE_INDEX_BUFFER);
+     }
+diff --git a/src/graphics/d3d12/render_target_cache.cpp b/src/graphics/d3d12/render_target_cache.cpp
+index bf2472a..ef06755 100644
+--- a/src/graphics/d3d12/render_target_cache.cpp
++++ b/src/graphics/d3d12/render_target_cache.cpp
+@@ -1020,11 +1020,15 @@ void D3D12RenderTargetCache::Shutdown(bool from_destructor) {
+   }
+   ui::d3d12::util::ReleaseAndNull(host_depth_store_root_signature_);
+ 
+-  if (isolated_replay_readback_.buffer && isolated_replay_readback_.mapping) {
+-    D3D12_RANGE write_range = {};
+-    isolated_replay_readback_.buffer->Unmap(0, &write_range);
+-  }
+-  isolated_replay_readback_ = {};
++  const auto release_isolated_readback = [](IsolatedReplayReadback& readback) {
++    if (readback.buffer && readback.mapping) {
++      D3D12_RANGE write_range = {};
++      readback.buffer->Unmap(0, &write_range);
++    }
++    readback = {};
++  };
++  release_isolated_readback(isolated_replay_readback_);
++  release_isolated_readback(guest_reference_readback_);
+   isolated_replay_preview_resolved_target_.Reset();
+   isolated_replay_preview_resolved_target_state_ =
+       D3D12_RESOURCE_STATE_RESOLVE_DEST;
+@@ -1054,25 +1058,30 @@ void D3D12RenderTargetCache::CompletedSubmissionUpdated() {
+   if (transfer_vertex_buffer_pool_) {
+     transfer_vertex_buffer_pool_->Reclaim(command_processor_.GetCompletedSubmission());
+   }
+-  if (isolated_replay_readback_.buffer &&
+-      isolated_replay_readback_.submission <=
+-          command_processor_.GetCompletedSubmission()) {
++  const auto complete_isolated_readback = [this](
++                                              IsolatedReplayReadback& readback) {
++    if (!readback.buffer ||
++        readback.submission > command_processor_.GetCompletedSubmission()) {
++      return;
++    }
+     system::GraphicsIsolatedDrawReadback result;
+     result.status = system::GraphicsIsolatedDrawReadbackStatus::kReady;
+-    result.data = isolated_replay_readback_.mapping;
+-    result.data_size = isolated_replay_readback_.data_size;
+-    result.width = isolated_replay_readback_.width;
+-    result.height = isolated_replay_readback_.height;
+-    result.row_pitch = isolated_replay_readback_.row_pitch;
+-    result.format = isolated_replay_readback_.format;
+-    auto completion = isolated_replay_readback_.completion;
++    result.data = readback.mapping;
++    result.data_size = readback.data_size;
++    result.width = readback.width;
++    result.height = readback.height;
++    result.row_pitch = readback.row_pitch;
++    result.format = readback.format;
++    auto completion = readback.completion;
+     if (completion) {
+       completion(result);
+     }
+     D3D12_RANGE write_range = {};
+-    isolated_replay_readback_.buffer->Unmap(0, &write_range);
+-    isolated_replay_readback_ = {};
+-  }
++    readback.buffer->Unmap(0, &write_range);
++    readback = {};
++  };
++  complete_isolated_readback(isolated_replay_readback_);
++  complete_isolated_readback(guest_reference_readback_);
+ }
+ 
+ void D3D12RenderTargetCache::BeginSubmission() {
+@@ -1862,16 +1871,43 @@ system::GraphicsIsolatedDrawReadbackStatus
+ D3D12RenderTargetCache::QueueIsolatedReplayReadback(
+     system::GraphicsIsolatedDrawReadbackCompletion completion,
+     uint32_t* failure_detail_out) {
++  if (!isolated_replay_color_target_) {
++    return system::GraphicsIsolatedDrawReadbackStatus::kUnsupportedTarget;
++  }
++  return QueueRenderTargetReadback(
++      static_cast<D3D12RenderTarget*>(isolated_replay_color_target_.get()),
++      isolated_replay_readback_, completion, failure_detail_out);
++}
++
++system::GraphicsIsolatedDrawReadbackStatus
++D3D12RenderTargetCache::QueueGuestColorReadback(
++    system::GraphicsIsolatedDrawReadbackCompletion completion,
++    uint32_t* failure_detail_out) {
++  if (GetPath() != Path::kHostRenderTargets) {
++    return system::GraphicsIsolatedDrawReadbackStatus::kUnsupportedTarget;
++  }
++  RenderTarget* const* guest_targets =
++      last_update_accumulated_render_targets();
++  if (!guest_targets[1]) {
++    return system::GraphicsIsolatedDrawReadbackStatus::kUnsupportedTarget;
++  }
++  return QueueRenderTargetReadback(
++      static_cast<D3D12RenderTarget*>(guest_targets[1]),
++      guest_reference_readback_, completion, failure_detail_out);
++}
++
++system::GraphicsIsolatedDrawReadbackStatus
++D3D12RenderTargetCache::QueueRenderTargetReadback(
++    D3D12RenderTarget* target, IsolatedReplayReadback& pending_readback,
++    system::GraphicsIsolatedDrawReadbackCompletion completion,
++    uint32_t* failure_detail_out) {
+   if (failure_detail_out) {
+     *failure_detail_out = 0;
+   }
+-  if (!completion || isolated_replay_readback_.buffer ||
+-      !isolated_replay_color_target_) {
++  if (!completion || pending_readback.buffer || !target) {
+     return system::GraphicsIsolatedDrawReadbackStatus::kUnsupportedTarget;
+   }
+-  auto* isolated_color = static_cast<D3D12RenderTarget*>(
+-      isolated_replay_color_target_.get());
+-  ID3D12Resource* source = isolated_color->resource();
++  ID3D12Resource* source = target->resource();
+   const D3D12_RESOURCE_DESC source_desc = source->GetDesc();
+   if (source_desc.Dimension != D3D12_RESOURCE_DIMENSION_TEXTURE2D ||
+       source_desc.DepthOrArraySize != 1 || source_desc.MipLevels != 1) {
+@@ -1940,7 +1976,7 @@ D3D12RenderTargetCache::QueueIsolatedReplayReadback(
+   }
+ 
+   D3D12_RESOURCE_STATES old_state =
+-      isolated_color->SetResourceState(
++      target->SetResourceState(
+           source_desc.SampleDesc.Count > 1
+               ? D3D12_RESOURCE_STATE_RESOLVE_SOURCE
+               : D3D12_RESOURCE_STATE_COPY_SOURCE);
+@@ -1956,7 +1992,7 @@ D3D12RenderTargetCache::QueueIsolatedReplayReadback(
+     command_processor_.PushTransitionBarrier(
+         copy_source, D3D12_RESOURCE_STATE_RESOLVE_DEST,
+         D3D12_RESOURCE_STATE_COPY_SOURCE);
+-    isolated_color->SetResourceState(old_state);
++    target->SetResourceState(old_state);
+     command_processor_.PushTransitionBarrier(
+         source, D3D12_RESOURCE_STATE_RESOLVE_SOURCE, old_state);
+     command_processor_.SubmitBarriers();
+@@ -1972,22 +2008,22 @@ D3D12RenderTargetCache::QueueIsolatedReplayReadback(
+   command_processor_.GetDeferredCommandList().D3DCopyTextureRegion(
+       &destination, 0, 0, 0, &source_location, nullptr);
+   if (source_desc.SampleDesc.Count == 1) {
+-    isolated_color->SetResourceState(old_state);
++    target->SetResourceState(old_state);
+     command_processor_.PushTransitionBarrier(
+         source, D3D12_RESOURCE_STATE_COPY_SOURCE, old_state);
+   }
+ 
+-  isolated_replay_readback_.buffer = std::move(buffer);
+-  isolated_replay_readback_.resolved_target = std::move(resolved_target);
+-  isolated_replay_readback_.mapping = static_cast<uint8_t*>(mapping);
+-  isolated_replay_readback_.submission =
++  pending_readback.buffer = std::move(buffer);
++  pending_readback.resolved_target = std::move(resolved_target);
++  pending_readback.mapping = static_cast<uint8_t*>(mapping);
++  pending_readback.submission =
+       command_processor_.GetCurrentSubmission();
+-  isolated_replay_readback_.data_size = total_size;
+-  isolated_replay_readback_.width = uint32_t(source_desc.Width);
+-  isolated_replay_readback_.height = source_desc.Height;
+-  isolated_replay_readback_.row_pitch = footprint.Footprint.RowPitch;
+-  isolated_replay_readback_.format = uint32_t(source_desc.Format);
+-  isolated_replay_readback_.completion = completion;
++  pending_readback.data_size = total_size;
++  pending_readback.width = uint32_t(source_desc.Width);
++  pending_readback.height = source_desc.Height;
++  pending_readback.row_pitch = footprint.Footprint.RowPitch;
++  pending_readback.format = uint32_t(source_desc.Format);
++  pending_readback.completion = completion;
+   return system::GraphicsIsolatedDrawReadbackStatus::kReady;
+ }
+ 

--- a/src/native_renderer/graphics_hooks.cpp
+++ b/src/native_renderer/graphics_hooks.cpp
@@ -113,6 +113,7 @@ struct IsolatedDrawState {
   uint64_t pass_anchor_draw = 0;
   std::filesystem::path output_root;
   std::jthread artifact_writer;
+  std::jthread reference_artifact_writer;
   bool requested = false;
   bool readback_requested = false;
   bool completed = false;
@@ -1924,8 +1925,10 @@ float HalfToFloat(uint16_t value) {
   return std::bit_cast<float>(bits);
 }
 
-void CompleteIsolatedDrawReadback(
-    const rex::system::GraphicsIsolatedDrawReadback &readback) {
+void CompleteIsolatedReadbackArtifact(
+    const rex::system::GraphicsIsolatedDrawReadback &readback,
+    const char *capture_role, const std::filesystem::path &artifact_root,
+    std::jthread &artifact_writer) {
   const auto reject = [&](const char *status) {
     pinyon_shift::diagnostics::RecordEvent(
         "native_renderer.isolated_draw.readback",
@@ -1935,6 +1938,7 @@ void CompleteIsolatedDrawReadback(
          {"detail", fmt::format("0x{:08X}", readback.detail)},
          {"frame", std::to_string(g_isolated_draw.captured_frame)},
          {"draw", std::to_string(g_isolated_draw.captured_draw)},
+         {"capture_role", capture_role},
          {"output_authority", "xenos"},
          {"suppression_eligible", "false"}});
   };
@@ -1976,14 +1980,15 @@ void CompleteIsolatedDrawReadback(
   const uint64_t signature = g_isolated_draw.captured_signature;
   const uint64_t frame = g_isolated_draw.captured_frame;
   const uint64_t draw = g_isolated_draw.captured_draw;
-  const auto output_root = g_isolated_draw.output_root;
+  const auto output_root = artifact_root;
   const uint32_t width = readback.width;
   const uint32_t height = readback.height;
   const uint32_t row_pitch = readback.row_pitch;
   const uint32_t format = readback.format;
-  g_isolated_draw.artifact_writer = std::jthread(
+  artifact_writer = std::jthread(
       [bytes = std::move(bytes), signature, frame, draw, output_root, width,
-       height, row_pitch, format, bytes_per_pixel]() {
+       height, row_pitch, format, bytes_per_pixel,
+       capture_role = std::string(capture_role)]() {
         uint32_t left = width;
         uint32_t top = height;
         uint32_t right = 0;
@@ -2013,6 +2018,7 @@ void CompleteIsolatedDrawReadback(
                {"status", "empty_target"},
                {"frame", std::to_string(frame)},
                {"draw", std::to_string(draw)},
+               {"capture_role", capture_role},
                {"output_authority", "xenos"},
                {"suppression_eligible", "false"}});
           return;
@@ -2054,6 +2060,7 @@ void CompleteIsolatedDrawReadback(
               "native_renderer.isolated_draw.readback",
               {{"signature", fmt::format("{:016X}", signature)},
                {"status", "output_directory_unavailable"},
+               {"capture_role", capture_role},
                {"output_authority", "xenos"},
                {"suppression_eligible", "false"}});
           return;
@@ -2061,7 +2068,8 @@ void CompleteIsolatedDrawReadback(
         const std::string metadata = fmt::format(
             "{{\n  \"schema\": \"pinyon-shift.isolated-draw-readback.v1\",\n"
             "  \"signature\": \"{:016X}\",\n  \"frame\": {},\n"
-            "  \"draw\": {},\n  \"source\": {{\"width\":{},"
+            "  \"draw\": {},\n  \"capture_role\": \"{}\",\n"
+            "  \"source\": {{\"width\":{},"
             "\"height\":{},\"row_pitch\":{},\"dxgi_format\":{},"
             "\"bytes\":{},\"hash\":\"{:016X}\"}},\n"
             "  \"crop\": {{\"left\":{},\"top\":{},\"right\":{},"
@@ -2070,7 +2078,8 @@ void CompleteIsolatedDrawReadback(
             "\"encoding\":\"ppm-p6-linear-clamp\"}},\n"
             "  \"safety\": {{\"output_authority\":\"xenos\","
             "\"suppression_allowed\":false}}\n}}\n",
-            signature, frame, draw, width, height, row_pitch, format,
+            signature, frame, draw, capture_role, width, height, row_pitch,
+            format,
             bytes.size(), HashBytes(bytes.data(), bytes.size()), left, top,
             right, bottom, crop_width, crop_height);
         const auto metadata_bytes = std::span(
@@ -2084,6 +2093,7 @@ void CompleteIsolatedDrawReadback(
               "native_renderer.isolated_draw.readback",
               {{"signature", fmt::format("{:016X}", signature)},
                {"status", "artifact_write_failed"},
+               {"capture_role", capture_role},
                {"output_authority", "xenos"},
                {"suppression_eligible", "false"}});
           return;
@@ -2100,9 +2110,26 @@ void CompleteIsolatedDrawReadback(
              {"crop_width", std::to_string(crop_width)},
              {"crop_height", std::to_string(crop_height)},
              {"readback_bytes", std::to_string(bytes.size())},
+             {"capture_role", capture_role},
              {"output_authority", "xenos"},
              {"suppression_eligible", "false"}});
       });
+}
+
+void CompleteIsolatedDrawReadback(
+    const rex::system::GraphicsIsolatedDrawReadback &readback) {
+  CompleteIsolatedReadbackArtifact(
+      readback, "native", g_isolated_draw.output_root,
+      g_isolated_draw.artifact_writer);
+}
+
+void CompleteIsolatedReferenceReadback(
+    const rex::system::GraphicsIsolatedDrawReadback &readback) {
+  std::filesystem::path reference_root = g_isolated_draw.output_root;
+  reference_root += L".xenos";
+  CompleteIsolatedReadbackArtifact(
+      readback, "xenos", reference_root,
+      g_isolated_draw.reference_artifact_writer);
 }
 
 void CompleteIsolatedDraw(
@@ -2206,9 +2233,9 @@ void CompleteIsolatedPassRepeat(
        {"follower_signature",
         fmt::format("{:016X}", g_isolated_draw.target_signature)},
        {"status", recorded ? "recorded" : "failed"},
-       {"frame", std::to_string(g_isolated_draw.captured_frame)},
+       {"frame", std::to_string(g_isolated_draw.frame)},
        {"anchor_draw", std::to_string(g_isolated_draw.pass_anchor_draw)},
-       {"follower_draw", std::to_string(g_isolated_draw.captured_draw)},
+       {"follower_draw", std::to_string(g_isolated_draw.draw)},
        {"target_width", std::to_string(result.target_width)},
        {"target_height", std::to_string(result.target_height)},
        {"xenos_draw", "preserved"},
@@ -2269,13 +2296,17 @@ void RequestIsolatedDraw(
       g_isolated_draw.captured_frame = g_isolated_draw.frame;
       g_isolated_draw.captured_draw = g_isolated_draw.draw;
       request.readback_requested = g_isolated_draw.readback_requested;
+      request.reference_readback_requested =
+          g_isolated_draw.readback_requested;
       request.completion = &CompleteIsolatedPassFollower;
       request.readback_completion = g_isolated_draw.readback_requested
                                         ? &CompleteIsolatedDrawReadback
                                         : nullptr;
+      request.reference_readback_completion =
+          g_isolated_draw.readback_requested
+              ? &CompleteIsolatedReferenceReadback
+              : nullptr;
     } else if (!g_isolated_draw.pass_repeat_reported) {
-      g_isolated_draw.captured_frame = g_isolated_draw.frame;
-      g_isolated_draw.captured_draw = g_isolated_draw.draw;
       request.completion = &CompleteIsolatedPassRepeat;
     }
     return;
@@ -2803,6 +2834,9 @@ void UninstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system) {
   }
   if (g_isolated_draw.artifact_writer.joinable()) {
     g_isolated_draw.artifact_writer.join();
+  }
+  if (g_isolated_draw.reference_artifact_writer.joinable()) {
+    g_isolated_draw.reference_artifact_writer.join();
   }
   g_graphics_census_installed = false;
   if (g_draw_census.window_first_frame && g_draw_census.window_draw_count) {

--- a/tools/compare-native-renderer-pass-readbacks.py
+++ b/tools/compare-native-renderer-pass-readbacks.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+"""Compare same-frame native and authoritative Xenos pass readbacks."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+
+SCHEMA = "pinyon-shift.native-renderer-pass-readback-comparison.v1"
+READBACK_SCHEMA = "pinyon-shift.isolated-draw-readback.v1"
+BYTES_PER_PIXEL = {10: 8, 28: 4}
+
+
+def _sha256(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest().upper()
+
+
+def _load(root: Path, expected_role: str) -> tuple[dict[str, Any], bytes]:
+    metadata_path = root / "readback.json"
+    binary_path = root / "isolated.bin"
+    metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+    if metadata.get("schema") != READBACK_SCHEMA:
+        raise ValueError(f"{metadata_path}: unsupported readback schema")
+    if metadata.get("capture_role") != expected_role:
+        raise ValueError(
+            f"{metadata_path}: expected capture_role {expected_role!r}"
+        )
+    safety = metadata.get("safety", {})
+    if safety.get("output_authority") != "xenos" or safety.get(
+        "suppression_allowed"
+    ) is not False:
+        raise ValueError(f"{metadata_path}: unsafe readback metadata")
+    data = binary_path.read_bytes()
+    source = metadata.get("source", {})
+    if source.get("bytes") != len(data):
+        raise ValueError(f"{binary_path}: byte count does not match metadata")
+    return metadata, data
+
+
+def compare(native_root: Path, xenos_root: Path) -> dict[str, Any]:
+    native, native_data = _load(native_root, "native")
+    xenos, xenos_data = _load(xenos_root, "xenos")
+    for field in ("signature", "frame", "draw"):
+        if native.get(field) != xenos.get(field):
+            raise ValueError(f"readback {field} values differ")
+
+    native_source = native["source"]
+    xenos_source = xenos["source"]
+    layout_fields = ("width", "height", "row_pitch", "dxgi_format")
+    for field in layout_fields:
+        if native_source.get(field) != xenos_source.get(field):
+            raise ValueError(f"readback source {field} values differ")
+
+    width = int(native_source["width"])
+    height = int(native_source["height"])
+    row_pitch = int(native_source["row_pitch"])
+    dxgi_format = int(native_source["dxgi_format"])
+    bytes_per_pixel = BYTES_PER_PIXEL.get(dxgi_format)
+    if bytes_per_pixel is None:
+        raise ValueError(f"unsupported DXGI format {dxgi_format}")
+    active_row_bytes = width * bytes_per_pixel
+    required_bytes = row_pitch * height
+    if (
+        width <= 0
+        or height <= 0
+        or active_row_bytes > row_pitch
+        or len(native_data) < required_bytes
+        or len(xenos_data) < required_bytes
+    ):
+        raise ValueError("invalid readback layout")
+
+    compared_bytes = 0
+    different_bytes = 0
+    absolute_error = 0
+    maximum_error = 0
+    for row in range(height):
+        start = row * row_pitch
+        end = start + active_row_bytes
+        for left, right in zip(
+            native_data[start:end], xenos_data[start:end], strict=True
+        ):
+            error = abs(left - right)
+            compared_bytes += 1
+            different_bytes += error != 0
+            absolute_error += error
+            maximum_error = max(maximum_error, error)
+
+    exact = different_bytes == 0
+    return {
+        "schema": SCHEMA,
+        "result": "pass" if exact else "fail",
+        "identity": {
+            "signature": native["signature"],
+            "frame": native["frame"],
+            "follower_draw": native["draw"],
+            "same_guest_frame": True,
+        },
+        "layout": {
+            "width": width,
+            "height": height,
+            "row_pitch": row_pitch,
+            "active_row_bytes": active_row_bytes,
+            "dxgi_format": dxgi_format,
+        },
+        "metrics": {
+            "compared_bytes": compared_bytes,
+            "different_bytes": different_bytes,
+            "different_byte_ratio": (
+                different_bytes / compared_bytes if compared_bytes else 0.0
+            ),
+            "mean_absolute_byte_error": (
+                absolute_error / compared_bytes if compared_bytes else 0.0
+            ),
+            "maximum_byte_error": maximum_error,
+            "exact_active_bytes": exact,
+        },
+        "artifacts": {
+            "native": {
+                "root": str(native_root),
+                "binary_sha256": _sha256(native_data),
+            },
+            "xenos": {
+                "root": str(xenos_root),
+                "binary_sha256": _sha256(xenos_data),
+            },
+        },
+        "safety": {
+            "xenos_draw_preserved": True,
+            "output_authority": "xenos",
+            "suppression_allowed": False,
+            "gpu_wait_added": False,
+        },
+    }
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("native_root", type=Path)
+    parser.add_argument(
+        "--xenos-root",
+        type=Path,
+        help="defaults to the native root with '.xenos' appended",
+    )
+    parser.add_argument("--output", "-o", type=Path)
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    xenos_root = args.xenos_root or Path(str(args.native_root) + ".xenos")
+    report = compare(args.native_root, xenos_root)
+    rendered = json.dumps(report, indent=2) + "\n"
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(rendered, encoding="utf-8")
+    else:
+        print(rendered, end="")
+    return 0 if report["result"] == "pass" else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/export-native-renderer-renderdoc.ps1
+++ b/tools/export-native-renderer-renderdoc.ps1
@@ -7,7 +7,8 @@ param(
     [Parameter(Mandatory)]
     [string]$OutputDir,
     [string]$NativeMarker = 'PinyonShift NR-02E isolated native draw',
-    [string]$XenosMarker = 'PinyonShift NR-02E authoritative Xenos draw'
+    [string]$XenosMarker = 'PinyonShift NR-02E authoritative Xenos draw',
+    [switch]$CompletePass
 )
 
 Set-StrictMode -Version Latest
@@ -46,11 +47,13 @@ $savedCapture = $env:PINYON_SHIFT_RENDERDOC_CAPTURE
 $savedOutput = $env:PINYON_SHIFT_RENDERDOC_EXPORT_DIR
 $savedNativeMarker = $env:PINYON_SHIFT_RENDERDOC_NATIVE_MARKER
 $savedXenosMarker = $env:PINYON_SHIFT_RENDERDOC_XENOS_MARKER
+$savedCompletePass = $env:PINYON_SHIFT_RENDERDOC_COMPLETE_PASS
 try {
     $env:PINYON_SHIFT_RENDERDOC_CAPTURE = $resolvedCapture
     $env:PINYON_SHIFT_RENDERDOC_EXPORT_DIR = $resolvedOutputDir
     $env:PINYON_SHIFT_RENDERDOC_NATIVE_MARKER = $NativeMarker
     $env:PINYON_SHIFT_RENDERDOC_XENOS_MARKER = $XenosMarker
+    $env:PINYON_SHIFT_RENDERDOC_COMPLETE_PASS = if ($CompletePass) { '1' } else { '0' }
     $process = Start-Process -FilePath $qrenderdoc `
         -ArgumentList @('--python', $script) -PassThru -Wait
     if ($process.ExitCode) {
@@ -62,6 +65,7 @@ finally {
     $env:PINYON_SHIFT_RENDERDOC_EXPORT_DIR = $savedOutput
     $env:PINYON_SHIFT_RENDERDOC_NATIVE_MARKER = $savedNativeMarker
     $env:PINYON_SHIFT_RENDERDOC_XENOS_MARKER = $savedXenosMarker
+    $env:PINYON_SHIFT_RENDERDOC_COMPLETE_PASS = $savedCompletePass
 }
 
 $report = Join-Path $resolvedOutputDir 'renderdoc-export.json'

--- a/tools/export-native-renderer-renderdoc.py
+++ b/tools/export-native-renderer-renderdoc.py
@@ -22,7 +22,15 @@ XENOS_MARKER = os.environ.get(
     "PINYON_SHIFT_RENDERDOC_XENOS_MARKER",
     "PinyonShift NR-02E authoritative Xenos draw",
 )
+COMPLETE_PASS = os.environ.get(
+    "PINYON_SHIFT_RENDERDOC_COMPLETE_PASS", "0"
+) == "1"
+PASS_NATIVE_ANCHOR_MARKER = "PinyonShift NR-02F isolated native pass anchor"
+PASS_XENOS_ANCHOR_MARKER = "PinyonShift NR-02F authoritative Xenos pass anchor"
+PASS_NATIVE_FOLLOWER_MARKER = "PinyonShift NR-02F isolated native pass follower"
+PASS_XENOS_FOLLOWER_MARKER = "PinyonShift NR-02F authoritative Xenos pass follower"
 SCHEMA = "pinyon-shift.native-renderer-renderdoc-export.v1"
+COMPLETE_PASS_SCHEMA = "pinyon-shift.native-renderer-pass-renderdoc-export.v1"
 
 
 def _flatten(actions):
@@ -98,6 +106,76 @@ def _bound_targets(controller):
     return colors, depth
 
 
+def _first_named_after(actions, name, event_id):
+    return next(
+        (action for action in actions
+         if action.customName == name and action.eventId > event_id),
+        None,
+    )
+
+
+def _export_bound_state(controller, output_dir, basename):
+    colors, depth = _bound_targets(controller)
+    if not colors:
+        raise RuntimeError("complete pass has no color output at {}".format(basename))
+    result = {
+        "color": _export_texture(
+            controller, colors[0], os.path.join(output_dir, basename + ".png")
+        ),
+        "depth": None,
+    }
+    if depth.resource != rd.ResourceId.Null():
+        result["depth"] = _export_texture(
+            controller,
+            depth,
+            os.path.join(output_dir, basename + "-depth.png"),
+            channel_extract=0,
+        )
+    return result
+
+
+def _export_pass_span(controller, first_marker, last_marker, output_dir, basename):
+    first_draw = _first_draw(first_marker)
+    last_draw = _first_draw(last_marker)
+    if first_draw is None or last_draw is None:
+        raise RuntimeError("complete-pass marker span contains no draw")
+    if not (
+        first_marker.eventId <= first_draw.eventId < last_marker.eventId <= last_draw.eventId
+    ):
+        raise RuntimeError("complete-pass marker/draw order is invalid")
+
+    controller.SetFrameEvent(first_marker.eventId, True)
+    before = _export_bound_state(controller, output_dir, basename + "-before")
+    controller.SetFrameEvent(last_draw.eventId, True)
+    after = _export_bound_state(controller, output_dir, basename)
+
+    for target in ("color", "depth"):
+        before_target = before[target]
+        after_target = after[target]
+        if (before_target is None) != (after_target is None):
+            raise RuntimeError("{} attachment presence changed across pass".format(target))
+        if before_target is None:
+            continue
+        if before_target["resource_id"] != after_target["resource_id"]:
+            raise RuntimeError("{} resource changed across pass".format(target))
+        if (before_target["width"], before_target["height"]) != (
+            after_target["width"], after_target["height"]
+        ):
+            raise RuntimeError("{} dimensions changed across pass".format(target))
+
+    return {
+        "start_marker": first_marker.customName,
+        "start_marker_event_id": first_marker.eventId,
+        "start_draw_event_id": first_draw.eventId,
+        "end_marker": last_marker.customName,
+        "end_marker_event_id": last_marker.eventId,
+        "end_draw_event_id": last_draw.eventId,
+        "draw_count": 2,
+        "before": before,
+        "after": after,
+    }
+
+
 def _export_marker(controller, marker, output_dir, basename):
     draw = _first_draw(marker)
     if draw is None:
@@ -148,6 +226,91 @@ def _export_marker(controller, marker, output_dir, basename):
     return result
 
 
+def _export_complete_pass(controller, actions, capture_path, output_dir):
+    native_anchors = [
+        action for action in actions
+        if action.customName == PASS_NATIVE_ANCHOR_MARKER
+    ]
+    if not native_anchors:
+        available_markers = sorted(
+            set(
+                action.customName
+                for action in actions
+                if action.customName and "PinyonShift" in action.customName
+            )
+        )
+        raise RuntimeError(
+            "no complete-pass native anchor marker was found; "
+            "available PinyonShift markers={}".format(available_markers)
+        )
+    native_anchor = native_anchors[0]
+    xenos_anchor = _first_named_after(
+        actions, PASS_XENOS_ANCHOR_MARKER, native_anchor.eventId
+    )
+    native_follower = _first_named_after(
+        actions, PASS_NATIVE_FOLLOWER_MARKER,
+        xenos_anchor.eventId if xenos_anchor else native_anchor.eventId,
+    )
+    xenos_follower = _first_named_after(
+        actions, PASS_XENOS_FOLLOWER_MARKER,
+        native_follower.eventId if native_follower else native_anchor.eventId,
+    )
+    if not xenos_anchor or not native_follower or not xenos_follower:
+        raise RuntimeError("a complete native/Xenos anchor/follower marker chain was not found")
+    marker_order = [
+        native_anchor.eventId,
+        xenos_anchor.eventId,
+        native_follower.eventId,
+        xenos_follower.eventId,
+    ]
+    if marker_order != sorted(marker_order) or len(set(marker_order)) != 4:
+        raise RuntimeError("complete-pass markers are not strictly ordered")
+
+    native = _export_pass_span(
+        controller, native_anchor, native_follower, output_dir, "isolated-native"
+    )
+    xenos = _export_pass_span(
+        controller, xenos_anchor, xenos_follower, output_dir, "authoritative-xenos"
+    )
+    native_color = native["after"]["color"]
+    xenos_color = xenos["after"]["color"]
+    if native_color["resource_id"] == xenos_color["resource_id"]:
+        raise RuntimeError("native and Xenos pass outputs alias")
+    if (native_color["width"], native_color["height"]) != (
+        xenos_color["width"], xenos_color["height"]
+    ):
+        raise RuntimeError("native and Xenos pass output dimensions differ")
+
+    return {
+        "schema": COMPLETE_PASS_SCHEMA,
+        "capture": {
+            "path": os.path.basename(capture_path),
+            "sha256": _sha256(capture_path),
+        },
+        "marker_counts": {
+            "native_anchor": len(native_anchors),
+            "xenos_anchor": sum(
+                action.customName == PASS_XENOS_ANCHOR_MARKER for action in actions
+            ),
+            "native_follower": sum(
+                action.customName == PASS_NATIVE_FOLLOWER_MARKER for action in actions
+            ),
+            "xenos_follower": sum(
+                action.customName == PASS_XENOS_FOLLOWER_MARKER for action in actions
+            ),
+        },
+        "marker_order": marker_order,
+        "native_pass": native,
+        "xenos_pass": xenos,
+        "safety": {
+            "xenos_draws_preserved": True,
+            "draw_suppression_implemented": False,
+            "resolve_suppression_implemented": False,
+            "suppression_allowed": False,
+        },
+    }
+
+
 def main():
     capture_path = os.environ["PINYON_SHIFT_RENDERDOC_CAPTURE"]
     output_dir = os.environ["PINYON_SHIFT_RENDERDOC_EXPORT_DIR"]
@@ -168,6 +331,16 @@ def main():
             raise RuntimeError("could not initialise replay: {}".format(result))
 
         actions = _flatten(controller.GetRootActions())
+        if COMPLETE_PASS:
+            report = _export_complete_pass(
+                controller, actions, capture_path, output_dir
+            )
+            with open(report_path, "w") as output:
+                json.dump(report, output, indent=2, sort_keys=True)
+                output.write("\n")
+            print(report_path)
+            return 0
+
         isolated = [a for a in actions if a.customName == ISOLATED_MARKER]
         xenos = [a for a in actions if a.customName == XENOS_MARKER]
         if not isolated or not xenos:
@@ -220,16 +393,23 @@ def main():
         capture.Shutdown()
 
 
-try:
-    sys.exit(main())
-except Exception as error:
-    message = "native renderer RenderDoc export failed: {}\n{}".format(
-        error, traceback.format_exc()
-    )
-    output_dir = os.environ.get("PINYON_SHIFT_RENDERDOC_EXPORT_DIR")
-    if output_dir:
-        os.makedirs(output_dir, exist_ok=True)
-        with open(os.path.join(output_dir, "renderdoc-export-error.txt"), "w") as output:
-            output.write(message)
-    sys.stderr.write(message)
-    sys.exit(1)
+def _entrypoint():
+    try:
+        return main()
+    except Exception as error:
+        message = "native renderer RenderDoc export failed: {}\n{}".format(
+            error, traceback.format_exc()
+        )
+        output_dir = os.environ.get("PINYON_SHIFT_RENDERDOC_EXPORT_DIR")
+        if output_dir:
+            os.makedirs(output_dir, exist_ok=True)
+            with open(
+                os.path.join(output_dir, "renderdoc-export-error.txt"), "w"
+            ) as output:
+                output.write(message)
+        sys.stderr.write(message)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(_entrypoint())

--- a/tools/tests/test_native_renderer_contract.py
+++ b/tools/tests/test_native_renderer_contract.py
@@ -436,6 +436,24 @@ class NativeRendererContractTests(unittest.TestCase):
         self.assertIn('"resolve_suppression_implemented": False', evaluator)
         self.assertNotIn("SetDrawSuppression", evaluator)
 
+    def test_complete_pass_export_spans_anchor_and_follower(self):
+        exporter = (
+            ROOT / "tools/export-native-renderer-renderdoc.py"
+        ).read_text(encoding="utf-8")
+        wrapper = (
+            ROOT / "tools/export-native-renderer-renderdoc.ps1"
+        ).read_text(encoding="utf-8")
+        self.assertIn("PASS_NATIVE_ANCHOR_MARKER", exporter)
+        self.assertIn("PASS_XENOS_ANCHOR_MARKER", exporter)
+        self.assertIn("PASS_NATIVE_FOLLOWER_MARKER", exporter)
+        self.assertIn("PASS_XENOS_FOLLOWER_MARKER", exporter)
+        self.assertIn("_export_pass_span", exporter)
+        self.assertIn('"draw_count": 2', exporter)
+        self.assertIn('"suppression_allowed": False', exporter)
+        self.assertIn("[switch]$CompletePass", wrapper)
+        self.assertIn("PINYON_SHIFT_RENDERDOC_COMPLETE_PASS", wrapper)
+        self.assertNotIn("SetDrawSuppression", exporter)
+
     def test_shader_capture_is_local_bounded_and_passive(self):
         patch = (
             ROOT
@@ -705,6 +723,33 @@ class NativeRendererContractTests(unittest.TestCase):
         self.assertIn("request.reuse_target = true", scanner)
         self.assertIn("native_renderer.isolated_pass.result", scanner)
         self.assertIn("native_renderer.isolated_pass.repeat", scanner)
+        repeat_request = scanner.split(
+            "} else if (!g_isolated_draw.pass_repeat_reported) {", 1
+        )[1].split("}", 1)[0]
+        self.assertNotIn("captured_frame =", repeat_request)
+        self.assertNotIn("captured_draw =", repeat_request)
+
+        paired_readback_patch = (
+            ROOT
+            / "patches/rexglue/0071-d3d12-paired-pass-color-readback.patch"
+        ).read_text(encoding="utf-8")
+        self.assertIn("reference_readback_requested", paired_readback_patch)
+        self.assertIn("QueueGuestColorReadback", paired_readback_patch)
+        self.assertIn("guest_reference_readback_", paired_readback_patch)
+        self.assertIn("GetCompletedSubmission", paired_readback_patch)
+        self.assertNotIn("AwaitAllQueueOperationsCompletion", paired_readback_patch)
+        self.assertNotIn("SetDrawSuppression", paired_readback_patch)
+        marker_end = paired_readback_patch.index(
+            "deferred_command_list_.EndDebugMarker"
+        )
+        xenos_readback = paired_readback_patch.index(
+            "QueueGuestColorReadback", marker_end
+        )
+        self.assertLess(marker_end, xenos_readback)
+        self.assertIn("CompleteIsolatedReferenceReadback", scanner)
+        self.assertIn("request.reference_readback_requested", scanner)
+        self.assertIn('readback, "xenos"', scanner)
+        self.assertIn('"suppression_eligible", "false"', scanner)
 
         texture_resource_patch = (
             ROOT

--- a/tools/tests/test_native_renderer_pass_readbacks.py
+++ b/tools/tests/test_native_renderer_pass_readbacks.py
@@ -1,0 +1,87 @@
+import importlib.util
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+TOOL = ROOT / "tools" / "compare-native-renderer-pass-readbacks.py"
+SPEC = importlib.util.spec_from_file_location("native_pass_readbacks", TOOL)
+assert SPEC and SPEC.loader
+MODULE = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = MODULE
+SPEC.loader.exec_module(MODULE)
+
+
+def write_readback(root: Path, role: str, data: bytes, *, row_pitch: int = 8) -> None:
+    root.mkdir()
+    metadata = {
+        "schema": "pinyon-shift.isolated-draw-readback.v1",
+        "signature": "747837906D0BF484",
+        "frame": 100,
+        "draw": 42,
+        "capture_role": role,
+        "source": {
+            "width": 1,
+            "height": 1,
+            "row_pitch": row_pitch,
+            "dxgi_format": 10,
+            "bytes": len(data),
+        },
+        "safety": {
+            "output_authority": "xenos",
+            "suppression_allowed": False,
+        },
+    }
+    (root / "readback.json").write_text(json.dumps(metadata), encoding="utf-8")
+    (root / "isolated.bin").write_bytes(data)
+
+
+class NativeRendererPassReadbackTests(unittest.TestCase):
+    def test_exact_active_bytes_pass(self):
+        with tempfile.TemporaryDirectory() as directory:
+            native = Path(directory) / "pass"
+            xenos = Path(str(native) + ".xenos")
+            write_readback(native, "native", bytes(range(8)))
+            write_readback(xenos, "xenos", bytes(range(8)))
+            report = MODULE.compare(native, xenos)
+            self.assertEqual(report["result"], "pass")
+            self.assertTrue(report["metrics"]["exact_active_bytes"])
+            self.assertFalse(report["safety"]["suppression_allowed"])
+
+    def test_padding_is_excluded(self):
+        with tempfile.TemporaryDirectory() as directory:
+            native = Path(directory) / "pass"
+            xenos = Path(str(native) + ".xenos")
+            write_readback(native, "native", bytes(range(8)) + b"\x00" * 8, row_pitch=16)
+            write_readback(xenos, "xenos", bytes(range(8)) + b"\xFF" * 8, row_pitch=16)
+            self.assertEqual(MODULE.compare(native, xenos)["result"], "pass")
+
+    def test_active_difference_fails(self):
+        with tempfile.TemporaryDirectory() as directory:
+            native = Path(directory) / "pass"
+            xenos = Path(str(native) + ".xenos")
+            write_readback(native, "native", bytes(range(8)))
+            write_readback(xenos, "xenos", bytes([99]) + bytes(range(1, 8)))
+            report = MODULE.compare(native, xenos)
+            self.assertEqual(report["result"], "fail")
+            self.assertEqual(report["metrics"]["different_bytes"], 1)
+
+    def test_mismatched_frame_is_rejected(self):
+        with tempfile.TemporaryDirectory() as directory:
+            native = Path(directory) / "pass"
+            xenos = Path(str(native) + ".xenos")
+            write_readback(native, "native", bytes(range(8)))
+            write_readback(xenos, "xenos", bytes(range(8)))
+            metadata_path = xenos / "readback.json"
+            metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+            metadata["frame"] += 1
+            metadata_path.write_text(json.dumps(metadata), encoding="utf-8")
+            with self.assertRaisesRegex(ValueError, "frame values differ"):
+                MODULE.compare(native, xenos)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/tests/test_native_renderer_renderdoc_export.py
+++ b/tools/tests/test_native_renderer_renderdoc_export.py
@@ -1,0 +1,97 @@
+import importlib.util
+import sys
+import tempfile
+import types
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+ROOT = Path(__file__).resolve().parents[2]
+TOOL = ROOT / "tools" / "export-native-renderer-renderdoc.py"
+
+
+class FakeResourceId:
+    @staticmethod
+    def Null():
+        return "null"
+
+
+fake_renderdoc = types.SimpleNamespace(
+    ResourceId=FakeResourceId,
+    ActionFlags=types.SimpleNamespace(Drawcall=1),
+)
+sys.modules.setdefault("renderdoc", fake_renderdoc)
+SPEC = importlib.util.spec_from_file_location("native_renderdoc_export", TOOL)
+assert SPEC and SPEC.loader
+MODULE = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = MODULE
+SPEC.loader.exec_module(MODULE)
+
+
+class Action:
+    def __init__(self, name, event_id):
+        self.customName = name
+        self.eventId = event_id
+        self.flags = 0
+        self.children = []
+
+
+def marker_chain():
+    return [
+        Action(MODULE.PASS_NATIVE_ANCHOR_MARKER, 10),
+        Action(MODULE.PASS_XENOS_ANCHOR_MARKER, 20),
+        Action(MODULE.PASS_NATIVE_FOLLOWER_MARKER, 30),
+        Action(MODULE.PASS_XENOS_FOLLOWER_MARKER, 40),
+    ]
+
+
+def span(resource_id):
+    target = {"resource_id": resource_id, "width": 640, "height": 8192}
+    return {"before": {"color": target}, "after": {"color": target}}
+
+
+class NativeRendererRenderDocExportTests(unittest.TestCase):
+    def test_complete_pass_requires_ordered_distinct_paths(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            capture = Path(temporary) / "capture.rdc"
+            capture.write_bytes(b"capture")
+
+            def export_span(_, first, last, __, basename):
+                self.assertLess(first.eventId, last.eventId)
+                return span("native" if basename == "isolated-native" else "xenos")
+
+            with mock.patch.object(MODULE, "_export_pass_span", export_span):
+                result = MODULE._export_complete_pass(
+                    object(), marker_chain(), str(capture), temporary
+                )
+
+        self.assertEqual(result["schema"], MODULE.COMPLETE_PASS_SCHEMA)
+        self.assertEqual(result["marker_order"], [10, 20, 30, 40])
+        self.assertFalse(result["safety"]["suppression_allowed"])
+        self.assertFalse(result["safety"]["draw_suppression_implemented"])
+
+    def test_complete_pass_rejects_missing_follower(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            capture = Path(temporary) / "capture.rdc"
+            capture.write_bytes(b"capture")
+            with self.assertRaisesRegex(RuntimeError, "marker chain"):
+                MODULE._export_complete_pass(
+                    object(), marker_chain()[:-1], str(capture), temporary
+                )
+
+    def test_complete_pass_rejects_native_xenos_alias(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            capture = Path(temporary) / "capture.rdc"
+            capture.write_bytes(b"capture")
+            with mock.patch.object(
+                MODULE, "_export_pass_span", return_value=span("shared")
+            ):
+                with self.assertRaisesRegex(RuntimeError, "outputs alias"):
+                    MODULE._export_complete_pass(
+                        object(), marker_chain(), str(capture), temporary
+                    )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/tests/test_release_contract.py
+++ b/tools/tests/test_release_contract.py
@@ -43,10 +43,10 @@ class ReleaseContractTests(unittest.TestCase):
 
     def test_rexglue_patches_have_stable_order_and_no_binary_payload(self):
         patches = sorted((ROOT / "patches/rexglue").glob("*.patch"))
-        self.assertEqual(len(patches), 70)
+        self.assertEqual(len(patches), 71)
         self.assertEqual(
             patches[-1].name,
-            "0070-d3d12-native-gpu-timing.patch",
+            "0071-d3d12-paired-pass-color-readback.patch",
         )
         self.assertEqual(len(patches), len({path.name[:4] for path in patches}))
         for path in patches:


### PR DESCRIPTION
## Summary
- capture private-native and authoritative-Xenos complete-pass color output from the same frame using independent asynchronous readbacks
- compare exact active texel bytes while excluding D3D12 row padding
- add strict complete-pass RenderDoc export for color/depth evidence
- preserve Xenos output authority and keep suppression prohibited

## Qualification
- exact parity across 41,943,040 active bytes
- 8/12 suppression-admission gates now pass
- remaining blockers: depth parity, later GPU consumers, guest CPU visibility, rollback switch

## Tests
- `python -m unittest discover -s tools/tests` (172 passed)
- five native renderer resource test executables
- `.\tools\build-preview.ps1 -CleanGenerated`
- AppData-backed paired-readback runtime qualification