### PR TITLE
feat(native-renderer): trace title draw dispatch callers

### DIFF
--- a/config/rexglue/analysis/main-xex.toml
+++ b/config/rexglue/analysis/main-xex.toml
@@ -12,6 +12,22 @@ includes = ["fh1-post-processing.toml"]
 address = 0x829EFEB8
 name = "PinyonShiftObserveGraphicsFrame"
 
+# NR-00/NR-05A title dispatch discovery. Static PM4 construction evidence maps
+# 0x8240F4D8 to the title's indexed draw wrapper and 0x829F7C70 to its embedded-
+# index draw wrapper. Each hook runs after the wrapper's opening mflr r12, so
+# r12 contains the unmodified caller LR while r3-r5 still contain the entry
+# arguments. The bounded, default-off census neither reads guest resource
+# payloads nor changes registers, command packets, or control flow.
+[[midasm_hook]]
+address = 0x8240F4DC
+name = "PinyonShiftObserveDrawIndexedDispatch"
+registers = ["r3", "r4", "r5", "r12"]
+
+[[midasm_hook]]
+address = 0x829F7C74
+name = "PinyonShiftObserveDrawImmediateDispatch"
+registers = ["r3", "r4", "r5", "r12"]
+
 # Microsoft CRT non-local jump pair. These must be semantic codegen hooks so a
 # longjmp restores the host-side PPCContext captured at the setjmp call site.
 setjmp_address = 0x82A81E80

--- a/docs/native-renderer/HIGH_LEVEL_RENDER_HOOKS.md
+++ b/docs/native-renderer/HIGH_LEVEL_RENDER_HOOKS.md
@@ -1,0 +1,128 @@
+# High-level render hook inventory
+
+This is the NR-00A and NR-05A title-dispatch ledger for the supported USA
+retail MS-2505 executable. It separates packet-wrapper identity, which is now
+proved, from semantic renderer identity, which remains unknown until runtime
+scene evidence supports a family name.
+
+The dispatch extension starts from Pinyon Shift `dev` merge
+`38bc3a2239b5c3d1689d0810ab2349e0527cadc6`, ReXGlue `v0.10.0` at
+`f5337cdc947ff6d4c4196737e2c807a48f2a1fc2`, and patch stack `0001` through
+`0079`. The supported `default.xex` SHA-256 remains
+`DB40DF605ADE49A612B35A7A24C38F6004BCB17A88ED6B48288DE16DF9E3987C`.
+
+## Safety boundary
+
+The discovery path is opt-in through
+`pinyon_shift_native_renderer_dispatch_discovery` and defaults to `false`.
+Each wrapper opens with `mflr r12`; the hook on the following instruction
+observes the caller `LR` through `r12` plus unchanged entry `r3`, `r4`, and
+`r5`. A fixed 256-entry atomic table aggregates caller frequency; it does not read guest
+resource payloads or write guest state. The original wrapper, PM4 packet,
+Xenos draw, arguments, registers, and control flow are preserved. Discovery
+records are never suppression evidence.
+
+## Proved draw wrappers
+
+The generated AOT instruction inventory establishes these two runtime wrapper
+families:
+
+| Entry | Packet construction | Reviewed identity | Runtime observation |
+| --- | --- | --- | --- |
+| `0x8240F4D8` | At `0x82410320`, combines a dynamic Type-3 count with opcode `0x36` and stores the resulting `PM4_DRAW_INDX_2` header | Indexed draw wrapper | Hook `0x8240F4DC`: entry `LR` in `r12`, plus `r3-r5` |
+| `0x829F7C70` | At `0x829F7CA8`, stores fixed Type-3 count-one header `0xC0003600`, followed by embedded index/draw metadata | Immediate/embedded-index draw wrapper | Hook `0x829F7C74`: entry `LR` in `r12`, plus `r3-r5` |
+
+Three additional opcode-`0x36` constructors at `0x829E82D0`, `0x829E8428`,
+and `0x829EDB68` build initialization templates. They are inventoried but are
+not runtime draw hooks.
+
+No `PM4_DRAW_INDX` (`0x22`) title constructor has yet passed the same stored-
+header proof. The scanner reports only proved stored opcode-`0x36` headers and
+explicitly rejects a matching numeric operation in `sub_83051E48` because its
+result is not stored as a command packet.
+
+## Static direct callers
+
+`tools/discover-native-renderer-dispatch.py` scans all generated AOT C++ files,
+reconstructs instruction addresses from function entries and labels, and
+produces a deterministic payload-free JSON inventory. At the current baseline
+it finds 11 direct call sites:
+
+| Wrapper | Caller function | Call site | Entry `LR` |
+| --- | --- | --- | --- |
+| `0x8240F4D8` | `sub_824079B8` | `0x824079F8` | `0x824079FC` |
+| `0x8240F4D8` | `sub_82B2B180` | `0x82B2BD74` | `0x82B2BD78` |
+| `0x8240F4D8` | `sub_82B40E60` | `0x82B42294` | `0x82B42298` |
+| `0x8240F4D8` | `sub_82B425B0` | `0x82B4386C` | `0x82B43870` |
+| `0x8240F4D8` | `sub_82B425B0` | `0x82B44420` | `0x82B44424` |
+| `0x8240F4D8` | `sub_82B425B0` | `0x82B44740` | `0x82B44744` |
+| `0x8240F4D8` | `sub_82B425B0` | `0x82B4478C` | `0x82B44790` |
+| `0x8240F4D8` | `sub_82B425B0` | `0x82B449C0` | `0x82B449C4` |
+| `0x8240F4D8` | `sub_82B425B0` | `0x82B44A00` | `0x82B44A04` |
+| `0x829F7C70` | `sub_829F8D88` | `0x829F93F0` | `0x829F93F4` |
+| `0x829F7C70` | `sub_829F9540` | `0x829F9980` | `0x829F9984` |
+
+The entry `LR` is sufficient to correlate runtime frequency with this table.
+It is not sufficient to name a call site terrain, road, vehicle, HUD, or any
+other semantic family. Those names remain `unknown`.
+
+## Capture and correlation
+
+Generate static evidence and launch the installed AppData save with discovery
+enabled:
+
+```powershell
+$stateRoot = Join-Path $env:LOCALAPPDATA `
+    'PinyonShift\source\0.1.0\.local\preview'
+.\tools\capture-native-renderer-dispatch.ps1 `
+    -StateRoot $stateRoot `
+    -StaticOutput .local\qualification\native-dispatch-static.json
+```
+
+After a clean exit, correlate the diagnostics JSONL with the static inventory:
+
+```powershell
+python .\tools\summarize-native-renderer-dispatch.py `
+    <diagnostics.jsonl> `
+    --static .local\qualification\native-dispatch-static.json `
+    --output .local\qualification\native-dispatch-runtime.json
+```
+
+The summarizer requires one read-only session summary, verifies aggregate
+caller counts, rejects any session that does not prove the no-mutation safety
+boundary, and labels every semantic identity `unknown`. An unmatched `LR` is
+retained rather than guessed.
+
+## AppData qualification — 2026-08-29
+
+Clean Release executable
+`67794B647E91049F9B818EFFC21053527520DFCB78F48A0E28B7182A9CF3FCFA`
+ran against the installed `0.1.0` AppData save through menu, save load, and
+live festival gameplay. Session `20260829T102356Z-p41836` exited normally.
+
+The 5,302-frame capture observed 110,057 indexed-wrapper calls, all from entry
+`LR` `0x824079FC`. Static correlation resolves that address to the sole call at
+`0x824079F8` in `sub_824079B8`. The caller table had zero overflow, the immediate
+wrapper was not observed, and the summary proves no guest payload read, guest
+state mutation, control-flow change, or suppression. This promotes
+`sub_824079B8` to the next wrapper-layer discovery seed, not to a semantic
+render-family identity.
+
+Performance telemetry covered 152.765 seconds: median derived FPS was 30.755,
+simulation cadence was 29.621 Hz, presentation cadence was 59.988 Hz, and
+texture/pipeline cache hit rates were 99.978%/100%. No crash, fatal error,
+device loss, or unexpected shutdown appeared. The local visual evidence is
+`native-renderer-dispatch-appdata-20260829.png`, SHA-256
+`F0368B13C31951126D6B87ECA24A904CD718B79C59AEB20D0B11C83E42777E79`.
+
+## Next promotion gate
+
+A direct caller becomes a semantic hook candidate only after independent scene
+captures show a stable association and the relevant object, instance,
+material, transform, visibility, LOD, streaming, and destruction ownership is
+understood. Required coverage remains world, vehicle, road, HUD, garage,
+mirror, shadow, exposure, livery, thumbnail, and rewind.
+
+Resolve, query, tiled-rendering, resource-lifetime, and dirty-state-clear
+wrappers remain open title-side inventory work. Until those gates are met,
+all work stays on Xenos and no new draw family may be suppressed.

--- a/docs/native-renderer/RENDER_PASS_CENSUS.md
+++ b/docs/native-renderer/RENDER_PASS_CENSUS.md
@@ -23,9 +23,9 @@ cvar at its default it must preserve the original instruction, registers,
 arguments, and control flow. General runtime fixes remain in
 `src/pinyon_shift_runtime_hooks.cpp`.
 
-This first change adds no native RHI, guest payload capture, Xenos suppression,
-or presentation changes. The only setting is
-`pinyon_shift_native_renderer_census`, and it defaults to `false`.
+The dispatch-discovery extension adds no native RHI, guest payload capture,
+Xenos suppression, or presentation changes. Its setting,
+`pinyon_shift_native_renderer_dispatch_discovery`, defaults to `false`.
 
 ## Verified inventory
 
@@ -34,7 +34,9 @@ or presentation changes. The only setting is
 | System command-buffer request | `0x829EFD80` | `sub_829EFB30` calls `VdGetSystemCommandBuffer`; output pointers are passed in `r3` and `r4` | The returned buffer cursor is subsequently written into the graphics-device object | Verified, not hooked |
 | Frame submission | `0x829EFEB8` | `sub_829EFB30` calls the sole `VdSwap` import; continuation is `0x829EFEBC` | Device command-buffer cursor is updated after return | Verified, pass-through hook |
 | Xenos swap packet | ReXGlue `CommandProcessor::ExecutePacketType3_XE_SWAP` | Consumes the `VdSwap` packet and calls backend `IssueSwap` | ReXGlue snapshots/reset per-frame counters before decoding the packet payload | Verified runtime boundary |
-| Draw packet | ReXGlue `PM4_DRAW_INDX` / `PM4_DRAW_INDX_2` | Generic command processor decodes the packet before backend `IssueDraw` | Register-derived draw state is consumed by the backend | Backend boundary verified; title wrapper unknown |
+| Indexed draw wrapper | `0x8240F4D8` | Stored `PM4_DRAW_INDX_2` header at `0x82410320`; dynamic Type-3 count | First three GPR arguments and caller `LR` are observed only when discovery is enabled | Verified, bounded pass-through hook |
+| Immediate draw wrapper | `0x829F7C70` | Stored count-one `PM4_DRAW_INDX_2` header at `0x829F7CA8` | First three GPR arguments and caller `LR` are observed only when discovery is enabled | Verified, bounded pass-through hook |
+| Draw packet backend | ReXGlue `PM4_DRAW_INDX` / `PM4_DRAW_INDX_2` | Generic command processor decodes the packet before backend `IssueDraw` | Register-derived draw state is consumed by the backend | Verified runtime boundary |
 | Resolve/copy | ReXGlue backend `IssueCopy` | Triggered by the Xenos copy path | Render-target and guest-memory dependencies may be produced | Backend boundary verified; title wrapper unknown |
 
 ## Bounded draw observation
@@ -82,12 +84,16 @@ read or serialize guest memory.
 
 ## Open inventory work
 
-- Prove the FH1 draw-wrapper families and their ABI before adding draw hooks.
+- Prove whether the title has a stored `PM4_DRAW_INDX` (`0x22`) constructor.
 - Locate the title-side resolve and query wrapper families.
 - Establish where each wrapper consumes or clears dirty graphics state.
 - Inventory memexport-producing draws and guest-visible resolve destinations.
 - Map high-level world, vehicle, road, HUD, garage, mirror, shadow, exposure,
   livery, thumbnail, and rewind dispatch families.
+
+The proved wrapper entries, all 11 static direct calls, runtime correlation
+contract, and explicit semantic unknowns are recorded in
+[`HIGH_LEVEL_RENDER_HOOKS.md`](HIGH_LEVEL_RENDER_HOOKS.md).
 
 Resolve-to-texture dependency tracking is documented in
 `GUEST_VISIBLE_RENDER_DEPENDENCIES.md`. The evidence-based classifier and scene

--- a/src/native_renderer/graphics_hooks.cpp
+++ b/src/native_renderer/graphics_hooks.cpp
@@ -22,6 +22,7 @@
 #include <rex/cvar.h>
 #include <rex/graphics/xenos.h>
 #include <rex/memory.h>
+#include <rex/ppc/context.h>
 #include <rex/system/interfaces/graphics.h>
 #include <rex/system/kernel_state.h>
 #include <rex/system/xmemory.h>
@@ -33,6 +34,10 @@
 REXCVAR_DEFINE_BOOL(
     pinyon_shift_native_renderer_census, false, "Pinyon Shift",
     "Record bounded native-renderer census metadata without changing rendering")
+    .lifecycle(rex::cvar::Lifecycle::kRequiresRestart);
+REXCVAR_DEFINE_BOOL(
+    pinyon_shift_native_renderer_dispatch_discovery, false, "Pinyon Shift",
+    "Record bounded title draw-wrapper caller metadata without changing rendering")
     .lifecycle(rex::cvar::Lifecycle::kRequiresRestart);
 REXCVAR_DEFINE_BOOL(
     pinyon_shift_native_renderer_sky_horizon_suppression, false,
@@ -66,9 +71,163 @@ constexpr uint64_t kPassPublicationDetailLimit = 64;
 constexpr uint64_t kSuppressionWarmupFrameCount = 8;
 constexpr uint64_t kSuppressionFailureCooldownFrameCount = 120;
 constexpr uint64_t kSuppressionStateDetailLimit = 32;
+constexpr size_t kDispatchCallerCapacity = 256;
 constexpr uint64_t kSkyHorizonAnchorSignature = UINT64_C(0x747837906D0BF484);
 constexpr uint64_t kSkyHorizonFollowerSignature = UINT64_C(0x1D253A52B55C9FB3);
 std::atomic<uint64_t> g_frame_sequence{};
+
+enum class DispatchWrapper : uint32_t {
+  kDrawIndexed = 1,
+  kDrawImmediate = 2,
+};
+
+struct DispatchCallerEntry {
+  std::atomic<uint64_t> key{};
+  std::atomic<uint64_t> calls{};
+  std::atomic<uint64_t> first_frame{};
+  std::atomic<uint32_t> first_r3{};
+  std::atomic<uint32_t> first_r4{};
+  std::atomic<uint32_t> first_r5{};
+};
+
+std::array<DispatchCallerEntry, kDispatchCallerCapacity> g_dispatch_callers;
+std::atomic<uint64_t> g_dispatch_caller_overflow{};
+std::atomic<bool> g_dispatch_discovery_installed{};
+
+const char *DispatchWrapperName(DispatchWrapper wrapper) {
+  switch (wrapper) {
+  case DispatchWrapper::kDrawIndexed:
+    return "draw_indexed";
+  case DispatchWrapper::kDrawImmediate:
+    return "draw_immediate";
+  }
+  return "unknown";
+}
+
+const char *DispatchWrapperAddress(DispatchWrapper wrapper) {
+  switch (wrapper) {
+  case DispatchWrapper::kDrawIndexed:
+    return "8240F4D8";
+  case DispatchWrapper::kDrawImmediate:
+    return "829F7C70";
+  }
+  return "00000000";
+}
+
+void ResetDispatchDiscovery() {
+  for (DispatchCallerEntry &entry : g_dispatch_callers) {
+    entry.key.store(0, std::memory_order_relaxed);
+    entry.calls.store(0, std::memory_order_relaxed);
+    entry.first_frame.store(0, std::memory_order_relaxed);
+    entry.first_r3.store(0, std::memory_order_relaxed);
+    entry.first_r4.store(0, std::memory_order_relaxed);
+    entry.first_r5.store(0, std::memory_order_relaxed);
+  }
+  g_dispatch_caller_overflow.store(0, std::memory_order_relaxed);
+}
+
+void ConfigureDispatchDiscovery() {
+  ResetDispatchDiscovery();
+  const bool requested =
+      REXCVAR_GET(pinyon_shift_native_renderer_dispatch_discovery);
+  g_dispatch_discovery_installed.store(requested, std::memory_order_release);
+  pinyon_shift::diagnostics::RecordEvent(
+      "native_renderer.discovery.dispatch_config",
+      {{"status", requested ? "armed" : "disabled"},
+       {"wrappers", "8240F4D8,829F7C70"},
+       {"caller_capacity", std::to_string(kDispatchCallerCapacity)},
+       {"metadata", "entry_lr_via_r12,r3,r4,r5,frame"},
+       {"guest_payload_read", "false"},
+       {"xenos_draw", "preserved"},
+       {"suppression_eligible", "false"}});
+}
+
+void ObserveTitleDispatch(DispatchWrapper wrapper, uint32_t caller,
+                          uint32_t r3, uint32_t r4, uint32_t r5) {
+  if (!g_dispatch_discovery_installed.load(std::memory_order_acquire)) {
+    return;
+  }
+  const uint32_t caller_key = caller ? caller : 1;
+  const uint64_t key = (static_cast<uint64_t>(wrapper) << 32) | caller_key;
+  size_t index = (caller_key ^ (caller_key >> 11)) % kDispatchCallerCapacity;
+  for (size_t probe = 0; probe < kDispatchCallerCapacity; ++probe) {
+    DispatchCallerEntry &entry = g_dispatch_callers[index];
+    uint64_t observed = entry.key.load(std::memory_order_acquire);
+    if (observed == key) {
+      entry.calls.fetch_add(1, std::memory_order_relaxed);
+      return;
+    }
+    if (observed == 0 &&
+        entry.key.compare_exchange_strong(observed, key,
+                                          std::memory_order_acq_rel)) {
+      // Publish the initial count before the descriptive first-sample fields.
+      // A second graphics thread may observe the claimed key immediately; its
+      // fetch_add must not be overwritten by a late initializing store.
+      entry.calls.store(1, std::memory_order_release);
+      entry.first_frame.store(g_frame_sequence.load(std::memory_order_relaxed),
+                              std::memory_order_relaxed);
+      entry.first_r3.store(r3, std::memory_order_relaxed);
+      entry.first_r4.store(r4, std::memory_order_relaxed);
+      entry.first_r5.store(r5, std::memory_order_relaxed);
+      return;
+    }
+    index = (index + 1) % kDispatchCallerCapacity;
+  }
+  g_dispatch_caller_overflow.fetch_add(1, std::memory_order_relaxed);
+}
+
+void EmitDispatchDiscoverySummary() {
+  if (!g_dispatch_discovery_installed.exchange(false,
+                                                std::memory_order_acq_rel)) {
+    return;
+  }
+  uint64_t tracked_calls = 0;
+  uint64_t tracked_callers = 0;
+  for (const DispatchCallerEntry &entry : g_dispatch_callers) {
+    const uint64_t calls = entry.calls.load(std::memory_order_acquire);
+    const uint64_t key = entry.key.load(std::memory_order_acquire);
+    if (!calls || !key) {
+      continue;
+    }
+    const auto wrapper = static_cast<DispatchWrapper>(key >> 32);
+    const uint32_t caller = static_cast<uint32_t>(key);
+    tracked_calls += calls;
+    ++tracked_callers;
+    pinyon_shift::diagnostics::RecordEvent(
+        "native_renderer.discovery.dispatch_caller",
+        {{"wrapper", DispatchWrapperName(wrapper)},
+         {"wrapper_address", DispatchWrapperAddress(wrapper)},
+         {"caller", fmt::format("{:08X}", caller)},
+         {"calls", std::to_string(calls)},
+         {"first_frame",
+          std::to_string(entry.first_frame.load(std::memory_order_relaxed))},
+         {"first_r3",
+          fmt::format("{:08X}",
+                      entry.first_r3.load(std::memory_order_relaxed))},
+         {"first_r4",
+          fmt::format("{:08X}",
+                      entry.first_r4.load(std::memory_order_relaxed))},
+         {"first_r5",
+          fmt::format("{:08X}",
+                      entry.first_r5.load(std::memory_order_relaxed))},
+         {"mode", "read_only_metadata"},
+         {"xenos_draw", "preserved"},
+         {"suppression_eligible", "false"}});
+  }
+  pinyon_shift::diagnostics::RecordEvent(
+      "native_renderer.discovery.dispatch_summary",
+      {{"tracked_callers", std::to_string(tracked_callers)},
+       {"tracked_calls", std::to_string(tracked_calls)},
+       {"overflow_calls",
+        std::to_string(
+            g_dispatch_caller_overflow.load(std::memory_order_relaxed))},
+       {"capacity", std::to_string(kDispatchCallerCapacity)},
+       {"guest_payload_read", "false"},
+       {"guest_state_changed", "false"},
+       {"control_flow_changed", "false"},
+       {"xenos_authority", "true"},
+       {"suppression_allowed", "false"}});
+}
 
 std::string CensusSceneMarker() {
   char *value = nullptr;
@@ -4104,6 +4263,7 @@ void InstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system,
   if (!graphics_system || !memory) {
     return;
   }
+  ConfigureDispatchDiscovery();
   g_sky_horizon_suppression = {};
   g_sky_horizon_suppression.requested =
       REXCVAR_GET(pinyon_shift_native_renderer_sky_horizon_suppression);
@@ -4312,6 +4472,7 @@ void UninstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system) {
     graphics_system->SetPreparedDrawObserver(nullptr);
     graphics_system->SetIsolatedDrawRequestObserver(nullptr);
   }
+  EmitDispatchDiscoverySummary();
   if (!g_graphics_census_installed) {
     return;
   }
@@ -4773,7 +4934,11 @@ void UninstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system) {
 // All renderer experiments remain passive until their own explicit cvars are
 // enabled and must dispatch through this owner.
 void PinyonShiftObserveGraphicsFrame() {
-  if (!REXCVAR_GET(pinyon_shift_native_renderer_census)) {
+  const bool census_requested =
+      REXCVAR_GET(pinyon_shift_native_renderer_census);
+  const bool dispatch_requested =
+      REXCVAR_GET(pinyon_shift_native_renderer_dispatch_discovery);
+  if (!census_requested && !dispatch_requested) {
     return;
   }
 
@@ -4784,8 +4949,31 @@ void PinyonShiftObserveGraphicsFrame() {
   }
 
   const std::string frame = std::to_string(frame_sequence);
-  pinyon_shift::diagnostics::RecordEvent("native_renderer.census.frame",
-                                         {{"frame_sequence", frame},
-                                          {"guest_address", "829EFEB8"},
-                                          {"mode", "pass_through"}});
+  if (census_requested) {
+    pinyon_shift::diagnostics::RecordEvent("native_renderer.census.frame",
+                                           {{"frame_sequence", frame},
+                                            {"guest_address", "829EFEB8"},
+                                            {"mode", "pass_through"}});
+  }
+  if (dispatch_requested) {
+    pinyon_shift::diagnostics::RecordEvent(
+        "native_renderer.discovery.dispatch_frame",
+        {{"frame_sequence", frame},
+         {"guest_address", "829EFEB8"},
+         {"mode", "read_only_metadata"}});
+  }
+}
+
+void PinyonShiftObserveDrawIndexedDispatch(PPCRegister &r3, PPCRegister &r4,
+                                           PPCRegister &r5,
+                                           PPCRegister &r12) {
+  ObserveTitleDispatch(DispatchWrapper::kDrawIndexed, r12.u32, r3.u32, r4.u32,
+                       r5.u32);
+}
+
+void PinyonShiftObserveDrawImmediateDispatch(PPCRegister &r3, PPCRegister &r4,
+                                             PPCRegister &r5,
+                                             PPCRegister &r12) {
+  ObserveTitleDispatch(DispatchWrapper::kDrawImmediate, r12.u32, r3.u32, r4.u32,
+                       r5.u32);
 }

--- a/tools/capture-native-renderer-dispatch.ps1
+++ b/tools/capture-native-renderer-dispatch.ps1
@@ -1,0 +1,74 @@
+[CmdletBinding()]
+param(
+    [string]$StateRoot,
+    [string]$StaticOutput,
+    [switch]$Json
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$repositoryRoot = Split-Path $PSScriptRoot -Parent
+if (-not $StateRoot) {
+    $sourceRoot = Join-Path $env:LOCALAPPDATA 'PinyonShift\source'
+    $profile = Get-ChildItem -LiteralPath $sourceRoot -Recurse -File `
+        -ErrorAction SilentlyContinue |
+        Where-Object {
+            $_.Name -eq 'ForzaProfile' -and
+            $_.Directory.Name -eq 'ForzaProfile'
+        } |
+        Sort-Object LastWriteTimeUtc -Descending |
+        Select-Object -First 1
+    if ($null -eq $profile) {
+        throw "No installed preview ForzaProfile was found under $sourceRoot"
+    }
+    $separator = [IO.Path]::DirectorySeparatorChar
+    $marker = "${separator}user${separator}"
+    $markerIndex = $profile.FullName.IndexOf(
+        $marker, [StringComparison]::OrdinalIgnoreCase)
+    if ($markerIndex -lt 0) {
+        throw "The discovered profile is not under a preview user tree: $($profile.FullName)"
+    }
+    $StateRoot = $profile.FullName.Substring(0, $markerIndex)
+}
+
+$resolvedStateRoot = [IO.Path]::GetFullPath($StateRoot)
+$profiles = @(Get-ChildItem -LiteralPath (Join-Path $resolvedStateRoot 'user') `
+    -Recurse -File -ErrorAction SilentlyContinue |
+    Where-Object {
+        $_.Name -eq 'ForzaProfile' -and
+        $_.Directory.Name -eq 'ForzaProfile'
+    })
+if ($profiles.Count -eq 0) {
+    throw "No ForzaProfile save exists under $resolvedStateRoot\user"
+}
+if (@(Get-Process -Name 'pinyon_shift' -ErrorAction SilentlyContinue).Count -ne 0) {
+    throw 'Pinyon Shift is already running.'
+}
+
+if ($StaticOutput) {
+    $localRoot = [IO.Path]::GetFullPath((Join-Path $repositoryRoot '.local'))
+    $resolvedStaticOutput = [IO.Path]::GetFullPath($StaticOutput)
+    $localPrefix = $localRoot.TrimEnd([IO.Path]::DirectorySeparatorChar) +
+        [IO.Path]::DirectorySeparatorChar
+    if (-not $resolvedStaticOutput.StartsWith(
+            $localPrefix, [StringComparison]::OrdinalIgnoreCase)) {
+        throw "StaticOutput must be below $localRoot"
+    }
+    $generatedRoot = Join-Path $repositoryRoot '.local\generated\default'
+    & python (Join-Path $PSScriptRoot 'discover-native-renderer-dispatch.py') `
+        $generatedRoot --output $resolvedStaticOutput
+    if ($LASTEXITCODE -ne 0) {
+        throw 'Static dispatch discovery failed.'
+    }
+}
+
+$savedDiscovery = $env:REX_PINYON_SHIFT_NATIVE_RENDERER_DISPATCH_DISCOVERY
+try {
+    $env:REX_PINYON_SHIFT_NATIVE_RENDERER_DISPATCH_DISCOVERY = 'true'
+    & (Join-Path $PSScriptRoot 'launch-preview.ps1') `
+        -StateRoot $resolvedStateRoot -Json:$Json
+}
+finally {
+    $env:REX_PINYON_SHIFT_NATIVE_RENDERER_DISPATCH_DISCOVERY = $savedDiscovery
+}

--- a/tools/discover-native-renderer-dispatch.py
+++ b/tools/discover-native-renderer-dispatch.py
@@ -1,0 +1,234 @@
+"""Inventory reviewed FH1 draw-packet constructors from generated AOT code.
+
+This tool is intentionally payload-free.  It reads generated C++ instruction
+comments, identifies stores of PM4_DRAW_INDX_2 packet headers, and records the
+direct title call sites for the two reviewed runtime wrappers.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import pathlib
+import re
+import sys
+
+
+SCHEMA = "pinyon-shift.native-renderer-dispatch-static.v1"
+DRAW_OPCODE = 0x36
+DRAW_OPCODE_IMMEDIATE = 0x22
+REVIEWED_WRAPPERS = {
+    0x8240F4D8: "draw_indexed",
+    0x829F7C70: "draw_immediate",
+}
+INITIALIZATION_CONSTRUCTORS = {
+    0x829E82D0,
+    0x829E8428,
+    0x829EDB68,
+}
+
+FUNCTION_RE = re.compile(r"^DEFINE_REX_FUNC\(sub_([0-9A-F]{8})\) \{")
+LABEL_RE = re.compile(r"^loc_([0-9A-F]{8}):")
+COMMENT_RE = re.compile(r"^\s*//\s+(.+?)\s*$")
+ORI_RE = re.compile(r"ori (r\d+),\1,(\d+)$")
+STORE_RE = re.compile(r"stw(?:u|x|ux)? (r\d+),.*$")
+LIS_RE = re.compile(r"lis (r\d+),(-?\d+)$")
+ORIS_RE = re.compile(r"oris (r\d+),\1,(\d+)$")
+CALL_RE = re.compile(r"bl 0x([0-9a-fA-F]{8})$")
+
+
+def parse_functions(paths: list[pathlib.Path]) -> list[dict]:
+    functions: list[dict] = []
+    for path in sorted(paths, key=lambda item: item.as_posix()):
+        current = None
+        address = None
+        for line_number, line in enumerate(
+            path.read_text(encoding="utf-8").splitlines(), 1
+        ):
+            match = FUNCTION_RE.match(line)
+            if match:
+                address = int(match.group(1), 16)
+                current = {
+                    "address": address,
+                    "name": "sub_{}".format(match.group(1)),
+                    "source": path.as_posix(),
+                    "line": line_number,
+                    "instructions": [],
+                }
+                functions.append(current)
+                continue
+            label = LABEL_RE.match(line)
+            if current and label:
+                address = int(label.group(1), 16)
+                continue
+            comment = COMMENT_RE.match(line)
+            if current and comment and address is not None:
+                current["instructions"].append(
+                    {"address": address, "text": comment.group(1)}
+                )
+                address += 4
+    return functions
+
+
+def find_prior(
+    instructions: list[dict], index: int, pattern: re.Pattern, register: str
+):
+    for instruction in reversed(instructions[max(0, index - 24) : index]):
+        match = pattern.fullmatch(instruction["text"])
+        if match and match.group(1) == register:
+            return instruction, match
+    return None, None
+
+
+def packet_constructors(functions: list[dict]) -> list[dict]:
+    constructors = []
+    for function in functions:
+        instructions = function["instructions"]
+        for index, instruction in enumerate(instructions):
+            match = ORI_RE.fullmatch(instruction["text"])
+            if not match or int(match.group(2)) != DRAW_OPCODE << 8:
+                continue
+            register = match.group(1)
+            stored = any(
+                (store := STORE_RE.fullmatch(item["text"]))
+                and store.group(1) == register
+                for item in instructions[index + 1 : index + 13]
+            )
+            if not stored:
+                continue
+            lis_instruction, lis = find_prior(
+                instructions, index, LIS_RE, register
+            )
+            oris_instruction, oris = find_prior(
+                instructions, index, ORIS_RE, register
+            )
+            header_source = "unknown"
+            if lis and int(lis.group(2)) == -16384:
+                header_source = "fixed_type3_count_1"
+            elif (
+                oris
+                and int(oris.group(2)) == 49152
+            ):
+                header_source = "dynamic_type3_count"
+            role = "unreviewed"
+            if function["address"] in REVIEWED_WRAPPERS:
+                role = "runtime_wrapper"
+            elif function["address"] in INITIALIZATION_CONSTRUCTORS:
+                role = "initialization_template"
+            constructors.append(
+                {
+                    "function": function["name"],
+                    "function_address": "{:08X}".format(function["address"]),
+                    "constructor_address": "{:08X}".format(
+                        instruction["address"]
+                    ),
+                    "opcode": "PM4_DRAW_INDX_2",
+                    "opcode_value": "{:02X}".format(DRAW_OPCODE),
+                    "header_source": header_source,
+                    "role": role,
+                    "source": function["source"],
+                    "source_line": function["line"],
+                }
+            )
+    return sorted(
+        constructors,
+        key=lambda item: (item["function_address"], item["constructor_address"]),
+    )
+
+
+def direct_calls(functions: list[dict], targets: set[int]) -> list[dict]:
+    calls = []
+    for function in functions:
+        for instruction in function["instructions"]:
+            match = CALL_RE.fullmatch(instruction["text"])
+            if not match:
+                continue
+            target = int(match.group(1), 16)
+            if target not in targets:
+                continue
+            calls.append(
+                {
+                    "wrapper": "{:08X}".format(target),
+                    "wrapper_kind": REVIEWED_WRAPPERS[target],
+                    "caller_function": function["name"],
+                    "caller_function_address": "{:08X}".format(
+                        function["address"]
+                    ),
+                    "callsite": "{:08X}".format(instruction["address"]),
+                    "return_address": "{:08X}".format(
+                        instruction["address"] + 4
+                    ),
+                }
+            )
+    return sorted(calls, key=lambda item: (item["wrapper"], item["callsite"]))
+
+
+def build(paths: list[pathlib.Path]) -> dict:
+    functions = parse_functions(paths)
+    constructors = packet_constructors(functions)
+    constructor_addresses = {
+        int(item["function_address"], 16) for item in constructors
+    }
+    missing = set(REVIEWED_WRAPPERS) - constructor_addresses
+    if missing:
+        raise ValueError(
+            "reviewed draw wrapper packet evidence missing: {}".format(
+                ", ".join("{:08X}".format(address) for address in sorted(missing))
+            )
+        )
+    calls = direct_calls(functions, set(REVIEWED_WRAPPERS))
+    return {
+        "schema": SCHEMA,
+        "input": {
+            "generated_files": len(paths),
+            "functions": len(functions),
+        },
+        "packet_constructors": constructors,
+        "reviewed_wrappers": [
+            {
+                "address": "{:08X}".format(address),
+                "kind": kind,
+                "packet_evidence": "PM4_DRAW_INDX_2",
+                "runtime_trace": "entry_lr_and_bounded_argument_metadata",
+            }
+            for address, kind in sorted(REVIEWED_WRAPPERS.items())
+        ],
+        "direct_calls": calls,
+        "totals": {
+            "packet_constructors": len(constructors),
+            "reviewed_wrappers": len(REVIEWED_WRAPPERS),
+            "direct_calls": len(calls),
+        },
+        "safety": {
+            "guest_payload_read": False,
+            "guest_state_changed": False,
+            "control_flow_changed": False,
+            "xenos_authority": True,
+            "suppression_allowed": False,
+        },
+    }
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("generated_root", type=pathlib.Path)
+    parser.add_argument("--output", required=True, type=pathlib.Path)
+    args = parser.parse_args(argv)
+    try:
+        paths = list(args.generated_root.glob("pinyon_shift_recomp.*.cpp"))
+        if not paths:
+            raise ValueError("no generated AOT C++ files found")
+        document = build(paths)
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(
+            json.dumps(document, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        return 0
+    except (OSError, ValueError) as error:
+        print("native renderer dispatch discovery failed: {}".format(error), file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/summarize-native-renderer-dispatch.py
+++ b/tools/summarize-native-renderer-dispatch.py
@@ -1,0 +1,168 @@
+"""Correlate bounded title draw-wrapper telemetry with static call sites."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import pathlib
+import sys
+
+
+SCHEMA = "pinyon-shift.native-renderer-dispatch-runtime.v1"
+STATIC_SCHEMA = "pinyon-shift.native-renderer-dispatch-static.v1"
+PREFIX = "native_renderer.discovery.dispatch_"
+
+
+def read_events(paths: list[pathlib.Path]) -> list[dict]:
+    events = []
+    for path in paths:
+        for line_number, line in enumerate(
+            path.read_text(encoding="utf-8").splitlines(), 1
+        ):
+            if not line.strip():
+                continue
+            try:
+                event = json.loads(line)
+            except json.JSONDecodeError as error:
+                raise ValueError(f"{path}:{line_number}: invalid JSON: {error}") from error
+            if str(event.get("event", "")).startswith(PREFIX):
+                events.append(event)
+    return events
+
+
+def select_session(events: list[dict], requested: str | None) -> str:
+    if requested:
+        if not any(event.get("session") == requested for event in events):
+            raise ValueError(f"dispatch discovery session not found: {requested}")
+        return requested
+    armed = [
+        str(event.get("session", ""))
+        for event in events
+        if event.get("event") == f"{PREFIX}config"
+        and event.get("status") == "armed"
+    ]
+    if not armed or not armed[-1]:
+        raise ValueError("no armed dispatch discovery session found")
+    return armed[-1]
+
+
+def build(events: list[dict], static: dict, requested: str | None = None) -> dict:
+    if static.get("schema") != STATIC_SCHEMA:
+        raise ValueError("unsupported static dispatch inventory schema")
+    session = select_session(events, requested)
+    selected = [event for event in events if event.get("session") == session]
+    summaries = [
+        event for event in selected if event.get("event") == f"{PREFIX}summary"
+    ]
+    if len(summaries) != 1:
+        raise ValueError("dispatch session must contain exactly one summary")
+    summary = summaries[0]
+    required_safety = {
+        "guest_payload_read": "false",
+        "guest_state_changed": "false",
+        "control_flow_changed": "false",
+        "xenos_authority": "true",
+        "suppression_allowed": "false",
+    }
+    if any(str(summary.get(key)).lower() != value for key, value in required_safety.items()):
+        raise ValueError("dispatch summary does not prove the read-only safety boundary")
+
+    static_calls = {
+        (item["wrapper"], item["return_address"]): item
+        for item in static.get("direct_calls", [])
+    }
+    callers = []
+    for event in selected:
+        if event.get("event") != f"{PREFIX}caller":
+            continue
+        wrapper = str(event.get("wrapper_address", "")).upper()
+        caller = str(event.get("caller", "")).upper()
+        callsite = static_calls.get((wrapper, caller))
+        callers.append(
+            {
+                "wrapper": str(event.get("wrapper", "unknown")),
+                "wrapper_address": wrapper,
+                "caller": caller,
+                "calls": int(event.get("calls", 0)),
+                "first_frame": int(event.get("first_frame", 0)),
+                "first_arguments": {
+                    "r3": str(event.get("first_r3", "")).upper(),
+                    "r4": str(event.get("first_r4", "")).upper(),
+                    "r5": str(event.get("first_r5", "")).upper(),
+                },
+                "static_match": (
+                    {
+                        "caller_function": callsite["caller_function"],
+                        "caller_function_address": callsite[
+                            "caller_function_address"
+                        ],
+                        "callsite": callsite["callsite"],
+                    }
+                    if callsite
+                    else None
+                ),
+                "semantic_identity": "unknown",
+                "suppression_eligible": False,
+            }
+        )
+    callers.sort(key=lambda item: (-item["calls"], item["wrapper"], item["caller"]))
+    observed_calls = sum(item["calls"] for item in callers)
+    observed_callers = len(callers)
+    if observed_calls != int(summary.get("tracked_calls", 0)):
+        raise ValueError("dispatch caller counts do not match the runtime summary")
+    if observed_callers != int(summary.get("tracked_callers", 0)):
+        raise ValueError("dispatch caller cardinality does not match the runtime summary")
+    return {
+        "schema": SCHEMA,
+        "session": session,
+        "frames_observed": max(
+            (int(event.get("frame_sequence", 0)) for event in selected),
+            default=0,
+        ),
+        "callers": callers,
+        "totals": {
+            "tracked_callers": observed_callers,
+            "tracked_calls": observed_calls,
+            "static_matches": sum(
+                item["static_match"] is not None for item in callers
+            ),
+            "unknown_callers": sum(
+                item["static_match"] is None for item in callers
+            ),
+            "overflow_calls": int(summary.get("overflow_calls", 0)),
+        },
+        "qualification": "wrapper_identity_and_frequency_only",
+        "safety": {
+            "metadata_only": True,
+            "guest_payload_read": False,
+            "guest_state_changed": False,
+            "control_flow_changed": False,
+            "xenos_authority": True,
+            "suppression_allowed": False,
+        },
+    }
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("logs", nargs="+", type=pathlib.Path)
+    parser.add_argument("--static", required=True, type=pathlib.Path)
+    parser.add_argument("--session")
+    parser.add_argument("--output", required=True, type=pathlib.Path)
+    args = parser.parse_args(argv)
+    try:
+        static = json.loads(args.static.read_text(encoding="utf-8"))
+        document = build(read_events(args.logs), static, args.session)
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(
+            json.dumps(document, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        return 0
+    except (OSError, ValueError, TypeError, json.JSONDecodeError) as error:
+        print("native renderer dispatch summary failed: {}".format(error), file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/tests/test_native_renderer_dispatch_discovery.py
+++ b/tools/tests/test_native_renderer_dispatch_discovery.py
@@ -1,0 +1,147 @@
+import importlib.util
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+TOOL = ROOT / "tools" / "discover-native-renderer-dispatch.py"
+SPEC = importlib.util.spec_from_file_location("native_dispatch_discovery", TOOL)
+assert SPEC and SPEC.loader
+MODULE = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = MODULE
+SPEC.loader.exec_module(MODULE)
+
+
+def fixture(address, body):
+    return "\n".join(
+        [
+            "DEFINE_REX_FUNC(sub_{:08X}) {{".format(address),
+            "\tREX_FUNC_PROLOGUE();",
+            *["\t// {}".format(line) for line in body],
+            "}",
+        ]
+    )
+
+
+class NativeRendererDispatchDiscoveryTests(unittest.TestCase):
+    def build(self, chunks):
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "pinyon_shift_recomp.1.cpp"
+            path.write_text("\n\n".join(chunks), encoding="utf-8")
+            return MODULE.build([path])
+
+    def test_finds_reviewed_wrappers_and_direct_calls(self):
+        indexed = fixture(
+            0x8240F4D8,
+            [
+                "oris r11,r11,49152",
+                "ori r11,r11,13824",
+                "stwu r11,4(r3)",
+            ],
+        )
+        immediate = fixture(
+            0x829F7C70,
+            [
+                "lis r11,-16384",
+                "ori r11,r11,13824",
+                "stwu r11,4(r3)",
+            ],
+        )
+        caller = fixture(
+            0x82B00000,
+            ["bl 0x8240f4d8", "bl 0x829f7c70"],
+        )
+        document = self.build([indexed, immediate, caller])
+        self.assertEqual(document["totals"]["reviewed_wrappers"], 2)
+        self.assertEqual(document["totals"]["direct_calls"], 2)
+        self.assertEqual(
+            document["packet_constructors"][0]["header_source"],
+            "dynamic_type3_count",
+        )
+        self.assertEqual(
+            document["packet_constructors"][1]["header_source"],
+            "fixed_type3_count_1",
+        )
+        self.assertEqual(document["direct_calls"][0]["return_address"], "82B00004")
+        self.assertFalse(document["safety"]["suppression_allowed"])
+
+    def test_rejects_missing_reviewed_packet_evidence(self):
+        only_one = fixture(
+            0x8240F4D8,
+            [
+                "oris r11,r11,49152",
+                "ori r11,r11,13824",
+                "stwu r11,4(r3)",
+            ],
+        )
+        with self.assertRaisesRegex(ValueError, "829F7C70"):
+            self.build([only_one])
+
+    def test_ignores_matching_numeric_work_without_a_packet_store(self):
+        false_positive = fixture(
+            0x83051E48,
+            ["ori r12,r12,13824", "add r11,r11,r12"],
+        )
+        indexed = fixture(
+            0x8240F4D8,
+            [
+                "oris r11,r11,49152",
+                "ori r11,r11,13824",
+                "stwu r11,4(r3)",
+            ],
+        )
+        immediate = fixture(
+            0x829F7C70,
+            [
+                "lis r11,-16384",
+                "ori r11,r11,13824",
+                "stwu r11,4(r3)",
+            ],
+        )
+        document = self.build([false_positive, indexed, immediate])
+        addresses = {
+            item["function_address"] for item in document["packet_constructors"]
+        }
+        self.assertNotIn("83051E48", addresses)
+
+    def test_runtime_hooks_are_default_off_bounded_and_passive(self):
+        hooks = (ROOT / "src/native_renderer/graphics_hooks.cpp").read_text(
+            encoding="utf-8"
+        )
+        analysis = (ROOT / "config/rexglue/analysis/main-xex.toml").read_text(
+            encoding="utf-8"
+        )
+        capture = (
+            ROOT / "tools/capture-native-renderer-dispatch.ps1"
+        ).read_text(encoding="utf-8")
+        self.assertIn(
+            "pinyon_shift_native_renderer_dispatch_discovery, false", hooks
+        )
+        self.assertIn("kDispatchCallerCapacity = 256", hooks)
+        self.assertIn('"suppression_allowed", "false"', hooks)
+        claim = hooks.index("entry.key.compare_exchange_strong")
+        initial_count = hooks.index("entry.calls.store(1", claim)
+        first_sample = hooks.index("entry.first_frame.store", claim)
+        self.assertLess(initial_count, first_sample)
+        self.assertEqual(
+            analysis.count('name = "PinyonShiftObserveDrawIndexedDispatch"'), 1
+        )
+        self.assertEqual(
+            analysis.count('name = "PinyonShiftObserveDrawImmediateDispatch"'),
+            1,
+        )
+        self.assertIn('address = 0x8240F4DC', analysis)
+        self.assertIn('address = 0x829F7C74', analysis)
+        self.assertIn('registers = ["r3", "r4", "r5", "r12"]', analysis)
+        self.assertIn(
+            "REX_PINYON_SHIFT_NATIVE_RENDERER_DISPATCH_DISCOVERY", capture
+        )
+        self.assertIn("launch-preview.ps1", capture)
+        for forbidden in ("SetDrawSuppression", "SetCopySuppression"):
+            self.assertNotIn(forbidden, hooks + analysis + capture)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/tests/test_native_renderer_dispatch_summary.py
+++ b/tools/tests/test_native_renderer_dispatch_summary.py
@@ -1,0 +1,99 @@
+import importlib.util
+import sys
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+TOOL = ROOT / "tools" / "summarize-native-renderer-dispatch.py"
+SPEC = importlib.util.spec_from_file_location("native_dispatch_summary", TOOL)
+assert SPEC and SPEC.loader
+MODULE = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = MODULE
+SPEC.loader.exec_module(MODULE)
+
+
+def static_inventory():
+    return {
+        "schema": MODULE.STATIC_SCHEMA,
+        "direct_calls": [
+            {
+                "wrapper": "8240F4D8",
+                "return_address": "82B2BD78",
+                "caller_function": "sub_82B2B180",
+                "caller_function_address": "82B2B180",
+                "callsite": "82B2BD74",
+            }
+        ],
+    }
+
+
+def events(safe=True):
+    summary = {
+        "event": "native_renderer.discovery.dispatch_summary",
+        "session": "run",
+        "tracked_callers": "1",
+        "tracked_calls": "12",
+        "overflow_calls": "0",
+        "guest_payload_read": "false",
+        "guest_state_changed": "false",
+        "control_flow_changed": "false",
+        "xenos_authority": "true",
+        "suppression_allowed": "false" if safe else "true",
+    }
+    return [
+        {
+            "event": "native_renderer.discovery.dispatch_config",
+            "session": "run",
+            "status": "armed",
+        },
+        {
+            "event": "native_renderer.discovery.dispatch_frame",
+            "session": "run",
+            "frame_sequence": "300",
+        },
+        {
+            "event": "native_renderer.discovery.dispatch_caller",
+            "session": "run",
+            "wrapper": "draw_indexed",
+            "wrapper_address": "8240F4D8",
+            "caller": "82B2BD78",
+            "calls": "12",
+            "first_frame": "4",
+            "first_r3": "10000000",
+            "first_r4": "00000004",
+            "first_r5": "00000000",
+        },
+        summary,
+    ]
+
+
+class NativeRendererDispatchSummaryTests(unittest.TestCase):
+    def test_correlates_runtime_lr_with_static_callsite(self):
+        document = MODULE.build(events(), static_inventory())
+        self.assertEqual(document["frames_observed"], 300)
+        self.assertEqual(document["totals"]["tracked_calls"], 12)
+        self.assertEqual(document["totals"]["static_matches"], 1)
+        self.assertEqual(
+            document["callers"][0]["static_match"]["callsite"], "82B2BD74"
+        )
+        self.assertEqual(document["callers"][0]["semantic_identity"], "unknown")
+        self.assertFalse(document["safety"]["suppression_allowed"])
+
+    def test_rejects_unsafe_or_incomplete_summary(self):
+        with self.assertRaisesRegex(ValueError, "safety"):
+            MODULE.build(events(safe=False), static_inventory())
+        mismatch = events()
+        mismatch[-1]["tracked_calls"] = "13"
+        with self.assertRaisesRegex(ValueError, "counts"):
+            MODULE.build(mismatch, static_inventory())
+
+    def test_requires_armed_session(self):
+        disabled = events()
+        disabled[0]["status"] = "disabled"
+        with self.assertRaisesRegex(ValueError, "armed"):
+            MODULE.build(disabled, static_inventory())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- prove the indexed and immediate PM4 draw-wrapper entry points from generated MS-2505 code
- add a default-off, fixed-capacity runtime caller census with Xenos preserved
- correlate runtime LR evidence with deterministic static call sites
- document the high-level hook inventory and keep semantic identities explicit unknowns

## Runtime evidence
- AppData session: 20260829T102356Z-p41836
- 5,302 frames, 110,057 indexed-wrapper calls, 1 statically matched caller, 0 overflow
- median derived FPS 30.755; simulation 29.621 Hz; present 59.988 Hz
- normal exit; no crash, fatal error, device loss, mutation, or suppression

## Validation
- Python suite: 247 passed
- tracked Markdown links: passed
- repository boundary: passed
- launcher Release build: passed with 0 warnings/errors
- clean 79-patch preview Release build: passed
- executable SHA-256: 67794B647E91049F9B818EFFC21053527520DFCB78F48A0E28B7182A9CF3FCFA