### PR TITLE
test(native-renderer): observe guest cpu pass reads

### DIFF
--- a/docs/native-renderer/GUEST_CPU_VISIBILITY.md
+++ b/docs/native-renderer/GUEST_CPU_VISIBILITY.md
@@ -1,0 +1,93 @@
+# Exact pass-family guest CPU visibility
+
+NR-00D requires evidence for guest CPU reads of render-target output before a
+pass family can be considered for suppression. The retained sky/horizon family
+now has a bounded, default-off observer for that question. Xenos remains the
+only authoritative renderer and no draw, resolve, query, or guest-memory side
+effect is suppressed.
+
+## Observation boundary
+
+ReXGlue patch `0074-physical-memory-read-observer.patch` adds one-shot access
+notifications to explicitly armed physical-memory pages. A real guest CPU read
+or write faults the protected alias, reports the physical page range and access
+kind, retires that page's access watch, and restores the least-permissive
+protection still required by existing write-invalidation watches.
+
+Host-side explicit invalidations do not dispatch the access observer. The
+observer never reads or serializes guest payload bytes, and the existing write
+invalidation contract remains active independently.
+
+The title arms only successful resolve destinations produced by the exact pair:
+
+- anchor `747837906D0BF484`;
+- follower `1D253A52B55C9FB3`.
+
+The process-scoped table is limited to 64 distinct physical base addresses.
+Each entry records resolve generations, page-level read and write events, and
+the number of distinct resolve generations touched by each access kind. A CPU
+write before a read is retained as overwrite evidence, not misclassified as a
+read dependency.
+
+## Admission interpretation
+
+The summarizer emits `guest_cpu_visibility` as:
+
+- `fail` when at least one armed resolve generation is read by the guest CPU;
+- `pass` when every exact-family resolve was armed, the table did not overflow,
+  and no guest CPU read was observed in the selected qualification session;
+- `unknown` when arming or bounded coverage is incomplete.
+
+A `pass` is evidence for the selected scene and route only. It does not override
+the independent later-GPU-consumer gate, which currently fails, or authorize
+suppression by itself.
+
+## Capture workflow
+
+Use the AppData-backed census launcher with the exact pair:
+
+```powershell
+.\tools\capture-native-renderer-census.ps1 `
+  -StateRoot "$env:LOCALAPPDATA\PinyonShift\source\0.1.0\.local\preview" `
+  -Scene open_world_day `
+  -PassAnchorSignature 747837906D0BF484 `
+  -IsolatedDrawSignature 1D253A52B55C9FB3
+```
+
+After a normal exit, summarize the emitted JSONL with:
+
+```powershell
+python .\tools\summarize-native-renderer-pass-consumers.py `
+  "$stateRoot\logs\<session>.jsonl" `
+  --output .artifacts\native-renderer-pass-consumers.json
+```
+
+## Qualified open-world result
+
+The 2026-08-29 batched AppData-backed `open_world_day` run used executable
+SHA-256 `F3E8DEF38B0AF876D1AD053067E33E7C63A255BA0237562162C061E01EBA14D4`
+and session `20260829T053639Z-p40004`. The clean replacement build recorded
+all 74 ReXGlue patches. The run reached the saved festival scene, rendered for
+an additional 30-second observation window, and exited normally with no error,
+fatal, crash, exception, or device-loss event.
+
+The schema-v3 deterministic inventory reported:
+
+- 348 exact-family resolves totaling 91,226,112 bytes;
+- six rotating 262,144-byte guest physical destinations;
+- all 348 resolve generations armed, with zero target-table overflow;
+- zero guest CPU read page events and zero read generations; and
+- zero guest CPU write page events and zero write generations.
+
+This promotes `guest_cpu_visibility` to `pass` for this exact build, saved
+scene, and observation route: `0 of 348 armed resolve generations were read by
+the guest CPU`. It is not a global proof that no other scene reads the output.
+The independent `later_gpu_consumers` gate still fails, so suppression remains
+prohibited and every Xenos draw and resolve remains authoritative.
+
+The local deterministic inventory SHA-256 is
+`B58B6D100EE3BBD83B6DD4EA04CC079D2BC93211F4CABC3E6CD09CE12FDD5B80`.
+It remains local because its source field contains a machine-specific path.
+Performance telemetry from the same 153.13-second process contained 5,143
+samples with median 30.606 FPS, 18.802 FPS one-percent low, zero present
+deadline misses, and zero native GPU timing drops.

--- a/docs/native-renderer/GUEST_VISIBLE_RENDER_DEPENDENCIES.md
+++ b/docs/native-renderer/GUEST_VISIBLE_RENDER_DEPENDENCIES.md
@@ -8,8 +8,10 @@ and which unknowns block future draw or resolve suppression.
 
 No render target is suppression-eligible yet. The census can prove that a
 successful D3D12 resolve destination is sampled by a later vertex or pixel
-shader texture fetch. It does not yet prove that an unsampled target is
-presentation-only, that the guest CPU never reads it, or that it has no query,
+shader texture fetch. For the retained exact pass family, it can also prove
+that every resolve generation was armed and no guest CPU read occurred in one
+bounded qualification scene. It does not prove that an unsampled target is
+presentation-only, that another scene never reads it, or that it has no query,
 memexport, livery, thumbnail, mirror, exposure, shadow, or rewind role.
 
 Those missing facts keep Gate B closed. Xenos executes every draw and resolve,
@@ -54,7 +56,7 @@ earlier resolve.
 | --- | --- | --- |
 | Later draw samples output | Resolve byte range matched against a used vertex/pixel base or mip fetch | `true` when observed; otherwise `unobserved`, not false |
 | Final presentation only | No native presentation-source observer yet | `unknown_uninstrumented` |
-| Guest CPU reads output | No bounded shared-memory read observer yet | `unknown_uninstrumented` |
+| Guest CPU reads output | Exact-family physical pages can be armed for one-shot real guest CPU read/write observation | `observed` when read; otherwise bounded scene evidence, never a global absence claim |
 | Query depends on output | Conditional and active visibility-query state are correlated with sampling draws, but causality is not established | `related_draw_observed` or `unknown_uninstrumented` |
 | Memexport interaction | Sampling draws record whether the vertex shader has memexport | Correlation only; never proof of independence |
 | Livery / thumbnail / mirror / exposure / shadow / rewind | No pass classifier has assigned semantic roles yet | `unknown_unclassified` |
@@ -122,12 +124,18 @@ that may be inferred from the absence of a texture-fetch match.
 ## Exact-family follow-up
 
 The retained sky/horizon pair now has a family-specific resolve-to-consumer
-inventory in [PASS_CONSUMER_GRAPH.md](PASS_CONSUMER_GRAPH.md). Its qualified
-open-world run linked six rotating resolve destinations to 51 distinct prepared
-later-draw signatures across 26 shader families without overflowing the bounded
-signature table or missing prepared metadata. This proves the selected family
-is not presentation-only. Gate B remains closed because those consumers have
-not yet been replaced, and guest CPU visibility is still unknown.
+inventory in [PASS_CONSUMER_GRAPH.md](PASS_CONSUMER_GRAPH.md). The latest
+qualified open-world run linked six rotating resolve destinations to 63
+distinct prepared later-draw signatures across 38 shader families without
+overflowing the bounded signature table or missing prepared metadata. This
+proves the selected family is not presentation-only. Gate B remains closed
+because those consumers have not yet been replaced.
+
+The same session armed all 348 exact-family resolve generations and observed
+zero guest CPU reads or writes. This promotes the scene-bounded CPU visibility
+gate to `pass`; [GUEST_CPU_VISIBILITY.md](GUEST_CPU_VISIBILITY.md) records the
+full boundary and hashes. It does not convert absence in this route into a
+global claim about other scenes.
 
 NR-04D evaluates these unknowns per exact pass family with the fail-closed
 admission contract in [SUPPRESSION_ADMISSION.md](SUPPRESSION_ADMISSION.md).

--- a/docs/native-renderer/PASS_CONSUMER_GRAPH.md
+++ b/docs/native-renderer/PASS_CONSUMER_GRAPH.md
@@ -51,35 +51,35 @@ any event that does not preserve Xenos authority and prohibit suppression.
 
 ## Qualified open-world result
 
-The 2026-08-29 AppData-backed `open_world_day` run used executable SHA-256
-`C6DBC2AD3E98C68BE2DEF762C6C309DE70C9DAC2C015306B596DE1C82A450EFE` and
-session `20260829T044716Z-p33048`. It exited normally with no error, fatal,
+The latest 2026-08-29 AppData-backed `open_world_day` run used executable
+SHA-256 `F3E8DEF38B0AF876D1AD053067E33E7C63A255BA0237562162C061E01EBA14D4`
+and session `20260829T053639Z-p40004`. It exited normally with no error, fatal,
 crash, or device-loss event. The deterministic inventory reported:
 
-- 13,650 exact family occurrences.
-- 384 matching color-source resolves totaling 100,663,296 bytes.
+- 8,892 exact family occurrences.
+- 348 matching color-source resolves totaling 91,226,112 bytes.
 - Six rotating 262,144-byte guest destinations.
-- 378 resolves sampled before replacement by a later resolve.
-- 8,552 prepared resolve-to-consumer draws and texture references.
-- 51 distinct prepared consumer draw signatures grouped into 26 exact shader
+- 342 resolves sampled before replacement by a later resolve.
+- 9,229 prepared resolve-to-consumer draws and texture references.
+- 63 distinct prepared consumer draw signatures grouped into 38 exact shader
   specialization families, with zero signature overflow and zero missing
   prepared metadata.
-- 80 provisional fetch matches discarded because the backend did not reach the
+- 48 provisional fetch matches discarded because the backend did not reach the
   prepared-draw stage; these are not classified as GPU consumers.
 - Zero query-correlated and zero memexport-correlated sample events.
 - Six outputs overwritten without a sampled consumer in the observed interval.
 
 The local inventory SHA-256 is
-`2913349E4B666AD88B23F0896ADB3F644446CF08EF041319247800695587C3F6`.
+`B58B6D100EE3BBD83B6DD4EA04CC079D2BC93211F4CABC3E6CD09CE12FDD5B80`.
 It remains local because it includes a machine-specific diagnostic source path.
 
 The leading shader family used vertex shader `2E5E0A854BE00027` and pixel
-shader `BDFFA72B7ED2FBA4`; its two pipeline variants accounted for 1,220
-prepared consumer draws. This broad 26-family fan-out proves that the selected
+shader `BDFFA72B7ED2FBA4`; its two pipeline variants accounted for 1,186
+prepared consumer draws. This broad 38-family fan-out proves that the selected
 output is not a presentation-only leaf.
 
-Performance telemetry contained 5,570 samples: median 30.698 FPS, 1% low
-19.287 FPS, one present-deadline miss, and zero native GPU timing drops.
+Performance telemetry contained 5,143 samples: median 30.606 FPS, 1% low
+18.802 FPS, zero present-deadline misses, and zero native GPU timing drops.
 The diagnostic table therefore did not disturb the established 30 FPS cadence
 in this qualification.
 
@@ -89,9 +89,12 @@ The `later_gpu_consumers` admission gate is now `fail`, not `unknown`: later
 GPU consumers are positively observed and have not been replaced. This is
 useful closure of the dependency question, but it prohibits suppressing the
 producer family. The next implementation milestone must assign semantic roles
-to the 26 stable shader families and provide the native resource publication or
+to the 38 stable shader families and provide the native resource publication or
 native consumer coverage they require.
 
 Guest CPU visibility and the independent rollback switch remain separate
-unknown gates. Neither the absence of query/memexport correlation nor the
-visual parity result can substitute for those proofs.
+gates. The same session fully armed all 348 exact-family resolve generations
+and observed zero guest CPU reads or writes, promoting the scene-bounded CPU
+gate to `pass`. The bounded observer and interpretation contract are documented
+in [GUEST_CPU_VISIBILITY.md](GUEST_CPU_VISIBILITY.md); this does not weaken the
+failing later-GPU-consumer gate.

--- a/docs/native-renderer/SUPPRESSION_ADMISSION.md
+++ b/docs/native-renderer/SUPPRESSION_ADMISSION.md
@@ -43,9 +43,12 @@ The exact pair `747837906D0BF484` / `1D253A52B55C9FB3` has stable boundaries,
 complete-pass color/depth parity, continuous exact-frame output, fallback
 behavior, and native GPU timing. It is not admitted for suppression yet:
 
-- the exact-family graph positively observes 51 prepared later-GPU-consumer
-  signatures across 26 shader families that have not been replaced;
-- guest CPU visibility remains uninstrumented; and
+- the latest exact-family graph positively observes 63 prepared
+  later-GPU-consumer signatures across 38 shader families that have not been
+  replaced;
+- guest CPU visibility passes for one bounded exact-family AppData
+  qualification route, with zero reads across 348 fully armed resolve
+  generations; and
 - no independently reversible suppression switch exists.
 
 Consequently the next work is evidence collection and complete-pass comparison,
@@ -64,10 +67,16 @@ across 41,943,040 active bytes and exact two-sample depth/stencil parity across
 83,886,080 bytes. This promotes both `color_parity` and `depth_parity` to
 `pass`.
 
-The subsequent bounded consumer qualification linked 384 family resolves to
-51 distinct prepared later-draw signatures across 26 shader families, with zero
-signature overflow and complete prepared metadata. This promotes
-`later_gpu_consumers` from `unknown` to `fail`: consumers are proven present
-but are not native-replaced. The admission result remains 9/12 passing gates;
-`guest_cpu_visibility` and `rollback_switch` remain `unknown`, and suppression
-is still prohibited. See [PASS_CONSUMER_GRAPH.md](PASS_CONSUMER_GRAPH.md).
+The latest combined bounded qualification linked 348 family resolves to 63
+distinct prepared later-draw signatures across 38 shader families, with zero
+signature overflow and complete prepared metadata. This keeps
+`later_gpu_consumers` at `fail`: consumers are proven present but are not
+native-replaced.
+
+The same session armed every one of those 348 resolve generations and observed
+zero guest CPU read or write events. This promotes `guest_cpu_visibility` from
+`unknown` to scene-bounded `pass`, as documented in
+[GUEST_CPU_VISIBILITY.md](GUEST_CPU_VISIBILITY.md). The admission result is now
+10/12 passing gates, one failing gate (`later_gpu_consumers`), and one unknown
+gate (`rollback_switch`). Suppression is still prohibited. See
+[PASS_CONSUMER_GRAPH.md](PASS_CONSUMER_GRAPH.md).

--- a/patches/rexglue/0074-physical-memory-read-observer.patch
+++ b/patches/rexglue/0074-physical-memory-read-observer.patch
@@ -1,0 +1,360 @@
+diff --git a/include/rex/system/xmemory.h b/include/rex/system/xmemory.h
+index 0c39a42..83cbe9d 100644
+--- a/include/rex/system/xmemory.h
++++ b/include/rex/system/xmemory.h
+@@ -314,11 +314,13 @@ class PhysicalHeap : public BaseHeap {
+                uint32_t* old_protect = nullptr) override;
+ 
+   void EnableAccessCallbacks(uint32_t physical_address, uint32_t length,
+-                             bool enable_invalidation_notifications, bool enable_data_providers);
++                             bool enable_invalidation_notifications, bool enable_data_providers,
++                             bool enable_access_notifications = false);
+   // Returns true if any page in the range was watched.
+   bool TriggerCallbacks(std::unique_lock<std::recursive_mutex> global_lock_locked_once,
+                         uint32_t virtual_address, uint32_t length, bool is_write,
+-                        bool unwatch_exact_range, bool unprotect = true);
++                        bool unwatch_exact_range, bool unprotect = true,
++                        bool notify_access_observers = false);
+ 
+   uint32_t GetPhysicalAddress(uint32_t address) const;
+ 
+@@ -340,6 +342,8 @@ class PhysicalHeap : public BaseHeap {
+     // Whether writing to each page should result trigger invalidation
+     // callbacks.
+     uint64_t notify_on_invalidation;
++    // Whether the next real guest CPU read or write should be observed.
++    uint64_t notify_on_access;
+   };
+   // Protected by global_critical_region. Flags for each 64 system pages,
+   // interleaved as blocks, so bit scan can be used to quickly extract ranges.
+@@ -495,11 +499,22 @@ class Memory {
+   // RegisterPhysicalMemoryInvalidationCallback.
+   void UnregisterPhysicalMemoryInvalidationCallback(void* callback_handle);
+ 
++  // One-shot observation of real guest CPU accesses to explicitly armed
++  // physical pages. Unlike invalidation callbacks, this reports reads as well
++  // as writes and is not dispatched by host-side explicit invalidations.
++  typedef void (*PhysicalMemoryAccessCallback)(void* context_ptr,
++                                               uint32_t physical_address_start,
++                                               uint32_t length, bool is_write);
++  void* RegisterPhysicalMemoryAccessCallback(PhysicalMemoryAccessCallback callback,
++                                             void* callback_context);
++  void UnregisterPhysicalMemoryAccessCallback(void* callback_handle);
++
+   // Enables physical memory access callbacks for the specified memory range,
+   // snapped to system page boundaries.
+   void EnablePhysicalMemoryAccessCallbacks(uint32_t physical_address, uint32_t length,
+                                            bool enable_invalidation_notifications,
+-                                           bool enable_data_providers);
++                                           bool enable_data_providers,
++                                           bool enable_access_notifications = false);
+ 
+   // Forces triggering of watch callbacks for a virtual address range if pages
+   // are watched there and unwatching them. Returns whether any page was
+@@ -624,6 +639,8 @@ class Memory {
+   rex::thread::global_critical_region global_critical_region_;
+   std::vector<std::pair<PhysicalMemoryInvalidationCallback, void*>*>
+       physical_memory_invalidation_callbacks_;
++  std::vector<std::pair<PhysicalMemoryAccessCallback, void*>*>
++      physical_memory_access_callbacks_;
+ };
+ 
+ }  // namespace rex::memory
+diff --git a/src/system/xmemory.cpp b/src/system/xmemory.cpp
+index 76cc877..54c1278 100644
+--- a/src/system/xmemory.cpp
++++ b/src/system/xmemory.cpp
+@@ -109,6 +110,9 @@ Memory::~Memory() {
+   for (auto invalidation_callback : physical_memory_invalidation_callbacks_) {
+     delete invalidation_callback;
+   }
++  for (auto access_callback : physical_memory_access_callbacks_) {
++    delete access_callback;
++  }
+ 
+   heaps_.v00000000.Dispose();
+   heaps_.v40000000.Dispose();
+@@ -557,7 +561,8 @@ bool Memory::AccessViolationCallback(std::unique_lock<std::recursive_mutex> glob
+   // the length - guranteed not to cross page boundaries also.
+   auto physical_heap = static_cast<PhysicalHeap*>(heap);
+   if (physical_heap->TriggerCallbacks(std::move(global_lock_locked_once), virtual_address, 1,
+-                                      is_write, false)) {
++                                      is_write, false, true,
++                                      runtime::ThreadState::Get() != nullptr)) {
+     return true;
+   }
+ 
+@@ -679,15 +684,41 @@ void Memory::UnregisterPhysicalMemoryInvalidationCallback(void* callback_handle)
+   delete entry;
+ }
+ 
++void* Memory::RegisterPhysicalMemoryAccessCallback(PhysicalMemoryAccessCallback callback,
++                                                   void* callback_context) {
++  auto entry = new std::pair<PhysicalMemoryAccessCallback, void*>(callback, callback_context);
++  auto lock = global_critical_region_.Acquire();
++  physical_memory_access_callbacks_.push_back(entry);
++  return entry;
++}
++
++void Memory::UnregisterPhysicalMemoryAccessCallback(void* callback_handle) {
++  auto entry = reinterpret_cast<std::pair<PhysicalMemoryAccessCallback, void*>*>(callback_handle);
++  {
++    auto lock = global_critical_region_.Acquire();
++    auto it = std::find(physical_memory_access_callbacks_.begin(),
++                        physical_memory_access_callbacks_.end(), entry);
++    assert_true(it != physical_memory_access_callbacks_.end());
++    if (it != physical_memory_access_callbacks_.end()) {
++      physical_memory_access_callbacks_.erase(it);
++    }
++  }
++  delete entry;
++}
++
+ void Memory::EnablePhysicalMemoryAccessCallbacks(uint32_t physical_address, uint32_t length,
+                                                  bool enable_invalidation_notifications,
+-                                                 bool enable_data_providers) {
++                                                 bool enable_data_providers,
++                                                 bool enable_access_notifications) {
+   heaps_.vA0000000.EnableAccessCallbacks(physical_address, length,
+-                                         enable_invalidation_notifications, enable_data_providers);
++                                         enable_invalidation_notifications, enable_data_providers,
++                                         enable_access_notifications);
+   heaps_.vC0000000.EnableAccessCallbacks(physical_address, length,
+-                                         enable_invalidation_notifications, enable_data_providers);
++                                         enable_invalidation_notifications, enable_data_providers,
++                                         enable_access_notifications);
+   heaps_.vE0000000.EnableAccessCallbacks(physical_address, length,
+-                                         enable_invalidation_notifications, enable_data_providers);
++                                         enable_invalidation_notifications, enable_data_providers,
++                                         enable_access_notifications);
+ }
+ 
+ uint32_t Memory::SystemHeapAlloc(uint32_t size, uint32_t alignment, uint32_t system_heap_flags) {
+@@ -2064,10 +2111,12 @@ bool PhysicalHeap::Protect(uint32_t address, uint32_t size, uint32_t protect,
+ 
+ void PhysicalHeap::EnableAccessCallbacks(uint32_t physical_address, uint32_t length,
+                                          bool enable_invalidation_notifications,
+-                                         bool enable_data_providers) {
++                                         bool enable_data_providers,
++                                         bool enable_access_notifications) {
+   // TODO(Triang3l): Implement data providers.
+   assert_false(enable_data_providers);
+-  if (!enable_invalidation_notifications && !enable_data_providers) {
++  if (!enable_invalidation_notifications && !enable_data_providers &&
++      !enable_access_notifications) {
+     return;
+   }
+   uint32_t physical_address_offset = GetPhysicalAddress(heap_base_);
+@@ -2095,7 +2144,8 @@ void PhysicalHeap::EnableAccessCallbacks(uint32_t physical_address, uint32_t len
+ 
+   // Update callback flags for system pages and make their protection stricter
+   // if needed.
+-  rex::memory::PageAccess protect_access = enable_data_providers
++  rex::memory::PageAccess protect_access =
++      (enable_data_providers || enable_access_notifications)
+                                                ? rex::memory::PageAccess::kNoAccess
+                                                : rex::memory::PageAccess::kReadOnly;
+   uint8_t* protect_base = membase_ + heap_base_;
+@@ -2152,6 +2202,11 @@ void PhysicalHeap::EnableAccessCallbacks(uint32_t physical_address, uint32_t len
+           page_flags_block.notify_on_invalidation |= page_flags_bit;
+         }
+       }
++      if (enable_access_notifications &&
++          (page_flags_block.notify_on_access & page_flags_bit) == 0) {
++        protect_system_page = true;
++        page_flags_block.notify_on_access |= page_flags_bit;
++      }
+     }
+     if (protect_system_page) {
+       if (protect_system_page_first == UINT32_MAX) {
+@@ -2174,12 +2229,8 @@ void PhysicalHeap::EnableAccessCallbacks(uint32_t physical_address, uint32_t len
+ 
+ bool PhysicalHeap::TriggerCallbacks(std::unique_lock<std::recursive_mutex> global_lock_locked_once,
+                                     uint32_t virtual_address, uint32_t length, bool is_write,
+-                                    bool unwatch_exact_range, bool unprotect) {
+-  // TODO(Triang3l): Support read watches.
+-  assert_true(is_write);
+-  if (!is_write) {
+-    return false;
+-  }
++                                    bool unwatch_exact_range, bool unprotect,
++                                    bool notify_access_observers) {
+ 
+   if (virtual_address < heap_base_) {
+     if (heap_base_ - virtual_address >= length) {
+@@ -2204,21 +2255,35 @@ bool PhysicalHeap::TriggerCallbacks(std::unique_lock<std::recursive_mutex> globa
+   assert_true(system_page_first <= system_page_last);
+   uint32_t block_index_first = system_page_first >> 6;
+   uint32_t block_index_last = system_page_last >> 6;
++  const uint32_t access_system_page_first = system_page_first;
++  const uint32_t access_system_page_last = system_page_last;
+ 
+   // Check if watching any page, whether need to call the callback at all.
+   bool any_watched = false;
++  bool any_access_watched = false;
++  bool any_invalidation_watched = false;
+   for (uint32_t i = block_index_first; i <= block_index_last; ++i) {
+-    uint64_t block = system_page_flags_[i].notify_on_invalidation;
++    uint64_t access_block = notify_access_observers
++                                ? system_page_flags_[i].notify_on_access
++                                : 0;
++    uint64_t invalidation_block =
++        is_write ? system_page_flags_[i].notify_on_invalidation : 0;
++    uint64_t block = access_block | invalidation_block;
++    uint64_t range_mask = UINT64_MAX;
+     if (i == block_index_first) {
+-      block &= ~((uint64_t(1) << (system_page_first & 63)) - 1);
++      range_mask &= ~((uint64_t(1) << (system_page_first & 63)) - 1);
+     }
+     if (i == block_index_last && (system_page_last & 63) != 63) {
+-      block &= (uint64_t(1) << ((system_page_last & 63) + 1)) - 1;
++      range_mask &= (uint64_t(1) << ((system_page_last & 63) + 1)) - 1;
+     }
++    access_block &= range_mask;
++    invalidation_block &= range_mask;
++    block &= range_mask;
+     if (block) {
+       any_watched = true;
+-      break;
+     }
++    any_access_watched |= access_block != 0;
++    any_invalidation_watched |= invalidation_block != 0;
+   }
+   if (!any_watched) {
+     return false;
+@@ -2241,18 +2306,26 @@ bool PhysicalHeap::TriggerCallbacks(std::unique_lock<std::recursive_mutex> globa
+                heap_size_ - (physical_address_start - physical_address_offset));
+   uint32_t unwatch_first = 0;
+   uint32_t unwatch_last = UINT32_MAX;
+-  for (auto invalidation_callback : memory_->physical_memory_invalidation_callbacks_) {
+-    std::pair<uint32_t, uint32_t> callback_unwatch_range =
+-        invalidation_callback->first(invalidation_callback->second, physical_address_start,
+-                                     physical_length, unwatch_exact_range);
+-    if (!unwatch_exact_range) {
+-      unwatch_first = std::max(unwatch_first, callback_unwatch_range.first);
+-      unwatch_last = std::min(
+-          unwatch_last, rex::sat_add(callback_unwatch_range.first,
+-                                     std::max(callback_unwatch_range.second, uint32_t(1)) - 1));
+-    }
+-  }
+-  if (!unwatch_exact_range) {
++  if (any_access_watched) {
++    for (auto access_callback : memory_->physical_memory_access_callbacks_) {
++      access_callback->first(access_callback->second, physical_address_start, physical_length,
++                             is_write);
++    }
++  }
++  if (any_invalidation_watched) {
++    for (auto invalidation_callback : memory_->physical_memory_invalidation_callbacks_) {
++      std::pair<uint32_t, uint32_t> callback_unwatch_range =
++          invalidation_callback->first(invalidation_callback->second, physical_address_start,
++                                       physical_length, unwatch_exact_range);
++      if (!unwatch_exact_range) {
++        unwatch_first = std::max(unwatch_first, callback_unwatch_range.first);
++        unwatch_last = std::min(
++            unwatch_last, rex::sat_add(callback_unwatch_range.first,
++                                       std::max(callback_unwatch_range.second, uint32_t(1)) - 1));
++      }
++    }
++  }
++  if (any_invalidation_watched && !unwatch_exact_range) {
+     // Always unwatch at least the requested pages.
+     unwatch_first = std::min(unwatch_first, physical_address_start);
+     unwatch_last = std::max(unwatch_last, physical_address_start + physical_length - 1);
+@@ -2278,52 +2351,56 @@ bool PhysicalHeap::TriggerCallbacks(std::unique_lock<std::recursive_mutex> globa
+     block_index_last = system_page_last >> 6;
+   }
+ 
+-  // Unprotect ranges that need unprotection.
+-  if (unprotect) {
+-    uint8_t* protect_base = membase_ + heap_base_;
+-    uint32_t unprotect_system_page_first = UINT32_MAX;
+-    for (uint32_t i = system_page_first; i <= system_page_last; ++i) {
+-      // Check if need to allow writing to this page.
+-      bool unprotect_page =
+-          (system_page_flags_[i >> 6].notify_on_invalidation & (uint64_t(1) << (i & 63))) != 0;
+-      if (unprotect_page) {
+-        uint32_t guest_page_number =
+-            rex::sat_sub(i * system_page_size_, host_address_offset()) >> page_size_shift_;
+-        if (ToPageAccess(page_table_[guest_page_number].current_protect) !=
+-            rex::memory::PageAccess::kReadWrite) {
+-          unprotect_page = false;
+-        }
++  auto clear_page_flags = [&](uint32_t page_first, uint32_t page_last,
++                              bool clear_invalidation, bool clear_access) {
++    uint32_t clear_block_first = page_first >> 6;
++    uint32_t clear_block_last = page_last >> 6;
++    for (uint32_t i = clear_block_first; i <= clear_block_last; ++i) {
++      uint64_t mask = 0;
++      if (i == clear_block_first) {
++        mask |= (uint64_t(1) << (page_first & 63)) - 1;
+       }
+-      if (unprotect_page) {
+-        if (unprotect_system_page_first == UINT32_MAX) {
+-          unprotect_system_page_first = i;
+-        }
+-      } else {
+-        if (unprotect_system_page_first != UINT32_MAX) {
+-          rex::memory::Protect(protect_base + unprotect_system_page_first * system_page_size_,
+-                               (i - unprotect_system_page_first) * system_page_size_,
+-                               rex::memory::PageAccess::kReadWrite);
+-          unprotect_system_page_first = UINT32_MAX;
+-        }
++      if (i == clear_block_last && (page_last & 63) != 63) {
++        mask |= ~((uint64_t(1) << ((page_last & 63) + 1)) - 1);
++      }
++      if (clear_invalidation) {
++        system_page_flags_[i].notify_on_invalidation &= mask;
++      }
++      if (clear_access) {
++        system_page_flags_[i].notify_on_access &= mask;
+       }
+     }
+-    if (unprotect_system_page_first != UINT32_MAX) {
+-      rex::memory::Protect(protect_base + unprotect_system_page_first * system_page_size_,
+-                           (system_page_last + 1 - unprotect_system_page_first) * system_page_size_,
+-                           rex::memory::PageAccess::kReadWrite);
+-    }
++  };
++  if (any_access_watched) {
++    clear_page_flags(access_system_page_first, access_system_page_last, false, true);
++  }
++  if (any_invalidation_watched) {
++    clear_page_flags(system_page_first, system_page_last, true, false);
+   }
+ 
+-  // Mark pages as not write-watched.
+-  for (uint32_t i = block_index_first; i <= block_index_last; ++i) {
+-    uint64_t mask = 0;
+-    if (i == block_index_first) {
+-      mask |= (uint64_t(1) << (system_page_first & 63)) - 1;
+-    }
+-    if (i == block_index_last && (system_page_last & 63) != 63) {
+-      mask |= ~((uint64_t(1) << ((system_page_last & 63) + 1)) - 1);
++  // Restore the least-permissive protection still required by another watch,
++  // otherwise return to the protection requested by the guest allocation.
++  if (unprotect) {
++    uint8_t* protect_base = membase_ + heap_base_;
++    uint32_t restore_page_first =
++        std::min(access_system_page_first, system_page_first);
++    uint32_t restore_page_last =
++        std::max(access_system_page_last, system_page_last);
++    for (uint32_t i = restore_page_first; i <= restore_page_last; ++i) {
++      uint64_t page_bit = uint64_t(1) << (i & 63);
++      const SystemPageFlagsBlock& flags = system_page_flags_[i >> 6];
++      uint32_t guest_page_number =
++          rex::sat_sub(i * system_page_size_, host_address_offset()) >> page_size_shift_;
++      rex::memory::PageAccess page_access =
++          ToPageAccess(page_table_[guest_page_number].current_protect);
++      if (flags.notify_on_access & page_bit) {
++        page_access = rex::memory::PageAccess::kNoAccess;
++      } else if ((flags.notify_on_invalidation & page_bit) &&
++                 page_access == rex::memory::PageAccess::kReadWrite) {
++        page_access = rex::memory::PageAccess::kReadOnly;
++      }
++      rex::memory::Protect(protect_base + i * system_page_size_, system_page_size_, page_access);
+     }
+-    system_page_flags_[i].notify_on_invalidation &= mask;
+   }
+ 
+   return true;

--- a/src/native_renderer/graphics_hooks.cpp
+++ b/src/native_renderer/graphics_hooks.cpp
@@ -24,6 +24,7 @@
 #include <rex/memory.h>
 #include <rex/system/interfaces/graphics.h>
 #include <rex/system/kernel_state.h>
+#include <rex/system/xmemory.h>
 
 #include "native_renderer/graphics_hooks.h"
 #include "native_renderer/resource_identity.h"
@@ -46,6 +47,7 @@ constexpr size_t kResolvePageCapacity = 32768;
 constexpr size_t kResolveSummaryLimit = 32;
 constexpr size_t kPassConsumerDetailLimit = 64;
 constexpr size_t kPassConsumerSignatureCapacity = 1024;
+constexpr size_t kGuestCpuVisibilityTargetCapacity = 64;
 constexpr uint64_t kGuestPageSize = 4096;
 constexpr uint64_t kPhysicalApertureSize = UINT64_C(0x20000000);
 constexpr uint32_t kVertexIndexMask = 0x00FFFFFF;
@@ -290,6 +292,29 @@ uint64_t g_prepared_shader_pair_overflow = 0;
 uint64_t g_candidate_unprepared_draw_count = 0;
 uint64_t g_candidate_prepared_without_observation_count = 0;
 bool g_graphics_census_installed = false;
+rex::memory::Memory *g_graphics_census_memory = nullptr;
+void *g_guest_cpu_access_callback = nullptr;
+
+struct GuestCpuVisibilityTargetEntry {
+  std::atomic<uint32_t> address{};
+  std::atomic<uint32_t> length{};
+  std::atomic<uint64_t> generation{};
+  std::atomic<uint64_t> resolve_count{};
+  std::atomic<uint64_t> read_page_events{};
+  std::atomic<uint64_t> write_page_events{};
+  std::atomic<uint64_t> read_generations{};
+  std::atomic<uint64_t> write_generations{};
+  std::atomic<uint64_t> last_read_generation{};
+  std::atomic<uint64_t> last_write_generation{};
+};
+
+std::array<GuestCpuVisibilityTargetEntry,
+           kGuestCpuVisibilityTargetCapacity>
+    g_guest_cpu_visibility_targets{};
+std::atomic<size_t> g_guest_cpu_visibility_target_count{};
+std::atomic<uint64_t> g_guest_cpu_visibility_armed_resolves{};
+std::atomic<uint64_t> g_guest_cpu_visibility_armed_bytes{};
+std::atomic<uint64_t> g_guest_cpu_visibility_target_overflow{};
 
 struct PendingCandidateObservation {
   rex::system::GraphicsDrawObservation sample;
@@ -423,6 +448,101 @@ void ResetPreparedShaderPairs() {
 void ResetDependencyCensus() {
   std::memset(&g_dependency_census, 0, sizeof(g_dependency_census));
   std::memset(&g_pass_consumer_trace, 0, sizeof(g_pass_consumer_trace));
+}
+
+void ResetGuestCpuVisibility() {
+  for (auto &target : g_guest_cpu_visibility_targets) {
+    target.address.store(0, std::memory_order_relaxed);
+    target.length.store(0, std::memory_order_relaxed);
+    target.generation.store(0, std::memory_order_relaxed);
+    target.resolve_count.store(0, std::memory_order_relaxed);
+    target.read_page_events.store(0, std::memory_order_relaxed);
+    target.write_page_events.store(0, std::memory_order_relaxed);
+    target.read_generations.store(0, std::memory_order_relaxed);
+    target.write_generations.store(0, std::memory_order_relaxed);
+    target.last_read_generation.store(0, std::memory_order_relaxed);
+    target.last_write_generation.store(0, std::memory_order_relaxed);
+  }
+  g_guest_cpu_visibility_target_count.store(0, std::memory_order_relaxed);
+  g_guest_cpu_visibility_armed_resolves.store(0, std::memory_order_relaxed);
+  g_guest_cpu_visibility_armed_bytes.store(0, std::memory_order_relaxed);
+  g_guest_cpu_visibility_target_overflow.store(0,
+                                                std::memory_order_relaxed);
+}
+
+void ObserveGuestCpuAccess(void *, uint32_t physical_address, uint32_t length,
+                           bool is_write) {
+  const uint64_t access_first = physical_address;
+  const uint64_t access_last = access_first + length;
+  const size_t target_count = g_guest_cpu_visibility_target_count.load(
+      std::memory_order_acquire);
+  for (size_t i = 0; i < target_count; ++i) {
+    auto &target = g_guest_cpu_visibility_targets[i];
+    const uint64_t target_first =
+        target.address.load(std::memory_order_acquire);
+    const uint64_t target_length =
+        target.length.load(std::memory_order_acquire);
+    if (!target_length || access_first >= target_first + target_length ||
+        access_last <= target_first) {
+      continue;
+    }
+    const uint64_t generation =
+        target.generation.load(std::memory_order_acquire);
+    auto &page_events = is_write ? target.write_page_events
+                                 : target.read_page_events;
+    auto &generations = is_write ? target.write_generations
+                                 : target.read_generations;
+    auto &last_generation = is_write ? target.last_write_generation
+                                     : target.last_read_generation;
+    page_events.fetch_add(1, std::memory_order_relaxed);
+    uint64_t previous = last_generation.load(std::memory_order_relaxed);
+    while (previous != generation &&
+           !last_generation.compare_exchange_weak(
+               previous, generation, std::memory_order_relaxed,
+               std::memory_order_relaxed)) {
+    }
+    if (previous != generation) {
+      generations.fetch_add(1, std::memory_order_relaxed);
+    }
+  }
+}
+
+void ArmGuestCpuVisibility(uint32_t address, uint32_t length) {
+  if (!g_graphics_census_memory || !g_guest_cpu_access_callback || !length) {
+    return;
+  }
+  size_t target_count = g_guest_cpu_visibility_target_count.load(
+      std::memory_order_relaxed);
+  GuestCpuVisibilityTargetEntry *target = nullptr;
+  for (size_t i = 0; i < target_count; ++i) {
+    if (g_guest_cpu_visibility_targets[i].address.load(
+            std::memory_order_relaxed) == address) {
+      target = &g_guest_cpu_visibility_targets[i];
+      break;
+    }
+  }
+  if (!target) {
+    if (target_count == kGuestCpuVisibilityTargetCapacity) {
+      g_guest_cpu_visibility_target_overflow.fetch_add(
+          1, std::memory_order_relaxed);
+      return;
+    }
+    target = &g_guest_cpu_visibility_targets[target_count];
+    target->address.store(address, std::memory_order_relaxed);
+    g_guest_cpu_visibility_target_count.store(target_count + 1,
+                                               std::memory_order_release);
+  }
+  const uint64_t generation =
+      g_guest_cpu_visibility_armed_resolves.fetch_add(
+          1, std::memory_order_relaxed) +
+      1;
+  g_guest_cpu_visibility_armed_bytes.fetch_add(length,
+                                                std::memory_order_relaxed);
+  target->length.store(length, std::memory_order_relaxed);
+  target->generation.store(generation, std::memory_order_release);
+  target->resolve_count.fetch_add(1, std::memory_order_relaxed);
+  g_graphics_census_memory->EnablePhysicalMemoryAccessCallbacks(
+      address, length, false, false, true);
 }
 
 uint64_t HashCombine(uint64_t hash, uint64_t value) {
@@ -2931,6 +3051,8 @@ void ObserveCopy(const rex::system::GraphicsCopyObservation &observation) {
     target.family_sample_reference_count = 0;
     ++g_pass_consumer_trace.family_resolves;
     g_pass_consumer_trace.family_resolve_bytes += observation.written_length;
+    ArmGuestCpuVisibility(observation.written_address,
+                          observation.written_length);
     if (ShouldEmitPassConsumerDetail()) {
       pinyon_shift::diagnostics::RecordEvent(
           "native_renderer.census.pass_family_resolve",
@@ -3170,18 +3292,28 @@ void ObserveDraw(const rex::system::GraphicsDrawObservation &observation) {
 
 namespace pinyon_shift::native_renderer {
 
-void InstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system) {
-  if (!graphics_system || !REXCVAR_GET(pinyon_shift_native_renderer_census)) {
+void InstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system,
+                           rex::memory::Memory *memory) {
+  if (!graphics_system || !memory ||
+      !REXCVAR_GET(pinyon_shift_native_renderer_census)) {
     return;
   }
   ResetDrawCensus();
   ResetPreparedShaderPairs();
   ResetDependencyCensus();
+  ResetGuestCpuVisibility();
   ConfigureIndexScan();
   ConfigureTextureScan();
   ConfigureReplaySnapshot();
   ConfigureIsolatedDraw();
   ConfigurePassFollower();
+  g_graphics_census_memory = memory;
+  if (g_pass_follower.requested && g_pass_follower.valid &&
+      g_isolated_draw.requested && g_isolated_draw.valid) {
+    g_guest_cpu_access_callback =
+        memory->RegisterPhysicalMemoryAccessCallback(&ObserveGuestCpuAccess,
+                                                     nullptr);
+  }
   g_graphics_census_installed = true;
   graphics_system->SetDrawObserver(&ObserveDraw);
   graphics_system->SetCopyObserver(&ObserveCopy);
@@ -3196,6 +3328,7 @@ void InstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system) {
                             {"resolve_page_capacity", "32768"},
                             {"resolve_summary_limit", "32"},
                             {"prepared_shader_pair_capacity", "1024"},
+                            {"guest_cpu_visibility_target_capacity", "64"},
                             {"scene", scene},
                             {"mode", "pass_through"}});
   diagnostics::RecordEvent("native_renderer.census.scene_marker",
@@ -3285,6 +3418,15 @@ void InstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system) {
        {"xenos_draw", "preserved"},
        {"output_authority", "xenos"},
        {"suppression_eligible", "false"}});
+  diagnostics::RecordEvent(
+      "native_renderer.census.guest_cpu_visibility_config",
+      {{"status", g_guest_cpu_access_callback ? "armed" : "disabled"},
+       {"scope", "exact_retained_pass_resolves"},
+       {"observation", "one_shot_guest_page_access"},
+       {"target_capacity",
+        std::to_string(kGuestCpuVisibilityTargetCapacity)},
+       {"xenos_draw", "preserved"},
+       {"suppression_eligible", "false"}});
 }
 
 void UninstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system) {
@@ -3296,6 +3438,13 @@ void UninstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system) {
   }
   if (!g_graphics_census_installed) {
     return;
+  }
+  const bool guest_cpu_observer_installed =
+      g_guest_cpu_access_callback != nullptr;
+  if (g_guest_cpu_access_callback && g_graphics_census_memory) {
+    g_graphics_census_memory->UnregisterPhysicalMemoryAccessCallback(
+        g_guest_cpu_access_callback);
+    g_guest_cpu_access_callback = nullptr;
   }
   if (g_isolated_draw.artifact_writer.joinable()) {
     g_isolated_draw.artifact_writer.join();
@@ -3326,6 +3475,84 @@ void UninstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system) {
   }
   if (g_pass_follower.requested && g_pass_follower.valid &&
       g_isolated_draw.requested && g_isolated_draw.valid) {
+    uint64_t guest_cpu_read_page_events = 0;
+    uint64_t guest_cpu_write_page_events = 0;
+    uint64_t guest_cpu_read_generations = 0;
+    uint64_t guest_cpu_write_generations = 0;
+    const size_t guest_cpu_target_count =
+        g_guest_cpu_visibility_target_count.load(std::memory_order_acquire);
+    for (size_t i = 0; i < guest_cpu_target_count; ++i) {
+      const auto &target = g_guest_cpu_visibility_targets[i];
+      const uint64_t read_page_events =
+          target.read_page_events.load(std::memory_order_relaxed);
+      const uint64_t write_page_events =
+          target.write_page_events.load(std::memory_order_relaxed);
+      const uint64_t read_generations =
+          target.read_generations.load(std::memory_order_relaxed);
+      const uint64_t write_generations =
+          target.write_generations.load(std::memory_order_relaxed);
+      guest_cpu_read_page_events += read_page_events;
+      guest_cpu_write_page_events += write_page_events;
+      guest_cpu_read_generations += read_generations;
+      guest_cpu_write_generations += write_generations;
+      diagnostics::RecordEvent(
+          "native_renderer.census.pass_family_guest_cpu_target",
+          {{"anchor_signature",
+            fmt::format("{:016X}", g_pass_follower.target_signature)},
+           {"follower_signature",
+            fmt::format("{:016X}", g_isolated_draw.target_signature)},
+           {"address", fmt::format(
+                           "{:08X}", target.address.load(
+                                             std::memory_order_relaxed))},
+           {"latest_length", std::to_string(target.length.load(
+                                 std::memory_order_relaxed))},
+           {"resolve_count", std::to_string(target.resolve_count.load(
+                                std::memory_order_relaxed))},
+           {"read_page_events", std::to_string(read_page_events)},
+           {"write_page_events", std::to_string(write_page_events)},
+           {"read_generations", std::to_string(read_generations)},
+           {"write_generations", std::to_string(write_generations)},
+           {"guest_cpu_read", read_generations ? "observed" : "unobserved"},
+           {"xenos_draw", "preserved"},
+           {"suppression_eligible", "false"}});
+    }
+    const uint64_t armed_resolves =
+        g_guest_cpu_visibility_armed_resolves.load(std::memory_order_relaxed);
+    const uint64_t target_overflow =
+        g_guest_cpu_visibility_target_overflow.load(std::memory_order_relaxed);
+    const bool guest_cpu_observation_complete =
+        guest_cpu_observer_installed && armed_resolves && !target_overflow &&
+        armed_resolves == g_pass_consumer_trace.family_resolves;
+    diagnostics::RecordEvent(
+        "native_renderer.census.pass_family_guest_cpu_summary",
+        {{"anchor_signature",
+          fmt::format("{:016X}", g_pass_follower.target_signature)},
+         {"follower_signature",
+          fmt::format("{:016X}", g_isolated_draw.target_signature)},
+         {"armed_resolves", std::to_string(armed_resolves)},
+         {"armed_bytes",
+          std::to_string(g_guest_cpu_visibility_armed_bytes.load(
+              std::memory_order_relaxed))},
+         {"target_count", std::to_string(guest_cpu_target_count)},
+         {"target_overflow", std::to_string(target_overflow)},
+         {"read_page_events", std::to_string(guest_cpu_read_page_events)},
+         {"write_page_events", std::to_string(guest_cpu_write_page_events)},
+         {"read_generations", std::to_string(guest_cpu_read_generations)},
+         {"write_generations", std::to_string(guest_cpu_write_generations)},
+         {"observation_complete",
+          guest_cpu_observation_complete ? "true" : "false"},
+         {"guest_cpu_visibility",
+          !guest_cpu_observation_complete
+              ? "unknown"
+              : (guest_cpu_read_generations ? "fail" : "pass")},
+         {"classification",
+          !guest_cpu_observation_complete
+              ? "incomplete_guest_cpu_observation"
+              : (guest_cpu_read_generations
+                     ? "guest_cpu_read_observed"
+                     : "bounded_no_guest_cpu_read_observed")},
+         {"xenos_draw", "preserved"},
+         {"suppression_eligible", "false"}});
     uint64_t prepared_metadata_count = 0;
     for (size_t i = 0; i < g_pass_consumer_trace.consumer_signature_count; ++i) {
       const PassConsumerSignatureEntry &entry =
@@ -3457,6 +3684,7 @@ void UninstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system) {
          {"suppression_eligible", "false"}});
   }
   g_graphics_census_installed = false;
+  g_graphics_census_memory = nullptr;
   if (g_draw_census.window_first_frame && g_draw_census.window_draw_count) {
     EmitDrawCensusWindow(g_draw_census.window_last_frame);
   }

--- a/src/native_renderer/graphics_hooks.h
+++ b/src/native_renderer/graphics_hooks.h
@@ -3,10 +3,14 @@
 namespace rex::system {
 class IGraphicsSystem;
 }
+namespace rex::memory {
+class Memory;
+}
 
 namespace pinyon_shift::native_renderer {
 
-void InstallGraphicsCensus(rex::system::IGraphicsSystem* graphics_system);
+void InstallGraphicsCensus(rex::system::IGraphicsSystem* graphics_system,
+                           rex::memory::Memory* memory);
 void UninstallGraphicsCensus(rex::system::IGraphicsSystem* graphics_system);
 
 }  // namespace pinyon_shift::native_renderer

--- a/src/pinyon_shift_app.cpp
+++ b/src/pinyon_shift_app.cpp
@@ -350,7 +350,8 @@ void PinyonShiftApp::OnPostSetup() {
   pinyon_shift::native_renderer::InstallGuestOutputRenderer(
       runtime() ? runtime()->graphics_system() : nullptr);
   pinyon_shift::native_renderer::InstallGraphicsCensus(
-      runtime() ? runtime()->graphics_system() : nullptr);
+      runtime() ? runtime()->graphics_system() : nullptr,
+      runtime() ? runtime()->memory() : nullptr);
   pinyon_shift::native_renderer::InstallTextureResourceBridge(
       runtime() ? runtime()->graphics_system() : nullptr);
   pinyon_shift::native_renderer::InstallShaderCapture(

--- a/tools/summarize-native-renderer-pass-consumers.py
+++ b/tools/summarize-native-renderer-pass-consumers.py
@@ -9,12 +9,14 @@ from pathlib import Path
 from typing import Any, Iterable
 
 
-SCHEMA = "pinyon-shift.native-renderer-pass-consumer-inventory.v2"
+SCHEMA = "pinyon-shift.native-renderer-pass-consumer-inventory.v3"
 PREFIX = "native_renderer.census.pass_family_"
 SUMMARY_EVENT = f"{PREFIX}consumer_summary"
 RESOLVE_EVENT = f"{PREFIX}resolve"
 CONSUMER_EVENT = f"{PREFIX}consumer"
 CONSUMER_SIGNATURE_EVENT = f"{PREFIX}consumer_signature"
+GUEST_CPU_SUMMARY_EVENT = f"{PREFIX}guest_cpu_summary"
+GUEST_CPU_TARGET_EVENT = f"{PREFIX}guest_cpu_target"
 SAFETY_FIELDS = {
     "xenos_draw": "preserved",
     "suppression_eligible": "false",
@@ -237,8 +239,22 @@ def summarize(
     consumer_signatures = [
         event for event in related if event.get("event") == CONSUMER_SIGNATURE_EVENT
     ]
-    for event in resolves + consumers + consumer_signatures:
+    guest_cpu_summaries = [
+        event for event in related if event.get("event") == GUEST_CPU_SUMMARY_EVENT
+    ]
+    guest_cpu_targets = [
+        event for event in related if event.get("event") == GUEST_CPU_TARGET_EVENT
+    ]
+    for event in (
+        resolves
+        + consumers
+        + consumer_signatures
+        + guest_cpu_summaries
+        + guest_cpu_targets
+    ):
         require_safety(event)
+    if len(guest_cpu_summaries) != 1:
+        raise ValueError("exactly one guest CPU visibility summary is required")
 
     counts: dict[str, int] = {}
     for field in COUNT_FIELDS:
@@ -332,6 +348,73 @@ def summarize(
             ),
         }
 
+    guest_cpu_summary = guest_cpu_summaries[0]
+    guest_cpu_count_fields = (
+        "armed_resolves",
+        "armed_bytes",
+        "target_count",
+        "target_overflow",
+        "read_page_events",
+        "write_page_events",
+        "read_generations",
+        "write_generations",
+    )
+    guest_cpu_counts: dict[str, int] = {}
+    for field in guest_cpu_count_fields:
+        try:
+            guest_cpu_counts[field] = int(guest_cpu_summary[field])
+        except (KeyError, TypeError, ValueError) as error:
+            raise ValueError(f"guest CPU summary has invalid {field}") from error
+        if guest_cpu_counts[field] < 0:
+            raise ValueError(f"guest CPU summary has negative {field}")
+    if guest_cpu_counts["target_count"] != len(guest_cpu_targets):
+        raise ValueError("guest CPU target count does not match target records")
+    target_count_totals = {
+        field: sum(int(target[field]) for target in guest_cpu_targets)
+        for field in (
+            "resolve_count",
+            "read_page_events",
+            "write_page_events",
+            "read_generations",
+            "write_generations",
+        )
+    }
+    if target_count_totals["resolve_count"] != guest_cpu_counts["armed_resolves"]:
+        raise ValueError("guest CPU target resolves contradict armed resolves")
+    for field in (
+        "read_page_events",
+        "write_page_events",
+        "read_generations",
+        "write_generations",
+    ):
+        if target_count_totals[field] != guest_cpu_counts[field]:
+            raise ValueError(f"guest CPU target {field} contradicts summary")
+    expected_guest_cpu_complete = (
+        guest_cpu_counts["armed_resolves"] > 0
+        and guest_cpu_counts["armed_resolves"] == counts["family_resolves"]
+        and guest_cpu_counts["target_overflow"] == 0
+    )
+    if (guest_cpu_summary.get("observation_complete") == "true") != (
+        expected_guest_cpu_complete
+    ):
+        raise ValueError("guest CPU observation completeness contradicts counts")
+    expected_guest_cpu_gate = (
+        "unknown"
+        if not expected_guest_cpu_complete
+        else ("fail" if guest_cpu_counts["read_generations"] else "pass")
+    )
+    if guest_cpu_summary.get("guest_cpu_visibility") != expected_guest_cpu_gate:
+        raise ValueError("guest CPU visibility classification contradicts counts")
+    guest_cpu_gate = {
+        "status": expected_guest_cpu_gate,
+        "evidence": (
+            f"{guest_cpu_counts['read_generations']} of "
+            f"{guest_cpu_counts['armed_resolves']} armed resolve generations "
+            "were read by the guest CPU"
+            if expected_guest_cpu_complete
+            else "the bounded exact-family guest CPU observation is incomplete"
+        ),
+    }
     lineage_complete = (
         counts["family_occurrences"] > 0
         and counts["family_resolves"] > 0
@@ -361,6 +444,15 @@ def summarize(
             )
         ],
         "consumer_shader_families": shader_families,
+        "guest_cpu_visibility": {
+            "counts": guest_cpu_counts,
+            "targets": [
+                clean(event)
+                for event in sorted(
+                    guest_cpu_targets, key=lambda event: str(event["address"])
+                )
+            ],
+        },
         "classification_counts": {
             "classified_signatures": counts["prepared_metadata_count"],
             "unclassified_signatures": counts["prepared_metadata_missing"],
@@ -374,7 +466,10 @@ def summarize(
             if counts["sampled_draws"]
             else "no consumer was observed; absence is not proof of independence"
         ),
-        "admission": {"later_gpu_consumers": later_gpu_consumer_gate},
+        "admission": {
+            "later_gpu_consumers": later_gpu_consumer_gate,
+            "guest_cpu_visibility": guest_cpu_gate,
+        },
         "safety": {
             "xenos_authority": True,
             "suppression_allowed": False,

--- a/tools/tests/test_native_renderer_contract.py
+++ b/tools/tests/test_native_renderer_contract.py
@@ -108,6 +108,33 @@ class NativeRendererContractTests(unittest.TestCase):
         self.assertIn('"retained_unknown"', summarizer)
         self.assertIn('"retained_on_xenos"', summarizer)
 
+    def test_exact_pass_guest_cpu_visibility_is_bounded_and_passive(self):
+        source = (ROOT / "src/native_renderer/graphics_hooks.cpp").read_text(
+            encoding="utf-8"
+        )
+        patch = (
+            ROOT / "patches/rexglue/0074-physical-memory-read-observer.patch"
+        ).read_text(encoding="utf-8")
+        summarizer = (
+            ROOT / "tools/summarize-native-renderer-pass-consumers.py"
+        ).read_text(encoding="utf-8")
+
+        self.assertIn("kGuestCpuVisibilityTargetCapacity = 64", source)
+        self.assertIn("RegisterPhysicalMemoryAccessCallback", source)
+        self.assertIn("EnablePhysicalMemoryAccessCallbacks", source)
+        self.assertIn('"native_renderer.census.pass_family_guest_cpu_summary"', source)
+        self.assertIn('"native_renderer.census.pass_family_guest_cpu_target"', source)
+        self.assertIn('{"xenos_draw", "preserved"}', source)
+        self.assertIn('{"suppression_eligible", "false"}', source)
+        self.assertIn("PhysicalMemoryAccessCallback", patch)
+        self.assertIn("notify_on_access", patch)
+        self.assertIn("notify_access_observers", patch)
+        self.assertIn("runtime::ThreadState::Get() != nullptr", patch)
+        self.assertIn("One-shot", patch)
+        self.assertNotIn("SetDrawSuppression", patch)
+        self.assertIn('"guest_cpu_visibility": guest_cpu_gate', summarizer)
+        self.assertIn('"suppression_allowed": False', summarizer)
+
     def test_resolve_dependency_observer_is_passive_and_payload_free(self):
         patch = (
             ROOT

--- a/tools/tests/test_native_renderer_pass_consumers.py
+++ b/tools/tests/test_native_renderer_pass_consumers.py
@@ -76,8 +76,54 @@ def consumer_signature(signature="0123456789ABCDEF", sample_events=1, **fields):
     return event("consumer_signature", **values)
 
 
+def guest_cpu_target(**overrides):
+    values = {
+        "address": "00100000",
+        "latest_length": 4096,
+        "resolve_count": 2,
+        "read_page_events": 0,
+        "write_page_events": 0,
+        "read_generations": 0,
+        "write_generations": 0,
+        "guest_cpu_read": "unobserved",
+    }
+    values.update(overrides)
+    return event("guest_cpu_target", **values)
+
+
+def guest_cpu_summary(**overrides):
+    values = {
+        "armed_resolves": 2,
+        "armed_bytes": 8192,
+        "target_count": 1,
+        "target_overflow": 0,
+        "read_page_events": 0,
+        "write_page_events": 0,
+        "read_generations": 0,
+        "write_generations": 0,
+        "observation_complete": "true",
+        "guest_cpu_visibility": "pass",
+        "classification": "bounded_no_guest_cpu_read_observed",
+    }
+    values.update(overrides)
+    return event("guest_cpu_summary", **values)
+
+
 class PassConsumerSummaryTests(unittest.TestCase):
-    def write(self, root, records):
+    def write(self, root, records, add_cpu=True):
+        records = list(records)
+        has_consumer_summary = any(
+            record.get("event")
+            == "native_renderer.census.pass_family_consumer_summary"
+            for record in records
+        )
+        has_cpu_summary = any(
+            record.get("event")
+            == "native_renderer.census.pass_family_guest_cpu_summary"
+            for record in records
+        )
+        if add_cpu and has_consumer_summary and not has_cpu_summary:
+            records.extend([guest_cpu_target(), guest_cpu_summary()])
         path = Path(root) / "diagnostics.jsonl"
         path.write_text(
             "".join(json.dumps(record) + "\n" for record in records),
@@ -114,6 +160,10 @@ class PassConsumerSummaryTests(unittest.TestCase):
         self.assertEqual(
             "fail", result["admission"]["later_gpu_consumers"]["status"]
         )
+        self.assertEqual(
+            "pass", result["admission"]["guest_cpu_visibility"]["status"]
+        )
+        self.assertEqual(2, result["guest_cpu_visibility"]["counts"]["armed_resolves"])
 
     def test_unobserved_consumers_remain_fail_closed(self):
         record = summary(
@@ -141,6 +191,37 @@ class PassConsumerSummaryTests(unittest.TestCase):
             path = self.write(temp, [event("resolve")])
             with self.assertRaisesRegex(ValueError, "no matching completed"):
                 MODULE.summarize([path])
+
+    def test_rejects_missing_guest_cpu_summary(self):
+        with tempfile.TemporaryDirectory() as temp:
+            path = self.write(temp, [summary()], add_cpu=False)
+            with self.assertRaisesRegex(ValueError, "guest CPU visibility summary"):
+                MODULE.summarize([path])
+
+    def test_guest_cpu_read_closes_gate_as_failure(self):
+        records = [
+            event("resolve"),
+            event("consumer"),
+            event("resolve"),
+            consumer_signature(),
+            guest_cpu_target(
+                read_page_events=1,
+                read_generations=1,
+                guest_cpu_read="observed",
+            ),
+            guest_cpu_summary(
+                read_page_events=1,
+                read_generations=1,
+                guest_cpu_visibility="fail",
+                classification="guest_cpu_read_observed",
+            ),
+            summary(),
+        ]
+        with tempfile.TemporaryDirectory() as temp:
+            result = MODULE.summarize([self.write(temp, records)])
+        self.assertEqual(
+            "fail", result["admission"]["guest_cpu_visibility"]["status"]
+        )
 
     def test_rejects_unsafe_event(self):
         unsafe = summary(suppression_eligible="true")

--- a/tools/tests/test_release_contract.py
+++ b/tools/tests/test_release_contract.py
@@ -43,10 +43,10 @@ class ReleaseContractTests(unittest.TestCase):
 
     def test_rexglue_patches_have_stable_order_and_no_binary_payload(self):
         patches = sorted((ROOT / "patches/rexglue").glob("*.patch"))
-        self.assertEqual(len(patches), 73)
+        self.assertEqual(len(patches), 74)
         self.assertEqual(
             patches[-1].name,
-            "0073-d3d12-msaa-depth-readback.patch",
+            "0074-physical-memory-read-observer.patch",
         )
         self.assertEqual(len(patches), len({path.name[:4] for path in patches}))
         for path in patches:


### PR DESCRIPTION
## Summary
- add one-shot ReXGlue physical-memory access watches for exact retained-pass resolve destinations
- correlate guest CPU read/write generations without reading or serializing guest payload bytes
- promote guest CPU visibility to a schema-v3 fail-closed admission gate and record the qualified AppData evidence
- preserve Xenos authority and keep suppression disabled

## Qualification
- full repository suite: 191 tests passed
- focused renderer/release contracts: 54 tests passed
- clean preview build with 74 ReXGlue patches
- AppData open-world session 20260829T053639Z-p40004: normal exit, no error/fatal/crash/device-loss events
- 348/348 resolve generations armed; 0 guest CPU read or write generations
- 63 later GPU consumer signatures remain, so suppression stays blocked
- median 30.606 FPS across 5,143 samples