### PR TITLE
test(native-renderer): inventory pass consumers

### DIFF
--- a/docs/native-renderer/GUEST_VISIBLE_RENDER_DEPENDENCIES.md
+++ b/docs/native-renderer/GUEST_VISIBLE_RENDER_DEPENDENCIES.md
@@ -119,6 +119,16 @@ Gate B remains closed after this capture. CPU-read observation, presentation
 provenance, and semantic classification are separate evidence tasks, not facts
 that may be inferred from the absence of a texture-fetch match.
 
+## Exact-family follow-up
+
+The retained sky/horizon pair now has a family-specific resolve-to-consumer
+inventory in [PASS_CONSUMER_GRAPH.md](PASS_CONSUMER_GRAPH.md). Its qualified
+open-world run linked six rotating resolve destinations to 51 distinct prepared
+later-draw signatures across 26 shader families without overflowing the bounded
+signature table or missing prepared metadata. This proves the selected family
+is not presentation-only. Gate B remains closed because those consumers have
+not yet been replaced, and guest CPU visibility is still unknown.
+
 NR-04D evaluates these unknowns per exact pass family with the fail-closed
 admission contract in [SUPPRESSION_ADMISSION.md](SUPPRESSION_ADMISSION.md).
 Neither this aggregate census nor a visually correct native output can bypass

--- a/docs/native-renderer/PASS_CONSUMER_GRAPH.md
+++ b/docs/native-renderer/PASS_CONSUMER_GRAPH.md
@@ -1,0 +1,97 @@
+# Exact pass-family consumer graph
+
+This document records the bounded later-GPU-consumer inventory for the retained
+sky/horizon family selected by anchor signature `747837906D0BF484` and follower
+signature `1D253A52B55C9FB3`. The inventory is diagnostic only: Xenos executes
+every draw and resolve, and suppression remains disabled.
+
+## Observation contract
+
+When the exact adjacent family occurs, the census retains its EDRAM surface and
+color/depth target identity. A later successful Xenos copy is attributed to the
+family only when its selected copy source exactly matches that identity. The
+existing guest-physical page map then links each resolve destination to later
+used base or mip texture fetches.
+
+Raw fetch observation is provisional. A consumer enters the graph only after
+the backend reports its prepared draw, so an async-compilation skip cannot be
+misclassified as executed guest GPU work. Provisional matches discarded before
+preparation are counted separately in the shutdown summary.
+
+The implementation keeps fixed-capacity state:
+
+- 4,096 resolve destinations and 32,768 guest pages from the dependency census.
+- 1,024 exact consumer draw signatures for the selected family.
+- 64 resolve/first-consumer detail examples.
+
+Every unique consumer signature receives an aggregate record at shutdown with
+its shader hashes, specialization masks, prepared pipeline identity, geometry
+shape, pipeline state, and the base/mip fetch slots that consumed the family
+output. The shutdown summary independently counts present and missing prepared
+metadata. The summarizer groups pipeline variants by exact shader
+specialization, assigns a stable family identifier and activity rank, and
+leaves semantic role and native coverage fail-closed. A signature-table
+overflow makes the deterministic inventory incomplete. Missing prepared
+metadata makes classification incomplete. Detail overflow only truncates
+examples; it does not discard the aggregate signature graph. An unobserved
+consumer is never interpreted as proof of independence.
+
+Convert a completed diagnostic JSONL log with:
+
+```powershell
+python .\tools\summarize-native-renderer-pass-consumers.py `
+  $eventLog `
+  --anchor 747837906D0BF484 `
+  --follower 1D253A52B55C9FB3 `
+  --output .artifacts\native-renderer-pass-consumers.json
+```
+
+The command rejects missing shutdown summaries, signature/count conflicts, and
+any event that does not preserve Xenos authority and prohibit suppression.
+
+## Qualified open-world result
+
+The 2026-08-29 AppData-backed `open_world_day` run used executable SHA-256
+`C6DBC2AD3E98C68BE2DEF762C6C309DE70C9DAC2C015306B596DE1C82A450EFE` and
+session `20260829T044716Z-p33048`. It exited normally with no error, fatal,
+crash, or device-loss event. The deterministic inventory reported:
+
+- 13,650 exact family occurrences.
+- 384 matching color-source resolves totaling 100,663,296 bytes.
+- Six rotating 262,144-byte guest destinations.
+- 378 resolves sampled before replacement by a later resolve.
+- 8,552 prepared resolve-to-consumer draws and texture references.
+- 51 distinct prepared consumer draw signatures grouped into 26 exact shader
+  specialization families, with zero signature overflow and zero missing
+  prepared metadata.
+- 80 provisional fetch matches discarded because the backend did not reach the
+  prepared-draw stage; these are not classified as GPU consumers.
+- Zero query-correlated and zero memexport-correlated sample events.
+- Six outputs overwritten without a sampled consumer in the observed interval.
+
+The local inventory SHA-256 is
+`2913349E4B666AD88B23F0896ADB3F644446CF08EF041319247800695587C3F6`.
+It remains local because it includes a machine-specific diagnostic source path.
+
+The leading shader family used vertex shader `2E5E0A854BE00027` and pixel
+shader `BDFFA72B7ED2FBA4`; its two pipeline variants accounted for 1,220
+prepared consumer draws. This broad 26-family fan-out proves that the selected
+output is not a presentation-only leaf.
+
+Performance telemetry contained 5,570 samples: median 30.698 FPS, 1% low
+19.287 FPS, one present-deadline miss, and zero native GPU timing drops.
+The diagnostic table therefore did not disturb the established 30 FPS cadence
+in this qualification.
+
+## Suppression consequence
+
+The `later_gpu_consumers` admission gate is now `fail`, not `unknown`: later
+GPU consumers are positively observed and have not been replaced. This is
+useful closure of the dependency question, but it prohibits suppressing the
+producer family. The next implementation milestone must assign semantic roles
+to the 26 stable shader families and provide the native resource publication or
+native consumer coverage they require.
+
+Guest CPU visibility and the independent rollback switch remain separate
+unknown gates. Neither the absence of query/memexport correlation nor the
+visual parity result can substitute for those proofs.

--- a/docs/native-renderer/SUPPRESSION_ADMISSION.md
+++ b/docs/native-renderer/SUPPRESSION_ADMISSION.md
@@ -40,12 +40,11 @@ code 1.
 ## Current retained sky/horizon family
 
 The exact pair `747837906D0BF484` / `1D253A52B55C9FB3` has stable boundaries,
-one-draw parity, continuous exact-frame output, fallback behavior, and native
-GPU timing. It is not admitted for suppression yet:
+complete-pass color/depth parity, continuous exact-frame output, fallback
+behavior, and native GPU timing. It is not admitted for suppression yet:
 
-- the current RenderDoc parity result covers the anchor draw, not the complete
-  two-draw retained pass;
-- the target's later GPU-consumer graph is not closed;
+- the exact-family graph positively observes 51 prepared later-GPU-consumer
+  signatures across 26 shader families that have not been replaced;
 - guest CPU visibility remains uninstrumented; and
 - no independently reversible suppression switch exists.
 
@@ -63,6 +62,12 @@ so both depth and stencil participate in the comparison.
 The 2026-08-29 same-frame qualification passed exact complete-pass color parity
 across 41,943,040 active bytes and exact two-sample depth/stencil parity across
 83,886,080 bytes. This promotes both `color_parity` and `depth_parity` to
-`pass`. The admission result is now 9/12; `later_gpu_consumers`,
-`guest_cpu_visibility`, and `rollback_switch` remain `unknown`, so suppression
-is still prohibited.
+`pass`.
+
+The subsequent bounded consumer qualification linked 384 family resolves to
+51 distinct prepared later-draw signatures across 26 shader families, with zero
+signature overflow and complete prepared metadata. This promotes
+`later_gpu_consumers` from `unknown` to `fail`: consumers are proven present
+but are not native-replaced. The admission result remains 9/12 passing gates;
+`guest_cpu_visibility` and `rollback_switch` remain `unknown`, and suppression
+is still prohibited. See [PASS_CONSUMER_GRAPH.md](PASS_CONSUMER_GRAPH.md).

--- a/src/native_renderer/graphics_hooks.cpp
+++ b/src/native_renderer/graphics_hooks.cpp
@@ -44,6 +44,8 @@ constexpr size_t kPreparedShaderPairCapacity = 1024;
 constexpr size_t kResolveTargetCapacity = 4096;
 constexpr size_t kResolvePageCapacity = 32768;
 constexpr size_t kResolveSummaryLimit = 32;
+constexpr size_t kPassConsumerDetailLimit = 64;
+constexpr size_t kPassConsumerSignatureCapacity = 1024;
 constexpr uint64_t kGuestPageSize = 4096;
 constexpr uint64_t kPhysicalApertureSize = UINT64_C(0x20000000);
 constexpr uint32_t kVertexIndexMask = 0x00FFFFFF;
@@ -111,6 +113,7 @@ struct IsolatedDrawState {
   uint64_t captured_draw = 0;
   uint64_t pass_anchor_frame = 0;
   uint64_t pass_anchor_draw = 0;
+  rex::system::GraphicsDrawObservation prepared_sample;
   std::filesystem::path output_root;
   std::jthread artifact_writer;
   std::jthread reference_artifact_writer;
@@ -290,6 +293,13 @@ bool g_graphics_census_installed = false;
 
 struct PendingCandidateObservation {
   rex::system::GraphicsDrawObservation sample;
+  std::array<size_t, 64> family_targets{};
+  size_t family_target_count = 0;
+  uint64_t family_base_fetch_mask = 0;
+  uint64_t family_mip_fetch_mask = 0;
+  uint64_t family_sample_references = 0;
+  uint32_t first_family_fetch_index = 0;
+  bool first_family_fetch_is_mip = false;
   bool samples_resolved_target = false;
   bool valid = false;
 };
@@ -314,7 +324,13 @@ struct ResolveTargetEntry {
   uint64_t memexport_sample_draw_count = 0;
   uint64_t window_resolve_count = 0;
   uint64_t window_sampled_draw_count = 0;
+  uint64_t family_frame = 0;
+  uint64_t family_draw = 0;
+  uint64_t family_sampled_draw_count = 0;
+  uint64_t family_sample_reference_count = 0;
   bool last_fetch_was_mip = false;
+  bool latest_resolve_from_traced_family = false;
+  bool family_consumer_reported = false;
   rex::system::GraphicsCopyObservation sample;
 };
 
@@ -345,8 +361,49 @@ struct DependencyCensus {
 
 DependencyCensus g_dependency_census;
 
+struct PassConsumerSignatureEntry {
+  uint64_t signature = 0;
+  uint64_t sample_events = 0;
+  uint64_t first_frame = 0;
+  uint64_t last_frame = 0;
+  uint64_t query_sample_events = 0;
+  uint64_t memexport_sample_events = 0;
+  uint64_t family_base_fetch_mask = 0;
+  uint64_t family_mip_fetch_mask = 0;
+  bool prepared_valid = false;
+  rex::system::GraphicsDrawObservation sample;
+  rex::system::GraphicsPreparedDrawObservation prepared_sample;
+};
+
+struct PassConsumerTrace {
+  rex::system::GraphicsDrawObservation pending_target;
+  uint64_t pending_frame = 0;
+  uint64_t pending_draw = 0;
+  uint64_t family_occurrences = 0;
+  uint64_t family_resolves = 0;
+  uint64_t family_resolve_bytes = 0;
+  uint64_t sampled_resolves = 0;
+  uint64_t sampled_draws = 0;
+  uint64_t sample_references = 0;
+  uint64_t overwritten_unsampled = 0;
+  uint64_t active_unsampled = 0;
+  uint64_t superseded_without_resolve = 0;
+  uint64_t consumer_signature_count = 0;
+  uint64_t consumer_signature_overflow = 0;
+  uint64_t unprepared_consumer_draws = 0;
+  uint64_t unprepared_consumer_references = 0;
+  uint64_t detail_events = 0;
+  uint64_t detail_overflow = 0;
+  bool pending = false;
+  std::array<PassConsumerSignatureEntry, kPassConsumerSignatureCapacity>
+      consumer_signatures{};
+};
+
+PassConsumerTrace g_pass_consumer_trace;
+
 static_assert(std::is_trivially_copyable_v<DrawCensus>);
 static_assert(std::is_trivially_copyable_v<DependencyCensus>);
+static_assert(std::is_trivially_copyable_v<PassConsumerTrace>);
 
 void ResetDrawCensus() {
   std::memset(&g_draw_census, 0, sizeof(g_draw_census));
@@ -365,6 +422,7 @@ void ResetPreparedShaderPairs() {
 
 void ResetDependencyCensus() {
   std::memset(&g_dependency_census, 0, sizeof(g_dependency_census));
+  std::memset(&g_pass_consumer_trace, 0, sizeof(g_pass_consumer_trace));
 }
 
 uint64_t HashCombine(uint64_t hash, uint64_t value) {
@@ -1561,6 +1619,10 @@ void RecordCandidate(
     const rex::system::GraphicsDrawObservation &observation,
     bool samples_resolved_target,
     const rex::system::GraphicsPreparedDrawObservation &prepared);
+void CommitPassConsumer(
+    const rex::system::GraphicsDrawObservation &observation,
+    const rex::system::GraphicsPreparedDrawObservation &prepared,
+    const PendingCandidateObservation &candidate);
 
 void ObservePreparedDraw(
     const rex::system::GraphicsPreparedDrawObservation &observation) {
@@ -1571,11 +1633,13 @@ void ObservePreparedDraw(
     auto sample = g_pending_candidate.sample;
     sample.vertex_shader_hash = observation.vertex_shader_hash;
     sample.pixel_shader_hash = observation.pixel_shader_hash;
+    CommitPassConsumer(sample, observation, g_pending_candidate);
     const uint64_t prepared_signature = CandidateSignature(
         sample, g_pending_candidate.samples_resolved_target, observation);
     g_isolated_draw.prepared_signature = prepared_signature;
     g_isolated_draw.frame = sample.frame_sequence;
     g_isolated_draw.draw = sample.draw_sequence;
+    g_isolated_draw.prepared_sample = sample;
     g_isolated_draw.prepared_candidate_eligible = IsIsolatedDrawEligible(
         sample, g_pending_candidate.samples_resolved_target, observation);
     g_isolated_draw.prepared_candidate_valid = true;
@@ -2472,6 +2536,14 @@ void RequestIsolatedDraw(
         !g_isolated_draw.prepared_candidate_eligible) {
       return;
     }
+    if (g_pass_consumer_trace.pending) {
+      ++g_pass_consumer_trace.superseded_without_resolve;
+    }
+    g_pass_consumer_trace.pending_target = g_isolated_draw.prepared_sample;
+    g_pass_consumer_trace.pending_frame = g_isolated_draw.frame;
+    g_pass_consumer_trace.pending_draw = g_isolated_draw.draw;
+    ++g_pass_consumer_trace.family_occurrences;
+    g_pass_consumer_trace.pending = true;
     request.requested = true;
     request.frame_sequence = g_isolated_draw.frame;
     request.reuse_target = true;
@@ -2669,6 +2741,143 @@ void EmitDrawCensusWindow(uint64_t last_frame_value) {
   ResetDrawCensus();
 }
 
+bool CopyReadsPassTarget(
+    const rex::system::GraphicsCopyObservation &copy,
+    const rex::system::GraphicsDrawObservation &target) {
+  if (copy.surface_info != target.surface_info) {
+    return false;
+  }
+  const uint32_t source = copy.rb_copy_control & 7;
+  if (source < 4) {
+    return copy.color_info[source] == target.color_info[source];
+  }
+  return source == 4 && copy.depth_info == target.depth_info;
+}
+
+bool ShouldEmitPassConsumerDetail() {
+  if (g_pass_consumer_trace.detail_events == kPassConsumerDetailLimit) {
+    ++g_pass_consumer_trace.detail_overflow;
+    return false;
+  }
+  ++g_pass_consumer_trace.detail_events;
+  return true;
+}
+
+void ObservePassConsumerSignature(
+    const rex::system::GraphicsDrawObservation &observation,
+    const rex::system::GraphicsPreparedDrawObservation &prepared,
+    uint64_t base_fetch_mask, uint64_t mip_fetch_mask) {
+  const uint64_t signature = DrawSignature(observation);
+  PassConsumerSignatureEntry *entry = nullptr;
+  for (size_t i = 0; i < g_pass_consumer_trace.consumer_signature_count; ++i) {
+    if (g_pass_consumer_trace.consumer_signatures[i].signature == signature) {
+      entry = &g_pass_consumer_trace.consumer_signatures[i];
+      break;
+    }
+  }
+  if (!entry) {
+    if (g_pass_consumer_trace.consumer_signature_count ==
+        kPassConsumerSignatureCapacity) {
+      ++g_pass_consumer_trace.consumer_signature_overflow;
+      return;
+    }
+    entry = &g_pass_consumer_trace.consumer_signatures
+                 [g_pass_consumer_trace.consumer_signature_count++];
+    entry->signature = signature;
+    entry->first_frame = observation.frame_sequence;
+    entry->sample = observation;
+    entry->prepared_sample = prepared;
+    entry->prepared_valid = true;
+  }
+  ++entry->sample_events;
+  entry->last_frame = observation.frame_sequence;
+  if (observation.viz_query_condition || (observation.pa_sc_viz_query & 1)) {
+    ++entry->query_sample_events;
+  }
+  if (observation.vertex_memexport) {
+    ++entry->memexport_sample_events;
+  }
+  entry->family_base_fetch_mask |= base_fetch_mask;
+  entry->family_mip_fetch_mask |= mip_fetch_mask;
+}
+
+void CommitPassConsumer(
+    const rex::system::GraphicsDrawObservation &observation,
+    const rex::system::GraphicsPreparedDrawObservation &prepared,
+    const PendingCandidateObservation &candidate) {
+  if (!candidate.family_sample_references) {
+    return;
+  }
+  bool active_family_target = false;
+  for (size_t i = 0; i < candidate.family_target_count; ++i) {
+    active_family_target |=
+        g_dependency_census.targets[candidate.family_targets[i]]
+            .latest_resolve_from_traced_family;
+  }
+  if (!active_family_target) {
+    return;
+  }
+  ++g_pass_consumer_trace.sampled_draws;
+  g_pass_consumer_trace.sample_references +=
+      candidate.family_sample_references;
+  ObservePassConsumerSignature(observation, prepared,
+                               candidate.family_base_fetch_mask,
+                               candidate.family_mip_fetch_mask);
+  for (size_t i = 0; i < candidate.family_target_count; ++i) {
+    ResolveTargetEntry &target =
+        g_dependency_census.targets[candidate.family_targets[i]];
+    if (!target.latest_resolve_from_traced_family) {
+      continue;
+    }
+    ++target.family_sampled_draw_count;
+    target.family_sample_reference_count +=
+        candidate.family_sample_references;
+    if (!target.family_consumer_reported) {
+      ++g_pass_consumer_trace.sampled_resolves;
+      target.family_consumer_reported = true;
+      if (ShouldEmitPassConsumerDetail()) {
+        pinyon_shift::diagnostics::RecordEvent(
+            "native_renderer.census.pass_family_consumer",
+            {{"anchor_signature",
+              fmt::format("{:016X}", g_pass_follower.target_signature)},
+             {"follower_signature",
+              fmt::format("{:016X}", g_isolated_draw.target_signature)},
+             {"family_frame", std::to_string(target.family_frame)},
+             {"family_follower_draw", std::to_string(target.family_draw)},
+             {"resolve_frame", std::to_string(target.last_resolve_frame)},
+             {"address", fmt::format("{:08X}", target.address)},
+             {"length", std::to_string(target.length)},
+             {"consumer_frame", std::to_string(observation.frame_sequence)},
+             {"consumer_draw", std::to_string(observation.draw_sequence)},
+             {"consumer_signature",
+              fmt::format("{:016X}", DrawSignature(observation))},
+             {"fetch_index",
+              std::to_string(candidate.first_family_fetch_index)},
+             {"fetch_kind",
+              candidate.first_family_fetch_is_mip ? "mip" : "base"},
+             {"query", observation.viz_query_condition ||
+                           (observation.pa_sc_viz_query & 1)
+                       ? "true"
+                       : "false"},
+             {"memexport", observation.vertex_memexport ? "true" : "false"},
+             {"prepared_metadata", "observed"},
+             {"xenos_draw", "preserved"},
+             {"suppression_eligible", "false"}});
+      }
+    }
+  }
+}
+
+void DiscardPendingPassConsumer() {
+  if (!g_pending_candidate.valid ||
+      !g_pending_candidate.family_sample_references) {
+    return;
+  }
+  ++g_pass_consumer_trace.unprepared_consumer_draws;
+  g_pass_consumer_trace.unprepared_consumer_references +=
+      g_pending_candidate.family_sample_references;
+}
+
 void ObserveCopy(const rex::system::GraphicsCopyObservation &observation) {
   AdvanceDependencyWindow(observation.frame_sequence);
   if (!observation.succeeded) {
@@ -2689,6 +2898,17 @@ void ObserveCopy(const rex::system::GraphicsCopyObservation &observation) {
   }
 
   ResolveTargetEntry &target = g_dependency_census.targets[target_index];
+  const bool family_resolve = g_pass_consumer_trace.pending &&
+                              CopyReadsPassTarget(
+                                  observation,
+                                  g_pass_consumer_trace.pending_target);
+  if (target.latest_resolve_from_traced_family) {
+    if (!target.family_sampled_draw_count) {
+      ++g_pass_consumer_trace.overwritten_unsampled;
+    }
+    target.latest_resolve_from_traced_family = false;
+    target.family_consumer_reported = false;
+  }
   if (!target.resolve_count) {
     target.address = observation.written_address;
     target.first_resolve_frame = observation.frame_sequence;
@@ -2702,6 +2922,35 @@ void ObserveCopy(const rex::system::GraphicsCopyObservation &observation) {
   target.last_resolve_frame = observation.frame_sequence;
   ++target.window_resolve_count;
   target.sample = observation;
+  if (family_resolve) {
+    target.latest_resolve_from_traced_family = true;
+    target.family_consumer_reported = false;
+    target.family_frame = g_pass_consumer_trace.pending_frame;
+    target.family_draw = g_pass_consumer_trace.pending_draw;
+    target.family_sampled_draw_count = 0;
+    target.family_sample_reference_count = 0;
+    ++g_pass_consumer_trace.family_resolves;
+    g_pass_consumer_trace.family_resolve_bytes += observation.written_length;
+    if (ShouldEmitPassConsumerDetail()) {
+      pinyon_shift::diagnostics::RecordEvent(
+          "native_renderer.census.pass_family_resolve",
+          {{"anchor_signature",
+            fmt::format("{:016X}", g_pass_follower.target_signature)},
+           {"follower_signature",
+            fmt::format("{:016X}", g_isolated_draw.target_signature)},
+           {"family_frame", std::to_string(target.family_frame)},
+           {"family_follower_draw", std::to_string(target.family_draw)},
+           {"resolve_frame", std::to_string(observation.frame_sequence)},
+           {"resolve_sequence", std::to_string(observation.copy_sequence)},
+           {"address", fmt::format("{:08X}", observation.written_address)},
+           {"length", std::to_string(observation.written_length)},
+           {"copy_source", std::to_string(observation.rb_copy_control & 7)},
+           {"classification", "tracked_guest_gpu_output"},
+           {"xenos_draw", "preserved"},
+           {"suppression_eligible", "false"}});
+    }
+    g_pass_consumer_trace.pending = false;
+  }
   MapResolveRange(target_index, observation.written_address,
                   observation.written_length);
 }
@@ -2731,7 +2980,8 @@ void EmitResolvedTextureDependency(
 void ObserveResolvedFetch(
     const rex::system::GraphicsDrawObservation &observation,
     uint32_t fetch_index, uint32_t address, bool is_mip,
-    std::array<size_t, 64> &sampled_targets, size_t &sampled_target_count) {
+    std::array<size_t, 64> &sampled_targets, size_t &sampled_target_count,
+    PendingCandidateObservation &candidate) {
   if (!address) {
     return;
   }
@@ -2743,6 +2993,17 @@ void ObserveResolvedFetch(
   ResolveTargetEntry &target = g_dependency_census.targets[target_index];
   ++target.sample_reference_count;
   ++g_dependency_census.window_sample_reference_count;
+  if (target.latest_resolve_from_traced_family) {
+    if (!candidate.family_sample_references) {
+      candidate.first_family_fetch_index = fetch_index;
+      candidate.first_family_fetch_is_mip = is_mip;
+    }
+    ++candidate.family_sample_references;
+    if (fetch_index < 64) {
+      (is_mip ? candidate.family_mip_fetch_mask
+              : candidate.family_base_fetch_mask) |= UINT64_C(1) << fetch_index;
+    }
+  }
   target.last_fetch_index = fetch_index;
   target.last_fetch_was_mip = is_mip;
   for (size_t i = 0; i < sampled_target_count; ++i) {
@@ -2761,6 +3022,9 @@ void ObserveResolvedFetch(
   }
   ++target.sampled_draw_count;
   ++target.window_sampled_draw_count;
+  if (target.latest_resolve_from_traced_family) {
+    candidate.family_targets[candidate.family_target_count++] = target_index;
+  }
   target.last_sample_frame = observation.frame_sequence;
   if (observation.viz_query_condition) {
     ++target.conditional_sample_draw_count;
@@ -2838,16 +3102,20 @@ void ObserveDraw(const rex::system::GraphicsDrawObservation &observation) {
 
   std::array<size_t, 64> sampled_targets{};
   size_t sampled_target_count = 0;
+  PendingCandidateObservation candidate;
+  candidate.sample = observation;
   for (uint32_t fetch_index = 0; fetch_index < 32; ++fetch_index) {
     if (!(observation.texture_fetch_mask & (uint32_t(1) << fetch_index))) {
       continue;
     }
     ObserveResolvedFetch(observation, fetch_index,
                          observation.texture_fetch_addresses[fetch_index],
-                         false, sampled_targets, sampled_target_count);
+                         false, sampled_targets, sampled_target_count,
+                         candidate);
     ObserveResolvedFetch(observation, fetch_index,
                          observation.texture_fetch_mip_addresses[fetch_index],
-                         true, sampled_targets, sampled_target_count);
+                         true, sampled_targets, sampled_target_count,
+                         candidate);
   }
   if (sampled_target_count) {
     ++g_dependency_census.window_sampled_draw_count;
@@ -2869,9 +3137,10 @@ void ObserveDraw(const rex::system::GraphicsDrawObservation &observation) {
   const bool samples_resolved_target = sampled_target_count != 0;
   if (g_pending_candidate.valid) {
     ++g_candidate_unprepared_draw_count;
+    DiscardPendingPassConsumer();
   }
-  g_pending_candidate.sample = observation;
-  g_pending_candidate.samples_resolved_target = samples_resolved_target;
+  candidate.samples_resolved_target = samples_resolved_target;
+  g_pending_candidate = candidate;
   g_pending_candidate.valid = true;
   const uint64_t signature = DrawSignature(observation);
   size_t index = size_t(signature % kSignatureCapacity);
@@ -3040,13 +3309,156 @@ void UninstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system) {
   if (g_isolated_draw.reference_depth_artifact_writer.joinable()) {
     g_isolated_draw.reference_depth_artifact_writer.join();
   }
+  if (g_pending_candidate.valid) {
+    ++g_candidate_unprepared_draw_count;
+    DiscardPendingPassConsumer();
+    g_pending_candidate.valid = false;
+  }
+  if (g_pass_consumer_trace.pending) {
+    ++g_pass_consumer_trace.superseded_without_resolve;
+    g_pass_consumer_trace.pending = false;
+  }
+  for (const ResolveTargetEntry &target : g_dependency_census.targets) {
+    if (target.latest_resolve_from_traced_family &&
+        !target.family_sampled_draw_count) {
+      ++g_pass_consumer_trace.active_unsampled;
+    }
+  }
+  if (g_pass_follower.requested && g_pass_follower.valid &&
+      g_isolated_draw.requested && g_isolated_draw.valid) {
+    uint64_t prepared_metadata_count = 0;
+    for (size_t i = 0; i < g_pass_consumer_trace.consumer_signature_count; ++i) {
+      const PassConsumerSignatureEntry &entry =
+          g_pass_consumer_trace.consumer_signatures[i];
+      prepared_metadata_count += entry.prepared_valid ? 1 : 0;
+      const auto &sample = entry.sample;
+      const auto &prepared = entry.prepared_sample;
+      const std::string pipeline_state = fmt::format(
+          "color_mask={:08X};blend={:08X}:{:08X}:{:08X}:{:08X};"
+          "depth={:08X};raster={:08X};vertex={:08X}",
+          sample.rb_color_mask, sample.rb_blendcontrol[0],
+          sample.rb_blendcontrol[1], sample.rb_blendcontrol[2],
+          sample.rb_blendcontrol[3], sample.rb_depthcontrol,
+          sample.pa_su_sc_mode_cntl, sample.pa_su_vtx_cntl);
+      diagnostics::RecordEvent(
+          "native_renderer.census.pass_family_consumer_signature",
+          {{"anchor_signature",
+            fmt::format("{:016X}", g_pass_follower.target_signature)},
+           {"follower_signature",
+            fmt::format("{:016X}", g_isolated_draw.target_signature)},
+           {"consumer_signature", fmt::format("{:016X}", entry.signature)},
+           {"sample_events", std::to_string(entry.sample_events)},
+           {"first_frame", std::to_string(entry.first_frame)},
+           {"last_frame", std::to_string(entry.last_frame)},
+           {"query_sample_events",
+            std::to_string(entry.query_sample_events)},
+           {"memexport_sample_events",
+            std::to_string(entry.memexport_sample_events)},
+           {"family_base_fetch_mask",
+            fmt::format("{:016X}", entry.family_base_fetch_mask)},
+           {"family_mip_fetch_mask",
+            fmt::format("{:016X}", entry.family_mip_fetch_mask)},
+           {"vertex_shader", fmt::format("{:016X}", sample.vertex_shader_hash)},
+           {"pixel_shader", fmt::format("{:016X}", sample.pixel_shader_hash)},
+           {"vertex_specialization_mask",
+            entry.prepared_valid
+                ? fmt::format("{:016X}", prepared.vertex_specialization_mask)
+                : "unknown"},
+           {"pixel_specialization_mask",
+            entry.prepared_valid
+                ? fmt::format("{:016X}", prepared.pixel_specialization_mask)
+                : "unknown"},
+           {"prepared_pipeline_hash",
+            entry.prepared_valid
+                ? fmt::format("{:016X}", PreparedPipelineHash(prepared))
+                : "unknown"},
+           {"host_primitive",
+            entry.prepared_valid
+                ? std::to_string(prepared.host_primitive_type)
+                : "unknown"},
+           {"host_index_buffer_type",
+            entry.prepared_valid
+                ? std::to_string(prepared.index_buffer_type)
+                : "unknown"},
+           {"host_index_format",
+            entry.prepared_valid
+                ? std::to_string(prepared.host_index_format)
+                : "unknown"},
+           {"prepared_pipeline_flags",
+            entry.prepared_valid ? fmt::format("{:08X}", prepared.flags)
+                                 : "unknown"},
+           {"bound_render_target_bits",
+            entry.prepared_valid
+                ? fmt::format("{:08X}", prepared.bound_render_target_bits)
+                : "unknown"},
+           {"primitive", std::to_string(sample.primitive_type)},
+           {"source_select", std::to_string(sample.source_select)},
+           {"indexed", sample.indexed ? "true" : "false"},
+           {"index_count", std::to_string(sample.index_count)},
+           {"vertex_binding_count",
+            std::to_string(sample.vertex_binding_count)},
+           {"vertex_attribute_count",
+            std::to_string(sample.vertex_attribute_count)},
+           {"texture_fetch_count",
+            std::to_string(std::popcount(sample.texture_fetch_mask))},
+           {"pipeline_state", pipeline_state},
+           {"prepared_metadata", entry.prepared_valid ? "observed" : "missing"},
+           {"classification", "exact_family_guest_gpu_consumer"},
+           {"xenos_draw", "preserved"},
+           {"suppression_eligible", "false"}});
+    }
+    diagnostics::RecordEvent(
+        "native_renderer.census.pass_family_consumer_summary",
+        {{"anchor_signature",
+          fmt::format("{:016X}", g_pass_follower.target_signature)},
+         {"follower_signature",
+          fmt::format("{:016X}", g_isolated_draw.target_signature)},
+         {"family_occurrences",
+          std::to_string(g_pass_consumer_trace.family_occurrences)},
+         {"family_resolves",
+          std::to_string(g_pass_consumer_trace.family_resolves)},
+         {"family_resolve_bytes",
+          std::to_string(g_pass_consumer_trace.family_resolve_bytes)},
+         {"sampled_resolves",
+          std::to_string(g_pass_consumer_trace.sampled_resolves)},
+         {"sampled_draws",
+          std::to_string(g_pass_consumer_trace.sampled_draws)},
+         {"sample_references",
+          std::to_string(g_pass_consumer_trace.sample_references)},
+         {"overwritten_unsampled",
+          std::to_string(g_pass_consumer_trace.overwritten_unsampled)},
+         {"active_unsampled",
+          std::to_string(g_pass_consumer_trace.active_unsampled)},
+         {"superseded_without_resolve",
+          std::to_string(
+              g_pass_consumer_trace.superseded_without_resolve)},
+         {"consumer_signature_count",
+          std::to_string(g_pass_consumer_trace.consumer_signature_count)},
+         {"consumer_signature_overflow",
+          std::to_string(g_pass_consumer_trace.consumer_signature_overflow)},
+         {"unprepared_consumer_draws",
+          std::to_string(g_pass_consumer_trace.unprepared_consumer_draws)},
+         {"unprepared_consumer_references",
+          std::to_string(
+              g_pass_consumer_trace.unprepared_consumer_references)},
+         {"prepared_metadata_count",
+          std::to_string(prepared_metadata_count)},
+         {"prepared_metadata_missing",
+          std::to_string(g_pass_consumer_trace.consumer_signature_count -
+                         prepared_metadata_count)},
+         {"detail_events",
+          std::to_string(g_pass_consumer_trace.detail_events)},
+         {"detail_overflow",
+          std::to_string(g_pass_consumer_trace.detail_overflow)},
+         {"classification", "bounded_exact_family_lineage"},
+         {"guest_gpu_consumers",
+          g_pass_consumer_trace.sampled_draws ? "observed" : "unobserved"},
+         {"xenos_draw", "preserved"},
+         {"suppression_eligible", "false"}});
+  }
   g_graphics_census_installed = false;
   if (g_draw_census.window_first_frame && g_draw_census.window_draw_count) {
     EmitDrawCensusWindow(g_draw_census.window_last_frame);
-  }
-  if (g_pending_candidate.valid) {
-    ++g_candidate_unprepared_draw_count;
-    g_pending_candidate.valid = false;
   }
   EmitDependencyCensusWindow();
   if (g_index_scan.requested && g_index_scan.valid && !g_index_scan.completed) {

--- a/tools/summarize-native-renderer-pass-consumers.py
+++ b/tools/summarize-native-renderer-pass-consumers.py
@@ -1,0 +1,415 @@
+#!/usr/bin/env python3
+"""Summarize exact pass-family resolve and later-GPU-consumer diagnostics."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any, Iterable
+
+
+SCHEMA = "pinyon-shift.native-renderer-pass-consumer-inventory.v2"
+PREFIX = "native_renderer.census.pass_family_"
+SUMMARY_EVENT = f"{PREFIX}consumer_summary"
+RESOLVE_EVENT = f"{PREFIX}resolve"
+CONSUMER_EVENT = f"{PREFIX}consumer"
+CONSUMER_SIGNATURE_EVENT = f"{PREFIX}consumer_signature"
+SAFETY_FIELDS = {
+    "xenos_draw": "preserved",
+    "suppression_eligible": "false",
+}
+COUNT_FIELDS = (
+    "family_occurrences",
+    "family_resolves",
+    "family_resolve_bytes",
+    "sampled_resolves",
+    "sampled_draws",
+    "sample_references",
+    "overwritten_unsampled",
+    "active_unsampled",
+    "superseded_without_resolve",
+    "consumer_signature_count",
+    "consumer_signature_overflow",
+    "unprepared_consumer_draws",
+    "unprepared_consumer_references",
+    "prepared_metadata_count",
+    "prepared_metadata_missing",
+    "detail_events",
+    "detail_overflow",
+)
+HEX_METADATA_FIELDS = (
+    "consumer_signature",
+    "vertex_shader",
+    "pixel_shader",
+    "vertex_specialization_mask",
+    "pixel_specialization_mask",
+    "prepared_pipeline_hash",
+    "family_base_fetch_mask",
+    "family_mip_fetch_mask",
+)
+
+
+def read_events(paths: Iterable[Path]) -> list[dict[str, Any]]:
+    events: list[dict[str, Any]] = []
+    for path in paths:
+        with path.open("r", encoding="utf-8") as source:
+            for line_number, line in enumerate(source, 1):
+                if not line.strip():
+                    continue
+                try:
+                    event = json.loads(line)
+                except json.JSONDecodeError as error:
+                    raise ValueError(f"{path}:{line_number}: invalid JSON: {error}") from error
+                if str(event.get("event", "")).startswith(PREFIX):
+                    event["_source"] = str(path)
+                    event["_line"] = line_number
+                    events.append(event)
+    return events
+
+
+def normalize_signature(value: str) -> str:
+    signature = value.upper()
+    if len(signature) != 16 or any(
+        character not in "0123456789ABCDEF" for character in signature
+    ):
+        raise ValueError(f"invalid 64-bit signature: {value!r}")
+    return signature
+
+
+def require_safety(event: dict[str, Any]) -> None:
+    location = f"{event.get('_source')}:{event.get('_line')}"
+    for key, expected in SAFETY_FIELDS.items():
+        if event.get(key) != expected:
+            raise ValueError(
+                f"{location}: unsafe {key}={event.get(key)!r}; expected {expected!r}"
+            )
+
+
+def clean(event: dict[str, Any]) -> dict[str, Any]:
+    private = {"pid", "tid", "utc", "schema", "event", "session", "_source", "_line"}
+    return {key: value for key, value in event.items() if key not in private}
+
+
+def build_shader_families(
+    consumer_signatures: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    families: dict[tuple[str, str, str, str], dict[str, Any]] = {}
+    for event in consumer_signatures:
+        if event.get("prepared_metadata") != "observed":
+            continue
+        normalized = {
+            field: normalize_signature(str(event.get(field, "")))
+            for field in HEX_METADATA_FIELDS
+        }
+        key = (
+            normalized["vertex_shader"],
+            normalized["pixel_shader"],
+            normalized["vertex_specialization_mask"],
+            normalized["pixel_specialization_mask"],
+        )
+        family = families.setdefault(
+            key,
+            {
+                "shader_family_id": "/".join(key),
+                "vertex_shader": key[0],
+                "pixel_shader": key[1],
+                "vertex_specialization_mask": key[2],
+                "pixel_specialization_mask": key[3],
+                "sample_events": 0,
+                "query_sample_events": 0,
+                "memexport_sample_events": 0,
+                "first_frame": None,
+                "last_frame": 0,
+                "consumer_signatures": set(),
+                "prepared_pipeline_hashes": set(),
+                "family_base_fetch_mask": 0,
+                "family_mip_fetch_mask": 0,
+            },
+        )
+        try:
+            sample_events = int(event["sample_events"])
+            query_events = int(event["query_sample_events"])
+            memexport_events = int(event["memexport_sample_events"])
+            first_frame = int(event["first_frame"])
+            last_frame = int(event["last_frame"])
+        except (KeyError, TypeError, ValueError) as error:
+            raise ValueError("consumer signature metadata has invalid counts") from error
+        family["sample_events"] += sample_events
+        family["query_sample_events"] += query_events
+        family["memexport_sample_events"] += memexport_events
+        family["first_frame"] = (
+            first_frame
+            if family["first_frame"] is None
+            else min(family["first_frame"], first_frame)
+        )
+        family["last_frame"] = max(family["last_frame"], last_frame)
+        family["consumer_signatures"].add(normalized["consumer_signature"])
+        family["prepared_pipeline_hashes"].add(
+            normalized["prepared_pipeline_hash"]
+        )
+        family["family_base_fetch_mask"] |= int(
+            normalized["family_base_fetch_mask"], 16
+        )
+        family["family_mip_fetch_mask"] |= int(
+            normalized["family_mip_fetch_mask"], 16
+        )
+
+    rendered: list[dict[str, Any]] = []
+    for family in families.values():
+        signatures = sorted(family.pop("consumer_signatures"))
+        pipeline_hashes = sorted(family.pop("prepared_pipeline_hashes"))
+        family.update(
+            {
+                "signature_count": len(signatures),
+                "consumer_signatures": signatures,
+                "pipeline_hash_count": len(pipeline_hashes),
+                "prepared_pipeline_hashes": pipeline_hashes,
+                "family_base_fetch_mask": f"{family['family_base_fetch_mask']:016X}",
+                "family_mip_fetch_mask": f"{family['family_mip_fetch_mask']:016X}",
+                "semantic_role": "unknown_unclassified",
+                "native_coverage": False,
+                "suppression_eligible": False,
+            }
+        )
+        rendered.append(family)
+    ranked = sorted(
+        rendered,
+        key=lambda family: (
+            -int(family["sample_events"]),
+            family["vertex_shader"],
+            family["pixel_shader"],
+        ),
+    )
+    total_samples = sum(int(family["sample_events"]) for family in ranked)
+    for rank, family in enumerate(ranked, 1):
+        family["rank"] = rank
+        family["sample_share_ppm"] = (
+            int(family["sample_events"]) * 1_000_000 // total_samples
+            if total_samples
+            else 0
+        )
+    return ranked
+
+
+def summarize(
+    paths: Iterable[Path],
+    anchor: str | None = None,
+    follower: str | None = None,
+    session: str | None = None,
+) -> dict[str, Any]:
+    paths = list(paths)
+    events = read_events(paths)
+    if anchor is not None:
+        anchor = normalize_signature(anchor)
+    if follower is not None:
+        follower = normalize_signature(follower)
+
+    summaries = [event for event in events if event.get("event") == SUMMARY_EVENT]
+    if session is not None:
+        summaries = [event for event in summaries if event.get("session") == session]
+    if anchor is not None:
+        summaries = [event for event in summaries if event.get("anchor_signature") == anchor]
+    if follower is not None:
+        summaries = [event for event in summaries if event.get("follower_signature") == follower]
+    if not summaries:
+        raise ValueError("no matching completed pass-family consumer summary found")
+
+    summary = summaries[-1]
+    selected_session = str(summary.get("session", ""))
+    if not selected_session:
+        raise ValueError("summary has no diagnostic session")
+    selected_anchor = normalize_signature(str(summary.get("anchor_signature", "")))
+    selected_follower = normalize_signature(str(summary.get("follower_signature", "")))
+    require_safety(summary)
+    if summary.get("classification") != "bounded_exact_family_lineage":
+        raise ValueError("summary does not use the exact-family lineage classification")
+
+    related = [
+        event
+        for event in events
+        if event.get("session") == selected_session
+        and event.get("anchor_signature") == selected_anchor
+        and event.get("follower_signature") == selected_follower
+    ]
+    resolves = [event for event in related if event.get("event") == RESOLVE_EVENT]
+    consumers = [event for event in related if event.get("event") == CONSUMER_EVENT]
+    consumer_signatures = [
+        event for event in related if event.get("event") == CONSUMER_SIGNATURE_EVENT
+    ]
+    for event in resolves + consumers + consumer_signatures:
+        require_safety(event)
+
+    counts: dict[str, int] = {}
+    for field in COUNT_FIELDS:
+        try:
+            counts[field] = int(summary[field])
+        except (KeyError, TypeError, ValueError) as error:
+            raise ValueError(f"summary has invalid {field}") from error
+        if counts[field] < 0:
+            raise ValueError(f"summary has negative {field}")
+
+    if counts["family_resolves"] > counts["family_occurrences"]:
+        raise ValueError("family resolves exceed observed family occurrences")
+    if counts["sampled_resolves"] > counts["family_resolves"]:
+        raise ValueError("sampled resolves exceed family resolves")
+    if (
+        counts["unprepared_consumer_draws"]
+        > counts["unprepared_consumer_references"]
+    ):
+        raise ValueError("unprepared consumer draws exceed provisional references")
+    expected_consumer_state = "observed" if counts["sampled_draws"] else "unobserved"
+    if summary.get("guest_gpu_consumers") != expected_consumer_state:
+        raise ValueError("guest GPU consumer classification contradicts summary counts")
+    if counts["detail_events"] != len(resolves) + len(consumers):
+        raise ValueError("detail event count does not match retained detail records")
+    if counts["consumer_signature_count"] != len(consumer_signatures):
+        raise ValueError("consumer signature count does not match aggregate records")
+    if (
+        counts["prepared_metadata_count"]
+        + counts["prepared_metadata_missing"]
+        != counts["consumer_signature_count"]
+    ):
+        raise ValueError("prepared metadata counts contradict signature count")
+    if counts["sampled_draws"] and not consumer_signatures:
+        raise ValueError("observed consumer events have no consumer signature aggregate")
+    normalized_consumer_signatures = [
+        normalize_signature(str(event.get("consumer_signature", "")))
+        for event in consumer_signatures
+    ]
+    if len(set(normalized_consumer_signatures)) != len(normalized_consumer_signatures):
+        raise ValueError("duplicate consumer signature aggregate")
+    aggregate_sample_events = 0
+    observed_prepared_metadata = 0
+    for event in consumer_signatures:
+        try:
+            sample_events = int(event["sample_events"])
+            first_frame = int(event["first_frame"])
+            last_frame = int(event["last_frame"])
+        except (KeyError, TypeError, ValueError) as error:
+            raise ValueError("consumer signature aggregate has invalid counts") from error
+        if sample_events <= 0 or first_frame <= 0 or last_frame < first_frame:
+            raise ValueError("consumer signature aggregate has inconsistent counts")
+        aggregate_sample_events += sample_events
+        observed_prepared_metadata += event.get("prepared_metadata") == "observed"
+    if observed_prepared_metadata != counts["prepared_metadata_count"]:
+        raise ValueError("prepared metadata summary contradicts aggregate records")
+    if (
+        counts["consumer_signature_overflow"] == 0
+        and aggregate_sample_events != counts["sampled_draws"]
+    ):
+        raise ValueError("consumer signature sample totals contradict summary counts")
+    shader_families = build_shader_families(consumer_signatures)
+    classified_sample_events = sum(
+        int(family["sample_events"]) for family in shader_families
+    )
+    if counts["prepared_metadata_missing"] == 0 and (
+        classified_sample_events != aggregate_sample_events
+    ):
+        raise ValueError("shader family sample totals contradict aggregate records")
+    if counts["sampled_draws"]:
+        classification_evidence = (
+            f"{counts['prepared_metadata_count']} of "
+            f"{len(consumer_signatures)} later consumer signatures are grouped "
+            f"into {len(shader_families)} shader families"
+        )
+        if counts["prepared_metadata_missing"]:
+            classification_evidence += (
+                f"; {counts['prepared_metadata_missing']} signatures lack "
+                "prepared metadata"
+            )
+        later_gpu_consumer_gate = {
+            "status": "fail",
+            "evidence": classification_evidence
+            + "; none has a native replacement",
+        }
+    else:
+        later_gpu_consumer_gate = {
+            "status": "unknown",
+            "evidence": (
+                "no later consumer was observed; absence is not proof that the "
+                "family has no later GPU dependency"
+            ),
+        }
+
+    lineage_complete = (
+        counts["family_occurrences"] > 0
+        and counts["family_resolves"] > 0
+        and counts["consumer_signature_overflow"] == 0
+    )
+    return {
+        "schema": SCHEMA,
+        "session": selected_session,
+        "anchor_signature": selected_anchor,
+        "follower_signature": selected_follower,
+        "sources": [str(path) for path in paths],
+        "lineage_status": "complete" if lineage_complete else "incomplete",
+        "classification_status": (
+            "complete"
+            if lineage_complete and counts["prepared_metadata_missing"] == 0
+            else "incomplete"
+        ),
+        "guest_gpu_consumers": expected_consumer_state,
+        "counts": counts,
+        "resolves": [clean(event) for event in resolves],
+        "consumers": [clean(event) for event in consumers],
+        "consumer_signatures": [
+            clean(event)
+            for event in sorted(
+                consumer_signatures,
+                key=lambda event: str(event["consumer_signature"]),
+            )
+        ],
+        "consumer_shader_families": shader_families,
+        "classification_counts": {
+            "classified_signatures": counts["prepared_metadata_count"],
+            "unclassified_signatures": counts["prepared_metadata_missing"],
+            "classified_sample_events": classified_sample_events,
+            "unclassified_sample_events": (
+                aggregate_sample_events - classified_sample_events
+            ),
+        },
+        "interpretation": (
+            "observed consumers are proven dependencies"
+            if counts["sampled_draws"]
+            else "no consumer was observed; absence is not proof of independence"
+        ),
+        "admission": {"later_gpu_consumers": later_gpu_consumer_gate},
+        "safety": {
+            "xenos_authority": True,
+            "suppression_allowed": False,
+            "unobserved_means_independent": False,
+        },
+    }
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("logs", nargs="+", type=Path)
+    parser.add_argument("--anchor")
+    parser.add_argument("--follower")
+    parser.add_argument("--session")
+    parser.add_argument("--output", "-o", type=Path)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        result = summarize(
+            args.logs, anchor=args.anchor, follower=args.follower, session=args.session
+        )
+    except ValueError as error:
+        print(f"error: {error}")
+        return 1
+    rendered = json.dumps(result, indent=2) + "\n"
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(rendered, encoding="utf-8")
+    else:
+        print(rendered, end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/tests/test_native_renderer_contract.py
+++ b/tools/tests/test_native_renderer_contract.py
@@ -51,6 +51,41 @@ class NativeRendererContractTests(unittest.TestCase):
         self.assertNotIn("REX_STORE", source)
         self.assertNotIn("GuestPtr", source)
 
+    def test_exact_pass_consumer_trace_is_bounded_and_fail_closed(self):
+        source = (ROOT / "src/native_renderer/graphics_hooks.cpp").read_text(
+            encoding="utf-8"
+        )
+        summarizer = (
+            ROOT / "tools/summarize-native-renderer-pass-consumers.py"
+        ).read_text(encoding="utf-8")
+
+        self.assertIn("kPassConsumerDetailLimit = 64", source)
+        self.assertIn("kPassConsumerSignatureCapacity = 1024", source)
+        self.assertIn("CopyReadsPassTarget", source)
+        self.assertIn("copy.surface_info != target.surface_info", source)
+        self.assertIn("copy.color_info[source] == target.color_info[source]", source)
+        self.assertIn("copy.depth_info == target.depth_info", source)
+        self.assertIn('"native_renderer.census.pass_family_resolve"', source)
+        self.assertIn('"native_renderer.census.pass_family_consumer"', source)
+        self.assertIn(
+            '"native_renderer.census.pass_family_consumer_summary"', source
+        )
+        self.assertIn(
+            '"native_renderer.census.pass_family_consumer_signature"', source
+        )
+        self.assertIn('"prepared_metadata"', source)
+        self.assertIn('"family_base_fetch_mask"', source)
+        self.assertIn('"family_mip_fetch_mask"', source)
+        self.assertIn('"prepared_metadata_count"', source)
+        self.assertIn('"prepared_metadata_missing"', source)
+        self.assertIn('"unprepared_consumer_draws"', source)
+        self.assertIn('"unprepared_consumer_references"', source)
+        self.assertIn('{"xenos_draw", "preserved"}', source)
+        self.assertIn('{"suppression_eligible", "false"}', source)
+        self.assertIn('"unobserved_means_independent": False', summarizer)
+        self.assertIn('"suppression_allowed": False', summarizer)
+        self.assertIn('"later_gpu_consumers": later_gpu_consumer_gate', summarizer)
+
     def test_scene_markers_and_classifier_are_explicit_and_safe(self):
         source = (ROOT / "src/native_renderer/graphics_hooks.cpp").read_text(
             encoding="utf-8"
@@ -547,7 +582,8 @@ class NativeRendererContractTests(unittest.TestCase):
             prepared_patch.index("// Update the textures"),
         )
         self.assertNotIn("SetDrawSuppression", prepared_patch)
-        self.assertIn("g_pending_candidate.sample = observation;", source)
+        self.assertIn("candidate.sample = observation;", source)
+        self.assertIn("g_pending_candidate = candidate;", source)
         self.assertIn(
             "sample.vertex_shader_hash = observation.vertex_shader_hash;",
             source,

--- a/tools/tests/test_native_renderer_pass_consumers.py
+++ b/tools/tests/test_native_renderer_pass_consumers.py
@@ -1,0 +1,264 @@
+import importlib.util
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SPEC = importlib.util.spec_from_file_location(
+    "native_renderer_pass_consumers",
+    ROOT / "tools/summarize-native-renderer-pass-consumers.py",
+)
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+ANCHOR = "747837906D0BF484"
+FOLLOWER = "1D253A52B55C9FB3"
+
+
+def event(kind, **fields):
+    return {
+        "event": f"native_renderer.census.pass_family_{kind}",
+        "session": "session-1",
+        "anchor_signature": ANCHOR,
+        "follower_signature": FOLLOWER,
+        "xenos_draw": "preserved",
+        "suppression_eligible": "false",
+        **{key: str(value) for key, value in fields.items()},
+    }
+
+
+def summary(**overrides):
+    values = {
+        "family_occurrences": 2,
+        "family_resolves": 2,
+        "family_resolve_bytes": 8192,
+        "sampled_resolves": 1,
+        "sampled_draws": 1,
+        "sample_references": 2,
+        "overwritten_unsampled": 1,
+        "active_unsampled": 0,
+        "superseded_without_resolve": 8,
+        "consumer_signature_count": 1,
+        "consumer_signature_overflow": 0,
+        "unprepared_consumer_draws": 0,
+        "unprepared_consumer_references": 0,
+        "prepared_metadata_count": 1,
+        "prepared_metadata_missing": 0,
+        "detail_events": 3,
+        "detail_overflow": 0,
+        "classification": "bounded_exact_family_lineage",
+        "guest_gpu_consumers": "observed",
+    }
+    values.update(overrides)
+    return event("consumer_summary", **values)
+
+
+def consumer_signature(signature="0123456789ABCDEF", sample_events=1, **fields):
+    values = {
+        "consumer_signature": signature,
+        "sample_events": sample_events,
+        "first_frame": 10,
+        "last_frame": 10,
+        "query_sample_events": 0,
+        "memexport_sample_events": 0,
+        "family_base_fetch_mask": "0000000000000001",
+        "family_mip_fetch_mask": "0000000000000000",
+        "vertex_shader": "1111111111111111",
+        "pixel_shader": "2222222222222222",
+        "vertex_specialization_mask": "0000000000000001",
+        "pixel_specialization_mask": "0000000000000002",
+        "prepared_pipeline_hash": "3333333333333333",
+        "prepared_metadata": "observed",
+    }
+    values.update(fields)
+    return event("consumer_signature", **values)
+
+
+class PassConsumerSummaryTests(unittest.TestCase):
+    def write(self, root, records):
+        path = Path(root) / "diagnostics.jsonl"
+        path.write_text(
+            "".join(json.dumps(record) + "\n" for record in records),
+            encoding="utf-8",
+        )
+        return path
+
+    def test_summarizes_complete_observed_lineage(self):
+        records = [
+            event("resolve", address="1000"),
+            event("consumer", consumer_signature="0123456789ABCDEF"),
+            event("resolve", address="2000"),
+            consumer_signature(),
+            summary(),
+        ]
+        with tempfile.TemporaryDirectory() as temp:
+            result = MODULE.summarize([self.write(temp, records)])
+        self.assertEqual("complete", result["lineage_status"])
+        self.assertEqual("complete", result["classification_status"])
+        self.assertEqual("observed", result["guest_gpu_consumers"])
+        self.assertFalse(result["safety"]["suppression_allowed"])
+        self.assertFalse(result["safety"]["unobserved_means_independent"])
+        self.assertEqual(1, len(result["consumer_shader_families"]))
+        self.assertEqual(
+            "unknown_unclassified",
+            result["consumer_shader_families"][0]["semantic_role"],
+        )
+        self.assertFalse(result["consumer_shader_families"][0]["native_coverage"])
+        self.assertEqual(1, result["consumer_shader_families"][0]["rank"])
+        self.assertEqual(
+            1_000_000,
+            result["consumer_shader_families"][0]["sample_share_ppm"],
+        )
+        self.assertEqual(
+            "fail", result["admission"]["later_gpu_consumers"]["status"]
+        )
+
+    def test_unobserved_consumers_remain_fail_closed(self):
+        record = summary(
+            sampled_resolves=0,
+            sampled_draws=0,
+            sample_references=0,
+            consumer_signature_count=0,
+            prepared_metadata_count=0,
+            detail_events=2,
+            guest_gpu_consumers="unobserved",
+        )
+        with tempfile.TemporaryDirectory() as temp:
+            result = MODULE.summarize(
+                [self.write(temp, [event("resolve"), event("resolve"), record])]
+            )
+        self.assertEqual("unobserved", result["guest_gpu_consumers"])
+        self.assertIn("not proof", result["interpretation"])
+        self.assertFalse(result["safety"]["suppression_allowed"])
+        self.assertEqual(
+            "unknown", result["admission"]["later_gpu_consumers"]["status"]
+        )
+
+    def test_rejects_missing_summary(self):
+        with tempfile.TemporaryDirectory() as temp:
+            path = self.write(temp, [event("resolve")])
+            with self.assertRaisesRegex(ValueError, "no matching completed"):
+                MODULE.summarize([path])
+
+    def test_rejects_unsafe_event(self):
+        unsafe = summary(suppression_eligible="true")
+        with tempfile.TemporaryDirectory() as temp:
+            path = self.write(temp, [unsafe])
+            with self.assertRaisesRegex(ValueError, "unsafe suppression_eligible"):
+                MODULE.summarize([path])
+
+    def test_rejects_inconsistent_detail_count(self):
+        with tempfile.TemporaryDirectory() as temp:
+            path = self.write(temp, [event("resolve"), summary()])
+            with self.assertRaisesRegex(ValueError, "detail event count"):
+                MODULE.summarize([path])
+
+    def test_marks_signature_overflow_incomplete(self):
+        record = summary(consumer_signature_overflow=1)
+        records = [
+            event("resolve"),
+            event("consumer"),
+            event("resolve"),
+            consumer_signature(),
+            record,
+        ]
+        with tempfile.TemporaryDirectory() as temp:
+            result = MODULE.summarize([self.write(temp, records)])
+        self.assertEqual("incomplete", result["lineage_status"])
+
+    def test_reports_missing_prepared_metadata_as_incomplete(self):
+        records = [
+            event("resolve"),
+            event("consumer"),
+            event("resolve"),
+            consumer_signature(
+                prepared_metadata="missing",
+                vertex_specialization_mask="unknown",
+                pixel_specialization_mask="unknown",
+                prepared_pipeline_hash="unknown",
+            ),
+            summary(prepared_metadata_count=0, prepared_metadata_missing=1),
+        ]
+        with tempfile.TemporaryDirectory() as temp:
+            result = MODULE.summarize([self.write(temp, records)])
+        self.assertEqual("complete", result["lineage_status"])
+        self.assertEqual("incomplete", result["classification_status"])
+        self.assertEqual([], result["consumer_shader_families"])
+        self.assertEqual(1, result["classification_counts"]["unclassified_signatures"])
+        self.assertEqual(
+            1, result["classification_counts"]["unclassified_sample_events"]
+        )
+
+    def test_rejects_prepared_metadata_count_mismatch(self):
+        records = [
+            event("resolve"),
+            event("consumer"),
+            event("resolve"),
+            consumer_signature(),
+            summary(prepared_metadata_count=0, prepared_metadata_missing=1),
+        ]
+        with tempfile.TemporaryDirectory() as temp:
+            path = self.write(temp, records)
+            with self.assertRaisesRegex(ValueError, "prepared metadata summary"):
+                MODULE.summarize([path])
+
+    def test_rejects_consumer_sample_total_mismatch(self):
+        records = [
+            event("resolve"),
+            event("consumer"),
+            event("resolve"),
+            consumer_signature(sample_events=2),
+            summary(),
+        ]
+        with tempfile.TemporaryDirectory() as temp:
+            path = self.write(temp, records)
+            with self.assertRaisesRegex(ValueError, "sample totals"):
+                MODULE.summarize([path])
+
+    def test_rejects_impossible_unprepared_consumer_counts(self):
+        records = [
+            event("resolve"),
+            event("consumer"),
+            event("resolve"),
+            consumer_signature(),
+            summary(
+                unprepared_consumer_draws=2,
+                unprepared_consumer_references=1,
+            ),
+        ]
+        with tempfile.TemporaryDirectory() as temp:
+            path = self.write(temp, records)
+            with self.assertRaisesRegex(ValueError, "provisional references"):
+                MODULE.summarize([path])
+
+    def test_groups_pipeline_variants_by_shader_specialization(self):
+        records = [
+            event("resolve"),
+            event("consumer"),
+            event("resolve"),
+            consumer_signature(),
+            consumer_signature(
+                signature="FEDCBA9876543210",
+                prepared_pipeline_hash="4444444444444444",
+            ),
+            summary(
+                sampled_draws=2,
+                sample_references=2,
+                consumer_signature_count=2,
+                prepared_metadata_count=2,
+            ),
+        ]
+        with tempfile.TemporaryDirectory() as temp:
+            result = MODULE.summarize([self.write(temp, records)])
+        families = result["consumer_shader_families"]
+        self.assertEqual(1, len(families))
+        self.assertEqual(2, families[0]["signature_count"])
+        self.assertEqual(2, families[0]["pipeline_hash_count"])
+        self.assertEqual(1_000_000, families[0]["sample_share_ppm"])
+        self.assertFalse(families[0]["suppression_eligible"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- correlate exact retained-pass resolves with prepared downstream draws
- group 51 observed consumers into 26 stable shader-specialization families
- exclude and report provisional async-compilation skips
- keep Xenos authoritative and suppression disabled
- document the fail-closed later-GPU-consumer admission result

## Validation

- `python -m unittest discover -s tools/tests -p 'test_*.py'` (188 passed)
- `.\tools\build-preview.ps1`
- AppData-backed `open_world_day` qualification, session `20260829T044716Z-p33048`
- executable SHA-256 `C6DBC2AD3E98C68BE2DEF762C6C309DE70C9DAC2C015306B596DE1C82A450EFE`
- normal exit; no error, fatal, crash, or device-loss events
- median 30.698 FPS; 1% low 19.287 FPS

## Safety

Xenos remains authoritative. No draw or resolve suppression is enabled. The `later_gpu_consumers` gate is explicitly `fail` until native resource publication or consumer coverage exists.