### PR TITLE
feat(native-renderer): trace title wrapper families

### DIFF
--- a/config/rexglue/analysis/main-xex.toml
+++ b/config/rexglue/analysis/main-xex.toml
@@ -13,20 +13,46 @@ address = 0x829EFEB8
 name = "PinyonShiftObserveGraphicsFrame"
 
 # NR-00/NR-05A title dispatch discovery. Static PM4 construction evidence maps
-# 0x8240F4D8 to the title's indexed draw wrapper and 0x829F7C70 to its embedded-
-# index draw wrapper. Each hook runs after the wrapper's opening mflr r12, so
-# r12 contains the unmodified caller LR while r3-r5 still contain the entry
-# arguments. The bounded, default-off census neither reads guest resource
-# payloads nor changes registers, command packets, or control flow.
+# the draw and visibility-query packet wrappers; 0x824079B8 is the promoted
+# title adapter that directly calls the indexed wrapper. Each hook runs after
+# the wrapper's opening mflr r12, so r12 contains the unmodified caller LR
+# while r3-r10 still contain entry metadata. The bounded, default-off census
+# neither reads guest resource payloads nor changes registers, packets, or
+# control flow.
+[[midasm_hook]]
+address = 0x824079BC
+name = "PinyonShiftObserveDrawAdapterDispatch"
+registers = ["r3", "r4", "r5", "r6", "r7", "r8", "r9", "r10", "r12"]
+
 [[midasm_hook]]
 address = 0x8240F4DC
 name = "PinyonShiftObserveDrawIndexedDispatch"
-registers = ["r3", "r4", "r5", "r12"]
+registers = ["r3", "r4", "r5", "r6", "r7", "r8", "r9", "r10", "r12"]
+
+[[midasm_hook]]
+address = 0x824587DC
+name = "PinyonShiftObserveResolveControllerDispatch"
+registers = ["r3", "r4", "r5", "r6", "r7", "r8", "r9", "r10", "r12"]
+
+[[midasm_hook]]
+address = 0x82458A8C
+name = "PinyonShiftObserveResolveSetupDispatch"
+registers = ["r3", "r4", "r5", "r6", "r7", "r8", "r9", "r10", "r12"]
+
+[[midasm_hook]]
+address = 0x829F21A4
+name = "PinyonShiftObserveVizQueryBeginDispatch"
+registers = ["r3", "r4", "r5", "r6", "r7", "r8", "r9", "r10", "r12"]
+
+[[midasm_hook]]
+address = 0x829F2284
+name = "PinyonShiftObserveVizQueryEndDispatch"
+registers = ["r3", "r4", "r5", "r6", "r7", "r8", "r9", "r10", "r12"]
 
 [[midasm_hook]]
 address = 0x829F7C74
 name = "PinyonShiftObserveDrawImmediateDispatch"
-registers = ["r3", "r4", "r5", "r12"]
+registers = ["r3", "r4", "r5", "r6", "r7", "r8", "r9", "r10", "r12"]
 
 # Microsoft CRT non-local jump pair. These must be semantic codegen hooks so a
 # longjmp restores the host-side PPCContext captured at the setjmp call site.

--- a/docs/native-renderer/HIGH_LEVEL_RENDER_HOOKS.md
+++ b/docs/native-renderer/HIGH_LEVEL_RENDER_HOOKS.md
@@ -15,52 +15,104 @@ The dispatch extension starts from Pinyon Shift `dev` merge
 
 The discovery path is opt-in through
 `pinyon_shift_native_renderer_dispatch_discovery` and defaults to `false`.
-Each wrapper opens with `mflr r12`; the hook on the following instruction
-observes the caller `LR` through `r12` plus unchanged entry `r3`, `r4`, and
-`r5`. A fixed 256-entry atomic table aggregates caller frequency; it does not read guest
-resource payloads or write guest state. The original wrapper, PM4 packet,
-Xenos draw, arguments, registers, and control flow are preserved. Discovery
-records are never suppression evidence.
+Each reviewed wrapper opens with `mflr r12`; the hook on the following
+instruction observes the caller `LR` through `r12` plus unchanged entry
+`r3-r10`. A fixed 256-entry atomic table aggregates caller frequency; it does
+not read guest resource payloads or write guest state. The original wrapper,
+PM4 packet, Xenos work, arguments, registers, and control flow are preserved.
+Discovery records are never suppression evidence.
 
-## Proved draw wrappers
+## Proved wrapper layers
 
-The generated AOT instruction inventory establishes these two runtime wrapper
+The generated AOT instruction inventory establishes seven runtime wrapper
 families:
 
-| Entry | Packet construction | Reviewed identity | Runtime observation |
+| Entry | Static evidence | Reviewed identity | Runtime observation |
 | --- | --- | --- | --- |
-| `0x8240F4D8` | At `0x82410320`, combines a dynamic Type-3 count with opcode `0x36` and stores the resulting `PM4_DRAW_INDX_2` header | Indexed draw wrapper | Hook `0x8240F4DC`: entry `LR` in `r12`, plus `r3-r5` |
-| `0x829F7C70` | At `0x829F7CA8`, stores fixed Type-3 count-one header `0xC0003600`, followed by embedded index/draw metadata | Immediate/embedded-index draw wrapper | Hook `0x829F7C74`: entry `LR` in `r12`, plus `r3-r5` |
+| `0x824079B8` | Directly adapts its entry arguments and calls `0x8240F4D8` at `0x824079F8` | Title draw adapter; semantic family unknown | Hook `0x824079BC`: entry `LR` and `r3-r10` |
+| `0x8240F4D8` | At `0x82410320`, stores a dynamic-count Type-3 `PM4_DRAW_INDX_2` (`0x36`) header | Indexed draw packet wrapper | Hook `0x8240F4DC`: entry `LR` and `r3-r10` |
+| `0x824587D8` | Calls `0x82458A88` at `0x82458828` and `0x824589E4` while managing resolve state | Title resolve controller | Hook `0x824587DC`: entry `LR` and `r3-r10` |
+| `0x82458A88` | Writes register `0x2208` (`RB_MODECONTROL`) followed by value 6 (`EdramMode::kCopy`) at `0x82458AC0`/`0x82458AD4` | Resolve state-packet setup wrapper | Hook `0x82458A8C`: entry `LR` and `r3-r10` |
+| `0x829F21A0` | At `0x829F225C`, stores `0xC0002300`; then marks the query ID active at `0x829F2270` | Visibility-query begin wrapper | Hook `0x829F21A4`: entry `LR` and `r3-r10` |
+| `0x829F2280` | At `0x829F22E4`, stores `0xC0002300`; then clears the active query ID at `0x829F2308` | Visibility-query end wrapper | Hook `0x829F2284`: entry `LR` and `r3-r10` |
+| `0x829F7C70` | At `0x829F7CA8`, stores fixed Type-3 count-one `PM4_DRAW_INDX_2` (`0x36`) header | Immediate/embedded-index draw wrapper | Hook `0x829F7C74`: entry `LR` and `r3-r10` |
 
 Three additional opcode-`0x36` constructors at `0x829E82D0`, `0x829E8428`,
 and `0x829EDB68` build initialization templates. They are inventoried but are
 not runtime draw hooks.
 
 No `PM4_DRAW_INDX` (`0x22`) title constructor has yet passed the same stored-
-header proof. The scanner reports only proved stored opcode-`0x36` headers and
-explicitly rejects a matching numeric operation in `sub_83051E48` because its
-result is not stored as a command packet.
+header proof. The scanner reports only proved stored opcode-`0x36` and
+opcode-`0x23` headers and explicitly rejects a matching numeric operation in
+`sub_83051E48` because its result is not stored as a command packet.
+
+The adapter ABI exposes `r3-r10` at entry and reads two additional stack words
+at entry-stack offsets 92 and 100 before calling the packet wrapper. Those
+stack values are documented by the static inventory but are intentionally not
+read by the passive runtime hook.
+
+## Dirty-state consumption boundary
+
+The indexed packet wrapper consumes and then clears six dirty-mask slices
+before packet emission. Four clears affect the 64-bit word at device offset
+16 (`0x8240FAF4`, `0x8240FB2C`, `0x8240FB74`, `0x8240FBB8`); one affects offset
+24 (`0x8240FC08`); and one affects offset 32 (`0x8240FC40`). Each clear follows
+a state-submission call and a mask operation on the loaded word. The adapter
+hook therefore runs before all six clears. This proves the capture boundary;
+it does not assign semantic names to any mask bit.
+
+## Resolve boundary
+
+ReXGlue's backend boundary remains proved: a Xenos draw with
+`RB_MODECONTROL.edram_mode == kCopy` enters `IssueCopy`. The title side is now
+also bounded: `sub_824587D8` controls the lifecycle and calls
+`sub_82458A88`, which emits the exact `RB_MODECONTROL = kCopy` state pair.
+This proves resolve setup and its controller, not which subsequent draw covers
+the copy rectangle or which semantic system owns the destination. The
+inventory records `title_resolve_setup_and_backend_copy_proved` without using
+timing or dimensions as identity evidence.
 
 ## Static direct callers
 
 `tools/discover-native-renderer-dispatch.py` scans all generated AOT C++ files,
 reconstructs instruction addresses from function entries and labels, and
 produces a deterministic payload-free JSON inventory. At the current baseline
-it finds 11 direct call sites:
+it finds 56 direct call sites: 38 into the promoted adapter, nine into the
+indexed packet wrapper, two into the immediate wrapper, two into resolve
+setup, three into the resolve controller, and one into each visibility-query
+wrapper. The adapter's 38 sites group into 25 caller functions:
 
-| Wrapper | Caller function | Call site | Entry `LR` |
-| --- | --- | --- | --- |
-| `0x8240F4D8` | `sub_824079B8` | `0x824079F8` | `0x824079FC` |
-| `0x8240F4D8` | `sub_82B2B180` | `0x82B2BD74` | `0x82B2BD78` |
-| `0x8240F4D8` | `sub_82B40E60` | `0x82B42294` | `0x82B42298` |
-| `0x8240F4D8` | `sub_82B425B0` | `0x82B4386C` | `0x82B43870` |
-| `0x8240F4D8` | `sub_82B425B0` | `0x82B44420` | `0x82B44424` |
-| `0x8240F4D8` | `sub_82B425B0` | `0x82B44740` | `0x82B44744` |
-| `0x8240F4D8` | `sub_82B425B0` | `0x82B4478C` | `0x82B44790` |
-| `0x8240F4D8` | `sub_82B425B0` | `0x82B449C0` | `0x82B449C4` |
-| `0x8240F4D8` | `sub_82B425B0` | `0x82B44A00` | `0x82B44A04` |
-| `0x829F7C70` | `sub_829F8D88` | `0x829F93F0` | `0x829F93F4` |
-| `0x829F7C70` | `sub_829F9540` | `0x829F9980` | `0x829F9984` |
+| Caller function | Adapter call sites |
+| --- | --- |
+| `sub_823E6EF0` | `0x823E6F4C` |
+| `sub_823F10C8` | `0x823F117C`, `0x823F11BC`, `0x823F12B0`, `0x823F12E4`, `0x823F13DC`, `0x823F1410` |
+| `sub_823F74B0` | `0x823F7590` |
+| `sub_823FA990` | `0x823FAD40` |
+| `sub_82403C38` | `0x824043A8`, `0x82404970` |
+| `sub_824426B8` | `0x82442BF0` |
+| `sub_82461108` | `0x82461334` |
+| `sub_82463AD8` | `0x82463B34` |
+| `sub_82469478` | `0x824695D8`, `0x82469608` |
+| `sub_829F0298` | `0x829F0348` |
+| `sub_829F8D88` | `0x829F94C0` |
+| `sub_82B3FB98` | `0x82B4093C`, `0x82B40BE0`, `0x82B40D70` |
+| `sub_82B40E60` | `0x82B41BB4` |
+| `sub_82C39E98` | `0x82C39F78` |
+| `sub_82C3B7D8` | `0x82C3BCF4` |
+| `sub_82C3BD78` | `0x82C3C2CC`, `0x82C3C2E8`, `0x82C3C31C`, `0x82C3C354` |
+| `sub_82C3F0E0` | `0x82C3F1F0` |
+| `sub_82C8C340` | `0x82C8C62C` |
+| `sub_82C8F000` | `0x82C8F828` |
+| `sub_82C90178` | `0x82C90CB8` |
+| `sub_82C90D88` | `0x82C912F0` |
+| `sub_82C97CA8` | `0x82C98134` |
+| `sub_82DDF158` | `0x82DDF274` |
+| `sub_82E67C48` | `0x82E67FCC` |
+| `sub_8314A138` | `0x8314A194`, `0x8314A1AC` |
+
+The exact lower-wrapper and query-wrapper sites, return addresses, wrapper
+layers, packet constructors, dirty transitions, and hook ABIs remain in the
+versioned JSON rather than a second hand-maintained table.
 
 The entry `LR` is sufficient to correlate runtime frequency with this table.
 It is not sufficient to name a call site terrain, road, vehicle, HUD, or any
@@ -76,6 +128,7 @@ $stateRoot = Join-Path $env:LOCALAPPDATA `
     'PinyonShift\source\0.1.0\.local\preview'
 .\tools\capture-native-renderer-dispatch.ps1 `
     -StateRoot $stateRoot `
+    -Scene open_world `
     -StaticOutput .local\qualification\native-dispatch-static.json
 ```
 
@@ -93,27 +146,43 @@ caller counts, rejects any session that does not prove the no-mutation safety
 boundary, and labels every semantic identity `unknown`. An unmatched `LR` is
 retained rather than guessed.
 
+Repeat each marked scene at least twice, then build a conservative cross-scene
+matrix from the runtime reports:
+
+```powershell
+python .\tools\summarize-native-renderer-dispatch-scenes.py `
+    .local\qualification\dispatch-*.json `
+    --output .local\qualification\native-dispatch-scenes.json
+```
+
+The scene summarizer rejects unsafe reports and duplicate sessions. It can
+label a caller as a stable single- or multi-scene frequency candidate only
+after repeated coverage, but it deliberately leaves `semantic_identity` as
+`unknown` and both promotion and suppression disabled. Frequency is a lead for
+object/lifetime investigation, not semantic proof.
+
 ## AppData qualification — 2026-08-29
 
 Clean Release executable
-`67794B647E91049F9B818EFFC21053527520DFCB78F48A0E28B7182A9CF3FCFA`
+`7FDD30F7FA8F8BDAFEC710770D55C5D91CE5CE59A62F5D7BD1DD3480B478B9A2`
 ran against the installed `0.1.0` AppData save through menu, save load, and
-live festival gameplay. Session `20260829T102356Z-p41836` exited normally.
+live festival gameplay. Session `20260829T105816Z-p27600` exited normally.
 
-The 5,302-frame capture observed 110,057 indexed-wrapper calls, all from entry
-`LR` `0x824079FC`. Static correlation resolves that address to the sole call at
-`0x824079F8` in `sub_824079B8`. The caller table had zero overflow, the immediate
-wrapper was not observed, and the summary proves no guest payload read, guest
-state mutation, control-flow change, or suppression. This promotes
-`sub_824079B8` to the next wrapper-layer discovery seed, not to a semantic
-render-family identity.
+The 7,500-frame capture observed 165,637 title-adapter calls from 14 runtime
+callers and the same 165,637 calls through the indexed packet wrapper. All 15
+runtime caller records matched the static callsite inventory; there were zero
+unknown callers and zero caller-table overflow. Resolve controller/setup,
+query begin/end, and immediate-draw wrappers were not observed in this scene.
+The summary proves no guest payload read, guest-state mutation, control-flow
+change, or suppression. All wrapper and caller identities therefore remain
+packet-layer evidence, not semantic render-family identities.
 
-Performance telemetry covered 152.765 seconds: median derived FPS was 30.755,
-simulation cadence was 29.621 Hz, presentation cadence was 59.988 Hz, and
-texture/pipeline cache hit rates were 99.978%/100%. No crash, fatal error,
+Performance telemetry covered 233.758 seconds: median derived FPS was 30.472,
+simulation cadence was 29.740 Hz, presentation cadence was 59.985 Hz, and
+texture/pipeline cache hit rates were 99.975%/100%. No crash, fatal error,
 device loss, or unexpected shutdown appeared. The local visual evidence is
-`native-renderer-dispatch-appdata-20260829.png`, SHA-256
-`F0368B13C31951126D6B87ECA24A904CD718B79C59AEB20D0B11C83E42777E79`.
+`native-renderer-wrapper-families-open-world.png`, SHA-256
+`93F34AF4AAEB1E75FF58A0E4F726343F70F33C868F6956577B551513D33DBF54`.
 
 ## Next promotion gate
 
@@ -123,6 +192,8 @@ material, transform, visibility, LOD, streaming, and destruction ownership is
 understood. Required coverage remains world, vehicle, road, HUD, garage,
 mirror, shadow, exposure, livery, thumbnail, and rewind.
 
-Resolve, query, tiled-rendering, resource-lifetime, and dirty-state-clear
-wrappers remain open title-side inventory work. Until those gates are met,
-all work stays on Xenos and no new draw family may be suppressed.
+Query begin/end, resolve setup/controller, and the indexed-wrapper dirty-state
+clears are now proved. Resolve-draw ownership, query result ownership,
+tiled-rendering, resource lifetime, and semantic caller identities remain open
+title-side inventory work. Until those gates are met, all work stays on Xenos
+and no new draw family may be suppressed.

--- a/docs/native-renderer/RENDER_PASS_CENSUS.md
+++ b/docs/native-renderer/RENDER_PASS_CENSUS.md
@@ -34,10 +34,15 @@ Xenos suppression, or presentation changes. Its setting,
 | System command-buffer request | `0x829EFD80` | `sub_829EFB30` calls `VdGetSystemCommandBuffer`; output pointers are passed in `r3` and `r4` | The returned buffer cursor is subsequently written into the graphics-device object | Verified, not hooked |
 | Frame submission | `0x829EFEB8` | `sub_829EFB30` calls the sole `VdSwap` import; continuation is `0x829EFEBC` | Device command-buffer cursor is updated after return | Verified, pass-through hook |
 | Xenos swap packet | ReXGlue `CommandProcessor::ExecutePacketType3_XE_SWAP` | Consumes the `VdSwap` packet and calls backend `IssueSwap` | ReXGlue snapshots/reset per-frame counters before decoding the packet payload | Verified runtime boundary |
-| Indexed draw wrapper | `0x8240F4D8` | Stored `PM4_DRAW_INDX_2` header at `0x82410320`; dynamic Type-3 count | First three GPR arguments and caller `LR` are observed only when discovery is enabled | Verified, bounded pass-through hook |
-| Immediate draw wrapper | `0x829F7C70` | Stored count-one `PM4_DRAW_INDX_2` header at `0x829F7CA8` | First three GPR arguments and caller `LR` are observed only when discovery is enabled | Verified, bounded pass-through hook |
+| Title draw adapter | `0x824079B8` | Direct call to indexed wrapper at `0x824079F8`; 38 call sites across 25 caller functions | Entry `r3-r10` and caller `LR` are observed only when discovery is enabled; stack arguments remain unread | Verified, bounded pass-through hook; semantic family unknown |
+| Indexed draw wrapper | `0x8240F4D8` | Stored `PM4_DRAW_INDX_2` header at `0x82410320`; dynamic Type-3 count | Entry `r3-r10` and caller `LR` are observed; six consume-then-clear dirty-mask sites are statically proved | Verified, bounded pass-through hook |
+| Immediate draw wrapper | `0x829F7C70` | Stored count-one `PM4_DRAW_INDX_2` header at `0x829F7CA8` | Entry `r3-r10` and caller `LR` are observed only when discovery is enabled | Verified, bounded pass-through hook |
+| Visibility-query begin | `0x829F21A0` | Stored count-one `PM4_VIZ_QUERY` header at `0x829F225C`; active-query bit set at `0x829F2270` | Entry `r3-r10` and caller `LR` are observed only when discovery is enabled | Verified, bounded pass-through hook |
+| Visibility-query end | `0x829F2280` | Stored count-one `PM4_VIZ_QUERY` header at `0x829F22E4`; active-query bit cleared at `0x829F2308` | Entry `r3-r10` and caller `LR` are observed only when discovery is enabled | Verified, bounded pass-through hook |
 | Draw packet backend | ReXGlue `PM4_DRAW_INDX` / `PM4_DRAW_INDX_2` | Generic command processor decodes the packet before backend `IssueDraw` | Register-derived draw state is consumed by the backend | Verified runtime boundary |
-| Resolve/copy | ReXGlue backend `IssueCopy` | Triggered by the Xenos copy path | Render-target and guest-memory dependencies may be produced | Backend boundary verified; title wrapper unknown |
+| Resolve controller | `0x824587D8` | Two direct calls to setup wrapper `0x82458A88`; three direct controller callers | Entry `r3-r10` and caller `LR` are observed only when discovery is enabled | Verified, bounded pass-through hook |
+| Resolve setup | `0x82458A88` | Emits `RB_MODECONTROL` register index `0x2208` followed by `EdramMode::kCopy` value 6 | Entry `r3-r10` and caller `LR` are observed only when discovery is enabled | Title setup verified; subsequent resolve draw ownership unknown |
+| Resolve/copy backend | ReXGlue backend `IssueCopy` | Triggered by a Xenos draw while `RB_MODECONTROL.edram_mode == kCopy` | Render-target and guest-memory dependencies may be produced | Verified runtime boundary |
 
 ## Bounded draw observation
 
@@ -85,13 +90,15 @@ read or serialize guest memory.
 ## Open inventory work
 
 - Prove whether the title has a stored `PM4_DRAW_INDX` (`0x22`) constructor.
-- Locate the title-side resolve and query wrapper families.
-- Establish where each wrapper consumes or clears dirty graphics state.
+- Correlate the proved title resolve controller/setup with the subsequent copy
+  draw and its semantic destination owner.
+- Locate query-result ownership beyond the proved begin/end packet wrappers.
+- Extend dirty-state proof beyond the six indexed-wrapper clear sites.
 - Inventory memexport-producing draws and guest-visible resolve destinations.
 - Map high-level world, vehicle, road, HUD, garage, mirror, shadow, exposure,
   livery, thumbnail, and rewind dispatch families.
 
-The proved wrapper entries, all 11 static direct calls, runtime correlation
+The proved wrapper entries, all 56 static direct calls, runtime correlation
 contract, and explicit semantic unknowns are recorded in
 [`HIGH_LEVEL_RENDER_HOOKS.md`](HIGH_LEVEL_RENDER_HOOKS.md).
 
@@ -102,6 +109,22 @@ CPU-read observation, and presentation provenance remain subsequent NR-00
 work.
 
 Unknown work stays on Xenos.
+
+### Wrapper-family qualification — 2026-08-29
+
+The expanded passive wrapper hooks were qualified in session
+`20260829T105816Z-p27600` against the installed `0.1.0` AppData save. The
+7,500-frame report recorded 331,274 total calls: 165,637 through the title draw
+adapter and the same 165,637 through its indexed packet wrapper. Fourteen
+adapter callers and the indexed wrapper's sole caller all matched the static
+inventory, with zero unknown callers and zero overflow.
+
+The run exited normally, retained Xenos authority, and confirmed that the
+hooks performed no guest payload reads, guest-state writes, control-flow
+changes, or suppression. Median derived performance was 30.472 FPS over
+233.758 seconds. The other five proved wrappers were not exercised by this
+festival scene and remain explicitly unclassified pending repeated marked
+scene coverage.
 
 Candidate-specific index, vertex-layout, blend, depth, and raster metadata is
 documented in [`CANDIDATE_DRAW_SELECTION.md`](CANDIDATE_DRAW_SELECTION.md).

--- a/src/native_renderer/graphics_hooks.cpp
+++ b/src/native_renderer/graphics_hooks.cpp
@@ -37,7 +37,7 @@ REXCVAR_DEFINE_BOOL(
     .lifecycle(rex::cvar::Lifecycle::kRequiresRestart);
 REXCVAR_DEFINE_BOOL(
     pinyon_shift_native_renderer_dispatch_discovery, false, "Pinyon Shift",
-    "Record bounded title draw-wrapper caller metadata without changing rendering")
+    "Record bounded title graphics-wrapper caller metadata without changing rendering")
     .lifecycle(rex::cvar::Lifecycle::kRequiresRestart);
 REXCVAR_DEFINE_BOOL(
     pinyon_shift_native_renderer_sky_horizon_suppression, false,
@@ -79,6 +79,11 @@ std::atomic<uint64_t> g_frame_sequence{};
 enum class DispatchWrapper : uint32_t {
   kDrawIndexed = 1,
   kDrawImmediate = 2,
+  kDrawAdapter = 3,
+  kVizQueryBegin = 4,
+  kVizQueryEnd = 5,
+  kResolveController = 6,
+  kResolveSetup = 7,
 };
 
 struct DispatchCallerEntry {
@@ -88,6 +93,11 @@ struct DispatchCallerEntry {
   std::atomic<uint32_t> first_r3{};
   std::atomic<uint32_t> first_r4{};
   std::atomic<uint32_t> first_r5{};
+  std::atomic<uint32_t> first_r6{};
+  std::atomic<uint32_t> first_r7{};
+  std::atomic<uint32_t> first_r8{};
+  std::atomic<uint32_t> first_r9{};
+  std::atomic<uint32_t> first_r10{};
 };
 
 std::array<DispatchCallerEntry, kDispatchCallerCapacity> g_dispatch_callers;
@@ -100,6 +110,16 @@ const char *DispatchWrapperName(DispatchWrapper wrapper) {
     return "draw_indexed";
   case DispatchWrapper::kDrawImmediate:
     return "draw_immediate";
+  case DispatchWrapper::kDrawAdapter:
+    return "draw_adapter";
+  case DispatchWrapper::kVizQueryBegin:
+    return "viz_query_begin";
+  case DispatchWrapper::kVizQueryEnd:
+    return "viz_query_end";
+  case DispatchWrapper::kResolveController:
+    return "resolve_controller";
+  case DispatchWrapper::kResolveSetup:
+    return "resolve_setup";
   }
   return "unknown";
 }
@@ -110,6 +130,16 @@ const char *DispatchWrapperAddress(DispatchWrapper wrapper) {
     return "8240F4D8";
   case DispatchWrapper::kDrawImmediate:
     return "829F7C70";
+  case DispatchWrapper::kDrawAdapter:
+    return "824079B8";
+  case DispatchWrapper::kVizQueryBegin:
+    return "829F21A0";
+  case DispatchWrapper::kVizQueryEnd:
+    return "829F2280";
+  case DispatchWrapper::kResolveController:
+    return "824587D8";
+  case DispatchWrapper::kResolveSetup:
+    return "82458A88";
   }
   return "00000000";
 }
@@ -122,9 +152,16 @@ void ResetDispatchDiscovery() {
     entry.first_r3.store(0, std::memory_order_relaxed);
     entry.first_r4.store(0, std::memory_order_relaxed);
     entry.first_r5.store(0, std::memory_order_relaxed);
+    entry.first_r6.store(0, std::memory_order_relaxed);
+    entry.first_r7.store(0, std::memory_order_relaxed);
+    entry.first_r8.store(0, std::memory_order_relaxed);
+    entry.first_r9.store(0, std::memory_order_relaxed);
+    entry.first_r10.store(0, std::memory_order_relaxed);
   }
   g_dispatch_caller_overflow.store(0, std::memory_order_relaxed);
 }
+
+std::string CensusSceneMarker();
 
 void ConfigureDispatchDiscovery() {
   ResetDispatchDiscovery();
@@ -134,16 +171,20 @@ void ConfigureDispatchDiscovery() {
   pinyon_shift::diagnostics::RecordEvent(
       "native_renderer.discovery.dispatch_config",
       {{"status", requested ? "armed" : "disabled"},
-       {"wrappers", "8240F4D8,829F7C70"},
+       {"scene", CensusSceneMarker()},
+       {"wrappers",
+        "824079B8,8240F4D8,824587D8,82458A88,829F21A0,829F2280,829F7C70"},
        {"caller_capacity", std::to_string(kDispatchCallerCapacity)},
-       {"metadata", "entry_lr_via_r12,r3,r4,r5,frame"},
+       {"metadata", "entry_lr_via_r12,r3-r10,frame"},
        {"guest_payload_read", "false"},
        {"xenos_draw", "preserved"},
        {"suppression_eligible", "false"}});
 }
 
 void ObserveTitleDispatch(DispatchWrapper wrapper, uint32_t caller,
-                          uint32_t r3, uint32_t r4, uint32_t r5) {
+                          uint32_t r3, uint32_t r4, uint32_t r5,
+                          uint32_t r6, uint32_t r7, uint32_t r8,
+                          uint32_t r9, uint32_t r10) {
   if (!g_dispatch_discovery_installed.load(std::memory_order_acquire)) {
     return;
   }
@@ -169,6 +210,11 @@ void ObserveTitleDispatch(DispatchWrapper wrapper, uint32_t caller,
       entry.first_r3.store(r3, std::memory_order_relaxed);
       entry.first_r4.store(r4, std::memory_order_relaxed);
       entry.first_r5.store(r5, std::memory_order_relaxed);
+      entry.first_r6.store(r6, std::memory_order_relaxed);
+      entry.first_r7.store(r7, std::memory_order_relaxed);
+      entry.first_r8.store(r8, std::memory_order_relaxed);
+      entry.first_r9.store(r9, std::memory_order_relaxed);
+      entry.first_r10.store(r10, std::memory_order_relaxed);
       return;
     }
     index = (index + 1) % kDispatchCallerCapacity;
@@ -210,6 +256,21 @@ void EmitDispatchDiscoverySummary() {
          {"first_r5",
           fmt::format("{:08X}",
                       entry.first_r5.load(std::memory_order_relaxed))},
+         {"first_r6",
+          fmt::format("{:08X}",
+                      entry.first_r6.load(std::memory_order_relaxed))},
+         {"first_r7",
+          fmt::format("{:08X}",
+                      entry.first_r7.load(std::memory_order_relaxed))},
+         {"first_r8",
+          fmt::format("{:08X}",
+                      entry.first_r8.load(std::memory_order_relaxed))},
+         {"first_r9",
+          fmt::format("{:08X}",
+                      entry.first_r9.load(std::memory_order_relaxed))},
+         {"first_r10",
+          fmt::format("{:08X}",
+                      entry.first_r10.load(std::memory_order_relaxed))},
          {"mode", "read_only_metadata"},
          {"xenos_draw", "preserved"},
          {"suppression_eligible", "false"}});
@@ -4964,16 +5025,60 @@ void PinyonShiftObserveGraphicsFrame() {
   }
 }
 
-void PinyonShiftObserveDrawIndexedDispatch(PPCRegister &r3, PPCRegister &r4,
-                                           PPCRegister &r5,
-                                           PPCRegister &r12) {
+void PinyonShiftObserveDrawIndexedDispatch(
+    PPCRegister &r3, PPCRegister &r4, PPCRegister &r5, PPCRegister &r6,
+    PPCRegister &r7, PPCRegister &r8, PPCRegister &r9, PPCRegister &r10,
+    PPCRegister &r12) {
   ObserveTitleDispatch(DispatchWrapper::kDrawIndexed, r12.u32, r3.u32, r4.u32,
-                       r5.u32);
+                       r5.u32, r6.u32, r7.u32, r8.u32, r9.u32, r10.u32);
 }
 
-void PinyonShiftObserveDrawImmediateDispatch(PPCRegister &r3, PPCRegister &r4,
-                                             PPCRegister &r5,
-                                             PPCRegister &r12) {
+void PinyonShiftObserveDrawImmediateDispatch(
+    PPCRegister &r3, PPCRegister &r4, PPCRegister &r5, PPCRegister &r6,
+    PPCRegister &r7, PPCRegister &r8, PPCRegister &r9, PPCRegister &r10,
+    PPCRegister &r12) {
   ObserveTitleDispatch(DispatchWrapper::kDrawImmediate, r12.u32, r3.u32, r4.u32,
-                       r5.u32);
+                       r5.u32, r6.u32, r7.u32, r8.u32, r9.u32, r10.u32);
+}
+
+void PinyonShiftObserveDrawAdapterDispatch(
+    PPCRegister &r3, PPCRegister &r4, PPCRegister &r5, PPCRegister &r6,
+    PPCRegister &r7, PPCRegister &r8, PPCRegister &r9, PPCRegister &r10,
+    PPCRegister &r12) {
+  ObserveTitleDispatch(DispatchWrapper::kDrawAdapter, r12.u32, r3.u32, r4.u32,
+                       r5.u32, r6.u32, r7.u32, r8.u32, r9.u32, r10.u32);
+}
+
+void PinyonShiftObserveResolveControllerDispatch(
+    PPCRegister &r3, PPCRegister &r4, PPCRegister &r5, PPCRegister &r6,
+    PPCRegister &r7, PPCRegister &r8, PPCRegister &r9, PPCRegister &r10,
+    PPCRegister &r12) {
+  ObserveTitleDispatch(DispatchWrapper::kResolveController, r12.u32, r3.u32,
+                       r4.u32, r5.u32, r6.u32, r7.u32, r8.u32, r9.u32,
+                       r10.u32);
+}
+
+void PinyonShiftObserveResolveSetupDispatch(
+    PPCRegister &r3, PPCRegister &r4, PPCRegister &r5, PPCRegister &r6,
+    PPCRegister &r7, PPCRegister &r8, PPCRegister &r9, PPCRegister &r10,
+    PPCRegister &r12) {
+  ObserveTitleDispatch(DispatchWrapper::kResolveSetup, r12.u32, r3.u32, r4.u32,
+                       r5.u32, r6.u32, r7.u32, r8.u32, r9.u32, r10.u32);
+}
+
+void PinyonShiftObserveVizQueryBeginDispatch(
+    PPCRegister &r3, PPCRegister &r4, PPCRegister &r5, PPCRegister &r6,
+    PPCRegister &r7, PPCRegister &r8, PPCRegister &r9, PPCRegister &r10,
+    PPCRegister &r12) {
+  ObserveTitleDispatch(DispatchWrapper::kVizQueryBegin, r12.u32, r3.u32,
+                       r4.u32, r5.u32, r6.u32, r7.u32, r8.u32, r9.u32,
+                       r10.u32);
+}
+
+void PinyonShiftObserveVizQueryEndDispatch(
+    PPCRegister &r3, PPCRegister &r4, PPCRegister &r5, PPCRegister &r6,
+    PPCRegister &r7, PPCRegister &r8, PPCRegister &r9, PPCRegister &r10,
+    PPCRegister &r12) {
+  ObserveTitleDispatch(DispatchWrapper::kVizQueryEnd, r12.u32, r3.u32, r4.u32,
+                       r5.u32, r6.u32, r7.u32, r8.u32, r9.u32, r10.u32);
 }

--- a/tools/capture-native-renderer-dispatch.ps1
+++ b/tools/capture-native-renderer-dispatch.ps1
@@ -2,6 +2,8 @@
 param(
     [string]$StateRoot,
     [string]$StaticOutput,
+    [ValidatePattern('^[a-z_]{1,32}$')]
+    [string]$Scene = 'unmarked',
     [switch]$Json
 )
 
@@ -64,11 +66,14 @@ if ($StaticOutput) {
 }
 
 $savedDiscovery = $env:REX_PINYON_SHIFT_NATIVE_RENDERER_DISPATCH_DISCOVERY
+$savedScene = $env:PINYON_SHIFT_NATIVE_RENDERER_SCENE
 try {
     $env:REX_PINYON_SHIFT_NATIVE_RENDERER_DISPATCH_DISCOVERY = 'true'
+    $env:PINYON_SHIFT_NATIVE_RENDERER_SCENE = $Scene
     & (Join-Path $PSScriptRoot 'launch-preview.ps1') `
         -StateRoot $resolvedStateRoot -Json:$Json
 }
 finally {
     $env:REX_PINYON_SHIFT_NATIVE_RENDERER_DISPATCH_DISCOVERY = $savedDiscovery
+    $env:PINYON_SHIFT_NATIVE_RENDERER_SCENE = $savedScene
 }

--- a/tools/discover-native-renderer-dispatch.py
+++ b/tools/discover-native-renderer-dispatch.py
@@ -1,25 +1,70 @@
-"""Inventory reviewed FH1 draw-packet constructors from generated AOT code.
+"""Inventory reviewed FH1 graphics wrappers from generated AOT code.
 
 This tool is intentionally payload-free.  It reads generated C++ instruction
-comments, identifies stores of PM4_DRAW_INDX_2 packet headers, and records the
-direct title call sites for the two reviewed runtime wrappers.
+comments, identifies stored draw and visibility-query packet headers, records
+the direct title call graph, and proves the dirty-mask transitions that happen
+inside the indexed draw wrapper.
 """
 
 from __future__ import annotations
 
 import argparse
+import collections
 import json
 import pathlib
 import re
 import sys
 
 
-SCHEMA = "pinyon-shift.native-renderer-dispatch-static.v1"
-DRAW_OPCODE = 0x36
-DRAW_OPCODE_IMMEDIATE = 0x22
+SCHEMA = "pinyon-shift.native-renderer-dispatch-static.v2"
+PACKET_OPCODES = {
+    0x23: "PM4_VIZ_QUERY",
+    0x36: "PM4_DRAW_INDX_2",
+}
 REVIEWED_WRAPPERS = {
-    0x8240F4D8: "draw_indexed",
-    0x829F7C70: "draw_immediate",
+    0x824079B8: {
+        "kind": "draw_adapter",
+        "layer": "title_adapter",
+        "evidence": "direct_call_to_8240F4D8",
+        "hook_address": 0x824079BC,
+        "stack_argument_offsets": [92, 100],
+    },
+    0x8240F4D8: {
+        "kind": "draw_indexed",
+        "layer": "packet_wrapper",
+        "packet_opcode": 0x36,
+        "hook_address": 0x8240F4DC,
+    },
+    0x824587D8: {
+        "kind": "resolve_controller",
+        "layer": "title_adapter",
+        "evidence": "two_direct_calls_to_82458A88",
+        "hook_address": 0x824587DC,
+    },
+    0x82458A88: {
+        "kind": "resolve_setup",
+        "layer": "state_packet_wrapper",
+        "evidence": "RB_MODECONTROL_0x2208_written_kCopy_6",
+        "hook_address": 0x82458A8C,
+    },
+    0x829F21A0: {
+        "kind": "viz_query_begin",
+        "layer": "packet_wrapper",
+        "packet_opcode": 0x23,
+        "hook_address": 0x829F21A4,
+    },
+    0x829F2280: {
+        "kind": "viz_query_end",
+        "layer": "packet_wrapper",
+        "packet_opcode": 0x23,
+        "hook_address": 0x829F2284,
+    },
+    0x829F7C70: {
+        "kind": "draw_immediate",
+        "layer": "packet_wrapper",
+        "packet_opcode": 0x36,
+        "hook_address": 0x829F7C74,
+    },
 }
 INITIALIZATION_CONSTRUCTORS = {
     0x829E82D0,
@@ -35,6 +80,8 @@ STORE_RE = re.compile(r"stw(?:u|x|ux)? (r\d+),.*$")
 LIS_RE = re.compile(r"lis (r\d+),(-?\d+)$")
 ORIS_RE = re.compile(r"oris (r\d+),\1,(\d+)$")
 CALL_RE = re.compile(r"bl 0x([0-9a-fA-F]{8})$")
+DIRTY_STORE_RE = re.compile(r"std (r\d+),(16|24|32)\(r31\)$")
+QUERY_STATE_STORE_RE = re.compile(r"std (r\d+),12424\(r31\)$")
 
 
 def parse_functions(paths: list[pathlib.Path]) -> list[dict]:
@@ -86,7 +133,13 @@ def packet_constructors(functions: list[dict]) -> list[dict]:
         instructions = function["instructions"]
         for index, instruction in enumerate(instructions):
             match = ORI_RE.fullmatch(instruction["text"])
-            if not match or int(match.group(2)) != DRAW_OPCODE << 8:
+            if not match:
+                continue
+            opcode_value = int(match.group(2)) >> 8
+            if (
+                int(match.group(2)) & 0xFF
+                or opcode_value not in PACKET_OPCODES
+            ):
                 continue
             register = match.group(1)
             stored = any(
@@ -111,9 +164,13 @@ def packet_constructors(functions: list[dict]) -> list[dict]:
             ):
                 header_source = "dynamic_type3_count"
             role = "unreviewed"
-            if function["address"] in REVIEWED_WRAPPERS:
+            reviewed = REVIEWED_WRAPPERS.get(function["address"])
+            if reviewed and reviewed.get("packet_opcode") == opcode_value:
                 role = "runtime_wrapper"
-            elif function["address"] in INITIALIZATION_CONSTRUCTORS:
+            elif (
+                opcode_value == 0x36
+                and function["address"] in INITIALIZATION_CONSTRUCTORS
+            ):
                 role = "initialization_template"
             constructors.append(
                 {
@@ -122,8 +179,8 @@ def packet_constructors(functions: list[dict]) -> list[dict]:
                     "constructor_address": "{:08X}".format(
                         instruction["address"]
                     ),
-                    "opcode": "PM4_DRAW_INDX_2",
-                    "opcode_value": "{:02X}".format(DRAW_OPCODE),
+                    "opcode": PACKET_OPCODES[opcode_value],
+                    "opcode_value": "{:02X}".format(opcode_value),
                     "header_source": header_source,
                     "role": role,
                     "source": function["source"],
@@ -149,7 +206,8 @@ def direct_calls(functions: list[dict], targets: set[int]) -> list[dict]:
             calls.append(
                 {
                     "wrapper": "{:08X}".format(target),
-                    "wrapper_kind": REVIEWED_WRAPPERS[target],
+                    "wrapper_kind": REVIEWED_WRAPPERS[target]["kind"],
+                    "wrapper_layer": REVIEWED_WRAPPERS[target]["layer"],
                     "caller_function": function["name"],
                     "caller_function_address": "{:08X}".format(
                         function["address"]
@@ -163,20 +221,222 @@ def direct_calls(functions: list[dict], targets: set[int]) -> list[dict]:
     return sorted(calls, key=lambda item: (item["wrapper"], item["callsite"]))
 
 
+def dirty_state_clears(functions: list[dict]) -> list[dict]:
+    """Find reviewed consume-then-clear writes in the indexed draw wrapper."""
+    sites = []
+    function = next(
+        (item for item in functions if item["address"] == 0x8240F4D8), None
+    )
+    if function is None:
+        return sites
+    instructions = function["instructions"]
+    for index, instruction in enumerate(instructions):
+        store = DIRTY_STORE_RE.fullmatch(instruction["text"])
+        if not store:
+            continue
+        register, offset = store.groups()
+        prior = instructions[max(0, index - 7) : index]
+        loaded = any(
+            item["text"] == f"ld {register},{offset}(r31)" for item in prior
+        )
+        cleared = any(
+            re.fullmatch(rf"(?:and|rldicr) {register},{register},.+", item["text"])
+            for item in prior
+        )
+        if not loaded or not cleared:
+            continue
+        submission = next(
+            (
+                item
+                for item in reversed(prior)
+                if CALL_RE.fullmatch(item["text"])
+            ),
+            None,
+        )
+        sites.append(
+            {
+                "wrapper": "8240F4D8",
+                "wrapper_kind": "draw_indexed",
+                "address": "{:08X}".format(instruction["address"]),
+                "mask_word_offset": int(offset),
+                "transition": "consume_then_clear",
+                "submission_callsite": (
+                    "{:08X}".format(submission["address"])
+                    if submission
+                    else None
+                ),
+            }
+        )
+    return sites
+
+
+def query_state_transitions(functions: list[dict]) -> list[dict]:
+    sites = []
+    for function in functions:
+        reviewed = REVIEWED_WRAPPERS.get(function["address"])
+        if not reviewed or not reviewed["kind"].startswith("viz_query_"):
+            continue
+        instructions = function["instructions"]
+        for index, instruction in enumerate(instructions):
+            store = QUERY_STATE_STORE_RE.fullmatch(instruction["text"])
+            if not store:
+                continue
+            register = store.group(1)
+            prior = instructions[max(0, index - 5) : index]
+            operation = next(
+                (
+                    item["text"].split(" ", 1)[0]
+                    for item in reversed(prior)
+                    if re.fullmatch(rf"(?:or|andc) {register},.+", item["text"])
+                ),
+                None,
+            )
+            if operation not in ("or", "andc"):
+                continue
+            sites.append(
+                {
+                    "wrapper": "{:08X}".format(function["address"]),
+                    "wrapper_kind": reviewed["kind"],
+                    "address": "{:08X}".format(instruction["address"]),
+                    "active_query_word_offset": 12424,
+                    "transition": "set_active" if operation == "or" else "clear_active",
+                }
+            )
+    return sites
+
+
+def resolve_mode_writes(functions: list[dict]) -> list[dict]:
+    function = next(
+        (item for item in functions if item["address"] == 0x82458A88), None
+    )
+    if function is None:
+        return []
+    instructions = function["instructions"]
+    sites = []
+    for index, instruction in enumerate(instructions):
+        register_match = re.fullmatch(r"li (r\d+),8712", instruction["text"])
+        if not register_match:
+            continue
+        window = instructions[index + 1 : index + 10]
+        value_load = next(
+            (
+                item
+                for item in window
+                if re.fullmatch(r"li (r\d+),6", item["text"])
+            ),
+            None,
+        )
+        register_store = next(
+            (
+                item
+                for item in window
+                if item["text"].startswith(f"stwu {register_match.group(1)},")
+            ),
+            None,
+        )
+        if value_load is None or register_store is None:
+            continue
+        value_register = value_load["text"].split(" ", 1)[1].split(",", 1)[0]
+        value_store = next(
+            (
+                item
+                for item in window
+                if item["address"] > register_store["address"]
+                and item["text"].startswith(f"stwu {value_register},")
+            ),
+            None,
+        )
+        if value_store is None:
+            continue
+        sites.append(
+            {
+                "wrapper": "82458A88",
+                "wrapper_kind": "resolve_setup",
+                "register_index": "2208",
+                "register_name": "RB_MODECONTROL",
+                "register_write_address": "{:08X}".format(
+                    register_store["address"]
+                ),
+                "value": 6,
+                "value_name": "EdramMode::kCopy",
+                "value_write_address": "{:08X}".format(value_store["address"]),
+            }
+        )
+    return sites
+
+
 def build(paths: list[pathlib.Path]) -> dict:
     functions = parse_functions(paths)
+    functions_by_address = {item["address"]: item for item in functions}
+    for address, wrapper in REVIEWED_WRAPPERS.items():
+        function = functions_by_address.get(address)
+        if (
+            function is None
+            or not function["instructions"]
+            or function["instructions"][0]["address"] != address
+            or function["instructions"][0]["text"] != "mflr r12"
+            or wrapper["hook_address"] != address + 4
+        ):
+            raise ValueError(
+                "reviewed wrapper entry LR evidence missing: {:08X}".format(address)
+            )
     constructors = packet_constructors(functions)
-    constructor_addresses = {
-        int(item["function_address"], 16) for item in constructors
+    constructor_evidence = {
+        (int(item["function_address"], 16), int(item["opcode_value"], 16))
+        for item in constructors
     }
-    missing = set(REVIEWED_WRAPPERS) - constructor_addresses
+    expected_packet_evidence = {
+        (address, int(wrapper["packet_opcode"]))
+        for address, wrapper in REVIEWED_WRAPPERS.items()
+        if "packet_opcode" in wrapper
+    }
+    missing = expected_packet_evidence - constructor_evidence
     if missing:
         raise ValueError(
-            "reviewed draw wrapper packet evidence missing: {}".format(
-                ", ".join("{:08X}".format(address) for address in sorted(missing))
+            "reviewed wrapper packet evidence missing: {}".format(
+                ", ".join(
+                    "{:08X}/0x{:02X}".format(address, opcode)
+                    for address, opcode in sorted(missing)
+                )
             )
         )
     calls = direct_calls(functions, set(REVIEWED_WRAPPERS))
+    adapter_calls = [
+        item
+        for item in calls
+        if item["caller_function_address"] == "824079B8"
+        and item["wrapper"] == "8240F4D8"
+    ]
+    if len(adapter_calls) != 1:
+        raise ValueError("draw adapter must directly call indexed wrapper once")
+    resolve_controller_calls = [
+        item
+        for item in calls
+        if item["caller_function_address"] == "824587D8"
+        and item["wrapper"] == "82458A88"
+    ]
+    if len(resolve_controller_calls) != 2:
+        raise ValueError("resolve controller must directly call setup wrapper twice")
+    clears = dirty_state_clears(functions)
+    observed_clear_words = collections.Counter(
+        item["mask_word_offset"] for item in clears
+    )
+    if observed_clear_words != {16: 4, 24: 1, 32: 1}:
+        raise ValueError("reviewed indexed-draw dirty-state clear evidence drifted")
+    query_transitions = query_state_transitions(functions)
+    expected_query_transitions = {
+        ("viz_query_begin", "set_active"),
+        ("viz_query_end", "clear_active"),
+    }
+    observed_query_transitions = {
+        (item["wrapper_kind"], item["transition"])
+        for item in query_transitions
+    }
+    if observed_query_transitions != expected_query_transitions:
+        raise ValueError("reviewed visibility-query state evidence drifted")
+    resolve_writes = resolve_mode_writes(functions)
+    if len(resolve_writes) != 1:
+        raise ValueError("reviewed title resolve-mode write evidence drifted")
     return {
         "schema": SCHEMA,
         "input": {
@@ -187,17 +447,50 @@ def build(paths: list[pathlib.Path]) -> dict:
         "reviewed_wrappers": [
             {
                 "address": "{:08X}".format(address),
-                "kind": kind,
-                "packet_evidence": "PM4_DRAW_INDX_2",
-                "runtime_trace": "entry_lr_and_bounded_argument_metadata",
+                "kind": wrapper["kind"],
+                "layer": wrapper["layer"],
+                "evidence": (
+                    wrapper["evidence"]
+                    if "evidence" in wrapper
+                    else PACKET_OPCODES[wrapper["packet_opcode"]]
+                ),
+                "runtime_trace": "entry_lr_and_bounded_r3_r10_metadata",
+                "hook_address": "{:08X}".format(wrapper["hook_address"]),
+                "observed_entry_registers": [
+                    "r3",
+                    "r4",
+                    "r5",
+                    "r6",
+                    "r7",
+                    "r8",
+                    "r9",
+                    "r10",
+                ],
+                "caller_lr_register": "r12_after_opening_mflr",
+                "stack_argument_offsets": wrapper.get(
+                    "stack_argument_offsets", []
+                ),
             }
-            for address, kind in sorted(REVIEWED_WRAPPERS.items())
+            for address, wrapper in sorted(REVIEWED_WRAPPERS.items())
         ],
         "direct_calls": calls,
+        "dirty_state_clears": clears,
+        "query_state_transitions": query_transitions,
+        "resolve_mode_writes": resolve_writes,
+        "resolve_boundary": {
+            "backend": "IssueCopy",
+            "trigger": "RB_MODECONTROL.edram_mode == kCopy during Xenos draw",
+            "title_controller": "824587D8",
+            "title_wrapper": "82458A88",
+            "classification": "title_resolve_setup_and_backend_copy_proved",
+        },
         "totals": {
             "packet_constructors": len(constructors),
             "reviewed_wrappers": len(REVIEWED_WRAPPERS),
             "direct_calls": len(calls),
+            "dirty_state_clears": len(clears),
+            "query_state_transitions": len(query_transitions),
+            "resolve_mode_writes": len(resolve_writes),
         },
         "safety": {
             "guest_payload_read": False,

--- a/tools/summarize-native-renderer-dispatch-scenes.py
+++ b/tools/summarize-native-renderer-dispatch-scenes.py
@@ -1,0 +1,154 @@
+"""Build a conservative cross-scene matrix from dispatch runtime reports."""
+
+from __future__ import annotations
+
+import argparse
+import collections
+import json
+import pathlib
+import re
+import sys
+
+
+SCHEMA = "pinyon-shift.native-renderer-dispatch-scenes.v1"
+RUNTIME_SCHEMA = "pinyon-shift.native-renderer-dispatch-runtime.v2"
+SCENE_RE = re.compile(r"^[a-z_]{1,32}$")
+
+
+def _validate_report(report: dict) -> None:
+    if report.get("schema") != RUNTIME_SCHEMA:
+        raise ValueError("unsupported dispatch runtime report schema")
+    scene = str(report.get("scene", ""))
+    if not SCENE_RE.fullmatch(scene):
+        raise ValueError(f"invalid dispatch scene marker: {scene}")
+    required_safety = {
+        "metadata_only": True,
+        "guest_payload_read": False,
+        "guest_state_changed": False,
+        "control_flow_changed": False,
+        "xenos_authority": True,
+        "suppression_allowed": False,
+    }
+    safety = report.get("safety", {})
+    if any(safety.get(key) is not value for key, value in required_safety.items()):
+        raise ValueError("dispatch runtime report does not prove passive safety")
+
+
+def build(reports: list[dict], minimum_scene_sessions: int = 2) -> dict:
+    if minimum_scene_sessions < 2:
+        raise ValueError("scene qualification requires at least two sessions")
+    if not reports:
+        raise ValueError("no dispatch runtime reports supplied")
+    for report in reports:
+        _validate_report(report)
+    sessions = [str(report.get("session", "")) for report in reports]
+    if any(not session for session in sessions) or len(set(sessions)) != len(sessions):
+        raise ValueError("dispatch runtime report sessions must be unique and non-empty")
+
+    scene_sessions = collections.Counter(str(report["scene"]) for report in reports)
+    families: dict[tuple[str, str], dict] = {}
+    observed_sessions: dict[tuple[str, str], dict[str, set[str]]] = {}
+    for report in reports:
+        scene = str(report["scene"])
+        session = str(report["session"])
+        for caller in report.get("callers", []):
+            wrapper = str(caller.get("wrapper_address", "")).upper()
+            address = str(caller.get("caller", "")).upper()
+            key = (wrapper, address)
+            family = families.setdefault(
+                key,
+                {
+                    "wrapper": str(caller.get("wrapper", "unknown")),
+                    "wrapper_address": wrapper,
+                    "caller": address,
+                    "calls_by_scene": collections.Counter(),
+                    "semantic_identity": "unknown",
+                    "suppression_eligible": False,
+                },
+            )
+            family["calls_by_scene"][scene] += int(caller.get("calls", 0))
+            observed_sessions.setdefault(key, {}).setdefault(scene, set()).add(session)
+
+    rows = []
+    for key, family in families.items():
+        coverage = {}
+        stable_scenes = []
+        repeated_scene_available = False
+        for scene in sorted(scene_sessions):
+            total = scene_sessions[scene]
+            observed = len(observed_sessions.get(key, {}).get(scene, set()))
+            calls = int(family["calls_by_scene"].get(scene, 0))
+            coverage[scene] = {
+                "calls": calls,
+                "observed_sessions": observed,
+                "total_sessions": total,
+            }
+            if scene != "unmarked" and total >= minimum_scene_sessions:
+                repeated_scene_available = True
+                if observed == total:
+                    stable_scenes.append(scene)
+        if not repeated_scene_available:
+            status = "insufficient_repeats"
+        elif len(stable_scenes) == 1:
+            status = "stable_scene_candidate"
+        elif len(stable_scenes) > 1:
+            status = "stable_multi_scene_candidate"
+        else:
+            status = "unstable_or_unobserved"
+        rows.append(
+            {
+                "wrapper": family["wrapper"],
+                "wrapper_address": family["wrapper_address"],
+                "caller": family["caller"],
+                "scene_coverage": coverage,
+                "stable_scenes": stable_scenes,
+                "candidate_status": status,
+                "semantic_identity": "unknown",
+                "promotion_eligible": False,
+                "suppression_eligible": False,
+            }
+        )
+    rows.sort(key=lambda item: (item["wrapper_address"], item["caller"]))
+    status_counts = collections.Counter(item["candidate_status"] for item in rows)
+    return {
+        "schema": SCHEMA,
+        "minimum_scene_sessions": minimum_scene_sessions,
+        "scene_sessions": dict(sorted(scene_sessions.items())),
+        "families": rows,
+        "totals": {
+            "reports": len(reports),
+            "families": len(rows),
+            "status_counts": dict(sorted(status_counts.items())),
+        },
+        "qualification": "scene_frequency_only_semantics_unknown",
+        "safety": {
+            "metadata_only": True,
+            "xenos_authority": True,
+            "promotion_allowed": False,
+            "suppression_allowed": False,
+        },
+    }
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("reports", nargs="+", type=pathlib.Path)
+    parser.add_argument("--minimum-scene-sessions", type=int, default=2)
+    parser.add_argument("--output", required=True, type=pathlib.Path)
+    args = parser.parse_args(argv)
+    try:
+        reports = [json.loads(path.read_text(encoding="utf-8")) for path in args.reports]
+        document = build(reports, args.minimum_scene_sessions)
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(
+            json.dumps(document, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        return 0
+    except (OSError, ValueError, TypeError, json.JSONDecodeError) as error:
+        print("native renderer dispatch scene summary failed: {}".format(error), file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/summarize-native-renderer-dispatch.py
+++ b/tools/summarize-native-renderer-dispatch.py
@@ -1,4 +1,4 @@
-"""Correlate bounded title draw-wrapper telemetry with static call sites."""
+"""Correlate bounded title graphics-wrapper telemetry with static call sites."""
 
 from __future__ import annotations
 
@@ -8,8 +8,8 @@ import pathlib
 import sys
 
 
-SCHEMA = "pinyon-shift.native-renderer-dispatch-runtime.v1"
-STATIC_SCHEMA = "pinyon-shift.native-renderer-dispatch-static.v1"
+SCHEMA = "pinyon-shift.native-renderer-dispatch-runtime.v2"
+STATIC_SCHEMA = "pinyon-shift.native-renderer-dispatch-static.v2"
 PREFIX = "native_renderer.discovery.dispatch_"
 
 
@@ -51,6 +51,15 @@ def build(events: list[dict], static: dict, requested: str | None = None) -> dic
         raise ValueError("unsupported static dispatch inventory schema")
     session = select_session(events, requested)
     selected = [event for event in events if event.get("session") == session]
+    configs = [
+        event
+        for event in selected
+        if event.get("event") == f"{PREFIX}config"
+        and event.get("status") == "armed"
+    ]
+    if len(configs) != 1:
+        raise ValueError("dispatch session must contain exactly one armed config")
+    scene = str(configs[0].get("scene", "unmarked"))
     summaries = [
         event for event in selected if event.get("event") == f"{PREFIX}summary"
     ]
@@ -86,9 +95,10 @@ def build(events: list[dict], static: dict, requested: str | None = None) -> dic
                 "calls": int(event.get("calls", 0)),
                 "first_frame": int(event.get("first_frame", 0)),
                 "first_arguments": {
-                    "r3": str(event.get("first_r3", "")).upper(),
-                    "r4": str(event.get("first_r4", "")).upper(),
-                    "r5": str(event.get("first_r5", "")).upper(),
+                    f"r{index}": str(
+                        event.get(f"first_r{index}", "")
+                    ).upper()
+                    for index in range(3, 11)
                 },
                 "static_match": (
                     {
@@ -97,6 +107,9 @@ def build(events: list[dict], static: dict, requested: str | None = None) -> dic
                             "caller_function_address"
                         ],
                         "callsite": callsite["callsite"],
+                        "wrapper_layer": callsite.get(
+                            "wrapper_layer", "unknown"
+                        ),
                     }
                     if callsite
                     else None
@@ -115,6 +128,7 @@ def build(events: list[dict], static: dict, requested: str | None = None) -> dic
     return {
         "schema": SCHEMA,
         "session": session,
+        "scene": scene,
         "frames_observed": max(
             (int(event.get("frame_sequence", 0)) for event in selected),
             default=0,
@@ -131,7 +145,8 @@ def build(events: list[dict], static: dict, requested: str | None = None) -> dic
             ),
             "overflow_calls": int(summary.get("overflow_calls", 0)),
         },
-        "qualification": "wrapper_identity_and_frequency_only",
+        "resolve_boundary": static.get("resolve_boundary"),
+        "qualification": "wrapper_layer_identity_and_frequency_only",
         "safety": {
             "metadata_only": True,
             "guest_payload_read": False,

--- a/tools/tests/test_native_renderer_dispatch_discovery.py
+++ b/tools/tests/test_native_renderer_dispatch_discovery.py
@@ -25,6 +25,85 @@ def fixture(address, body):
     )
 
 
+def reviewed_fixtures(include_immediate=True):
+    dirty_clears = []
+    for offset in (16, 16, 16, 16, 24, 32):
+        dirty_clears.extend(
+            [
+                f"ld r20,{offset}(r31)",
+                "rldicr r20,r20,0,51",
+                f"std r20,{offset}(r31)",
+            ]
+        )
+    chunks = [
+        fixture(0x824079B8, ["mflr r12", "bl 0x8240f4d8"]),
+        fixture(
+            0x8240F4D8,
+            [
+                "mflr r12",
+                "oris r11,r11,49152",
+                "ori r11,r11,13824",
+                "stwu r11,4(r3)",
+                *dirty_clears,
+            ],
+        ),
+        fixture(
+            0x824587D8,
+            [
+                "mflr r12",
+                "bl 0x82458a88",
+                "bl 0x82458a88",
+            ],
+        ),
+        fixture(
+            0x82458A88,
+            [
+                "mflr r12",
+                "li r11,8712",
+                "li r10,6",
+                "stwu r11,4(r3)",
+                "lis r11,1",
+                "stwu r10,4(r3)",
+            ],
+        ),
+        fixture(
+            0x829F21A0,
+            [
+                "mflr r12",
+                "lis r9,-16384",
+                "ori r9,r9,8960",
+                "stwu r9,4(r11)",
+                "or r10,r9,r10",
+                "std r10,12424(r31)",
+            ],
+        ),
+        fixture(
+            0x829F2280,
+            [
+                "mflr r12",
+                "lis r11,-16384",
+                "ori r11,r11,8960",
+                "stwu r11,4(r3)",
+                "andc r11,r10,r11",
+                "std r11,12424(r31)",
+            ],
+        ),
+    ]
+    if include_immediate:
+        chunks.append(
+            fixture(
+                0x829F7C70,
+                [
+                    "mflr r12",
+                    "lis r11,-16384",
+                    "ori r11,r11,13824",
+                    "stwu r11,4(r3)",
+                ],
+            )
+        )
+    return chunks
+
+
 class NativeRendererDispatchDiscoveryTests(unittest.TestCase):
     def build(self, chunks):
         with tempfile.TemporaryDirectory() as directory:
@@ -33,29 +112,21 @@ class NativeRendererDispatchDiscoveryTests(unittest.TestCase):
             return MODULE.build([path])
 
     def test_finds_reviewed_wrappers_and_direct_calls(self):
-        indexed = fixture(
-            0x8240F4D8,
-            [
-                "oris r11,r11,49152",
-                "ori r11,r11,13824",
-                "stwu r11,4(r3)",
-            ],
-        )
-        immediate = fixture(
-            0x829F7C70,
-            [
-                "lis r11,-16384",
-                "ori r11,r11,13824",
-                "stwu r11,4(r3)",
-            ],
-        )
         caller = fixture(
             0x82B00000,
-            ["bl 0x8240f4d8", "bl 0x829f7c70"],
+            [
+                "bl 0x824079b8",
+                "bl 0x8240f4d8",
+                "bl 0x829f21a0",
+                "bl 0x829f2280",
+                "bl 0x829f7c70",
+            ],
         )
-        document = self.build([indexed, immediate, caller])
-        self.assertEqual(document["totals"]["reviewed_wrappers"], 2)
-        self.assertEqual(document["totals"]["direct_calls"], 2)
+        document = self.build([*reviewed_fixtures(), caller])
+        self.assertEqual(document["totals"]["reviewed_wrappers"], 7)
+        self.assertEqual(document["totals"]["direct_calls"], 8)
+        self.assertEqual(document["totals"]["dirty_state_clears"], 6)
+        self.assertEqual(document["totals"]["query_state_transitions"], 2)
         self.assertEqual(
             document["packet_constructors"][0]["header_source"],
             "dynamic_type3_count",
@@ -64,43 +135,30 @@ class NativeRendererDispatchDiscoveryTests(unittest.TestCase):
             document["packet_constructors"][1]["header_source"],
             "fixed_type3_count_1",
         )
-        self.assertEqual(document["direct_calls"][0]["return_address"], "82B00004")
+        adapter_call = next(
+            item
+            for item in document["direct_calls"]
+            if item["wrapper_kind"] == "draw_adapter"
+        )
+        self.assertEqual(adapter_call["return_address"], "82B00004")
+        self.assertEqual(
+            document["resolve_boundary"]["classification"],
+            "title_resolve_setup_and_backend_copy_proved",
+        )
+        self.assertEqual(document["totals"]["resolve_mode_writes"], 1)
         self.assertFalse(document["safety"]["suppression_allowed"])
 
     def test_rejects_missing_reviewed_packet_evidence(self):
-        only_one = fixture(
-            0x8240F4D8,
-            [
-                "oris r11,r11,49152",
-                "ori r11,r11,13824",
-                "stwu r11,4(r3)",
-            ],
-        )
+        incomplete = reviewed_fixtures(include_immediate=False)
         with self.assertRaisesRegex(ValueError, "829F7C70"):
-            self.build([only_one])
+            self.build(incomplete)
 
     def test_ignores_matching_numeric_work_without_a_packet_store(self):
         false_positive = fixture(
             0x83051E48,
             ["ori r12,r12,13824", "add r11,r11,r12"],
         )
-        indexed = fixture(
-            0x8240F4D8,
-            [
-                "oris r11,r11,49152",
-                "ori r11,r11,13824",
-                "stwu r11,4(r3)",
-            ],
-        )
-        immediate = fixture(
-            0x829F7C70,
-            [
-                "lis r11,-16384",
-                "ori r11,r11,13824",
-                "stwu r11,4(r3)",
-            ],
-        )
-        document = self.build([false_positive, indexed, immediate])
+        document = self.build([false_positive, *reviewed_fixtures()])
         addresses = {
             item["function_address"] for item in document["packet_constructors"]
         }
@@ -132,12 +190,45 @@ class NativeRendererDispatchDiscoveryTests(unittest.TestCase):
             analysis.count('name = "PinyonShiftObserveDrawImmediateDispatch"'),
             1,
         )
+        self.assertEqual(
+            analysis.count('name = "PinyonShiftObserveDrawAdapterDispatch"'),
+            1,
+        )
+        self.assertEqual(
+            analysis.count('name = "PinyonShiftObserveVizQueryBeginDispatch"'),
+            1,
+        )
+        self.assertEqual(
+            analysis.count('name = "PinyonShiftObserveVizQueryEndDispatch"'),
+            1,
+        )
+        self.assertEqual(
+            analysis.count('name = "PinyonShiftObserveResolveControllerDispatch"'),
+            1,
+        )
+        self.assertEqual(
+            analysis.count('name = "PinyonShiftObserveResolveSetupDispatch"'),
+            1,
+        )
+        self.assertIn('address = 0x824079BC', analysis)
         self.assertIn('address = 0x8240F4DC', analysis)
+        self.assertIn('address = 0x824587DC', analysis)
+        self.assertIn('address = 0x82458A8C', analysis)
+        self.assertIn('address = 0x829F21A4', analysis)
+        self.assertIn('address = 0x829F2284', analysis)
         self.assertIn('address = 0x829F7C74', analysis)
-        self.assertIn('registers = ["r3", "r4", "r5", "r12"]', analysis)
+        self.assertEqual(
+            analysis.count(
+                'registers = ["r3", "r4", "r5", "r6", "r7", "r8", '
+                '"r9", "r10", "r12"]'
+            ),
+            7,
+        )
         self.assertIn(
             "REX_PINYON_SHIFT_NATIVE_RENDERER_DISPATCH_DISCOVERY", capture
         )
+        self.assertIn("PINYON_SHIFT_NATIVE_RENDERER_SCENE", capture)
+        self.assertIn("[string]$Scene = 'unmarked'", capture)
         self.assertIn("launch-preview.ps1", capture)
         for forbidden in ("SetDrawSuppression", "SetCopySuppression"):
             self.assertNotIn(forbidden, hooks + analysis + capture)

--- a/tools/tests/test_native_renderer_dispatch_scenes.py
+++ b/tools/tests/test_native_renderer_dispatch_scenes.py
@@ -1,0 +1,85 @@
+import importlib.util
+import sys
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+TOOL = ROOT / "tools" / "summarize-native-renderer-dispatch-scenes.py"
+SPEC = importlib.util.spec_from_file_location("native_dispatch_scenes", TOOL)
+assert SPEC and SPEC.loader
+MODULE = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = MODULE
+SPEC.loader.exec_module(MODULE)
+
+
+def report(session, scene, callers):
+    return {
+        "schema": MODULE.RUNTIME_SCHEMA,
+        "session": session,
+        "scene": scene,
+        "callers": [
+            {
+                "wrapper": "draw_adapter",
+                "wrapper_address": "824079B8",
+                "caller": caller,
+                "calls": calls,
+            }
+            for caller, calls in callers
+        ],
+        "safety": {
+            "metadata_only": True,
+            "guest_payload_read": False,
+            "guest_state_changed": False,
+            "control_flow_changed": False,
+            "xenos_authority": True,
+            "suppression_allowed": False,
+        },
+    }
+
+
+class NativeRendererDispatchSceneTests(unittest.TestCase):
+    def test_requires_repeated_scene_evidence_and_retains_unknowns(self):
+        reports = [
+            report("ow-a", "open_world", [("AAA00004", 10), ("CCC00004", 5)]),
+            report("ow-b", "open_world", [("AAA00004", 12), ("CCC00004", 6)]),
+            report("g-a", "garage", [("BBB00004", 4), ("CCC00004", 2)]),
+            report("g-b", "garage", [("BBB00004", 5), ("CCC00004", 3)]),
+        ]
+        document = MODULE.build(reports)
+        by_caller = {item["caller"]: item for item in document["families"]}
+        self.assertEqual(
+            by_caller["AAA00004"]["candidate_status"],
+            "stable_scene_candidate",
+        )
+        self.assertEqual(by_caller["AAA00004"]["stable_scenes"], ["open_world"])
+        self.assertEqual(
+            by_caller["CCC00004"]["candidate_status"],
+            "stable_multi_scene_candidate",
+        )
+        self.assertEqual(by_caller["AAA00004"]["semantic_identity"], "unknown")
+        self.assertFalse(by_caller["AAA00004"]["promotion_eligible"])
+        self.assertFalse(document["safety"]["suppression_allowed"])
+
+    def test_rejects_unsafe_or_duplicate_sessions(self):
+        unsafe = report("one", "garage", [("AAA00004", 1)])
+        unsafe["safety"]["suppression_allowed"] = True
+        with self.assertRaisesRegex(ValueError, "passive safety"):
+            MODULE.build([unsafe])
+        duplicate = report("one", "garage", [("AAA00004", 1)])
+        with self.assertRaisesRegex(ValueError, "unique"):
+            MODULE.build([duplicate, duplicate])
+
+    def test_refuses_single_session_promotion(self):
+        document = MODULE.build(
+            [report("one", "race", [("AAA00004", 7)])]
+        )
+        self.assertEqual(
+            document["families"][0]["candidate_status"],
+            "insufficient_repeats",
+        )
+        self.assertFalse(document["families"][0]["promotion_eligible"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/tests/test_native_renderer_dispatch_summary.py
+++ b/tools/tests/test_native_renderer_dispatch_summary.py
@@ -23,8 +23,14 @@ def static_inventory():
                 "caller_function": "sub_82B2B180",
                 "caller_function_address": "82B2B180",
                 "callsite": "82B2BD74",
+                "wrapper_layer": "packet_wrapper",
             }
         ],
+        "resolve_boundary": {
+            "backend": "IssueCopy",
+            "title_wrapper": "82458A88",
+            "classification": "title_resolve_setup_and_backend_copy_proved",
+        },
     }
 
 
@@ -46,6 +52,7 @@ def events(safe=True):
             "event": "native_renderer.discovery.dispatch_config",
             "session": "run",
             "status": "armed",
+            "scene": "open_world",
         },
         {
             "event": "native_renderer.discovery.dispatch_frame",
@@ -63,6 +70,11 @@ def events(safe=True):
             "first_r3": "10000000",
             "first_r4": "00000004",
             "first_r5": "00000000",
+            "first_r6": "00000004",
+            "first_r7": "00000000",
+            "first_r8": "00000000",
+            "first_r9": "00000000",
+            "first_r10": "00000020",
         },
         summary,
     ]
@@ -72,10 +84,16 @@ class NativeRendererDispatchSummaryTests(unittest.TestCase):
     def test_correlates_runtime_lr_with_static_callsite(self):
         document = MODULE.build(events(), static_inventory())
         self.assertEqual(document["frames_observed"], 300)
+        self.assertEqual(document["scene"], "open_world")
         self.assertEqual(document["totals"]["tracked_calls"], 12)
         self.assertEqual(document["totals"]["static_matches"], 1)
         self.assertEqual(
             document["callers"][0]["static_match"]["callsite"], "82B2BD74"
+        )
+        self.assertEqual(document["callers"][0]["first_arguments"]["r10"], "00000020")
+        self.assertEqual(
+            document["resolve_boundary"]["classification"],
+            "title_resolve_setup_and_backend_copy_proved",
         )
         self.assertEqual(document["callers"][0]["semantic_identity"], "unknown")
         self.assertFalse(document["safety"]["suppression_allowed"])


### PR DESCRIPTION
## Summary
- inventory seven reviewed title draw, resolve, and query wrapper layers
- add bounded passive runtime caller telemetry and scene-marked summaries
- preserve Xenos authority, unknown semantic identities, and no suppression
- document static and AppData qualification evidence

## Validation
- `python -m unittest discover -s tools/tests -v` (250 passed)
- `python tools/check-markdown-links.py`
- `tools/check-repository-boundary.ps1`
- Launcher Release build (0 warnings, 0 errors)
- `tools/build-preview.ps1 -CleanGenerated -JsonEvents`
- AppData session `20260829T105816Z-p27600` (normal exit, median 30.472 FPS)