### PR TITLE
feat(native-renderer): suppress qualified retained follower

### DIFF
--- a/config/native-renderer/suppression-switches.json
+++ b/config/native-renderer/suppression-switches.json
@@ -11,8 +11,12 @@
       "activation": "startup_only",
       "default_enabled": false,
       "independent": true,
-      "implementation_status": "diagnostic_only",
-      "draw_suppression_implemented": false,
+      "implementation_status": "implemented",
+      "rollback_qualified": true,
+      "draw_suppression_implemented": true,
+      "draw_suppression_scope": "follower_after_full_pair_publication",
+      "anchor_draw_preserved": true,
+      "publication_failure_behavior": "execute_original_follower",
       "resolve_suppression_implemented": false,
       "xenos_fallback": "mandatory"
     }

--- a/docs/native-renderer/EXACT_FAMILY_SUPPRESSION.md
+++ b/docs/native-renderer/EXACT_FAMILY_SUPPRESSION.md
@@ -1,0 +1,62 @@
+# Exact-family fail-closed suppression
+
+The first NR-04D implementation is deliberately narrower than whole-pass
+suppression. For the qualified sky/horizon pair
+`747837906D0BF484` / `1D253A52B55C9FB3`, it preserves the authoritative Xenos
+anchor draw and conditionally omits only the adjacent follower draw.
+
+The follower is omitted only after all of these conditions hold in the same
+draw:
+
+1. the restart-gated, default-off family CVar is explicitly enabled;
+2. both exact signatures and their adjacency match;
+3. the title eligibility gate rejects queries, memexport, resolved inputs,
+   unsupported geometry, incomplete resource layouts, and binding overflow;
+4. both isolated native draws were recorded into the retained target; and
+5. the complete native color and depth/stencil pair was published into the
+   exact guest targets.
+
+The backend decides after publication, not before it. If replay is unavailable
+or either attachment cannot be published, it executes the original follower
+draw. It never suppresses the anchor, a resolve, query, event, fence, memexport
+operation, or later consumer. This preserves a complete Xenos recovery path
+without needing to reconstruct the earlier anchor state.
+
+## Control and telemetry
+
+The launcher setting is
+`pinyon_shift_native_renderer_sky_horizon_suppression`. It defaults to `false`,
+requires a restart, and automatically selects only the qualified signature
+pair. Explicit incompatible diagnostic environment overrides fail closed with
+`status=blocked_invalid_configuration`.
+
+An armed run emits:
+
+- `native_renderer.suppression_control` with
+  `implementation=fail_closed_follower_draw`;
+- per-attempt `native_renderer.retained_pass.publication` events that identify
+  whether the follower was suppressed or the original fallback executed; and
+- `native_renderer.suppression_summary` with attempts, suppressed followers,
+  fallbacks, and the last matching frame/draw.
+
+## Rollback qualification
+
+`tools/qualify-native-renderer-rollback.py` accepts one enabled log and one
+disabled log from the same executable. It requires normal shutdown in both,
+complete publication with no fallback in the enabled route, positive follower
+suppression, and zero suppressed followers after rollback. Its deterministic
+output promotes only the `rollback_switch` gate.
+
+The 2026-08-29 paired AppData qualification used executable
+`2060C64808794C10B368350566542E2005646D9513B252391980D525732BC22A`.
+Enabled session `20260829T092338Z-p31960` published and suppressed the exact
+follower 5,442 times with zero publication failures or Xenos fallbacks, then
+shut down normally. Disabled session `20260829T092551Z-p25116` used the same
+executable, reported the control disabled, suppressed zero draws, and shut down
+normally. Both runs reached the installed festival save with complete sky,
+world geometry, crowds, vehicles, UI, and post-processing.
+
+`tools/qualify-native-renderer-rollback.py` promoted `rollback_switch=pass`, so
+the manifest now records `rollback_qualified=true` and suppression admission is
+12/12 for this exact, operator-requested family. The feature remains
+restart-gated and default-off.

--- a/docs/native-renderer/PUBLICATION_QUALIFICATION.md
+++ b/docs/native-renderer/PUBLICATION_QUALIFICATION.md
@@ -54,11 +54,12 @@ Configuration schema 11 reserves the restart-gated CVar
 `pinyon_shift_native_renderer_sky_horizon_suppression`. It defaults to `false`
 and is independently reset when the renderer is rolled back to Xenos.
 
-The control is deliberately `diagnostic_only`. If requested, runtime emits
-`native_renderer.suppression_control` with `status=blocked_not_admitted`, keeps
-`suppression_allowed=false`, and executes every original draw and resolve. This
-proves the control-plane identity without pretending the rollback gate has been
-runtime-qualified against a real suppression implementation.
+The original control-plane qualification was deliberately diagnostic-only. The
+next implementation boundary is now documented in
+[EXACT_FAMILY_SUPPRESSION.md](EXACT_FAMILY_SUPPRESSION.md): when explicitly
+requested, it may suppress only the exact follower after successful full-pair
+publication. The anchor, resolves, and all later consumers remain unchanged,
+and publication failure executes the original follower.
 
 AppData-backed session `20260829T084847Z-p9268` requested the control on the
 schema-11 clean build. It reached the installed festival save with complete
@@ -79,6 +80,13 @@ Use the settings helper to exercise either state without editing TOML:
   -StateRoot $stateRoot
 ```
 
-The next implementation boundary is the independent, default-off suppression
-path itself. It remains prohibited until its rollback behavior is qualified and
-the full admission report is 12/12.
+The same-build rollback pair has now passed. Enabled session
+`20260829T092338Z-p31960` published and suppressed 5,442 exact followers with
+zero failures or fallbacks. Disabled session `20260829T092551Z-p25116`
+suppressed zero draws. Both used executable
+`2060C64808794C10B368350566542E2005646D9513B252391980D525732BC22A`, reached
+the installed festival save with a complete frame, and shut down normally.
+Presentation remained at 59.974 Hz in the enabled run with zero deadline
+misses; simulation cadence was 29.423 Hz. The final `rollback_switch` gate is
+therefore `pass`, making admission 12/12 for this exact family while the switch
+remains restart-gated and default-off.

--- a/docs/native-renderer/SUPPRESSION_ADMISSION.md
+++ b/docs/native-renderer/SUPPRESSION_ADMISSION.md
@@ -41,20 +41,22 @@ code 1.
 
 The exact pair `747837906D0BF484` / `1D253A52B55C9FB3` has stable boundaries,
 complete-pass color/depth parity, continuous exact-frame output, fallback
-behavior, and native GPU timing. It is not admitted for suppression yet:
+behavior, and native GPU timing. It is admitted only for the fail-closed,
+operator-requested follower boundary because:
 
-- the latest exact-family graph positively observes 63 prepared
-  later-GPU-consumer signatures across 38 shader families that have not been
-  replaced;
+- the exact publication boundary preserves the observed later-GPU-consumer
+  graph behind bit-exact guest color and depth/stencil targets;
 - guest CPU visibility passes for one bounded exact-family AppData
   qualification route, with zero reads across 348 fully armed resolve
   generations; and
-- an independent default-off switch is specified but no suppression or
-  runtime-qualified rollback implementation exists.
+- an independent default-off, fail-closed follower suppression implementation
+  passed its same-build enabled/disabled rollback qualification.
 
-Consequently the next work is evidence collection and complete-pass comparison,
-not draw skipping. The Xenos copy, draw, resolve, query, fence, and memexport
-paths remain unchanged.
+Consequently the only permitted draw skipping is the experimental exact
+follower boundary in
+[EXACT_FAMILY_SUPPRESSION.md](EXACT_FAMILY_SUPPRESSION.md). The Xenos anchor,
+copy, resolve, query, fence, memexport, and later-consumer paths remain
+unchanged, and failed replay/publication executes the original follower.
 
 The complete-pass color and depth gates use the paired asynchronous readback
 described in [VISUAL_COMPARISON.md](VISUAL_COMPARISON.md). It captures
@@ -87,9 +89,11 @@ The same session armed every one of those 348 resolve generations and observed
 zero guest CPU read or write events. This promotes `guest_cpu_visibility` from
 `unknown` to scene-bounded `pass`, as documented in
 [GUEST_CPU_VISIBILITY.md](GUEST_CPU_VISIBILITY.md). The admission result is now
-11/12 passing gates and one unknown gate (`rollback_switch`). The exact
-38-family identity classifier and the fail-closed, diagnostic-only switch
-control are documented in
-[CONSUMER_FAMILY_CLASSIFICATION.md](CONSUMER_FAMILY_CLASSIFICATION.md). They do
-not promote the remaining blocker. Suppression is still prohibited. See
+12/12 passing gates for the exact, scene-bounded sky/horizon family. Enabled
+AppData session `20260829T092338Z-p31960` suppressed 5,442 followers after
+5,442 complete publications with zero fallbacks. Disabled session
+`20260829T092551Z-p25116` used the same executable, suppressed zero draws, and
+both sessions shut down normally. The exact 38-family identity classifier and
+fail-closed switch control are documented in
+[CONSUMER_FAMILY_CLASSIFICATION.md](CONSUMER_FAMILY_CLASSIFICATION.md). See
 [PASS_CONSUMER_GRAPH.md](PASS_CONSUMER_GRAPH.md).

--- a/patches/rexglue/0079-d3d12-fail-closed-retained-pass-suppression.patch
+++ b/patches/rexglue/0079-d3d12-fail-closed-retained-pass-suppression.patch
@@ -1,0 +1,144 @@
+diff --git a/include/rex/system/interfaces/graphics.h b/include/rex/system/interfaces/graphics.h
+index 19ee4a5..3540c35 100644
+--- a/include/rex/system/interfaces/graphics.h
++++ b/include/rex/system/interfaces/graphics.h
+@@ -406,6 +406,10 @@ struct GraphicsIsolatedDrawPublicationResult {
+   uint32_t sample_count = 0;
+   bool color_published = false;
+   bool depth_stencil_published = false;
++  // True only when publication completed before the authoritative guest draw
++  // and the backend consequently omitted that draw. A failed or incomplete
++  // publication must leave this false and execute the original guest draw.
++  bool guest_draw_suppressed = false;
+ };
+ 
+ using GraphicsIsolatedDrawPublicationCompletion = void (*)(
+@@ -444,6 +448,10 @@ struct GraphicsIsolatedDrawRequest {
+   // must validate the entire pair before recording either copy. This never
+   // skips a draw, resolve, query, event, fence, or memexport operation.
+   bool publish_to_guest_requested = false;
++  // Publish the completed isolated replay before the guest draw and omit only
++  // that draw if the full color and depth/stencil pair was published. This is
++  // fail-closed: replay or publication failure executes the guest draw.
++  bool suppress_guest_draw_if_published = false;
+   uint64_t frame_sequence = 0;
+   GraphicsIsolatedDrawCompletion completion = nullptr;
+   GraphicsIsolatedDrawReadbackCompletion readback_completion = nullptr;
+diff --git a/src/graphics/d3d12/command_processor.cpp b/src/graphics/d3d12/command_processor.cpp
+index 1e1a691..6c2a3d1 100644
+--- a/src/graphics/d3d12/command_processor.cpp
++++ b/src/graphics/d3d12/command_processor.cpp
+@@ -3352,17 +3352,28 @@ bool D3D12CommandProcessor::IssueDraw(xenos::PrimitiveType primitive_type, uint3
+       queue(true);
+     }
+   };
+-  const auto publish_isolated_replay_to_guest = [&]() {
+-    if (!isolated_draw_request.publish_to_guest_requested) {
+-      return;
+-    }
+-    system::GraphicsIsolatedDrawPublicationResult publication;
++  system::GraphicsIsolatedDrawPublicationResult isolated_publication;
++  bool isolated_publication_attempted = false;
++  const auto publish_isolated_replay_to_guest = [&]() -> bool {
++    if (!isolated_draw_request.publish_to_guest_requested ||
++        isolated_publication_attempted) {
++      return isolated_publication.guest_draw_suppressed;
++    }
++    isolated_publication_attempted = true;
+     if (isolated_replay_recorded) {
+-      publication = render_target_cache_->PublishIsolatedReplayTarget();
+-    }
++      isolated_publication =
++          render_target_cache_->PublishIsolatedReplayTarget();
++    }
++    isolated_publication.guest_draw_suppressed =
++        isolated_draw_request.suppress_guest_draw_if_published &&
++        isolated_publication.status ==
++            system::GraphicsIsolatedDrawPublicationStatus::kPublished &&
++        isolated_publication.color_published &&
++        isolated_publication.depth_stencil_published;
+     if (isolated_draw_request.publication_completion) {
+-      isolated_draw_request.publication_completion(publication);
++      isolated_draw_request.publication_completion(isolated_publication);
+     }
++    return isolated_publication.guest_draw_suppressed;
+   };
+ 
+   // Draw.
+@@ -3438,6 +3449,9 @@ bool D3D12CommandProcessor::IssueDraw(xenos::PrimitiveType primitive_type, uint3
+         isolated_draw_request.completion(isolated_result);
+       }
+     }
++    const bool suppress_guest_draw =
++        isolated_draw_request.suppress_guest_draw_if_published &&
++        publish_isolated_replay_to_guest();
+     queue_consumer_reference_readback(true);
+     if (isolated_draw_request.consumer_reference_marker_requested) {
+       deferred_command_list_.BeginDebugMarker(
+@@ -3448,10 +3462,12 @@ bool D3D12CommandProcessor::IssueDraw(xenos::PrimitiveType primitive_type, uint3
+               ? "PinyonShift NR-02F authoritative Xenos pass follower"
+               : "PinyonShift NR-02F authoritative Xenos auto-index draw");
+     }
+-    PROFILE_DRAW_CALL();
+-    PROFILE_VERTICES(primitive_processing_result.host_draw_vertex_count);
+-    deferred_command_list_.D3DDrawInstanced(primitive_processing_result.host_draw_vertex_count, 1,
+-                                            0, 0);
++    if (!suppress_guest_draw) {
++      PROFILE_DRAW_CALL();
++      PROFILE_VERTICES(primitive_processing_result.host_draw_vertex_count);
++      deferred_command_list_.D3DDrawInstanced(
++          primitive_processing_result.host_draw_vertex_count, 1, 0, 0);
++    }
+     if (isolated_draw_request.consumer_reference_marker_requested ||
+         isolated_draw_request.reference_marker_requested) {
+       deferred_command_list_.EndDebugMarker();
+@@ -3486,7 +3502,9 @@ bool D3D12CommandProcessor::IssueDraw(xenos::PrimitiveType primitive_type, uint3
+             readback_result);
+       }
+     }
+-    publish_isolated_replay_to_guest();
++    if (!isolated_draw_request.suppress_guest_draw_if_published) {
++      publish_isolated_replay_to_guest();
++    }
+   } else {
+     D3D12_INDEX_BUFFER_VIEW index_buffer_view;
+     index_buffer_view.SizeInBytes = primitive_processing_result.host_draw_vertex_count;
+@@ -3608,6 +3626,9 @@ bool D3D12CommandProcessor::IssueDraw(xenos::PrimitiveType primitive_type, uint3
+         isolated_draw_request.completion(isolated_result);
+       }
+     }
++    const bool suppress_guest_draw =
++        isolated_draw_request.suppress_guest_draw_if_published &&
++        publish_isolated_replay_to_guest();
+     queue_consumer_reference_readback(true);
+     if (isolated_draw_request.consumer_reference_marker_requested) {
+       deferred_command_list_.BeginDebugMarker(
+@@ -3618,10 +3639,12 @@ bool D3D12CommandProcessor::IssueDraw(xenos::PrimitiveType primitive_type, uint3
+               ? "PinyonShift NR-02F authoritative Xenos pass anchor"
+               : "PinyonShift NR-02E authoritative Xenos draw");
+     }
+-    PROFILE_DRAW_CALL();
+-    PROFILE_VERTICES(primitive_processing_result.host_draw_vertex_count);
+-    deferred_command_list_.D3DDrawIndexedInstanced(
+-        primitive_processing_result.host_draw_vertex_count, 1, 0, 0, 0);
++    if (!suppress_guest_draw) {
++      PROFILE_DRAW_CALL();
++      PROFILE_VERTICES(primitive_processing_result.host_draw_vertex_count);
++      deferred_command_list_.D3DDrawIndexedInstanced(
++          primitive_processing_result.host_draw_vertex_count, 1, 0, 0, 0);
++    }
+     if (isolated_draw_request.consumer_reference_marker_requested ||
+         isolated_draw_request.reference_marker_requested) {
+       deferred_command_list_.EndDebugMarker();
+@@ -3656,7 +3679,9 @@ bool D3D12CommandProcessor::IssueDraw(xenos::PrimitiveType primitive_type, uint3
+             readback_result);
+       }
+     }
+-    publish_isolated_replay_to_guest();
++    if (!isolated_draw_request.suppress_guest_draw_if_published) {
++      publish_isolated_replay_to_guest();
++    }
+     if (scratch_index_buffer != nullptr) {
+       ReleaseScratchGPUBuffer(scratch_index_buffer, D3D12_RESOURCE_STATE_INDEX_BUFFER);
+     }
+

--- a/src/native_renderer/graphics_hooks.cpp
+++ b/src/native_renderer/graphics_hooks.cpp
@@ -63,6 +63,8 @@ constexpr uint64_t kMaximumTextureScanResourceBytes = UINT64_C(16) << 20;
 constexpr uint64_t kMaximumTextureScanTotalBytes = UINT64_C(32) << 20;
 constexpr uint32_t kMaximumConsumerReadbackSamples = 16;
 constexpr uint64_t kPassPublicationDetailLimit = 64;
+constexpr uint64_t kSkyHorizonAnchorSignature = UINT64_C(0x747837906D0BF484);
+constexpr uint64_t kSkyHorizonFollowerSignature = UINT64_C(0x1D253A52B55C9FB3);
 std::atomic<uint64_t> g_frame_sequence{};
 
 std::string CensusSceneMarker() {
@@ -168,6 +170,18 @@ struct PassPublicationState {
 
 PassPublicationState g_pass_publication;
 
+struct SkyHorizonSuppressionState {
+  uint64_t attempts = 0;
+  uint64_t suppressed = 0;
+  uint64_t fallbacks = 0;
+  uint64_t last_frame = 0;
+  uint64_t last_draw = 0;
+  bool requested = false;
+  bool armed = false;
+};
+
+SkyHorizonSuppressionState g_sky_horizon_suppression;
+
 struct ConsumerFamilyMarkerState {
   uint64_t vertex_shader_hash = 0;
   uint64_t pixel_shader_hash = 0;
@@ -232,6 +246,11 @@ void ConfigurePassFollower() {
       "PINYON_SHIFT_NATIVE_RENDERER_PASS_ANCHOR_SIGNATURE",
       g_pass_follower.target_signature, g_pass_follower.requested,
       g_pass_follower.valid);
+  if (!g_pass_follower.requested &&
+      g_sky_horizon_suppression.requested) {
+    g_pass_follower.target_signature = kSkyHorizonAnchorSignature;
+    g_pass_follower.requested = true;
+  }
 }
 
 void ConfigureConsumerFamilyMarker() {
@@ -374,6 +393,11 @@ void ConfigureIsolatedDraw() {
       "PINYON_SHIFT_NATIVE_RENDERER_ISOLATED_DRAW_SIGNATURE",
       g_isolated_draw.target_signature, g_isolated_draw.requested,
       g_isolated_draw.valid);
+  if (!g_isolated_draw.requested &&
+      g_sky_horizon_suppression.requested) {
+    g_isolated_draw.target_signature = kSkyHorizonFollowerSignature;
+    g_isolated_draw.requested = true;
+  }
   const bool signature_requested = g_isolated_draw.requested;
   char *value = nullptr;
   size_t length = 0;
@@ -401,6 +425,14 @@ void ConfigurePassPublication() {
                 "PINYON_SHIFT_NATIVE_RENDERER_PUBLISH_RETAINED_PASS") != 0 ||
       !value || length <= 1) {
     std::free(value);
+    if (g_sky_horizon_suppression.requested) {
+      g_pass_publication.requested = true;
+      g_pass_publication.valid =
+          g_isolated_draw.requested && g_isolated_draw.valid &&
+          g_pass_follower.requested && g_pass_follower.valid &&
+          g_isolated_draw.target_signature !=
+              g_pass_follower.target_signature;
+    }
     return;
   }
   const std::string setting(value);
@@ -417,23 +449,39 @@ void ConfigurePassPublication() {
 }
 
 void EmitSkyHorizonSuppressionControl() {
-  const bool requested =
-      REXCVAR_GET(pinyon_shift_native_renderer_sky_horizon_suppression);
+  const bool requested = g_sky_horizon_suppression.requested;
   pinyon_shift::diagnostics::RecordEvent(
       "native_renderer.suppression_control",
       {{"family", "sky_horizon"},
        {"anchor_signature", "747837906D0BF484"},
        {"follower_signature", "1D253A52B55C9FB3"},
        {"requested", requested ? "true" : "false"},
-       {"status", requested ? "blocked_not_admitted" : "disabled"},
+       {"status", !requested
+                      ? "disabled"
+                      : (g_sky_horizon_suppression.armed
+                             ? "armed_experimental"
+                             : "blocked_invalid_configuration")},
        {"activation", "startup_only"},
        {"default_enabled", "false"},
-       {"implementation", "diagnostic_only"},
+       {"implementation", "fail_closed_follower_draw"},
        {"xenos_fallback", "mandatory"},
-       {"xenos_draw", "preserved"},
-       {"draw_suppression", "false"},
+       {"xenos_draw", requested ? "anchor_preserved_follower_conditional"
+                                  : "preserved"},
+       {"draw_suppression", requested ? "follower_after_publication_only"
+                                        : "false"},
        {"resolve_suppression", "false"},
-       {"suppression_allowed", "false"}});
+       {"suppression_allowed",
+        g_sky_horizon_suppression.armed ? "operator_requested" : "false"}});
+}
+
+void ArmSkyHorizonSuppression() {
+  g_sky_horizon_suppression.armed =
+      g_sky_horizon_suppression.requested && g_isolated_draw.requested &&
+      g_isolated_draw.valid &&
+      g_isolated_draw.target_signature == kSkyHorizonFollowerSignature &&
+      g_pass_follower.requested && g_pass_follower.valid &&
+      g_pass_follower.target_signature == kSkyHorizonAnchorSignature &&
+      g_pass_publication.requested && g_pass_publication.valid;
 }
 
 struct DrawSignatureEntry {
@@ -3058,6 +3106,16 @@ void CompleteRetainedPassPublication(
   } else {
     ++g_pass_publication.failures;
   }
+  if (g_sky_horizon_suppression.armed) {
+    ++g_sky_horizon_suppression.attempts;
+    g_sky_horizon_suppression.last_frame = g_isolated_draw.frame;
+    g_sky_horizon_suppression.last_draw = g_isolated_draw.draw;
+    if (result.guest_draw_suppressed) {
+      ++g_sky_horizon_suppression.suppressed;
+    } else {
+      ++g_sky_horizon_suppression.fallbacks;
+    }
+  }
   const char *status = "unavailable";
   switch (result.status) {
   case rex::system::GraphicsIsolatedDrawPublicationStatus::kPublished:
@@ -3093,11 +3151,18 @@ void CompleteRetainedPassPublication(
        {"depth_stencil",
         result.depth_stencil_published ? "published" : "preserved_xenos"},
        {"guest_target_content", published ? "native_retained_pass" : "xenos"},
-       {"xenos_draw", "preserved"},
-       {"draw_suppression", "false"},
+       {"xenos_draw", result.guest_draw_suppressed
+                          ? "anchor_preserved_follower_suppressed"
+                          : "preserved"},
+       {"draw_suppression",
+        result.guest_draw_suppressed ? "follower" : "false"},
        {"resolve_suppression", "false"},
-       {"side_effects", "preserved"},
-       {"suppression_eligible", "false"}});
+       {"side_effects", "setup_barriers_resolves_consumers_preserved"},
+       {"fallback", result.guest_draw_suppressed
+                        ? "not_needed"
+                        : "original_follower_executed"},
+       {"suppression_eligible",
+        g_sky_horizon_suppression.armed ? "true" : "false"}});
 }
 
 void RequestIsolatedDraw(
@@ -3183,6 +3248,8 @@ void RequestIsolatedDraw(
     if (g_pass_publication.requested && g_pass_publication.valid) {
       request.publish_to_guest_requested = true;
       request.publication_completion = &CompleteRetainedPassPublication;
+      request.suppress_guest_draw_if_published =
+          g_sky_horizon_suppression.armed;
     }
     if (!g_isolated_draw.completed) {
       g_isolated_draw.captured_signature = signature;
@@ -3833,8 +3900,13 @@ void InstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system,
   if (!graphics_system || !memory) {
     return;
   }
-  EmitSkyHorizonSuppressionControl();
-  if (!REXCVAR_GET(pinyon_shift_native_renderer_census)) {
+  g_sky_horizon_suppression = {};
+  g_sky_horizon_suppression.requested =
+      REXCVAR_GET(pinyon_shift_native_renderer_sky_horizon_suppression);
+  const bool census_requested =
+      REXCVAR_GET(pinyon_shift_native_renderer_census);
+  if (!census_requested && !g_sky_horizon_suppression.requested) {
+    EmitSkyHorizonSuppressionControl();
     return;
   }
   ResetDrawCensus();
@@ -3847,6 +3919,8 @@ void InstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system,
   ConfigureIsolatedDraw();
   ConfigurePassFollower();
   ConfigurePassPublication();
+  ArmSkyHorizonSuppression();
+  EmitSkyHorizonSuppressionControl();
   ConfigureConsumerFamilyMarker();
   g_graphics_census_memory = memory;
   if (g_pass_follower.requested && g_pass_follower.valid &&
@@ -3871,7 +3945,9 @@ void InstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system,
                             {"prepared_shader_pair_capacity", "1024"},
                             {"guest_cpu_visibility_target_capacity", "64"},
                             {"scene", scene},
-                            {"mode", "pass_through"}});
+                            {"mode", g_sky_horizon_suppression.armed
+                                         ? "experimental_suppression"
+                                         : "pass_through"}});
   diagnostics::RecordEvent("native_renderer.census.scene_marker",
                            {{"scene", scene}, {"source", "operator"}});
   diagnostics::RecordEvent(
@@ -4004,11 +4080,16 @@ void InstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system,
        {"guest_target_content", "xenos_until_successful_publication"},
        {"fallback", "preserve_xenos_targets"},
        {"detail_limit", std::to_string(kPassPublicationDetailLimit)},
-       {"xenos_draw", "preserved"},
-       {"draw_suppression", "false"},
+       {"xenos_draw", g_sky_horizon_suppression.armed
+                          ? "anchor_preserved_follower_conditional"
+                          : "preserved"},
+       {"draw_suppression", g_sky_horizon_suppression.armed
+                                ? "follower_after_publication_only"
+                                : "false"},
        {"resolve_suppression", "false"},
        {"side_effects", "preserved"},
-       {"suppression_eligible", "false"}});
+       {"suppression_eligible",
+        g_sky_horizon_suppression.armed ? "true" : "false"}});
   diagnostics::RecordEvent(
       "native_renderer.census.guest_cpu_visibility_config",
       {{"status", g_guest_cpu_access_callback ? "armed" : "disabled"},
@@ -4335,11 +4416,38 @@ void UninstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system) {
        {"last_draw", std::to_string(g_pass_publication.last_draw)},
        {"published_attachments", "color_and_depth_stencil"},
        {"guest_target_content", "per_attempt"},
-       {"xenos_draw", "preserved"},
-       {"draw_suppression", "false"},
+       {"xenos_draw", g_sky_horizon_suppression.suppressed
+                          ? "anchor_preserved_follower_suppressed"
+                          : "preserved"},
+       {"draw_suppression", g_sky_horizon_suppression.suppressed
+                                ? "follower"
+                                : "false"},
        {"resolve_suppression", "false"},
        {"side_effects", "preserved"},
-       {"suppression_eligible", "false"}});
+       {"suppression_eligible",
+        g_sky_horizon_suppression.armed ? "true" : "false"}});
+  diagnostics::RecordEvent(
+      "native_renderer.suppression_summary",
+      {{"family", "sky_horizon"},
+       {"status", !g_sky_horizon_suppression.requested
+                      ? "disabled"
+                      : (!g_sky_horizon_suppression.armed
+                             ? "blocked_invalid_configuration"
+                             : (g_sky_horizon_suppression.suppressed
+                                    ? "active"
+                                    : "not_observed"))},
+       {"scope", "exact_follower_draw_after_full_pair_publication"},
+       {"attempts", std::to_string(g_sky_horizon_suppression.attempts)},
+       {"suppressed", std::to_string(g_sky_horizon_suppression.suppressed)},
+       {"fallbacks", std::to_string(g_sky_horizon_suppression.fallbacks)},
+       {"last_frame", std::to_string(g_sky_horizon_suppression.last_frame)},
+       {"last_draw", std::to_string(g_sky_horizon_suppression.last_draw)},
+       {"anchor_draw", "preserved"},
+       {"follower_draw", g_sky_horizon_suppression.suppressed
+                             ? "suppressed_after_publication"
+                             : "preserved"},
+       {"resolve_suppression", "false"},
+       {"xenos_fallback", "mandatory_on_replay_or_publication_failure"}});
   g_graphics_census_installed = false;
   g_graphics_census_memory = nullptr;
   if (g_draw_census.window_first_frame && g_draw_census.window_draw_count) {

--- a/tools/qualify-native-renderer-rollback.py
+++ b/tools/qualify-native-renderer-rollback.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+"""Qualify enabled/disabled rollback for the exact retained-pass family."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+
+OUTPUT_SCHEMA = "pinyon-shift.native-renderer-rollback-qualification.v1"
+
+
+def _require(condition: bool, message: str) -> None:
+    if not condition:
+        raise ValueError(message)
+
+
+def _load(path: Path) -> list[dict[str, Any]]:
+    events: list[dict[str, Any]] = []
+    for line_number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+        if not line.strip():
+            continue
+        value = json.loads(line)
+        _require(isinstance(value, dict), f"{path}:{line_number} is not an object")
+        events.append(value)
+    _require(bool(events), f"{path} is empty")
+    return events
+
+
+def _one(events: list[dict[str, Any]], name: str) -> dict[str, Any]:
+    matches = [event for event in events if event.get("event") == name]
+    _require(len(matches) == 1, f"expected one {name} event, found {len(matches)}")
+    return matches[0]
+
+
+def _integer(event: dict[str, Any], name: str) -> int:
+    try:
+        value = int(str(event[name]))
+    except (KeyError, TypeError, ValueError) as error:
+        raise ValueError(f"{event.get('event')} has invalid {name}") from error
+    _require(value >= 0, f"{event.get('event')}.{name} must be non-negative")
+    return value
+
+
+def qualify(enabled_path: Path, disabled_path: Path) -> dict[str, Any]:
+    enabled = _load(enabled_path)
+    disabled = _load(disabled_path)
+    enabled_start = _one(enabled, "process.start")
+    disabled_start = _one(disabled, "process.start")
+    executable_sha256 = str(enabled_start.get("executable_sha256", ""))
+    _require(len(executable_sha256) == 64, "enabled executable SHA-256 is missing")
+    _require(
+        executable_sha256 == str(disabled_start.get("executable_sha256", "")),
+        "enabled and disabled runs must use the same executable",
+    )
+    _one(enabled, "process.shutdown")
+    _one(disabled, "process.shutdown")
+
+    enabled_control = _one(enabled, "native_renderer.suppression_control")
+    _require(enabled_control.get("requested") == "true", "enabled run was not requested")
+    _require(
+        enabled_control.get("status") == "armed_experimental",
+        "enabled run was not armed",
+    )
+    _require(
+        enabled_control.get("implementation") == "fail_closed_follower_draw",
+        "enabled run used an unexpected implementation",
+    )
+    _require(enabled_control.get("resolve_suppression") == "false", "resolve suppression observed")
+    enabled_summary = _one(enabled, "native_renderer.suppression_summary")
+    attempts = _integer(enabled_summary, "attempts")
+    suppressed = _integer(enabled_summary, "suppressed")
+    fallbacks = _integer(enabled_summary, "fallbacks")
+    _require(enabled_summary.get("status") == "active", "enabled suppression was not active")
+    _require(attempts > 0 and suppressed == attempts, "not every enabled attempt suppressed the follower")
+    _require(fallbacks == 0, "enabled qualification observed a fallback")
+    _require(enabled_summary.get("anchor_draw") == "preserved", "anchor draw was not preserved")
+    _require(enabled_summary.get("resolve_suppression") == "false", "enabled run suppressed resolves")
+    publication = _one(enabled, "native_renderer.retained_pass.publication_summary")
+    _require(_integer(publication, "attempts") == attempts, "publication attempt count drift")
+    _require(_integer(publication, "published") == attempts, "publication was incomplete")
+    _require(_integer(publication, "failures") == 0, "publication failure observed")
+
+    disabled_control = _one(disabled, "native_renderer.suppression_control")
+    _require(disabled_control.get("requested") == "false", "disabled run requested suppression")
+    _require(disabled_control.get("status") == "disabled", "disabled run did not roll back")
+    suppressed_details = [
+        event
+        for event in disabled
+        if event.get("event") == "native_renderer.retained_pass.publication"
+        and event.get("draw_suppression") == "follower"
+    ]
+    _require(not suppressed_details, "disabled run still suppressed a follower draw")
+
+    return {
+        "schema": OUTPUT_SCHEMA,
+        "family": "sky_horizon",
+        "scope": "exact_follower_draw_after_full_pair_publication",
+        "executable_sha256": executable_sha256,
+        "enabled": {
+            "session": enabled_start.get("session"),
+            "attempts": attempts,
+            "suppressed": suppressed,
+            "fallbacks": fallbacks,
+            "normal_shutdown": True,
+        },
+        "disabled": {
+            "session": disabled_start.get("session"),
+            "status": "disabled",
+            "suppressed": 0,
+            "normal_shutdown": True,
+        },
+        "gate": {"rollback_switch": "pass"},
+        "safety": {
+            "default_enabled": False,
+            "activation": "startup_only",
+            "anchor_xenos_draw_preserved": True,
+            "follower_xenos_fallback": "mandatory_on_failure",
+            "resolve_suppression_implemented": False,
+            "suppression_scope": "scene_bounded_operator_requested_only",
+        },
+    }
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--enabled-log", type=Path, required=True)
+    parser.add_argument("--disabled-log", type=Path, required=True)
+    parser.add_argument("--output", "-o", type=Path)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    result = qualify(args.enabled_log, args.disabled_log)
+    rendered = json.dumps(result, indent=2) + "\n"
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(rendered, encoding="utf-8")
+    else:
+        print(rendered, end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/tests/test_native_renderer_contract.py
+++ b/tools/tests/test_native_renderer_contract.py
@@ -517,10 +517,21 @@ class NativeRendererContractTests(unittest.TestCase):
         self.assertIn(
             "pinyon_shift_native_renderer_sky_horizon_suppression", hooks
         )
-        self.assertIn('"blocked_not_admitted"', hooks)
-        self.assertIn('"draw_suppression", "false"', hooks)
+        self.assertIn('"armed_experimental"', hooks)
+        self.assertIn('"fail_closed_follower_draw"', hooks)
+        self.assertIn('"follower_after_publication_only"', hooks)
         self.assertIn('"resolve_suppression", "false"', hooks)
         self.assertNotIn("SetDrawSuppression", hooks)
+
+        patch = (
+            ROOT
+            / "patches/rexglue/0079-d3d12-fail-closed-retained-pass-suppression.patch"
+        ).read_text(encoding="utf-8")
+        self.assertIn("suppress_guest_draw_if_published", patch)
+        self.assertIn("guest_draw_suppressed", patch)
+        self.assertIn("PublishIsolatedReplayTarget", patch)
+        self.assertIn("if (!suppress_guest_draw)", patch)
+        self.assertNotIn("SetCopySuppression", patch)
 
         settings = (ROOT / "tools/set-graphics-experiment.ps1").read_text(
             encoding="utf-8"
@@ -552,7 +563,7 @@ class NativeRendererContractTests(unittest.TestCase):
             all(rule["native_coverage"] is False for rule in classifier["rules"])
         )
 
-    def test_suppression_switch_spec_is_default_off_and_diagnostic_only(self):
+    def test_suppression_switch_spec_is_default_off_and_fail_closed(self):
         switches = json.loads(
             (ROOT / "config/native-renderer/suppression-switches.json").read_text(
                 encoding="utf-8"
@@ -561,13 +572,17 @@ class NativeRendererContractTests(unittest.TestCase):
         family = switches["families"][0]
         self.assertFalse(family["default_enabled"])
         self.assertTrue(family["independent"])
-        self.assertEqual("diagnostic_only", family["implementation_status"])
+        self.assertEqual("implemented", family["implementation_status"])
         self.assertEqual(
             "pinyon_shift_native_renderer_sky_horizon_suppression",
             family["cvar"],
         )
-        self.assertFalse(family["draw_suppression_implemented"])
+        self.assertTrue(family["draw_suppression_implemented"])
         self.assertFalse(family["resolve_suppression_implemented"])
+        self.assertTrue(family["anchor_draw_preserved"])
+        self.assertEqual(
+            "execute_original_follower", family["publication_failure_behavior"]
+        )
 
     def test_complete_pass_export_spans_anchor_and_follower(self):
         exporter = (

--- a/tools/tests/test_native_renderer_rollback_qualification.py
+++ b/tools/tests/test_native_renderer_rollback_qualification.py
@@ -1,0 +1,111 @@
+import copy
+import importlib.util
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+TOOL = ROOT / "tools" / "qualify-native-renderer-rollback.py"
+SPEC = importlib.util.spec_from_file_location("native_rollback", TOOL)
+assert SPEC and SPEC.loader
+MODULE = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = MODULE
+SPEC.loader.exec_module(MODULE)
+
+
+SHA = "A" * 64
+
+
+def event(name, **fields):
+    return {"schema": 1, "session": "session", "event": name, **fields}
+
+
+def logs():
+    enabled = [
+        event("process.start", executable_sha256=SHA),
+        event(
+            "native_renderer.suppression_control",
+            requested="true",
+            status="armed_experimental",
+            implementation="fail_closed_follower_draw",
+            resolve_suppression="false",
+        ),
+        event(
+            "native_renderer.retained_pass.publication_summary",
+            attempts="12",
+            published="12",
+            failures="0",
+        ),
+        event(
+            "native_renderer.suppression_summary",
+            status="active",
+            attempts="12",
+            suppressed="12",
+            fallbacks="0",
+            anchor_draw="preserved",
+            resolve_suppression="false",
+        ),
+        event("process.shutdown"),
+    ]
+    disabled = [
+        event("process.start", executable_sha256=SHA),
+        event("native_renderer.suppression_control", requested="false", status="disabled"),
+        event("process.shutdown"),
+    ]
+    return enabled, disabled
+
+
+class NativeRendererRollbackQualificationTests(unittest.TestCase):
+    def qualify(self, enabled, disabled):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            enabled_path = root / "enabled.jsonl"
+            disabled_path = root / "disabled.jsonl"
+            enabled_path.write_text("".join(json.dumps(item) + "\n" for item in enabled), encoding="utf-8")
+            disabled_path.write_text("".join(json.dumps(item) + "\n" for item in disabled), encoding="utf-8")
+            return MODULE.qualify(enabled_path, disabled_path)
+
+    def test_accepts_same_build_enabled_and_disabled_pair(self):
+        enabled, disabled = logs()
+        result = self.qualify(enabled, disabled)
+        self.assertEqual(result["gate"]["rollback_switch"], "pass")
+        self.assertEqual(result["enabled"]["suppressed"], 12)
+        self.assertEqual(result["disabled"]["suppressed"], 0)
+        self.assertTrue(result["safety"]["anchor_xenos_draw_preserved"])
+        self.assertFalse(result["safety"]["resolve_suppression_implemented"])
+
+    def test_rejects_fallback_or_partial_publication(self):
+        enabled, disabled = logs()
+        enabled[3]["suppressed"] = "11"
+        enabled[3]["fallbacks"] = "1"
+        with self.assertRaisesRegex(ValueError, "not every enabled attempt"):
+            self.qualify(enabled, disabled)
+
+        enabled, disabled = logs()
+        enabled[2]["published"] = "11"
+        with self.assertRaisesRegex(ValueError, "publication was incomplete"):
+            self.qualify(enabled, disabled)
+
+    def test_rejects_build_drift_and_failed_rollback(self):
+        enabled, disabled = logs()
+        disabled[0]["executable_sha256"] = "B" * 64
+        with self.assertRaisesRegex(ValueError, "same executable"):
+            self.qualify(enabled, disabled)
+
+        enabled, disabled = logs()
+        disabled.insert(
+            -1,
+            event(
+                "native_renderer.retained_pass.publication",
+                draw_suppression="follower",
+            ),
+        )
+        with self.assertRaisesRegex(ValueError, "still suppressed"):
+            self.qualify(enabled, disabled)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/tests/test_native_renderer_suppression_switches.py
+++ b/tools/tests/test_native_renderer_suppression_switches.py
@@ -64,6 +64,22 @@ class NativeRendererSuppressionSwitchTests(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "before implementation"):
             MODULE.validate(document)
 
+    def test_implemented_switch_requires_runtime_rollback_qualification(self):
+        document = manifest()
+        family = document["families"][0]
+        family["implementation_status"] = "implemented"
+        family["draw_suppression_implemented"] = True
+        family["rollback_qualified"] = False
+        result = MODULE.validate(document)
+        self.assertEqual("requires_runtime_test", result["families"][0]["rollback_gate"])
+        self.assertEqual("unknown", result["summary"]["rollback_switch_gate"])
+        self.assertFalse(result["safety"]["suppression_allowed"])
+
+        family["rollback_qualified"] = True
+        result = MODULE.validate(document)
+        self.assertEqual("pass", result["summary"]["rollback_switch_gate"])
+        self.assertTrue(result["safety"]["suppression_allowed"])
+
     def test_rejects_duplicate_switch(self):
         document = manifest()
         duplicate = copy.deepcopy(document["families"][0])

--- a/tools/tests/test_release_contract.py
+++ b/tools/tests/test_release_contract.py
@@ -43,10 +43,10 @@ class ReleaseContractTests(unittest.TestCase):
 
     def test_rexglue_patches_have_stable_order_and_no_binary_payload(self):
         patches = sorted((ROOT / "patches/rexglue").glob("*.patch"))
-        self.assertEqual(len(patches), 78)
+        self.assertEqual(len(patches), 79)
         self.assertEqual(
             patches[-1].name,
-            "0078-d3d12-retained-pass-output-publication.patch",
+            "0079-d3d12-fail-closed-retained-pass-suppression.patch",
         )
         self.assertEqual(len(patches), len({path.name[:4] for path in patches}))
         for path in patches:

--- a/tools/validate-native-renderer-suppression-switches.py
+++ b/tools/validate-native-renderer-suppression-switches.py
@@ -77,6 +77,15 @@ def validate(document: dict[str, Any]) -> dict[str, Any]:
                 draw_implemented is False and resolve_implemented is False,
                 f"family {family} cannot claim suppression before implementation",
             )
+        rollback_qualified = entry.get("rollback_qualified", False)
+        require(
+            isinstance(rollback_qualified, bool),
+            f"family {family} rollback qualification flag must be boolean",
+        )
+        require(
+            status == "implemented" or rollback_qualified is False,
+            f"family {family} cannot qualify rollback before implementation",
+        )
         require(
             entry.get("xenos_fallback") == "mandatory",
             f"family {family} must retain mandatory Xenos fallback",
@@ -95,9 +104,12 @@ def validate(document: dict[str, Any]) -> dict[str, Any]:
                 "implementation_status": status,
                 "draw_suppression_implemented": draw_implemented,
                 "resolve_suppression_implemented": resolve_implemented,
+                "rollback_qualified": rollback_qualified,
                 "xenos_fallback": "mandatory",
                 "rollback_gate": (
-                    "unknown" if status != "implemented" else "requires_runtime_test"
+                    "pass"
+                    if rollback_qualified
+                    else ("unknown" if status != "implemented" else "requires_runtime_test")
                 ),
             }
         )
@@ -114,12 +126,21 @@ def validate(document: dict[str, Any]) -> dict[str, Any]:
                 entry["implementation_status"] == "diagnostic_only"
                 for entry in normalized
             ),
-            "rollback_switch_gate": "unknown",
-            "reason": "switches are specified fail-closed but rollback is not runtime-qualified",
+            "rollback_switch_gate": (
+                "pass" if all(entry["rollback_qualified"] for entry in normalized) else "unknown"
+            ),
+            "reason": (
+                "every implemented switch has a same-build enabled/disabled rollback qualification"
+                if all(entry["rollback_qualified"] for entry in normalized)
+                else "one or more switches still require runtime rollback qualification"
+            ),
         },
         "safety": {
             "xenos_authority": True,
-            "suppression_allowed": False,
+            "suppression_allowed": all(
+                entry["rollback_qualified"] and entry["draw_suppression_implemented"]
+                for entry in normalized
+            ),
         },
     }
 


### PR DESCRIPTION
## Summary
- add fail-closed D3D12 suppression for the qualified sky/horizon follower draw
- preserve the Xenos anchor, resolves, consumers, and original follower fallback
- add same-build enabled/disabled rollback qualification and promote the exact family to 12/12 admission

## Validation
- 236-test full suite passed
- clean generated build replayed all 79 ReXGlue patches
- 57 focused native-renderer/release tests passed
- enabled AppData session `20260829T092338Z-p31960`: 5,442/5,442 published and suppressed, zero fallbacks, normal shutdown
- disabled AppData session `20260829T092551Z-p25116`: zero suppressed, normal shutdown
- same executable SHA-256: `2060C64808794C10B368350566542E2005646D9513B252391980D525732BC22A`
- enabled presentation cadence 59.974 Hz, zero deadline misses; simulation cadence 29.423 Hz
- visual inspection: complete sky, world, crowds, vehicle, UI, and post-processing