### PR TITLE
feat(native-renderer): capture exact consumer family draws

### DIFF
--- a/docs/native-renderer/CONSUMER_FAMILY_CLASSIFICATION.md
+++ b/docs/native-renderer/CONSUMER_FAMILY_CLASSIFICATION.md
@@ -68,6 +68,48 @@ semantically classified families. The local deterministic report SHA-256 is
 The later-GPU-consumer gate remained `fail`, guest CPU visibility remained
 `pass`, Xenos remained authoritative, and suppression remained disallowed.
 
+## Targeted RenderDoc evidence
+
+The census and RenderDoc helpers can mark only authoritative draws that both
+consume an output from the exact retained producer family and match one exact
+four-field consumer identity. The first activity-ranked family is:
+
+```text
+2E5E0A854BE00027/BDFFA72B7ED2FBA4/000000000000003F/000000000016003F
+```
+
+Capture it with the AppData save and the exact producer anchor/follower pair:
+
+```powershell
+$family = '2E5E0A854BE00027/BDFFA72B7ED2FBA4/000000000000003F/000000000016003F'
+.\tools\capture-native-renderer-renderdoc.ps1 `
+  -StateRoot "$env:LOCALAPPDATA\PinyonShift\source\0.1.0\.local\preview" `
+  -RenderDocRoot '.local\tools\renderdoc-1.45\RenderDoc_1.45_64' `
+  -IsolatedDrawSignature '1D253A52B55C9FB3' `
+  -PassAnchorSignature '747837906D0BF484' `
+  -IsolatedDrawDir '.local\qualification\consumer-family-isolated' `
+  -ConsumerFamily $family `
+  -CaptureDir '.local\qualification\consumer-family-capture'
+```
+
+After closing the captured run, export the first marked draw's bound color and
+depth attachments before and after the draw:
+
+```powershell
+.\tools\export-native-renderer-renderdoc.ps1 `
+  -Capture '.local\qualification\consumer-family-capture\reference_frame1.rdc' `
+  -RenderDocRoot '.local\tools\renderdoc-1.45\RenderDoc_1.45_64' `
+  -OutputDir '.local\qualification\consumer-family-export' `
+  -ConsumerFamily $family
+```
+
+The schema-v1 report records the exact family, total marker count, up to 64
+deterministic marker event IDs, capture and attachment hashes, and the first
+draw's before/after images. This is evidence for operator semantic review, not
+an automatic role promotion. Marker insertion does not replay, redirect, or
+suppress work: every Xenos draw remains authoritative and both draw and resolve
+suppression remain false.
+
 ## Rollback-switch boundary
 
 `config/native-renderer/suppression-switches.json` reserves one independent,

--- a/patches/rexglue/0075-d3d12-consumer-family-marker.patch
+++ b/patches/rexglue/0075-d3d12-consumer-family-marker.patch
@@ -1,0 +1,60 @@
+diff --git a/include/rex/system/interfaces/graphics.h b/include/rex/system/interfaces/graphics.h
+--- a/include/rex/system/interfaces/graphics.h
++++ b/include/rex/system/interfaces/graphics.h
+@@ -404,6 +404,9 @@ struct GraphicsIsolatedDrawRequest {
+   bool depth_readback_requested = false;
+   bool reference_depth_readback_requested = false;
+   bool reference_marker_requested = false;
++  // Mark the authoritative guest draw as an exact later-consumer-family
++  // target. This never duplicates, redirects, or suppresses the draw.
++  bool consumer_reference_marker_requested = false;
+   bool retain_target = false;
+   // Rebind the retained private target without copying the guest target. This
+   // is valid only for the immediately following draw of an isolated pass.
+diff --git a/src/graphics/d3d12/command_processor.cpp b/src/graphics/d3d12/command_processor.cpp
+--- a/src/graphics/d3d12/command_processor.cpp
++++ b/src/graphics/d3d12/command_processor.cpp
+@@ -3382,7 +3382,10 @@ bool D3D12CommandProcessor::IssueDraw(xenos::PrimitiveType primitive_type, uint3
+         isolated_draw_request.completion(isolated_result);
+       }
+     }
+-    if (isolated_draw_request.reference_marker_requested) {
++    if (isolated_draw_request.consumer_reference_marker_requested) {
++      deferred_command_list_.BeginDebugMarker(
++          "PinyonShift NR-00E authoritative consumer family draw");
++    } else if (isolated_draw_request.reference_marker_requested) {
+       deferred_command_list_.BeginDebugMarker(
+           isolated_draw_request.reuse_target
+               ? "PinyonShift NR-02F authoritative Xenos pass follower"
+@@ -3392,7 +3395,8 @@ bool D3D12CommandProcessor::IssueDraw(xenos::PrimitiveType primitive_type, uint3
+     PROFILE_VERTICES(primitive_processing_result.host_draw_vertex_count);
+     deferred_command_list_.D3DDrawInstanced(primitive_processing_result.host_draw_vertex_count, 1,
+                                             0, 0);
+-    if (isolated_draw_request.reference_marker_requested) {
++    if (isolated_draw_request.consumer_reference_marker_requested ||
++        isolated_draw_request.reference_marker_requested) {
+       deferred_command_list_.EndDebugMarker();
+     }
+     if (isolated_draw_request.reference_readback_requested &&
+@@ -3544,7 +3548,10 @@ bool D3D12CommandProcessor::IssueDraw(xenos::PrimitiveType primitive_type, uint3
+         isolated_draw_request.completion(isolated_result);
+       }
+     }
+-    if (isolated_draw_request.reference_marker_requested) {
++    if (isolated_draw_request.consumer_reference_marker_requested) {
++      deferred_command_list_.BeginDebugMarker(
++          "PinyonShift NR-00E authoritative consumer family draw");
++    } else if (isolated_draw_request.reference_marker_requested) {
+       deferred_command_list_.BeginDebugMarker(
+           isolated_draw_request.retain_target
+               ? "PinyonShift NR-02F authoritative Xenos pass anchor"
+@@ -3554,7 +3561,8 @@ bool D3D12CommandProcessor::IssueDraw(xenos::PrimitiveType primitive_type, uint3
+     PROFILE_VERTICES(primitive_processing_result.host_draw_vertex_count);
+     deferred_command_list_.D3DDrawIndexedInstanced(
+         primitive_processing_result.host_draw_vertex_count, 1, 0, 0, 0);
+-    if (isolated_draw_request.reference_marker_requested) {
++    if (isolated_draw_request.consumer_reference_marker_requested ||
++        isolated_draw_request.reference_marker_requested) {
+       deferred_command_list_.EndDebugMarker();
+     }
+     if (isolated_draw_request.reference_readback_requested &&

--- a/src/native_renderer/graphics_hooks.cpp
+++ b/src/native_renderer/graphics_hooks.cpp
@@ -147,6 +147,20 @@ struct PassFollowerState {
 
 PassFollowerState g_pass_follower;
 
+struct ConsumerFamilyMarkerState {
+  uint64_t vertex_shader_hash = 0;
+  uint64_t pixel_shader_hash = 0;
+  uint64_t vertex_specialization_mask = 0;
+  uint64_t pixel_specialization_mask = 0;
+  uint64_t matched_draws = 0;
+  uint64_t marker_requests = 0;
+  bool requested = false;
+  bool valid = true;
+  bool current_match = false;
+};
+
+ConsumerFamilyMarkerState g_consumer_family_marker;
+
 void ConfigureSignatureScan(const char *name, uint64_t &target_signature,
                             bool &requested, bool &valid) {
   char *value = nullptr;
@@ -183,6 +197,58 @@ void ConfigurePassFollower() {
       "PINYON_SHIFT_NATIVE_RENDERER_PASS_ANCHOR_SIGNATURE",
       g_pass_follower.target_signature, g_pass_follower.requested,
       g_pass_follower.valid);
+}
+
+void ConfigureConsumerFamilyMarker() {
+  g_consumer_family_marker = {};
+  char *value = nullptr;
+  size_t length = 0;
+  if (_dupenv_s(&value, &length,
+                "PINYON_SHIFT_NATIVE_RENDERER_CONSUMER_FAMILY") != 0 ||
+      !value || length <= 1) {
+    std::free(value);
+    return;
+  }
+  const std::string setting(value);
+  std::free(value);
+  g_consumer_family_marker.requested = true;
+  if (setting.size() != 67 || setting[16] != '/' || setting[33] != '/' ||
+      setting[50] != '/') {
+    g_consumer_family_marker.valid = false;
+    return;
+  }
+  std::array<uint64_t *, 4> fields = {
+      &g_consumer_family_marker.vertex_shader_hash,
+      &g_consumer_family_marker.pixel_shader_hash,
+      &g_consumer_family_marker.vertex_specialization_mask,
+      &g_consumer_family_marker.pixel_specialization_mask,
+  };
+  for (size_t index = 0; index < fields.size(); ++index) {
+    const char *begin = setting.data() + index * 17;
+    const char *end = begin + 16;
+    const auto parsed = std::from_chars(begin, end, *fields[index], 16);
+    if (parsed.ec != std::errc{} || parsed.ptr != end) {
+      g_consumer_family_marker.valid = false;
+      return;
+    }
+  }
+  if (!g_consumer_family_marker.vertex_shader_hash ||
+      !g_consumer_family_marker.pixel_shader_hash) {
+    g_consumer_family_marker.valid = false;
+  }
+}
+
+std::string ConsumerFamilyId() {
+  if (!g_consumer_family_marker.requested ||
+      !g_consumer_family_marker.valid) {
+    return "";
+  }
+  return fmt::format(
+      "{:016X}/{:016X}/{:016X}/{:016X}",
+      g_consumer_family_marker.vertex_shader_hash,
+      g_consumer_family_marker.pixel_shader_hash,
+      g_consumer_family_marker.vertex_specialization_mask,
+      g_consumer_family_marker.pixel_specialization_mask);
 }
 
 void ConfigureTextureScan() {
@@ -1747,6 +1813,7 @@ void CommitPassConsumer(
 void ObservePreparedDraw(
     const rex::system::GraphicsPreparedDrawObservation &observation) {
   g_isolated_draw.prepared_candidate_valid = false;
+  g_consumer_family_marker.current_match = false;
   if (!g_pending_candidate.valid) {
     ++g_candidate_prepared_without_observation_count;
   } else {
@@ -2615,6 +2682,10 @@ void CompleteIsolatedPassRepeat(
 void RequestIsolatedDraw(
     const rex::system::GraphicsPreparedDrawObservation &,
     rex::system::GraphicsIsolatedDrawRequest &request) {
+  if (g_consumer_family_marker.current_match) {
+    request.consumer_reference_marker_requested = true;
+    ++g_consumer_family_marker.marker_requests;
+  }
   if (!g_isolated_draw.requested || !g_isolated_draw.valid ||
       !g_isolated_draw.prepared_candidate_valid) {
     return;
@@ -2940,6 +3011,19 @@ void CommitPassConsumer(
   ++g_pass_consumer_trace.sampled_draws;
   g_pass_consumer_trace.sample_references +=
       candidate.family_sample_references;
+  if (g_consumer_family_marker.requested &&
+      g_consumer_family_marker.valid &&
+      observation.vertex_shader_hash ==
+          g_consumer_family_marker.vertex_shader_hash &&
+      observation.pixel_shader_hash ==
+          g_consumer_family_marker.pixel_shader_hash &&
+      prepared.vertex_specialization_mask ==
+          g_consumer_family_marker.vertex_specialization_mask &&
+      prepared.pixel_specialization_mask ==
+          g_consumer_family_marker.pixel_specialization_mask) {
+    g_consumer_family_marker.current_match = true;
+    ++g_consumer_family_marker.matched_draws;
+  }
   ObservePassConsumerSignature(observation, prepared,
                                candidate.family_base_fetch_mask,
                                candidate.family_mip_fetch_mask);
@@ -3307,6 +3391,7 @@ void InstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system,
   ConfigureReplaySnapshot();
   ConfigureIsolatedDraw();
   ConfigurePassFollower();
+  ConfigureConsumerFamilyMarker();
   g_graphics_census_memory = memory;
   if (g_pass_follower.requested && g_pass_follower.valid &&
       g_isolated_draw.requested && g_isolated_draw.valid) {
@@ -3373,6 +3458,18 @@ void InstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system,
        {"mode", "bounded_metadata"},
        {"xenos_draw", "preserved"},
        {"native_draw", "false"},
+       {"suppression_eligible", "false"}});
+  diagnostics::RecordEvent(
+      "native_renderer.census.consumer_family_marker_config",
+      {{"status", !g_consumer_family_marker.requested
+                      ? "disabled"
+                      : (g_consumer_family_marker.valid ? "armed"
+                                                        : "invalid_family")},
+       {"consumer_family", ConsumerFamilyId()},
+       {"mode", "authoritative_draw_marker_only"},
+       {"xenos_draw", "preserved"},
+       {"draw_suppression", "false"},
+       {"resolve_suppression", "false"},
        {"suppression_eligible", "false"}});
   diagnostics::RecordEvent(
       "native_renderer.snapshot.config",
@@ -3683,6 +3780,22 @@ void UninstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system) {
          {"xenos_draw", "preserved"},
          {"suppression_eligible", "false"}});
   }
+  diagnostics::RecordEvent(
+      "native_renderer.census.consumer_family_marker_summary",
+      {{"status", !g_consumer_family_marker.requested
+                      ? "disabled"
+                      : (g_consumer_family_marker.valid ? "complete"
+                                                        : "invalid_family")},
+       {"consumer_family", ConsumerFamilyId()},
+       {"matched_draws",
+        std::to_string(g_consumer_family_marker.matched_draws)},
+       {"marker_requests",
+        std::to_string(g_consumer_family_marker.marker_requests)},
+       {"mode", "authoritative_draw_marker_only"},
+       {"xenos_draw", "preserved"},
+       {"draw_suppression", "false"},
+       {"resolve_suppression", "false"},
+       {"suppression_eligible", "false"}});
   g_graphics_census_installed = false;
   g_graphics_census_memory = nullptr;
   if (g_draw_census.window_first_frame && g_draw_census.window_draw_count) {

--- a/tools/capture-native-renderer-census.ps1
+++ b/tools/capture-native-renderer-census.ps1
@@ -18,6 +18,8 @@ param(
     [string]$IsolatedDrawDir,
     [ValidatePattern('^[0-9A-Fa-f]{16}$')]
     [string]$PassAnchorSignature,
+    [ValidatePattern('^[0-9A-Fa-f]{16}(?:/[0-9A-Fa-f]{16}){3}$')]
+    [string]$ConsumerFamily,
     [switch]$Json
 )
 
@@ -105,6 +107,7 @@ $savedReplaySnapshotDir = $env:PINYON_SHIFT_NATIVE_RENDERER_SNAPSHOT_DIR
 $savedIsolatedDraw = $env:PINYON_SHIFT_NATIVE_RENDERER_ISOLATED_DRAW_SIGNATURE
 $savedIsolatedDrawDir = $env:PINYON_SHIFT_NATIVE_RENDERER_ISOLATED_DRAW_DIR
 $savedPassAnchor = $env:PINYON_SHIFT_NATIVE_RENDERER_PASS_ANCHOR_SIGNATURE
+$savedConsumerFamily = $env:PINYON_SHIFT_NATIVE_RENDERER_CONSUMER_FAMILY
 try {
     $env:REX_PINYON_SHIFT_NATIVE_RENDERER_CENSUS = 'true'
     $env:PINYON_SHIFT_NATIVE_RENDERER_SCENE = $Scene
@@ -115,6 +118,7 @@ try {
     $env:PINYON_SHIFT_NATIVE_RENDERER_ISOLATED_DRAW_SIGNATURE = $IsolatedDrawSignature
     $env:PINYON_SHIFT_NATIVE_RENDERER_ISOLATED_DRAW_DIR = $IsolatedDrawDir
     $env:PINYON_SHIFT_NATIVE_RENDERER_PASS_ANCHOR_SIGNATURE = $PassAnchorSignature
+    $env:PINYON_SHIFT_NATIVE_RENDERER_CONSUMER_FAMILY = $ConsumerFamily
     & (Join-Path $PSScriptRoot 'launch-preview.ps1') `
         -StateRoot $resolvedStateRoot -ShaderCaptureDir $ShaderCaptureDir `
         -Json:$Json
@@ -129,4 +133,5 @@ finally {
     $env:PINYON_SHIFT_NATIVE_RENDERER_ISOLATED_DRAW_SIGNATURE = $savedIsolatedDraw
     $env:PINYON_SHIFT_NATIVE_RENDERER_ISOLATED_DRAW_DIR = $savedIsolatedDrawDir
     $env:PINYON_SHIFT_NATIVE_RENDERER_PASS_ANCHOR_SIGNATURE = $savedPassAnchor
+    $env:PINYON_SHIFT_NATIVE_RENDERER_CONSUMER_FAMILY = $savedConsumerFamily
 }

--- a/tools/capture-native-renderer-renderdoc.ps1
+++ b/tools/capture-native-renderer-renderdoc.ps1
@@ -9,6 +9,8 @@ param(
     [string]$IsolatedDrawSignature,
     [ValidatePattern('^[0-9A-Fa-f]{16}$')]
     [string]$PassAnchorSignature,
+    [ValidatePattern('^[0-9A-Fa-f]{16}(?:/[0-9A-Fa-f]{16}){3}$')]
+    [string]$ConsumerFamily,
     [string]$IsolatedDrawDir,
     [Parameter(Mandatory)]
     [string]$CaptureDir,
@@ -83,6 +85,7 @@ $saved = @{
     draw = $env:PINYON_SHIFT_NATIVE_RENDERER_ISOLATED_DRAW_SIGNATURE
     draw_dir = $env:PINYON_SHIFT_NATIVE_RENDERER_ISOLATED_DRAW_DIR
     pass_anchor = $env:PINYON_SHIFT_NATIVE_RENDERER_PASS_ANCHOR_SIGNATURE
+    consumer_family = $env:PINYON_SHIFT_NATIVE_RENDERER_CONSUMER_FAMILY
 }
 try {
     $env:PINYON_SHIFT_STATE_ROOT = $resolvedStateRoot
@@ -99,6 +102,7 @@ try {
         } else {
             $null
         }
+    $env:PINYON_SHIFT_NATIVE_RENDERER_CONSUMER_FAMILY = $ConsumerFamily
     & $renderdoc capture -w `
         -d (Split-Path $executable -Parent) `
         -c (Join-Path $resolvedCaptureDir 'reference') `
@@ -116,6 +120,7 @@ finally {
     $env:PINYON_SHIFT_NATIVE_RENDERER_ISOLATED_DRAW_SIGNATURE = $saved.draw
     $env:PINYON_SHIFT_NATIVE_RENDERER_ISOLATED_DRAW_DIR = $saved.draw_dir
     $env:PINYON_SHIFT_NATIVE_RENDERER_PASS_ANCHOR_SIGNATURE = $saved.pass_anchor
+    $env:PINYON_SHIFT_NATIVE_RENDERER_CONSUMER_FAMILY = $saved.consumer_family
 }
 
 $captures = @(Get-ChildItem -LiteralPath $resolvedCaptureDir -File -Filter '*.rdc')

--- a/tools/export-native-renderer-renderdoc.ps1
+++ b/tools/export-native-renderer-renderdoc.ps1
@@ -8,11 +8,17 @@ param(
     [string]$OutputDir,
     [string]$NativeMarker = 'PinyonShift NR-02E isolated native draw',
     [string]$XenosMarker = 'PinyonShift NR-02E authoritative Xenos draw',
-    [switch]$CompletePass
+    [switch]$CompletePass,
+    [ValidatePattern('^[0-9A-Fa-f]{16}(?:/[0-9A-Fa-f]{16}){3}$')]
+    [string]$ConsumerFamily
 )
 
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
+
+if ($CompletePass -and $ConsumerFamily) {
+    throw 'CompletePass and ConsumerFamily are mutually exclusive.'
+}
 
 $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
 $localRoot = [IO.Path]::GetFullPath((Join-Path $repoRoot '.local'))
@@ -48,12 +54,14 @@ $savedOutput = $env:PINYON_SHIFT_RENDERDOC_EXPORT_DIR
 $savedNativeMarker = $env:PINYON_SHIFT_RENDERDOC_NATIVE_MARKER
 $savedXenosMarker = $env:PINYON_SHIFT_RENDERDOC_XENOS_MARKER
 $savedCompletePass = $env:PINYON_SHIFT_RENDERDOC_COMPLETE_PASS
+$savedConsumerFamily = $env:PINYON_SHIFT_RENDERDOC_CONSUMER_FAMILY
 try {
     $env:PINYON_SHIFT_RENDERDOC_CAPTURE = $resolvedCapture
     $env:PINYON_SHIFT_RENDERDOC_EXPORT_DIR = $resolvedOutputDir
     $env:PINYON_SHIFT_RENDERDOC_NATIVE_MARKER = $NativeMarker
     $env:PINYON_SHIFT_RENDERDOC_XENOS_MARKER = $XenosMarker
     $env:PINYON_SHIFT_RENDERDOC_COMPLETE_PASS = if ($CompletePass) { '1' } else { '0' }
+    $env:PINYON_SHIFT_RENDERDOC_CONSUMER_FAMILY = $ConsumerFamily
     $process = Start-Process -FilePath $qrenderdoc `
         -ArgumentList @('--python', $script) -PassThru -Wait
     if ($process.ExitCode) {
@@ -66,6 +74,7 @@ finally {
     $env:PINYON_SHIFT_RENDERDOC_NATIVE_MARKER = $savedNativeMarker
     $env:PINYON_SHIFT_RENDERDOC_XENOS_MARKER = $savedXenosMarker
     $env:PINYON_SHIFT_RENDERDOC_COMPLETE_PASS = $savedCompletePass
+    $env:PINYON_SHIFT_RENDERDOC_CONSUMER_FAMILY = $savedConsumerFamily
 }
 
 $report = Join-Path $resolvedOutputDir 'renderdoc-export.json'

--- a/tools/export-native-renderer-renderdoc.py
+++ b/tools/export-native-renderer-renderdoc.py
@@ -8,6 +8,7 @@ so RenderDoc's command-line parser never needs to understand tool arguments.
 import hashlib
 import json
 import os
+import re
 import sys
 import traceback
 
@@ -25,12 +26,25 @@ XENOS_MARKER = os.environ.get(
 COMPLETE_PASS = os.environ.get(
     "PINYON_SHIFT_RENDERDOC_COMPLETE_PASS", "0"
 ) == "1"
+CONSUMER_FAMILY = os.environ.get(
+    "PINYON_SHIFT_RENDERDOC_CONSUMER_FAMILY", ""
+)
+CONSUMER_FAMILY_MARKER = (
+    "PinyonShift NR-00E authoritative consumer family draw"
+)
 PASS_NATIVE_ANCHOR_MARKER = "PinyonShift NR-02F isolated native pass anchor"
 PASS_XENOS_ANCHOR_MARKER = "PinyonShift NR-02F authoritative Xenos pass anchor"
 PASS_NATIVE_FOLLOWER_MARKER = "PinyonShift NR-02F isolated native pass follower"
 PASS_XENOS_FOLLOWER_MARKER = "PinyonShift NR-02F authoritative Xenos pass follower"
 SCHEMA = "pinyon-shift.native-renderer-renderdoc-export.v1"
 COMPLETE_PASS_SCHEMA = "pinyon-shift.native-renderer-pass-renderdoc-export.v1"
+CONSUMER_FAMILY_SCHEMA = (
+    "pinyon-shift.native-renderer-consumer-family-renderdoc-export.v1"
+)
+CONSUMER_FAMILY_PATTERN = re.compile(
+    r"^[0-9A-Fa-f]{16}(?:/[0-9A-Fa-f]{16}){3}$"
+)
+MAX_CONSUMER_MARKER_EVENT_IDS = 64
 
 
 def _flatten(actions):
@@ -311,6 +325,60 @@ def _export_complete_pass(controller, actions, capture_path, output_dir):
     }
 
 
+def _export_consumer_family(
+    controller, actions, capture_path, output_dir, consumer_family
+):
+    if not CONSUMER_FAMILY_PATTERN.fullmatch(consumer_family):
+        raise RuntimeError("consumer family id is malformed")
+    markers = [
+        action for action in actions
+        if action.customName == CONSUMER_FAMILY_MARKER
+    ]
+    if not markers:
+        available_markers = sorted(
+            set(
+                action.customName
+                for action in actions
+                if action.customName and "PinyonShift" in action.customName
+            )
+        )
+        raise RuntimeError(
+            "no authoritative consumer-family marker was found; "
+            "available PinyonShift markers={}".format(available_markers)
+        )
+    return {
+        "schema": CONSUMER_FAMILY_SCHEMA,
+        "capture": {
+            "path": os.path.basename(capture_path),
+            "sha256": _sha256(capture_path),
+        },
+        "consumer_family": consumer_family.upper(),
+        "marker": CONSUMER_FAMILY_MARKER,
+        "marker_count": len(markers),
+        "marker_event_ids": [
+            marker.eventId
+            for marker in markers[:MAX_CONSUMER_MARKER_EVENT_IDS]
+        ],
+        "marker_event_id_overflow": max(
+            0, len(markers) - MAX_CONSUMER_MARKER_EVENT_IDS
+        ),
+        "first_authoritative_draw": _export_marker(
+            controller, markers[0], output_dir, "consumer-family-first"
+        ),
+        "evidence": {
+            "scope": "exact_lineage_consumer_and_four_field_family",
+            "comparison": "bound_color_and_depth_before_after_first_draw",
+            "semantic_role": "operator_review_required",
+        },
+        "safety": {
+            "xenos_draws_preserved": True,
+            "draw_suppression_implemented": False,
+            "resolve_suppression_implemented": False,
+            "suppression_allowed": False,
+        },
+    }
+
+
 def main():
     capture_path = os.environ["PINYON_SHIFT_RENDERDOC_CAPTURE"]
     output_dir = os.environ["PINYON_SHIFT_RENDERDOC_EXPORT_DIR"]
@@ -331,6 +399,20 @@ def main():
             raise RuntimeError("could not initialise replay: {}".format(result))
 
         actions = _flatten(controller.GetRootActions())
+        if CONSUMER_FAMILY:
+            if COMPLETE_PASS:
+                raise RuntimeError(
+                    "consumer-family and complete-pass exports are mutually exclusive"
+                )
+            report = _export_consumer_family(
+                controller, actions, capture_path, output_dir,
+                CONSUMER_FAMILY,
+            )
+            with open(report_path, "w") as output:
+                json.dump(report, output, indent=2, sort_keys=True)
+                output.write("\n")
+            print(report_path)
+            return 0
         if COMPLETE_PASS:
             report = _export_complete_pass(
                 controller, actions, capture_path, output_dir

--- a/tools/tests/test_native_renderer_contract.py
+++ b/tools/tests/test_native_renderer_contract.py
@@ -554,6 +554,45 @@ class NativeRendererContractTests(unittest.TestCase):
         self.assertIn("PINYON_SHIFT_RENDERDOC_COMPLETE_PASS", wrapper)
         self.assertNotIn("SetDrawSuppression", exporter)
 
+    def test_consumer_family_marker_is_exact_passive_and_exportable(self):
+        hooks = (ROOT / "src/native_renderer/graphics_hooks.cpp").read_text(
+            encoding="utf-8"
+        )
+        patch = (
+            ROOT / "patches/rexglue/0075-d3d12-consumer-family-marker.patch"
+        ).read_text(encoding="utf-8")
+        capture = (
+            ROOT / "tools/capture-native-renderer-census.ps1"
+        ).read_text(encoding="utf-8")
+        exporter = (
+            ROOT / "tools/export-native-renderer-renderdoc.py"
+        ).read_text(encoding="utf-8")
+        wrapper = (
+            ROOT / "tools/export-native-renderer-renderdoc.ps1"
+        ).read_text(encoding="utf-8")
+
+        self.assertIn("PINYON_SHIFT_NATIVE_RENDERER_CONSUMER_FAMILY", hooks)
+        for field in (
+            "vertex_shader_hash",
+            "pixel_shader_hash",
+            "vertex_specialization_mask",
+            "pixel_specialization_mask",
+        ):
+            self.assertIn(field, hooks)
+        self.assertIn("consumer_reference_marker_requested", hooks)
+        self.assertIn("authoritative_draw_marker_only", hooks)
+        self.assertIn("consumer_reference_marker_requested", patch)
+        self.assertIn(
+            "PinyonShift NR-00E authoritative consumer family draw", patch
+        )
+        self.assertNotIn("SetDrawSuppression", hooks + patch)
+        self.assertNotIn("SetCopySuppression", hooks + patch)
+        self.assertIn("[string]$ConsumerFamily", capture)
+        self.assertIn("PINYON_SHIFT_RENDERDOC_CONSUMER_FAMILY", wrapper)
+        self.assertIn("CONSUMER_FAMILY_SCHEMA", exporter)
+        self.assertIn("operator_review_required", exporter)
+        self.assertIn("MAX_CONSUMER_MARKER_EVENT_IDS = 64", exporter)
+
     def test_shader_capture_is_local_bounded_and_passive(self):
         patch = (
             ROOT

--- a/tools/tests/test_native_renderer_renderdoc_export.py
+++ b/tools/tests/test_native_renderer_renderdoc_export.py
@@ -52,6 +52,44 @@ def span(resource_id):
 
 
 class NativeRendererRenderDocExportTests(unittest.TestCase):
+    def test_consumer_family_exports_bounded_exact_marker_evidence(self):
+        family = (
+            "2E5E0A854BE00027/BDFFA72B7ED2FBA4/"
+            "000000000000003F/000000000016003F"
+        )
+        markers = [
+            Action(MODULE.CONSUMER_FAMILY_MARKER, index)
+            for index in range(1, 67)
+        ]
+        with tempfile.TemporaryDirectory() as temporary:
+            capture = Path(temporary) / "capture.rdc"
+            capture.write_bytes(b"capture")
+            with mock.patch.object(
+                MODULE, "_export_marker", return_value={"draw_event_id": 2}
+            ):
+                result = MODULE._export_consumer_family(
+                    object(), markers, str(capture), temporary, family.lower()
+                )
+
+        self.assertEqual(result["schema"], MODULE.CONSUMER_FAMILY_SCHEMA)
+        self.assertEqual(result["consumer_family"], family)
+        self.assertEqual(result["marker_count"], 66)
+        self.assertEqual(len(result["marker_event_ids"]), 64)
+        self.assertEqual(result["marker_event_id_overflow"], 2)
+        self.assertEqual(
+            result["evidence"]["semantic_role"], "operator_review_required"
+        )
+        self.assertFalse(result["safety"]["suppression_allowed"])
+
+    def test_consumer_family_rejects_malformed_identity(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            capture = Path(temporary) / "capture.rdc"
+            capture.write_bytes(b"capture")
+            with self.assertRaisesRegex(RuntimeError, "malformed"):
+                MODULE._export_consumer_family(
+                    object(), [], str(capture), temporary, "not-a-family"
+                )
+
     def test_complete_pass_requires_ordered_distinct_paths(self):
         with tempfile.TemporaryDirectory() as temporary:
             capture = Path(temporary) / "capture.rdc"

--- a/tools/tests/test_release_contract.py
+++ b/tools/tests/test_release_contract.py
@@ -43,10 +43,10 @@ class ReleaseContractTests(unittest.TestCase):
 
     def test_rexglue_patches_have_stable_order_and_no_binary_payload(self):
         patches = sorted((ROOT / "patches/rexglue").glob("*.patch"))
-        self.assertEqual(len(patches), 74)
+        self.assertEqual(len(patches), 75)
         self.assertEqual(
             patches[-1].name,
-            "0074-physical-memory-read-observer.patch",
+            "0075-d3d12-consumer-family-marker.patch",
         )
         self.assertEqual(len(patches), len({path.name[:4] for path in patches}))
         for path in patches:


### PR DESCRIPTION
## Summary
- identify one exact later GPU consumer family by shader hashes and specialization masks
- mark authoritative Xenos draws for bounded RenderDoc inspection without replay, redirection, or suppression
- plumb the family selector through census/capture/export tooling and document the workflow
- add deterministic exporter and contract coverage

## Safety
- authoritative Xenos draws remain preserved
- draw suppression remains false
- resolve suppression remains false
- this change adds observability only and is not suppression-eligible

## Validation
- `python -m unittest discover -s tools/tests -p "test_*.py"` (204 passed)
- fresh ReXGlue reconstruction at pinned base with 75 patches
- `tools/build-preview.ps1 -CleanGenerated -Parallel 16` (passed)
- AppData gameplay qualification exited normally; 1,040 exact-family matches and 1,040 marker requests in the RenderDoc run
- open-world RenderDoc capture completed successfully; the sampled frame did not contain the selected family, and the exporter correctly rejected it instead of producing misleading evidence
- observed runtime median: 30.0 FPS over 5,486 samples in the prior boundary run