### PR TITLE
feat(native-renderer): capture exact consumer contributions

### DIFF
--- a/docs/native-renderer/CONSUMER_FAMILY_CLASSIFICATION.md
+++ b/docs/native-renderer/CONSUMER_FAMILY_CLASSIFICATION.md
@@ -110,6 +110,65 @@ an automatic role promotion. Marker insertion does not replay, redirect, or
 suppress work: every Xenos draw remains authoritative and both draw and resolve
 suppression remain false.
 
+### Automatic exact-draw contribution capture
+
+Manual F12 capture can land on a frame that does not contain the selected
+family. For deterministic semantic evidence, request a one-shot asynchronous
+readback of the authoritative color attachment immediately before and after
+the first exact lineage/four-field match:
+
+```powershell
+$family = '2E5E0A854BE00027/BDFFA72B7ED2FBA4/000000000000003F/000000000016003F'
+$readback = '.local\qualification\consumer-family-readback'
+.\tools\capture-native-renderer-census.ps1 `
+  -StateRoot "$env:LOCALAPPDATA\PinyonShift\source\0.1.0\.local\preview" `
+  -Scene open_world_day `
+  -IsolatedDrawSignature '1D253A52B55C9FB3' `
+  -PassAnchorSignature '747837906D0BF484' `
+  -ConsumerFamily $family `
+  -ConsumerReadbackDir $readback
+```
+
+The D3D12 backend owns two independent pending slots, so the pre-draw and
+post-draw copies cannot alias each other or the existing isolated-pass
+readbacks. Both copies are queued around the original authoritative draw and
+complete after its submission fence without a GPU wait. The output remains
+local and contains raw row-pitched target bytes plus fail-closed metadata.
+
+Build a deterministic visual contribution report with:
+
+```powershell
+.\tools\analyze-native-renderer-consumer-readback.ps1 `
+  -ReadbackRoot $readback `
+  -OutputDir '.local\qualification\consumer-family-contribution'
+```
+
+The report validates exact family/frame/draw identity, attachment layout, and
+the no-suppression safety fields before producing `before.png`, `after.png`, a
+4x absolute-difference image, a changed-pixel mask, and numeric change bounds.
+It deliberately leaves `semantic_role=operator_review_required`; a visible
+contribution is evidence for classification, not permission to claim native
+coverage or suppress the producer. Xenos remains authoritative throughout.
+
+### Qualification evidence
+
+The `open_world_day` AppData qualification on 2026-08-29 captured the selected
+family at frame 3876, draw 419, from a 2560x1024
+`R16G16B16A16_FLOAT` attachment. Runtime diagnostics reported one bounded
+request, two successful completions, 1364 exact matches, a normal process exit,
+and no error or device-loss events. The before and after payloads were identical
+(`7FA5516C3FA339D267CCC801D3B558FA655597D085284F58F914C5BAD5904FFD`),
+so this sampled draw changed zero color pixels. That is negative contribution
+evidence for this occurrence, not sufficient proof that every draw in the
+family is semantically inert; its role therefore remains
+`operator_review_required`.
+
+The same 131.118-second run recorded 4642 frame samples, 31.094 median FPS,
+19.107 one-percent-low FPS, 59.969 Hz host presentation cadence, no presentation
+deadline misses, and no pipeline-cache misses. Xenos remained authoritative,
+the original draw was preserved, and both draw and resolve suppression stayed
+false.
+
 ## Rollback-switch boundary
 
 `config/native-renderer/suppression-switches.json` reserves one independent,

--- a/patches/rexglue/0076-d3d12-consumer-family-readback.patch
+++ b/patches/rexglue/0076-d3d12-consumer-family-readback.patch
@@ -1,0 +1,172 @@
+diff --git a/include/rex/system/interfaces/graphics.h b/include/rex/system/interfaces/graphics.h
+--- a/include/rex/system/interfaces/graphics.h
++++ b/include/rex/system/interfaces/graphics.h
+@@ -407,6 +407,10 @@ struct GraphicsIsolatedDrawRequest {
+   // Mark the authoritative guest draw as an exact later-consumer-family
+   // target. This never duplicates, redirects, or suppresses the draw.
+   bool consumer_reference_marker_requested = false;
++  // Capture the authoritative guest color target immediately before and after
++  // one exact consumer-family draw. Both copies are diagnostic-only and the
++  // original draw remains authoritative.
++  bool consumer_reference_readback_requested = false;
+   bool retain_target = false;
+   // Rebind the retained private target without copying the guest target. This
+   // is valid only for the immediately following draw of an isolated pass.
+@@ -419,6 +423,10 @@ struct GraphicsIsolatedDrawRequest {
+   GraphicsIsolatedDrawReadbackCompletion depth_readback_completion = nullptr;
+   GraphicsIsolatedDrawReadbackCompletion
+       reference_depth_readback_completion = nullptr;
++  GraphicsIsolatedDrawReadbackCompletion
++      consumer_reference_before_readback_completion = nullptr;
++  GraphicsIsolatedDrawReadbackCompletion
++      consumer_reference_after_readback_completion = nullptr;
+ };
+ 
+ // Called after the host pipeline has been prepared. A request duplicates the
+diff --git a/include/rex/graphics/d3d12/render_target_cache.h b/include/rex/graphics/d3d12/render_target_cache.h
+--- a/include/rex/graphics/d3d12/render_target_cache.h
++++ b/include/rex/graphics/d3d12/render_target_cache.h
+@@ -107,6 +107,10 @@ class D3D12RenderTargetCache final : public RenderTargetCache {
+   system::GraphicsIsolatedDrawReadbackStatus QueueGuestColorReadback(
+       system::GraphicsIsolatedDrawReadbackCompletion completion,
+       uint32_t* failure_detail_out);
++  system::GraphicsIsolatedDrawReadbackStatus QueueGuestConsumerColorReadback(
++      bool before_draw,
++      system::GraphicsIsolatedDrawReadbackCompletion completion,
++      uint32_t* failure_detail_out);
+   system::GraphicsIsolatedDrawReadbackStatus QueueIsolatedReplayDepthReadback(
+       system::GraphicsIsolatedDrawReadbackCompletion completion,
+       uint32_t* failure_detail_out);
+@@ -733,6 +737,8 @@ class D3D12RenderTargetCache final : public RenderTargetCache {
+     system::GraphicsIsolatedDrawReadbackCompletion completion = nullptr;
+   } isolated_replay_readback_;
+   IsolatedReplayReadback guest_reference_readback_;
++  IsolatedReplayReadback guest_consumer_before_readback_;
++  IsolatedReplayReadback guest_consumer_after_readback_;
+   IsolatedReplayReadback isolated_replay_depth_readback_;
+   IsolatedReplayReadback guest_depth_reference_readback_;
+   system::GraphicsIsolatedDrawReadbackStatus QueueRenderTargetReadback(
+diff --git a/src/graphics/d3d12/command_processor.cpp b/src/graphics/d3d12/command_processor.cpp
+--- a/src/graphics/d3d12/command_processor.cpp
++++ b/src/graphics/d3d12/command_processor.cpp
+@@ -3310,6 +3310,32 @@ bool D3D12CommandProcessor::IssueDraw(xenos::PrimitiveType primitive_type, uint3
+   SetPrimitiveTopology(primitive_topology);
+   // Must not call anything that may change the primitive topology from now on!
+ 
++  const auto queue_consumer_reference_readback = [&](bool before_draw) {
++    if (!isolated_draw_request.consumer_reference_readback_requested) {
++      return;
++    }
++    auto completion =
++        before_draw
++            ? isolated_draw_request
++                  .consumer_reference_before_readback_completion
++            : isolated_draw_request
++                  .consumer_reference_after_readback_completion;
++    if (!completion) {
++      return;
++    }
++    uint32_t readback_detail = 0;
++    auto readback_status =
++        render_target_cache_->QueueGuestConsumerColorReadback(
++            before_draw, completion, &readback_detail);
++    if (readback_status !=
++        system::GraphicsIsolatedDrawReadbackStatus::kReady) {
++      system::GraphicsIsolatedDrawReadback readback_result;
++      readback_result.status = readback_status;
++      readback_result.detail = readback_detail;
++      completion(readback_result);
++    }
++  };
++
+   // Draw.
+   if (primitive_processing_result.index_buffer_type ==
+       PrimitiveProcessor::ProcessedIndexBufferType::kNone) {
+@@ -3382,6 +3408,7 @@ bool D3D12CommandProcessor::IssueDraw(xenos::PrimitiveType primitive_type, uint3
+         isolated_draw_request.completion(isolated_result);
+       }
+     }
++    queue_consumer_reference_readback(true);
+     if (isolated_draw_request.consumer_reference_marker_requested) {
+       deferred_command_list_.BeginDebugMarker(
+           "PinyonShift NR-00E authoritative consumer family draw");
+@@ -3399,6 +3426,7 @@ bool D3D12CommandProcessor::IssueDraw(xenos::PrimitiveType primitive_type, uint3
+         isolated_draw_request.reference_marker_requested) {
+       deferred_command_list_.EndDebugMarker();
+     }
++    queue_consumer_reference_readback(false);
+     if (isolated_draw_request.reference_readback_requested &&
+         isolated_draw_request.reference_readback_completion) {
+       uint32_t readback_detail = 0;
+@@ -3548,6 +3576,7 @@ bool D3D12CommandProcessor::IssueDraw(xenos::PrimitiveType primitive_type, uint3
+         isolated_draw_request.completion(isolated_result);
+       }
+     }
++    queue_consumer_reference_readback(true);
+     if (isolated_draw_request.consumer_reference_marker_requested) {
+       deferred_command_list_.BeginDebugMarker(
+           "PinyonShift NR-00E authoritative consumer family draw");
+@@ -3565,6 +3594,7 @@ bool D3D12CommandProcessor::IssueDraw(xenos::PrimitiveType primitive_type, uint3
+         isolated_draw_request.reference_marker_requested) {
+       deferred_command_list_.EndDebugMarker();
+     }
++    queue_consumer_reference_readback(false);
+     if (isolated_draw_request.reference_readback_requested &&
+         isolated_draw_request.reference_readback_completion) {
+       uint32_t readback_detail = 0;
+diff --git a/src/graphics/d3d12/render_target_cache.cpp b/src/graphics/d3d12/render_target_cache.cpp
+--- a/src/graphics/d3d12/render_target_cache.cpp
++++ b/src/graphics/d3d12/render_target_cache.cpp
+@@ -1033,6 +1033,8 @@ void D3D12RenderTargetCache::Shutdown(bool from_destructor) {
+   };
+   release_isolated_readback(isolated_replay_readback_);
+   release_isolated_readback(guest_reference_readback_);
++  release_isolated_readback(guest_consumer_before_readback_);
++  release_isolated_readback(guest_consumer_after_readback_);
+   release_isolated_readback(isolated_replay_depth_readback_);
+   release_isolated_readback(guest_depth_reference_readback_);
+   isolated_replay_preview_resolved_target_.Reset();
+@@ -1098,6 +1100,8 @@ void D3D12RenderTargetCache::CompletedSubmissionUpdated() {
+   };
+   complete_isolated_readback(isolated_replay_readback_);
+   complete_isolated_readback(guest_reference_readback_);
++  complete_isolated_readback(guest_consumer_before_readback_);
++  complete_isolated_readback(guest_consumer_after_readback_);
+   complete_isolated_readback(isolated_replay_depth_readback_);
+   complete_isolated_readback(guest_depth_reference_readback_);
+ }
+@@ -1914,6 +1918,34 @@ D3D12RenderTargetCache::QueueGuestColorReadback(
+       guest_reference_readback_, completion, failure_detail_out);
+ }
+ 
++system::GraphicsIsolatedDrawReadbackStatus
++D3D12RenderTargetCache::QueueGuestConsumerColorReadback(
++    bool before_draw,
++    system::GraphicsIsolatedDrawReadbackCompletion completion,
++    uint32_t* failure_detail_out) {
++  if (GetPath() != Path::kHostRenderTargets) {
++    return system::GraphicsIsolatedDrawReadbackStatus::kUnsupportedTarget;
++  }
++  RenderTarget* const* guest_targets =
++      last_update_accumulated_render_targets();
++  if (!guest_targets[1]) {
++    return system::GraphicsIsolatedDrawReadbackStatus::kUnsupportedTarget;
++  }
++  auto status = QueueRenderTargetReadback(
++      static_cast<D3D12RenderTarget*>(guest_targets[1]),
++      before_draw ? guest_consumer_before_readback_
++                  : guest_consumer_after_readback_,
++      completion, failure_detail_out);
++  if (before_draw &&
++      status == system::GraphicsIsolatedDrawReadbackStatus::kReady) {
++    // The generic readback queues restoration of a single-sample target for
++    // later submission. This diagnostic copy runs before the authoritative
++    // draw, so make the restoration barrier visible before recording it.
++    command_processor_.SubmitBarriers();
++  }
++  return status;
++}
++
+ system::GraphicsIsolatedDrawReadbackStatus
+ D3D12RenderTargetCache::QueueIsolatedReplayDepthReadback(
+     system::GraphicsIsolatedDrawReadbackCompletion completion,

--- a/src/native_renderer/graphics_hooks.cpp
+++ b/src/native_renderer/graphics_hooks.cpp
@@ -152,14 +152,25 @@ struct ConsumerFamilyMarkerState {
   uint64_t pixel_shader_hash = 0;
   uint64_t vertex_specialization_mask = 0;
   uint64_t pixel_specialization_mask = 0;
+  uint64_t capture_frame = 0;
+  uint64_t capture_draw = 0;
   uint64_t matched_draws = 0;
   uint64_t marker_requests = 0;
+  uint64_t readback_requests = 0;
+  uint64_t readback_completions = 0;
+  std::filesystem::path readback_root;
+  std::jthread before_artifact_writer;
+  std::jthread after_artifact_writer;
   bool requested = false;
+  bool readback_requested = false;
+  bool readback_queued = false;
   bool valid = true;
   bool current_match = false;
 };
 
 ConsumerFamilyMarkerState g_consumer_family_marker;
+
+bool IsLocalArtifactRoot(const std::filesystem::path &path);
 
 void ConfigureSignatureScan(const char *name, uint64_t &target_signature,
                             bool &requested, bool &valid) {
@@ -234,6 +245,22 @@ void ConfigureConsumerFamilyMarker() {
   }
   if (!g_consumer_family_marker.vertex_shader_hash ||
       !g_consumer_family_marker.pixel_shader_hash) {
+    g_consumer_family_marker.valid = false;
+  }
+  value = nullptr;
+  length = 0;
+  if (_dupenv_s(&value, &length,
+                "PINYON_SHIFT_NATIVE_RENDERER_CONSUMER_READBACK_DIR") != 0 ||
+      !value || length <= 1) {
+    std::free(value);
+    return;
+  }
+  g_consumer_family_marker.readback_requested = true;
+  g_consumer_family_marker.readback_root =
+      std::filesystem::absolute(std::filesystem::path(value)).lexically_normal();
+  std::free(value);
+  if (!g_consumer_family_marker.valid ||
+      !IsLocalArtifactRoot(g_consumer_family_marker.readback_root)) {
     g_consumer_family_marker.valid = false;
   }
 }
@@ -2178,6 +2205,155 @@ float HalfToFloat(uint16_t value) {
   return std::bit_cast<float>(bits);
 }
 
+void CompleteConsumerFamilyReadbackArtifact(
+    const rex::system::GraphicsIsolatedDrawReadback &readback,
+    const char *phase, std::jthread &artifact_writer) {
+  ++g_consumer_family_marker.readback_completions;
+  const auto reject = [&](const char *status) {
+    pinyon_shift::diagnostics::RecordEvent(
+        "native_renderer.census.consumer_family_readback",
+        {{"consumer_family", ConsumerFamilyId()},
+         {"status", status},
+         {"detail", fmt::format("0x{:08X}", readback.detail)},
+         {"frame", std::to_string(g_consumer_family_marker.capture_frame)},
+         {"draw", std::to_string(g_consumer_family_marker.capture_draw)},
+         {"phase", phase},
+         {"xenos_draw", "preserved"},
+         {"draw_suppression", "false"},
+         {"resolve_suppression", "false"},
+         {"suppression_eligible", "false"}});
+  };
+  if (readback.status !=
+      rex::system::GraphicsIsolatedDrawReadbackStatus::kReady) {
+    if (readback.status ==
+        rex::system::GraphicsIsolatedDrawReadbackStatus::
+            kResolveAllocationFailed) {
+      reject("resolve_allocation_failed");
+    } else if (readback.status ==
+               rex::system::GraphicsIsolatedDrawReadbackStatus::
+                   kAllocationFailed) {
+      reject("allocation_failed");
+    } else if (readback.status ==
+               rex::system::GraphicsIsolatedDrawReadbackStatus::kMapFailed) {
+      reject("map_failed");
+    } else {
+      reject("unsupported_target");
+    }
+    return;
+  }
+
+  constexpr uint32_t kR16G16B16A16Float = 10;
+  constexpr uint32_t kR8G8B8A8Unorm = 28;
+  const uint32_t bytes_per_pixel =
+      readback.format == kR16G16B16A16Float
+          ? 8
+          : (readback.format == kR8G8B8A8Unorm ? 4 : 0);
+  const uint64_t required_size =
+      uint64_t(readback.row_pitch) * readback.height;
+  if (!bytes_per_pixel || !readback.data || !readback.width ||
+      !readback.height ||
+      uint64_t(readback.width) * bytes_per_pixel > readback.row_pitch ||
+      required_size > readback.data_size || required_size > SIZE_MAX) {
+    reject("unsupported_layout");
+    return;
+  }
+
+  std::vector<uint8_t> bytes(readback.data,
+                             readback.data + size_t(required_size));
+  const std::string family = ConsumerFamilyId();
+  const uint64_t frame = g_consumer_family_marker.capture_frame;
+  const uint64_t draw = g_consumer_family_marker.capture_draw;
+  const auto output_root = g_consumer_family_marker.readback_root / phase;
+  const uint32_t width = readback.width;
+  const uint32_t height = readback.height;
+  const uint32_t row_pitch = readback.row_pitch;
+  const uint32_t format = readback.format;
+  artifact_writer = std::jthread(
+      [bytes = std::move(bytes), family, frame, draw, output_root, width,
+       height, row_pitch, format, bytes_per_pixel,
+       phase = std::string(phase)]() {
+        std::filesystem::path staging = output_root;
+        staging += L".partial";
+        std::error_code error;
+        if (std::filesystem::exists(output_root, error) || error ||
+            std::filesystem::exists(staging, error) || error ||
+            !std::filesystem::create_directories(staging, error) || error) {
+          pinyon_shift::diagnostics::RecordEvent(
+              "native_renderer.census.consumer_family_readback",
+              {{"consumer_family", family},
+               {"status", "output_directory_unavailable"},
+               {"frame", std::to_string(frame)},
+               {"draw", std::to_string(draw)},
+               {"phase", phase},
+               {"xenos_draw", "preserved"},
+               {"suppression_eligible", "false"}});
+          return;
+        }
+        const std::string metadata = fmt::format(
+            "{{\n  \"schema\": "
+            "\"pinyon-shift.consumer-family-readback.v1\",\n"
+            "  \"consumer_family\": \"{}\",\n  \"frame\": {},\n"
+            "  \"draw\": {},\n  \"phase\": \"{}\",\n"
+            "  \"source\": {{\"width\":{},\"height\":{},"
+            "\"row_pitch\":{},\"dxgi_format\":{},"
+            "\"bytes_per_pixel\":{},\"bytes\":{},"
+            "\"hash\":\"{:016X}\"}},\n"
+            "  \"payload\": {{\"file\":\"target.bin\"}},\n"
+            "  \"safety\": {{\"output_authority\":\"xenos\","
+            "\"xenos_draw_preserved\":true,"
+            "\"draw_suppression\":false,"
+            "\"resolve_suppression\":false,"
+            "\"suppression_allowed\":false}}\n}}\n",
+            family, frame, draw, phase, width, height, row_pitch, format,
+            bytes_per_pixel, bytes.size(),
+            HashBytes(bytes.data(), bytes.size()));
+        const auto metadata_bytes = std::span(
+            reinterpret_cast<const uint8_t *>(metadata.data()),
+            metadata.size());
+        if (!WriteSnapshotFile(staging / L"target.bin", bytes) ||
+            !WriteSnapshotFile(staging / L"readback.json", metadata_bytes)) {
+          std::filesystem::remove_all(staging, error);
+          pinyon_shift::diagnostics::RecordEvent(
+              "native_renderer.census.consumer_family_readback",
+              {{"consumer_family", family},
+               {"status", "artifact_write_failed"},
+               {"frame", std::to_string(frame)},
+               {"draw", std::to_string(draw)},
+               {"phase", phase},
+               {"xenos_draw", "preserved"},
+               {"suppression_eligible", "false"}});
+          return;
+        }
+        std::filesystem::rename(staging, output_root, error);
+        pinyon_shift::diagnostics::RecordEvent(
+            "native_renderer.census.consumer_family_readback",
+            {{"consumer_family", family},
+             {"status", error ? "artifact_commit_failed" : "captured"},
+             {"frame", std::to_string(frame)},
+             {"draw", std::to_string(draw)},
+             {"phase", phase},
+             {"source_width", std::to_string(width)},
+             {"source_height", std::to_string(height)},
+             {"readback_bytes", std::to_string(bytes.size())},
+             {"xenos_draw", "preserved"},
+             {"draw_suppression", "false"},
+             {"resolve_suppression", "false"},
+             {"suppression_eligible", "false"}});
+      });
+}
+
+void CompleteConsumerFamilyBeforeReadback(
+    const rex::system::GraphicsIsolatedDrawReadback &readback) {
+  CompleteConsumerFamilyReadbackArtifact(
+      readback, "before", g_consumer_family_marker.before_artifact_writer);
+}
+
+void CompleteConsumerFamilyAfterReadback(
+    const rex::system::GraphicsIsolatedDrawReadback &readback) {
+  CompleteConsumerFamilyReadbackArtifact(
+      readback, "after", g_consumer_family_marker.after_artifact_writer);
+}
+
 void CompleteIsolatedReadbackArtifact(
     const rex::system::GraphicsIsolatedDrawReadback &readback,
     const char *capture_role, const std::filesystem::path &artifact_root,
@@ -2685,6 +2861,16 @@ void RequestIsolatedDraw(
   if (g_consumer_family_marker.current_match) {
     request.consumer_reference_marker_requested = true;
     ++g_consumer_family_marker.marker_requests;
+    if (g_consumer_family_marker.readback_requested &&
+        !g_consumer_family_marker.readback_queued) {
+      g_consumer_family_marker.readback_queued = true;
+      ++g_consumer_family_marker.readback_requests;
+      request.consumer_reference_readback_requested = true;
+      request.consumer_reference_before_readback_completion =
+          &CompleteConsumerFamilyBeforeReadback;
+      request.consumer_reference_after_readback_completion =
+          &CompleteConsumerFamilyAfterReadback;
+    }
   }
   if (!g_isolated_draw.requested || !g_isolated_draw.valid ||
       !g_isolated_draw.prepared_candidate_valid) {
@@ -3023,6 +3209,11 @@ void CommitPassConsumer(
           g_consumer_family_marker.pixel_specialization_mask) {
     g_consumer_family_marker.current_match = true;
     ++g_consumer_family_marker.matched_draws;
+    if (g_consumer_family_marker.readback_requested &&
+        !g_consumer_family_marker.readback_queued) {
+      g_consumer_family_marker.capture_frame = observation.frame_sequence;
+      g_consumer_family_marker.capture_draw = observation.draw_sequence;
+    }
   }
   ObservePassConsumerSignature(observation, prepared,
                                candidate.family_base_fetch_mask,
@@ -3463,10 +3654,20 @@ void InstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system,
       "native_renderer.census.consumer_family_marker_config",
       {{"status", !g_consumer_family_marker.requested
                       ? "disabled"
-                      : (g_consumer_family_marker.valid ? "armed"
-                                                        : "invalid_family")},
+                      : (g_consumer_family_marker.valid
+                             ? (g_consumer_family_marker.readback_requested
+                                    ? "armed_with_readback"
+                                    : "armed")
+                             : "invalid_configuration")},
        {"consumer_family", ConsumerFamilyId()},
-       {"mode", "authoritative_draw_marker_only"},
+       {"mode", g_consumer_family_marker.readback_requested
+                    ? "authoritative_draw_marker_and_paired_async_readback"
+                    : "authoritative_draw_marker_only"},
+       {"readback",
+        g_consumer_family_marker.readback_requested ? "before_after_color"
+                                                    : "disabled"},
+       {"readback_output",
+        g_consumer_family_marker.readback_requested ? "local_only" : ""},
        {"xenos_draw", "preserved"},
        {"draw_suppression", "false"},
        {"resolve_suppression", "false"},
@@ -3554,6 +3755,12 @@ void UninstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system) {
   }
   if (g_isolated_draw.reference_depth_artifact_writer.joinable()) {
     g_isolated_draw.reference_depth_artifact_writer.join();
+  }
+  if (g_consumer_family_marker.before_artifact_writer.joinable()) {
+    g_consumer_family_marker.before_artifact_writer.join();
+  }
+  if (g_consumer_family_marker.after_artifact_writer.joinable()) {
+    g_consumer_family_marker.after_artifact_writer.join();
   }
   if (g_pending_candidate.valid) {
     ++g_candidate_unprepared_draw_count;
@@ -3791,7 +3998,18 @@ void UninstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system) {
         std::to_string(g_consumer_family_marker.matched_draws)},
        {"marker_requests",
         std::to_string(g_consumer_family_marker.marker_requests)},
-       {"mode", "authoritative_draw_marker_only"},
+       {"readback_requested",
+        g_consumer_family_marker.readback_requested ? "true" : "false"},
+       {"readback_requests",
+        std::to_string(g_consumer_family_marker.readback_requests)},
+       {"readback_completions",
+        std::to_string(g_consumer_family_marker.readback_completions)},
+       {"capture_frame",
+        std::to_string(g_consumer_family_marker.capture_frame)},
+       {"capture_draw", std::to_string(g_consumer_family_marker.capture_draw)},
+       {"mode", g_consumer_family_marker.readback_requested
+                    ? "authoritative_draw_marker_and_paired_async_readback"
+                    : "authoritative_draw_marker_only"},
        {"xenos_draw", "preserved"},
        {"draw_suppression", "false"},
        {"resolve_suppression", "false"},

--- a/tools/analyze-native-renderer-consumer-readback.ps1
+++ b/tools/analyze-native-renderer-consumer-readback.ps1
@@ -1,0 +1,34 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)]
+    [string]$ReadbackRoot,
+    [Parameter(Mandatory)]
+    [string]$OutputDir
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$repositoryRoot = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
+$localRoot = [IO.Path]::GetFullPath((Join-Path $repositoryRoot '.local'))
+$localPrefix = $localRoot.TrimEnd([IO.Path]::DirectorySeparatorChar) +
+    [IO.Path]::DirectorySeparatorChar
+$resolvedReadbackRoot = [IO.Path]::GetFullPath($ReadbackRoot)
+$resolvedOutputDir = [IO.Path]::GetFullPath($OutputDir)
+foreach ($path in @($resolvedReadbackRoot, $resolvedOutputDir)) {
+    if (-not $path.StartsWith($localPrefix, [StringComparison]::OrdinalIgnoreCase)) {
+        throw "Consumer evidence paths must remain below $localRoot"
+    }
+}
+if (-not (Test-Path -LiteralPath $resolvedReadbackRoot -PathType Container)) {
+    throw "ReadbackRoot does not exist: $resolvedReadbackRoot"
+}
+if (Test-Path -LiteralPath $resolvedOutputDir) {
+    throw "OutputDir already exists: $resolvedOutputDir"
+}
+
+python (Join-Path $PSScriptRoot 'analyze-native-renderer-consumer-readback.py') `
+    $resolvedReadbackRoot $resolvedOutputDir
+if ($LASTEXITCODE) {
+    throw "Consumer readback analysis exited with code $LASTEXITCODE"
+}

--- a/tools/analyze-native-renderer-consumer-readback.py
+++ b/tools/analyze-native-renderer-consumer-readback.py
@@ -1,0 +1,228 @@
+#!/usr/bin/env python3
+"""Build deterministic visual evidence from an exact consumer draw readback."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+import struct
+import zlib
+from pathlib import Path
+
+
+READBACK_SCHEMA = "pinyon-shift.consumer-family-readback.v1"
+REPORT_SCHEMA = "pinyon-shift.consumer-family-contribution.v1"
+SUPPORTED_FORMATS = {10: 8, 28: 4}
+
+
+def _require(condition: bool, message: str) -> None:
+    if not condition:
+        raise ValueError(message)
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as source:
+        for block in iter(lambda: source.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest().upper()
+
+
+def _load_readback(root: Path, phase: str) -> tuple[dict, bytes]:
+    phase_root = root / phase
+    metadata_path = phase_root / "readback.json"
+    payload_path = phase_root / "target.bin"
+    _require(metadata_path.is_file(), f"missing {phase} metadata")
+    _require(payload_path.is_file(), f"missing {phase} payload")
+    metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+    _require(metadata.get("schema") == READBACK_SCHEMA, f"invalid {phase} schema")
+    _require(metadata.get("phase") == phase, f"invalid {phase} phase")
+    safety = metadata.get("safety", {})
+    _require(safety.get("output_authority") == "xenos", "Xenos authority missing")
+    _require(safety.get("xenos_draw_preserved") is True, "Xenos draw not preserved")
+    _require(safety.get("draw_suppression") is False, "draw suppression present")
+    _require(safety.get("resolve_suppression") is False, "resolve suppression present")
+    _require(safety.get("suppression_allowed") is False, "suppression unexpectedly allowed")
+    source = metadata.get("source", {})
+    width = source.get("width")
+    height = source.get("height")
+    row_pitch = source.get("row_pitch")
+    dxgi_format = source.get("dxgi_format")
+    _require(isinstance(width, int) and width > 0, f"invalid {phase} width")
+    _require(isinstance(height, int) and height > 0, f"invalid {phase} height")
+    _require(dxgi_format in SUPPORTED_FORMATS, f"unsupported {phase} format")
+    bytes_per_pixel = SUPPORTED_FORMATS[dxgi_format]
+    _require(source.get("bytes_per_pixel") == bytes_per_pixel, f"invalid {phase} pixel size")
+    _require(
+        isinstance(row_pitch, int) and row_pitch >= width * bytes_per_pixel,
+        f"invalid {phase} row pitch",
+    )
+    payload = payload_path.read_bytes()
+    _require(len(payload) == row_pitch * height, f"invalid {phase} payload size")
+    _require(source.get("bytes") == len(payload), f"invalid {phase} byte count")
+    return metadata, payload
+
+
+def _to_rgb(metadata: dict, payload: bytes) -> bytes:
+    source = metadata["source"]
+    width = source["width"]
+    height = source["height"]
+    row_pitch = source["row_pitch"]
+    dxgi_format = source["dxgi_format"]
+    bytes_per_pixel = SUPPORTED_FORMATS[dxgi_format]
+    pixels = bytearray(width * height * 3)
+    destination = 0
+    for y in range(height):
+        row = y * row_pitch
+        for x in range(width):
+            offset = row + x * bytes_per_pixel
+            if dxgi_format == 28:
+                pixels[destination : destination + 3] = payload[offset : offset + 3]
+            else:
+                for channel in range(3):
+                    value = struct.unpack_from("<e", payload, offset + channel * 2)[0]
+                    if not math.isfinite(value):
+                        value = 0.0
+                    pixels[destination + channel] = round(max(0.0, min(1.0, value)) * 255)
+            destination += 3
+    return bytes(pixels)
+
+
+def _png_chunk(kind: bytes, payload: bytes) -> bytes:
+    return (
+        struct.pack(">I", len(payload))
+        + kind
+        + payload
+        + struct.pack(">I", zlib.crc32(kind + payload) & 0xFFFFFFFF)
+    )
+
+
+def _write_png(path: Path, width: int, height: int, pixels: bytes) -> None:
+    _require(len(pixels) == width * height * 3, "invalid PNG pixel count")
+    rows = b"".join(
+        b"\x00" + pixels[y * width * 3 : (y + 1) * width * 3]
+        for y in range(height)
+    )
+    header = struct.pack(">IIBBBBB", width, height, 8, 2, 0, 0, 0)
+    path.write_bytes(
+        b"\x89PNG\r\n\x1a\n"
+        + _png_chunk(b"IHDR", header)
+        + _png_chunk(b"IDAT", zlib.compress(rows, 9))
+        + _png_chunk(b"IEND", b"")
+    )
+
+
+def analyze(root: Path, output: Path) -> dict:
+    before_metadata, before_payload = _load_readback(root, "before")
+    after_metadata, after_payload = _load_readback(root, "after")
+    for field in ("consumer_family", "frame", "draw"):
+        _require(
+            before_metadata.get(field) == after_metadata.get(field),
+            f"readback {field} mismatch",
+        )
+    for field in (
+        "width",
+        "height",
+        "row_pitch",
+        "dxgi_format",
+        "bytes_per_pixel",
+        "bytes",
+    ):
+        _require(
+            before_metadata["source"].get(field)
+            == after_metadata["source"].get(field),
+            f"readback source {field} mismatch",
+        )
+    _require(not output.exists(), f"output already exists: {output}")
+    output.mkdir(parents=True)
+
+    width = before_metadata["source"]["width"]
+    height = before_metadata["source"]["height"]
+    before = _to_rgb(before_metadata, before_payload)
+    after = _to_rgb(after_metadata, after_payload)
+    differences = bytearray(len(before))
+    mask = bytearray(len(before))
+    changed_pixels = 0
+    left, top, right, bottom = width, height, 0, 0
+    squared_sum = 0
+    absolute_sum = 0
+    maximum = 0
+    for pixel in range(width * height):
+        changed = False
+        for channel in range(3):
+            index = pixel * 3 + channel
+            delta = abs(after[index] - before[index])
+            differences[index] = min(255, delta * 4)
+            absolute_sum += delta
+            squared_sum += delta * delta
+            maximum = max(maximum, delta)
+            changed |= delta != 0
+        if changed:
+            changed_pixels += 1
+            x, y = pixel % width, pixel // width
+            left, top = min(left, x), min(top, y)
+            right, bottom = max(right, x), max(bottom, y)
+            mask[pixel * 3 : pixel * 3 + 3] = b"\xff\xff\xff"
+
+    _write_png(output / "before.png", width, height, before)
+    _write_png(output / "after.png", width, height, after)
+    _write_png(output / "difference-4x.png", width, height, bytes(differences))
+    _write_png(output / "changed-mask.png", width, height, bytes(mask))
+    channel_count = width * height * 3
+    report = {
+        "schema": REPORT_SCHEMA,
+        "consumer_family": before_metadata["consumer_family"],
+        "frame": before_metadata["frame"],
+        "draw": before_metadata["draw"],
+        "source": {
+            **before_metadata["source"],
+            "before_sha256": _sha256(root / "before" / "target.bin"),
+            "after_sha256": _sha256(root / "after" / "target.bin"),
+        },
+        "contribution": {
+            "changed_pixels": changed_pixels,
+            "total_pixels": width * height,
+            "changed_fraction": changed_pixels / (width * height),
+            "mae_8bit_rgb": absolute_sum / channel_count,
+            "rmse_8bit_rgb": math.sqrt(squared_sum / channel_count),
+            "maximum_channel_delta": maximum,
+            "bounds": (
+                {"left": left, "top": top, "right": right, "bottom": bottom}
+                if changed_pixels
+                else None
+            ),
+            "semantic_role": "operator_review_required",
+        },
+        "images": {
+            "before": "before.png",
+            "after": "after.png",
+            "difference_4x": "difference-4x.png",
+            "changed_mask": "changed-mask.png",
+        },
+        "safety": {
+            "output_authority": "xenos",
+            "xenos_draw_preserved": True,
+            "draw_suppression": False,
+            "resolve_suppression": False,
+            "suppression_allowed": False,
+        },
+    }
+    report_path = output / "consumer-contribution.json"
+    report_path.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return report
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("readback_root", type=Path)
+    parser.add_argument("output", type=Path)
+    arguments = parser.parse_args()
+    report = analyze(arguments.readback_root.resolve(), arguments.output.resolve())
+    print(json.dumps(report, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/capture-native-renderer-census.ps1
+++ b/tools/capture-native-renderer-census.ps1
@@ -20,6 +20,7 @@ param(
     [string]$PassAnchorSignature,
     [ValidatePattern('^[0-9A-Fa-f]{16}(?:/[0-9A-Fa-f]{16}){3}$')]
     [string]$ConsumerFamily,
+    [string]$ConsumerReadbackDir,
     [switch]$Json
 )
 
@@ -98,6 +99,28 @@ if ($IsolatedDrawDir) {
     $IsolatedDrawDir = $resolvedIsolatedDrawDir
 }
 
+if ($ConsumerReadbackDir) {
+    if (-not $ConsumerFamily) {
+        throw 'ConsumerReadbackDir requires ConsumerFamily'
+    }
+    $repositoryRoot = Split-Path $PSScriptRoot -Parent
+    $localRoot = [IO.Path]::GetFullPath((Join-Path $repositoryRoot '.local'))
+    $resolvedConsumerReadbackDir = [IO.Path]::GetFullPath($ConsumerReadbackDir)
+    $localPrefix = $localRoot.TrimEnd([IO.Path]::DirectorySeparatorChar) +
+        [IO.Path]::DirectorySeparatorChar
+    if (-not $resolvedConsumerReadbackDir.StartsWith(
+            $localPrefix, [StringComparison]::OrdinalIgnoreCase)) {
+        throw "ConsumerReadbackDir must be below $localRoot"
+    }
+    if (Test-Path -LiteralPath $resolvedConsumerReadbackDir) {
+        throw "ConsumerReadbackDir already exists: $resolvedConsumerReadbackDir"
+    }
+    if (Test-Path -LiteralPath "$resolvedConsumerReadbackDir.partial") {
+        throw "Consumer readback staging directory already exists: $resolvedConsumerReadbackDir.partial"
+    }
+    $ConsumerReadbackDir = $resolvedConsumerReadbackDir
+}
+
 $savedCensus = $env:REX_PINYON_SHIFT_NATIVE_RENDERER_CENSUS
 $savedScene = $env:PINYON_SHIFT_NATIVE_RENDERER_SCENE
 $savedIndexScan = $env:PINYON_SHIFT_NATIVE_RENDERER_INDEX_SCAN_SIGNATURE
@@ -108,6 +131,7 @@ $savedIsolatedDraw = $env:PINYON_SHIFT_NATIVE_RENDERER_ISOLATED_DRAW_SIGNATURE
 $savedIsolatedDrawDir = $env:PINYON_SHIFT_NATIVE_RENDERER_ISOLATED_DRAW_DIR
 $savedPassAnchor = $env:PINYON_SHIFT_NATIVE_RENDERER_PASS_ANCHOR_SIGNATURE
 $savedConsumerFamily = $env:PINYON_SHIFT_NATIVE_RENDERER_CONSUMER_FAMILY
+$savedConsumerReadbackDir = $env:PINYON_SHIFT_NATIVE_RENDERER_CONSUMER_READBACK_DIR
 try {
     $env:REX_PINYON_SHIFT_NATIVE_RENDERER_CENSUS = 'true'
     $env:PINYON_SHIFT_NATIVE_RENDERER_SCENE = $Scene
@@ -119,6 +143,7 @@ try {
     $env:PINYON_SHIFT_NATIVE_RENDERER_ISOLATED_DRAW_DIR = $IsolatedDrawDir
     $env:PINYON_SHIFT_NATIVE_RENDERER_PASS_ANCHOR_SIGNATURE = $PassAnchorSignature
     $env:PINYON_SHIFT_NATIVE_RENDERER_CONSUMER_FAMILY = $ConsumerFamily
+    $env:PINYON_SHIFT_NATIVE_RENDERER_CONSUMER_READBACK_DIR = $ConsumerReadbackDir
     & (Join-Path $PSScriptRoot 'launch-preview.ps1') `
         -StateRoot $resolvedStateRoot -ShaderCaptureDir $ShaderCaptureDir `
         -Json:$Json
@@ -134,4 +159,5 @@ finally {
     $env:PINYON_SHIFT_NATIVE_RENDERER_ISOLATED_DRAW_DIR = $savedIsolatedDrawDir
     $env:PINYON_SHIFT_NATIVE_RENDERER_PASS_ANCHOR_SIGNATURE = $savedPassAnchor
     $env:PINYON_SHIFT_NATIVE_RENDERER_CONSUMER_FAMILY = $savedConsumerFamily
+    $env:PINYON_SHIFT_NATIVE_RENDERER_CONSUMER_READBACK_DIR = $savedConsumerReadbackDir
 }

--- a/tools/capture-native-renderer-renderdoc.ps1
+++ b/tools/capture-native-renderer-renderdoc.ps1
@@ -11,6 +11,7 @@ param(
     [string]$PassAnchorSignature,
     [ValidatePattern('^[0-9A-Fa-f]{16}(?:/[0-9A-Fa-f]{16}){3}$')]
     [string]$ConsumerFamily,
+    [string]$ConsumerReadbackDir,
     [string]$IsolatedDrawDir,
     [Parameter(Mandatory)]
     [string]$CaptureDir,
@@ -47,6 +48,20 @@ if ($IsolatedDrawDir) {
         throw "IsolatedDrawDir already exists: $resolvedIsolatedDrawDir"
     }
     $IsolatedDrawDir = $resolvedIsolatedDrawDir
+}
+if ($ConsumerReadbackDir) {
+    if (-not $ConsumerFamily) {
+        throw 'ConsumerReadbackDir requires ConsumerFamily'
+    }
+    $resolvedConsumerReadbackDir = [IO.Path]::GetFullPath($ConsumerReadbackDir)
+    if (-not $resolvedConsumerReadbackDir.StartsWith(
+            $localPrefix, [StringComparison]::OrdinalIgnoreCase)) {
+        throw "ConsumerReadbackDir must be below $localRoot"
+    }
+    if (Test-Path -LiteralPath $resolvedConsumerReadbackDir) {
+        throw "ConsumerReadbackDir already exists: $resolvedConsumerReadbackDir"
+    }
+    $ConsumerReadbackDir = $resolvedConsumerReadbackDir
 }
 
 $profile = Get-ChildItem -LiteralPath (Join-Path $resolvedStateRoot 'user') `
@@ -86,6 +101,7 @@ $saved = @{
     draw_dir = $env:PINYON_SHIFT_NATIVE_RENDERER_ISOLATED_DRAW_DIR
     pass_anchor = $env:PINYON_SHIFT_NATIVE_RENDERER_PASS_ANCHOR_SIGNATURE
     consumer_family = $env:PINYON_SHIFT_NATIVE_RENDERER_CONSUMER_FAMILY
+    consumer_readback_dir = $env:PINYON_SHIFT_NATIVE_RENDERER_CONSUMER_READBACK_DIR
 }
 try {
     $env:PINYON_SHIFT_STATE_ROOT = $resolvedStateRoot
@@ -103,6 +119,7 @@ try {
             $null
         }
     $env:PINYON_SHIFT_NATIVE_RENDERER_CONSUMER_FAMILY = $ConsumerFamily
+    $env:PINYON_SHIFT_NATIVE_RENDERER_CONSUMER_READBACK_DIR = $ConsumerReadbackDir
     & $renderdoc capture -w `
         -d (Split-Path $executable -Parent) `
         -c (Join-Path $resolvedCaptureDir 'reference') `
@@ -121,6 +138,8 @@ finally {
     $env:PINYON_SHIFT_NATIVE_RENDERER_ISOLATED_DRAW_DIR = $saved.draw_dir
     $env:PINYON_SHIFT_NATIVE_RENDERER_PASS_ANCHOR_SIGNATURE = $saved.pass_anchor
     $env:PINYON_SHIFT_NATIVE_RENDERER_CONSUMER_FAMILY = $saved.consumer_family
+    $env:PINYON_SHIFT_NATIVE_RENDERER_CONSUMER_READBACK_DIR =
+        $saved.consumer_readback_dir
 }
 
 $captures = @(Get-ChildItem -LiteralPath $resolvedCaptureDir -File -Filter '*.rdc')

--- a/tools/tests/test_native_renderer_consumer_readback.py
+++ b/tools/tests/test_native_renderer_consumer_readback.py
@@ -1,0 +1,146 @@
+import importlib.util
+import json
+import struct
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+TOOL = ROOT / "tools" / "analyze-native-renderer-consumer-readback.py"
+SPEC = importlib.util.spec_from_file_location("consumer_readback", TOOL)
+assert SPEC and SPEC.loader
+MODULE = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = MODULE
+SPEC.loader.exec_module(MODULE)
+
+
+FAMILY = (
+    "2E5E0A854BE00027/BDFFA72B7ED2FBA4/"
+    "000000000000003F/000000000016003F"
+)
+
+
+def write_readback(root: Path, phase: str, payload: bytes, *, width=2, height=1):
+    phase_root = root / phase
+    phase_root.mkdir(parents=True)
+    metadata = {
+        "schema": MODULE.READBACK_SCHEMA,
+        "consumer_family": FAMILY,
+        "frame": 42,
+        "draw": 7,
+        "phase": phase,
+        "source": {
+            "width": width,
+            "height": height,
+            "row_pitch": len(payload) // height,
+            "dxgi_format": 28,
+            "bytes_per_pixel": 4,
+            "bytes": len(payload),
+            "hash": "0000000000000000",
+        },
+        "payload": {"file": "target.bin"},
+        "safety": {
+            "output_authority": "xenos",
+            "xenos_draw_preserved": True,
+            "draw_suppression": False,
+            "resolve_suppression": False,
+            "suppression_allowed": False,
+        },
+    }
+    (phase_root / "readback.json").write_text(json.dumps(metadata))
+    (phase_root / "target.bin").write_bytes(payload)
+
+
+class ConsumerReadbackTests(unittest.TestCase):
+    def test_reports_exact_draw_contribution_and_writes_pngs(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary) / "readback"
+            output = Path(temporary) / "report"
+            write_readback(root, "before", bytes([10, 20, 30, 255, 1, 2, 3, 255]))
+            write_readback(root, "after", bytes([10, 25, 30, 255, 1, 2, 3, 255]))
+
+            report = MODULE.analyze(root, output)
+
+            self.assertEqual(MODULE.REPORT_SCHEMA, report["schema"])
+            self.assertEqual(FAMILY, report["consumer_family"])
+            self.assertEqual(1, report["contribution"]["changed_pixels"])
+            self.assertEqual(5, report["contribution"]["maximum_channel_delta"])
+            self.assertEqual(
+                {"left": 0, "top": 0, "right": 0, "bottom": 0},
+                report["contribution"]["bounds"],
+            )
+            self.assertFalse(report["safety"]["suppression_allowed"])
+            for name in ("before.png", "after.png", "difference-4x.png", "changed-mask.png"):
+                self.assertTrue((output / name).read_bytes().startswith(b"\x89PNG"))
+
+    def test_ignores_row_padding(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary) / "readback"
+            output = Path(temporary) / "report"
+            before = bytes([10, 20, 30, 255, 90, 91, 92, 93])
+            after = bytes([10, 20, 30, 255, 1, 2, 3, 4])
+            write_readback(root, "before", before, width=1)
+            write_readback(root, "after", after, width=1)
+
+            report = MODULE.analyze(root, output)
+
+            self.assertEqual(0, report["contribution"]["changed_pixels"])
+            self.assertIsNone(report["contribution"]["bounds"])
+
+    def test_decodes_half_float_color(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary) / "readback"
+            for phase, red in (("before", 0.0), ("after", 1.0)):
+                phase_root = root / phase
+                phase_root.mkdir(parents=True)
+                payload = struct.pack("<eeee", red, 0.5, 0.0, 1.0)
+                metadata = {
+                    "schema": MODULE.READBACK_SCHEMA,
+                    "consumer_family": FAMILY,
+                    "frame": 42,
+                    "draw": 7,
+                    "phase": phase,
+                    "source": {
+                        "width": 1,
+                        "height": 1,
+                        "row_pitch": 8,
+                        "dxgi_format": 10,
+                        "bytes_per_pixel": 8,
+                        "bytes": 8,
+                        "hash": "0000000000000000",
+                    },
+                    "payload": {"file": "target.bin"},
+                    "safety": {
+                        "output_authority": "xenos",
+                        "xenos_draw_preserved": True,
+                        "draw_suppression": False,
+                        "resolve_suppression": False,
+                        "suppression_allowed": False,
+                    },
+                }
+                (phase_root / "readback.json").write_text(json.dumps(metadata))
+                (phase_root / "target.bin").write_bytes(payload)
+
+            report = MODULE.analyze(root, Path(temporary) / "report")
+
+            self.assertEqual(255, report["contribution"]["maximum_channel_delta"])
+
+    def test_rejects_unsafe_metadata(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary) / "readback"
+            payload = bytes([0, 0, 0, 255])
+            write_readback(root, "before", payload, width=1)
+            write_readback(root, "after", payload, width=1)
+            path = root / "after" / "readback.json"
+            metadata = json.loads(path.read_text())
+            metadata["safety"]["draw_suppression"] = True
+            path.write_text(json.dumps(metadata))
+
+            with self.assertRaisesRegex(ValueError, "draw suppression"):
+                MODULE.analyze(root, Path(temporary) / "report")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/tests/test_native_renderer_contract.py
+++ b/tools/tests/test_native_renderer_contract.py
@@ -593,6 +593,37 @@ class NativeRendererContractTests(unittest.TestCase):
         self.assertIn("operator_review_required", exporter)
         self.assertIn("MAX_CONSUMER_MARKER_EVENT_IDS = 64", exporter)
 
+    def test_consumer_family_readback_is_paired_bounded_and_passive(self):
+        hooks = (ROOT / "src/native_renderer/graphics_hooks.cpp").read_text(
+            encoding="utf-8"
+        )
+        patch = (
+            ROOT / "patches/rexglue/0076-d3d12-consumer-family-readback.patch"
+        ).read_text(encoding="utf-8")
+        capture = (
+            ROOT / "tools/capture-native-renderer-census.ps1"
+        ).read_text(encoding="utf-8")
+        analyzer = (
+            ROOT / "tools/analyze-native-renderer-consumer-readback.py"
+        ).read_text(encoding="utf-8")
+
+        self.assertIn(
+            "PINYON_SHIFT_NATIVE_RENDERER_CONSUMER_READBACK_DIR", hooks
+        )
+        self.assertIn("consumer_reference_readback_requested", patch)
+        self.assertIn("QueueGuestConsumerColorReadback", patch)
+        self.assertIn("guest_consumer_before_readback_", patch)
+        self.assertIn("guest_consumer_after_readback_", patch)
+        self.assertIn("before_after_color", hooks)
+        self.assertIn("[string]$ConsumerReadbackDir", capture)
+        self.assertIn("operator_review_required", analyzer)
+        self.assertIn('"xenos_draw_preserved": True', analyzer)
+        self.assertIn('"draw_suppression": False', analyzer)
+        self.assertIn('"resolve_suppression": False', analyzer)
+        self.assertIn('"suppression_allowed": False', analyzer)
+        self.assertNotIn("SetDrawSuppression", hooks + patch + analyzer)
+        self.assertNotIn("SetCopySuppression", hooks + patch + analyzer)
+
     def test_shader_capture_is_local_bounded_and_passive(self):
         patch = (
             ROOT

--- a/tools/tests/test_release_contract.py
+++ b/tools/tests/test_release_contract.py
@@ -43,10 +43,10 @@ class ReleaseContractTests(unittest.TestCase):
 
     def test_rexglue_patches_have_stable_order_and_no_binary_payload(self):
         patches = sorted((ROOT / "patches/rexglue").glob("*.patch"))
-        self.assertEqual(len(patches), 75)
+        self.assertEqual(len(patches), 76)
         self.assertEqual(
             patches[-1].name,
-            "0075-d3d12-consumer-family-marker.patch",
+            "0076-d3d12-consumer-family-readback.patch",
         )
         self.assertEqual(len(patches), len({path.name[:4] for path in patches}))
         for path in patches:


### PR DESCRIPTION
## Summary

- capture authoritative color targets immediately before and after one exact consumer-family draw
- emit deterministic local before/after, difference, mask, and numeric contribution evidence
- preserve the original Xenos draw and keep draw/resolve suppression disabled
- add fail-closed capture plumbing, analyzer coverage, and qualification documentation

## Validation

- full automated suite: 209/209 passed
- clean local build: 76 ReXGlue patches, executable SHA-256 `4FE5A2A23ADBD3FE7BB0A786098587AE632A981448FF31229DD4297B4E72DB7E`
- AppData open-world qualification: normal exit, no error/device-loss events
- exact family: 1364 matches, one bounded request, two successful readback completions
- performance: 31.094 median FPS, 19.107 one-percent low, 59.969 Hz presentation cadence, zero deadline misses
- sampled frame 3876/draw 419: zero color delta; retained as operator-review evidence, not promoted to a semantic role

## Safety

Xenos remains authoritative. The original draw is preserved, draw suppression is false, resolve suppression is false, and suppression remains ineligible.