### PR TITLE
test(native-renderer): prove complete pass depth parity

### DIFF
--- a/docs/native-renderer/SUPPRESSION_ADMISSION.md
+++ b/docs/native-renderer/SUPPRESSION_ADMISSION.md
@@ -53,14 +53,16 @@ Consequently the next work is evidence collection and complete-pass comparison,
 not draw skipping. The Xenos copy, draw, resolve, query, fence, and memexport
 paths remain unchanged.
 
-The complete-pass color gate may use the paired asynchronous readback described
-in [VISUAL_COMPARISON.md](VISUAL_COMPARISON.md). It captures private-native and
-authoritative-Xenos color after the same follower draw, checks exact active
-texel bytes, adds no GPU wait, and preserves the original draw. It does not
-prove the independent depth gate.
+The complete-pass color and depth gates use the paired asynchronous readback
+described in [VISUAL_COMPARISON.md](VISUAL_COMPARISON.md). It captures
+private-native and authoritative-Xenos attachments after the same follower
+draw, checks exact active bytes, adds no GPU wait, and preserves the original
+draw. Two-sample depth/stencil targets are extracted as raw per-sample tuples
+so both depth and stencil participate in the comparison.
 
-The 2026-08-28 same-frame qualification passed exact complete-pass color parity
-across 41,943,040 active bytes. This promotes `color_parity` to `pass`. The
-admission result is now 8/12; `depth_parity`, `later_gpu_consumers`,
+The 2026-08-29 same-frame qualification passed exact complete-pass color parity
+across 41,943,040 active bytes and exact two-sample depth/stencil parity across
+83,886,080 bytes. This promotes both `color_parity` and `depth_parity` to
+`pass`. The admission result is now 9/12; `later_gpu_consumers`,
 `guest_cpu_visibility`, and `rollback_switch` remain `unknown`, so suppression
 is still prohibited.

--- a/docs/native-renderer/VISUAL_COMPARISON.md
+++ b/docs/native-renderer/VISUAL_COMPARISON.md
@@ -128,27 +128,37 @@ documented in [PASS_INVENTORY.md](PASS_INVENTORY.md).
 ## Complete-pass comparison
 
 NR-04D admission compares the entire two-draw family rather than promoting the
-anchor result above. The preferred color path is a same-frame paired asynchronous
-readback. Launch the pass with the existing isolated readback directory set. The
-native artifact is committed at that path and the authoritative guest artifact
-is committed beside it with `.xenos` appended. Compare active texel bytes while
-excluding D3D12 row padding:
+anchor result above. The preferred color and depth path is a same-frame paired
+asynchronous readback. Launch the pass with the existing isolated readback
+directory set. The native color artifact is committed at that path and the
+authoritative guest color artifact is committed beside it with `.xenos`
+appended. Their corresponding depth/stencil artifacts use `.depth` and
+`.depth.xenos`. Compare active texel bytes while excluding D3D12 row padding:
 
 ```powershell
 python .\tools\compare-native-renderer-pass-readbacks.py `
   '.local\qualification\nr04d-pass-readback' `
   --output '.local\qualification\nr04d-pass-color-report.json'
+
+python .\tools\compare-native-renderer-pass-readbacks.py `
+  '.local\qualification\nr04d-pass-readback.depth' `
+  --content depth-stencil `
+  --output '.local\qualification\nr04d-pass-depth-report.json'
 ```
 
-Both copies are inserted into the same command list: native after the private
+All copies are inserted into the same command list: native after the private
 follower, and Xenos after the original authoritative follower. They retire by
-submission fence without a CPU/GPU wait. The comparison rejects mismatched
-signature, frame, follower draw, dimensions, row pitch, format, role, or safety
-metadata, and requires exact active color bytes. Xenos remains the displayed
-and authoritative output throughout.
+submission fence without a CPU/GPU wait. Single-sample depth uses the native
+D3D12 texture-plane layout. Multisample depth is extracted by a diagnostic
+compute shader into interleaved raw `depth32` and `stencil8` tuples for every
+pixel and sample. The comparison rejects mismatched signature, frame, follower
+draw, dimensions, sample count, encoding, layout, format, role, or safety
+metadata, and requires exact active bytes. Xenos remains the displayed and
+authoritative output throughout.
 
-RenderDoc remains the strict color-and-depth path. Capture with both the anchor
-and follower configured, then export their native/Xenos spans:
+RenderDoc remains available for visual inspection and external confirmation.
+Capture with both the anchor and follower configured, then export their
+native/Xenos spans:
 
 ```powershell
 .\tools\export-native-renderer-renderdoc.ps1 `
@@ -167,10 +177,10 @@ remain compatible with the color and depth comparator commands above.
 The complete-pass report records
 `pinyon-shift.native-renderer-pass-renderdoc-export.v1`, two draws per path,
 all marker/event IDs, capture and image hashes, and an explicit safety object.
-It never enables draw or resolve suppression. A passing paired readback can
-promote `color_parity`; `depth_parity` still requires the RenderDoc depth export
-or a future same-frame depth capture. Both gates must pass before suppression
-admission can complete.
+It never enables draw or resolve suppression. Passing same-frame paired color
+and depth/stencil readbacks may promote `color_parity` and `depth_parity`.
+Every remaining admission gate must still pass before suppression work can
+begin.
 
 ### Qualified complete-pass color result
 
@@ -189,3 +199,22 @@ timing recorded zero drops; native composition averaged 77.223 microseconds
 and native selection averaged 19.245 microseconds. The admission report now
 passes 8 of 12 gates, with depth parity, later GPU consumers, guest CPU
 visibility, and a rollback switch still deliberately blocking suppression.
+
+### Qualified complete-pass depth result
+
+The 2026-08-29 AppData-backed `open_world_day` run used clean-build executable
+SHA-256 `4B9421BBB6DA05A02D580984361477DF9F6C02BCF5848FB5A790DCA156794D3D`.
+Frame 3468 replayed the complete pass and captured the follower
+`1D253A52B55C9FB3` at draw 118. The bound `R32G8X24_TYPELESS` depth/stencil
+target was 640 by 8192 with two samples. Both paths produced 83,886,080 bytes
+encoded as raw `depth32_stencil8_sample_tuples`.
+
+The depth/stencil comparison passed exactly: zero differing bytes, zero
+maximum error, and identical binary SHA-256
+`33A3A11D54DE8EDE604C243CEDFDE1EF4B534D5EA3279C9DD57DF314045C23DF`.
+The paired color capture from the same frame also remained exact across
+41,943,040 bytes. Runtime diagnostics recorded all four captures, preserved
+Xenos authority with suppression disabled, reported no error or fatal events,
+and exited normally. Across 4,402 performance samples, median frame rate was
+31.531 FPS and the 1% low was 19.419 FPS. This promotes `depth_parity`; the
+admission report now passes 9 of 12 gates.

--- a/patches/rexglue/0072-d3d12-paired-pass-depth-readback.patch
+++ b/patches/rexglue/0072-d3d12-paired-pass-depth-readback.patch
@@ -1,0 +1,368 @@
+diff --git a/include/rex/graphics/d3d12/render_target_cache.h b/include/rex/graphics/d3d12/render_target_cache.h
+index d328cc1..7301c7b 100644
+--- a/include/rex/graphics/d3d12/render_target_cache.h
++++ b/include/rex/graphics/d3d12/render_target_cache.h
+@@ -107,6 +107,12 @@ class D3D12RenderTargetCache final : public RenderTargetCache {
+   system::GraphicsIsolatedDrawReadbackStatus QueueGuestColorReadback(
+       system::GraphicsIsolatedDrawReadbackCompletion completion,
+       uint32_t* failure_detail_out);
++  system::GraphicsIsolatedDrawReadbackStatus QueueIsolatedReplayDepthReadback(
++      system::GraphicsIsolatedDrawReadbackCompletion completion,
++      uint32_t* failure_detail_out);
++  system::GraphicsIsolatedDrawReadbackStatus QueueGuestDepthReadback(
++      system::GraphicsIsolatedDrawReadbackCompletion completion,
++      uint32_t* failure_detail_out);
+   void EndIsolatedReplayTarget(uint64_t frame_sequence);
+ 
+   struct IsolatedReplayPreviewSource {
+@@ -713,9 +719,21 @@ class D3D12RenderTargetCache final : public RenderTargetCache {
+     uint32_t height = 0;
+     uint32_t row_pitch = 0;
+     uint32_t format = 0;
++    uint32_t plane_count = 0;
++    uint64_t plane_offsets[system::GraphicsIsolatedDrawReadback::kMaxPlanes] =
++        {};
++    uint32_t
++        plane_row_pitches[system::GraphicsIsolatedDrawReadback::kMaxPlanes] =
++            {};
++    uint32_t
++        plane_row_sizes[system::GraphicsIsolatedDrawReadback::kMaxPlanes] = {};
++    uint32_t
++        plane_row_counts[system::GraphicsIsolatedDrawReadback::kMaxPlanes] = {};
+     system::GraphicsIsolatedDrawReadbackCompletion completion = nullptr;
+   } isolated_replay_readback_;
+   IsolatedReplayReadback guest_reference_readback_;
++  IsolatedReplayReadback isolated_replay_depth_readback_;
++  IsolatedReplayReadback guest_depth_reference_readback_;
+   system::GraphicsIsolatedDrawReadbackStatus QueueRenderTargetReadback(
+       D3D12RenderTarget* target, IsolatedReplayReadback& pending_readback,
+       system::GraphicsIsolatedDrawReadbackCompletion completion,
+diff --git a/include/rex/system/interfaces/graphics.h b/include/rex/system/interfaces/graphics.h
+index b6385ee..d9b4818 100644
+--- a/include/rex/system/interfaces/graphics.h
++++ b/include/rex/system/interfaces/graphics.h
+@@ -370,6 +370,7 @@ enum class GraphicsIsolatedDrawReadbackStatus : uint32_t {
+ };
+ 
+ struct GraphicsIsolatedDrawReadback {
++  static constexpr uint32_t kMaxPlanes = 2;
+   GraphicsIsolatedDrawReadbackStatus status =
+       GraphicsIsolatedDrawReadbackStatus::kUnsupportedTarget;
+   uint32_t detail = 0;
+@@ -379,6 +380,11 @@ struct GraphicsIsolatedDrawReadback {
+   uint32_t height = 0;
+   uint32_t row_pitch = 0;
+   uint32_t format = 0;
++  uint32_t plane_count = 0;
++  uint64_t plane_offsets[kMaxPlanes] = {};
++  uint32_t plane_row_pitches[kMaxPlanes] = {};
++  uint32_t plane_row_sizes[kMaxPlanes] = {};
++  uint32_t plane_row_counts[kMaxPlanes] = {};
+ };
+ 
+ using GraphicsIsolatedDrawReadbackCompletion = void (*)(
+@@ -391,6 +397,11 @@ struct GraphicsIsolatedDrawRequest {
+   // This is independent of the private replay readback and never suppresses
+   // or redirects the guest draw.
+   bool reference_readback_requested = false;
++  // Capture the private and authoritative depth/stencil attachments after the
++  // same pass follower. These readbacks are diagnostic only and never suppress
++  // or redirect the guest draw.
++  bool depth_readback_requested = false;
++  bool reference_depth_readback_requested = false;
+   bool reference_marker_requested = false;
+   bool retain_target = false;
+   // Rebind the retained private target without copying the guest target. This
+@@ -401,6 +412,9 @@ struct GraphicsIsolatedDrawRequest {
+   GraphicsIsolatedDrawReadbackCompletion readback_completion = nullptr;
+   GraphicsIsolatedDrawReadbackCompletion reference_readback_completion =
+       nullptr;
++  GraphicsIsolatedDrawReadbackCompletion depth_readback_completion = nullptr;
++  GraphicsIsolatedDrawReadbackCompletion
++      reference_depth_readback_completion = nullptr;
+ };
+ 
+ // Called after the host pipeline has been prepared. A request duplicates the
+diff --git a/src/graphics/d3d12/command_processor.cpp b/src/graphics/d3d12/command_processor.cpp
+index 0885b89..facdf4b 100644
+--- a/src/graphics/d3d12/command_processor.cpp
++++ b/src/graphics/d3d12/command_processor.cpp
+@@ -3355,6 +3355,21 @@ bool D3D12CommandProcessor::IssueDraw(xenos::PrimitiveType primitive_type, uint3
+             isolated_draw_request.readback_completion(readback_result);
+           }
+         }
++        if (isolated_draw_request.depth_readback_requested &&
++            isolated_draw_request.depth_readback_completion) {
++          uint32_t readback_detail = 0;
++          auto readback_status =
++              render_target_cache_->QueueIsolatedReplayDepthReadback(
++                  isolated_draw_request.depth_readback_completion,
++                  &readback_detail);
++          if (readback_status !=
++              system::GraphicsIsolatedDrawReadbackStatus::kReady) {
++            system::GraphicsIsolatedDrawReadback readback_result;
++            readback_result.status = readback_status;
++            readback_result.detail = readback_detail;
++            isolated_draw_request.depth_readback_completion(readback_result);
++          }
++        }
+         render_target_cache_->EndIsolatedReplayTarget(
+             isolated_draw_request.frame_sequence);
+         isolated_result.status =
+@@ -3394,6 +3409,21 @@ bool D3D12CommandProcessor::IssueDraw(xenos::PrimitiveType primitive_type, uint3
+         isolated_draw_request.reference_readback_completion(readback_result);
+       }
+     }
++    if (isolated_draw_request.reference_depth_readback_requested &&
++        isolated_draw_request.reference_depth_readback_completion) {
++      uint32_t readback_detail = 0;
++      auto readback_status = render_target_cache_->QueueGuestDepthReadback(
++          isolated_draw_request.reference_depth_readback_completion,
++          &readback_detail);
++      if (readback_status !=
++          system::GraphicsIsolatedDrawReadbackStatus::kReady) {
++        system::GraphicsIsolatedDrawReadback readback_result;
++        readback_result.status = readback_status;
++        readback_result.detail = readback_detail;
++        isolated_draw_request.reference_depth_readback_completion(
++            readback_result);
++      }
++    }
+   } else {
+     D3D12_INDEX_BUFFER_VIEW index_buffer_view;
+     index_buffer_view.SizeInBytes = primitive_processing_result.host_draw_vertex_count;
+@@ -3487,6 +3517,21 @@ bool D3D12CommandProcessor::IssueDraw(xenos::PrimitiveType primitive_type, uint3
+             isolated_draw_request.readback_completion(readback_result);
+           }
+         }
++        if (isolated_draw_request.depth_readback_requested &&
++            isolated_draw_request.depth_readback_completion) {
++          uint32_t readback_detail = 0;
++          auto readback_status =
++              render_target_cache_->QueueIsolatedReplayDepthReadback(
++                  isolated_draw_request.depth_readback_completion,
++                  &readback_detail);
++          if (readback_status !=
++              system::GraphicsIsolatedDrawReadbackStatus::kReady) {
++            system::GraphicsIsolatedDrawReadback readback_result;
++            readback_result.status = readback_status;
++            readback_result.detail = readback_detail;
++            isolated_draw_request.depth_readback_completion(readback_result);
++          }
++        }
+         render_target_cache_->EndIsolatedReplayTarget(
+             isolated_draw_request.frame_sequence);
+         isolated_result.status =
+@@ -3526,6 +3571,21 @@ bool D3D12CommandProcessor::IssueDraw(xenos::PrimitiveType primitive_type, uint3
+         isolated_draw_request.reference_readback_completion(readback_result);
+       }
+     }
++    if (isolated_draw_request.reference_depth_readback_requested &&
++        isolated_draw_request.reference_depth_readback_completion) {
++      uint32_t readback_detail = 0;
++      auto readback_status = render_target_cache_->QueueGuestDepthReadback(
++          isolated_draw_request.reference_depth_readback_completion,
++          &readback_detail);
++      if (readback_status !=
++          system::GraphicsIsolatedDrawReadbackStatus::kReady) {
++        system::GraphicsIsolatedDrawReadback readback_result;
++        readback_result.status = readback_status;
++        readback_result.detail = readback_detail;
++        isolated_draw_request.reference_depth_readback_completion(
++            readback_result);
++      }
++    }
+     if (scratch_index_buffer != nullptr) {
+       ReleaseScratchGPUBuffer(scratch_index_buffer, D3D12_RESOURCE_STATE_INDEX_BUFFER);
+     }
+diff --git a/src/graphics/d3d12/render_target_cache.cpp b/src/graphics/d3d12/render_target_cache.cpp
+index ef06755..924804f 100644
+--- a/src/graphics/d3d12/render_target_cache.cpp
++++ b/src/graphics/d3d12/render_target_cache.cpp
+@@ -1029,6 +1029,8 @@ void D3D12RenderTargetCache::Shutdown(bool from_destructor) {
+   };
+   release_isolated_readback(isolated_replay_readback_);
+   release_isolated_readback(guest_reference_readback_);
++  release_isolated_readback(isolated_replay_depth_readback_);
++  release_isolated_readback(guest_depth_reference_readback_);
+   isolated_replay_preview_resolved_target_.Reset();
+   isolated_replay_preview_resolved_target_state_ =
+       D3D12_RESOURCE_STATE_RESOLVE_DEST;
+@@ -1072,6 +1074,15 @@ void D3D12RenderTargetCache::CompletedSubmissionUpdated() {
+     result.height = readback.height;
+     result.row_pitch = readback.row_pitch;
+     result.format = readback.format;
++    result.plane_count = readback.plane_count;
++    std::copy_n(readback.plane_offsets, readback.plane_count,
++                result.plane_offsets);
++    std::copy_n(readback.plane_row_pitches, readback.plane_count,
++                result.plane_row_pitches);
++    std::copy_n(readback.plane_row_sizes, readback.plane_count,
++                result.plane_row_sizes);
++    std::copy_n(readback.plane_row_counts, readback.plane_count,
++                result.plane_row_counts);
+     auto completion = readback.completion;
+     if (completion) {
+       completion(result);
+@@ -1082,6 +1093,8 @@ void D3D12RenderTargetCache::CompletedSubmissionUpdated() {
+   };
+   complete_isolated_readback(isolated_replay_readback_);
+   complete_isolated_readback(guest_reference_readback_);
++  complete_isolated_readback(isolated_replay_depth_readback_);
++  complete_isolated_readback(guest_depth_reference_readback_);
+ }
+ 
+ void D3D12RenderTargetCache::BeginSubmission() {
+@@ -1896,6 +1909,35 @@ D3D12RenderTargetCache::QueueGuestColorReadback(
+       guest_reference_readback_, completion, failure_detail_out);
+ }
+ 
++system::GraphicsIsolatedDrawReadbackStatus
++D3D12RenderTargetCache::QueueIsolatedReplayDepthReadback(
++    system::GraphicsIsolatedDrawReadbackCompletion completion,
++    uint32_t* failure_detail_out) {
++  if (!isolated_replay_depth_target_) {
++    return system::GraphicsIsolatedDrawReadbackStatus::kUnsupportedTarget;
++  }
++  return QueueRenderTargetReadback(
++      static_cast<D3D12RenderTarget*>(isolated_replay_depth_target_.get()),
++      isolated_replay_depth_readback_, completion, failure_detail_out);
++}
++
++system::GraphicsIsolatedDrawReadbackStatus
++D3D12RenderTargetCache::QueueGuestDepthReadback(
++    system::GraphicsIsolatedDrawReadbackCompletion completion,
++    uint32_t* failure_detail_out) {
++  if (GetPath() != Path::kHostRenderTargets) {
++    return system::GraphicsIsolatedDrawReadbackStatus::kUnsupportedTarget;
++  }
++  RenderTarget* const* guest_targets =
++      last_update_accumulated_render_targets();
++  if (!guest_targets[0]) {
++    return system::GraphicsIsolatedDrawReadbackStatus::kUnsupportedTarget;
++  }
++  return QueueRenderTargetReadback(
++      static_cast<D3D12RenderTarget*>(guest_targets[0]),
++      guest_depth_reference_readback_, completion, failure_detail_out);
++}
++
+ system::GraphicsIsolatedDrawReadbackStatus
+ D3D12RenderTargetCache::QueueRenderTargetReadback(
+     D3D12RenderTarget* target, IsolatedReplayReadback& pending_readback,
+@@ -1913,18 +1955,25 @@ D3D12RenderTargetCache::QueueRenderTargetReadback(
+       source_desc.DepthOrArraySize != 1 || source_desc.MipLevels != 1) {
+     return system::GraphicsIsolatedDrawReadbackStatus::kUnsupportedTarget;
+   }
++  const bool is_depth = target->key().is_depth != 0;
++  if (is_depth && source_desc.SampleDesc.Count > 1) {
++    if (failure_detail_out) {
++      *failure_detail_out = source_desc.SampleDesc.Count;
++    }
++    return system::GraphicsIsolatedDrawReadbackStatus::kUnsupportedTarget;
++  }
+ 
+   Microsoft::WRL::ComPtr<ID3D12Resource> resolved_target;
+   D3D12_RESOURCE_DESC copy_desc = source_desc;
+   copy_desc.Alignment = 0;
+   copy_desc.SampleDesc.Count = 1;
+   copy_desc.SampleDesc.Quality = 0;
+-  copy_desc.Flags = D3D12_RESOURCE_FLAG_ALLOW_RENDER_TARGET;
+   D3D12_CLEAR_VALUE resolved_clear = {};
+   resolved_clear.Format = source_desc.Format;
+   ID3D12Resource* copy_source = source;
+   ID3D12Device* device = command_processor_.GetD3D12Provider().GetDevice();
+   if (source_desc.SampleDesc.Count > 1) {
++    copy_desc.Flags = D3D12_RESOURCE_FLAG_ALLOW_RENDER_TARGET;
+     HRESULT resolve_result = device->CreateCommittedResource(
+         &ui::d3d12::util::kHeapPropertiesDefault, D3D12_HEAP_FLAG_NONE,
+         &copy_desc, D3D12_RESOURCE_STATE_RESOLVE_DEST, &resolved_clear,
+@@ -1947,16 +1996,36 @@ D3D12RenderTargetCache::QueueRenderTargetReadback(
+     copy_source = resolved_target.Get();
+   }
+ 
+-  D3D12_PLACED_SUBRESOURCE_FOOTPRINT footprint = {};
+-  UINT row_count = 0;
+-  UINT64 row_size = 0;
++  uint32_t plane_count = 1;
++  if (is_depth) {
++    D3D12_FEATURE_DATA_FORMAT_INFO format_info = {source_desc.Format, 0};
++    if (FAILED(device->CheckFeatureSupport(D3D12_FEATURE_FORMAT_INFO,
++                                           &format_info,
++                                           sizeof(format_info))) ||
++        !format_info.PlaneCount ||
++        format_info.PlaneCount >
++            system::GraphicsIsolatedDrawReadback::kMaxPlanes) {
++      return system::GraphicsIsolatedDrawReadbackStatus::kUnsupportedTarget;
++    }
++    plane_count = format_info.PlaneCount;
++  }
++  D3D12_PLACED_SUBRESOURCE_FOOTPRINT footprints
++      [system::GraphicsIsolatedDrawReadback::kMaxPlanes] = {};
++  UINT row_counts[system::GraphicsIsolatedDrawReadback::kMaxPlanes] = {};
++  UINT64 row_sizes[system::GraphicsIsolatedDrawReadback::kMaxPlanes] = {};
+   UINT64 total_size = 0;
+-  device->GetCopyableFootprints(&copy_desc, 0, 1, 0, &footprint, &row_count,
+-                                &row_size, &total_size);
++  device->GetCopyableFootprints(&copy_desc, 0, plane_count, 0, footprints,
++                                row_counts, row_sizes, &total_size);
+   if (!total_size || total_size > UINT32_MAX ||
+-      source_desc.Width > UINT32_MAX || !row_count) {
++      source_desc.Width > UINT32_MAX) {
+     return system::GraphicsIsolatedDrawReadbackStatus::kUnsupportedTarget;
+   }
++  for (uint32_t plane = 0; plane < plane_count; ++plane) {
++    if (!row_counts[plane] || !row_sizes[plane] ||
++        row_sizes[plane] > UINT32_MAX) {
++      return system::GraphicsIsolatedDrawReadbackStatus::kUnsupportedTarget;
++    }
++  }
+ 
+   D3D12_RESOURCE_DESC buffer_desc;
+   ui::d3d12::util::FillBufferResourceDesc(
+@@ -1997,16 +2066,18 @@ D3D12RenderTargetCache::QueueRenderTargetReadback(
+         source, D3D12_RESOURCE_STATE_RESOLVE_SOURCE, old_state);
+     command_processor_.SubmitBarriers();
+   }
+-  D3D12_TEXTURE_COPY_LOCATION destination = {};
+-  destination.pResource = buffer.Get();
+-  destination.Type = D3D12_TEXTURE_COPY_TYPE_PLACED_FOOTPRINT;
+-  destination.PlacedFootprint = footprint;
+-  D3D12_TEXTURE_COPY_LOCATION source_location = {};
+-  source_location.pResource = copy_source;
+-  source_location.Type = D3D12_TEXTURE_COPY_TYPE_SUBRESOURCE_INDEX;
+-  source_location.SubresourceIndex = 0;
+-  command_processor_.GetDeferredCommandList().D3DCopyTextureRegion(
+-      &destination, 0, 0, 0, &source_location, nullptr);
++  for (uint32_t plane = 0; plane < plane_count; ++plane) {
++    D3D12_TEXTURE_COPY_LOCATION destination = {};
++    destination.pResource = buffer.Get();
++    destination.Type = D3D12_TEXTURE_COPY_TYPE_PLACED_FOOTPRINT;
++    destination.PlacedFootprint = footprints[plane];
++    D3D12_TEXTURE_COPY_LOCATION source_location = {};
++    source_location.pResource = copy_source;
++    source_location.Type = D3D12_TEXTURE_COPY_TYPE_SUBRESOURCE_INDEX;
++    source_location.SubresourceIndex = plane;
++    command_processor_.GetDeferredCommandList().D3DCopyTextureRegion(
++        &destination, 0, 0, 0, &source_location, nullptr);
++  }
+   if (source_desc.SampleDesc.Count == 1) {
+     target->SetResourceState(old_state);
+     command_processor_.PushTransitionBarrier(
+@@ -2021,8 +2092,16 @@ D3D12RenderTargetCache::QueueRenderTargetReadback(
+   pending_readback.data_size = total_size;
+   pending_readback.width = uint32_t(source_desc.Width);
+   pending_readback.height = source_desc.Height;
+-  pending_readback.row_pitch = footprint.Footprint.RowPitch;
++  pending_readback.row_pitch = footprints[0].Footprint.RowPitch;
+   pending_readback.format = uint32_t(source_desc.Format);
++  pending_readback.plane_count = plane_count;
++  for (uint32_t plane = 0; plane < plane_count; ++plane) {
++    pending_readback.plane_offsets[plane] = footprints[plane].Offset;
++    pending_readback.plane_row_pitches[plane] =
++        footprints[plane].Footprint.RowPitch;
++    pending_readback.plane_row_sizes[plane] = uint32_t(row_sizes[plane]);
++    pending_readback.plane_row_counts[plane] = row_counts[plane];
++  }
+   pending_readback.completion = completion;
+   return system::GraphicsIsolatedDrawReadbackStatus::kReady;
+ }

--- a/patches/rexglue/0073-d3d12-msaa-depth-readback.patch
+++ b/patches/rexglue/0073-d3d12-msaa-depth-readback.patch
@@ -1,0 +1,455 @@
+diff --git a/include/rex/graphics/d3d12/render_target_cache.h b/include/rex/graphics/d3d12/render_target_cache.h
+index 7301c7b..d57fbce 100644
+--- a/include/rex/graphics/d3d12/render_target_cache.h
++++ b/include/rex/graphics/d3d12/render_target_cache.h
+@@ -719,6 +719,7 @@ class D3D12RenderTargetCache final : public RenderTargetCache {
+     uint32_t height = 0;
+     uint32_t row_pitch = 0;
+     uint32_t format = 0;
++    uint32_t sample_count = 1;
+     uint32_t plane_count = 0;
+     uint64_t plane_offsets[system::GraphicsIsolatedDrawReadback::kMaxPlanes] =
+         {};
+@@ -738,6 +739,8 @@ class D3D12RenderTargetCache final : public RenderTargetCache {
+       D3D12RenderTarget* target, IsolatedReplayReadback& pending_readback,
+       system::GraphicsIsolatedDrawReadbackCompletion completion,
+       uint32_t* failure_detail_out);
++  ID3D12RootSignature* isolated_depth_readback_root_signature_ = nullptr;
++  ID3D12PipelineState* isolated_depth_readback_pipeline_ = nullptr;
+   std::shared_ptr<ui::d3d12::D3D12CpuDescriptorPool> descriptor_pool_srv_;
+   ui::d3d12::D3D12CpuDescriptorPool::Descriptor null_rtv_descriptor_ss_;
+   ui::d3d12::D3D12CpuDescriptorPool::Descriptor null_rtv_descriptor_ms_;
+diff --git a/include/rex/system/interfaces/graphics.h b/include/rex/system/interfaces/graphics.h
+index d9b4818..d16281a 100644
+--- a/include/rex/system/interfaces/graphics.h
++++ b/include/rex/system/interfaces/graphics.h
+@@ -380,6 +380,7 @@ struct GraphicsIsolatedDrawReadback {
+   uint32_t height = 0;
+   uint32_t row_pitch = 0;
+   uint32_t format = 0;
++  uint32_t sample_count = 1;
+   uint32_t plane_count = 0;
+   uint64_t plane_offsets[kMaxPlanes] = {};
+   uint32_t plane_row_pitches[kMaxPlanes] = {};
+diff --git a/src/graphics/d3d12/render_target_cache.cpp b/src/graphics/d3d12/render_target_cache.cpp
+index 924804f..d2c87b3 100644
+--- a/src/graphics/d3d12/render_target_cache.cpp
++++ b/src/graphics/d3d12/render_target_cache.cpp
+@@ -56,6 +56,7 @@ namespace shaders {
+ #include "../shaders/bytecode/d3d12_5_1/host_depth_store_1xmsaa_cs.h"
+ #include "../shaders/bytecode/d3d12_5_1/host_depth_store_2xmsaa_cs.h"
+ #include "../shaders/bytecode/d3d12_5_1/host_depth_store_4xmsaa_cs.h"
++#include "../shaders/bytecode/d3d12_5_1/isolated_depth_readback_msaa_cs.h"
+ #include "../shaders/bytecode/d3d12_5_1/passthrough_position_xy_vs.h"
+ #include "../shaders/bytecode/d3d12_5_1/resolve_clear_32bpp_cs.h"
+ #include "../shaders/bytecode/d3d12_5_1/resolve_clear_32bpp_scaled_cs.h"
+@@ -1020,6 +1021,9 @@ void D3D12RenderTargetCache::Shutdown(bool from_destructor) {
+   }
+   ui::d3d12::util::ReleaseAndNull(host_depth_store_root_signature_);
+ 
++  ui::d3d12::util::ReleaseAndNull(isolated_depth_readback_pipeline_);
++  ui::d3d12::util::ReleaseAndNull(isolated_depth_readback_root_signature_);
++
+   const auto release_isolated_readback = [](IsolatedReplayReadback& readback) {
+     if (readback.buffer && readback.mapping) {
+       D3D12_RANGE write_range = {};
+@@ -1074,6 +1078,7 @@ void D3D12RenderTargetCache::CompletedSubmissionUpdated() {
+     result.height = readback.height;
+     result.row_pitch = readback.row_pitch;
+     result.format = readback.format;
++    result.sample_count = readback.sample_count;
+     result.plane_count = readback.plane_count;
+     std::copy_n(readback.plane_offsets, readback.plane_count,
+                 result.plane_offsets);
+@@ -1933,16 +1938,13 @@ D3D12RenderTargetCache::QueueGuestDepthReadback(
+   if (!guest_targets[0]) {
+     return system::GraphicsIsolatedDrawReadbackStatus::kUnsupportedTarget;
+   }
+-  return QueueRenderTargetReadback(
+-      static_cast<D3D12RenderTarget*>(guest_targets[0]),
+-      guest_depth_reference_readback_, completion, failure_detail_out);
++  return QueueRenderTargetReadback(static_cast<D3D12RenderTarget*>(guest_targets[0]),
++                                   guest_depth_reference_readback_, completion, failure_detail_out);
+ }
+ 
+-system::GraphicsIsolatedDrawReadbackStatus
+-D3D12RenderTargetCache::QueueRenderTargetReadback(
++system::GraphicsIsolatedDrawReadbackStatus D3D12RenderTargetCache::QueueRenderTargetReadback(
+     D3D12RenderTarget* target, IsolatedReplayReadback& pending_readback,
+-    system::GraphicsIsolatedDrawReadbackCompletion completion,
+-    uint32_t* failure_detail_out) {
++    system::GraphicsIsolatedDrawReadbackCompletion completion, uint32_t* failure_detail_out) {
+   if (failure_detail_out) {
+     *failure_detail_out = 0;
+   }
+@@ -1956,11 +1958,166 @@ D3D12RenderTargetCache::QueueRenderTargetReadback(
+     return system::GraphicsIsolatedDrawReadbackStatus::kUnsupportedTarget;
+   }
+   const bool is_depth = target->key().is_depth != 0;
++  ID3D12Device* device = command_processor_.GetD3D12Provider().GetDevice();
++  if (!device) {
++    return system::GraphicsIsolatedDrawReadbackStatus::kUnsupportedTarget;
++  }
+   if (is_depth && source_desc.SampleDesc.Count > 1) {
+-    if (failure_detail_out) {
+-      *failure_detail_out = source_desc.SampleDesc.Count;
++    const uint64_t row_pitch = source_desc.Width * source_desc.SampleDesc.Count * 8;
++    const uint64_t total_size = row_pitch * source_desc.Height;
++    if (!source_desc.Width || !source_desc.Height || source_desc.Width > UINT32_MAX ||
++        row_pitch > UINT32_MAX || !total_size || total_size > UINT32_MAX) {
++      return system::GraphicsIsolatedDrawReadbackStatus::kUnsupportedTarget;
+     }
+-    return system::GraphicsIsolatedDrawReadbackStatus::kUnsupportedTarget;
++
++    if (!isolated_depth_readback_root_signature_) {
++      D3D12_ROOT_PARAMETER root_parameters[3] = {};
++      root_parameters[0].ParameterType = D3D12_ROOT_PARAMETER_TYPE_32BIT_CONSTANTS;
++      root_parameters[0].Constants.ShaderRegister = 0;
++      root_parameters[0].Constants.RegisterSpace = 0;
++      root_parameters[0].Constants.Num32BitValues = 3;
++      root_parameters[0].ShaderVisibility = D3D12_SHADER_VISIBILITY_ALL;
++
++      D3D12_DESCRIPTOR_RANGE source_range = {};
++      source_range.RangeType = D3D12_DESCRIPTOR_RANGE_TYPE_SRV;
++      source_range.NumDescriptors = 2;
++      source_range.BaseShaderRegister = 0;
++      source_range.RegisterSpace = 0;
++      source_range.OffsetInDescriptorsFromTableStart = 0;
++      root_parameters[1].ParameterType = D3D12_ROOT_PARAMETER_TYPE_DESCRIPTOR_TABLE;
++      root_parameters[1].DescriptorTable.NumDescriptorRanges = 1;
++      root_parameters[1].DescriptorTable.pDescriptorRanges = &source_range;
++      root_parameters[1].ShaderVisibility = D3D12_SHADER_VISIBILITY_ALL;
++
++      D3D12_DESCRIPTOR_RANGE output_range = {};
++      output_range.RangeType = D3D12_DESCRIPTOR_RANGE_TYPE_UAV;
++      output_range.NumDescriptors = 1;
++      output_range.BaseShaderRegister = 0;
++      output_range.RegisterSpace = 0;
++      output_range.OffsetInDescriptorsFromTableStart = 0;
++      root_parameters[2].ParameterType = D3D12_ROOT_PARAMETER_TYPE_DESCRIPTOR_TABLE;
++      root_parameters[2].DescriptorTable.NumDescriptorRanges = 1;
++      root_parameters[2].DescriptorTable.pDescriptorRanges = &output_range;
++      root_parameters[2].ShaderVisibility = D3D12_SHADER_VISIBILITY_ALL;
++
++      D3D12_ROOT_SIGNATURE_DESC root_signature_desc = {};
++      root_signature_desc.NumParameters = uint32_t(rex::countof(root_parameters));
++      root_signature_desc.pParameters = root_parameters;
++      isolated_depth_readback_root_signature_ = ui::d3d12::util::CreateRootSignature(
++          command_processor_.GetD3D12Provider(), root_signature_desc);
++      if (!isolated_depth_readback_root_signature_) {
++        return system::GraphicsIsolatedDrawReadbackStatus::kAllocationFailed;
++      }
++      isolated_depth_readback_root_signature_->SetName(
++          L"Isolated MSAA depth readback root signature");
++    }
++    if (!isolated_depth_readback_pipeline_) {
++      isolated_depth_readback_pipeline_ =
++          ui::d3d12::util::CreateComputePipeline(device, shaders::isolated_depth_readback_msaa_cs,
++                                                 sizeof(shaders::isolated_depth_readback_msaa_cs),
++                                                 isolated_depth_readback_root_signature_);
++      if (!isolated_depth_readback_pipeline_) {
++        return system::GraphicsIsolatedDrawReadbackStatus::kAllocationFailed;
++      }
++      isolated_depth_readback_pipeline_->SetName(L"Isolated MSAA depth readback pipeline");
++    }
++
++    D3D12_RESOURCE_DESC extraction_desc;
++    ui::d3d12::util::FillBufferResourceDesc(extraction_desc, total_size,
++                                            D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS);
++    Microsoft::WRL::ComPtr<ID3D12Resource> extraction_buffer;
++    HRESULT create_result = device->CreateCommittedResource(
++        &ui::d3d12::util::kHeapPropertiesDefault, D3D12_HEAP_FLAG_NONE, &extraction_desc,
++        D3D12_RESOURCE_STATE_UNORDERED_ACCESS, nullptr, IID_PPV_ARGS(&extraction_buffer));
++    if (FAILED(create_result)) {
++      if (failure_detail_out) {
++        *failure_detail_out = uint32_t(create_result);
++      }
++      return system::GraphicsIsolatedDrawReadbackStatus::kAllocationFailed;
++    }
++    extraction_buffer->SetName(L"Isolated MSAA depth extraction buffer");
++
++    D3D12_RESOURCE_DESC readback_desc;
++    ui::d3d12::util::FillBufferResourceDesc(readback_desc, total_size, D3D12_RESOURCE_FLAG_NONE);
++    Microsoft::WRL::ComPtr<ID3D12Resource> buffer;
++    const auto& provider = command_processor_.GetD3D12Provider();
++    create_result = device->CreateCommittedResource(
++        &ui::d3d12::util::kHeapPropertiesReadback, provider.GetHeapFlagCreateNotZeroed(),
++        &readback_desc, D3D12_RESOURCE_STATE_COPY_DEST, nullptr, IID_PPV_ARGS(&buffer));
++    if (FAILED(create_result)) {
++      if (failure_detail_out) {
++        *failure_detail_out = uint32_t(create_result);
++      }
++      return system::GraphicsIsolatedDrawReadbackStatus::kAllocationFailed;
++    }
++    D3D12_RANGE read_range = {0, SIZE_T(total_size)};
++    void* mapping = nullptr;
++    if (FAILED(buffer->Map(0, &read_range, &mapping))) {
++      return system::GraphicsIsolatedDrawReadbackStatus::kMapFailed;
++    }
++
++    ui::d3d12::util::DescriptorCpuGpuHandlePair descriptors[3];
++    if (!command_processor_.RequestOneUseSingleViewDescriptors(uint32_t(rex::countof(descriptors)),
++                                                               descriptors)) {
++      D3D12_RANGE write_range = {};
++      buffer->Unmap(0, &write_range);
++      return system::GraphicsIsolatedDrawReadbackStatus::kAllocationFailed;
++    }
++    device->CopyDescriptorsSimple(1, descriptors[0].first, target->descriptor_srv().GetHandle(),
++                                  D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV);
++    device->CopyDescriptorsSimple(1, descriptors[1].first,
++                                  target->descriptor_srv_stencil().GetHandle(),
++                                  D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV);
++    D3D12_UNORDERED_ACCESS_VIEW_DESC output_view = {};
++    output_view.Format = DXGI_FORMAT_R32_TYPELESS;
++    output_view.ViewDimension = D3D12_UAV_DIMENSION_BUFFER;
++    output_view.Buffer.NumElements = uint32_t(total_size / sizeof(uint32_t));
++    output_view.Buffer.Flags = D3D12_BUFFER_UAV_FLAG_RAW;
++    device->CreateUnorderedAccessView(extraction_buffer.Get(), nullptr, &output_view,
++                                      descriptors[2].first);
++
++    const D3D12_RESOURCE_STATES old_state =
++        target->SetResourceState(D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE);
++    command_processor_.PushTransitionBarrier(source, old_state,
++                                             D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE);
++    command_processor_.SubmitBarriers();
++    DeferredCommandList& command_list = command_processor_.GetDeferredCommandList();
++    command_list.D3DSetComputeRootSignature(isolated_depth_readback_root_signature_);
++    const uint32_t constants[3] = {uint32_t(source_desc.Width), source_desc.Height,
++                                   source_desc.SampleDesc.Count};
++    command_list.D3DSetComputeRoot32BitConstants(0, uint32_t(rex::countof(constants)), constants,
++                                                 0);
++    command_list.D3DSetComputeRootDescriptorTable(1, descriptors[0].second);
++    command_list.D3DSetComputeRootDescriptorTable(2, descriptors[2].second);
++    command_processor_.SetExternalPipeline(isolated_depth_readback_pipeline_);
++    command_list.D3DDispatch((uint32_t(source_desc.Width) + 7) / 8, (source_desc.Height + 7) / 8,
++                             1);
++    target->SetResourceState(old_state);
++    command_processor_.PushTransitionBarrier(source, D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE,
++                                             old_state);
++    command_processor_.PushTransitionBarrier(extraction_buffer.Get(),
++                                             D3D12_RESOURCE_STATE_UNORDERED_ACCESS,
++                                             D3D12_RESOURCE_STATE_COPY_SOURCE);
++    command_processor_.SubmitBarriers();
++    command_list.D3DCopyBufferRegion(buffer.Get(), 0, extraction_buffer.Get(), 0, total_size);
++
++    pending_readback.buffer = std::move(buffer);
++    pending_readback.resolved_target = std::move(extraction_buffer);
++    pending_readback.mapping = static_cast<uint8_t*>(mapping);
++    pending_readback.submission = command_processor_.GetCurrentSubmission();
++    pending_readback.data_size = total_size;
++    pending_readback.width = uint32_t(source_desc.Width);
++    pending_readback.height = source_desc.Height;
++    pending_readback.row_pitch = uint32_t(row_pitch);
++    pending_readback.format = uint32_t(source_desc.Format);
++    pending_readback.sample_count = source_desc.SampleDesc.Count;
++    pending_readback.plane_count = 1;
++    pending_readback.plane_offsets[0] = 0;
++    pending_readback.plane_row_pitches[0] = uint32_t(row_pitch);
++    pending_readback.plane_row_sizes[0] = uint32_t(row_pitch);
++    pending_readback.plane_row_counts[0] = source_desc.Height;
++    pending_readback.completion = completion;
++    return system::GraphicsIsolatedDrawReadbackStatus::kReady;
+   }
+ 
+   Microsoft::WRL::ComPtr<ID3D12Resource> resolved_target;
+@@ -1971,7 +2128,6 @@ D3D12RenderTargetCache::QueueRenderTargetReadback(
+   D3D12_CLEAR_VALUE resolved_clear = {};
+   resolved_clear.Format = source_desc.Format;
+   ID3D12Resource* copy_source = source;
+-  ID3D12Device* device = command_processor_.GetD3D12Provider().GetDevice();
+   if (source_desc.SampleDesc.Count > 1) {
+     copy_desc.Flags = D3D12_RESOURCE_FLAG_ALLOW_RENDER_TARGET;
+     HRESULT resolve_result = device->CreateCommittedResource(
+@@ -2094,6 +2250,7 @@ D3D12RenderTargetCache::QueueRenderTargetReadback(
+   pending_readback.height = source_desc.Height;
+   pending_readback.row_pitch = footprints[0].Footprint.RowPitch;
+   pending_readback.format = uint32_t(source_desc.Format);
++  pending_readback.sample_count = source_desc.SampleDesc.Count;
+   pending_readback.plane_count = plane_count;
+   for (uint32_t plane = 0; plane < plane_count; ++plane) {
+     pending_readback.plane_offsets[plane] = footprints[plane].Offset;
+diff --git a/src/graphics/shaders/bytecode/d3d12_5_1/isolated_depth_readback_msaa_cs.h b/src/graphics/shaders/bytecode/d3d12_5_1/isolated_depth_readback_msaa_cs.h
+new file mode 100644
+index 0000000..27b0234
+--- /dev/null
++++ b/src/graphics/shaders/bytecode/d3d12_5_1/isolated_depth_readback_msaa_cs.h
+@@ -0,0 +1,151 @@
++#if 0
++//
++// Generated by Microsoft (R) HLSL Shader Compiler 10.1
++//
++//
++// Buffer Definitions:
++//
++// cbuffer IsolatedDepthReadbackConstants
++// {
++//
++//   uint2 source_size;                 // Offset:    0 Size:     8
++//   uint sample_count;                 // Offset:    8 Size:     4
++//
++// }
++//
++//
++// Resource Bindings:
++//
++// Name                                 Type  Format         Dim      ID      HLSL Bind  Count
++// ------------------------------ ---------- ------- ----------- ------- -------------- ------
++// source_depth                      texture   float        2dMS      T0             t0      1
++// source_stencil                    texture   uint2        2dMS      T1             t1      1
++// output_samples                        UAV    byte         r/w      U0             u0      1
++// IsolatedDepthReadbackConstants    cbuffer      NA          NA     CB0            cb0      1
++//
++//
++//
++// Input signature:
++//
++// Name                 Index   Mask Register SysValue  Format   Used
++// -------------------- ----- ------ -------- -------- ------- ------
++// no Input
++//
++// Output signature:
++//
++// Name                 Index   Mask Register SysValue  Format   Used
++// -------------------- ----- ------ -------- -------- ------- ------
++// no Output
++cs_5_1
++dcl_globalFlags refactoringAllowed
++dcl_constantbuffer CB0[0:0][1], immediateIndexed, space=0
++dcl_resource_texture2dms(0) (float,float,float,float) T0[0:0], space=0
++dcl_resource_texture2dms(0) (uint,uint,uint,uint) T1[1:1], space=0
++dcl_uav_raw U0[0:0], space=0
++dcl_input vThreadID.xy
++dcl_temps 3
++dcl_thread_group 8, 8, 1
++uge r0.xy, vThreadID.xyxx, CB0[0][0].xyxx
++or r0.x, r0.y, r0.x
++if_nz r0.x
++  ret
++endif
++imad r0.x, vThreadID.y, CB0[0][0].x, vThreadID.x
++imul null, r0.x, r0.x, CB0[0][0].z
++ishl r0.x, r0.x, l(3)
++mov r1.xy, vThreadID.xyxx
++mov r1.zw, l(0,0,0,0)
++mov r2.x, r0.x
++mov r2.y, l(0)
++loop
++  uge r0.y, r2.y, CB0[0][0].z
++  breakc_nz r0.y
++  ldms r0.y, r1.xyww, T0[0].zxyw, r2.y
++  ldms r0.w, r1.xyzw, T1[1].xzwy, r2.y
++  and r0.z, r0.w, l(255)
++  store_raw U0[0].xy, r2.x, r0.yzyy
++  iadd r2.xy, r2.xyxx, l(8, 1, 0, 0)
++endloop
++ret
++// Approximately 22 instruction slots used
++#endif
++
++const BYTE isolated_depth_readback_msaa_cs[] = {
++    68,  88,  66,  67,  143, 127, 136, 3,   43,  82,  43,  192, 39,  180, 198, 173, 134, 243, 36,
++    196, 1,   0,   0,   0,   192, 5,   0,   0,   5,   0,   0,   0,   52,  0,   0,   0,   100, 2,
++    0,   0,   116, 2,   0,   0,   132, 2,   0,   0,   36,  5,   0,   0,   82,  68,  69,  70,  40,
++    2,   0,   0,   1,   0,   0,   0,   40,  1,   0,   0,   4,   0,   0,   0,   60,  0,   0,   0,
++    1,   5,   83,  67,  0,   133, 0,   0,   0,   2,   0,   0,   19,  19,  68,  37,  60,  0,   0,
++    0,   24,  0,   0,   0,   40,  0,   0,   0,   40,  0,   0,   0,   36,  0,   0,   0,   12,  0,
++    0,   0,   0,   0,   0,   0,   220, 0,   0,   0,   2,   0,   0,   0,   5,   0,   0,   0,   6,
++    0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   1,   0,   0,   0,   0,   0,   0,   0,
++    0,   0,   0,   0,   0,   0,   0,   0,   233, 0,   0,   0,   2,   0,   0,   0,   4,   0,   0,
++    0,   6,   0,   0,   0,   0,   0,   0,   0,   1,   0,   0,   0,   1,   0,   0,   0,   4,   0,
++    0,   0,   0,   0,   0,   0,   1,   0,   0,   0,   248, 0,   0,   0,   8,   0,   0,   0,   6,
++    0,   0,   0,   1,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   1,   0,   0,   0,
++    0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   7,   1,   0,   0,   0,   0,   0,
++    0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   1,   0,
++    0,   0,   1,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   115, 111, 117, 114, 99,
++    101, 95,  100, 101, 112, 116, 104, 0,   115, 111, 117, 114, 99,  101, 95,  115, 116, 101, 110,
++    99,  105, 108, 0,   111, 117, 116, 112, 117, 116, 95,  115, 97,  109, 112, 108, 101, 115, 0,
++    73,  115, 111, 108, 97,  116, 101, 100, 68,  101, 112, 116, 104, 82,  101, 97,  100, 98,  97,
++    99,  107, 67,  111, 110, 115, 116, 97,  110, 116, 115, 0,   171, 171, 7,   1,   0,   0,   2,
++    0,   0,   0,   64,  1,   0,   0,   16,  0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,
++    144, 1,   0,   0,   0,   0,   0,   0,   8,   0,   0,   0,   2,   0,   0,   0,   164, 1,   0,
++    0,   0,   0,   0,   0,   255, 255, 255, 255, 0,   0,   0,   0,   255, 255, 255, 255, 0,   0,
++    0,   0,   200, 1,   0,   0,   8,   0,   0,   0,   4,   0,   0,   0,   2,   0,   0,   0,   220,
++    1,   0,   0,   0,   0,   0,   0,   255, 255, 255, 255, 0,   0,   0,   0,   255, 255, 255, 255,
++    0,   0,   0,   0,   115, 111, 117, 114, 99,  101, 95,  115, 105, 122, 101, 0,   117, 105, 110,
++    116, 50,  0,   171, 171, 1,   0,   19,  0,   1,   0,   2,   0,   0,   0,   0,   0,   0,   0,
++    0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   156,
++    1,   0,   0,   115, 97,  109, 112, 108, 101, 95,  99,  111, 117, 110, 116, 0,   100, 119, 111,
++    114, 100, 0,   171, 0,   0,   19,  0,   1,   0,   1,   0,   0,   0,   0,   0,   0,   0,   0,
++    0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   213, 1,
++    0,   0,   77,  105, 99,  114, 111, 115, 111, 102, 116, 32,  40,  82,  41,  32,  72,  76,  83,
++    76,  32,  83,  104, 97,  100, 101, 114, 32,  67,  111, 109, 112, 105, 108, 101, 114, 32,  49,
++    48,  46,  49,  0,   73,  83,  71,  78,  8,   0,   0,   0,   0,   0,   0,   0,   8,   0,   0,
++    0,   79,  83,  71,  78,  8,   0,   0,   0,   0,   0,   0,   0,   8,   0,   0,   0,   83,  72,
++    69,  88,  152, 2,   0,   0,   81,  0,   5,   0,   166, 0,   0,   0,   106, 8,   0,   1,   89,
++    0,   0,   7,   70,  142, 48,  0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,
++    1,   0,   0,   0,   0,   0,   0,   0,   88,  32,  0,   7,   70,  126, 48,  0,   0,   0,   0,
++    0,   0,   0,   0,   0,   0,   0,   0,   0,   85,  85,  0,   0,   0,   0,   0,   0,   88,  32,
++    0,   7,   70,  126, 48,  0,   1,   0,   0,   0,   1,   0,   0,   0,   1,   0,   0,   0,   68,
++    68,  0,   0,   0,   0,   0,   0,   157, 0,   0,   6,   70,  238, 49,  0,   0,   0,   0,   0,
++    0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   95,  0,   0,   2,   50,  0,   2,
++    0,   104, 0,   0,   2,   3,   0,   0,   0,   155, 0,   0,   4,   8,   0,   0,   0,   8,   0,
++    0,   0,   1,   0,   0,   0,   80,  0,   0,   8,   50,  0,   16,  0,   0,   0,   0,   0,   70,
++    0,   2,   0,   70,  128, 48,  0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,
++    60,  0,   0,   7,   18,  0,   16,  0,   0,   0,   0,   0,   26,  0,   16,  0,   0,   0,   0,
++    0,   10,  0,   16,  0,   0,   0,   0,   0,   31,  0,   4,   3,   10,  0,   16,  0,   0,   0,
++    0,   0,   62,  0,   0,   1,   21,  0,   0,   1,   35,  0,   0,   9,   18,  0,   16,  0,   0,
++    0,   0,   0,   26,  0,   2,   0,   10,  128, 48,  0,   0,   0,   0,   0,   0,   0,   0,   0,
++    0,   0,   0,   0,   10,  0,   2,   0,   38,  0,   0,   10,  0,   208, 0,   0,   18,  0,   16,
++    0,   0,   0,   0,   0,   10,  0,   16,  0,   0,   0,   0,   0,   42,  128, 48,  0,   0,   0,
++    0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   41,  0,   0,   7,   18,  0,   16,  0,   0,
++    0,   0,   0,   10,  0,   16,  0,   0,   0,   0,   0,   1,   64,  0,   0,   3,   0,   0,   0,
++    54,  0,   0,   4,   50,  0,   16,  0,   1,   0,   0,   0,   70,  0,   2,   0,   54,  0,   0,
++    8,   194, 0,   16,  0,   1,   0,   0,   0,   2,   64,  0,   0,   0,   0,   0,   0,   0,   0,
++    0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   54,  0,   0,   5,   18,  0,   16,  0,   2,
++    0,   0,   0,   10,  0,   16,  0,   0,   0,   0,   0,   54,  0,   0,   5,   34,  0,   16,  0,
++    2,   0,   0,   0,   1,   64,  0,   0,   0,   0,   0,   0,   48,  0,   0,   1,   80,  0,   0,
++    9,   34,  0,   16,  0,   0,   0,   0,   0,   26,  0,   16,  0,   2,   0,   0,   0,   42,  128,
++    48,  0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   3,   0,   4,   3,   26,
++    0,   16,  0,   0,   0,   0,   0,   46,  0,   0,   10,  34,  0,   16,  0,   0,   0,   0,   0,
++    70,  15,  16,  0,   1,   0,   0,   0,   38,  125, 32,  0,   0,   0,   0,   0,   0,   0,   0,
++    0,   26,  0,   16,  0,   2,   0,   0,   0,   46,  0,   0,   10,  130, 0,   16,  0,   0,   0,
++    0,   0,   70,  14,  16,  0,   1,   0,   0,   0,   134, 119, 32,  0,   1,   0,   0,   0,   1,
++    0,   0,   0,   26,  0,   16,  0,   2,   0,   0,   0,   1,   0,   0,   7,   66,  0,   16,  0,
++    0,   0,   0,   0,   58,  0,   16,  0,   0,   0,   0,   0,   1,   64,  0,   0,   255, 0,   0,
++    0,   166, 0,   0,   8,   50,  224, 33,  0,   0,   0,   0,   0,   0,   0,   0,   0,   10,  0,
++    16,  0,   2,   0,   0,   0,   150, 5,   16,  0,   0,   0,   0,   0,   30,  0,   0,   10,  50,
++    0,   16,  0,   2,   0,   0,   0,   70,  0,   16,  0,   2,   0,   0,   0,   2,   64,  0,   0,
++    8,   0,   0,   0,   1,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   22,  0,   0,
++    1,   62,  0,   0,   1,   83,  84,  65,  84,  148, 0,   0,   0,   22,  0,   0,   0,   3,   0,
++    0,   0,   0,   0,   0,   0,   1,   0,   0,   0,   0,   0,   0,   0,   4,   0,   0,   0,   4,
++    0,   0,   0,   2,   0,   0,   0,   2,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,
++    0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   2,   0,   0,
++    0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   4,   0,   0,   0,   0,   0,
++    0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,
++    0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,
++    0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,
++    0,   0,   0,   0,   0,   1,   0,   0,   0};
+diff --git a/src/graphics/shaders/isolated_depth_readback_msaa.cs.hlsl b/src/graphics/shaders/isolated_depth_readback_msaa.cs.hlsl
+new file mode 100644
+index 0000000..28def43
+--- /dev/null
++++ b/src/graphics/shaders/isolated_depth_readback_msaa.cs.hlsl
+@@ -0,0 +1,22 @@
++cbuffer IsolatedDepthReadbackConstants : register(b0) {
++  uint2 source_size;
++  uint sample_count;
++};
++
++Texture2DMS<float> source_depth : register(t0);
++Texture2DMS<uint2> source_stencil : register(t1);
++RWByteAddressBuffer output_samples : register(u0);
++
++[numthreads(8, 8, 1)] void main(uint3 dispatch_thread_id : SV_DispatchThreadID) {
++  uint2 position = dispatch_thread_id.xy;
++  if (any(position >= source_size)) {
++    return;
++  }
++
++  uint output_offset = ((position.y * source_size.x + position.x) * sample_count) * 8;
++  for (uint sample_index = 0; sample_index < sample_count; ++sample_index) {
++    output_samples.Store(output_offset, asuint(source_depth.Load(position, sample_index)));
++    output_samples.Store(output_offset + 4, source_stencil.Load(position, sample_index).y & 0xFFu);
++    output_offset += 8;
++  }
++}

--- a/src/native_renderer/graphics_hooks.cpp
+++ b/src/native_renderer/graphics_hooks.cpp
@@ -114,6 +114,8 @@ struct IsolatedDrawState {
   std::filesystem::path output_root;
   std::jthread artifact_writer;
   std::jthread reference_artifact_writer;
+  std::jthread depth_artifact_writer;
+  std::jthread reference_depth_artifact_writer;
   bool requested = false;
   bool readback_requested = false;
   bool completed = false;
@@ -2132,6 +2134,189 @@ void CompleteIsolatedReferenceReadback(
       g_isolated_draw.reference_artifact_writer);
 }
 
+void CompleteIsolatedDepthReadbackArtifact(
+    const rex::system::GraphicsIsolatedDrawReadback &readback,
+    const char *capture_role, const std::filesystem::path &artifact_root,
+    std::jthread &artifact_writer) {
+  const auto reject = [&](const char *status) {
+    pinyon_shift::diagnostics::RecordEvent(
+        "native_renderer.isolated_draw.readback",
+        {{"signature",
+          fmt::format("{:016X}", g_isolated_draw.captured_signature)},
+         {"status", status},
+         {"detail", fmt::format("0x{:08X}", readback.detail)},
+         {"frame", std::to_string(g_isolated_draw.captured_frame)},
+         {"draw", std::to_string(g_isolated_draw.captured_draw)},
+         {"capture_role", capture_role},
+         {"capture_content", "depth_stencil"},
+         {"output_authority", "xenos"},
+         {"suppression_eligible", "false"}});
+  };
+  if (readback.status !=
+      rex::system::GraphicsIsolatedDrawReadbackStatus::kReady) {
+    if (readback.status ==
+        rex::system::GraphicsIsolatedDrawReadbackStatus::
+            kResolveAllocationFailed) {
+      reject("resolve_allocation_failed");
+    } else if (readback.status ==
+               rex::system::GraphicsIsolatedDrawReadbackStatus::
+                   kAllocationFailed) {
+      reject("allocation_failed");
+    } else if (readback.status ==
+               rex::system::GraphicsIsolatedDrawReadbackStatus::kMapFailed) {
+      reject("map_failed");
+    } else {
+      reject("unsupported_target");
+    }
+    return;
+  }
+  if (!readback.data || !readback.width || !readback.height ||
+      !readback.sample_count || !readback.plane_count ||
+      readback.plane_count >
+          rex::system::GraphicsIsolatedDrawReadback::kMaxPlanes ||
+      !readback.data_size || readback.data_size > SIZE_MAX) {
+    reject("unsupported_layout");
+    return;
+  }
+  for (uint32_t plane = 0; plane < readback.plane_count; ++plane) {
+    const uint64_t offset = readback.plane_offsets[plane];
+    const uint64_t row_pitch = readback.plane_row_pitches[plane];
+    const uint64_t row_size = readback.plane_row_sizes[plane];
+    const uint64_t row_count = readback.plane_row_counts[plane];
+    const uint64_t end =
+        offset + (row_count ? (row_count - 1) * row_pitch : 0) + row_size;
+    if (!row_count || !row_size || row_size > row_pitch ||
+        end > readback.data_size) {
+      reject("unsupported_layout");
+      return;
+    }
+  }
+
+  std::vector<uint8_t> bytes(readback.data,
+                             readback.data + size_t(readback.data_size));
+  const uint64_t signature = g_isolated_draw.captured_signature;
+  const uint64_t frame = g_isolated_draw.captured_frame;
+  const uint64_t draw = g_isolated_draw.captured_draw;
+  const auto output_root = artifact_root;
+  const uint32_t width = readback.width;
+  const uint32_t height = readback.height;
+  const uint32_t format = readback.format;
+  const uint32_t sample_count = readback.sample_count;
+  const uint32_t plane_count = readback.plane_count;
+  std::array<uint64_t, rex::system::GraphicsIsolatedDrawReadback::kMaxPlanes>
+      plane_offsets = {};
+  std::array<uint32_t, rex::system::GraphicsIsolatedDrawReadback::kMaxPlanes>
+      plane_row_pitches = {};
+  std::array<uint32_t, rex::system::GraphicsIsolatedDrawReadback::kMaxPlanes>
+      plane_row_sizes = {};
+  std::array<uint32_t, rex::system::GraphicsIsolatedDrawReadback::kMaxPlanes>
+      plane_row_counts = {};
+  std::copy_n(readback.plane_offsets, plane_count, plane_offsets.begin());
+  std::copy_n(readback.plane_row_pitches, plane_count,
+              plane_row_pitches.begin());
+  std::copy_n(readback.plane_row_sizes, plane_count, plane_row_sizes.begin());
+  std::copy_n(readback.plane_row_counts, plane_count, plane_row_counts.begin());
+  artifact_writer = std::jthread(
+      [bytes = std::move(bytes), signature, frame, draw, output_root, width,
+       height, format, sample_count, plane_count, plane_offsets,
+       plane_row_pitches, plane_row_sizes, plane_row_counts,
+       capture_role = std::string(capture_role)]() {
+        std::string planes;
+        for (uint32_t plane = 0; plane < plane_count; ++plane) {
+          if (!planes.empty()) {
+            planes += ",";
+          }
+          planes +=
+              fmt::format("{{\"index\":{},\"offset\":{},\"row_pitch\":{},"
+                          "\"row_size\":{},\"row_count\":{}}}",
+                          plane, plane_offsets[plane], plane_row_pitches[plane],
+                          plane_row_sizes[plane], plane_row_counts[plane]);
+        }
+        std::filesystem::path staging = output_root;
+        staging += L".partial";
+        std::error_code error;
+        if (std::filesystem::exists(output_root, error) || error ||
+            std::filesystem::exists(staging, error) || error ||
+            !std::filesystem::create_directories(staging, error) || error) {
+          pinyon_shift::diagnostics::RecordEvent(
+              "native_renderer.isolated_draw.readback",
+              {{"signature", fmt::format("{:016X}", signature)},
+               {"status", "output_directory_unavailable"},
+               {"capture_role", capture_role},
+               {"capture_content", "depth_stencil"},
+               {"output_authority", "xenos"},
+               {"suppression_eligible", "false"}});
+          return;
+        }
+        const std::string metadata = fmt::format(
+            "{{\n  \"schema\": "
+            "\"pinyon-shift.isolated-depth-readback.v1\",\n"
+            "  \"signature\": \"{:016X}\",\n  \"frame\": {},\n"
+            "  \"draw\": {},\n  \"capture_role\": \"{}\",\n"
+            "  \"capture_content\": \"depth_stencil\",\n"
+            "  \"source\": {{\"width\":{},\"height\":{},"
+            "\"dxgi_format\":{},\"sample_count\":{},"
+            "\"encoding\":\"{}\",\"bytes\":{},\"hash\":\"{:016X}\","
+            "\"planes\":[{}]}},\n"
+            "  \"safety\": {{\"output_authority\":\"xenos\","
+            "\"suppression_allowed\":false}}\n}}\n",
+            signature, frame, draw, capture_role, width, height, format,
+            sample_count,
+            sample_count > 1 ? "depth32_stencil8_sample_tuples"
+                             : "d3d12_texture_planes",
+            bytes.size(), HashBytes(bytes.data(), bytes.size()), planes);
+        const auto metadata_bytes =
+            std::span(reinterpret_cast<const uint8_t *>(metadata.data()),
+                      metadata.size());
+        if (!WriteSnapshotFile(staging / L"isolated.bin", bytes) ||
+            !WriteSnapshotFile(staging / L"readback.json", metadata_bytes)) {
+          std::filesystem::remove_all(staging, error);
+          pinyon_shift::diagnostics::RecordEvent(
+              "native_renderer.isolated_draw.readback",
+              {{"signature", fmt::format("{:016X}", signature)},
+               {"status", "artifact_write_failed"},
+               {"capture_role", capture_role},
+               {"capture_content", "depth_stencil"},
+               {"output_authority", "xenos"},
+               {"suppression_eligible", "false"}});
+          return;
+        }
+        std::filesystem::rename(staging, output_root, error);
+        pinyon_shift::diagnostics::RecordEvent(
+            "native_renderer.isolated_draw.readback",
+            {{"signature", fmt::format("{:016X}", signature)},
+             {"status", error ? "artifact_commit_failed" : "captured"},
+             {"frame", std::to_string(frame)},
+             {"draw", std::to_string(draw)},
+             {"source_width", std::to_string(width)},
+             {"source_height", std::to_string(height)},
+             {"sample_count", std::to_string(sample_count)},
+             {"plane_count", std::to_string(plane_count)},
+             {"readback_bytes", std::to_string(bytes.size())},
+             {"capture_role", capture_role},
+             {"capture_content", "depth_stencil"},
+             {"output_authority", "xenos"},
+             {"suppression_eligible", "false"}});
+      });
+}
+
+void CompleteIsolatedDepthReadback(
+    const rex::system::GraphicsIsolatedDrawReadback &readback) {
+  std::filesystem::path depth_root = g_isolated_draw.output_root;
+  depth_root += L".depth";
+  CompleteIsolatedDepthReadbackArtifact(
+      readback, "native", depth_root, g_isolated_draw.depth_artifact_writer);
+}
+
+void CompleteIsolatedReferenceDepthReadback(
+    const rex::system::GraphicsIsolatedDrawReadback &readback) {
+  std::filesystem::path depth_root = g_isolated_draw.output_root;
+  depth_root += L".depth.xenos";
+  CompleteIsolatedDepthReadbackArtifact(
+      readback, "xenos", depth_root,
+      g_isolated_draw.reference_depth_artifact_writer);
+}
+
 void CompleteIsolatedDraw(
     const rex::system::GraphicsIsolatedDrawResult &result) {
   const char *status = "unsupported_state";
@@ -2298,6 +2483,9 @@ void RequestIsolatedDraw(
       request.readback_requested = g_isolated_draw.readback_requested;
       request.reference_readback_requested =
           g_isolated_draw.readback_requested;
+      request.depth_readback_requested = g_isolated_draw.readback_requested;
+      request.reference_depth_readback_requested =
+          g_isolated_draw.readback_requested;
       request.completion = &CompleteIsolatedPassFollower;
       request.readback_completion = g_isolated_draw.readback_requested
                                         ? &CompleteIsolatedDrawReadback
@@ -2305,6 +2493,14 @@ void RequestIsolatedDraw(
       request.reference_readback_completion =
           g_isolated_draw.readback_requested
               ? &CompleteIsolatedReferenceReadback
+              : nullptr;
+      request.depth_readback_completion =
+          g_isolated_draw.readback_requested
+              ? &CompleteIsolatedDepthReadback
+              : nullptr;
+      request.reference_depth_readback_completion =
+          g_isolated_draw.readback_requested
+              ? &CompleteIsolatedReferenceDepthReadback
               : nullptr;
     } else if (!g_isolated_draw.pass_repeat_reported) {
       request.completion = &CompleteIsolatedPassRepeat;
@@ -2837,6 +3033,12 @@ void UninstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system) {
   }
   if (g_isolated_draw.reference_artifact_writer.joinable()) {
     g_isolated_draw.reference_artifact_writer.join();
+  }
+  if (g_isolated_draw.depth_artifact_writer.joinable()) {
+    g_isolated_draw.depth_artifact_writer.join();
+  }
+  if (g_isolated_draw.reference_depth_artifact_writer.joinable()) {
+    g_isolated_draw.reference_depth_artifact_writer.join();
   }
   g_graphics_census_installed = false;
   if (g_draw_census.window_first_frame && g_draw_census.window_draw_count) {

--- a/tools/compare-native-renderer-pass-readbacks.py
+++ b/tools/compare-native-renderer-pass-readbacks.py
@@ -10,8 +10,12 @@ from pathlib import Path
 from typing import Any
 
 
-SCHEMA = "pinyon-shift.native-renderer-pass-readback-comparison.v1"
-READBACK_SCHEMA = "pinyon-shift.isolated-draw-readback.v1"
+COLOR_SCHEMA = "pinyon-shift.native-renderer-pass-readback-comparison.v1"
+DEPTH_SCHEMA = (
+    "pinyon-shift.native-renderer-pass-depth-readback-comparison.v1"
+)
+COLOR_READBACK_SCHEMA = "pinyon-shift.isolated-draw-readback.v1"
+DEPTH_READBACK_SCHEMA = "pinyon-shift.isolated-depth-readback.v1"
 BYTES_PER_PIXEL = {10: 8, 28: 4}
 
 
@@ -19,16 +23,25 @@ def _sha256(data: bytes) -> str:
     return hashlib.sha256(data).hexdigest().upper()
 
 
-def _load(root: Path, expected_role: str) -> tuple[dict[str, Any], bytes]:
+def _load(
+    root: Path, expected_role: str, content: str
+) -> tuple[dict[str, Any], bytes]:
     metadata_path = root / "readback.json"
     binary_path = root / "isolated.bin"
     metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
-    if metadata.get("schema") != READBACK_SCHEMA:
+    expected_schema = (
+        COLOR_READBACK_SCHEMA if content == "color" else DEPTH_READBACK_SCHEMA
+    )
+    if metadata.get("schema") != expected_schema:
         raise ValueError(f"{metadata_path}: unsupported readback schema")
     if metadata.get("capture_role") != expected_role:
         raise ValueError(
             f"{metadata_path}: expected capture_role {expected_role!r}"
         )
+    if content == "depth-stencil" and metadata.get("capture_content") != (
+        "depth_stencil"
+    ):
+        raise ValueError(f"{metadata_path}: expected depth_stencil content")
     safety = metadata.get("safety", {})
     if safety.get("output_authority") != "xenos" or safety.get(
         "suppression_allowed"
@@ -41,83 +54,164 @@ def _load(root: Path, expected_role: str) -> tuple[dict[str, Any], bytes]:
     return metadata, data
 
 
-def compare(native_root: Path, xenos_root: Path) -> dict[str, Any]:
-    native, native_data = _load(native_root, "native")
-    xenos, xenos_data = _load(xenos_root, "xenos")
-    for field in ("signature", "frame", "draw"):
-        if native.get(field) != xenos.get(field):
-            raise ValueError(f"readback {field} values differ")
-
-    native_source = native["source"]
-    xenos_source = xenos["source"]
-    layout_fields = ("width", "height", "row_pitch", "dxgi_format")
-    for field in layout_fields:
-        if native_source.get(field) != xenos_source.get(field):
-            raise ValueError(f"readback source {field} values differ")
-
-    width = int(native_source["width"])
-    height = int(native_source["height"])
-    row_pitch = int(native_source["row_pitch"])
-    dxgi_format = int(native_source["dxgi_format"])
-    bytes_per_pixel = BYTES_PER_PIXEL.get(dxgi_format)
-    if bytes_per_pixel is None:
-        raise ValueError(f"unsupported DXGI format {dxgi_format}")
-    active_row_bytes = width * bytes_per_pixel
-    required_bytes = row_pitch * height
-    if (
-        width <= 0
-        or height <= 0
-        or active_row_bytes > row_pitch
-        or len(native_data) < required_bytes
-        or len(xenos_data) < required_bytes
-    ):
-        raise ValueError("invalid readback layout")
-
+def _compare_rows(
+    native_data: bytes,
+    xenos_data: bytes,
+    rows: list[tuple[int, int, int]],
+) -> dict[str, int | float | bool]:
     compared_bytes = 0
     different_bytes = 0
     absolute_error = 0
     maximum_error = 0
-    for row in range(height):
-        start = row * row_pitch
-        end = start + active_row_bytes
+    for offset, row_pitch, row_size in rows:
         for left, right in zip(
-            native_data[start:end], xenos_data[start:end], strict=True
+            native_data[offset : offset + row_size],
+            xenos_data[offset : offset + row_size],
+            strict=True,
         ):
             error = abs(left - right)
             compared_bytes += 1
             different_bytes += error != 0
             absolute_error += error
             maximum_error = max(maximum_error, error)
-
     exact = different_bytes == 0
     return {
-        "schema": SCHEMA,
+        "compared_bytes": compared_bytes,
+        "different_bytes": different_bytes,
+        "different_byte_ratio": (
+            different_bytes / compared_bytes if compared_bytes else 0.0
+        ),
+        "mean_absolute_byte_error": (
+            absolute_error / compared_bytes if compared_bytes else 0.0
+        ),
+        "maximum_byte_error": maximum_error,
+        "exact_active_bytes": exact,
+    }
+
+
+def compare(
+    native_root: Path, xenos_root: Path, content: str = "color"
+) -> dict[str, Any]:
+    native, native_data = _load(native_root, "native", content)
+    xenos, xenos_data = _load(xenos_root, "xenos", content)
+    for field in ("signature", "frame", "draw"):
+        if native.get(field) != xenos.get(field):
+            raise ValueError(f"readback {field} values differ")
+
+    native_source = native["source"]
+    xenos_source = xenos["source"]
+    layout_fields = ("width", "height", "dxgi_format")
+    if content == "color":
+        layout_fields += ("row_pitch",)
+    else:
+        layout_fields += ("sample_count", "encoding")
+    for field in layout_fields:
+        if native_source.get(field) != xenos_source.get(field):
+            raise ValueError(f"readback source {field} values differ")
+
+    width = int(native_source["width"])
+    height = int(native_source["height"])
+    dxgi_format = int(native_source["dxgi_format"])
+    if width <= 0 or height <= 0:
+        raise ValueError("invalid readback dimensions")
+
+    rows: list[tuple[int, int, int]] = []
+    if content == "color":
+        bytes_per_pixel = BYTES_PER_PIXEL.get(dxgi_format)
+        if bytes_per_pixel is None:
+            raise ValueError(f"unsupported DXGI format {dxgi_format}")
+        row_pitch = int(native_source["row_pitch"])
+        active_row_bytes = width * bytes_per_pixel
+        required_bytes = row_pitch * height
+        if (
+            active_row_bytes > row_pitch
+            or len(native_data) < required_bytes
+            or len(xenos_data) < required_bytes
+        ):
+            raise ValueError("invalid readback layout")
+        rows.extend(
+            (row * row_pitch, row_pitch, active_row_bytes)
+            for row in range(height)
+        )
+        layout: dict[str, Any] = {
+            "width": width,
+            "height": height,
+            "row_pitch": row_pitch,
+            "active_row_bytes": active_row_bytes,
+            "dxgi_format": dxgi_format,
+        }
+    else:
+        sample_count = int(native_source["sample_count"])
+        encoding = str(native_source["encoding"])
+        if sample_count <= 0:
+            raise ValueError("invalid depth sample count")
+        if encoding not in (
+            "d3d12_texture_planes",
+            "depth32_stencil8_sample_tuples",
+        ):
+            raise ValueError("unsupported depth encoding")
+        if encoding == "d3d12_texture_planes" and sample_count != 1:
+            raise ValueError("invalid texture-plane sample count")
+        if encoding == "depth32_stencil8_sample_tuples" and sample_count <= 1:
+            raise ValueError("invalid multisample tuple count")
+        native_planes = native_source.get("planes")
+        xenos_planes = xenos_source.get("planes")
+        if native_planes != xenos_planes or not isinstance(native_planes, list):
+            raise ValueError("readback depth plane layouts differ")
+        if not 1 <= len(native_planes) <= 2:
+            raise ValueError("invalid depth plane count")
+        if encoding == "depth32_stencil8_sample_tuples" and (
+            len(native_planes) != 1
+            or int(native_planes[0].get("offset", -1)) != 0
+            or int(native_planes[0].get("row_size", -1))
+            != width * sample_count * 8
+            or int(native_planes[0].get("row_count", -1)) != height
+        ):
+            raise ValueError("invalid multisample depth tuple layout")
+        for expected_index, plane in enumerate(native_planes):
+            if plane.get("index") != expected_index:
+                raise ValueError("invalid depth plane index")
+            offset = int(plane["offset"])
+            row_pitch = int(plane["row_pitch"])
+            row_size = int(plane["row_size"])
+            row_count = int(plane["row_count"])
+            end = offset + (row_count - 1) * row_pitch + row_size
+            if (
+                offset < 0
+                or row_count <= 0
+                or row_size <= 0
+                or row_size > row_pitch
+                or end > len(native_data)
+                or end > len(xenos_data)
+            ):
+                raise ValueError("invalid depth plane layout")
+            rows.extend(
+                (offset + row * row_pitch, row_pitch, row_size)
+                for row in range(row_count)
+            )
+        layout = {
+            "width": width,
+            "height": height,
+            "dxgi_format": dxgi_format,
+            "sample_count": sample_count,
+            "encoding": encoding,
+            "planes": native_planes,
+        }
+
+    metrics = _compare_rows(native_data, xenos_data, rows)
+    exact = bool(metrics["exact_active_bytes"])
+    return {
+        "schema": COLOR_SCHEMA if content == "color" else DEPTH_SCHEMA,
         "result": "pass" if exact else "fail",
+        "scope": {"content": content},
         "identity": {
             "signature": native["signature"],
             "frame": native["frame"],
             "follower_draw": native["draw"],
             "same_guest_frame": True,
         },
-        "layout": {
-            "width": width,
-            "height": height,
-            "row_pitch": row_pitch,
-            "active_row_bytes": active_row_bytes,
-            "dxgi_format": dxgi_format,
-        },
-        "metrics": {
-            "compared_bytes": compared_bytes,
-            "different_bytes": different_bytes,
-            "different_byte_ratio": (
-                different_bytes / compared_bytes if compared_bytes else 0.0
-            ),
-            "mean_absolute_byte_error": (
-                absolute_error / compared_bytes if compared_bytes else 0.0
-            ),
-            "maximum_byte_error": maximum_error,
-            "exact_active_bytes": exact,
-        },
+        "layout": layout,
+        "metrics": metrics,
         "artifacts": {
             "native": {
                 "root": str(native_root),
@@ -146,13 +240,16 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         help="defaults to the native root with '.xenos' appended",
     )
     parser.add_argument("--output", "-o", type=Path)
+    parser.add_argument(
+        "--content", choices=("color", "depth-stencil"), default="color"
+    )
     return parser.parse_args(argv)
 
 
 def main(argv: list[str] | None = None) -> int:
     args = parse_args(argv)
     xenos_root = args.xenos_root or Path(str(args.native_root) + ".xenos")
-    report = compare(args.native_root, xenos_root)
+    report = compare(args.native_root, xenos_root, args.content)
     rendered = json.dumps(report, indent=2) + "\n"
     if args.output:
         args.output.parent.mkdir(parents=True, exist_ok=True)

--- a/tools/tests/test_native_renderer_contract.py
+++ b/tools/tests/test_native_renderer_contract.py
@@ -751,6 +751,40 @@ class NativeRendererContractTests(unittest.TestCase):
         self.assertIn('readback, "xenos"', scanner)
         self.assertIn('"suppression_eligible", "false"', scanner)
 
+        depth_readback_patch = (
+            ROOT
+            / "patches/rexglue/0072-d3d12-paired-pass-depth-readback.patch"
+        ).read_text(encoding="utf-8")
+        self.assertIn("QueueIsolatedReplayDepthReadback", depth_readback_patch)
+        self.assertIn("QueueGuestDepthReadback", depth_readback_patch)
+        self.assertIn("plane_row_sizes", depth_readback_patch)
+        self.assertIn("GetCopyableFootprints", depth_readback_patch)
+        self.assertIn(
+            "complete_isolated_readback(isolated_replay_depth_readback_)",
+            depth_readback_patch,
+        )
+        self.assertIn(
+            "complete_isolated_readback(guest_depth_reference_readback_)",
+            depth_readback_patch,
+        )
+        self.assertNotIn("AwaitAllQueueOperationsCompletion", depth_readback_patch)
+        self.assertNotIn("SetDrawSuppression", depth_readback_patch)
+        msaa_depth_patch = (
+            ROOT / "patches/rexglue/0073-d3d12-msaa-depth-readback.patch"
+        ).read_text(encoding="utf-8")
+        self.assertIn("Texture2DMS<float> source_depth", msaa_depth_patch)
+        self.assertIn("Texture2DMS<uint2> source_stencil", msaa_depth_patch)
+        self.assertIn("depth32_stencil8_sample_tuples", scanner)
+        self.assertIn("sample_count", msaa_depth_patch)
+        self.assertIn("D3DCopyBufferRegion", msaa_depth_patch)
+        self.assertIn("GetCurrentSubmission", msaa_depth_patch)
+        self.assertNotIn("AwaitAllQueueOperationsCompletion", msaa_depth_patch)
+        self.assertNotIn("SetDrawSuppression", msaa_depth_patch)
+        self.assertIn("request.depth_readback_requested", scanner)
+        self.assertIn("request.reference_depth_readback_requested", scanner)
+        self.assertIn("CompleteIsolatedReferenceDepthReadback", scanner)
+        self.assertIn('"capture_content", "depth_stencil"', scanner)
+
         texture_resource_patch = (
             ROOT
             / "patches/rexglue/0064-d3d12-native-texture-resource-observer.patch"

--- a/tools/tests/test_native_renderer_pass_readbacks.py
+++ b/tools/tests/test_native_renderer_pass_readbacks.py
@@ -39,6 +39,83 @@ def write_readback(root: Path, role: str, data: bytes, *, row_pitch: int = 8) ->
     (root / "isolated.bin").write_bytes(data)
 
 
+def write_depth_readback(root: Path, role: str, data: bytes) -> None:
+    root.mkdir()
+    metadata = {
+        "schema": "pinyon-shift.isolated-depth-readback.v1",
+        "signature": "747837906D0BF484",
+        "frame": 100,
+        "draw": 42,
+        "capture_role": role,
+        "capture_content": "depth_stencil",
+        "source": {
+            "width": 1,
+            "height": 2,
+            "dxgi_format": 19,
+            "sample_count": 1,
+            "encoding": "d3d12_texture_planes",
+            "bytes": len(data),
+            "planes": [
+                {
+                    "index": 0,
+                    "offset": 0,
+                    "row_pitch": 8,
+                    "row_size": 4,
+                    "row_count": 2,
+                },
+                {
+                    "index": 1,
+                    "offset": 16,
+                    "row_pitch": 4,
+                    "row_size": 1,
+                    "row_count": 2,
+                },
+            ],
+        },
+        "safety": {
+            "output_authority": "xenos",
+            "suppression_allowed": False,
+        },
+    }
+    (root / "readback.json").write_text(json.dumps(metadata), encoding="utf-8")
+    (root / "isolated.bin").write_bytes(data)
+
+
+def write_msaa_depth_readback(root: Path, role: str, data: bytes) -> None:
+    root.mkdir()
+    metadata = {
+        "schema": "pinyon-shift.isolated-depth-readback.v1",
+        "signature": "747837906D0BF484",
+        "frame": 100,
+        "draw": 42,
+        "capture_role": role,
+        "capture_content": "depth_stencil",
+        "source": {
+            "width": 2,
+            "height": 2,
+            "dxgi_format": 19,
+            "sample_count": 2,
+            "encoding": "depth32_stencil8_sample_tuples",
+            "bytes": len(data),
+            "planes": [
+                {
+                    "index": 0,
+                    "offset": 0,
+                    "row_pitch": 32,
+                    "row_size": 32,
+                    "row_count": 2,
+                }
+            ],
+        },
+        "safety": {
+            "output_authority": "xenos",
+            "suppression_allowed": False,
+        },
+    }
+    (root / "readback.json").write_text(json.dumps(metadata), encoding="utf-8")
+    (root / "isolated.bin").write_bytes(data)
+
+
 class NativeRendererPassReadbackTests(unittest.TestCase):
     def test_exact_active_bytes_pass(self):
         with tempfile.TemporaryDirectory() as directory:
@@ -81,6 +158,56 @@ class NativeRendererPassReadbackTests(unittest.TestCase):
             metadata_path.write_text(json.dumps(metadata), encoding="utf-8")
             with self.assertRaisesRegex(ValueError, "frame values differ"):
                 MODULE.compare(native, xenos)
+
+    def test_exact_depth_and_stencil_planes_pass(self):
+        with tempfile.TemporaryDirectory() as directory:
+            native = Path(directory) / "pass.depth"
+            xenos = Path(str(native) + ".xenos")
+            data = bytes(range(21))
+            write_depth_readback(native, "native", data)
+            write_depth_readback(xenos, "xenos", data)
+            report = MODULE.compare(native, xenos, "depth-stencil")
+            self.assertEqual(report["result"], "pass")
+            self.assertEqual(report["scope"]["content"], "depth-stencil")
+            self.assertEqual(report["metrics"]["compared_bytes"], 10)
+
+    def test_depth_padding_is_excluded(self):
+        with tempfile.TemporaryDirectory() as directory:
+            native = Path(directory) / "pass.depth"
+            xenos = Path(str(native) + ".xenos")
+            native_data = bytearray(range(21))
+            xenos_data = bytearray(native_data)
+            for index in (4, 5, 6, 7, 12, 13, 14, 15, 17, 18, 19):
+                xenos_data[index] = 255
+            write_depth_readback(native, "native", bytes(native_data))
+            write_depth_readback(xenos, "xenos", bytes(xenos_data))
+            report = MODULE.compare(native, xenos, "depth-stencil")
+            self.assertEqual(report["result"], "pass")
+
+    def test_stencil_difference_fails(self):
+        with tempfile.TemporaryDirectory() as directory:
+            native = Path(directory) / "pass.depth"
+            xenos = Path(str(native) + ".xenos")
+            native_data = bytes(range(21))
+            xenos_data = bytearray(native_data)
+            xenos_data[20] ^= 0xFF
+            write_depth_readback(native, "native", native_data)
+            write_depth_readback(xenos, "xenos", bytes(xenos_data))
+            report = MODULE.compare(native, xenos, "depth-stencil")
+            self.assertEqual(report["result"], "fail")
+            self.assertEqual(report["metrics"]["different_bytes"], 1)
+
+    def test_exact_msaa_depth_sample_tuples_pass(self):
+        with tempfile.TemporaryDirectory() as directory:
+            native = Path(directory) / "pass.depth"
+            xenos = Path(str(native) + ".xenos")
+            data = bytes(range(64))
+            write_msaa_depth_readback(native, "native", data)
+            write_msaa_depth_readback(xenos, "xenos", data)
+            report = MODULE.compare(native, xenos, "depth-stencil")
+            self.assertEqual(report["result"], "pass")
+            self.assertEqual(report["metrics"]["compared_bytes"], 64)
+            self.assertEqual(report["layout"]["sample_count"], 2)
 
 
 if __name__ == "__main__":

--- a/tools/tests/test_release_contract.py
+++ b/tools/tests/test_release_contract.py
@@ -43,10 +43,10 @@ class ReleaseContractTests(unittest.TestCase):
 
     def test_rexglue_patches_have_stable_order_and_no_binary_payload(self):
         patches = sorted((ROOT / "patches/rexglue").glob("*.patch"))
-        self.assertEqual(len(patches), 71)
+        self.assertEqual(len(patches), 73)
         self.assertEqual(
             patches[-1].name,
-            "0071-d3d12-paired-pass-color-readback.patch",
+            "0073-d3d12-msaa-depth-readback.patch",
         )
         self.assertEqual(len(patches), len({path.name[:4] for path in patches}))
         for path in patches:


### PR DESCRIPTION
## Summary
- capture paired private-native and authoritative-Xenos depth/stencil after the complete pass
- extract 2x MSAA depth and stencil into deterministic per-sample tuples without GPU waits
- compare exact active bytes and promote depth parity to 9/12 admission gates

## Qualification
- clean preview build: \4B9421BBB6DA05A02D580984361477DF9F6C02BCF5848FB5A790DCA156794D3D\
- AppData session: \20260829T040041Z-p32896\
- depth/stencil: 83,886,080 bytes, zero differences
- color: 41,943,040 bytes, zero differences
- 4,402 performance samples: 31.531 median FPS, 19.419 FPS 1% low
- zero error/fatal events; normal exit
- Xenos remained authoritative; suppression stayed disabled

## Tests
- \python -m unittest discover -s tools/tests -p 'test_*.py'\ (176 passed)
- clean \	ools/build-preview.ps1\
- all five native renderer resource test executables
- verified suppression admission bundle: 9/12 (not ready for suppression)