### PR TITLE
feat(native-renderer): classify consumer family drift

### DIFF
--- a/config/native-renderer/consumer-family-classifier.json
+++ b/config/native-renderer/consumer-family-classifier.json
@@ -1,0 +1,281 @@
+{
+  "schema": "pinyon-shift.native-renderer-consumer-family-classifier.v1",
+  "producer_family": {
+    "anchor_signature": "747837906D0BF484",
+    "follower_signature": "1D253A52B55C9FB3"
+  },
+  "qualification": {
+    "scene": "open_world_day",
+    "session": "20260829T053639Z-p40004",
+    "inventory_sha256": "B58B6D100EE3BBD83B6DD4EA04CC079D2BC93211F4CABC3E6CD09CE12FDD5B80"
+  },
+  "maximum_drift_records": 64,
+  "rules": [
+    {
+      "shader_family_id": "2E5E0A854BE00027/BDFFA72B7ED2FBA4/000000000000003F/000000000016003F",
+      "semantic_role": "retained_unknown",
+      "confidence": "identity_only",
+      "evidence": "exact shader family observed in qualified open-world session 20260829T053639Z-p40004 at activity rank 1",
+      "native_coverage": false
+    },
+    {
+      "shader_family_id": "D34A83D9E6B3A399/E9CD565D9C61D037/000000000000003F/000000000016003F",
+      "semantic_role": "retained_unknown",
+      "confidence": "identity_only",
+      "evidence": "exact shader family observed in qualified open-world session 20260829T053639Z-p40004 at activity rank 2",
+      "native_coverage": false
+    },
+    {
+      "shader_family_id": "8DA8034341014FE7/E292B4109D327206/000000000000003F/000000000016003F",
+      "semantic_role": "retained_unknown",
+      "confidence": "identity_only",
+      "evidence": "exact shader family observed in qualified open-world session 20260829T053639Z-p40004 at activity rank 3",
+      "native_coverage": false
+    },
+    {
+      "shader_family_id": "A08FA79F323EEC31/CD83FD3F10989AE4/000000000000003F/000000000016003F",
+      "semantic_role": "retained_unknown",
+      "confidence": "identity_only",
+      "evidence": "exact shader family observed in qualified open-world session 20260829T053639Z-p40004 at activity rank 4",
+      "native_coverage": false
+    },
+    {
+      "shader_family_id": "C34795A841E7DEFF/21B70A5E4C9CFD11/000000000000003F/000000000016003F",
+      "semantic_role": "retained_unknown",
+      "confidence": "identity_only",
+      "evidence": "exact shader family observed in qualified open-world session 20260829T053639Z-p40004 at activity rank 5",
+      "native_coverage": false
+    },
+    {
+      "shader_family_id": "FAEE9034403E7696/40524ECE99AA3018/000000000000003F/000000000016003F",
+      "semantic_role": "retained_unknown",
+      "confidence": "identity_only",
+      "evidence": "exact shader family observed in qualified open-world session 20260829T053639Z-p40004 at activity rank 6",
+      "native_coverage": false
+    },
+    {
+      "shader_family_id": "2C24725629DBE122/1704F16A395F27AE/000000000000003F/000000000016003F",
+      "semantic_role": "retained_unknown",
+      "confidence": "identity_only",
+      "evidence": "exact shader family observed in qualified open-world session 20260829T053639Z-p40004 at activity rank 7",
+      "native_coverage": false
+    },
+    {
+      "shader_family_id": "FE11D9B18886DE97/6D990AE660186BBD/000000000000003F/000000000016003F",
+      "semantic_role": "retained_unknown",
+      "confidence": "identity_only",
+      "evidence": "exact shader family observed in qualified open-world session 20260829T053639Z-p40004 at activity rank 8",
+      "native_coverage": false
+    },
+    {
+      "shader_family_id": "2C53E1A563484076/21937679208E59A5/0000000000000001/0000400000000001",
+      "semantic_role": "retained_unknown",
+      "confidence": "identity_only",
+      "evidence": "exact shader family observed in qualified open-world session 20260829T053639Z-p40004 at activity rank 9",
+      "native_coverage": false
+    },
+    {
+      "shader_family_id": "1A7B4317D178A09D/7C7DBB6416315028/000000000000003F/000000000016003F",
+      "semantic_role": "retained_unknown",
+      "confidence": "identity_only",
+      "evidence": "exact shader family observed in qualified open-world session 20260829T053639Z-p40004 at activity rank 10",
+      "native_coverage": false
+    },
+    {
+      "shader_family_id": "DD93E28E162C04CA/DBD6CD1103FB255B/000000000000003F/000000000016003F",
+      "semantic_role": "retained_unknown",
+      "confidence": "identity_only",
+      "evidence": "exact shader family observed in qualified open-world session 20260829T053639Z-p40004 at activity rank 11",
+      "native_coverage": false
+    },
+    {
+      "shader_family_id": "072FFD70C61DE537/C5DA08AD2DE8B1F7/000000000000003F/000000000016003F",
+      "semantic_role": "retained_unknown",
+      "confidence": "identity_only",
+      "evidence": "exact shader family observed in qualified open-world session 20260829T053639Z-p40004 at activity rank 12",
+      "native_coverage": false
+    },
+    {
+      "shader_family_id": "356B59E653B0002A/D73B76038325E57A/000000000000003F/000000000016003F",
+      "semantic_role": "retained_unknown",
+      "confidence": "identity_only",
+      "evidence": "exact shader family observed in qualified open-world session 20260829T053639Z-p40004 at activity rank 13",
+      "native_coverage": false
+    },
+    {
+      "shader_family_id": "CE0FFEB0986E9971/1D38BA65C9D3C506/000000000000003F/000000000016003F",
+      "semantic_role": "retained_unknown",
+      "confidence": "identity_only",
+      "evidence": "exact shader family observed in qualified open-world session 20260829T053639Z-p40004 at activity rank 14",
+      "native_coverage": false
+    },
+    {
+      "shader_family_id": "D9D9962121E154B4/507643B27AFCACC4/000000000000003F/000000000016003F",
+      "semantic_role": "retained_unknown",
+      "confidence": "identity_only",
+      "evidence": "exact shader family observed in qualified open-world session 20260829T053639Z-p40004 at activity rank 15",
+      "native_coverage": false
+    },
+    {
+      "shader_family_id": "E84208AF54F9464E/388107518063483F/000000000000003F/000000000016003F",
+      "semantic_role": "retained_unknown",
+      "confidence": "identity_only",
+      "evidence": "exact shader family observed in qualified open-world session 20260829T053639Z-p40004 at activity rank 16",
+      "native_coverage": false
+    },
+    {
+      "shader_family_id": "0F6061F29F212B03/D895EFE654D43C08/000000000000003F/000000000016003F",
+      "semantic_role": "retained_unknown",
+      "confidence": "identity_only",
+      "evidence": "exact shader family observed in qualified open-world session 20260829T053639Z-p40004 at activity rank 17",
+      "native_coverage": false
+    },
+    {
+      "shader_family_id": "2951F2FBFDF5908F/5A99B359F506955C/000000000000003F/000000000016003F",
+      "semantic_role": "retained_unknown",
+      "confidence": "identity_only",
+      "evidence": "exact shader family observed in qualified open-world session 20260829T053639Z-p40004 at activity rank 18",
+      "native_coverage": false
+    },
+    {
+      "shader_family_id": "F9E04B937F210086/0518687FE751EB60/000000000000003F/000000000016003F",
+      "semantic_role": "retained_unknown",
+      "confidence": "identity_only",
+      "evidence": "exact shader family observed in qualified open-world session 20260829T053639Z-p40004 at activity rank 19",
+      "native_coverage": false
+    },
+    {
+      "shader_family_id": "5E6CEC1D38E67E79/273782D17D7A1A7E/000000000000003F/000000000016003F",
+      "semantic_role": "retained_unknown",
+      "confidence": "identity_only",
+      "evidence": "exact shader family observed in qualified open-world session 20260829T053639Z-p40004 at activity rank 20",
+      "native_coverage": false
+    },
+    {
+      "shader_family_id": "972F0220C6D5A9A2/129FCB5D371AE0FC/000000000000003F/000000000016003F",
+      "semantic_role": "retained_unknown",
+      "confidence": "identity_only",
+      "evidence": "exact shader family observed in qualified open-world session 20260829T053639Z-p40004 at activity rank 21",
+      "native_coverage": false
+    },
+    {
+      "shader_family_id": "1E7DAED6AA662849/059B86B12B584964/000000000000003F/000000000016003F",
+      "semantic_role": "retained_unknown",
+      "confidence": "identity_only",
+      "evidence": "exact shader family observed in qualified open-world session 20260829T053639Z-p40004 at activity rank 22",
+      "native_coverage": false
+    },
+    {
+      "shader_family_id": "793C8A91B885887F/31E9104FE3E14962/000000000000003F/000000000016003F",
+      "semantic_role": "retained_unknown",
+      "confidence": "identity_only",
+      "evidence": "exact shader family observed in qualified open-world session 20260829T053639Z-p40004 at activity rank 23",
+      "native_coverage": false
+    },
+    {
+      "shader_family_id": "55E497FC06D749B4/7A218408334F7E65/000000000000003F/000000000016003F",
+      "semantic_role": "retained_unknown",
+      "confidence": "identity_only",
+      "evidence": "exact shader family observed in qualified open-world session 20260829T053639Z-p40004 at activity rank 24",
+      "native_coverage": false
+    },
+    {
+      "shader_family_id": "BEE5D547E7838588/3958402C930D588E/000000000000003F/000000000016003F",
+      "semantic_role": "retained_unknown",
+      "confidence": "identity_only",
+      "evidence": "exact shader family observed in qualified open-world session 20260829T053639Z-p40004 at activity rank 25",
+      "native_coverage": false
+    },
+    {
+      "shader_family_id": "DAF439851D7EAD1B/009894C77B556583/000000000000003F/000000000016003F",
+      "semantic_role": "retained_unknown",
+      "confidence": "identity_only",
+      "evidence": "exact shader family observed in qualified open-world session 20260829T053639Z-p40004 at activity rank 26",
+      "native_coverage": false
+    },
+    {
+      "shader_family_id": "E5D399C47E9B946F/49DE5A3094315C75/000000000000003F/000000000016003F",
+      "semantic_role": "retained_unknown",
+      "confidence": "identity_only",
+      "evidence": "exact shader family observed in qualified open-world session 20260829T053639Z-p40004 at activity rank 27",
+      "native_coverage": false
+    },
+    {
+      "shader_family_id": "14B5E28404443782/62B9ED4D3F129FFA/000000000000003F/000000000016003F",
+      "semantic_role": "retained_unknown",
+      "confidence": "identity_only",
+      "evidence": "exact shader family observed in qualified open-world session 20260829T053639Z-p40004 at activity rank 28",
+      "native_coverage": false
+    },
+    {
+      "shader_family_id": "0192D7CBE94E8C93/6F012E173B6CBC9D/000000000000003F/000000000016003F",
+      "semantic_role": "retained_unknown",
+      "confidence": "identity_only",
+      "evidence": "exact shader family observed in qualified open-world session 20260829T053639Z-p40004 at activity rank 29",
+      "native_coverage": false
+    },
+    {
+      "shader_family_id": "47DDD4386DF90CB4/63AE49A53A0B280F/000000000000003F/000000000016003F",
+      "semantic_role": "retained_unknown",
+      "confidence": "identity_only",
+      "evidence": "exact shader family observed in qualified open-world session 20260829T053639Z-p40004 at activity rank 30",
+      "native_coverage": false
+    },
+    {
+      "shader_family_id": "4F34A6F5D0E151B6/0B062D2E75024FC5/000000000000003F/000000000016003F",
+      "semantic_role": "retained_unknown",
+      "confidence": "identity_only",
+      "evidence": "exact shader family observed in qualified open-world session 20260829T053639Z-p40004 at activity rank 31",
+      "native_coverage": false
+    },
+    {
+      "shader_family_id": "54EB5E246BD06502/F5D0FD6C1333940D/000000000000003F/000000000016003F",
+      "semantic_role": "retained_unknown",
+      "confidence": "identity_only",
+      "evidence": "exact shader family observed in qualified open-world session 20260829T053639Z-p40004 at activity rank 32",
+      "native_coverage": false
+    },
+    {
+      "shader_family_id": "840371BD234CAC5F/EE281696EDAA11A8/000000000000003F/000000000016003F",
+      "semantic_role": "retained_unknown",
+      "confidence": "identity_only",
+      "evidence": "exact shader family observed in qualified open-world session 20260829T053639Z-p40004 at activity rank 33",
+      "native_coverage": false
+    },
+    {
+      "shader_family_id": "D6B8ED4513834126/0D656E9CC6DBFFF7/000000000000003F/000000000016003F",
+      "semantic_role": "retained_unknown",
+      "confidence": "identity_only",
+      "evidence": "exact shader family observed in qualified open-world session 20260829T053639Z-p40004 at activity rank 34",
+      "native_coverage": false
+    },
+    {
+      "shader_family_id": "F2626E5F2A7719D4/9A94FC430D353637/000000000000003F/000000000016003F",
+      "semantic_role": "retained_unknown",
+      "confidence": "identity_only",
+      "evidence": "exact shader family observed in qualified open-world session 20260829T053639Z-p40004 at activity rank 35",
+      "native_coverage": false
+    },
+    {
+      "shader_family_id": "29A241DE6F9EEAFA/B59C5BD1316B3744/000000000000003F/000000000016003F",
+      "semantic_role": "retained_unknown",
+      "confidence": "identity_only",
+      "evidence": "exact shader family observed in qualified open-world session 20260829T053639Z-p40004 at activity rank 36",
+      "native_coverage": false
+    },
+    {
+      "shader_family_id": "5FE11090A1539CC6/D61DDDCCFED61E4A/000000000000003F/000000000016003F",
+      "semantic_role": "retained_unknown",
+      "confidence": "identity_only",
+      "evidence": "exact shader family observed in qualified open-world session 20260829T053639Z-p40004 at activity rank 37",
+      "native_coverage": false
+    },
+    {
+      "shader_family_id": "DEA366150B2DE02E/A23231ABA8455CCD/000000000000003F/000000000016003F",
+      "semantic_role": "retained_unknown",
+      "confidence": "identity_only",
+      "evidence": "exact shader family observed in qualified open-world session 20260829T053639Z-p40004 at activity rank 38",
+      "native_coverage": false
+    }
+  ]
+}

--- a/config/native-renderer/suppression-switches.json
+++ b/config/native-renderer/suppression-switches.json
@@ -1,0 +1,19 @@
+{
+  "schema": "pinyon-shift.native-renderer-suppression-switches.v1",
+  "families": [
+    {
+      "family": "sky_horizon",
+      "anchor_signature": "747837906D0BF484",
+      "follower_signature": "1D253A52B55C9FB3",
+      "switch": "native_renderer.sky_horizon_suppression",
+      "scope": "exact_pass_family",
+      "activation": "startup_only",
+      "default_enabled": false,
+      "independent": true,
+      "implementation_status": "absent",
+      "draw_suppression_implemented": false,
+      "resolve_suppression_implemented": false,
+      "xenos_fallback": "mandatory"
+    }
+  ]
+}

--- a/docs/native-renderer/CONSUMER_FAMILY_CLASSIFICATION.md
+++ b/docs/native-renderer/CONSUMER_FAMILY_CLASSIFICATION.md
@@ -1,0 +1,87 @@
+# Exact consumer-family classification
+
+The retained sky/horizon producer has 38 stable later-GPU-consumer shader
+families in qualified open-world session `20260829T053639Z-p40004`.
+`config/native-renderer/consumer-family-classifier.json` turns that observed
+set into a deterministic, drift-detecting identity contract without claiming
+semantic knowledge that the capture does not prove.
+
+## Fail-closed model
+
+Each rule matches the exact tuple of vertex shader, pixel shader, vertex
+specialization mask, and pixel specialization mask. The initial rules use:
+
+- `semantic_role=retained_unknown`;
+- `confidence=identity_only`;
+- a reference to the qualified session and activity rank; and
+- `native_coverage=false`.
+
+The classifier loader rejects duplicate or malformed family identifiers,
+unsupported roles or confidence values, blank evidence, a producer-signature
+mismatch, and any rule that claims native coverage. Classification changes
+only the deterministic report. It cannot submit native work, skip Xenos work,
+or authorize suppression.
+
+## Drift report
+
+Run the exact-family summarizer with the tracked manifest:
+
+```powershell
+python .\tools\summarize-native-renderer-pass-consumers.py `
+  "$stateRoot\logs\<session>.jsonl" `
+  --classifier .\config\native-renderer\consumer-family-classifier.json `
+  --output .artifacts\native-renderer-pass-consumers.json
+```
+
+The schema-v4 report adds `consumer_family_classification` with separate
+identity and semantic status. Exact known families are annotated with their
+rule evidence. Unknown families become bounded activity-ranked drift records;
+overflow remains explicit. A fully matched `identity_status=complete` does not
+make `semantic_status` complete while any family remains `retained_unknown`.
+
+## Promotion requirements
+
+A family may move beyond `retained_unknown` only when reproducible evidence
+identifies its role. Shader recurrence, texture slot, activity rank, or a
+correct-looking frame is insufficient. Promotion should reference one or more
+of:
+
+- paired draw isolation proving the visual contribution;
+- target and texture provenance across the producer/consumer boundary;
+- an identified high-level title render dispatch;
+- query, memexport, or guest-memory side-effect evidence; and
+- a scene matrix proving the classification does not drift across supported
+  states.
+
+Even a high-confidence semantic rule keeps `native_coverage=false` until a
+separate native consumer implementation and parity qualification exist. The
+current 38 identity-only rules therefore close classifier drift for the
+qualified scene but leave all 38 semantic roles and the later-GPU-consumer
+suppression gate unresolved.
+
+Reprocessing session `20260829T053639Z-p40004` through the tracked classifier
+produced schema-v4 `identity_status=complete`: 38 of 38 observed shader
+families matched, with zero drift records and zero drift overflow. It correctly
+reported `semantic_status=incomplete`, 38 retained-unknown families, and zero
+semantically classified families. The local deterministic report SHA-256 is
+`72BAF6322337F7E01A709BA1F2D5730100F70E2745B7B4C8E378358B86E7463B`.
+The later-GPU-consumer gate remained `fail`, guest CPU visibility remained
+`pass`, Xenos remained authoritative, and suppression remained disallowed.
+
+## Rollback-switch boundary
+
+`config/native-renderer/suppression-switches.json` reserves one independent,
+startup-only, default-off switch name for the exact producer family. The
+validator reports its implementation as absent and the rollback gate as
+`unknown`. This is intentional: specifying a switch before suppression exists
+prevents a future global or default-on implementation, but it is not evidence
+that rollback behavior has been runtime-qualified.
+
+Validate the specification with:
+
+```powershell
+python .\tools\validate-native-renderer-suppression-switches.py `
+  .\config\native-renderer\suppression-switches.json
+```
+
+The report always preserves Xenos authority and keeps suppression disallowed.

--- a/docs/native-renderer/PASS_CLASSIFICATION.md
+++ b/docs/native-renderer/PASS_CLASSIFICATION.md
@@ -93,3 +93,12 @@ After discarding 120 warm-up samples, the enabled/control comparison was:
 The observed deltas were 10 us at median (0.06%) and 37 us at p95 (0.20%).
 This front-end result proves the disabled path has no material overhead in the
 captured scene; it does not replace the required open-world and race captures.
+
+## Exact consumer-family extension
+
+The retained sky/horizon producer has a separate exact shader-family classifier
+for its later GPU consumers. It is documented in
+[CONSUMER_FAMILY_CLASSIFICATION.md](CONSUMER_FAMILY_CLASSIFICATION.md) and does
+not change this draw-signature manifest. Its 38 initial rules prove identity
+only, retain unknown semantics and false native coverage, emit bounded drift,
+and cannot affect rendering or suppression.

--- a/docs/native-renderer/PASS_CONSUMER_GRAPH.md
+++ b/docs/native-renderer/PASS_CONSUMER_GRAPH.md
@@ -88,9 +88,13 @@ in this qualification.
 The `later_gpu_consumers` admission gate is now `fail`, not `unknown`: later
 GPU consumers are positively observed and have not been replaced. This is
 useful closure of the dependency question, but it prohibits suppressing the
-producer family. The next implementation milestone must assign semantic roles
-to the 38 stable shader families and provide the native resource publication or
-native consumer coverage they require.
+producer family. The 38 stable shader families now have exact identity-only
+rules in
+[CONSUMER_FAMILY_CLASSIFICATION.md](CONSUMER_FAMILY_CLASSIFICATION.md).
+They deliberately remain `retained_unknown` with `native_coverage=false` until
+reproducible visual or high-level title evidence assigns semantic roles. The
+next implementation milestone must produce that evidence and then provide the
+native resource publication or native consumer coverage each role requires.
 
 Guest CPU visibility and the independent rollback switch remain separate
 gates. The same session fully armed all 348 exact-family resolve generations

--- a/docs/native-renderer/SUPPRESSION_ADMISSION.md
+++ b/docs/native-renderer/SUPPRESSION_ADMISSION.md
@@ -49,7 +49,8 @@ behavior, and native GPU timing. It is not admitted for suppression yet:
 - guest CPU visibility passes for one bounded exact-family AppData
   qualification route, with zero reads across 348 fully armed resolve
   generations; and
-- no independently reversible suppression switch exists.
+- an independent default-off switch is specified but no suppression or
+  runtime-qualified rollback implementation exists.
 
 Consequently the next work is evidence collection and complete-pass comparison,
 not draw skipping. The Xenos copy, draw, resolve, query, fence, and memexport
@@ -78,5 +79,8 @@ zero guest CPU read or write events. This promotes `guest_cpu_visibility` from
 `unknown` to scene-bounded `pass`, as documented in
 [GUEST_CPU_VISIBILITY.md](GUEST_CPU_VISIBILITY.md). The admission result is now
 10/12 passing gates, one failing gate (`later_gpu_consumers`), and one unknown
-gate (`rollback_switch`). Suppression is still prohibited. See
+gate (`rollback_switch`). The exact 38-family identity classifier and the
+fail-closed, unimplemented switch specification are documented in
+[CONSUMER_FAMILY_CLASSIFICATION.md](CONSUMER_FAMILY_CLASSIFICATION.md). They do
+not promote either remaining blocker. Suppression is still prohibited. See
 [PASS_CONSUMER_GRAPH.md](PASS_CONSUMER_GRAPH.md).

--- a/tools/summarize-native-renderer-pass-consumers.py
+++ b/tools/summarize-native-renderer-pass-consumers.py
@@ -9,7 +9,22 @@ from pathlib import Path
 from typing import Any, Iterable
 
 
-SCHEMA = "pinyon-shift.native-renderer-pass-consumer-inventory.v3"
+SCHEMA = "pinyon-shift.native-renderer-pass-consumer-inventory.v4"
+CONSUMER_CLASSIFIER_SCHEMA = (
+    "pinyon-shift.native-renderer-consumer-family-classifier.v1"
+)
+CLASSIFIER_CONFIDENCE = {"identity_only", "low", "medium", "high"}
+SEMANTIC_ROLES = {
+    "retained_unknown",
+    "world_material",
+    "post_process",
+    "shadow",
+    "reflection",
+    "exposure",
+    "ui_composite",
+    "livery_thumbnail",
+    "rewind",
+}
 PREFIX = "native_renderer.census.pass_family_"
 SUMMARY_EVENT = f"{PREFIX}consumer_summary"
 RESOLVE_EVENT = f"{PREFIX}resolve"
@@ -77,6 +92,127 @@ def normalize_signature(value: str) -> str:
     ):
         raise ValueError(f"invalid 64-bit signature: {value!r}")
     return signature
+
+
+def normalize_shader_family_id(value: str) -> str:
+    parts = value.split("/")
+    if len(parts) != 4:
+        raise ValueError(f"invalid shader family id: {value!r}")
+    return "/".join(normalize_signature(part) for part in parts)
+
+
+def load_consumer_classifier(
+    path: Path, *, anchor: str, follower: str
+) -> dict[str, Any]:
+    try:
+        document = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise ValueError(f"cannot read consumer classifier {path}: {error}") from error
+    if document.get("schema") != CONSUMER_CLASSIFIER_SCHEMA:
+        raise ValueError("unsupported consumer classifier schema")
+    producer = document.get("producer_family")
+    if not isinstance(producer, dict):
+        raise ValueError("consumer classifier producer_family must be an object")
+    if normalize_signature(str(producer.get("anchor_signature", ""))) != anchor:
+        raise ValueError("consumer classifier anchor does not match selected family")
+    if normalize_signature(str(producer.get("follower_signature", ""))) != follower:
+        raise ValueError("consumer classifier follower does not match selected family")
+    try:
+        maximum_drift_records = int(document["maximum_drift_records"])
+    except (KeyError, TypeError, ValueError) as error:
+        raise ValueError("consumer classifier has invalid drift capacity") from error
+    if not 0 <= maximum_drift_records <= 1024:
+        raise ValueError("consumer classifier drift capacity must be between 0 and 1024")
+    rules = document.get("rules")
+    if not isinstance(rules, list):
+        raise ValueError("consumer classifier rules must be an array")
+    normalized_rules: dict[str, dict[str, Any]] = {}
+    for index, rule in enumerate(rules):
+        if not isinstance(rule, dict):
+            raise ValueError(f"consumer classifier rule {index} must be an object")
+        family_id = normalize_shader_family_id(str(rule.get("shader_family_id", "")))
+        if family_id in normalized_rules:
+            raise ValueError(f"duplicate consumer classifier rule: {family_id}")
+        semantic_role = str(rule.get("semantic_role", ""))
+        confidence = str(rule.get("confidence", ""))
+        evidence = str(rule.get("evidence", "")).strip()
+        if semantic_role not in SEMANTIC_ROLES:
+            raise ValueError(f"consumer classifier rule {index} has invalid semantic role")
+        if confidence not in CLASSIFIER_CONFIDENCE:
+            raise ValueError(f"consumer classifier rule {index} has invalid confidence")
+        if not evidence:
+            raise ValueError(f"consumer classifier rule {index} requires evidence")
+        if rule.get("native_coverage") is not False:
+            raise ValueError(
+                f"consumer classifier rule {index} must keep native_coverage false"
+            )
+        normalized_rules[family_id] = {
+            "semantic_role": semantic_role,
+            "semantic_confidence": confidence,
+            "semantic_evidence": evidence,
+            "native_coverage": False,
+        }
+    return {
+        "path": str(path),
+        "maximum_drift_records": maximum_drift_records,
+        "rules": normalized_rules,
+    }
+
+
+def classify_shader_families(
+    families: list[dict[str, Any]], classifier: dict[str, Any] | None
+) -> dict[str, Any]:
+    if classifier is None:
+        return {
+            "manifest": None,
+            "identity_status": "not_configured",
+            "semantic_status": "not_configured",
+            "matched_family_count": 0,
+            "classified_semantic_family_count": 0,
+            "retained_unknown_family_count": 0,
+            "drift_records": [],
+            "drift_overflow": 0,
+        }
+    rules = classifier["rules"]
+    drift: list[dict[str, Any]] = []
+    matched = 0
+    semantic = 0
+    retained_unknown = 0
+    for family in families:
+        rule = rules.get(family["shader_family_id"])
+        if rule is None:
+            drift.append(
+                {
+                    "shader_family_id": family["shader_family_id"],
+                    "rank": family["rank"],
+                    "sample_events": family["sample_events"],
+                    "sample_share_ppm": family["sample_share_ppm"],
+                }
+            )
+            continue
+        matched += 1
+        family.update(rule)
+        family["classifier_match"] = True
+        if rule["semantic_role"] == "retained_unknown":
+            retained_unknown += 1
+        else:
+            semantic += 1
+    capacity = classifier["maximum_drift_records"]
+    retained_drift = drift[:capacity]
+    return {
+        "manifest": classifier["path"],
+        "identity_status": "complete" if not drift else "drift_observed",
+        "semantic_status": (
+            "complete"
+            if families and semantic == len(families)
+            else "incomplete"
+        ),
+        "matched_family_count": matched,
+        "classified_semantic_family_count": semantic,
+        "retained_unknown_family_count": retained_unknown,
+        "drift_records": retained_drift,
+        "drift_overflow": len(drift) - len(retained_drift),
+    }
 
 
 def require_safety(event: dict[str, Any]) -> None:
@@ -170,6 +306,9 @@ def build_shader_families(
                 "family_base_fetch_mask": f"{family['family_base_fetch_mask']:016X}",
                 "family_mip_fetch_mask": f"{family['family_mip_fetch_mask']:016X}",
                 "semantic_role": "unknown_unclassified",
+                "semantic_confidence": "none",
+                "semantic_evidence": "no exact consumer-family classifier rule",
+                "classifier_match": False,
                 "native_coverage": False,
                 "suppression_eligible": False,
             }
@@ -199,6 +338,7 @@ def summarize(
     anchor: str | None = None,
     follower: str | None = None,
     session: str | None = None,
+    classifier_path: Path | None = None,
 ) -> dict[str, Any]:
     paths = list(paths)
     events = read_events(paths)
@@ -316,6 +456,14 @@ def summarize(
     ):
         raise ValueError("consumer signature sample totals contradict summary counts")
     shader_families = build_shader_families(consumer_signatures)
+    classifier = (
+        load_consumer_classifier(
+            classifier_path, anchor=selected_anchor, follower=selected_follower
+        )
+        if classifier_path is not None
+        else None
+    )
+    consumer_classification = classify_shader_families(shader_families, classifier)
     classified_sample_events = sum(
         int(family["sample_events"]) for family in shader_families
     )
@@ -444,6 +592,7 @@ def summarize(
             )
         ],
         "consumer_shader_families": shader_families,
+        "consumer_family_classification": consumer_classification,
         "guest_cpu_visibility": {
             "counts": guest_cpu_counts,
             "targets": [
@@ -484,6 +633,11 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--anchor")
     parser.add_argument("--follower")
     parser.add_argument("--session")
+    parser.add_argument(
+        "--classifier",
+        type=Path,
+        help="exact consumer shader-family classifier manifest",
+    )
     parser.add_argument("--output", "-o", type=Path)
     return parser.parse_args()
 
@@ -492,7 +646,11 @@ def main() -> int:
     args = parse_args()
     try:
         result = summarize(
-            args.logs, anchor=args.anchor, follower=args.follower, session=args.session
+            args.logs,
+            anchor=args.anchor,
+            follower=args.follower,
+            session=args.session,
+            classifier_path=args.classifier,
         )
     except ValueError as error:
         print(f"error: {error}")

--- a/tools/tests/test_native_renderer_contract.py
+++ b/tools/tests/test_native_renderer_contract.py
@@ -1,3 +1,4 @@
+import json
 import pathlib
 import unittest
 
@@ -497,6 +498,43 @@ class NativeRendererContractTests(unittest.TestCase):
         self.assertIn('"draw_suppression_implemented": False', evaluator)
         self.assertIn('"resolve_suppression_implemented": False', evaluator)
         self.assertNotIn("SetDrawSuppression", evaluator)
+
+    def test_consumer_family_classifier_is_exact_and_fail_closed(self):
+        classifier = json.loads(
+            (ROOT / "config/native-renderer/consumer-family-classifier.json").read_text(
+                encoding="utf-8"
+            )
+        )
+        self.assertEqual(
+            "pinyon-shift.native-renderer-consumer-family-classifier.v1",
+            classifier["schema"],
+        )
+        self.assertEqual(38, len(classifier["rules"]))
+        self.assertEqual(
+            38, len({rule["shader_family_id"] for rule in classifier["rules"]})
+        )
+        self.assertTrue(
+            all(
+                rule["semantic_role"] == "retained_unknown"
+                for rule in classifier["rules"]
+            )
+        )
+        self.assertTrue(
+            all(rule["native_coverage"] is False for rule in classifier["rules"])
+        )
+
+    def test_suppression_switch_spec_is_default_off_and_unimplemented(self):
+        switches = json.loads(
+            (ROOT / "config/native-renderer/suppression-switches.json").read_text(
+                encoding="utf-8"
+            )
+        )
+        family = switches["families"][0]
+        self.assertFalse(family["default_enabled"])
+        self.assertTrue(family["independent"])
+        self.assertEqual("absent", family["implementation_status"])
+        self.assertFalse(family["draw_suppression_implemented"])
+        self.assertFalse(family["resolve_suppression_implemented"])
 
     def test_complete_pass_export_spans_anchor_and_follower(self):
         exporter = (

--- a/tools/tests/test_native_renderer_pass_consumers.py
+++ b/tools/tests/test_native_renderer_pass_consumers.py
@@ -131,6 +131,21 @@ class PassConsumerSummaryTests(unittest.TestCase):
         )
         return path
 
+    def write_classifier(self, root, rules, **overrides):
+        document = {
+            "schema": MODULE.CONSUMER_CLASSIFIER_SCHEMA,
+            "producer_family": {
+                "anchor_signature": ANCHOR,
+                "follower_signature": FOLLOWER,
+            },
+            "maximum_drift_records": 32,
+            "rules": rules,
+        }
+        document.update(overrides)
+        path = Path(root) / "consumer-classifier.json"
+        path.write_text(json.dumps(document), encoding="utf-8")
+        return path
+
     def test_summarizes_complete_observed_lineage(self):
         records = [
             event("resolve", address="1000"),
@@ -339,6 +354,108 @@ class PassConsumerSummaryTests(unittest.TestCase):
         self.assertEqual(2, families[0]["pipeline_hash_count"])
         self.assertEqual(1_000_000, families[0]["sample_share_ppm"])
         self.assertFalse(families[0]["suppression_eligible"])
+
+    def test_applies_exact_consumer_family_classifier(self):
+        records = [
+            event("resolve"),
+            event("consumer"),
+            event("resolve"),
+            consumer_signature(),
+            summary(),
+        ]
+        rule = {
+            "shader_family_id": (
+                "1111111111111111/2222222222222222/"
+                "0000000000000001/0000000000000002"
+            ),
+            "semantic_role": "retained_unknown",
+            "confidence": "identity_only",
+            "evidence": "exact family observed in the qualified scene",
+            "native_coverage": False,
+        }
+        with tempfile.TemporaryDirectory() as temp:
+            classifier = self.write_classifier(temp, [rule])
+            result = MODULE.summarize(
+                [self.write(temp, records)], classifier_path=classifier
+            )
+        family = result["consumer_shader_families"][0]
+        classification = result["consumer_family_classification"]
+        self.assertTrue(family["classifier_match"])
+        self.assertEqual("retained_unknown", family["semantic_role"])
+        self.assertEqual("identity_only", family["semantic_confidence"])
+        self.assertFalse(family["native_coverage"])
+        self.assertEqual("complete", classification["identity_status"])
+        self.assertEqual("incomplete", classification["semantic_status"])
+        self.assertEqual(1, classification["retained_unknown_family_count"])
+        self.assertEqual([], classification["drift_records"])
+
+    def test_reports_bounded_consumer_classifier_drift(self):
+        records = [
+            event("resolve"),
+            event("consumer"),
+            event("resolve"),
+            consumer_signature(),
+            summary(),
+        ]
+        with tempfile.TemporaryDirectory() as temp:
+            classifier = self.write_classifier(
+                temp, [], maximum_drift_records=0
+            )
+            result = MODULE.summarize(
+                [self.write(temp, records)], classifier_path=classifier
+            )
+        classification = result["consumer_family_classification"]
+        self.assertEqual("drift_observed", classification["identity_status"])
+        self.assertEqual([], classification["drift_records"])
+        self.assertEqual(1, classification["drift_overflow"])
+        self.assertFalse(result["safety"]["suppression_allowed"])
+
+    def test_rejects_unsafe_consumer_classifier_native_coverage(self):
+        records = [
+            event("resolve"),
+            event("consumer"),
+            event("resolve"),
+            consumer_signature(),
+            summary(),
+        ]
+        rule = {
+            "shader_family_id": (
+                "1111111111111111/2222222222222222/"
+                "0000000000000001/0000000000000002"
+            ),
+            "semantic_role": "post_process",
+            "confidence": "high",
+            "evidence": "fixture",
+            "native_coverage": True,
+        }
+        with tempfile.TemporaryDirectory() as temp:
+            classifier = self.write_classifier(temp, [rule])
+            with self.assertRaisesRegex(ValueError, "native_coverage false"):
+                MODULE.summarize(
+                    [self.write(temp, records)], classifier_path=classifier
+                )
+
+    def test_rejects_consumer_classifier_for_different_producer(self):
+        records = [
+            event("resolve"),
+            event("consumer"),
+            event("resolve"),
+            consumer_signature(),
+            summary(),
+        ]
+        with tempfile.TemporaryDirectory() as temp:
+            classifier = self.write_classifier(
+                temp,
+                [],
+                producer_family={
+                    "anchor_signature": "AAAAAAAAAAAAAAAA",
+                    "follower_signature": FOLLOWER,
+                },
+            )
+            with self.assertRaisesRegex(ValueError, "anchor does not match"):
+                MODULE.summarize(
+                    [self.write(temp, records)], classifier_path=classifier
+                )
 
 
 if __name__ == "__main__":

--- a/tools/tests/test_native_renderer_suppression_switches.py
+++ b/tools/tests/test_native_renderer_suppression_switches.py
@@ -1,0 +1,70 @@
+import copy
+import importlib.util
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SPEC = importlib.util.spec_from_file_location(
+    "native_renderer_suppression_switches",
+    ROOT / "tools/validate-native-renderer-suppression-switches.py",
+)
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+def manifest():
+    return {
+        "schema": MODULE.INPUT_SCHEMA,
+        "families": [
+            {
+                "family": "sky_horizon",
+                "anchor_signature": "747837906D0BF484",
+                "follower_signature": "1D253A52B55C9FB3",
+                "switch": "native_renderer.sky_horizon_suppression",
+                "scope": "exact_pass_family",
+                "activation": "startup_only",
+                "default_enabled": False,
+                "independent": True,
+                "implementation_status": "absent",
+                "draw_suppression_implemented": False,
+                "resolve_suppression_implemented": False,
+                "xenos_fallback": "mandatory",
+            }
+        ],
+    }
+
+
+class NativeRendererSuppressionSwitchTests(unittest.TestCase):
+    def test_validates_default_off_absent_switch(self):
+        result = MODULE.validate(manifest())
+        self.assertEqual("unknown", result["summary"]["rollback_switch_gate"])
+        self.assertEqual(0, result["summary"]["implemented_count"])
+        self.assertFalse(result["safety"]["suppression_allowed"])
+        self.assertTrue(result["safety"]["xenos_authority"])
+
+    def test_rejects_default_on_switch(self):
+        document = manifest()
+        document["families"][0]["default_enabled"] = True
+        with self.assertRaisesRegex(ValueError, "default off"):
+            MODULE.validate(document)
+
+    def test_rejects_suppression_claim_before_implementation(self):
+        document = manifest()
+        document["families"][0]["draw_suppression_implemented"] = True
+        with self.assertRaisesRegex(ValueError, "before implementation"):
+            MODULE.validate(document)
+
+    def test_rejects_duplicate_switch(self):
+        document = manifest()
+        duplicate = copy.deepcopy(document["families"][0])
+        duplicate["family"] = "other"
+        duplicate["anchor_signature"] = "AAAAAAAAAAAAAAAA"
+        duplicate["follower_signature"] = "BBBBBBBBBBBBBBBB"
+        document["families"].append(duplicate)
+        with self.assertRaisesRegex(ValueError, "duplicate switch"):
+            MODULE.validate(document)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/validate-native-renderer-suppression-switches.py
+++ b/tools/validate-native-renderer-suppression-switches.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""Validate fail-closed native-renderer suppression-switch specifications."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+
+INPUT_SCHEMA = "pinyon-shift.native-renderer-suppression-switches.v1"
+OUTPUT_SCHEMA = "pinyon-shift.native-renderer-suppression-switch-report.v1"
+IMPLEMENTATION_STATUSES = {"absent", "diagnostic_only", "implemented"}
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise ValueError(message)
+
+
+def signature(value: Any, label: str) -> str:
+    rendered = str(value)
+    require(
+        len(rendered) == 16
+        and all(character in "0123456789ABCDEF" for character in rendered),
+        f"{label} must be a 16-digit uppercase hexadecimal value",
+    )
+    return rendered
+
+
+def validate(document: dict[str, Any]) -> dict[str, Any]:
+    require(document.get("schema") == INPUT_SCHEMA, "unsupported switch schema")
+    families = document.get("families")
+    require(isinstance(families, list) and families, "families must be a non-empty array")
+    normalized: list[dict[str, Any]] = []
+    family_names: set[str] = set()
+    switch_names: set[str] = set()
+    for index, entry in enumerate(families):
+        require(isinstance(entry, dict), f"family {index} must be an object")
+        family = str(entry.get("family", "")).strip()
+        switch = str(entry.get("switch", "")).strip()
+        require(bool(family), f"family {index} requires a name")
+        require(bool(switch), f"family {index} requires a switch")
+        require(family not in family_names, f"duplicate family: {family}")
+        require(switch not in switch_names, f"duplicate switch: {switch}")
+        family_names.add(family)
+        switch_names.add(switch)
+        anchor = signature(entry.get("anchor_signature"), f"family {family} anchor")
+        follower = signature(
+            entry.get("follower_signature"), f"family {family} follower"
+        )
+        require(anchor != follower, f"family {family} signatures must be distinct")
+        require(entry.get("scope") == "exact_pass_family", f"family {family} scope")
+        require(entry.get("activation") == "startup_only", f"family {family} activation")
+        require(entry.get("default_enabled") is False, f"family {family} must default off")
+        require(entry.get("independent") is True, f"family {family} must be independent")
+        status = str(entry.get("implementation_status", ""))
+        require(
+            status in IMPLEMENTATION_STATUSES,
+            f"family {family} has invalid implementation status",
+        )
+        draw_implemented = entry.get("draw_suppression_implemented")
+        resolve_implemented = entry.get("resolve_suppression_implemented")
+        require(
+            isinstance(draw_implemented, bool),
+            f"family {family} draw implementation flag must be boolean",
+        )
+        require(
+            isinstance(resolve_implemented, bool),
+            f"family {family} resolve implementation flag must be boolean",
+        )
+        if status != "implemented":
+            require(
+                draw_implemented is False and resolve_implemented is False,
+                f"family {family} cannot claim suppression before implementation",
+            )
+        require(
+            entry.get("xenos_fallback") == "mandatory",
+            f"family {family} must retain mandatory Xenos fallback",
+        )
+        normalized.append(
+            {
+                "family": family,
+                "anchor_signature": anchor,
+                "follower_signature": follower,
+                "switch": switch,
+                "scope": "exact_pass_family",
+                "activation": "startup_only",
+                "default_enabled": False,
+                "independent": True,
+                "implementation_status": status,
+                "draw_suppression_implemented": draw_implemented,
+                "resolve_suppression_implemented": resolve_implemented,
+                "xenos_fallback": "mandatory",
+                "rollback_gate": (
+                    "unknown" if status != "implemented" else "requires_runtime_test"
+                ),
+            }
+        )
+    return {
+        "schema": OUTPUT_SCHEMA,
+        "families": normalized,
+        "summary": {
+            "family_count": len(normalized),
+            "implemented_count": sum(
+                entry["implementation_status"] == "implemented"
+                for entry in normalized
+            ),
+            "rollback_switch_gate": "unknown",
+            "reason": "switches are specified fail-closed but rollback is not runtime-qualified",
+        },
+        "safety": {
+            "xenos_authority": True,
+            "suppression_allowed": False,
+        },
+    }
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("manifest", type=Path)
+    parser.add_argument("--output", "-o", type=Path)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        document = json.loads(args.manifest.read_text(encoding="utf-8"))
+        result = validate(document)
+    except (OSError, json.JSONDecodeError, ValueError) as error:
+        print(f"error: {error}")
+        return 1
+    rendered = json.dumps(result, indent=2) + "\n"
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(rendered, encoding="utf-8")
+    else:
+        print(rendered, end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- track all 38 qualified later-GPU-consumer shader families with exact identity-only rules
- add schema-v4 bounded classifier drift and separate identity/semantic status
- keep every rule retained-unknown with native coverage false until stronger evidence exists
- specify and validate an independent startup-only default-off suppression switch while explicitly leaving implementation absent and rollback unknown
- preserve Xenos authority and keep suppression disallowed

## Validation
- 201 repository tests passed
- qualified session reprocessed with 38/38 identity matches, zero drift and incomplete semantics
- switch manifest validates fail-closed with rollback gate unknown
- git diff --check passed
- no preview rebuild/gameplay run: this batch changes only deterministic tooling, configuration, tests, and documentation