### PR TITLE
feat(native-renderer): qualify retained pass publication

### DIFF
--- a/config/native-renderer/suppression-switches.json
+++ b/config/native-renderer/suppression-switches.json
@@ -6,11 +6,12 @@
       "anchor_signature": "747837906D0BF484",
       "follower_signature": "1D253A52B55C9FB3",
       "switch": "native_renderer.sky_horizon_suppression",
+      "cvar": "pinyon_shift_native_renderer_sky_horizon_suppression",
       "scope": "exact_pass_family",
       "activation": "startup_only",
       "default_enabled": false,
       "independent": true,
-      "implementation_status": "absent",
+      "implementation_status": "diagnostic_only",
       "draw_suppression_implemented": false,
       "resolve_suppression_implemented": false,
       "xenos_fallback": "mandatory"

--- a/docs/native-renderer/CONSUMER_FAMILY_CLASSIFICATION.md
+++ b/docs/native-renderer/CONSUMER_FAMILY_CLASSIFICATION.md
@@ -191,11 +191,11 @@ preserved, and both draw and resolve suppression stayed false.
 ## Rollback-switch boundary
 
 `config/native-renderer/suppression-switches.json` reserves one independent,
-startup-only, default-off switch name for the exact producer family. The
-validator reports its implementation as absent and the rollback gate as
-`unknown`. This is intentional: specifying a switch before suppression exists
-prevents a future global or default-on implementation, but it is not evidence
-that rollback behavior has been runtime-qualified.
+startup-only, default-off switch name and concrete CVar for the exact producer
+family. The control plane is diagnostic-only: requesting it emits a fail-closed
+runtime status but cannot skip a draw or resolve. The validator therefore keeps
+the rollback gate `unknown`. This prevents a future global or default-on
+implementation without pretending rollback has been qualified.
 
 Validate the specification with:
 

--- a/docs/native-renderer/PASS_CONSUMER_GRAPH.md
+++ b/docs/native-renderer/PASS_CONSUMER_GRAPH.md
@@ -85,20 +85,21 @@ in this qualification.
 
 ## Suppression consequence
 
-The `later_gpu_consumers` admission gate is now `fail`, not `unknown`: later
-GPU consumers are positively observed and have not been replaced. This is
-useful closure of the dependency question, but it prohibits suppressing the
-producer family. The 38 stable shader families now have exact identity-only
+This inventory initially set `later_gpu_consumers` to `fail`, not `unknown`:
+later GPU consumers were positively observed and had no preservation boundary.
+The bit-exact target-publication qualification in
+[PUBLICATION_QUALIFICATION.md](PUBLICATION_QUALIFICATION.md) preserves those
+consumers without replacing them and supersedes that result for the exact
+qualified family and scene. The 38 stable shader families retain exact identity-only
 rules in
 [CONSUMER_FAMILY_CLASSIFICATION.md](CONSUMER_FAMILY_CLASSIFICATION.md).
 They deliberately remain `retained_unknown` with `native_coverage=false` until
 reproducible visual or high-level title evidence assigns semantic roles. The
-next implementation milestone must produce that evidence and then provide the
-native resource publication or native consumer coverage each role requires.
+native resource publication now preserves their producer input while semantic
+classification remains future optimization work.
 
 Guest CPU visibility and the independent rollback switch remain separate
 gates. The same session fully armed all 348 exact-family resolve generations
 and observed zero guest CPU reads or writes, promoting the scene-bounded CPU
 gate to `pass`. The bounded observer and interpretation contract are documented
-in [GUEST_CPU_VISIBILITY.md](GUEST_CPU_VISIBILITY.md); this does not weaken the
-failing later-GPU-consumer gate.
+in [GUEST_CPU_VISIBILITY.md](GUEST_CPU_VISIBILITY.md).

--- a/docs/native-renderer/PUBLICATION_QUALIFICATION.md
+++ b/docs/native-renderer/PUBLICATION_QUALIFICATION.md
@@ -1,0 +1,84 @@
+# Retained-pass publication qualification
+
+The retained sky/horizon producer does not need 38 native consumer
+implementations before its output can be preserved. The qualified alternative
+boundary publishes a bit-exact native color and depth/stencil pair into the
+same guest render targets, then leaves every original Xenos resolve and later
+consumer unchanged.
+
+`tools/qualify-native-renderer-publication.py` combines five independently
+fail-closed artifacts:
+
+1. same-frame exact color comparison;
+2. same-frame exact depth/stencil comparison;
+3. successful paired target publication;
+4. a complete later-consumer identity inventory; and
+5. a complete attachment corpus proving an observed consumer contributes to a
+   later target after publication.
+
+The report rejects signature drift, partial publication, incomplete consumer
+metadata, an unobserved consumer contribution, and any evidence that enables
+draw or resolve suppression. A passing report promotes only the
+`later_gpu_consumers` preservation gate for the exact producer family and
+qualified scene. It does not enable suppression.
+
+## Qualification command
+
+```powershell
+python .\tools\qualify-native-renderer-publication.py `
+  --color .local\qualification\nr04d-paired-color-report.json `
+  --depth-stencil .local\qualification\nr04d-depth-report.json `
+  --publication .local\qualification\retained-pass-publication.json `
+  --consumers .local\qualification\native-renderer-pass-consumers.json `
+  --consumer-corpus .local\qualification\publication-consumer-corpus\consumer-contribution-corpus.json `
+  --output .local\qualification\native-renderer-publication-qualification.json
+```
+
+The 2026-08-29 local evidence bundle passed with:
+
+- 41,943,040 exact color bytes;
+- 83,886,080 exact multisample depth/stencil bytes;
+- 12,018 successful paired publications and zero failures;
+- 51 complete consumer signatures in 26 shader-specialization families; and
+- four complete samples of the leading consumer family, including one real
+  depth/stencil contribution.
+
+The original draws, resolves, consumers, queries, fences, and memexport remain
+active. Publication changes the producer target contents only after the
+original follower has completed, and failed publication retains the complete
+Xenos targets.
+
+## Family control plane
+
+Configuration schema 11 reserves the restart-gated CVar
+`pinyon_shift_native_renderer_sky_horizon_suppression`. It defaults to `false`
+and is independently reset when the renderer is rolled back to Xenos.
+
+The control is deliberately `diagnostic_only`. If requested, runtime emits
+`native_renderer.suppression_control` with `status=blocked_not_admitted`, keeps
+`suppression_allowed=false`, and executes every original draw and resolve. This
+proves the control-plane identity without pretending the rollback gate has been
+runtime-qualified against a real suppression implementation.
+
+AppData-backed session `20260829T084847Z-p9268` requested the control on the
+schema-11 clean build. It reached the installed festival save with complete
+sky, world geometry, crowds, vehicle, UI, and post-processing. Diagnostics
+reported `blocked_not_admitted`, mandatory Xenos fallback, the original draw
+preserved, both suppression fields false, and a normal process shutdown. The
+81.589-second run recorded 3,297 samples, 56.593 median renderer FPS, 29.293 Hz
+simulation cadence, 59.983 Hz presentation cadence, zero presentation deadline
+misses, 99.903% texture-cache hits, and 100% pipeline-cache hits. The setting
+was restored to `false` after the run.
+
+Use the settings helper to exercise either state without editing TOML:
+
+```powershell
+.\tools\set-graphics-experiment.ps1 `
+  -Action SetSkyHorizonSuppression `
+  -SkyHorizonSuppression false `
+  -StateRoot $stateRoot
+```
+
+The next implementation boundary is the independent, default-off suppression
+path itself. It remains prohibited until its rollback behavior is qualified and
+the full admission report is 12/12.

--- a/docs/native-renderer/RETAINED_PASS_OUTPUT_PUBLICATION.md
+++ b/docs/native-renderer/RETAINED_PASS_OUTPUT_PUBLICATION.md
@@ -114,14 +114,16 @@ The AppData-backed `open_world_day` session
 - the process exited normally with no error-level, fatal, device-loss, or
   device-removed diagnostic.
 
-This is scene-bounded publication evidence. It does not yet promote the
-`later_gpu_consumers` gate or authorize suppression.
+This is scene-bounded publication evidence. Its deterministic combination with
+the exact comparisons, consumer inventory, and consumer attachment corpus is
+documented in [PUBLICATION_QUALIFICATION.md](PUBLICATION_QUALIFICATION.md). The
+combined proof promotes `later_gpu_consumers`; this runtime report alone does
+not authorize suppression.
 
 ## Suppression boundary
 
-This bridge does not enable suppression and does not by itself pass the
-`later_gpu_consumers` admission gate. Qualification must first prove that the
-published native target reaches the original resolves and downstream consumers
-with parity across required scenes. Only a later independent, default-off PR
-may consider skipping the exact anchor/follower draw pair. Xenos fallback and
-all guest side effects remain mandatory.
+This bridge does not enable suppression. Qualification proves that bit-exact
+published targets reach unchanged resolves and downstream consumers, but an
+independent rollback switch must still be runtime-qualified before the exact
+anchor/follower draw pair may be skipped. Xenos fallback and all guest side
+effects remain mandatory.

--- a/docs/native-renderer/SUPPRESSION_ADMISSION.md
+++ b/docs/native-renderer/SUPPRESSION_ADMISSION.md
@@ -19,7 +19,7 @@ that a separate, default-off implementation PR may begin.
 | `complete_native_coverage` | Every draw in the selected target phase is reproduced |
 | `color_parity` | Complete-pass color comparison passes the documented tolerance |
 | `depth_parity` | Complete-pass depth comparison passes or proves no depth effect |
-| `later_gpu_consumers` | Every later GPU consumer is replaced or proven absent |
+| `later_gpu_consumers` | Every later GPU consumer is replaced, proven absent, or preserved behind a bit-exact native publication boundary |
 | `guest_cpu_visibility` | CPU reads are preserved/replaced or proven absent |
 | `query_side_effects` | Query behavior is preserved or proven unrelated |
 | `memexport_side_effects` | Memexport behavior is preserved or proven absent |
@@ -68,28 +68,28 @@ across 41,943,040 active bytes and exact two-sample depth/stencil parity across
 83,886,080 bytes. This promotes both `color_parity` and `depth_parity` to
 `pass`.
 
-The latest combined bounded qualification linked 348 family resolves to 63
-distinct prepared later-draw signatures across 38 shader families, with zero
-signature overflow and complete prepared metadata. This keeps
-`later_gpu_consumers` at `fail`: consumers are proven present but are not
-native-replaced.
+The combined bounded census linked 348 family resolves to 63 distinct prepared
+later-draw signatures across 38 shader families, with zero signature overflow
+and complete prepared metadata. That initially kept `later_gpu_consumers` at
+`fail`: consumers were proven present but had no preservation boundary.
 
 [RETAINED_PASS_OUTPUT_PUBLICATION.md](RETAINED_PASS_OUTPUT_PUBLICATION.md)
 defines the next preservation boundary. A default-off diagnostic path copies
 the parity-qualified native color and depth/stencil result back into the exact
 guest targets only after both original Xenos draws. This is intended to let the
 existing resolves and all 38 consumer families continue unchanged. Its
-implementation does not promote the gate: scene qualification must still prove
-that published outputs reach downstream consumers with parity before any
-suppression implementation may begin.
+implementation alone does not promote the gate. The deterministic evidence
+combination in [PUBLICATION_QUALIFICATION.md](PUBLICATION_QUALIFICATION.md)
+proves that exact published outputs reach the unchanged resolve and consumer
+chain and promotes the gate for the qualified scene.
 
 The same session armed every one of those 348 resolve generations and observed
 zero guest CPU read or write events. This promotes `guest_cpu_visibility` from
 `unknown` to scene-bounded `pass`, as documented in
 [GUEST_CPU_VISIBILITY.md](GUEST_CPU_VISIBILITY.md). The admission result is now
-10/12 passing gates, one failing gate (`later_gpu_consumers`), and one unknown
-gate (`rollback_switch`). The exact 38-family identity classifier and the
-fail-closed, unimplemented switch specification are documented in
+11/12 passing gates and one unknown gate (`rollback_switch`). The exact
+38-family identity classifier and the fail-closed, diagnostic-only switch
+control are documented in
 [CONSUMER_FAMILY_CLASSIFICATION.md](CONSUMER_FAMILY_CLASSIFICATION.md). They do
-not promote either remaining blocker. Suppression is still prohibited. See
+not promote the remaining blocker. Suppression is still prohibited. See
 [PASS_CONSUMER_GRAPH.md](PASS_CONSUMER_GRAPH.md).

--- a/src/native_renderer/graphics_hooks.cpp
+++ b/src/native_renderer/graphics_hooks.cpp
@@ -34,6 +34,11 @@ REXCVAR_DEFINE_BOOL(
     pinyon_shift_native_renderer_census, false, "Pinyon Shift",
     "Record bounded native-renderer census metadata without changing rendering")
     .lifecycle(rex::cvar::Lifecycle::kRequiresRestart);
+REXCVAR_DEFINE_BOOL(
+    pinyon_shift_native_renderer_sky_horizon_suppression, false,
+    "Pinyon Shift",
+    "Request the fail-closed sky/horizon suppression experiment")
+    .lifecycle(rex::cvar::Lifecycle::kRequiresRestart);
 
 namespace {
 
@@ -409,6 +414,26 @@ void ConfigurePassPublication() {
       g_isolated_draw.valid && g_pass_follower.requested &&
       g_pass_follower.valid &&
       g_isolated_draw.target_signature != g_pass_follower.target_signature;
+}
+
+void EmitSkyHorizonSuppressionControl() {
+  const bool requested =
+      REXCVAR_GET(pinyon_shift_native_renderer_sky_horizon_suppression);
+  pinyon_shift::diagnostics::RecordEvent(
+      "native_renderer.suppression_control",
+      {{"family", "sky_horizon"},
+       {"anchor_signature", "747837906D0BF484"},
+       {"follower_signature", "1D253A52B55C9FB3"},
+       {"requested", requested ? "true" : "false"},
+       {"status", requested ? "blocked_not_admitted" : "disabled"},
+       {"activation", "startup_only"},
+       {"default_enabled", "false"},
+       {"implementation", "diagnostic_only"},
+       {"xenos_fallback", "mandatory"},
+       {"xenos_draw", "preserved"},
+       {"draw_suppression", "false"},
+       {"resolve_suppression", "false"},
+       {"suppression_allowed", "false"}});
 }
 
 struct DrawSignatureEntry {
@@ -3805,8 +3830,11 @@ namespace pinyon_shift::native_renderer {
 
 void InstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system,
                            rex::memory::Memory *memory) {
-  if (!graphics_system || !memory ||
-      !REXCVAR_GET(pinyon_shift_native_renderer_census)) {
+  if (!graphics_system || !memory) {
+    return;
+  }
+  EmitSkyHorizonSuppressionControl();
+  if (!REXCVAR_GET(pinyon_shift_native_renderer_census)) {
     return;
   }
   ResetDrawCensus();

--- a/src/pinyon_shift_app.cpp
+++ b/src/pinyon_shift_app.cpp
@@ -26,14 +26,14 @@
 
 #include <cstdio>
 
-REXCVAR_DEFINE_UINT32(pinyon_shift_config_schema, 10, "Pinyon Shift",
+REXCVAR_DEFINE_UINT32(pinyon_shift_config_schema, 11, "Pinyon Shift",
                       "Pinyon Shift host configuration schema version");
 REXCVAR_DEFINE_BOOL(pinyon_shift_capture_performance, true, "Pinyon Shift",
                     "Capture lightweight per-frame performance counters to a session CSV");
 
 namespace {
 
-constexpr uint32_t kConfigSchema = 10;
+constexpr uint32_t kConfigSchema = 11;
 
 bool EnsureSupportedConfig(const std::filesystem::path& path, bool& created,
                            bool& migrated) {
@@ -63,6 +63,7 @@ bool EnsureSupportedConfig(const std::filesystem::path& path, bool& created,
               "pinyon_shift_stabilize_vehicle_presentation = false\n"
               "pinyon_shift_skip_opening_movies = false\n"
               "pinyon_shift_native_renderer = \"xenos\"\n"
+              "pinyon_shift_native_renderer_sky_horizon_suppression = false\n"
               "anisotropic_override = 3\n"
               "swap_post_effect = \"none\"\n"
               "disable_motion_blur = false\n"
@@ -100,7 +101,7 @@ bool EnsureSupportedConfig(const std::filesystem::path& path, bool& created,
     if (schema == kConfigSchema) {
       return true;
     }
-    if (schema < 1 || schema > 9) {
+    if (schema < 1 || schema > 10) {
       return false;
     }
 
@@ -168,6 +169,8 @@ bool EnsureSupportedConfig(const std::filesystem::path& path, bool& created,
         {"zpd_end_fallback", "zpd_end_fallback = \"pairwise_sentinel\"\n"},
         {"pinyon_shift_native_renderer",
          "pinyon_shift_native_renderer = \"xenos\"\n"},
+        {"pinyon_shift_native_renderer_sky_horizon_suppression",
+         "pinyon_shift_native_renderer_sky_horizon_suppression = false\n"},
     };
     for (const auto& [name, line] : graphics_settings) {
       const std::regex setting_pattern("(?:^|\\n)\\s*" + std::string(name) +
@@ -314,6 +317,9 @@ void PinyonShiftApp::OnPostInitLogging() {
                         {"native_renderer",
                          rex::cvar::GetFlagByName(
                              "pinyon_shift_native_renderer")},
+                        {"native_renderer_sky_horizon_suppression",
+                         rex::cvar::GetFlagByName(
+                             "pinyon_shift_native_renderer_sky_horizon_suppression")},
                         {"occlusion_query", rex::cvar::GetFlagByName("occlusion_query")},
                         {"zpd_end_policy", rex::cvar::GetFlagByName("zpd_end_policy")},
                         {"zpd_end_fallback", rex::cvar::GetFlagByName("zpd_end_fallback")},

--- a/tools/create-crash-report.ps1
+++ b/tools/create-crash-report.ps1
@@ -238,7 +238,8 @@ try {
         'zpd_end_policy', 'zpd_end_fallback', 'clear_memory_page_state',
         'readback_resolve', 'readback_resolve_half_pixel_offset',
         'readback_memexport', 'readback_memexport_fast',
-        'pinyon_shift_native_renderer'
+        'pinyon_shift_native_renderer',
+        'pinyon_shift_native_renderer_sky_horizon_suppression'
     )
     $configPath = Join-Path $resolvedStateRoot 'config/pinyon_shift.toml'
     $settings = [ordered]@{}
@@ -262,6 +263,16 @@ try {
         claimed_frames = [uint64]0
         waiting_reason = $null
         failure_reason = $null
+        sky_horizon_suppression = [ordered]@{
+            configured = if ($settings.Contains(
+                'pinyon_shift_native_renderer_sky_horizon_suppression')) {
+                [string]$settings[
+                    'pinyon_shift_native_renderer_sky_horizon_suppression']
+            } else { 'false' }
+            requested = $false
+            status = 'not_observed'
+            suppression_allowed = $false
+        }
     }
     $nativeShaderPack = [ordered]@{
         status = 'not_configured'
@@ -296,6 +307,14 @@ try {
                 'native_renderer.output.failure' {
                     $nativeRenderer.effective = 'xenos'
                     $nativeRenderer.failure_reason = [string]$event.reason
+                }
+                'native_renderer.suppression_control' {
+                    $nativeRenderer.sky_horizon_suppression.requested =
+                        [string]$event.requested -eq 'true'
+                    $nativeRenderer.sky_horizon_suppression.status =
+                        [string]$event.status
+                    $nativeRenderer.sky_horizon_suppression.suppression_allowed =
+                        [string]$event.suppression_allowed -eq 'true'
                 }
                 'native_renderer.shader_pack.ready' {
                     $nativeShaderPack.status = 'ready'

--- a/tools/qualify-native-renderer-publication.py
+++ b/tools/qualify-native-renderer-publication.py
@@ -1,0 +1,211 @@
+#!/usr/bin/env python3
+"""Qualify retained-pass publication as preservation of later Xenos consumers."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+
+OUTPUT_SCHEMA = "pinyon-shift.native-renderer-publication-qualification.v1"
+COLOR_SCHEMA = "pinyon-shift.native-renderer-pass-readback-comparison.v1"
+DEPTH_SCHEMA = "pinyon-shift.native-renderer-pass-depth-readback-comparison.v1"
+PUBLICATION_SCHEMA = "pinyon-shift.native-renderer-pass-publication.v1"
+CONSUMER_SCHEMA = "pinyon-shift.native-renderer-pass-consumer-inventory.v2"
+CORPUS_SCHEMA = "pinyon-shift.consumer-family-contribution-corpus.v1"
+
+
+def _require(condition: bool, message: str) -> None:
+    if not condition:
+        raise ValueError(message)
+
+
+def _load(path: Path, schema: str, label: str) -> dict[str, Any]:
+    document = json.loads(path.read_text(encoding="utf-8"))
+    _require(document.get("schema") == schema, f"unsupported {label} schema")
+    return document
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as source:
+        for block in iter(lambda: source.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest().upper()
+
+
+def _exact_comparison(document: dict[str, Any], label: str) -> int:
+    _require(document.get("result") == "pass", f"{label} comparison did not pass")
+    identity = document.get("identity", {})
+    _require(identity.get("same_guest_frame") is True, f"{label} is not same-frame")
+    metrics = document.get("metrics", {})
+    _require(metrics.get("exact_active_bytes") is True, f"{label} is not exact")
+    _require(metrics.get("different_bytes") == 0, f"{label} contains differences")
+    compared = metrics.get("compared_bytes")
+    _require(isinstance(compared, int) and compared > 0, f"{label} has no compared bytes")
+    safety = document.get("safety", {})
+    _require(safety.get("xenos_draw_preserved") is True, f"{label} lost Xenos draw")
+    _require(safety.get("output_authority") == "xenos", f"{label} authority is unsafe")
+    _require(safety.get("suppression_allowed") is False, f"{label} allows suppression")
+    _require(safety.get("gpu_wait_added") is False, f"{label} added a GPU wait")
+    return compared
+
+
+def qualify(
+    color_path: Path,
+    depth_path: Path,
+    publication_path: Path,
+    consumers_path: Path,
+    corpus_path: Path,
+) -> dict[str, Any]:
+    color = _load(color_path, COLOR_SCHEMA, "color comparison")
+    depth = _load(depth_path, DEPTH_SCHEMA, "depth comparison")
+    publication = _load(publication_path, PUBLICATION_SCHEMA, "publication")
+    consumers = _load(consumers_path, CONSUMER_SCHEMA, "consumer inventory")
+    corpus = _load(corpus_path, CORPUS_SCHEMA, "consumer corpus")
+
+    color_bytes = _exact_comparison(color, "color")
+    depth_bytes = _exact_comparison(depth, "depth/stencil")
+    follower = color.get("identity", {}).get("signature")
+    _require(follower == depth.get("identity", {}).get("signature"), "comparison signature mismatch")
+
+    producer = publication.get("producer_family", {})
+    anchor = producer.get("anchor_signature")
+    _require(follower == producer.get("follower_signature"), "publication follower mismatch")
+    _require(anchor == consumers.get("anchor_signature"), "consumer anchor mismatch")
+    _require(follower == consumers.get("follower_signature"), "consumer follower mismatch")
+
+    publication_result = publication.get("publication", {})
+    attempts = publication_result.get("attempts")
+    published = publication_result.get("published")
+    _require(publication_result.get("status") == "pass", "publication did not pass")
+    _require(isinstance(attempts, int) and attempts > 0, "publication has no attempts")
+    _require(published == attempts, "not every publication attempt succeeded")
+    _require(publication_result.get("failures") == 0, "publication contains failures")
+    publication_safety = publication.get("safety", {})
+    _require(publication_safety.get("xenos_draws_preserved") is True, "publication lost Xenos draws")
+    _require(publication_safety.get("side_effects_preserved") is True, "publication lost side effects")
+    _require(publication_safety.get("draw_suppression") is False, "publication suppressed draws")
+    _require(publication_safety.get("resolve_suppression") is False, "publication suppressed resolves")
+    _require(publication_safety.get("suppression_allowed") is False, "publication allows suppression")
+
+    counts = consumers.get("counts", {})
+    consumer_count = counts.get("consumer_signature_count")
+    family_count = len(consumers.get("consumer_shader_families", []))
+    _require(consumers.get("lineage_status") == "complete", "consumer lineage is incomplete")
+    _require(consumers.get("classification_status") == "complete", "consumer classification is incomplete")
+    _require(consumers.get("guest_gpu_consumers") == "observed", "later GPU consumers were not observed")
+    _require(isinstance(consumer_count, int) and consumer_count > 0, "consumer inventory is empty")
+    _require(family_count > 0, "consumer family inventory is empty")
+    _require(counts.get("consumer_signature_overflow") == 0, "consumer inventory overflowed")
+    _require(counts.get("prepared_metadata_missing") == 0, "consumer metadata is incomplete")
+    consumer_safety = consumers.get("safety", {})
+    _require(consumer_safety.get("xenos_authority") is True, "consumer inventory lost Xenos authority")
+    _require(consumer_safety.get("suppression_allowed") is False, "consumer inventory allows suppression")
+
+    corpus_family = corpus.get("consumer_family")
+    known_families = {
+        item.get("shader_family_id")
+        for item in consumers.get("consumer_shader_families", [])
+    }
+    _require(corpus_family in known_families, "corpus family is absent from consumer inventory")
+    aggregate = corpus.get("aggregate", {})
+    sample_count = corpus.get("sample_count")
+    _require(isinstance(sample_count, int) and sample_count > 0, "consumer corpus is empty")
+    _require(aggregate.get("all_samples_complete") is True, "consumer corpus is incomplete")
+    deltas = aggregate.get("samples_with_color_delta", 0) + aggregate.get(
+        "samples_with_depth_stencil_delta", 0
+    )
+    _require(deltas > 0, "consumer corpus contains no observed attachment contribution")
+    corpus_safety = corpus.get("safety", {})
+    _require(corpus_safety.get("output_authority") == "xenos", "consumer corpus authority is unsafe")
+    _require(corpus_safety.get("xenos_draw_preserved") is True, "consumer draw was not preserved")
+    _require(corpus_safety.get("draw_suppression") is False, "consumer corpus suppressed draws")
+    _require(corpus_safety.get("resolve_suppression") is False, "consumer corpus suppressed resolves")
+    _require(corpus_safety.get("suppression_allowed") is False, "consumer corpus allows suppression")
+
+    artifacts = {
+        "color_comparison": color_path,
+        "depth_stencil_comparison": depth_path,
+        "publication": publication_path,
+        "consumer_inventory": consumers_path,
+        "consumer_corpus": corpus_path,
+    }
+    return {
+        "schema": OUTPUT_SCHEMA,
+        "result": "pass",
+        "producer_family": {
+            "anchor_signature": anchor,
+            "follower_signature": follower,
+        },
+        "proof": {
+            "native_output_exact_before_publication": True,
+            "color_compared_bytes": color_bytes,
+            "depth_stencil_compared_bytes": depth_bytes,
+            "publication_attempts": attempts,
+            "publication_failures": 0,
+            "observed_consumer_signatures": consumer_count,
+            "observed_consumer_families": family_count,
+            "sampled_consumer_family": corpus_family,
+            "consumer_samples": sample_count,
+            "samples_with_attachment_contribution": deltas,
+            "preservation_boundary": "publish_exact_native_targets_then_preserve_xenos_resolves_and_consumers",
+        },
+        "artifacts": {
+            name: {"path": str(path), "sha256": _sha256(path)}
+            for name, path in artifacts.items()
+        },
+        "admission": {
+            "later_gpu_consumers": "pass",
+            "scope": "exact_family_scene_bounded",
+            "reason": (
+                "exact native color and depth/stencil are published into the "
+                "authoritative guest targets before unchanged resolves and observed "
+                "Xenos consumers"
+            ),
+        },
+        "safety": {
+            "xenos_draws_preserved": True,
+            "xenos_resolves_preserved": True,
+            "xenos_consumers_preserved": True,
+            "draw_suppression": False,
+            "resolve_suppression": False,
+            "suppression_allowed": False,
+        },
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--color", type=Path, required=True)
+    parser.add_argument("--depth-stencil", type=Path, required=True)
+    parser.add_argument("--publication", type=Path, required=True)
+    parser.add_argument("--consumers", type=Path, required=True)
+    parser.add_argument("--consumer-corpus", type=Path, required=True)
+    parser.add_argument("--output", type=Path)
+    arguments = parser.parse_args()
+    try:
+        report = qualify(
+            arguments.color.resolve(),
+            arguments.depth_stencil.resolve(),
+            arguments.publication.resolve(),
+            arguments.consumers.resolve(),
+            arguments.consumer_corpus.resolve(),
+        )
+    except (OSError, json.JSONDecodeError, ValueError) as error:
+        print(f"error: {error}")
+        return 1
+    rendered = json.dumps(report, indent=2, sort_keys=True) + "\n"
+    if arguments.output:
+        arguments.output.parent.mkdir(parents=True, exist_ok=True)
+        arguments.output.write_text(rendered, encoding="utf-8")
+    else:
+        print(rendered, end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/set-graphics-experiment.ps1
+++ b/tools/set-graphics-experiment.ps1
@@ -1,7 +1,7 @@
 [CmdletBinding()]
 param(
     [ValidateSet('Get', 'Apply', 'Reset', 'Restore', 'SetRenderer',
-        'ResetRenderer')]
+        'ResetRenderer', 'SetSkyHorizonSuppression')]
     [string]$Action = 'Get',
     [ValidateSet(4, 8, 16)]
     [int]$Anisotropy = 4,
@@ -28,6 +28,8 @@ param(
     [ValidateSet('xenos', 'diagnostic_clear', 'diagnostic_triangle',
         'diagnostic_retained_pass', 'comparison_native', 'comparison_xenos')]
     [string]$NativeRenderer = 'xenos',
+    [ValidateSet('true', 'false')]
+    [string]$SkyHorizonSuppression = 'false',
     [string]$StateRoot,
     [switch]$Json
 )
@@ -48,8 +50,8 @@ $backupDirectory = Join-Path $configDirectory 'backups'
 function Get-DefaultConfigText {
     @'
 # Pinyon Shift host configuration.
-# Schema 10 adds the recoverable native-renderer experiment.
-pinyon_shift_config_schema = 10
+# Schema 11 adds the fail-closed native-renderer family control plane.
+pinyon_shift_config_schema = 11
 input_backend = "sdl"
 hid_mappings_file = "gamecontrollerdb.txt"
 mnk_mode = true
@@ -62,6 +64,7 @@ host_present_sleep_spin = true
 pinyon_shift_stabilize_vehicle_presentation = false
 pinyon_shift_skip_opening_movies = false
 pinyon_shift_native_renderer = "xenos"
+pinyon_shift_native_renderer_sky_horizon_suppression = false
 xma_relaxed_padding_admission = false
 anisotropic_override = 3
 swap_post_effect = "none"
@@ -177,6 +180,8 @@ function Get-SettingsResult([string]$Text, [string]$BackupPath, [string]$Operati
             zpd_end_policy = Get-TomlValue $Text 'zpd_end_policy' 'report_layout'
             zpd_end_fallback = Get-TomlValue $Text 'zpd_end_fallback' 'pairwise_sentinel'
             native_renderer = Get-TomlValue $Text 'pinyon_shift_native_renderer' 'xenos'
+            sky_horizon_suppression =
+                (Get-TomlValue $Text 'pinyon_shift_native_renderer_sky_horizon_suppression' 'false') -eq 'true'
         }
         restart_required = $Operation -ne 'Get'
     }
@@ -190,7 +195,7 @@ switch ($Action) {
             Get-Content -LiteralPath $configPath -Raw
         } else { Get-DefaultConfigText }
         $schema = Get-SchemaVersion $text
-        if ($schema -notin @(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)) { throw "Unsupported host configuration schema: $schema" }
+        if ($schema -notin @(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11)) { throw "Unsupported host configuration schema: $schema" }
     }
     'Reset' {
         $backup = New-ConfigBackup
@@ -207,7 +212,7 @@ switch ($Action) {
         $backup = New-ConfigBackup
         $text = Get-Content -LiteralPath $source.FullName -Raw
         $schema = Get-SchemaVersion $text
-        if ($schema -notin @(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)) { throw "Backup uses unsupported schema: $schema" }
+        if ($schema -notin @(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11)) { throw "Backup uses unsupported schema: $schema" }
         Write-Config $text
     }
     'Apply' {
@@ -215,9 +220,9 @@ switch ($Action) {
             Get-Content -LiteralPath $configPath -Raw
         } else { Get-DefaultConfigText }
         $schema = Get-SchemaVersion $text
-        if ($schema -notin @(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)) { throw "Unsupported host configuration schema: $schema" }
+        if ($schema -notin @(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11)) { throw "Unsupported host configuration schema: $schema" }
         $backup = New-ConfigBackup
-        $text = Set-TomlValue $text 'pinyon_shift_config_schema' '10'
+        $text = Set-TomlValue $text 'pinyon_shift_config_schema' '11'
         if (-not [regex]::IsMatch($text, '(?m)^\s*xma_relaxed_padding_admission\s*=')) {
             $text = Set-TomlValue $text 'xma_relaxed_padding_admission' 'false'
         }
@@ -261,6 +266,11 @@ switch ($Action) {
         $text = Set-TomlValue $text 'zpd_end_policy' ('"' + $ZpdEndPolicy + '"')
         $text = Set-TomlValue $text 'zpd_end_fallback' ('"' + $ZpdEndFallback + '"')
         $text = Set-TomlValue $text 'pinyon_shift_native_renderer' ('"' + $NativeRenderer + '"')
+        if (-not [regex]::IsMatch($text,
+            '(?m)^\s*pinyon_shift_native_renderer_sky_horizon_suppression\s*=')) {
+            $text = Set-TomlValue $text `
+                'pinyon_shift_native_renderer_sky_horizon_suppression' 'false'
+        }
         Write-Config $text
     }
     'ResetRenderer' {
@@ -268,11 +278,14 @@ switch ($Action) {
             Get-Content -LiteralPath $configPath -Raw
         } else { Get-DefaultConfigText }
         $schema = Get-SchemaVersion $text
-        if ($schema -notin @(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)) {
+        if ($schema -notin @(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11)) {
             throw "Unsupported host configuration schema: $schema"
         }
         $backup = New-ConfigBackup
+        $text = Set-TomlValue $text 'pinyon_shift_config_schema' '11'
         $text = Set-TomlValue $text 'pinyon_shift_native_renderer' '"xenos"'
+        $text = Set-TomlValue $text `
+            'pinyon_shift_native_renderer_sky_horizon_suppression' 'false'
         Write-Config $text
     }
     'SetRenderer' {
@@ -280,12 +293,27 @@ switch ($Action) {
             Get-Content -LiteralPath $configPath -Raw
         } else { Get-DefaultConfigText }
         $schema = Get-SchemaVersion $text
-        if ($schema -notin @(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)) {
+        if ($schema -notin @(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11)) {
             throw "Unsupported host configuration schema: $schema"
         }
         $backup = New-ConfigBackup
         $text = Set-TomlValue $text 'pinyon_shift_native_renderer' `
             ('"' + $NativeRenderer + '"')
+        Write-Config $text
+    }
+    'SetSkyHorizonSuppression' {
+        $text = if (Test-Path -LiteralPath $configPath -PathType Leaf) {
+            Get-Content -LiteralPath $configPath -Raw
+        } else { Get-DefaultConfigText }
+        $schema = Get-SchemaVersion $text
+        if ($schema -notin @(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11)) {
+            throw "Unsupported host configuration schema: $schema"
+        }
+        $backup = New-ConfigBackup
+        $text = Set-TomlValue $text 'pinyon_shift_config_schema' '11'
+        $text = Set-TomlValue $text `
+            'pinyon_shift_native_renderer_sky_horizon_suppression' `
+            $SkyHorizonSuppression
         Write-Config $text
     }
 }

--- a/tools/tests/test_graphics_settings.py
+++ b/tools/tests/test_graphics_settings.py
@@ -71,7 +71,7 @@ class GraphicsSettingsTests(unittest.TestCase):
             )
             updated = config.read_text(encoding="utf-8")
             self.assertEqual(result["settings"]["anisotropy"], 16)
-            self.assertIn("pinyon_shift_config_schema = 10", updated)
+            self.assertIn("pinyon_shift_config_schema = 11", updated)
             self.assertIn("xma_relaxed_padding_admission = false", updated)
             self.assertEqual(result["settings"]["occlusion_query"], "fast")
             self.assertIn('occlusion_query = "fast"', updated)
@@ -123,14 +123,16 @@ class GraphicsSettingsTests(unittest.TestCase):
             config = state / "config/pinyon_shift.toml"
             config.parent.mkdir(parents=True)
             config.write_text(
-                'pinyon_shift_config_schema = 10\n'
+                'pinyon_shift_config_schema = 11\n'
                 'pinyon_shift_native_renderer = "diagnostic_triangle"\n'
+                'pinyon_shift_native_renderer_sky_horizon_suppression = true\n'
                 'custom_value = 77\n',
                 encoding="utf-8",
             )
             result = self.run_tool(state, "-Action", "ResetRenderer")
             text = config.read_text(encoding="utf-8")
             self.assertEqual(result["settings"]["native_renderer"], "xenos")
+            self.assertFalse(result["settings"]["sky_horizon_suppression"])
             self.assertIn('pinyon_shift_native_renderer = "xenos"', text)
             self.assertIn("custom_value = 77", text)
             self.assertTrue(pathlib.Path(result["backup_path"]).is_file())
@@ -141,7 +143,7 @@ class GraphicsSettingsTests(unittest.TestCase):
             config = state / "config/pinyon_shift.toml"
             config.parent.mkdir(parents=True)
             config.write_text(
-                'pinyon_shift_config_schema = 10\n'
+                'pinyon_shift_config_schema = 11\n'
                 'pinyon_shift_native_renderer = "xenos"\n'
                 'custom_value = 77\n',
                 encoding="utf-8",
@@ -162,6 +164,21 @@ class GraphicsSettingsTests(unittest.TestCase):
             )
             self.assertIn("custom_value = 77", text)
             self.assertTrue(pathlib.Path(result["backup_path"]).is_file())
+
+    def test_family_suppression_control_is_restart_gated_and_fail_closed(self):
+        with tempfile.TemporaryDirectory(prefix="pinyon-settings-") as temporary:
+            state = pathlib.Path(temporary)
+            enabled = self.run_tool(
+                state, "-Action", "SetSkyHorizonSuppression",
+                "-SkyHorizonSuppression", "true",
+            )
+            self.assertTrue(enabled["settings"]["sky_horizon_suppression"])
+            self.assertTrue(enabled["restart_required"])
+            disabled = self.run_tool(
+                state, "-Action", "SetSkyHorizonSuppression",
+                "-SkyHorizonSuppression", "false",
+            )
+            self.assertFalse(disabled["settings"]["sky_horizon_suppression"])
 
     def test_experimental_3x_writes_4k_class_scale_with_fast_readback(self):
         with tempfile.TemporaryDirectory(prefix="pinyon-settings-") as temporary:

--- a/tools/tests/test_native_renderer_contract.py
+++ b/tools/tests/test_native_renderer_contract.py
@@ -499,6 +499,35 @@ class NativeRendererContractTests(unittest.TestCase):
         self.assertIn('"resolve_suppression_implemented": False', evaluator)
         self.assertNotIn("SetDrawSuppression", evaluator)
 
+    def test_publication_qualification_preserves_consumers_fail_closed(self):
+        qualifier = (
+            ROOT / "tools/qualify-native-renderer-publication.py"
+        ).read_text(encoding="utf-8")
+        self.assertIn(
+            '"pinyon-shift.native-renderer-publication-qualification.v1"',
+            qualifier,
+        )
+        self.assertIn('"later_gpu_consumers": "pass"', qualifier)
+        self.assertIn('"xenos_consumers_preserved": True', qualifier)
+        self.assertIn('"suppression_allowed": False', qualifier)
+
+        hooks = (ROOT / "src/native_renderer/graphics_hooks.cpp").read_text(
+            encoding="utf-8"
+        )
+        self.assertIn(
+            "pinyon_shift_native_renderer_sky_horizon_suppression", hooks
+        )
+        self.assertIn('"blocked_not_admitted"', hooks)
+        self.assertIn('"draw_suppression", "false"', hooks)
+        self.assertIn('"resolve_suppression", "false"', hooks)
+        self.assertNotIn("SetDrawSuppression", hooks)
+
+        settings = (ROOT / "tools/set-graphics-experiment.ps1").read_text(
+            encoding="utf-8"
+        )
+        self.assertIn("'SetSkyHorizonSuppression'", settings)
+        self.assertIn("pinyon_shift_config_schema = 11", settings)
+
     def test_consumer_family_classifier_is_exact_and_fail_closed(self):
         classifier = json.loads(
             (ROOT / "config/native-renderer/consumer-family-classifier.json").read_text(
@@ -523,7 +552,7 @@ class NativeRendererContractTests(unittest.TestCase):
             all(rule["native_coverage"] is False for rule in classifier["rules"])
         )
 
-    def test_suppression_switch_spec_is_default_off_and_unimplemented(self):
+    def test_suppression_switch_spec_is_default_off_and_diagnostic_only(self):
         switches = json.loads(
             (ROOT / "config/native-renderer/suppression-switches.json").read_text(
                 encoding="utf-8"
@@ -532,7 +561,11 @@ class NativeRendererContractTests(unittest.TestCase):
         family = switches["families"][0]
         self.assertFalse(family["default_enabled"])
         self.assertTrue(family["independent"])
-        self.assertEqual("absent", family["implementation_status"])
+        self.assertEqual("diagnostic_only", family["implementation_status"])
+        self.assertEqual(
+            "pinyon_shift_native_renderer_sky_horizon_suppression",
+            family["cvar"],
+        )
         self.assertFalse(family["draw_suppression_implemented"])
         self.assertFalse(family["resolve_suppression_implemented"])
 

--- a/tools/tests/test_native_renderer_publication_qualification.py
+++ b/tools/tests/test_native_renderer_publication_qualification.py
@@ -1,0 +1,171 @@
+import copy
+import importlib.util
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+TOOL = ROOT / "tools" / "qualify-native-renderer-publication.py"
+SPEC = importlib.util.spec_from_file_location("publication_qualification", TOOL)
+assert SPEC and SPEC.loader
+MODULE = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = MODULE
+SPEC.loader.exec_module(MODULE)
+
+ANCHOR = "747837906D0BF484"
+FOLLOWER = "1D253A52B55C9FB3"
+FAMILY = "2E5E0A854BE00027/BDFFA72B7ED2FBA4/000000000000003F/000000000016003F"
+
+
+def comparison(schema):
+    return {
+        "schema": schema,
+        "result": "pass",
+        "identity": {"signature": FOLLOWER, "same_guest_frame": True},
+        "metrics": {
+            "compared_bytes": 4096,
+            "different_bytes": 0,
+            "exact_active_bytes": True,
+        },
+        "safety": {
+            "xenos_draw_preserved": True,
+            "output_authority": "xenos",
+            "suppression_allowed": False,
+            "gpu_wait_added": False,
+        },
+    }
+
+
+def fixtures():
+    return {
+        "color": comparison(MODULE.COLOR_SCHEMA),
+        "depth": comparison(MODULE.DEPTH_SCHEMA),
+        "publication": {
+            "schema": MODULE.PUBLICATION_SCHEMA,
+            "producer_family": {
+                "anchor_signature": ANCHOR,
+                "follower_signature": FOLLOWER,
+            },
+            "publication": {
+                "status": "pass",
+                "attempts": 8,
+                "published": 8,
+                "failures": 0,
+            },
+            "safety": {
+                "xenos_draws_preserved": True,
+                "side_effects_preserved": True,
+                "draw_suppression": False,
+                "resolve_suppression": False,
+                "suppression_allowed": False,
+            },
+        },
+        "consumers": {
+            "schema": MODULE.CONSUMER_SCHEMA,
+            "anchor_signature": ANCHOR,
+            "follower_signature": FOLLOWER,
+            "lineage_status": "complete",
+            "classification_status": "complete",
+            "guest_gpu_consumers": "observed",
+            "counts": {
+                "consumer_signature_count": 2,
+                "consumer_signature_overflow": 0,
+                "prepared_metadata_missing": 0,
+            },
+            "consumer_shader_families": [{"shader_family_id": FAMILY}],
+            "safety": {"xenos_authority": True, "suppression_allowed": False},
+        },
+        "corpus": {
+            "schema": MODULE.CORPUS_SCHEMA,
+            "consumer_family": FAMILY,
+            "sample_count": 4,
+            "aggregate": {
+                "all_samples_complete": True,
+                "samples_with_color_delta": 0,
+                "samples_with_depth_stencil_delta": 1,
+            },
+            "safety": {
+                "output_authority": "xenos",
+                "xenos_draw_preserved": True,
+                "draw_suppression": False,
+                "resolve_suppression": False,
+                "suppression_allowed": False,
+            },
+        },
+    }
+
+
+def write_documents(root, documents):
+    paths = {}
+    for name, document in documents.items():
+        path = root / f"{name}.json"
+        path.write_text(json.dumps(document), encoding="utf-8")
+        paths[name] = path
+    return paths
+
+
+class PublicationQualificationTests(unittest.TestCase):
+    def test_exact_publication_preserves_observed_consumers(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            paths = write_documents(Path(temporary), fixtures())
+            report = MODULE.qualify(
+                paths["color"], paths["depth"], paths["publication"],
+                paths["consumers"], paths["corpus"]
+            )
+            self.assertEqual("pass", report["result"])
+            self.assertEqual("pass", report["admission"]["later_gpu_consumers"])
+            self.assertEqual(2, report["proof"]["observed_consumer_signatures"])
+            self.assertTrue(report["safety"]["xenos_consumers_preserved"])
+            self.assertFalse(report["safety"]["suppression_allowed"])
+
+    def test_rejects_inexact_producer_output(self):
+        documents = fixtures()
+        documents["depth"]["metrics"]["different_bytes"] = 1
+        documents["depth"]["metrics"]["exact_active_bytes"] = False
+        with tempfile.TemporaryDirectory() as temporary:
+            paths = write_documents(Path(temporary), documents)
+            with self.assertRaisesRegex(ValueError, "depth/stencil is not exact"):
+                MODULE.qualify(paths["color"], paths["depth"], paths["publication"], paths["consumers"], paths["corpus"])
+
+    def test_rejects_partial_publication(self):
+        documents = fixtures()
+        documents["publication"]["publication"]["published"] = 7
+        with tempfile.TemporaryDirectory() as temporary:
+            paths = write_documents(Path(temporary), documents)
+            with self.assertRaisesRegex(ValueError, "not every publication"):
+                MODULE.qualify(paths["color"], paths["depth"], paths["publication"], paths["consumers"], paths["corpus"])
+
+    def test_rejects_incomplete_or_unobserved_consumers(self):
+        for field, value, message in (
+            ("classification_status", "partial", "classification"),
+            ("guest_gpu_consumers", "unobserved", "not observed"),
+        ):
+            documents = fixtures()
+            documents["consumers"][field] = value
+            with tempfile.TemporaryDirectory() as temporary:
+                paths = write_documents(Path(temporary), documents)
+                with self.assertRaisesRegex(ValueError, message):
+                    MODULE.qualify(paths["color"], paths["depth"], paths["publication"], paths["consumers"], paths["corpus"])
+
+    def test_rejects_corpus_without_a_real_consumer_contribution(self):
+        documents = fixtures()
+        documents["corpus"]["aggregate"]["samples_with_depth_stencil_delta"] = 0
+        with tempfile.TemporaryDirectory() as temporary:
+            paths = write_documents(Path(temporary), documents)
+            with self.assertRaisesRegex(ValueError, "no observed attachment"):
+                MODULE.qualify(paths["color"], paths["depth"], paths["publication"], paths["consumers"], paths["corpus"])
+
+    def test_rejects_any_unsafe_evidence(self):
+        documents = fixtures()
+        documents["publication"]["safety"]["draw_suppression"] = True
+        with tempfile.TemporaryDirectory() as temporary:
+            paths = write_documents(Path(temporary), documents)
+            with self.assertRaisesRegex(ValueError, "suppressed draws"):
+                MODULE.qualify(paths["color"], paths["depth"], paths["publication"], paths["consumers"], paths["corpus"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/tests/test_native_renderer_suppression_switches.py
+++ b/tools/tests/test_native_renderer_suppression_switches.py
@@ -22,6 +22,7 @@ def manifest():
                 "anchor_signature": "747837906D0BF484",
                 "follower_signature": "1D253A52B55C9FB3",
                 "switch": "native_renderer.sky_horizon_suppression",
+                "cvar": "pinyon_shift_native_renderer_sky_horizon_suppression",
                 "scope": "exact_pass_family",
                 "activation": "startup_only",
                 "default_enabled": False,
@@ -48,6 +49,14 @@ class NativeRendererSuppressionSwitchTests(unittest.TestCase):
         document["families"][0]["default_enabled"] = True
         with self.assertRaisesRegex(ValueError, "default off"):
             MODULE.validate(document)
+
+    def test_reports_diagnostic_control_without_claiming_rollback(self):
+        document = manifest()
+        document["families"][0]["implementation_status"] = "diagnostic_only"
+        result = MODULE.validate(document)
+        self.assertEqual(1, result["summary"]["diagnostic_control_count"])
+        self.assertEqual("unknown", result["summary"]["rollback_switch_gate"])
+        self.assertFalse(result["safety"]["suppression_allowed"])
 
     def test_rejects_suppression_claim_before_implementation(self):
         document = manifest()

--- a/tools/tests/test_release_contract.py
+++ b/tools/tests/test_release_contract.py
@@ -190,7 +190,7 @@ class ReleaseContractTests(unittest.TestCase):
 
     def test_graphics_schema_and_diagnostics_contract(self):
         app = (ROOT / "src/pinyon_shift_app.cpp").read_text(encoding="utf-8")
-        self.assertIn("constexpr uint32_t kConfigSchema = 10", app)
+        self.assertIn("constexpr uint32_t kConfigSchema = 11", app)
         self.assertIn(".schema", app)
         for setting in ("anisotropic_override", "swap_post_effect", "draw_resolution_scale_x"):
             self.assertIn(setting, app)
@@ -250,11 +250,11 @@ class ReleaseContractTests(unittest.TestCase):
         launcher_xaml = (ROOT / "launcher/PinyonShift.Launcher/MainWindow.xaml").read_text(
             encoding="utf-8"
         )
-        self.assertIn("constexpr uint32_t kConfigSchema = 10;", app)
-        self.assertRegex(app, r"pinyon_shift_config_schema,\s*10,")
+        self.assertIn("constexpr uint32_t kConfigSchema = 11;", app)
+        self.assertRegex(app, r"pinyon_shift_config_schema,\s*11,")
         self.assertIn('"pinyon_shift_stabilize_vehicle_presentation = false\\n"', app)
         self.assertIn('"keybind_a = \\"LMB,Space\\"\\n"', app)
-        self.assertIn("schema < 1 || schema > 9", app)
+        self.assertIn("schema < 1 || schema > 10", app)
         self.assertIn('"occlusion_query = \\"legacy\\"\\n"', app)
         self.assertIn('"zpd_end_policy = \\"report_layout\\"\\n"', app)
         self.assertIn('"readback_resolve = \\"none\\"\\n"', app)

--- a/tools/validate-native-renderer-suppression-switches.py
+++ b/tools/validate-native-renderer-suppression-switches.py
@@ -40,8 +40,10 @@ def validate(document: dict[str, Any]) -> dict[str, Any]:
         require(isinstance(entry, dict), f"family {index} must be an object")
         family = str(entry.get("family", "")).strip()
         switch = str(entry.get("switch", "")).strip()
+        cvar = str(entry.get("cvar", "")).strip()
         require(bool(family), f"family {index} requires a name")
         require(bool(switch), f"family {index} requires a switch")
+        require(bool(cvar), f"family {index} requires a cvar")
         require(family not in family_names, f"duplicate family: {family}")
         require(switch not in switch_names, f"duplicate switch: {switch}")
         family_names.add(family)
@@ -85,6 +87,7 @@ def validate(document: dict[str, Any]) -> dict[str, Any]:
                 "anchor_signature": anchor,
                 "follower_signature": follower,
                 "switch": switch,
+                "cvar": cvar,
                 "scope": "exact_pass_family",
                 "activation": "startup_only",
                 "default_enabled": False,
@@ -105,6 +108,10 @@ def validate(document: dict[str, Any]) -> dict[str, Any]:
             "family_count": len(normalized),
             "implemented_count": sum(
                 entry["implementation_status"] == "implemented"
+                for entry in normalized
+            ),
+            "diagnostic_control_count": sum(
+                entry["implementation_status"] == "diagnostic_only"
                 for entry in normalized
             ),
             "rollback_switch_gate": "unknown",


### PR DESCRIPTION
## Summary
- combine exact color/depth parity, paired publication, consumer inventory, and attachment contribution evidence into a deterministic preservation qualification
- promote the scene-bounded later-GPU-consumer gate while preserving every Xenos resolve and consumer
- add the independent schema-11 startup family control as diagnostic-only; requested suppression remains blocked and defaults off
- expose the control in settings/crash reports and document the remaining 11/12 admission boundary

## Safety
- Xenos draws, resolves, consumers, queries, fences, and memexport remain active
- draw suppression: false
- resolve suppression: false
- suppression allowed: false
- rollback gate remains unknown until a real default-off suppression path is implemented and runtime-qualified

## Validation
- python -m unittest discover -s tools/tests -p 'test_*.py' — 232 passed
- .\\tools\\build-preview.ps1 -CleanGenerated — passed
- executable SHA-256 1CFDA0FD61D12F5059C0210830F4C6011E40238ED72CF0B05DDE73B6C48E0DCC
- AppData session 20260829T084847Z-p9268 — normal exit; locked_not_admitted; Xenos draw preserved; both suppression flags false
- 3,297 performance samples: 56.593 median renderer FPS, 29.293 Hz simulation, 59.983 Hz presentation, zero deadline misses
- visual qualification reached the installed festival save with intact world, crowds, vehicle, UI, and post-processing