### PR TITLE
feat(native-renderer): publish retained pass outputs

### DIFF
--- a/docs/native-renderer/RETAINED_PASS_OUTPUT_PUBLICATION.md
+++ b/docs/native-renderer/RETAINED_PASS_OUTPUT_PUBLICATION.md
@@ -1,0 +1,127 @@
+# Retained-pass output publication
+
+NR-04D cannot suppress the retained sky/horizon pass while its resolved output
+feeds 38 observed Xenos shader families. Replacing those consumers individually
+is not the only safe boundary: the native replay can publish its complete color
+and depth/stencil result into the same authoritative Xenos render-target
+resources, allowing the original resolves and downstream consumers to continue
+unchanged.
+
+This milestone implements that publication boundary without suppressing any
+guest work. It is diagnostic, startup-only, default-off, and fail-closed.
+
+## Ordering contract
+
+For each exact adjacent anchor/follower occurrence, ReXGlue records work in this
+order:
+
+1. seed the private color and depth/stencil targets from the current guest
+   targets;
+2. replay the anchor and follower into the private targets;
+3. restore the guest target bindings;
+4. execute both original Xenos draws;
+5. queue any requested authoritative parity readbacks;
+6. validate the complete private/guest target pair;
+7. copy private depth/stencil and color into the guest resources; and
+8. continue with the original Xenos resolves, consumers, queries, events,
+   fences, and memexport behavior.
+
+Publication never occurs before the original follower. Therefore a failure or
+identity mismatch leaves a complete Xenos result in place. The backend validates
+both targets before transitioning or copying either resource, preventing a
+partial color-only or depth-only publication.
+
+## Exact validation
+
+Publication requires all of the following:
+
+- the host-render-target D3D12 path;
+- retained private color and depth/stencil targets from the current exact pass;
+- exactly one bound guest color target plus one depth/stencil target;
+- identical private and guest render-target keys; and
+- matching D3D12 dimensions, array size, mip count, format, sample count, and
+  sample quality for both attachments.
+
+Any failed condition returns `unsupported_path`, `unavailable`, or
+`target_mismatch`. No copy is recorded, Xenos remains authoritative, and the
+runtime diagnostic reports the fallback.
+
+## Qualification launch
+
+Use the AppData save and exact retained-pass signatures:
+
+```powershell
+$stateRoot = Join-Path $env:LOCALAPPDATA `
+  'PinyonShift\source\0.1.0\.local\preview'
+.\tools\capture-native-renderer-census.ps1 `
+  -StateRoot $stateRoot `
+  -Scene open_world_day `
+  -IsolatedDrawSignature '1D253A52B55C9FB3' `
+  -PassAnchorSignature '747837906D0BF484' `
+  -PublishRetainedPass
+```
+
+`PINYON_SHIFT_NATIVE_RENDERER_PUBLISH_RETAINED_PASS=true` is scoped to that
+helper invocation and restored afterward. It is rejected unless both exact
+pass signatures are configured.
+
+Runtime evidence uses:
+
+- `native_renderer.retained_pass.publication_config`;
+- up to 64 `native_renderer.retained_pass.publication` detail events; and
+- `native_renderer.retained_pass.publication_summary` at shutdown.
+
+Each detail event names the resulting `guest_target_content` explicitly:
+`native_retained_pass` only when both attachments were copied, otherwise
+`xenos`. This prevents a failed or partial attempt from being interpreted as
+native output authority.
+
+Validate a completed session with:
+
+```powershell
+python .\tools\summarize-native-renderer-pass-publication.py `
+  "$stateRoot\logs\<session>.jsonl" `
+  --output '.local\qualification\retained-pass-publication.json' `
+  --require-complete
+```
+
+The schema-v1 report rejects signature drift, unsafe suppression fields,
+incomplete attachment pairs, and inconsistent bounded-detail or
+attempt/success/failure counts.
+It always records `suppression_allowed=false` and leaves the downstream-consumer
+gate at `qualification_required`.
+
+A qualifying run must report only `published` attempts, both attachments
+published, no target mismatch or device-loss event, normal exit, and normal
+downstream consumer activity. RenderDoc captures can use the same switch and
+must contain `PinyonShift NR-04D native retained-pass publication` after the
+authoritative follower marker.
+
+## Open-world-day qualification
+
+The AppData-backed `open_world_day` session
+`20260829T082307Z-p39652` qualified the bridge on the 78-patch build:
+
+- 12,018 of 12,018 retained-pass attempts published both color and
+  depth/stencil, with zero fallback or target-mismatch results;
+- all four downstream-consumer corpus samples completed while the original
+  Xenos consumer draws remained enabled, and one sample produced a real
+  depth/stencil delta;
+- gameplay reached the festival save with visually intact sky, world geometry,
+  lighting, crowds, vehicle, and HUD;
+- presentation held 59.971 Hz with zero deadline misses, while the measured
+  simulation median was 30.491 FPS; and
+- the process exited normally with no error-level, fatal, device-loss, or
+  device-removed diagnostic.
+
+This is scene-bounded publication evidence. It does not yet promote the
+`later_gpu_consumers` gate or authorize suppression.
+
+## Suppression boundary
+
+This bridge does not enable suppression and does not by itself pass the
+`later_gpu_consumers` admission gate. Qualification must first prove that the
+published native target reaches the original resolves and downstream consumers
+with parity across required scenes. Only a later independent, default-off PR
+may consider skipping the exact anchor/follower draw pair. Xenos fallback and
+all guest side effects remain mandatory.

--- a/docs/native-renderer/SUPPRESSION_ADMISSION.md
+++ b/docs/native-renderer/SUPPRESSION_ADMISSION.md
@@ -74,6 +74,15 @@ signature overflow and complete prepared metadata. This keeps
 `later_gpu_consumers` at `fail`: consumers are proven present but are not
 native-replaced.
 
+[RETAINED_PASS_OUTPUT_PUBLICATION.md](RETAINED_PASS_OUTPUT_PUBLICATION.md)
+defines the next preservation boundary. A default-off diagnostic path copies
+the parity-qualified native color and depth/stencil result back into the exact
+guest targets only after both original Xenos draws. This is intended to let the
+existing resolves and all 38 consumer families continue unchanged. Its
+implementation does not promote the gate: scene qualification must still prove
+that published outputs reach downstream consumers with parity before any
+suppression implementation may begin.
+
 The same session armed every one of those 348 resolve generations and observed
 zero guest CPU read or write events. This promotes `guest_cpu_visibility` from
 `unknown` to scene-bounded `pass`, as documented in

--- a/patches/rexglue/0078-d3d12-retained-pass-output-publication.patch
+++ b/patches/rexglue/0078-d3d12-retained-pass-output-publication.patch
@@ -1,0 +1,258 @@
+diff --git a/include/rex/graphics/d3d12/render_target_cache.h b/include/rex/graphics/d3d12/render_target_cache.h
+index 1a1caf4..6d38697 100644
+--- a/include/rex/graphics/d3d12/render_target_cache.h
++++ b/include/rex/graphics/d3d12/render_target_cache.h
+@@ -122,6 +122,7 @@ class D3D12RenderTargetCache final : public RenderTargetCache {
+       system::GraphicsIsolatedDrawReadbackCompletion completion,
+       uint32_t* failure_detail_out);
+   void EndIsolatedReplayTarget(uint64_t frame_sequence);
++  system::GraphicsIsolatedDrawPublicationResult PublishIsolatedReplayTarget();
+ 
+   struct IsolatedReplayPreviewSource {
+     ID3D12Resource* resource = nullptr;
+diff --git a/include/rex/system/interfaces/graphics.h b/include/rex/system/interfaces/graphics.h
+index 482f825..19ee4a5 100644
+--- a/include/rex/system/interfaces/graphics.h
++++ b/include/rex/system/interfaces/graphics.h
+@@ -391,6 +391,26 @@ struct GraphicsIsolatedDrawReadback {
+ using GraphicsIsolatedDrawReadbackCompletion = void (*)(
+     const GraphicsIsolatedDrawReadback& readback);
+ 
++enum class GraphicsIsolatedDrawPublicationStatus : uint32_t {
++  kPublished = 1,
++  kUnsupportedPath = 2,
++  kUnavailable = 3,
++  kTargetMismatch = 4,
++};
++
++struct GraphicsIsolatedDrawPublicationResult {
++  GraphicsIsolatedDrawPublicationStatus status =
++      GraphicsIsolatedDrawPublicationStatus::kUnavailable;
++  uint32_t target_width = 0;
++  uint32_t target_height = 0;
++  uint32_t sample_count = 0;
++  bool color_published = false;
++  bool depth_stencil_published = false;
++};
++
++using GraphicsIsolatedDrawPublicationCompletion = void (*)(
++    const GraphicsIsolatedDrawPublicationResult& result);
++
+ struct GraphicsIsolatedDrawRequest {
+   bool requested = false;
+   bool readback_requested = false;
+@@ -419,6 +439,11 @@ struct GraphicsIsolatedDrawRequest {
+   // Rebind the retained private target without copying the guest target. This
+   // is valid only for the immediately following draw of an isolated pass.
+   bool reuse_target = false;
++  // After the original authoritative guest draw, publish the completed private
++  // pass into the same guest color and depth/stencil resources. The backend
++  // must validate the entire pair before recording either copy. This never
++  // skips a draw, resolve, query, event, fence, or memexport operation.
++  bool publish_to_guest_requested = false;
+   uint64_t frame_sequence = 0;
+   GraphicsIsolatedDrawCompletion completion = nullptr;
+   GraphicsIsolatedDrawReadbackCompletion readback_completion = nullptr;
+@@ -435,6 +460,7 @@ struct GraphicsIsolatedDrawRequest {
+       consumer_reference_before_depth_readback_completion = nullptr;
+   GraphicsIsolatedDrawReadbackCompletion
+       consumer_reference_after_depth_readback_completion = nullptr;
++  GraphicsIsolatedDrawPublicationCompletion publication_completion = nullptr;
+ };
+ 
+ // Called after the host pipeline has been prepared. A request duplicates the
+diff --git a/src/graphics/d3d12/command_processor.cpp b/src/graphics/d3d12/command_processor.cpp
+index 0b95246..1e1a691 100644
+--- a/src/graphics/d3d12/command_processor.cpp
++++ b/src/graphics/d3d12/command_processor.cpp
+@@ -3310,6 +3310,7 @@ bool D3D12CommandProcessor::IssueDraw(xenos::PrimitiveType primitive_type, uint3
+   SetPrimitiveTopology(primitive_topology);
+   // Must not call anything that may change the primitive topology from now on!
+ 
++  bool isolated_replay_recorded = false;
+   const auto queue_consumer_reference_readback = [&](bool before_draw) {
+     if (!isolated_draw_request.consumer_reference_readback_requested &&
+         !isolated_draw_request.consumer_reference_depth_readback_requested) {
+@@ -3351,6 +3352,18 @@ bool D3D12CommandProcessor::IssueDraw(xenos::PrimitiveType primitive_type, uint3
+       queue(true);
+     }
+   };
++  const auto publish_isolated_replay_to_guest = [&]() {
++    if (!isolated_draw_request.publish_to_guest_requested) {
++      return;
++    }
++    system::GraphicsIsolatedDrawPublicationResult publication;
++    if (isolated_replay_recorded) {
++      publication = render_target_cache_->PublishIsolatedReplayTarget();
++    }
++    if (isolated_draw_request.publication_completion) {
++      isolated_draw_request.publication_completion(publication);
++    }
++  };
+ 
+   // Draw.
+   if (primitive_processing_result.index_buffer_type ==
+@@ -3414,6 +3427,7 @@ bool D3D12CommandProcessor::IssueDraw(xenos::PrimitiveType primitive_type, uint3
+         }
+         render_target_cache_->EndIsolatedReplayTarget(
+             isolated_draw_request.frame_sequence);
++        isolated_replay_recorded = true;
+         isolated_result.status =
+             system::GraphicsIsolatedDrawStatus::kRecorded;
+       } else {
+@@ -3472,6 +3486,7 @@ bool D3D12CommandProcessor::IssueDraw(xenos::PrimitiveType primitive_type, uint3
+             readback_result);
+       }
+     }
++    publish_isolated_replay_to_guest();
+   } else {
+     D3D12_INDEX_BUFFER_VIEW index_buffer_view;
+     index_buffer_view.SizeInBytes = primitive_processing_result.host_draw_vertex_count;
+@@ -3582,6 +3597,7 @@ bool D3D12CommandProcessor::IssueDraw(xenos::PrimitiveType primitive_type, uint3
+         }
+         render_target_cache_->EndIsolatedReplayTarget(
+             isolated_draw_request.frame_sequence);
++        isolated_replay_recorded = true;
+         isolated_result.status =
+             system::GraphicsIsolatedDrawStatus::kRecorded;
+       } else {
+@@ -3640,6 +3656,7 @@ bool D3D12CommandProcessor::IssueDraw(xenos::PrimitiveType primitive_type, uint3
+             readback_result);
+       }
+     }
++    publish_isolated_replay_to_guest();
+     if (scratch_index_buffer != nullptr) {
+       ReleaseScratchGPUBuffer(scratch_index_buffer, D3D12_RESOURCE_STATE_INDEX_BUFFER);
+     }
+diff --git a/src/graphics/d3d12/render_target_cache.cpp b/src/graphics/d3d12/render_target_cache.cpp
+index 1a21a9b..cd423bf 100644
+--- a/src/graphics/d3d12/render_target_cache.cpp
++++ b/src/graphics/d3d12/render_target_cache.cpp
+@@ -2335,6 +2335,127 @@ void D3D12RenderTargetCache::EndIsolatedReplayTarget(
+   isolated_replay_preview_frame_sequence_ = frame_sequence;
+ }
+ 
++system::GraphicsIsolatedDrawPublicationResult
++D3D12RenderTargetCache::PublishIsolatedReplayTarget() {
++  system::GraphicsIsolatedDrawPublicationResult result;
++  if (GetPath() != Path::kHostRenderTargets) {
++    result.status = system::GraphicsIsolatedDrawPublicationStatus::kUnsupportedPath;
++    return result;
++  }
++  if (!isolated_replay_depth_target_ || !isolated_replay_color_target_) {
++    result.status = system::GraphicsIsolatedDrawPublicationStatus::kUnavailable;
++    return result;
++  }
++
++  RenderTarget* const* guest_targets =
++      last_update_accumulated_render_targets();
++  if (!guest_targets[0] || !guest_targets[1]) {
++    result.status = system::GraphicsIsolatedDrawPublicationStatus::kUnavailable;
++    return result;
++  }
++  for (uint32_t i = 2; i <= xenos::kMaxColorRenderTargets; ++i) {
++    if (guest_targets[i]) {
++      result.status = system::GraphicsIsolatedDrawPublicationStatus::kTargetMismatch;
++      return result;
++    }
++  }
++  if (guest_targets[0]->key() != isolated_replay_depth_target_->key() ||
++      guest_targets[1]->key() != isolated_replay_color_target_->key()) {
++    result.status = system::GraphicsIsolatedDrawPublicationStatus::kTargetMismatch;
++    return result;
++  }
++
++  auto* guest_depth = static_cast<D3D12RenderTarget*>(guest_targets[0]);
++  auto* guest_color = static_cast<D3D12RenderTarget*>(guest_targets[1]);
++  auto* isolated_depth = static_cast<D3D12RenderTarget*>(
++      isolated_replay_depth_target_.get());
++  auto* isolated_color = static_cast<D3D12RenderTarget*>(
++      isolated_replay_color_target_.get());
++  const D3D12_RESOURCE_DESC guest_depth_desc =
++      guest_depth->resource()->GetDesc();
++  const D3D12_RESOURCE_DESC guest_color_desc =
++      guest_color->resource()->GetDesc();
++  const D3D12_RESOURCE_DESC isolated_depth_desc =
++      isolated_depth->resource()->GetDesc();
++  const D3D12_RESOURCE_DESC isolated_color_desc =
++      isolated_color->resource()->GetDesc();
++  const auto matching_desc = [](const D3D12_RESOURCE_DESC& left,
++                                const D3D12_RESOURCE_DESC& right) {
++    return left.Dimension == right.Dimension &&
++           left.Alignment == right.Alignment && left.Width == right.Width &&
++           left.Height == right.Height &&
++           left.DepthOrArraySize == right.DepthOrArraySize &&
++           left.MipLevels == right.MipLevels && left.Format == right.Format &&
++           left.SampleDesc.Count == right.SampleDesc.Count &&
++           left.SampleDesc.Quality == right.SampleDesc.Quality &&
++           left.Layout == right.Layout && left.Flags == right.Flags;
++  };
++  if (!matching_desc(guest_depth_desc, isolated_depth_desc) ||
++      !matching_desc(guest_color_desc, isolated_color_desc) ||
++      guest_color_desc.Width > UINT32_MAX) {
++    result.status = system::GraphicsIsolatedDrawPublicationStatus::kTargetMismatch;
++    return result;
++  }
++
++  const D3D12_RESOURCE_STATES guest_depth_state =
++      guest_depth->SetResourceState(D3D12_RESOURCE_STATE_COPY_DEST);
++  const D3D12_RESOURCE_STATES guest_color_state =
++      guest_color->SetResourceState(D3D12_RESOURCE_STATE_COPY_DEST);
++  const D3D12_RESOURCE_STATES isolated_depth_state =
++      isolated_depth->SetResourceState(D3D12_RESOURCE_STATE_COPY_SOURCE);
++  const D3D12_RESOURCE_STATES isolated_color_state =
++      isolated_color->SetResourceState(D3D12_RESOURCE_STATE_COPY_SOURCE);
++  command_processor_.PushTransitionBarrier(
++      guest_depth->resource(), guest_depth_state,
++      D3D12_RESOURCE_STATE_COPY_DEST);
++  command_processor_.PushTransitionBarrier(
++      guest_color->resource(), guest_color_state,
++      D3D12_RESOURCE_STATE_COPY_DEST);
++  command_processor_.PushTransitionBarrier(
++      isolated_depth->resource(), isolated_depth_state,
++      D3D12_RESOURCE_STATE_COPY_SOURCE);
++  command_processor_.PushTransitionBarrier(
++      isolated_color->resource(), isolated_color_state,
++      D3D12_RESOURCE_STATE_COPY_SOURCE);
++  command_processor_.SubmitBarriers();
++
++  DeferredCommandList& command_list =
++      command_processor_.GetDeferredCommandList();
++  command_list.BeginDebugMarker(
++      "PinyonShift NR-04D native retained-pass publication");
++  command_list.D3DCopyResource(guest_depth->resource(),
++                               isolated_depth->resource());
++  command_list.D3DCopyResource(guest_color->resource(),
++                               isolated_color->resource());
++  command_list.EndDebugMarker();
++
++  guest_depth->SetResourceState(guest_depth_state);
++  guest_color->SetResourceState(guest_color_state);
++  isolated_depth->SetResourceState(isolated_depth_state);
++  isolated_color->SetResourceState(isolated_color_state);
++  command_processor_.PushTransitionBarrier(
++      guest_depth->resource(), D3D12_RESOURCE_STATE_COPY_DEST,
++      guest_depth_state);
++  command_processor_.PushTransitionBarrier(
++      guest_color->resource(), D3D12_RESOURCE_STATE_COPY_DEST,
++      guest_color_state);
++  command_processor_.PushTransitionBarrier(
++      isolated_depth->resource(), D3D12_RESOURCE_STATE_COPY_SOURCE,
++      isolated_depth_state);
++  command_processor_.PushTransitionBarrier(
++      isolated_color->resource(), D3D12_RESOURCE_STATE_COPY_SOURCE,
++      isolated_color_state);
++  command_processor_.SubmitBarriers();
++
++  result.status = system::GraphicsIsolatedDrawPublicationStatus::kPublished;
++  result.target_width = uint32_t(guest_color_desc.Width);
++  result.target_height = guest_color_desc.Height;
++  result.sample_count = guest_color_desc.SampleDesc.Count;
++  result.color_published = true;
++  result.depth_stencil_published = true;
++  return result;
++}
++
+ bool D3D12RenderTargetCache::BeginIsolatedReplayPreview(
+     uint64_t required_frame_sequence,
+     IsolatedReplayPreviewSource& source_out) {

--- a/src/native_renderer/graphics_hooks.cpp
+++ b/src/native_renderer/graphics_hooks.cpp
@@ -57,6 +57,7 @@ constexpr uint32_t kMaximumTextureScanResources = 4;
 constexpr uint64_t kMaximumTextureScanResourceBytes = UINT64_C(16) << 20;
 constexpr uint64_t kMaximumTextureScanTotalBytes = UINT64_C(32) << 20;
 constexpr uint32_t kMaximumConsumerReadbackSamples = 16;
+constexpr uint64_t kPassPublicationDetailLimit = 64;
 std::atomic<uint64_t> g_frame_sequence{};
 
 std::string CensusSceneMarker() {
@@ -147,6 +148,20 @@ struct PassFollowerState {
 };
 
 PassFollowerState g_pass_follower;
+
+struct PassPublicationState {
+  uint64_t attempts = 0;
+  uint64_t published = 0;
+  uint64_t failures = 0;
+  uint64_t detail_events = 0;
+  uint64_t detail_overflow = 0;
+  uint64_t last_frame = 0;
+  uint64_t last_draw = 0;
+  bool requested = false;
+  bool valid = true;
+};
+
+PassPublicationState g_pass_publication;
 
 struct ConsumerFamilyMarkerState {
   uint64_t vertex_shader_hash = 0;
@@ -371,6 +386,29 @@ void ConfigureIsolatedDraw() {
       !IsLocalArtifactRoot(g_isolated_draw.output_root)) {
     g_isolated_draw.valid = false;
   }
+}
+
+void ConfigurePassPublication() {
+  g_pass_publication = {};
+  char *value = nullptr;
+  size_t length = 0;
+  if (_dupenv_s(&value, &length,
+                "PINYON_SHIFT_NATIVE_RENDERER_PUBLISH_RETAINED_PASS") != 0 ||
+      !value || length <= 1) {
+    std::free(value);
+    return;
+  }
+  const std::string setting(value);
+  std::free(value);
+  if (setting == "false") {
+    return;
+  }
+  g_pass_publication.requested = true;
+  g_pass_publication.valid =
+      setting == "true" && g_isolated_draw.requested &&
+      g_isolated_draw.valid && g_pass_follower.requested &&
+      g_pass_follower.valid &&
+      g_isolated_draw.target_signature != g_pass_follower.target_signature;
 }
 
 struct DrawSignatureEntry {
@@ -2981,6 +3019,62 @@ void CompleteIsolatedPassRepeat(
        {"suppression_eligible", "false"}});
 }
 
+void CompleteRetainedPassPublication(
+    const rex::system::GraphicsIsolatedDrawPublicationResult &result) {
+  ++g_pass_publication.attempts;
+  g_pass_publication.last_frame = g_isolated_draw.frame;
+  g_pass_publication.last_draw = g_isolated_draw.draw;
+  const bool published =
+      result.status ==
+          rex::system::GraphicsIsolatedDrawPublicationStatus::kPublished &&
+      result.color_published && result.depth_stencil_published;
+  if (published) {
+    ++g_pass_publication.published;
+  } else {
+    ++g_pass_publication.failures;
+  }
+  const char *status = "unavailable";
+  switch (result.status) {
+  case rex::system::GraphicsIsolatedDrawPublicationStatus::kPublished:
+    status = published ? "published" : "incomplete";
+    break;
+  case rex::system::GraphicsIsolatedDrawPublicationStatus::kUnsupportedPath:
+    status = "unsupported_path";
+    break;
+  case rex::system::GraphicsIsolatedDrawPublicationStatus::kTargetMismatch:
+    status = "target_mismatch";
+    break;
+  case rex::system::GraphicsIsolatedDrawPublicationStatus::kUnavailable:
+    break;
+  }
+  if (g_pass_publication.detail_events >= kPassPublicationDetailLimit) {
+    ++g_pass_publication.detail_overflow;
+    return;
+  }
+  ++g_pass_publication.detail_events;
+  pinyon_shift::diagnostics::RecordEvent(
+      "native_renderer.retained_pass.publication",
+      {{"anchor_signature",
+        fmt::format("{:016X}", g_pass_follower.target_signature)},
+       {"follower_signature",
+        fmt::format("{:016X}", g_isolated_draw.target_signature)},
+       {"status", status},
+       {"frame", std::to_string(g_isolated_draw.frame)},
+       {"follower_draw", std::to_string(g_isolated_draw.draw)},
+       {"target_width", std::to_string(result.target_width)},
+       {"target_height", std::to_string(result.target_height)},
+       {"sample_count", std::to_string(result.sample_count)},
+       {"color", result.color_published ? "published" : "preserved_xenos"},
+       {"depth_stencil",
+        result.depth_stencil_published ? "published" : "preserved_xenos"},
+       {"guest_target_content", published ? "native_retained_pass" : "xenos"},
+       {"xenos_draw", "preserved"},
+       {"draw_suppression", "false"},
+       {"resolve_suppression", "false"},
+       {"side_effects", "preserved"},
+       {"suppression_eligible", "false"}});
+}
+
 void RequestIsolatedDraw(
     const rex::system::GraphicsPreparedDrawObservation &,
     rex::system::GraphicsIsolatedDrawRequest &request) {
@@ -3061,6 +3155,10 @@ void RequestIsolatedDraw(
     request.frame_sequence = g_isolated_draw.frame;
     request.reuse_target = true;
     request.reference_marker_requested = true;
+    if (g_pass_publication.requested && g_pass_publication.valid) {
+      request.publish_to_guest_requested = true;
+      request.publication_completion = &CompleteRetainedPassPublication;
+    }
     if (!g_isolated_draw.completed) {
       g_isolated_draw.captured_signature = signature;
       g_isolated_draw.captured_frame = g_isolated_draw.frame;
@@ -3720,6 +3818,7 @@ void InstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system,
   ConfigureReplaySnapshot();
   ConfigureIsolatedDraw();
   ConfigurePassFollower();
+  ConfigurePassPublication();
   ConfigureConsumerFamilyMarker();
   g_graphics_census_memory = memory;
   if (g_pass_follower.requested && g_pass_follower.valid &&
@@ -3856,6 +3955,31 @@ void InstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system,
        {"reference_marker", "exact_signature"},
        {"xenos_draw", "preserved"},
        {"output_authority", "xenos"},
+       {"suppression_eligible", "false"}});
+  diagnostics::RecordEvent(
+      "native_renderer.retained_pass.publication_config",
+      {{"status", !g_pass_publication.requested
+                      ? "disabled"
+                      : (g_pass_publication.valid ? "armed"
+                                                  : "invalid_configuration")},
+       {"anchor_signature",
+        g_pass_publication.valid && g_pass_publication.requested
+            ? fmt::format("{:016X}", g_pass_follower.target_signature)
+            : ""},
+       {"follower_signature",
+        g_pass_publication.valid && g_pass_publication.requested
+            ? fmt::format("{:016X}", g_isolated_draw.target_signature)
+            : ""},
+       {"activation", "startup_only"},
+       {"default_enabled", "false"},
+       {"publication", "color_and_depth_stencil_after_xenos_follower"},
+       {"guest_target_content", "xenos_until_successful_publication"},
+       {"fallback", "preserve_xenos_targets"},
+       {"detail_limit", std::to_string(kPassPublicationDetailLimit)},
+       {"xenos_draw", "preserved"},
+       {"draw_suppression", "false"},
+       {"resolve_suppression", "false"},
+       {"side_effects", "preserved"},
        {"suppression_eligible", "false"}});
   diagnostics::RecordEvent(
       "native_renderer.census.guest_cpu_visibility_config",
@@ -4162,6 +4286,31 @@ void UninstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system) {
        {"xenos_draw", "preserved"},
        {"draw_suppression", "false"},
        {"resolve_suppression", "false"},
+       {"suppression_eligible", "false"}});
+  diagnostics::RecordEvent(
+      "native_renderer.retained_pass.publication_summary",
+      {{"status", !g_pass_publication.requested
+                      ? "disabled"
+                      : (!g_pass_publication.valid
+                             ? "invalid_configuration"
+                             : (g_pass_publication.failures
+                                    ? "fallback_observed"
+                                     : (g_pass_publication.published
+                                            ? "complete"
+                                           : "not_observed")))},
+       {"attempts", std::to_string(g_pass_publication.attempts)},
+       {"published", std::to_string(g_pass_publication.published)},
+       {"failures", std::to_string(g_pass_publication.failures)},
+       {"detail_events", std::to_string(g_pass_publication.detail_events)},
+       {"detail_overflow", std::to_string(g_pass_publication.detail_overflow)},
+       {"last_frame", std::to_string(g_pass_publication.last_frame)},
+       {"last_draw", std::to_string(g_pass_publication.last_draw)},
+       {"published_attachments", "color_and_depth_stencil"},
+       {"guest_target_content", "per_attempt"},
+       {"xenos_draw", "preserved"},
+       {"draw_suppression", "false"},
+       {"resolve_suppression", "false"},
+       {"side_effects", "preserved"},
        {"suppression_eligible", "false"}});
   g_graphics_census_installed = false;
   g_graphics_census_memory = nullptr;

--- a/tools/capture-native-renderer-census.ps1
+++ b/tools/capture-native-renderer-census.ps1
@@ -18,6 +18,7 @@ param(
     [string]$IsolatedDrawDir,
     [ValidatePattern('^[0-9A-Fa-f]{16}$')]
     [string]$PassAnchorSignature,
+    [switch]$PublishRetainedPass,
     [ValidatePattern('^[0-9A-Fa-f]{16}(?:/[0-9A-Fa-f]{16}){3}$')]
     [string]$ConsumerFamily,
     [string]$ConsumerReadbackDir,
@@ -59,6 +60,10 @@ if (@(Get-Process -Name 'pinyon_shift' -ErrorAction SilentlyContinue).Count -ne 
 }
 if ([bool]$ReplaySnapshotSignature -xor [bool]$ReplaySnapshotDir) {
     throw 'ReplaySnapshotSignature and ReplaySnapshotDir must be supplied together.'
+}
+if ($PublishRetainedPass -and
+    (-not $IsolatedDrawSignature -or -not $PassAnchorSignature)) {
+    throw 'PublishRetainedPass requires IsolatedDrawSignature and PassAnchorSignature.'
 }
 if ($ReplaySnapshotDir) {
     $repositoryRoot = Split-Path $PSScriptRoot -Parent
@@ -132,6 +137,7 @@ $savedReplaySnapshotDir = $env:PINYON_SHIFT_NATIVE_RENDERER_SNAPSHOT_DIR
 $savedIsolatedDraw = $env:PINYON_SHIFT_NATIVE_RENDERER_ISOLATED_DRAW_SIGNATURE
 $savedIsolatedDrawDir = $env:PINYON_SHIFT_NATIVE_RENDERER_ISOLATED_DRAW_DIR
 $savedPassAnchor = $env:PINYON_SHIFT_NATIVE_RENDERER_PASS_ANCHOR_SIGNATURE
+$savedPassPublication = $env:PINYON_SHIFT_NATIVE_RENDERER_PUBLISH_RETAINED_PASS
 $savedConsumerFamily = $env:PINYON_SHIFT_NATIVE_RENDERER_CONSUMER_FAMILY
 $savedConsumerReadbackDir = $env:PINYON_SHIFT_NATIVE_RENDERER_CONSUMER_READBACK_DIR
 $savedConsumerReadbackSamples = $env:PINYON_SHIFT_NATIVE_RENDERER_CONSUMER_READBACK_SAMPLES
@@ -145,6 +151,8 @@ try {
     $env:PINYON_SHIFT_NATIVE_RENDERER_ISOLATED_DRAW_SIGNATURE = $IsolatedDrawSignature
     $env:PINYON_SHIFT_NATIVE_RENDERER_ISOLATED_DRAW_DIR = $IsolatedDrawDir
     $env:PINYON_SHIFT_NATIVE_RENDERER_PASS_ANCHOR_SIGNATURE = $PassAnchorSignature
+    $env:PINYON_SHIFT_NATIVE_RENDERER_PUBLISH_RETAINED_PASS =
+        if ($PublishRetainedPass) { 'true' } else { $null }
     $env:PINYON_SHIFT_NATIVE_RENDERER_CONSUMER_FAMILY = $ConsumerFamily
     $env:PINYON_SHIFT_NATIVE_RENDERER_CONSUMER_READBACK_DIR = $ConsumerReadbackDir
     $env:PINYON_SHIFT_NATIVE_RENDERER_CONSUMER_READBACK_SAMPLES =
@@ -163,6 +171,7 @@ finally {
     $env:PINYON_SHIFT_NATIVE_RENDERER_ISOLATED_DRAW_SIGNATURE = $savedIsolatedDraw
     $env:PINYON_SHIFT_NATIVE_RENDERER_ISOLATED_DRAW_DIR = $savedIsolatedDrawDir
     $env:PINYON_SHIFT_NATIVE_RENDERER_PASS_ANCHOR_SIGNATURE = $savedPassAnchor
+    $env:PINYON_SHIFT_NATIVE_RENDERER_PUBLISH_RETAINED_PASS = $savedPassPublication
     $env:PINYON_SHIFT_NATIVE_RENDERER_CONSUMER_FAMILY = $savedConsumerFamily
     $env:PINYON_SHIFT_NATIVE_RENDERER_CONSUMER_READBACK_DIR = $savedConsumerReadbackDir
     $env:PINYON_SHIFT_NATIVE_RENDERER_CONSUMER_READBACK_SAMPLES =

--- a/tools/capture-native-renderer-renderdoc.ps1
+++ b/tools/capture-native-renderer-renderdoc.ps1
@@ -9,6 +9,7 @@ param(
     [string]$IsolatedDrawSignature,
     [ValidatePattern('^[0-9A-Fa-f]{16}$')]
     [string]$PassAnchorSignature,
+    [switch]$PublishRetainedPass,
     [ValidatePattern('^[0-9A-Fa-f]{16}(?:/[0-9A-Fa-f]{16}){3}$')]
     [string]$ConsumerFamily,
     [string]$ConsumerReadbackDir,
@@ -39,6 +40,9 @@ if (Test-Path -LiteralPath $resolvedCaptureDir) {
 }
 if ([bool]$PassAnchorSignature -xor [bool]$IsolatedDrawDir) {
     throw 'PassAnchorSignature and IsolatedDrawDir must be supplied together.'
+}
+if ($PublishRetainedPass -and -not $PassAnchorSignature) {
+    throw 'PublishRetainedPass requires PassAnchorSignature.'
 }
 if ($IsolatedDrawDir) {
     $resolvedIsolatedDrawDir = [IO.Path]::GetFullPath($IsolatedDrawDir)
@@ -102,6 +106,7 @@ $saved = @{
     draw = $env:PINYON_SHIFT_NATIVE_RENDERER_ISOLATED_DRAW_SIGNATURE
     draw_dir = $env:PINYON_SHIFT_NATIVE_RENDERER_ISOLATED_DRAW_DIR
     pass_anchor = $env:PINYON_SHIFT_NATIVE_RENDERER_PASS_ANCHOR_SIGNATURE
+    pass_publication = $env:PINYON_SHIFT_NATIVE_RENDERER_PUBLISH_RETAINED_PASS
     consumer_family = $env:PINYON_SHIFT_NATIVE_RENDERER_CONSUMER_FAMILY
     consumer_readback_dir = $env:PINYON_SHIFT_NATIVE_RENDERER_CONSUMER_READBACK_DIR
     consumer_readback_samples = $env:PINYON_SHIFT_NATIVE_RENDERER_CONSUMER_READBACK_SAMPLES
@@ -121,6 +126,8 @@ try {
         } else {
             $null
         }
+    $env:PINYON_SHIFT_NATIVE_RENDERER_PUBLISH_RETAINED_PASS =
+        if ($PublishRetainedPass) { 'true' } else { $null }
     $env:PINYON_SHIFT_NATIVE_RENDERER_CONSUMER_FAMILY = $ConsumerFamily
     $env:PINYON_SHIFT_NATIVE_RENDERER_CONSUMER_READBACK_DIR = $ConsumerReadbackDir
     $env:PINYON_SHIFT_NATIVE_RENDERER_CONSUMER_READBACK_SAMPLES =
@@ -142,6 +149,7 @@ finally {
     $env:PINYON_SHIFT_NATIVE_RENDERER_ISOLATED_DRAW_SIGNATURE = $saved.draw
     $env:PINYON_SHIFT_NATIVE_RENDERER_ISOLATED_DRAW_DIR = $saved.draw_dir
     $env:PINYON_SHIFT_NATIVE_RENDERER_PASS_ANCHOR_SIGNATURE = $saved.pass_anchor
+    $env:PINYON_SHIFT_NATIVE_RENDERER_PUBLISH_RETAINED_PASS = $saved.pass_publication
     $env:PINYON_SHIFT_NATIVE_RENDERER_CONSUMER_FAMILY = $saved.consumer_family
     $env:PINYON_SHIFT_NATIVE_RENDERER_CONSUMER_READBACK_DIR =
         $saved.consumer_readback_dir

--- a/tools/summarize-native-renderer-pass-publication.py
+++ b/tools/summarize-native-renderer-pass-publication.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python3
+"""Validate retained-pass publication diagnostics without enabling suppression."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any, Iterable
+
+
+SCHEMA = "pinyon-shift.native-renderer-pass-publication.v1"
+CONFIG_EVENT = "native_renderer.retained_pass.publication_config"
+PUBLICATION_EVENT = "native_renderer.retained_pass.publication"
+SUMMARY_EVENT = "native_renderer.retained_pass.publication_summary"
+SAFETY_FIELDS = {
+    "xenos_draw": "preserved",
+    "draw_suppression": "false",
+    "resolve_suppression": "false",
+    "side_effects": "preserved",
+    "suppression_eligible": "false",
+}
+
+
+def _read_events(paths: Iterable[Path]) -> list[dict[str, Any]]:
+    events: list[dict[str, Any]] = []
+    for path in paths:
+        with path.open("r", encoding="utf-8") as source:
+            for line_number, line in enumerate(source, 1):
+                if not line.strip():
+                    continue
+                try:
+                    event = json.loads(line)
+                except json.JSONDecodeError as error:
+                    raise ValueError(
+                        f"{path}:{line_number}: invalid JSON: {error}"
+                    ) from error
+                if event.get("event") in {
+                    CONFIG_EVENT,
+                    PUBLICATION_EVENT,
+                    SUMMARY_EVENT,
+                }:
+                    event["_source"] = str(path)
+                    event["_line"] = line_number
+                    events.append(event)
+    return events
+
+
+def _one(events: list[dict[str, Any]], name: str) -> dict[str, Any]:
+    matches = [event for event in events if event.get("event") == name]
+    if len(matches) != 1:
+        raise ValueError(f"expected exactly one {name} event, found {len(matches)}")
+    return matches[0]
+
+
+def _positive_int(event: dict[str, Any], name: str) -> int:
+    try:
+        value = int(event[name])
+    except (KeyError, TypeError, ValueError) as error:
+        raise ValueError(f"{event.get('event')}: invalid {name}") from error
+    if value <= 0:
+        raise ValueError(f"{event.get('event')}: {name} must be positive")
+    return value
+
+
+def _nonnegative_int(event: dict[str, Any], name: str) -> int:
+    try:
+        value = int(event[name])
+    except (KeyError, TypeError, ValueError) as error:
+        raise ValueError(f"{event.get('event')}: invalid {name}") from error
+    if value < 0:
+        raise ValueError(f"{event.get('event')}: {name} must be nonnegative")
+    return value
+
+
+def _require_safety(event: dict[str, Any]) -> None:
+    for field, expected in SAFETY_FIELDS.items():
+        if str(event.get(field, "")) != expected:
+            raise ValueError(
+                f"{event.get('event')}: unsafe {field}={event.get(field)!r}"
+            )
+
+
+def summarize(paths: Iterable[Path]) -> dict[str, Any]:
+    path_list = list(paths)
+    events = _read_events(path_list)
+    config = _one(events, CONFIG_EVENT)
+    summary = _one(events, SUMMARY_EVENT)
+    publications = [
+        event for event in events if event.get("event") == PUBLICATION_EVENT
+    ]
+    _require_safety(config)
+    _require_safety(summary)
+    for publication in publications:
+        _require_safety(publication)
+
+    config_status = str(config.get("status", ""))
+    if config_status not in {"disabled", "armed", "invalid_configuration"}:
+        raise ValueError("publication config has invalid status")
+    anchor = str(config.get("anchor_signature", ""))
+    follower = str(config.get("follower_signature", ""))
+    if config_status == "armed":
+        for name, value in (("anchor", anchor), ("follower", follower)):
+            if len(value) != 16 or any(
+                character not in "0123456789ABCDEF" for character in value
+            ):
+                raise ValueError(f"armed publication has invalid {name} signature")
+    detail_limit = _positive_int(config, "detail_limit")
+    if config.get("guest_target_content") != "xenos_until_successful_publication":
+        raise ValueError("publication config has invalid guest target authority")
+    if summary.get("guest_target_content") != "per_attempt":
+        raise ValueError("publication summary has invalid guest target authority")
+
+    samples: list[dict[str, Any]] = []
+    successful = 0
+    for publication in publications:
+        if str(publication.get("anchor_signature", "")) != anchor or str(
+            publication.get("follower_signature", "")
+        ) != follower:
+            raise ValueError("publication event signature drift")
+        status = str(publication.get("status", ""))
+        if status not in {
+            "published",
+            "incomplete",
+            "unsupported_path",
+            "target_mismatch",
+            "unavailable",
+        }:
+            raise ValueError(f"publication event has invalid status {status!r}")
+        color = str(publication.get("color", ""))
+        depth = str(publication.get("depth_stencil", ""))
+        published = status == "published" and color == depth == "published"
+        expected_content = "native_retained_pass" if published else "xenos"
+        if publication.get("guest_target_content") != expected_content:
+            raise ValueError("publication event has invalid guest target authority")
+        successful += int(published)
+        dimension = _positive_int if published else _nonnegative_int
+        sample = {
+            "frame": _positive_int(publication, "frame"),
+            "draw": _positive_int(publication, "follower_draw"),
+            "target_width": dimension(publication, "target_width"),
+            "target_height": dimension(publication, "target_height"),
+            "sample_count": dimension(publication, "sample_count"),
+            "status": status,
+            "guest_target_content": expected_content,
+            "complete_attachment_pair": published,
+        }
+        samples.append(sample)
+
+    attempts = _nonnegative_int(summary, "attempts")
+    published_count = _nonnegative_int(summary, "published")
+    failures = _nonnegative_int(summary, "failures")
+    detail_events = _nonnegative_int(summary, "detail_events")
+    detail_overflow = _nonnegative_int(summary, "detail_overflow")
+    if detail_events != len(publications):
+        raise ValueError("publication summary detail count mismatch")
+    if attempts != detail_events + detail_overflow:
+        raise ValueError("publication summary attempt count mismatch")
+    if detail_events > detail_limit or (
+        detail_overflow and detail_events != detail_limit
+    ):
+        raise ValueError("publication summary violates detail limit")
+    if published_count + failures != attempts:
+        raise ValueError("publication summary failure count mismatch")
+    if successful != detail_events and failures == 0:
+        raise ValueError("publication detail contradicts complete summary")
+    complete = (
+        config_status == "armed"
+        and bool(samples)
+        and published_count == attempts
+        and failures == 0
+        and str(summary.get("status", "")) == "complete"
+    )
+
+    return {
+        "schema": SCHEMA,
+        "source": [str(path) for path in path_list],
+        "producer_family": {
+            "anchor_signature": anchor,
+            "follower_signature": follower,
+        },
+        "configuration": {
+            "status": config_status,
+            "activation": config.get("activation"),
+            "default_enabled": config.get("default_enabled"),
+            "fallback": config.get("fallback"),
+            "detail_limit": detail_limit,
+        },
+        "publication": {
+            "status": "pass" if complete else "incomplete",
+            "attempts": attempts,
+            "published": published_count,
+            "failures": failures,
+            "detail_events": detail_events,
+            "detail_overflow": detail_overflow,
+            "samples": samples,
+        },
+        "safety": {
+            "xenos_draws_preserved": True,
+            "draw_suppression": False,
+            "resolve_suppression": False,
+            "side_effects_preserved": True,
+            "suppression_allowed": False,
+            "later_gpu_consumers_gate": "qualification_required",
+        },
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("logs", nargs="+", type=Path)
+    parser.add_argument("--output", type=Path)
+    parser.add_argument("--require-complete", action="store_true")
+    args = parser.parse_args()
+    try:
+        report = summarize(args.logs)
+    except (OSError, ValueError) as error:
+        parser.error(str(error))
+    encoded = json.dumps(report, indent=2, sort_keys=True) + "\n"
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(encoded, encoding="utf-8")
+    else:
+        print(encoded, end="")
+    if args.require_complete and report["publication"]["status"] != "pass":
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/tests/test_native_renderer_contract.py
+++ b/tools/tests/test_native_renderer_contract.py
@@ -659,6 +659,52 @@ class NativeRendererContractTests(unittest.TestCase):
         self.assertNotIn("SetDrawSuppression", hooks + patch + analyzer)
         self.assertNotIn("SetCopySuppression", hooks + patch + analyzer)
 
+    def test_retained_pass_publication_preserves_xenos_side_effects(self):
+        hooks = (ROOT / "src/native_renderer/graphics_hooks.cpp").read_text(
+            encoding="utf-8"
+        )
+        patch = (
+            ROOT
+            / "patches/rexglue/0078-d3d12-retained-pass-output-publication.patch"
+        ).read_text(encoding="utf-8")
+        census = (
+            ROOT / "tools/capture-native-renderer-census.ps1"
+        ).read_text(encoding="utf-8")
+        renderdoc = (
+            ROOT / "tools/capture-native-renderer-renderdoc.ps1"
+        ).read_text(encoding="utf-8")
+        summarizer = (
+            ROOT / "tools/summarize-native-renderer-pass-publication.py"
+        ).read_text(encoding="utf-8")
+
+        self.assertIn(
+            "PINYON_SHIFT_NATIVE_RENDERER_PUBLISH_RETAINED_PASS", hooks
+        )
+        self.assertIn("publication_config", hooks)
+        self.assertIn("publication_summary", hooks)
+        self.assertIn("guest_target_content", hooks)
+        self.assertIn("publish_to_guest_requested", patch)
+        self.assertIn("PublishIsolatedReplayTarget", patch)
+        self.assertIn("kTargetMismatch", patch)
+        self.assertIn("isolated_replay_recorded", patch)
+        self.assertIn("D3DCopyResource(guest_depth->resource()", patch)
+        self.assertIn("D3DCopyResource(guest_color->resource()", patch)
+        self.assertIn(
+            "PinyonShift NR-04D native retained-pass publication", patch
+        )
+        self.assertIn("[switch]$PublishRetainedPass", census)
+        self.assertIn("[switch]$PublishRetainedPass", renderdoc)
+        self.assertIn("native-renderer-pass-publication.v1", summarizer)
+        self.assertIn("native_retained_pass", summarizer)
+        self.assertIn('"suppression_allowed": False', summarizer)
+        self.assertIn('"later_gpu_consumers_gate": "qualification_required"', summarizer)
+        self.assertIn('"xenos_draw", "preserved"', hooks)
+        self.assertIn('"draw_suppression", "false"', hooks)
+        self.assertIn('"resolve_suppression", "false"', hooks)
+        for source in (hooks, patch):
+            self.assertNotIn("SetDrawSuppression", source)
+            self.assertNotIn("SetCopySuppression", source)
+
     def test_shader_capture_is_local_bounded_and_passive(self):
         patch = (
             ROOT

--- a/tools/tests/test_native_renderer_pass_publication.py
+++ b/tools/tests/test_native_renderer_pass_publication.py
@@ -1,0 +1,145 @@
+import importlib.util
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / "tools/summarize-native-renderer-pass-publication.py"
+SPEC = importlib.util.spec_from_file_location("pass_publication", SCRIPT)
+MODULE = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader
+SPEC.loader.exec_module(MODULE)
+
+ANCHOR = "747837906D0BF484"
+FOLLOWER = "1D253A52B55C9FB3"
+SAFETY = {
+    "xenos_draw": "preserved",
+    "draw_suppression": "false",
+    "resolve_suppression": "false",
+    "side_effects": "preserved",
+    "suppression_eligible": "false",
+}
+
+
+def event(name, **fields):
+    return {"event": name, **SAFETY, **fields}
+
+
+def records(status="published"):
+    published = status == "published"
+    return [
+        event(
+            MODULE.CONFIG_EVENT,
+            status="armed",
+            anchor_signature=ANCHOR,
+            follower_signature=FOLLOWER,
+            activation="startup_only",
+            default_enabled="false",
+            guest_target_content="xenos_until_successful_publication",
+            fallback="preserve_xenos_targets",
+            detail_limit="64",
+        ),
+        event(
+            MODULE.PUBLICATION_EVENT,
+            status=status,
+            anchor_signature=ANCHOR,
+            follower_signature=FOLLOWER,
+            frame="100",
+            follower_draw="20",
+            target_width="2560",
+            target_height="1024",
+            sample_count="4",
+            color="published" if published else "preserved_xenos",
+            depth_stencil="published" if published else "preserved_xenos",
+            guest_target_content=(
+                "native_retained_pass" if published else "xenos"
+            ),
+        ),
+        event(
+            MODULE.SUMMARY_EVENT,
+            status="complete" if published else "fallback_observed",
+            attempts="1",
+            published="1" if published else "0",
+            failures="0" if published else "1",
+            detail_events="1",
+            detail_overflow="0",
+            guest_target_content="per_attempt",
+        ),
+    ]
+
+
+class PassPublicationTests(unittest.TestCase):
+    def write(self, directory, values):
+        path = Path(directory) / "capture.jsonl"
+        path.write_text(
+            "".join(json.dumps(value) + "\n" for value in values),
+            encoding="utf-8",
+        )
+        return path
+
+    def test_accepts_complete_paired_publication(self):
+        with tempfile.TemporaryDirectory() as temp:
+            report = MODULE.summarize([self.write(temp, records())])
+        self.assertEqual("pass", report["publication"]["status"])
+        self.assertEqual(1, report["publication"]["published"])
+        self.assertTrue(
+            report["publication"]["samples"][0]["complete_attachment_pair"]
+        )
+        self.assertFalse(report["safety"]["suppression_allowed"])
+
+    def test_reports_fallback_as_incomplete(self):
+        values = records("target_mismatch")
+        values[1]["target_width"] = "0"
+        values[1]["target_height"] = "0"
+        values[1]["sample_count"] = "0"
+        with tempfile.TemporaryDirectory() as temp:
+            report = MODULE.summarize([self.write(temp, values)])
+        self.assertEqual("incomplete", report["publication"]["status"])
+        self.assertEqual(1, report["publication"]["failures"])
+        self.assertTrue(report["safety"]["xenos_draws_preserved"])
+
+    def test_rejects_summary_count_mismatch(self):
+        values = records()
+        values[-1]["attempts"] = "2"
+        with tempfile.TemporaryDirectory() as temp:
+            with self.assertRaisesRegex(ValueError, "attempt count mismatch"):
+                MODULE.summarize([self.write(temp, values)])
+
+    def test_accepts_bounded_detail_overflow(self):
+        values = records()
+        values[-1]["attempts"] = "3"
+        values[-1]["published"] = "3"
+        values[-1]["detail_events"] = "1"
+        values[-1]["detail_overflow"] = "2"
+        values[0]["detail_limit"] = "1"
+        with tempfile.TemporaryDirectory() as temp:
+            report = MODULE.summarize([self.write(temp, values)])
+        self.assertEqual("pass", report["publication"]["status"])
+        self.assertEqual(2, report["publication"]["detail_overflow"])
+
+    def test_rejects_signature_drift(self):
+        values = records()
+        values[1]["follower_signature"] = "AAAAAAAAAAAAAAAA"
+        with tempfile.TemporaryDirectory() as temp:
+            with self.assertRaisesRegex(ValueError, "signature drift"):
+                MODULE.summarize([self.write(temp, values)])
+
+    def test_rejects_any_suppression_claim(self):
+        values = records()
+        values[1]["draw_suppression"] = "true"
+        with tempfile.TemporaryDirectory() as temp:
+            with self.assertRaisesRegex(ValueError, "unsafe draw_suppression"):
+                MODULE.summarize([self.write(temp, values)])
+
+    def test_rejects_native_authority_on_fallback(self):
+        values = records("target_mismatch")
+        values[1]["guest_target_content"] = "native_retained_pass"
+        with tempfile.TemporaryDirectory() as temp:
+            with self.assertRaisesRegex(ValueError, "guest target authority"):
+                MODULE.summarize([self.write(temp, values)])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/tests/test_release_contract.py
+++ b/tools/tests/test_release_contract.py
@@ -43,10 +43,10 @@ class ReleaseContractTests(unittest.TestCase):
 
     def test_rexglue_patches_have_stable_order_and_no_binary_payload(self):
         patches = sorted((ROOT / "patches/rexglue").glob("*.patch"))
-        self.assertEqual(len(patches), 77)
+        self.assertEqual(len(patches), 78)
         self.assertEqual(
             patches[-1].name,
-            "0077-d3d12-consumer-family-depth-corpus.patch",
+            "0078-d3d12-retained-pass-output-publication.patch",
         )
         self.assertEqual(len(patches), len({path.name[:4] for path in patches}))
         for path in patches:


### PR DESCRIPTION
## Summary
- publish the retained native color and depth/stencil pair back into the exact guest render targets after the original follower draw
- preserve all Xenos draws, resolves, queries, fences, memexport behavior, and downstream consumers with fail-closed fallback
- add bounded publication diagnostics, launch switches, a strict qualifier, contract coverage, and qualification documentation

## Validation
- python -m unittest discover -s tools/tests -p 'test_*.py' (223 passed)
- fresh ReXGlue preparation applied all 78 patches
- clean local preview build completed after one syntax correction and incremental resume
- AppData open_world_day session 20260829T082307Z-p39652 exited normally
- 12,018 / 12,018 native pass publications completed; 0 failures
- four downstream-consumer attachment samples completed; original Xenos work remained enabled
- 59.971 Hz presentation, 30.491 median simulation FPS, 0 presentation deadline misses
- 0 error/fatal/device-loss/device-removed log matches

Suppression remains disabled and the later_gpu_consumers gate remains qualification-required.