### PR TITLE
feat(native-renderer): capture bounded attachment corpus

### DIFF
--- a/docs/native-renderer/CONSUMER_FAMILY_CLASSIFICATION.md
+++ b/docs/native-renderer/CONSUMER_FAMILY_CLASSIFICATION.md
@@ -110,12 +110,13 @@ an automatic role promotion. Marker insertion does not replay, redirect, or
 suppress work: every Xenos draw remains authoritative and both draw and resolve
 suppression remain false.
 
-### Automatic exact-draw contribution capture
+### Automatic exact-draw contribution corpus
 
 Manual F12 capture can land on a frame that does not contain the selected
-family. For deterministic semantic evidence, request a one-shot asynchronous
-readback of the authoritative color attachment immediately before and after
-the first exact lineage/four-field match:
+family. For deterministic semantic evidence, request a bounded asynchronous
+corpus of the authoritative color and depth/stencil attachments immediately
+before and after exact lineage/four-field matches. Capture between 1 and 16
+occurrences; eight is a useful qualification batch:
 
 ```powershell
 $family = '2E5E0A854BE00027/BDFFA72B7ED2FBA4/000000000000003F/000000000016003F'
@@ -126,14 +127,18 @@ $readback = '.local\qualification\consumer-family-readback'
   -IsolatedDrawSignature '1D253A52B55C9FB3' `
   -PassAnchorSignature '747837906D0BF484' `
   -ConsumerFamily $family `
-  -ConsumerReadbackDir $readback
+  -ConsumerReadbackDir $readback `
+  -ConsumerReadbackSamples 8
 ```
 
-The D3D12 backend owns two independent pending slots, so the pre-draw and
-post-draw copies cannot alias each other or the existing isolated-pass
-readbacks. Both copies are queued around the original authoritative draw and
-complete after its submission fence without a GPU wait. The output remains
-local and contains raw row-pitched target bytes plus fail-closed metadata.
+The D3D12 backend owns four independent pending slots for pre/post color and
+pre/post depth/stencil. A new occurrence is armed only after all four callbacks
+for the previous occurrence complete, so copies cannot alias each other or the
+existing isolated-pass readbacks. Every copy is queued around the original
+authoritative draw and completes after its submission fence without a GPU
+wait. The output remains local, is grouped into deterministic `sample-NNNN`
+directories, and contains raw row-pitched target bytes plus fail-closed
+metadata.
 
 Build a deterministic visual contribution report with:
 
@@ -143,31 +148,45 @@ Build a deterministic visual contribution report with:
   -OutputDir '.local\qualification\consumer-family-contribution'
 ```
 
-The report validates exact family/frame/draw identity, attachment layout, and
-the no-suppression safety fields before producing `before.png`, `after.png`, a
-4x absolute-difference image, a changed-pixel mask, and numeric change bounds.
-It deliberately leaves `semantic_role=operator_review_required`; a visible
-contribution is evidence for classification, not permission to claim native
-coverage or suppress the producer. Xenos remains authoritative throughout.
+The report validates exact family/frame/draw/sample identity, attachment
+layout, and the no-suppression safety fields. Each sample contains color
+before/after, difference, and mask images. Multisampled depth/stencil tuple
+captures also produce grayscale depth previews and an exact changed-sample
+mask; single-sample planar layouts are compared byte-exactly even when they
+cannot be visualized safely. The corpus summary counts samples with color and
+depth/stencil deltas and records whether every sampled occurrence is unchanged.
+
+The analyzer deliberately leaves
+`semantic_role=operator_review_required`. Multiple unchanged occurrences are
+stronger negative evidence than one occurrence, but never automatically
+promote a semantic role, claim native coverage, or permit suppression. Xenos
+remains authoritative throughout.
 
 ### Qualification evidence
 
-The `open_world_day` AppData qualification on 2026-08-29 captured the selected
-family at frame 3876, draw 419, from a 2560x1024
-`R16G16B16A16_FLOAT` attachment. Runtime diagnostics reported one bounded
-request, two successful completions, 1364 exact matches, a normal process exit,
-and no error or device-loss events. The before and after payloads were identical
-(`7FA5516C3FA339D267CCC801D3B558FA655597D085284F58F914C5BAD5904FFD`),
-so this sampled draw changed zero color pixels. That is negative contribution
-evidence for this occurrence, not sufficient proof that every draw in the
-family is semantically inert; its role therefore remains
-`operator_review_required`.
+The `open_world_day` AppData qualification on 2026-08-29 captured four
+occurrences of the selected family at frames 3226 through 3229 and draws 236,
+540, 338, and 389. Each occurrence produced complete before/after color and
+depth/stencil artifacts. The color source was a 2560x1024 four-sample
+`R16G16B16A16_FLOAT` target resolved to a single-sample readback payload; the
+depth source was retained as exact four-sample depth/stencil tuples.
 
-The same 131.118-second run recorded 4642 frame samples, 31.094 median FPS,
-19.107 one-percent-low FPS, 59.969 Hz host presentation cadence, no presentation
-deadline misses, and no pipeline-cache misses. Xenos remained authoritative,
-the original draw was preserved, and both draw and resolve suppression stayed
-false.
+All four color pairs were byte-identical. Samples 1 and 3 also left the
+depth/stencil attachment unchanged. Samples 2 and 4 changed 16,218 and 16
+stencil tuples respectively while changing zero depth tuples. The corpus is
+therefore complete but does not prove the family inert:
+`all_samples_no_attachment_delta=false` and
+`semantic_role=operator_review_required`. The stencil contribution is positive
+evidence that suppression must remain disallowed until its downstream role and
+native parity are understood.
+
+Runtime diagnostics reported four bounded requests, all 16 expected
+completions, 1080 exact matches, a normal process exit, and no error,
+unsupported-layout, or device-loss events. The 96.340-second run recorded 3744
+frame samples, 53.974 median derived FPS, 19.194 one-percent-low FPS, 59.944 Hz
+host presentation cadence, no presentation deadline misses, and no
+pipeline-cache misses. Xenos remained authoritative, every original draw was
+preserved, and both draw and resolve suppression stayed false.
 
 ## Rollback-switch boundary
 

--- a/patches/rexglue/0077-d3d12-consumer-family-depth-corpus.patch
+++ b/patches/rexglue/0077-d3d12-consumer-family-depth-corpus.patch
@@ -1,0 +1,173 @@
+diff --git a/include/rex/graphics/d3d12/render_target_cache.h b/include/rex/graphics/d3d12/render_target_cache.h
+index 330d2e5..1a1caf4 100644
+--- a/include/rex/graphics/d3d12/render_target_cache.h
++++ b/include/rex/graphics/d3d12/render_target_cache.h
+@@ -111,6 +111,10 @@ class D3D12RenderTargetCache final : public RenderTargetCache {
+       bool before_draw,
+       system::GraphicsIsolatedDrawReadbackCompletion completion,
+       uint32_t* failure_detail_out);
++  system::GraphicsIsolatedDrawReadbackStatus QueueGuestConsumerDepthReadback(
++      bool before_draw,
++      system::GraphicsIsolatedDrawReadbackCompletion completion,
++      uint32_t* failure_detail_out);
+   system::GraphicsIsolatedDrawReadbackStatus QueueIsolatedReplayDepthReadback(
+       system::GraphicsIsolatedDrawReadbackCompletion completion,
+       uint32_t* failure_detail_out);
+@@ -739,6 +743,8 @@ class D3D12RenderTargetCache final : public RenderTargetCache {
+   IsolatedReplayReadback guest_reference_readback_;
+   IsolatedReplayReadback guest_consumer_before_readback_;
+   IsolatedReplayReadback guest_consumer_after_readback_;
++  IsolatedReplayReadback guest_consumer_before_depth_readback_;
++  IsolatedReplayReadback guest_consumer_after_depth_readback_;
+   IsolatedReplayReadback isolated_replay_depth_readback_;
+   IsolatedReplayReadback guest_depth_reference_readback_;
+   system::GraphicsIsolatedDrawReadbackStatus QueueRenderTargetReadback(
+diff --git a/include/rex/system/interfaces/graphics.h b/include/rex/system/interfaces/graphics.h
+index 16745af..482f825 100644
+--- a/include/rex/system/interfaces/graphics.h
++++ b/include/rex/system/interfaces/graphics.h
+@@ -411,6 +411,10 @@ struct GraphicsIsolatedDrawRequest {
+   // one exact consumer-family draw. Both copies are diagnostic-only and the
+   // original draw remains authoritative.
+   bool consumer_reference_readback_requested = false;
++  // Capture the authoritative guest depth/stencil target around the same
++  // exact consumer draw. This remains independent from color readback and
++  // never changes draw execution or attachment ownership.
++  bool consumer_reference_depth_readback_requested = false;
+   bool retain_target = false;
+   // Rebind the retained private target without copying the guest target. This
+   // is valid only for the immediately following draw of an isolated pass.
+@@ -427,6 +431,10 @@ struct GraphicsIsolatedDrawRequest {
+       consumer_reference_before_readback_completion = nullptr;
+   GraphicsIsolatedDrawReadbackCompletion
+       consumer_reference_after_readback_completion = nullptr;
++  GraphicsIsolatedDrawReadbackCompletion
++      consumer_reference_before_depth_readback_completion = nullptr;
++  GraphicsIsolatedDrawReadbackCompletion
++      consumer_reference_after_depth_readback_completion = nullptr;
+ };
+ 
+ // Called after the host pipeline has been prepared. A request duplicates the
+diff --git a/src/graphics/d3d12/command_processor.cpp b/src/graphics/d3d12/command_processor.cpp
+index a1530c3..0b95246 100644
+--- a/src/graphics/d3d12/command_processor.cpp
++++ b/src/graphics/d3d12/command_processor.cpp
+@@ -3311,28 +3311,44 @@ bool D3D12CommandProcessor::IssueDraw(xenos::PrimitiveType primitive_type, uint3
+   // Must not call anything that may change the primitive topology from now on!
+ 
+   const auto queue_consumer_reference_readback = [&](bool before_draw) {
+-    if (!isolated_draw_request.consumer_reference_readback_requested) {
++    if (!isolated_draw_request.consumer_reference_readback_requested &&
++        !isolated_draw_request.consumer_reference_depth_readback_requested) {
+       return;
+     }
+-    auto completion =
+-        before_draw
+-            ? isolated_draw_request
+-                  .consumer_reference_before_readback_completion
+-            : isolated_draw_request
+-                  .consumer_reference_after_readback_completion;
+-    if (!completion) {
+-      return;
++    const auto queue = [&](bool depth) {
++      auto completion = depth
++                            ? (before_draw
++                                   ? isolated_draw_request
++                                         .consumer_reference_before_depth_readback_completion
++                                   : isolated_draw_request
++                                         .consumer_reference_after_depth_readback_completion)
++                            : (before_draw
++                                   ? isolated_draw_request
++                                         .consumer_reference_before_readback_completion
++                                   : isolated_draw_request
++                                         .consumer_reference_after_readback_completion);
++      if (!completion) {
++        return;
++      }
++      uint32_t readback_detail = 0;
++      auto readback_status =
++          depth ? render_target_cache_->QueueGuestConsumerDepthReadback(
++                      before_draw, completion, &readback_detail)
++                : render_target_cache_->QueueGuestConsumerColorReadback(
++                      before_draw, completion, &readback_detail);
++      if (readback_status !=
++          system::GraphicsIsolatedDrawReadbackStatus::kReady) {
++        system::GraphicsIsolatedDrawReadback readback_result;
++        readback_result.status = readback_status;
++        readback_result.detail = readback_detail;
++        completion(readback_result);
++      }
++    };
++    if (isolated_draw_request.consumer_reference_readback_requested) {
++      queue(false);
+     }
+-    uint32_t readback_detail = 0;
+-    auto readback_status =
+-        render_target_cache_->QueueGuestConsumerColorReadback(
+-            before_draw, completion, &readback_detail);
+-    if (readback_status !=
+-        system::GraphicsIsolatedDrawReadbackStatus::kReady) {
+-      system::GraphicsIsolatedDrawReadback readback_result;
+-      readback_result.status = readback_status;
+-      readback_result.detail = readback_detail;
+-      completion(readback_result);
++    if (isolated_draw_request.consumer_reference_depth_readback_requested) {
++      queue(true);
+     }
+   };
+ 
+diff --git a/src/graphics/d3d12/render_target_cache.cpp b/src/graphics/d3d12/render_target_cache.cpp
+index ba9d724..1a21a9b 100644
+--- a/src/graphics/d3d12/render_target_cache.cpp
++++ b/src/graphics/d3d12/render_target_cache.cpp
+@@ -1035,6 +1035,8 @@ void D3D12RenderTargetCache::Shutdown(bool from_destructor) {
+   release_isolated_readback(guest_reference_readback_);
+   release_isolated_readback(guest_consumer_before_readback_);
+   release_isolated_readback(guest_consumer_after_readback_);
++  release_isolated_readback(guest_consumer_before_depth_readback_);
++  release_isolated_readback(guest_consumer_after_depth_readback_);
+   release_isolated_readback(isolated_replay_depth_readback_);
+   release_isolated_readback(guest_depth_reference_readback_);
+   isolated_replay_preview_resolved_target_.Reset();
+@@ -1102,6 +1104,8 @@ void D3D12RenderTargetCache::CompletedSubmissionUpdated() {
+   complete_isolated_readback(guest_reference_readback_);
+   complete_isolated_readback(guest_consumer_before_readback_);
+   complete_isolated_readback(guest_consumer_after_readback_);
++  complete_isolated_readback(guest_consumer_before_depth_readback_);
++  complete_isolated_readback(guest_consumer_after_depth_readback_);
+   complete_isolated_readback(isolated_replay_depth_readback_);
+   complete_isolated_readback(guest_depth_reference_readback_);
+ }
+@@ -1946,6 +1950,32 @@ D3D12RenderTargetCache::QueueGuestConsumerColorReadback(
+   return status;
+ }
+ 
++system::GraphicsIsolatedDrawReadbackStatus
++D3D12RenderTargetCache::QueueGuestConsumerDepthReadback(
++    bool before_draw,
++    system::GraphicsIsolatedDrawReadbackCompletion completion,
++    uint32_t* failure_detail_out) {
++  if (GetPath() != Path::kHostRenderTargets) {
++    return system::GraphicsIsolatedDrawReadbackStatus::kUnsupportedTarget;
++  }
++  RenderTarget* const* guest_targets =
++      last_update_accumulated_render_targets();
++  if (!guest_targets[0]) {
++    return system::GraphicsIsolatedDrawReadbackStatus::kUnsupportedTarget;
++  }
++  auto status = QueueRenderTargetReadback(
++      static_cast<D3D12RenderTarget*>(guest_targets[0]),
++      before_draw ? guest_consumer_before_depth_readback_
++                  : guest_consumer_after_depth_readback_,
++      completion, failure_detail_out);
++  if (before_draw &&
++      status == system::GraphicsIsolatedDrawReadbackStatus::kReady) {
++    // Restore the depth target before the authoritative draw is recorded.
++    command_processor_.SubmitBarriers();
++  }
++  return status;
++}
++
+ system::GraphicsIsolatedDrawReadbackStatus
+ D3D12RenderTargetCache::QueueIsolatedReplayDepthReadback(
+     system::GraphicsIsolatedDrawReadbackCompletion completion,

--- a/src/native_renderer/graphics_hooks.cpp
+++ b/src/native_renderer/graphics_hooks.cpp
@@ -56,6 +56,7 @@ constexpr uint64_t kMaximumIndexScanBytes = UINT64_C(4) << 20;
 constexpr uint32_t kMaximumTextureScanResources = 4;
 constexpr uint64_t kMaximumTextureScanResourceBytes = UINT64_C(16) << 20;
 constexpr uint64_t kMaximumTextureScanTotalBytes = UINT64_C(32) << 20;
+constexpr uint32_t kMaximumConsumerReadbackSamples = 16;
 std::atomic<uint64_t> g_frame_sequence{};
 
 std::string CensusSceneMarker() {
@@ -158,12 +159,15 @@ struct ConsumerFamilyMarkerState {
   uint64_t marker_requests = 0;
   uint64_t readback_requests = 0;
   uint64_t readback_completions = 0;
+  uint64_t readback_samples_completed = 0;
+  uint32_t readback_sample_limit = 1;
+  uint32_t current_capture_completions = 0;
+  uint32_t current_capture_index = 0;
   std::filesystem::path readback_root;
-  std::jthread before_artifact_writer;
-  std::jthread after_artifact_writer;
+  std::vector<std::jthread> artifact_writers;
   bool requested = false;
   bool readback_requested = false;
-  bool readback_queued = false;
+  bool readback_in_flight = false;
   bool valid = true;
   bool current_match = false;
 };
@@ -262,7 +266,30 @@ void ConfigureConsumerFamilyMarker() {
   if (!g_consumer_family_marker.valid ||
       !IsLocalArtifactRoot(g_consumer_family_marker.readback_root)) {
     g_consumer_family_marker.valid = false;
+    return;
   }
+  value = nullptr;
+  length = 0;
+  if (_dupenv_s(&value, &length,
+                "PINYON_SHIFT_NATIVE_RENDERER_CONSUMER_READBACK_SAMPLES") !=
+          0 ||
+      !value || length <= 1) {
+    std::free(value);
+    return;
+  }
+  const std::string sample_setting(value);
+  std::free(value);
+  uint32_t sample_limit = 0;
+  const auto parsed = std::from_chars(
+      sample_setting.data(), sample_setting.data() + sample_setting.size(),
+      sample_limit, 10);
+  if (parsed.ec != std::errc{} ||
+      parsed.ptr != sample_setting.data() + sample_setting.size() ||
+      !sample_limit || sample_limit > kMaximumConsumerReadbackSamples) {
+    g_consumer_family_marker.valid = false;
+    return;
+  }
+  g_consumer_family_marker.readback_sample_limit = sample_limit;
 }
 
 std::string ConsumerFamilyId() {
@@ -2207,8 +2234,15 @@ float HalfToFloat(uint16_t value) {
 
 void CompleteConsumerFamilyReadbackArtifact(
     const rex::system::GraphicsIsolatedDrawReadback &readback,
-    const char *phase, std::jthread &artifact_writer) {
+    const char *attachment, const char *phase) {
   ++g_consumer_family_marker.readback_completions;
+  const auto finish = []() {
+    ++g_consumer_family_marker.current_capture_completions;
+    if (g_consumer_family_marker.current_capture_completions == 4) {
+      ++g_consumer_family_marker.readback_samples_completed;
+      g_consumer_family_marker.readback_in_flight = false;
+    }
+  };
   const auto reject = [&](const char *status) {
     pinyon_shift::diagnostics::RecordEvent(
         "native_renderer.census.consumer_family_readback",
@@ -2217,11 +2251,15 @@ void CompleteConsumerFamilyReadbackArtifact(
          {"detail", fmt::format("0x{:08X}", readback.detail)},
          {"frame", std::to_string(g_consumer_family_marker.capture_frame)},
          {"draw", std::to_string(g_consumer_family_marker.capture_draw)},
+         {"sample",
+          std::to_string(g_consumer_family_marker.current_capture_index)},
+         {"attachment", attachment},
          {"phase", phase},
          {"xenos_draw", "preserved"},
          {"draw_suppression", "false"},
          {"resolve_suppression", "false"},
          {"suppression_eligible", "false"}});
+    finish();
   };
   if (readback.status !=
       rex::system::GraphicsIsolatedDrawReadbackStatus::kReady) {
@@ -2244,16 +2282,46 @@ void CompleteConsumerFamilyReadbackArtifact(
 
   constexpr uint32_t kR16G16B16A16Float = 10;
   constexpr uint32_t kR8G8B8A8Unorm = 28;
-  const uint32_t bytes_per_pixel =
-      readback.format == kR16G16B16A16Float
-          ? 8
-          : (readback.format == kR8G8B8A8Unorm ? 4 : 0);
+  const bool is_color = std::strcmp(attachment, "color") == 0;
+  const uint32_t bytes_per_pixel = is_color
+                                       ? (readback.format ==
+                                                  kR16G16B16A16Float
+                                              ? 8
+                                              : (readback.format ==
+                                                         kR8G8B8A8Unorm
+                                                     ? 4
+                                                     : 0))
+                                       : 0;
   const uint64_t required_size =
-      uint64_t(readback.row_pitch) * readback.height;
-  if (!bytes_per_pixel || !readback.data || !readback.width ||
-      !readback.height ||
-      uint64_t(readback.width) * bytes_per_pixel > readback.row_pitch ||
-      required_size > readback.data_size || required_size > SIZE_MAX) {
+      is_color ? uint64_t(readback.row_pitch) * readback.height
+               : readback.data_size;
+  bool layout_valid = readback.data && readback.width && readback.height &&
+                      required_size && required_size <= readback.data_size &&
+                      required_size <= SIZE_MAX;
+  if (is_color) {
+    layout_valid &= bytes_per_pixel && readback.sample_count &&
+                    uint64_t(readback.width) * bytes_per_pixel <=
+                        readback.row_pitch;
+  } else {
+    layout_valid &= readback.sample_count && readback.plane_count &&
+                    readback.plane_count <=
+                        rex::system::GraphicsIsolatedDrawReadback::kMaxPlanes;
+    for (uint32_t plane = 0;
+         layout_valid && plane < readback.plane_count; ++plane) {
+      const uint64_t plane_end =
+          readback.plane_offsets[plane] +
+          uint64_t(readback.plane_row_pitches[plane]) *
+              (readback.plane_row_counts[plane] - 1) +
+          readback.plane_row_sizes[plane];
+      layout_valid &= readback.plane_row_pitches[plane] &&
+                      readback.plane_row_sizes[plane] &&
+                      readback.plane_row_sizes[plane] <=
+                          readback.plane_row_pitches[plane] &&
+                      readback.plane_row_counts[plane] &&
+                      plane_end <= required_size;
+    }
+  }
+  if (!layout_valid) {
     reject("unsupported_layout");
     return;
   }
@@ -2263,15 +2331,48 @@ void CompleteConsumerFamilyReadbackArtifact(
   const std::string family = ConsumerFamilyId();
   const uint64_t frame = g_consumer_family_marker.capture_frame;
   const uint64_t draw = g_consumer_family_marker.capture_draw;
-  const auto output_root = g_consumer_family_marker.readback_root / phase;
+  const uint32_t sample = g_consumer_family_marker.current_capture_index;
+  std::filesystem::path capture_root =
+      g_consumer_family_marker.readback_root;
+  if (g_consumer_family_marker.readback_sample_limit > 1) {
+    capture_root /= fmt::format("sample-{:04}", sample);
+  }
+  const auto output_root = is_color
+                               ? capture_root / phase
+                               : capture_root / L"depth" / phase;
   const uint32_t width = readback.width;
   const uint32_t height = readback.height;
   const uint32_t row_pitch = readback.row_pitch;
   const uint32_t format = readback.format;
-  artifact_writer = std::jthread(
-      [bytes = std::move(bytes), family, frame, draw, output_root, width,
-       height, row_pitch, format, bytes_per_pixel,
-       phase = std::string(phase)]() {
+  const uint32_t source_sample_count = readback.sample_count;
+  // D3D12 color MSAA readback is resolved before it reaches this callback.
+  // Depth/stencil MSAA is extracted per sample and remains multisampled.
+  const uint32_t sample_count = is_color ? 1 : source_sample_count;
+  const uint32_t plane_count = readback.plane_count;
+  std::string planes = "[";
+  for (uint32_t plane = 0; plane < plane_count; ++plane) {
+    if (plane) {
+      planes += ',';
+    }
+    planes += fmt::format(
+        "{{\"offset\":{},\"row_pitch\":{},\"row_size\":{},"
+        "\"row_count\":{}}}",
+        readback.plane_offsets[plane], readback.plane_row_pitches[plane],
+        readback.plane_row_sizes[plane],
+        readback.plane_row_counts[plane]);
+  }
+  planes += ']';
+  const std::string encoding =
+      is_color
+          ? (format == kR16G16B16A16Float ? "rgba16_float"
+                                          : "rgba8_unorm")
+          : (sample_count > 1 ? "depth32_stencil8_sample_tuples"
+                              : "d3d12_planar_depth_stencil");
+  g_consumer_family_marker.artifact_writers.emplace_back(
+      [bytes = std::move(bytes), family, frame, draw, sample, output_root,
+       width, height, row_pitch, format, bytes_per_pixel, sample_count,
+       source_sample_count, plane_count, planes = std::move(planes), encoding,
+       attachment = std::string(attachment), phase = std::string(phase)]() {
         std::filesystem::path staging = output_root;
         staging += L".partial";
         std::error_code error;
@@ -2284,6 +2385,8 @@ void CompleteConsumerFamilyReadbackArtifact(
                {"status", "output_directory_unavailable"},
                {"frame", std::to_string(frame)},
                {"draw", std::to_string(draw)},
+               {"sample", std::to_string(sample)},
+               {"attachment", attachment},
                {"phase", phase},
                {"xenos_draw", "preserved"},
                {"suppression_eligible", "false"}});
@@ -2293,10 +2396,15 @@ void CompleteConsumerFamilyReadbackArtifact(
             "{{\n  \"schema\": "
             "\"pinyon-shift.consumer-family-readback.v1\",\n"
             "  \"consumer_family\": \"{}\",\n  \"frame\": {},\n"
-            "  \"draw\": {},\n  \"phase\": \"{}\",\n"
+            "  \"draw\": {},\n  \"sample\": {},\n"
+            "  \"attachment\": \"{}\",\n"
+            "  \"phase\": \"{}\",\n"
             "  \"source\": {{\"width\":{},\"height\":{},"
             "\"row_pitch\":{},\"dxgi_format\":{},"
-            "\"bytes_per_pixel\":{},\"bytes\":{},"
+            "\"bytes_per_pixel\":{},\"sample_count\":{},"
+            "\"source_sample_count\":{},"
+            "\"plane_count\":{},\"planes\":{},"
+            "\"encoding\":\"{}\",\"bytes\":{},"
             "\"hash\":\"{:016X}\"}},\n"
             "  \"payload\": {{\"file\":\"target.bin\"}},\n"
             "  \"safety\": {{\"output_authority\":\"xenos\","
@@ -2304,8 +2412,9 @@ void CompleteConsumerFamilyReadbackArtifact(
             "\"draw_suppression\":false,"
             "\"resolve_suppression\":false,"
             "\"suppression_allowed\":false}}\n}}\n",
-            family, frame, draw, phase, width, height, row_pitch, format,
-            bytes_per_pixel, bytes.size(),
+            family, frame, draw, sample, attachment, phase, width, height,
+            row_pitch, format, bytes_per_pixel, sample_count,
+            source_sample_count, plane_count, planes, encoding, bytes.size(),
             HashBytes(bytes.data(), bytes.size()));
         const auto metadata_bytes = std::span(
             reinterpret_cast<const uint8_t *>(metadata.data()),
@@ -2319,6 +2428,8 @@ void CompleteConsumerFamilyReadbackArtifact(
                {"status", "artifact_write_failed"},
                {"frame", std::to_string(frame)},
                {"draw", std::to_string(draw)},
+               {"sample", std::to_string(sample)},
+               {"attachment", attachment},
                {"phase", phase},
                {"xenos_draw", "preserved"},
                {"suppression_eligible", "false"}});
@@ -2331,6 +2442,8 @@ void CompleteConsumerFamilyReadbackArtifact(
              {"status", error ? "artifact_commit_failed" : "captured"},
              {"frame", std::to_string(frame)},
              {"draw", std::to_string(draw)},
+             {"sample", std::to_string(sample)},
+             {"attachment", attachment},
              {"phase", phase},
              {"source_width", std::to_string(width)},
              {"source_height", std::to_string(height)},
@@ -2340,18 +2453,31 @@ void CompleteConsumerFamilyReadbackArtifact(
              {"resolve_suppression", "false"},
              {"suppression_eligible", "false"}});
       });
+  finish();
 }
 
 void CompleteConsumerFamilyBeforeReadback(
     const rex::system::GraphicsIsolatedDrawReadback &readback) {
   CompleteConsumerFamilyReadbackArtifact(
-      readback, "before", g_consumer_family_marker.before_artifact_writer);
+      readback, "color", "before");
 }
 
 void CompleteConsumerFamilyAfterReadback(
     const rex::system::GraphicsIsolatedDrawReadback &readback) {
   CompleteConsumerFamilyReadbackArtifact(
-      readback, "after", g_consumer_family_marker.after_artifact_writer);
+      readback, "color", "after");
+}
+
+void CompleteConsumerFamilyBeforeDepthReadback(
+    const rex::system::GraphicsIsolatedDrawReadback &readback) {
+  CompleteConsumerFamilyReadbackArtifact(readback, "depth_stencil",
+                                         "before");
+}
+
+void CompleteConsumerFamilyAfterDepthReadback(
+    const rex::system::GraphicsIsolatedDrawReadback &readback) {
+  CompleteConsumerFamilyReadbackArtifact(readback, "depth_stencil",
+                                         "after");
 }
 
 void CompleteIsolatedReadbackArtifact(
@@ -2862,14 +2988,24 @@ void RequestIsolatedDraw(
     request.consumer_reference_marker_requested = true;
     ++g_consumer_family_marker.marker_requests;
     if (g_consumer_family_marker.readback_requested &&
-        !g_consumer_family_marker.readback_queued) {
-      g_consumer_family_marker.readback_queued = true;
+        !g_consumer_family_marker.readback_in_flight &&
+        g_consumer_family_marker.readback_requests <
+            g_consumer_family_marker.readback_sample_limit) {
+      g_consumer_family_marker.readback_in_flight = true;
+      g_consumer_family_marker.current_capture_completions = 0;
       ++g_consumer_family_marker.readback_requests;
+      g_consumer_family_marker.current_capture_index =
+          uint32_t(g_consumer_family_marker.readback_requests);
       request.consumer_reference_readback_requested = true;
+      request.consumer_reference_depth_readback_requested = true;
       request.consumer_reference_before_readback_completion =
           &CompleteConsumerFamilyBeforeReadback;
       request.consumer_reference_after_readback_completion =
           &CompleteConsumerFamilyAfterReadback;
+      request.consumer_reference_before_depth_readback_completion =
+          &CompleteConsumerFamilyBeforeDepthReadback;
+      request.consumer_reference_after_depth_readback_completion =
+          &CompleteConsumerFamilyAfterDepthReadback;
     }
   }
   if (!g_isolated_draw.requested || !g_isolated_draw.valid ||
@@ -3210,7 +3346,9 @@ void CommitPassConsumer(
     g_consumer_family_marker.current_match = true;
     ++g_consumer_family_marker.matched_draws;
     if (g_consumer_family_marker.readback_requested &&
-        !g_consumer_family_marker.readback_queued) {
+        !g_consumer_family_marker.readback_in_flight &&
+        g_consumer_family_marker.readback_requests <
+            g_consumer_family_marker.readback_sample_limit) {
       g_consumer_family_marker.capture_frame = observation.frame_sequence;
       g_consumer_family_marker.capture_draw = observation.draw_sequence;
     }
@@ -3661,11 +3799,14 @@ void InstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system,
                              : "invalid_configuration")},
        {"consumer_family", ConsumerFamilyId()},
        {"mode", g_consumer_family_marker.readback_requested
-                    ? "authoritative_draw_marker_and_paired_async_readback"
+                    ? "authoritative_draw_marker_and_bounded_attachment_corpus"
                     : "authoritative_draw_marker_only"},
        {"readback",
-        g_consumer_family_marker.readback_requested ? "before_after_color"
-                                                    : "disabled"},
+        g_consumer_family_marker.readback_requested
+            ? "before_after_color_and_depth_stencil"
+            : "disabled"},
+       {"readback_sample_limit",
+        std::to_string(g_consumer_family_marker.readback_sample_limit)},
        {"readback_output",
         g_consumer_family_marker.readback_requested ? "local_only" : ""},
        {"xenos_draw", "preserved"},
@@ -3756,11 +3897,11 @@ void UninstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system) {
   if (g_isolated_draw.reference_depth_artifact_writer.joinable()) {
     g_isolated_draw.reference_depth_artifact_writer.join();
   }
-  if (g_consumer_family_marker.before_artifact_writer.joinable()) {
-    g_consumer_family_marker.before_artifact_writer.join();
-  }
-  if (g_consumer_family_marker.after_artifact_writer.joinable()) {
-    g_consumer_family_marker.after_artifact_writer.join();
+  for (std::jthread &artifact_writer :
+       g_consumer_family_marker.artifact_writers) {
+    if (artifact_writer.joinable()) {
+      artifact_writer.join();
+    }
   }
   if (g_pending_candidate.valid) {
     ++g_candidate_unprepared_draw_count;
@@ -4004,11 +4145,19 @@ void UninstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system) {
         std::to_string(g_consumer_family_marker.readback_requests)},
        {"readback_completions",
         std::to_string(g_consumer_family_marker.readback_completions)},
+       {"readback_sample_limit",
+        std::to_string(g_consumer_family_marker.readback_sample_limit)},
+       {"readback_samples_completed",
+        std::to_string(g_consumer_family_marker.readback_samples_completed)},
+       {"readback_expected_completions",
+        std::to_string(g_consumer_family_marker.readback_requests * 4)},
+       {"readback_in_flight",
+        g_consumer_family_marker.readback_in_flight ? "true" : "false"},
        {"capture_frame",
         std::to_string(g_consumer_family_marker.capture_frame)},
        {"capture_draw", std::to_string(g_consumer_family_marker.capture_draw)},
        {"mode", g_consumer_family_marker.readback_requested
-                    ? "authoritative_draw_marker_and_paired_async_readback"
+                    ? "authoritative_draw_marker_and_bounded_attachment_corpus"
                     : "authoritative_draw_marker_only"},
        {"xenos_draw", "preserved"},
        {"draw_suppression", "false"},

--- a/tools/analyze-native-renderer-consumer-readback.py
+++ b/tools/analyze-native-renderer-consumer-readback.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Build deterministic visual evidence from an exact consumer draw readback."""
+"""Build deterministic evidence from exact consumer attachment readbacks."""
 
 from __future__ import annotations
 
@@ -14,7 +14,12 @@ from pathlib import Path
 
 READBACK_SCHEMA = "pinyon-shift.consumer-family-readback.v1"
 REPORT_SCHEMA = "pinyon-shift.consumer-family-contribution.v1"
-SUPPORTED_FORMATS = {10: 8, 28: 4}
+CORPUS_SCHEMA = "pinyon-shift.consumer-family-contribution-corpus.v1"
+SUPPORTED_COLOR_FORMATS = {10: 8, 28: 4}
+DEPTH_ENCODINGS = {
+    "depth32_stencil8_sample_tuples",
+    "d3d12_planar_depth_stencil",
+}
 
 
 def _require(condition: bool, message: str) -> None:
@@ -30,48 +35,115 @@ def _sha256(path: Path) -> str:
     return digest.hexdigest().upper()
 
 
-def _load_readback(root: Path, phase: str) -> tuple[dict, bytes]:
-    phase_root = root / phase
-    metadata_path = phase_root / "readback.json"
-    payload_path = phase_root / "target.bin"
-    _require(metadata_path.is_file(), f"missing {phase} metadata")
-    _require(payload_path.is_file(), f"missing {phase} payload")
-    metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
-    _require(metadata.get("schema") == READBACK_SCHEMA, f"invalid {phase} schema")
-    _require(metadata.get("phase") == phase, f"invalid {phase} phase")
+def _attachment_root(root: Path, attachment: str, phase: str) -> Path:
+    return root / phase if attachment == "color" else root / "depth" / phase
+
+
+def _validate_safety(metadata: dict) -> None:
     safety = metadata.get("safety", {})
     _require(safety.get("output_authority") == "xenos", "Xenos authority missing")
     _require(safety.get("xenos_draw_preserved") is True, "Xenos draw not preserved")
     _require(safety.get("draw_suppression") is False, "draw suppression present")
     _require(safety.get("resolve_suppression") is False, "resolve suppression present")
     _require(safety.get("suppression_allowed") is False, "suppression unexpectedly allowed")
+
+
+def _load_readback(root: Path, phase: str, attachment: str) -> tuple[dict, bytes]:
+    phase_root = _attachment_root(root, attachment, phase)
+    metadata_path = phase_root / "readback.json"
+    payload_path = phase_root / "target.bin"
+    _require(metadata_path.is_file(), f"missing {attachment} {phase} metadata")
+    _require(payload_path.is_file(), f"missing {attachment} {phase} payload")
+    metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+    _require(metadata.get("schema") == READBACK_SCHEMA, f"invalid {phase} schema")
+    _require(metadata.get("phase") == phase, f"invalid {phase} phase")
+    _require(metadata.get("attachment", attachment) == attachment, "attachment mismatch")
+    _validate_safety(metadata)
     source = metadata.get("source", {})
     width = source.get("width")
     height = source.get("height")
-    row_pitch = source.get("row_pitch")
-    dxgi_format = source.get("dxgi_format")
     _require(isinstance(width, int) and width > 0, f"invalid {phase} width")
     _require(isinstance(height, int) and height > 0, f"invalid {phase} height")
-    _require(dxgi_format in SUPPORTED_FORMATS, f"unsupported {phase} format")
-    bytes_per_pixel = SUPPORTED_FORMATS[dxgi_format]
-    _require(source.get("bytes_per_pixel") == bytes_per_pixel, f"invalid {phase} pixel size")
-    _require(
-        isinstance(row_pitch, int) and row_pitch >= width * bytes_per_pixel,
-        f"invalid {phase} row pitch",
-    )
     payload = payload_path.read_bytes()
-    _require(len(payload) == row_pitch * height, f"invalid {phase} payload size")
     _require(source.get("bytes") == len(payload), f"invalid {phase} byte count")
+
+    if attachment == "color":
+        dxgi_format = source.get("dxgi_format")
+        row_pitch = source.get("row_pitch")
+        _require(dxgi_format in SUPPORTED_COLOR_FORMATS, f"unsupported {phase} format")
+        bytes_per_pixel = SUPPORTED_COLOR_FORMATS[dxgi_format]
+        _require(source.get("bytes_per_pixel") == bytes_per_pixel, f"invalid {phase} pixel size")
+        _require(source.get("sample_count", 1) == 1, "multisampled color is unsupported")
+        source_sample_count = source.get("source_sample_count", 1)
+        _require(
+            isinstance(source_sample_count, int) and source_sample_count > 0,
+            "invalid color source sample count",
+        )
+        _require(
+            isinstance(row_pitch, int) and row_pitch >= width * bytes_per_pixel,
+            f"invalid {phase} row pitch",
+        )
+        _require(len(payload) == row_pitch * height, f"invalid {phase} payload size")
+    else:
+        encoding = source.get("encoding")
+        sample_count = source.get("sample_count")
+        plane_count = source.get("plane_count")
+        planes = source.get("planes")
+        _require(encoding in DEPTH_ENCODINGS, f"unsupported {phase} depth encoding")
+        _require(isinstance(sample_count, int) and sample_count > 0, "invalid depth sample count")
+        _require(isinstance(plane_count, int) and 0 < plane_count <= 2, "invalid depth plane count")
+        _require(isinstance(planes, list) and len(planes) == plane_count, "invalid depth planes")
+        for plane in planes:
+            offset = plane.get("offset")
+            row_pitch = plane.get("row_pitch")
+            row_size = plane.get("row_size")
+            row_count = plane.get("row_count")
+            _require(
+                all(isinstance(value, int) for value in (offset, row_pitch, row_size, row_count))
+                and offset >= 0
+                and row_pitch >= row_size > 0
+                and row_count > 0
+                and offset + row_pitch * (row_count - 1) + row_size <= len(payload),
+                "invalid depth plane layout",
+            )
+        if encoding == "depth32_stencil8_sample_tuples":
+            plane = planes[0]
+            _require(sample_count > 1 and plane_count == 1, "invalid tuple depth topology")
+            _require(plane["row_size"] == width * sample_count * 8, "invalid tuple depth row size")
+            _require(plane["row_count"] == height, "invalid tuple depth row count")
+        else:
+            _require(sample_count == 1, "planar depth must be single-sampled")
     return metadata, payload
+
+
+def _validate_pair(before: dict, after: dict) -> None:
+    for field in ("consumer_family", "frame", "draw", "sample", "attachment"):
+        _require(before.get(field) == after.get(field), f"readback {field} mismatch")
+    for field in (
+        "width",
+        "height",
+        "row_pitch",
+        "dxgi_format",
+        "bytes_per_pixel",
+        "sample_count",
+        "source_sample_count",
+        "plane_count",
+        "planes",
+        "encoding",
+        "bytes",
+    ):
+        _require(
+            before["source"].get(field) == after["source"].get(field),
+            f"readback source {field} mismatch",
+        )
 
 
 def _to_rgb(metadata: dict, payload: bytes) -> bytes:
     source = metadata["source"]
-    width = source["width"]
-    height = source["height"]
+    width, height = source["width"], source["height"]
     row_pitch = source["row_pitch"]
     dxgi_format = source["dxgi_format"]
-    bytes_per_pixel = SUPPORTED_FORMATS[dxgi_format]
+    bytes_per_pixel = SUPPORTED_COLOR_FORMATS[dxgi_format]
     pixels = bytearray(width * height * 3)
     destination = 0
     for y in range(height):
@@ -91,64 +163,22 @@ def _to_rgb(metadata: dict, payload: bytes) -> bytes:
 
 
 def _png_chunk(kind: bytes, payload: bytes) -> bytes:
-    return (
-        struct.pack(">I", len(payload))
-        + kind
-        + payload
-        + struct.pack(">I", zlib.crc32(kind + payload) & 0xFFFFFFFF)
-    )
+    return struct.pack(">I", len(payload)) + kind + payload + struct.pack(">I", zlib.crc32(kind + payload) & 0xFFFFFFFF)
 
 
 def _write_png(path: Path, width: int, height: int, pixels: bytes) -> None:
     _require(len(pixels) == width * height * 3, "invalid PNG pixel count")
-    rows = b"".join(
-        b"\x00" + pixels[y * width * 3 : (y + 1) * width * 3]
-        for y in range(height)
-    )
+    rows = b"".join(b"\x00" + pixels[y * width * 3 : (y + 1) * width * 3] for y in range(height))
     header = struct.pack(">IIBBBBB", width, height, 8, 2, 0, 0, 0)
-    path.write_bytes(
-        b"\x89PNG\r\n\x1a\n"
-        + _png_chunk(b"IHDR", header)
-        + _png_chunk(b"IDAT", zlib.compress(rows, 9))
-        + _png_chunk(b"IEND", b"")
-    )
+    path.write_bytes(b"\x89PNG\r\n\x1a\n" + _png_chunk(b"IHDR", header) + _png_chunk(b"IDAT", zlib.compress(rows, 9)) + _png_chunk(b"IEND", b""))
 
 
-def analyze(root: Path, output: Path) -> dict:
-    before_metadata, before_payload = _load_readback(root, "before")
-    after_metadata, after_payload = _load_readback(root, "after")
-    for field in ("consumer_family", "frame", "draw"):
-        _require(
-            before_metadata.get(field) == after_metadata.get(field),
-            f"readback {field} mismatch",
-        )
-    for field in (
-        "width",
-        "height",
-        "row_pitch",
-        "dxgi_format",
-        "bytes_per_pixel",
-        "bytes",
-    ):
-        _require(
-            before_metadata["source"].get(field)
-            == after_metadata["source"].get(field),
-            f"readback source {field} mismatch",
-        )
-    _require(not output.exists(), f"output already exists: {output}")
-    output.mkdir(parents=True)
-
-    width = before_metadata["source"]["width"]
-    height = before_metadata["source"]["height"]
-    before = _to_rgb(before_metadata, before_payload)
-    after = _to_rgb(after_metadata, after_payload)
-    differences = bytearray(len(before))
-    mask = bytearray(len(before))
-    changed_pixels = 0
+def _compare_color(metadata: dict, before_payload: bytes, after_payload: bytes, output: Path) -> dict:
+    width, height = metadata["source"]["width"], metadata["source"]["height"]
+    before, after = _to_rgb(metadata, before_payload), _to_rgb(metadata, after_payload)
+    differences, mask = bytearray(len(before)), bytearray(len(before))
+    changed_pixels = absolute_sum = squared_sum = maximum = 0
     left, top, right, bottom = width, height, 0, 0
-    squared_sum = 0
-    absolute_sum = 0
-    maximum = 0
     for pixel in range(width * height):
         changed = False
         for channel in range(3):
@@ -162,55 +192,191 @@ def analyze(root: Path, output: Path) -> dict:
         if changed:
             changed_pixels += 1
             x, y = pixel % width, pixel // width
-            left, top = min(left, x), min(top, y)
-            right, bottom = max(right, x), max(bottom, y)
+            left, top, right, bottom = min(left, x), min(top, y), max(right, x), max(bottom, y)
             mask[pixel * 3 : pixel * 3 + 3] = b"\xff\xff\xff"
-
     _write_png(output / "before.png", width, height, before)
     _write_png(output / "after.png", width, height, after)
     _write_png(output / "difference-4x.png", width, height, bytes(differences))
     _write_png(output / "changed-mask.png", width, height, bytes(mask))
-    channel_count = width * height * 3
+    channels = width * height * 3
+    return {
+        "changed_pixels": changed_pixels,
+        "total_pixels": width * height,
+        "changed_fraction": changed_pixels / (width * height),
+        "mae_8bit_rgb": absolute_sum / channels,
+        "rmse_8bit_rgb": math.sqrt(squared_sum / channels),
+        "maximum_channel_delta": maximum,
+        "bounds": {"left": left, "top": top, "right": right, "bottom": bottom} if changed_pixels else None,
+        "semantic_role": "operator_review_required",
+    }
+
+
+def _active_plane_bytes(metadata: dict, payload: bytes) -> bytes:
+    active = bytearray()
+    for plane in metadata["source"]["planes"]:
+        for row in range(plane["row_count"]):
+            start = plane["offset"] + row * plane["row_pitch"]
+            active += payload[start : start + plane["row_size"]]
+    return bytes(active)
+
+
+def _depth_tuple_visuals(metadata: dict, before: bytes, after: bytes, output: Path) -> dict:
+    source = metadata["source"]
+    width, height, samples = source["width"], source["height"], source["sample_count"]
+    plane = source["planes"][0]
+    before_image, after_image = bytearray(width * height * 3), bytearray(width * height * 3)
+    mask = bytearray(width * height * 3)
+    changed_pixels = changed_samples = depth_changes = stencil_changes = 0
+    for y in range(height):
+        row = plane["offset"] + y * plane["row_pitch"]
+        for x in range(width):
+            pixel_changed = False
+            for sample in range(samples):
+                offset = row + x * samples * 8 + sample * 8
+                before_tuple = before[offset : offset + 8]
+                after_tuple = after[offset : offset + 8]
+                if before_tuple != after_tuple:
+                    changed_samples += 1
+                    pixel_changed = True
+                    depth_changes += before_tuple[:4] != after_tuple[:4]
+                    stencil_changes += before_tuple[4:8] != after_tuple[4:8]
+            for payload, image in ((before, before_image), (after, after_image)):
+                depth = struct.unpack_from("<f", payload, row + x * samples * 8)[0]
+                if not math.isfinite(depth):
+                    depth = 0.0
+                value = round(max(0.0, min(1.0, depth)) * 255)
+                image[(y * width + x) * 3 : (y * width + x + 1) * 3] = bytes((value, value, value))
+            if pixel_changed:
+                changed_pixels += 1
+                mask[(y * width + x) * 3 : (y * width + x + 1) * 3] = b"\xff\xff\xff"
+    _write_png(output / "depth-before.png", width, height, bytes(before_image))
+    _write_png(output / "depth-after.png", width, height, bytes(after_image))
+    _write_png(output / "depth-changed-mask.png", width, height, bytes(mask))
+    return {
+        "encoding": source["encoding"],
+        "changed_pixels": changed_pixels,
+        "total_pixels": width * height,
+        "changed_samples": changed_samples,
+        "total_samples": width * height * samples,
+        "depth_tuple_changes": depth_changes,
+        "stencil_tuple_changes": stencil_changes,
+        "semantic_role": "operator_review_required",
+        "images": {"before": "depth-before.png", "after": "depth-after.png", "changed_mask": "depth-changed-mask.png"},
+    }
+
+
+def _compare_depth(metadata: dict, before: bytes, after: bytes, output: Path) -> dict:
+    if metadata["source"]["encoding"] == "depth32_stencil8_sample_tuples":
+        return _depth_tuple_visuals(metadata, before, after, output)
+    before_active, after_active = _active_plane_bytes(metadata, before), _active_plane_bytes(metadata, after)
+    changed = sum(left != right for left, right in zip(before_active, after_active))
+    return {
+        "encoding": metadata["source"]["encoding"],
+        "active_bytes": len(before_active),
+        "changed_active_bytes": changed,
+        "exact_match": changed == 0,
+        "visual_decode": "unsupported_planar_layout",
+        "semantic_role": "operator_review_required",
+    }
+
+
+def _analyze_sample(root: Path, output: Path) -> dict:
+    before_metadata, before_payload = _load_readback(root, "before", "color")
+    after_metadata, after_payload = _load_readback(root, "after", "color")
+    _validate_pair(before_metadata, after_metadata)
+    _require(not output.exists(), f"output already exists: {output}")
+    output.mkdir(parents=True)
+    color = _compare_color(before_metadata, before_payload, after_payload, output)
+    depth_before_exists = (root / "depth" / "before" / "readback.json").is_file()
+    depth_after_exists = (root / "depth" / "after" / "readback.json").is_file()
+    _require(depth_before_exists == depth_after_exists, "incomplete depth readback pair")
+    depth = None
+    if depth_before_exists:
+        depth_before_metadata, depth_before_payload = _load_readback(root, "before", "depth_stencil")
+        depth_after_metadata, depth_after_payload = _load_readback(root, "after", "depth_stencil")
+        _validate_pair(depth_before_metadata, depth_after_metadata)
+        for field in ("consumer_family", "frame", "draw", "sample"):
+            default = 1 if field == "sample" else None
+            _require(
+                before_metadata.get(field, default)
+                == depth_before_metadata.get(field, default),
+                f"attachment {field} mismatch",
+            )
+        depth = _compare_depth(depth_before_metadata, depth_before_payload, depth_after_payload, output)
+    source = {
+        **before_metadata["source"],
+        "before_sha256": _sha256(root / "before" / "target.bin"),
+        "after_sha256": _sha256(root / "after" / "target.bin"),
+    }
     report = {
         "schema": REPORT_SCHEMA,
         "consumer_family": before_metadata["consumer_family"],
         "frame": before_metadata["frame"],
         "draw": before_metadata["draw"],
-        "source": {
-            **before_metadata["source"],
-            "before_sha256": _sha256(root / "before" / "target.bin"),
-            "after_sha256": _sha256(root / "after" / "target.bin"),
-        },
-        "contribution": {
-            "changed_pixels": changed_pixels,
-            "total_pixels": width * height,
-            "changed_fraction": changed_pixels / (width * height),
-            "mae_8bit_rgb": absolute_sum / channel_count,
-            "rmse_8bit_rgb": math.sqrt(squared_sum / channel_count),
-            "maximum_channel_delta": maximum,
-            "bounds": (
-                {"left": left, "top": top, "right": right, "bottom": bottom}
-                if changed_pixels
-                else None
+        "sample": before_metadata.get("sample", 1),
+        "source": source,
+        "contribution": color,
+        "attachments": {"color": color, "depth_stencil": depth},
+        "images": {"before": "before.png", "after": "after.png", "difference_4x": "difference-4x.png", "changed_mask": "changed-mask.png"},
+        "safety": {"output_authority": "xenos", "xenos_draw_preserved": True, "draw_suppression": False, "resolve_suppression": False, "suppression_allowed": False},
+    }
+    (output / "consumer-contribution.json").write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return report
+
+
+def _attachment_changed(report: dict) -> bool | None:
+    color_changed = report["attachments"]["color"]["changed_pixels"] > 0
+    depth = report["attachments"]["depth_stencil"]
+    if depth is None:
+        return None
+    depth_changed = depth.get("changed_pixels", 0) > 0 or depth.get("changed_active_bytes", 0) > 0
+    return color_changed or depth_changed
+
+
+def analyze(root: Path, output: Path) -> dict:
+    samples = sorted(path for path in root.glob("sample-*") if path.is_dir())
+    if not samples:
+        return _analyze_sample(root, output)
+    _require(not output.exists(), f"output already exists: {output}")
+    output.mkdir(parents=True)
+    reports = []
+    for expected, sample_root in enumerate(samples, 1):
+        _require(sample_root.name == f"sample-{expected:04d}", "non-contiguous sample corpus")
+        reports.append(_analyze_sample(sample_root, output / sample_root.name))
+    family = reports[0]["consumer_family"]
+    _require(all(report["consumer_family"] == family for report in reports), "consumer family mismatch")
+    attachment_deltas = [_attachment_changed(item) for item in reports]
+    report = {
+        "schema": CORPUS_SCHEMA,
+        "consumer_family": family,
+        "sample_count": len(reports),
+        "samples": [
+            {
+                "sample": item["sample"],
+                "frame": item["frame"],
+                "draw": item["draw"],
+                "report": f"sample-{index:04d}/consumer-contribution.json",
+                "attachments_complete": item["attachments"]["depth_stencil"] is not None,
+                "attachment_delta": attachment_deltas[index - 1],
+            }
+            for index, item in enumerate(reports, 1)
+        ],
+        "aggregate": {
+            "samples_with_complete_attachments": sum(delta is not None for delta in attachment_deltas),
+            "samples_with_color_delta": sum(item["attachments"]["color"]["changed_pixels"] > 0 for item in reports),
+            "samples_with_depth_stencil_delta": sum(
+                bool(item["attachments"]["depth_stencil"] and (
+                    item["attachments"]["depth_stencil"].get("changed_pixels", 0) > 0
+                    or item["attachments"]["depth_stencil"].get("changed_active_bytes", 0) > 0
+                )) for item in reports
             ),
+            "all_samples_complete": all(delta is not None for delta in attachment_deltas),
+            "all_samples_no_attachment_delta": all(delta is False for delta in attachment_deltas),
             "semantic_role": "operator_review_required",
         },
-        "images": {
-            "before": "before.png",
-            "after": "after.png",
-            "difference_4x": "difference-4x.png",
-            "changed_mask": "changed-mask.png",
-        },
-        "safety": {
-            "output_authority": "xenos",
-            "xenos_draw_preserved": True,
-            "draw_suppression": False,
-            "resolve_suppression": False,
-            "suppression_allowed": False,
-        },
+        "safety": {"output_authority": "xenos", "xenos_draw_preserved": True, "draw_suppression": False, "resolve_suppression": False, "suppression_allowed": False},
     }
-    report_path = output / "consumer-contribution.json"
-    report_path.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    (output / "consumer-contribution-corpus.json").write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
     return report
 
 

--- a/tools/capture-native-renderer-census.ps1
+++ b/tools/capture-native-renderer-census.ps1
@@ -21,6 +21,8 @@ param(
     [ValidatePattern('^[0-9A-Fa-f]{16}(?:/[0-9A-Fa-f]{16}){3}$')]
     [string]$ConsumerFamily,
     [string]$ConsumerReadbackDir,
+    [ValidateRange(1, 16)]
+    [int]$ConsumerReadbackSamples = 1,
     [switch]$Json
 )
 
@@ -132,6 +134,7 @@ $savedIsolatedDrawDir = $env:PINYON_SHIFT_NATIVE_RENDERER_ISOLATED_DRAW_DIR
 $savedPassAnchor = $env:PINYON_SHIFT_NATIVE_RENDERER_PASS_ANCHOR_SIGNATURE
 $savedConsumerFamily = $env:PINYON_SHIFT_NATIVE_RENDERER_CONSUMER_FAMILY
 $savedConsumerReadbackDir = $env:PINYON_SHIFT_NATIVE_RENDERER_CONSUMER_READBACK_DIR
+$savedConsumerReadbackSamples = $env:PINYON_SHIFT_NATIVE_RENDERER_CONSUMER_READBACK_SAMPLES
 try {
     $env:REX_PINYON_SHIFT_NATIVE_RENDERER_CENSUS = 'true'
     $env:PINYON_SHIFT_NATIVE_RENDERER_SCENE = $Scene
@@ -144,6 +147,8 @@ try {
     $env:PINYON_SHIFT_NATIVE_RENDERER_PASS_ANCHOR_SIGNATURE = $PassAnchorSignature
     $env:PINYON_SHIFT_NATIVE_RENDERER_CONSUMER_FAMILY = $ConsumerFamily
     $env:PINYON_SHIFT_NATIVE_RENDERER_CONSUMER_READBACK_DIR = $ConsumerReadbackDir
+    $env:PINYON_SHIFT_NATIVE_RENDERER_CONSUMER_READBACK_SAMPLES =
+        if ($ConsumerReadbackDir) { [string]$ConsumerReadbackSamples } else { $null }
     & (Join-Path $PSScriptRoot 'launch-preview.ps1') `
         -StateRoot $resolvedStateRoot -ShaderCaptureDir $ShaderCaptureDir `
         -Json:$Json
@@ -160,4 +165,6 @@ finally {
     $env:PINYON_SHIFT_NATIVE_RENDERER_PASS_ANCHOR_SIGNATURE = $savedPassAnchor
     $env:PINYON_SHIFT_NATIVE_RENDERER_CONSUMER_FAMILY = $savedConsumerFamily
     $env:PINYON_SHIFT_NATIVE_RENDERER_CONSUMER_READBACK_DIR = $savedConsumerReadbackDir
+    $env:PINYON_SHIFT_NATIVE_RENDERER_CONSUMER_READBACK_SAMPLES =
+        $savedConsumerReadbackSamples
 }

--- a/tools/capture-native-renderer-renderdoc.ps1
+++ b/tools/capture-native-renderer-renderdoc.ps1
@@ -12,6 +12,8 @@ param(
     [ValidatePattern('^[0-9A-Fa-f]{16}(?:/[0-9A-Fa-f]{16}){3}$')]
     [string]$ConsumerFamily,
     [string]$ConsumerReadbackDir,
+    [ValidateRange(1, 16)]
+    [int]$ConsumerReadbackSamples = 1,
     [string]$IsolatedDrawDir,
     [Parameter(Mandatory)]
     [string]$CaptureDir,
@@ -102,6 +104,7 @@ $saved = @{
     pass_anchor = $env:PINYON_SHIFT_NATIVE_RENDERER_PASS_ANCHOR_SIGNATURE
     consumer_family = $env:PINYON_SHIFT_NATIVE_RENDERER_CONSUMER_FAMILY
     consumer_readback_dir = $env:PINYON_SHIFT_NATIVE_RENDERER_CONSUMER_READBACK_DIR
+    consumer_readback_samples = $env:PINYON_SHIFT_NATIVE_RENDERER_CONSUMER_READBACK_SAMPLES
 }
 try {
     $env:PINYON_SHIFT_STATE_ROOT = $resolvedStateRoot
@@ -120,6 +123,8 @@ try {
         }
     $env:PINYON_SHIFT_NATIVE_RENDERER_CONSUMER_FAMILY = $ConsumerFamily
     $env:PINYON_SHIFT_NATIVE_RENDERER_CONSUMER_READBACK_DIR = $ConsumerReadbackDir
+    $env:PINYON_SHIFT_NATIVE_RENDERER_CONSUMER_READBACK_SAMPLES =
+        if ($ConsumerReadbackDir) { [string]$ConsumerReadbackSamples } else { $null }
     & $renderdoc capture -w `
         -d (Split-Path $executable -Parent) `
         -c (Join-Path $resolvedCaptureDir 'reference') `
@@ -140,6 +145,8 @@ finally {
     $env:PINYON_SHIFT_NATIVE_RENDERER_CONSUMER_FAMILY = $saved.consumer_family
     $env:PINYON_SHIFT_NATIVE_RENDERER_CONSUMER_READBACK_DIR =
         $saved.consumer_readback_dir
+    $env:PINYON_SHIFT_NATIVE_RENDERER_CONSUMER_READBACK_SAMPLES =
+        $saved.consumer_readback_samples
 }
 
 $captures = @(Get-ChildItem -LiteralPath $resolvedCaptureDir -File -Filter '*.rdc')

--- a/tools/tests/test_native_renderer_consumer_readback.py
+++ b/tools/tests/test_native_renderer_consumer_readback.py
@@ -22,7 +22,15 @@ FAMILY = (
 )
 
 
-def write_readback(root: Path, phase: str, payload: bytes, *, width=2, height=1):
+def write_readback(
+    root: Path,
+    phase: str,
+    payload: bytes,
+    *,
+    width=2,
+    height=1,
+    source_sample_count=None,
+):
     phase_root = root / phase
     phase_root.mkdir(parents=True)
     metadata = {
@@ -37,6 +45,66 @@ def write_readback(root: Path, phase: str, payload: bytes, *, width=2, height=1)
             "row_pitch": len(payload) // height,
             "dxgi_format": 28,
             "bytes_per_pixel": 4,
+            "sample_count": 1,
+            **(
+                {"source_sample_count": source_sample_count}
+                if source_sample_count is not None
+                else {}
+            ),
+            "bytes": len(payload),
+            "hash": "0000000000000000",
+        },
+        "payload": {"file": "target.bin"},
+        "safety": {
+            "output_authority": "xenos",
+            "xenos_draw_preserved": True,
+            "draw_suppression": False,
+            "resolve_suppression": False,
+            "suppression_allowed": False,
+        },
+    }
+    (phase_root / "readback.json").write_text(json.dumps(metadata))
+    (phase_root / "target.bin").write_bytes(payload)
+
+
+def write_depth_readback(
+    root: Path,
+    phase: str,
+    payload: bytes,
+    *,
+    sample=1,
+    width=1,
+    height=1,
+    sample_count=2,
+):
+    phase_root = root / "depth" / phase
+    phase_root.mkdir(parents=True)
+    row_size = width * sample_count * 8
+    metadata = {
+        "schema": MODULE.READBACK_SCHEMA,
+        "consumer_family": FAMILY,
+        "frame": 42,
+        "draw": 7,
+        "sample": sample,
+        "attachment": "depth_stencil",
+        "phase": phase,
+        "source": {
+            "width": width,
+            "height": height,
+            "row_pitch": row_size,
+            "dxgi_format": 20,
+            "bytes_per_pixel": 0,
+            "sample_count": sample_count,
+            "plane_count": 1,
+            "planes": [
+                {
+                    "offset": 0,
+                    "row_pitch": row_size,
+                    "row_size": row_size,
+                    "row_count": height,
+                }
+            ],
+            "encoding": "depth32_stencil8_sample_tuples",
             "bytes": len(payload),
             "hash": "0000000000000000",
         },
@@ -89,6 +157,22 @@ class ConsumerReadbackTests(unittest.TestCase):
             self.assertEqual(0, report["contribution"]["changed_pixels"])
             self.assertIsNone(report["contribution"]["bounds"])
 
+    def test_accepts_color_resolved_from_msaa_source(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary) / "readback"
+            color = bytes([10, 20, 30, 255])
+            write_readback(
+                root, "before", color, width=1, source_sample_count=4
+            )
+            write_readback(
+                root, "after", color, width=1, source_sample_count=4
+            )
+
+            report = MODULE.analyze(root, Path(temporary) / "report")
+
+            self.assertEqual(1, report["source"]["sample_count"])
+            self.assertEqual(4, report["source"]["source_sample_count"])
+
     def test_decodes_half_float_color(self):
         with tempfile.TemporaryDirectory() as temporary:
             root = Path(temporary) / "readback"
@@ -140,6 +224,93 @@ class ConsumerReadbackTests(unittest.TestCase):
 
             with self.assertRaisesRegex(ValueError, "draw suppression"):
                 MODULE.analyze(root, Path(temporary) / "report")
+
+    def test_reports_multisample_depth_and_stencil_changes(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary) / "readback"
+            color = bytes([0, 0, 0, 255])
+            write_readback(root, "before", color, width=1)
+            write_readback(root, "after", color, width=1)
+            before = struct.pack("<fIfI", 0.25, 0, 0.75, 1)
+            after = struct.pack("<fIfI", 0.50, 0, 0.75, 2)
+            write_depth_readback(root, "before", before)
+            write_depth_readback(root, "after", after)
+
+            report = MODULE.analyze(root, Path(temporary) / "report")
+
+            depth = report["attachments"]["depth_stencil"]
+            self.assertEqual(1, depth["changed_pixels"])
+            self.assertEqual(2, depth["changed_samples"])
+            self.assertEqual(1, depth["depth_tuple_changes"])
+            self.assertEqual(1, depth["stencil_tuple_changes"])
+            self.assertTrue((Path(temporary) / "report" / "depth-before.png").is_file())
+
+    def test_aggregates_contiguous_multi_sample_corpus(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary) / "readback"
+            for sample, changed in ((1, False), (2, True)):
+                sample_root = root / f"sample-{sample:04d}"
+                before_color = bytes([0, 0, 0, 255])
+                after_color = bytes([1 if changed else 0, 0, 0, 255])
+                write_readback(sample_root, "before", before_color, width=1)
+                write_readback(sample_root, "after", after_color, width=1)
+                for phase in ("before", "after"):
+                    path = sample_root / phase / "readback.json"
+                    metadata = json.loads(path.read_text())
+                    metadata["sample"] = sample
+                    metadata["frame"] = 40 + sample
+                    metadata["draw"] = 6 + sample
+                    path.write_text(json.dumps(metadata))
+                depth = struct.pack("<fIfI", 0.25, 0, 0.75, 1)
+                write_depth_readback(sample_root, "before", depth, sample=sample)
+                write_depth_readback(sample_root, "after", depth, sample=sample)
+                for phase in ("before", "after"):
+                    path = sample_root / "depth" / phase / "readback.json"
+                    metadata = json.loads(path.read_text())
+                    metadata["frame"] = 40 + sample
+                    metadata["draw"] = 6 + sample
+                    path.write_text(json.dumps(metadata))
+
+            report = MODULE.analyze(root, Path(temporary) / "report")
+
+            self.assertEqual(MODULE.CORPUS_SCHEMA, report["schema"])
+            self.assertEqual(2, report["sample_count"])
+            self.assertEqual(1, report["aggregate"]["samples_with_color_delta"])
+            self.assertFalse(report["aggregate"]["all_samples_no_attachment_delta"])
+
+    def test_rejects_malformed_depth_plane_metadata(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary) / "readback"
+            color = bytes([0, 0, 0, 255])
+            write_readback(root, "before", color, width=1)
+            write_readback(root, "after", color, width=1)
+            depth = struct.pack("<fIfI", 0.25, 0, 0.75, 1)
+            write_depth_readback(root, "before", depth)
+            write_depth_readback(root, "after", depth)
+            path = root / "depth" / "after" / "readback.json"
+            metadata = json.loads(path.read_text())
+            metadata["source"]["planes"][0]["row_size"] = len(depth) + 1
+            path.write_text(json.dumps(metadata))
+
+            with self.assertRaisesRegex(ValueError, "depth plane layout"):
+                MODULE.analyze(root, Path(temporary) / "report")
+
+    def test_incomplete_corpus_never_claims_no_attachment_delta(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            sample_root = Path(temporary) / "readback" / "sample-0001"
+            color = bytes([0, 0, 0, 255])
+            write_readback(sample_root, "before", color, width=1)
+            write_readback(sample_root, "after", color, width=1)
+
+            report = MODULE.analyze(
+                sample_root.parent, Path(temporary) / "report"
+            )
+
+            self.assertFalse(report["aggregate"]["all_samples_complete"])
+            self.assertFalse(
+                report["aggregate"]["all_samples_no_attachment_delta"]
+            )
+            self.assertIsNone(report["samples"][0]["attachment_delta"])
 
 
 if __name__ == "__main__":

--- a/tools/tests/test_native_renderer_contract.py
+++ b/tools/tests/test_native_renderer_contract.py
@@ -624,6 +624,41 @@ class NativeRendererContractTests(unittest.TestCase):
         self.assertNotIn("SetDrawSuppression", hooks + patch + analyzer)
         self.assertNotIn("SetCopySuppression", hooks + patch + analyzer)
 
+    def test_consumer_family_corpus_captures_depth_without_suppression(self):
+        hooks = (ROOT / "src/native_renderer/graphics_hooks.cpp").read_text(
+            encoding="utf-8"
+        )
+        patch = (
+            ROOT
+            / "patches/rexglue/0077-d3d12-consumer-family-depth-corpus.patch"
+        ).read_text(encoding="utf-8")
+        census = (
+            ROOT / "tools/capture-native-renderer-census.ps1"
+        ).read_text(encoding="utf-8")
+        renderdoc = (
+            ROOT / "tools/capture-native-renderer-renderdoc.ps1"
+        ).read_text(encoding="utf-8")
+        analyzer = (
+            ROOT / "tools/analyze-native-renderer-consumer-readback.py"
+        ).read_text(encoding="utf-8")
+
+        self.assertIn("kMaximumConsumerReadbackSamples = 16", hooks)
+        self.assertIn(
+            "PINYON_SHIFT_NATIVE_RENDERER_CONSUMER_READBACK_SAMPLES", hooks
+        )
+        self.assertIn("consumer_reference_depth_readback_requested", patch)
+        self.assertIn("QueueGuestConsumerDepthReadback", patch)
+        self.assertIn("guest_consumer_before_depth_readback_", patch)
+        self.assertIn("guest_consumer_after_depth_readback_", patch)
+        self.assertIn("before_after_color_and_depth_stencil", hooks)
+        self.assertIn("[ValidateRange(1, 16)]", census)
+        self.assertIn("[ValidateRange(1, 16)]", renderdoc)
+        self.assertIn("consumer-family-contribution-corpus.v1", analyzer)
+        self.assertIn("all_samples_no_attachment_delta", analyzer)
+        self.assertIn("operator_review_required", analyzer)
+        self.assertNotIn("SetDrawSuppression", hooks + patch + analyzer)
+        self.assertNotIn("SetCopySuppression", hooks + patch + analyzer)
+
     def test_shader_capture_is_local_bounded_and_passive(self):
         patch = (
             ROOT

--- a/tools/tests/test_release_contract.py
+++ b/tools/tests/test_release_contract.py
@@ -43,10 +43,10 @@ class ReleaseContractTests(unittest.TestCase):
 
     def test_rexglue_patches_have_stable_order_and_no_binary_payload(self):
         patches = sorted((ROOT / "patches/rexglue").glob("*.patch"))
-        self.assertEqual(len(patches), 76)
+        self.assertEqual(len(patches), 77)
         self.assertEqual(
             patches[-1].name,
-            "0076-d3d12-consumer-family-readback.patch",
+            "0077-d3d12-consumer-family-depth-corpus.patch",
         )
         self.assertEqual(len(patches), len({path.name[:4] for path in patches}))
         for path in patches:


### PR DESCRIPTION
## Summary

- capture 1-16 exact consumer-family occurrences with paired color and depth/stencil readbacks
- aggregate per-sample evidence into a fail-closed contribution corpus
- preserve Xenos draw authority and keep all suppression paths disabled
- document the four-sample AppData qualification and stencil-only contribution

## Validation

- 214/214 Python unit tests passed
- clean preview build passed with 77 ReXGlue patches
- AppData four-sample runtime capture completed with 16/16 readbacks
- corpus analyzer reported 4/4 complete samples
- runtime exited normally with zero error, failure, or device-loss events
- host presentation cadence: 59.944 Hz; deadline misses: 0

## Qualification result

All four color pairs were unchanged. Two samples changed stencil tuples only (16,218 and 16); depth tuples remained unchanged. The semantic role stays operator-review-required, Xenos remains authoritative, and suppression remains disallowed.