### PR TITLE
feat(native-renderer): trace side-effect boundaries

### DIFF
--- a/config/rexglue/analysis/main-xex.toml
+++ b/config/rexglue/analysis/main-xex.toml
@@ -30,6 +30,11 @@ name = "PinyonShiftObserveDrawIndexedDispatch"
 registers = ["r3", "r4", "r5", "r6", "r7", "r8", "r9", "r10", "r12"]
 
 [[midasm_hook]]
+address = 0x82413ABC
+name = "PinyonShiftObserveBinningScissorStateDispatch"
+registers = ["r3", "r4", "r5", "r6", "r7", "r8", "r9", "r10", "r12"]
+
+[[midasm_hook]]
 address = 0x824587DC
 name = "PinyonShiftObserveResolveControllerDispatch"
 registers = ["r3", "r4", "r5", "r6", "r7", "r8", "r9", "r10", "r12"]
@@ -37,6 +42,11 @@ registers = ["r3", "r4", "r5", "r6", "r7", "r8", "r9", "r10", "r12"]
 [[midasm_hook]]
 address = 0x82458A8C
 name = "PinyonShiftObserveResolveSetupDispatch"
+registers = ["r3", "r4", "r5", "r6", "r7", "r8", "r9", "r10", "r12"]
+
+[[midasm_hook]]
+address = 0x824736F4
+name = "PinyonShiftObserveBinningStateResetDispatch"
 registers = ["r3", "r4", "r5", "r6", "r7", "r8", "r9", "r10", "r12"]
 
 [[midasm_hook]]
@@ -52,6 +62,11 @@ registers = ["r3", "r4", "r5", "r6", "r7", "r8", "r9", "r10", "r12"]
 [[midasm_hook]]
 address = 0x829F7C74
 name = "PinyonShiftObserveDrawImmediateDispatch"
+registers = ["r3", "r4", "r5", "r6", "r7", "r8", "r9", "r10", "r12"]
+
+[[midasm_hook]]
+address = 0x82D951E4
+name = "PinyonShiftObserveVizQueryOwnerDispatch"
 registers = ["r3", "r4", "r5", "r6", "r7", "r8", "r9", "r10", "r12"]
 
 # Microsoft CRT non-local jump pair. These must be semantic codegen hooks so a

--- a/docs/native-renderer/GUEST_VISIBLE_RENDER_DEPENDENCIES.md
+++ b/docs/native-renderer/GUEST_VISIBLE_RENDER_DEPENDENCIES.md
@@ -66,6 +66,25 @@ An address absent from the dependency stream is not proof that it is
 presentation-only. Capacity overflow, an unobserved CPU read, a non-texture
 consumer, or an unclassified scene role may still exist.
 
+## Title side-effect boundaries
+
+The static dispatch inventory proves a visibility-query lifecycle owner at
+`0x82D951E0`: query begin at `0x82D95230`, five intervening work calls, and
+query end at `0x82D95378`. This establishes ownership of the begin/end pair,
+not the downstream query-result consumer or semantic purpose.
+
+The title resolve controller at `0x824587D8` emits, in order, one
+`PM4_EVENT_WRITE`, two `PM4_MEM_WRITE`, two `PM4_WAIT_REG_MEM`, and one
+`PM4_EVENT_WRITE_EXT` packet around its resolve setup. The setup wrapper at
+`0x82458A88` additionally emits four bin-mask/select writes and one
+`PM4_EVENT_WRITE_ZPD` packet. These packets are guest-visible ordering and
+memory-effect dependencies. A future native path must preserve their proved
+semantics before any corresponding Xenos work can be suppressed.
+
+Two additional wrappers bound Xenos bin-mask/select and scissor-state
+submission. This is tiled-rendering evidence, but it does not yet establish
+semantic tiled-pass ownership or a safe replacement boundary.
+
 ## Capture and inventory workflow
 
 Run the default-off census through the normal preview launcher. With the
@@ -98,6 +117,20 @@ resolve target, every observed resolve-to-texture dependency, overflow totals,
 and an explicit safety object that keeps suppression disabled. Retaining the
 target inventory lets later candidate selection reject a texture address even
 when the draw-window dependency bit did not observe the transition.
+
+For a combined query, memexport, resolve, and wrapper report, run:
+
+```powershell
+python .\tools\summarize-native-renderer-side-effects.py `
+  $eventLog.FullName `
+  --static .local\qualification\native-dispatch-static.json `
+  --output .local\qualification\native-side-effects.json
+```
+
+This report is bounded, rejects unsafe or overlapping windows, and retains
+capacity-overflow totals. Zero query or memexport draws are classified as
+`unobserved_not_absent`; absence is never inferred from one scene. Xenos stays
+authoritative and suppression remains disabled.
 
 ## Qualification status
 
@@ -141,3 +174,16 @@ NR-04D evaluates these unknowns per exact pass family with the fail-closed
 admission contract in [SUPPRESSION_ADMISSION.md](SUPPRESSION_ADMISSION.md).
 Neither this aggregate census nor a visually correct native output can bypass
 those family-specific gates.
+
+## Side-effect report qualification — 2026-08-29
+
+The combined side-effect report processed AppData-backed session
+`20260829T112833Z-p40656`. Across 24 non-overlapping windows it recorded
+263,328 resolves totaling 149,780,066,304 bytes with zero target/page
+overflow. Query and memexport draw observations were both zero and therefore
+remain `unobserved_not_absent`.
+
+The same session matched all 26 observed dispatch callers to the static
+inventory, including one tail-forwarded binning-state edge, and reported zero
+caller-table overflow. It exited normally with Xenos authoritative and no
+suppression, guest payload read, guest-state mutation, or control-flow change.

--- a/docs/native-renderer/HIGH_LEVEL_RENDER_HOOKS.md
+++ b/docs/native-renderer/HIGH_LEVEL_RENDER_HOOKS.md
@@ -24,7 +24,7 @@ Discovery records are never suppression evidence.
 
 ## Proved wrapper layers
 
-The generated AOT instruction inventory establishes seven runtime wrapper
+The generated AOT instruction inventory establishes ten runtime wrapper
 families:
 
 | Entry | Static evidence | Reviewed identity | Runtime observation |
@@ -33,8 +33,11 @@ families:
 | `0x8240F4D8` | At `0x82410320`, stores a dynamic-count Type-3 `PM4_DRAW_INDX_2` (`0x36`) header | Indexed draw packet wrapper | Hook `0x8240F4DC`: entry `LR` and `r3-r10` |
 | `0x824587D8` | Calls `0x82458A88` at `0x82458828` and `0x824589E4` while managing resolve state | Title resolve controller | Hook `0x824587DC`: entry `LR` and `r3-r10` |
 | `0x82458A88` | Writes register `0x2208` (`RB_MODECONTROL`) followed by value 6 (`EdramMode::kCopy`) at `0x82458AC0`/`0x82458AD4` | Resolve state-packet setup wrapper | Hook `0x82458A8C`: entry `LR` and `r3-r10` |
+| `0x82413AB8` | Stores `PM4_SET_BIN_MASK_LO` and `PM4_SET_BIN_MASK_HI` packet headers | Xenos binning/scissor-state wrapper; semantic tiled-pass role unknown | Hook `0x82413ABC`: entry `LR` and `r3-r10` |
+| `0x824736F0` | Stores all four `PM4_SET_BIN_MASK/SELECT_LO/HI` packet headers and calls `0x82413AB8` | Xenos binning-state reset wrapper; semantic tiled-pass role unknown | Hook `0x824736F4`: entry `LR` and `r3-r10` |
 | `0x829F21A0` | At `0x829F225C`, stores `0xC0002300`; then marks the query ID active at `0x829F2270` | Visibility-query begin wrapper | Hook `0x829F21A4`: entry `LR` and `r3-r10` |
 | `0x829F2280` | At `0x829F22E4`, stores `0xC0002300`; then clears the active query ID at `0x829F2308` | Visibility-query end wrapper | Hook `0x829F2284`: entry `LR` and `r3-r10` |
+| `0x82D951E0` | Calls query begin at `0x82D95230`, performs five intervening work calls, then calls query end at `0x82D95378` | Visibility-query lifecycle owner; result semantics unknown | Hook `0x82D951E4`: entry `LR` and `r3-r10` |
 | `0x829F7C70` | At `0x829F7CA8`, stores fixed Type-3 count-one `PM4_DRAW_INDX_2` (`0x36`) header | Immediate/embedded-index draw wrapper | Hook `0x829F7C74`: entry `LR` and `r3-r10` |
 
 Three additional opcode-`0x36` constructors at `0x829E82D0`, `0x829E8428`,
@@ -42,9 +45,10 @@ and `0x829EDB68` build initialization templates. They are inventoried but are
 not runtime draw hooks.
 
 No `PM4_DRAW_INDX` (`0x22`) title constructor has yet passed the same stored-
-header proof. The scanner reports only proved stored opcode-`0x36` and
-opcode-`0x23` headers and explicitly rejects a matching numeric operation in
-`sub_83051E48` because its result is not stored as a command packet.
+header proof. The scanner reports 91 proved stored packet constructors across
+the draw, query, resolve side-effect, and binning-state opcodes it recognizes.
+It explicitly rejects a matching numeric operation in `sub_83051E48` because
+its result is not stored as a command packet.
 
 The adapter ABI exposes `r3-r10` at entry and reads two additional stack words
 at entry-stack offsets 92 and 100 before calling the packet wrapper. Those
@@ -72,15 +76,35 @@ the copy rectangle or which semantic system owns the destination. The
 inventory records `title_resolve_setup_and_backend_copy_proved` without using
 timing or dimensions as identity evidence.
 
+The controller also proves the surrounding side-effect order: one
+`PM4_EVENT_WRITE`, two `PM4_MEM_WRITE`, two `PM4_WAIT_REG_MEM`, and one
+`PM4_EVENT_WRITE_EXT` packet. The setup wrapper proves four bin-mask/select
+writes and one `PM4_EVENT_WRITE_ZPD` packet. These are exact command-stream
+boundaries, not permission to reproduce, reorder, or suppress their effects.
+
+## Query and binning boundaries
+
+`sub_82D951E0` is the proved owner of one visibility-query lifecycle: it calls
+the begin wrapper, performs five intervening work calls, and calls the end
+wrapper. Exactly two direct callers reach it, at `0x82D9566C` and
+`0x82DA9458`. This locates lifecycle ownership but does not identify how the
+result is consumed or what semantic object the query represents.
+
+`sub_82413AB8` and `sub_824736F0` bound Xenos bin-mask/select and scissor-state
+submission. They provide a concrete lead for tiled rendering, but packet
+identity alone does not prove semantic tiled-pass begin/end ownership.
+
 ## Static direct callers
 
 `tools/discover-native-renderer-dispatch.py` scans all generated AOT C++ files,
 reconstructs instruction addresses from function entries and labels, and
 produces a deterministic payload-free JSON inventory. At the current baseline
-it finds 56 direct call sites: 38 into the promoted adapter, nine into the
+it finds 72 direct call sites: 38 into the promoted adapter, nine into the
 indexed packet wrapper, two into the immediate wrapper, two into resolve
 setup, three into the resolve controller, and one into each visibility-query
-wrapper. The adapter's 38 sites group into 25 caller functions:
+wrapper. The remaining 16 sites are ten into binning/scissor state, four into
+binning-state reset, and two into the query lifecycle owner. The adapter's 38
+sites group into 25 caller functions:
 
 | Caller function | Adapter call sites |
 | --- | --- |
@@ -114,6 +138,12 @@ The exact lower-wrapper and query-wrapper sites, return addresses, wrapper
 layers, packet constructors, dirty transitions, and hook ABIs remain in the
 versioned JSON rather than a second hand-maintained table.
 
+One additional runtime correlation edge is tail-forwarded: `sub_8246FB90`
+calls `sub_829ED510` at `0x8246FC74`, and that function preserves the caller
+`LR` while tail-branching to `0x82413AB8`. The static inventory records the
+original return address `0x8246FC78`, the forwarder, and its branch separately
+from the 72 direct wrapper calls.
+
 The entry `LR` is sufficient to correlate runtime frequency with this table.
 It is not sufficient to name a call site terrain, road, vehicle, HUD, or any
 other semantic family. Those names remain `unknown`.
@@ -145,6 +175,22 @@ The summarizer requires one read-only session summary, verifies aggregate
 caller counts, rejects any session that does not prove the no-mutation safety
 boundary, and labels every semantic identity `unknown`. An unmatched `LR` is
 retained rather than guessed.
+
+Combine the same diagnostics stream with the static inventory to produce a
+bounded side-effect report:
+
+```powershell
+python .\tools\summarize-native-renderer-side-effects.py `
+    <diagnostics.jsonl> `
+    --static .local\qualification\native-dispatch-static.json `
+    --output .local\qualification\native-side-effects.json
+```
+
+The report aggregates query and memexport draws, resolve counts and bytes,
+capacity overflow, wrapper activity, and the static query/resolve/binning
+proofs. A zero observation is always `unobserved_not_absent`; it is never
+absence evidence. The report preserves Xenos authority and suppression stays
+disabled.
 
 Repeat each marked scene at least twice, then build a conservative cross-scene
 matrix from the runtime reports:
@@ -192,8 +238,37 @@ material, transform, visibility, LOD, streaming, and destruction ownership is
 understood. Required coverage remains world, vehicle, road, HUD, garage,
 mirror, shadow, exposure, livery, thumbnail, and rewind.
 
-Query begin/end, resolve setup/controller, and the indexed-wrapper dirty-state
-clears are now proved. Resolve-draw ownership, query result ownership,
-tiled-rendering, resource lifetime, and semantic caller identities remain open
-title-side inventory work. Until those gates are met, all work stays on Xenos
-and no new draw family may be suppressed.
+Query begin/end and lifecycle ownership, resolve setup/controller and its
+side-effect packet order, Xenos binning-state submission, and the indexed-
+wrapper dirty-state clears are now proved. Resolve-draw ownership, downstream
+query-result consumption, semantic tiled-pass ownership, resource lifetime,
+and semantic caller identities remain open title-side inventory work. Until
+those gates are met, all work stays on Xenos and no new draw family may be
+suppressed.
+
+## Side-effect-boundary qualification — 2026-08-29
+
+Clean Release executable
+`9C0D2318A9B361014457FEBD96802559C694339640287CD3331EC63A92A93CC0`
+ran the installed `0.1.0` AppData save through menu, save load, and live
+festival gameplay. Session `20260829T112833Z-p40656` exited normally after
+6,916 frames.
+
+The ten passive hooks recorded 1,304,743 calls from 26 runtime callers. Static
+correlation matched all 26, including the tail-forwarded binning-state edge;
+there were zero unknown callers and zero caller-table overflow. The new
+binning/scissor wrapper observed 978,620 calls from eight callers, while the
+binning-state reset wrapper observed 11,845 calls from three callers. Query
+and resolve title wrappers were not exercised in this scene and remain
+unclassified.
+
+Twenty-four bounded census windows recorded 263,328 resolves totaling
+149,780,066,304 bytes, with zero target/page overflow. Query and memexport
+draw counts were zero and are classified `unobserved_not_absent`. Xenos stayed
+authoritative, suppression remained disabled, and the report proves no guest
+payload read, guest-state mutation, or control-flow change.
+
+Median derived performance was 30.463 FPS over 207.904 seconds; simulation and
+presentation cadence were 29.716 Hz and 59.984 Hz. Texture/pipeline cache hit
+rates were 99.983%/100%. No crash, fatal error, device loss, or unexpected
+shutdown marker appeared.

--- a/docs/native-renderer/RENDER_PASS_CENSUS.md
+++ b/docs/native-renderer/RENDER_PASS_CENSUS.md
@@ -39,9 +39,12 @@ Xenos suppression, or presentation changes. Its setting,
 | Immediate draw wrapper | `0x829F7C70` | Stored count-one `PM4_DRAW_INDX_2` header at `0x829F7CA8` | Entry `r3-r10` and caller `LR` are observed only when discovery is enabled | Verified, bounded pass-through hook |
 | Visibility-query begin | `0x829F21A0` | Stored count-one `PM4_VIZ_QUERY` header at `0x829F225C`; active-query bit set at `0x829F2270` | Entry `r3-r10` and caller `LR` are observed only when discovery is enabled | Verified, bounded pass-through hook |
 | Visibility-query end | `0x829F2280` | Stored count-one `PM4_VIZ_QUERY` header at `0x829F22E4`; active-query bit cleared at `0x829F2308` | Entry `r3-r10` and caller `LR` are observed only when discovery is enabled | Verified, bounded pass-through hook |
+| Visibility-query owner | `0x82D951E0` | Calls begin at `0x82D95230`, performs five work calls, then calls end at `0x82D95378`; two direct callers | Entry `r3-r10` and caller `LR` are observed only when discovery is enabled | Lifecycle owner verified; result consumer and semantics unknown |
 | Draw packet backend | ReXGlue `PM4_DRAW_INDX` / `PM4_DRAW_INDX_2` | Generic command processor decodes the packet before backend `IssueDraw` | Register-derived draw state is consumed by the backend | Verified runtime boundary |
 | Resolve controller | `0x824587D8` | Two direct calls to setup wrapper `0x82458A88`; three direct controller callers | Entry `r3-r10` and caller `LR` are observed only when discovery is enabled | Verified, bounded pass-through hook |
 | Resolve setup | `0x82458A88` | Emits `RB_MODECONTROL` register index `0x2208` followed by `EdramMode::kCopy` value 6 | Entry `r3-r10` and caller `LR` are observed only when discovery is enabled | Title setup verified; subsequent resolve draw ownership unknown |
+| Binning/scissor state | `0x82413AB8` | Stores `PM4_SET_BIN_MASK_LO/HI` headers; ten direct calls | Entry `r3-r10` and caller `LR` are observed only when discovery is enabled | Xenos state boundary verified; semantic tiled role unknown |
+| Binning-state reset | `0x824736F0` | Stores all `PM4_SET_BIN_MASK/SELECT_LO/HI` headers and calls the scissor-state wrapper; four direct callers | Entry `r3-r10` and caller `LR` are observed only when discovery is enabled | Xenos state boundary verified; semantic tiled role unknown |
 | Resolve/copy backend | ReXGlue backend `IssueCopy` | Triggered by a Xenos draw while `RB_MODECONTROL.edram_mode == kCopy` | Render-target and guest-memory dependencies may be produced | Verified runtime boundary |
 
 ## Bounded draw observation
@@ -92,14 +95,17 @@ read or serialize guest memory.
 - Prove whether the title has a stored `PM4_DRAW_INDX` (`0x22`) constructor.
 - Correlate the proved title resolve controller/setup with the subsequent copy
   draw and its semantic destination owner.
-- Locate query-result ownership beyond the proved begin/end packet wrappers.
+- Locate downstream query-result consumption beyond the proved lifecycle
+  owner.
+- Correlate the proved bin-mask/select wrappers with semantic tiled-pass
+  begin/end ownership.
 - Extend dirty-state proof beyond the six indexed-wrapper clear sites.
 - Inventory memexport-producing draws and guest-visible resolve destinations.
 - Map high-level world, vehicle, road, HUD, garage, mirror, shadow, exposure,
   livery, thumbnail, and rewind dispatch families.
 
-The proved wrapper entries, all 56 static direct calls, runtime correlation
-contract, and explicit semantic unknowns are recorded in
+The ten proved wrapper entries, all 72 static direct calls, one proved tail-
+forwarded correlation edge, and explicit semantic unknowns are recorded in
 [`HIGH_LEVEL_RENDER_HOOKS.md`](HIGH_LEVEL_RENDER_HOOKS.md).
 
 Resolve-to-texture dependency tracking is documented in
@@ -156,3 +162,17 @@ callback. Their signature includes the exact effective shader specialization,
 preventing a global guest-shader pair with multiple prepared variants from
 producing an ambiguous or guessed candidate identity. Draws that never reach a
 prepared pipeline are counted and excluded; Xenos remains authoritative.
+
+## Side-effect-boundary qualification — 2026-08-29
+
+Session `20260829T112833Z-p40656` qualified the ten-wrapper dispatch inventory
+against the installed AppData save. It reached live festival gameplay and
+exited normally after 6,916 frames. All 26 runtime callers matched the 72
+direct calls plus one tail-forwarded correlation edge; caller-table overflow
+was zero.
+
+The two newly active families were binning/scissor state with 978,620 calls
+from eight callers and binning-state reset with 11,845 calls from three
+callers. These frequencies prove runtime reachability only; semantic tiled-
+pass ownership remains unknown. Xenos performed every draw and resolve, and
+suppression stayed disabled.

--- a/src/native_renderer/graphics_hooks.cpp
+++ b/src/native_renderer/graphics_hooks.cpp
@@ -84,6 +84,9 @@ enum class DispatchWrapper : uint32_t {
   kVizQueryEnd = 5,
   kResolveController = 6,
   kResolveSetup = 7,
+  kVizQueryOwner = 8,
+  kBinningScissorState = 9,
+  kBinningStateReset = 10,
 };
 
 struct DispatchCallerEntry {
@@ -120,6 +123,12 @@ const char *DispatchWrapperName(DispatchWrapper wrapper) {
     return "resolve_controller";
   case DispatchWrapper::kResolveSetup:
     return "resolve_setup";
+  case DispatchWrapper::kVizQueryOwner:
+    return "viz_query_owner";
+  case DispatchWrapper::kBinningScissorState:
+    return "binning_scissor_state";
+  case DispatchWrapper::kBinningStateReset:
+    return "binning_state_reset";
   }
   return "unknown";
 }
@@ -140,6 +149,12 @@ const char *DispatchWrapperAddress(DispatchWrapper wrapper) {
     return "824587D8";
   case DispatchWrapper::kResolveSetup:
     return "82458A88";
+  case DispatchWrapper::kVizQueryOwner:
+    return "82D951E0";
+  case DispatchWrapper::kBinningScissorState:
+    return "82413AB8";
+  case DispatchWrapper::kBinningStateReset:
+    return "824736F0";
   }
   return "00000000";
 }
@@ -173,7 +188,8 @@ void ConfigureDispatchDiscovery() {
       {{"status", requested ? "armed" : "disabled"},
        {"scene", CensusSceneMarker()},
        {"wrappers",
-        "824079B8,8240F4D8,824587D8,82458A88,829F21A0,829F2280,829F7C70"},
+        "824079B8,8240F4D8,82413AB8,824587D8,82458A88,824736F0,"
+        "829F21A0,829F2280,829F7C70,82D951E0"},
        {"caller_capacity", std::to_string(kDispatchCallerCapacity)},
        {"metadata", "entry_lr_via_r12,r3-r10,frame"},
        {"guest_payload_read", "false"},
@@ -5081,4 +5097,31 @@ void PinyonShiftObserveVizQueryEndDispatch(
     PPCRegister &r12) {
   ObserveTitleDispatch(DispatchWrapper::kVizQueryEnd, r12.u32, r3.u32, r4.u32,
                        r5.u32, r6.u32, r7.u32, r8.u32, r9.u32, r10.u32);
+}
+
+void PinyonShiftObserveVizQueryOwnerDispatch(
+    PPCRegister &r3, PPCRegister &r4, PPCRegister &r5, PPCRegister &r6,
+    PPCRegister &r7, PPCRegister &r8, PPCRegister &r9, PPCRegister &r10,
+    PPCRegister &r12) {
+  ObserveTitleDispatch(DispatchWrapper::kVizQueryOwner, r12.u32, r3.u32,
+                       r4.u32, r5.u32, r6.u32, r7.u32, r8.u32, r9.u32,
+                       r10.u32);
+}
+
+void PinyonShiftObserveBinningScissorStateDispatch(
+    PPCRegister &r3, PPCRegister &r4, PPCRegister &r5, PPCRegister &r6,
+    PPCRegister &r7, PPCRegister &r8, PPCRegister &r9, PPCRegister &r10,
+    PPCRegister &r12) {
+  ObserveTitleDispatch(DispatchWrapper::kBinningScissorState, r12.u32, r3.u32,
+                       r4.u32, r5.u32, r6.u32, r7.u32, r8.u32, r9.u32,
+                       r10.u32);
+}
+
+void PinyonShiftObserveBinningStateResetDispatch(
+    PPCRegister &r3, PPCRegister &r4, PPCRegister &r5, PPCRegister &r6,
+    PPCRegister &r7, PPCRegister &r8, PPCRegister &r9, PPCRegister &r10,
+    PPCRegister &r12) {
+  ObserveTitleDispatch(DispatchWrapper::kBinningStateReset, r12.u32, r3.u32,
+                       r4.u32, r5.u32, r6.u32, r7.u32, r8.u32, r9.u32,
+                       r10.u32);
 }

--- a/tools/capture-native-renderer-dispatch.ps1
+++ b/tools/capture-native-renderer-dispatch.ps1
@@ -66,14 +66,17 @@ if ($StaticOutput) {
 }
 
 $savedDiscovery = $env:REX_PINYON_SHIFT_NATIVE_RENDERER_DISPATCH_DISCOVERY
+$savedCensus = $env:REX_PINYON_SHIFT_NATIVE_RENDERER_CENSUS
 $savedScene = $env:PINYON_SHIFT_NATIVE_RENDERER_SCENE
 try {
     $env:REX_PINYON_SHIFT_NATIVE_RENDERER_DISPATCH_DISCOVERY = 'true'
+    $env:REX_PINYON_SHIFT_NATIVE_RENDERER_CENSUS = 'true'
     $env:PINYON_SHIFT_NATIVE_RENDERER_SCENE = $Scene
     & (Join-Path $PSScriptRoot 'launch-preview.ps1') `
         -StateRoot $resolvedStateRoot -Json:$Json
 }
 finally {
     $env:REX_PINYON_SHIFT_NATIVE_RENDERER_DISPATCH_DISCOVERY = $savedDiscovery
+    $env:REX_PINYON_SHIFT_NATIVE_RENDERER_CENSUS = $savedCensus
     $env:PINYON_SHIFT_NATIVE_RENDERER_SCENE = $savedScene
 }

--- a/tools/discover-native-renderer-dispatch.py
+++ b/tools/discover-native-renderer-dispatch.py
@@ -16,8 +16,17 @@ import re
 import sys
 
 
-SCHEMA = "pinyon-shift.native-renderer-dispatch-static.v2"
+SCHEMA = "pinyon-shift.native-renderer-dispatch-static.v3"
 PACKET_OPCODES = {
+    0x3C: "PM4_WAIT_REG_MEM",
+    0x3D: "PM4_MEM_WRITE",
+    0x46: "PM4_EVENT_WRITE",
+    0x5A: "PM4_EVENT_WRITE_EXT",
+    0x5B: "PM4_EVENT_WRITE_ZPD",
+    0x60: "PM4_SET_BIN_MASK_LO",
+    0x61: "PM4_SET_BIN_MASK_HI",
+    0x62: "PM4_SET_BIN_SELECT_LO",
+    0x63: "PM4_SET_BIN_SELECT_HI",
     0x23: "PM4_VIZ_QUERY",
     0x36: "PM4_DRAW_INDX_2",
 }
@@ -65,6 +74,24 @@ REVIEWED_WRAPPERS = {
         "packet_opcode": 0x36,
         "hook_address": 0x829F7C74,
     },
+    0x82D951E0: {
+        "kind": "viz_query_owner",
+        "layer": "query_pass_owner",
+        "evidence": "begin_draw_end_lifecycle",
+        "hook_address": 0x82D951E4,
+    },
+    0x82413AB8: {
+        "kind": "binning_scissor_state",
+        "layer": "state_packet_wrapper",
+        "packet_opcodes": [0x60, 0x61],
+        "hook_address": 0x82413ABC,
+    },
+    0x824736F0: {
+        "kind": "binning_state_reset",
+        "layer": "state_packet_wrapper",
+        "packet_opcodes": [0x60, 0x61, 0x62, 0x63],
+        "hook_address": 0x824736F4,
+    },
 }
 INITIALIZATION_CONSTRUCTORS = {
     0x829E82D0,
@@ -75,11 +102,12 @@ INITIALIZATION_CONSTRUCTORS = {
 FUNCTION_RE = re.compile(r"^DEFINE_REX_FUNC\(sub_([0-9A-F]{8})\) \{")
 LABEL_RE = re.compile(r"^loc_([0-9A-F]{8}):")
 COMMENT_RE = re.compile(r"^\s*//\s+(.+?)\s*$")
-ORI_RE = re.compile(r"ori (r\d+),\1,(\d+)$")
+ORI_RE = re.compile(r"ori (r\d+),(r\d+),(\d+)$")
 STORE_RE = re.compile(r"stw(?:u|x|ux)? (r\d+),.*$")
 LIS_RE = re.compile(r"lis (r\d+),(-?\d+)$")
 ORIS_RE = re.compile(r"oris (r\d+),\1,(\d+)$")
 CALL_RE = re.compile(r"bl 0x([0-9a-fA-F]{8})$")
+BRANCH_RE = re.compile(r"b 0x([0-9a-fA-F]{8})$")
 DIRTY_STORE_RE = re.compile(r"std (r\d+),(16|24|32)\(r31\)$")
 QUERY_STATE_STORE_RE = re.compile(r"std (r\d+),12424\(r31\)$")
 
@@ -135,29 +163,38 @@ def packet_constructors(functions: list[dict]) -> list[dict]:
             match = ORI_RE.fullmatch(instruction["text"])
             if not match:
                 continue
-            opcode_value = int(match.group(2)) >> 8
+            opcode_value = int(match.group(3)) >> 8
             if (
-                int(match.group(2)) & 0xFF
+                int(match.group(3)) & 0xFF
                 or opcode_value not in PACKET_OPCODES
             ):
                 continue
             register = match.group(1)
-            stored = any(
-                (store := STORE_RE.fullmatch(item["text"]))
-                and store.group(1) == register
-                for item in instructions[index + 1 : index + 13]
+            source_register = match.group(2)
+            store_instruction = next(
+                (
+                    item
+                    for item in instructions[index + 1 : index + 65]
+                    if (store := STORE_RE.fullmatch(item["text"]))
+                    and store.group(1) == register
+                ),
+                None,
             )
-            if not stored:
+            if store_instruction is None:
                 continue
             lis_instruction, lis = find_prior(
-                instructions, index, LIS_RE, register
+                instructions, index, LIS_RE, source_register
             )
             oris_instruction, oris = find_prior(
-                instructions, index, ORIS_RE, register
+                instructions, index, ORIS_RE, source_register
             )
             header_source = "unknown"
-            if lis and int(lis.group(2)) == -16384:
-                header_source = "fixed_type3_count_1"
+            if lis:
+                upper = int(lis.group(2)) & 0xFFFF
+                if upper & 0xC000 == 0xC000:
+                    header_source = "fixed_type3_count_{}".format(
+                        (upper & 0x3FFF) + 1
+                    )
             elif (
                 oris
                 and int(oris.group(2)) == 49152
@@ -165,7 +202,10 @@ def packet_constructors(functions: list[dict]) -> list[dict]:
                 header_source = "dynamic_type3_count"
             role = "unreviewed"
             reviewed = REVIEWED_WRAPPERS.get(function["address"])
-            if reviewed and reviewed.get("packet_opcode") == opcode_value:
+            reviewed_opcodes = set(reviewed.get("packet_opcodes", [])) if reviewed else set()
+            if reviewed and "packet_opcode" in reviewed:
+                reviewed_opcodes.add(reviewed["packet_opcode"])
+            if opcode_value in reviewed_opcodes:
                 role = "runtime_wrapper"
             elif (
                 opcode_value == 0x36
@@ -178,6 +218,9 @@ def packet_constructors(functions: list[dict]) -> list[dict]:
                     "function_address": "{:08X}".format(function["address"]),
                     "constructor_address": "{:08X}".format(
                         instruction["address"]
+                    ),
+                    "store_address": "{:08X}".format(
+                        store_instruction["address"]
                     ),
                     "opcode": PACKET_OPCODES[opcode_value],
                     "opcode_value": "{:02X}".format(opcode_value),
@@ -216,6 +259,59 @@ def direct_calls(functions: list[dict], targets: set[int]) -> list[dict]:
                     "return_address": "{:08X}".format(
                         instruction["address"] + 4
                     ),
+                }
+            )
+    return sorted(calls, key=lambda item: (item["wrapper"], item["callsite"]))
+
+
+def tail_forwarded_calls(
+    functions: list[dict], targets: set[int]
+) -> list[dict]:
+    forwarders = {}
+    for function in functions:
+        branches = [
+            (instruction, int(match.group(1), 16))
+            for instruction in function["instructions"]
+            if (match := BRANCH_RE.fullmatch(instruction["text"]))
+            and int(match.group(1), 16) in targets
+        ]
+        if len(branches) > 1:
+            raise ValueError("reviewed wrapper tail-forwarder is ambiguous")
+        if branches:
+            forwarders[function["address"]] = branches[0]
+
+    calls = []
+    for function in functions:
+        for instruction in function["instructions"]:
+            match = CALL_RE.fullmatch(instruction["text"])
+            if not match:
+                continue
+            forwarder_address = int(match.group(1), 16)
+            forwarded = forwarders.get(forwarder_address)
+            if not forwarded:
+                continue
+            branch, target = forwarded
+            calls.append(
+                {
+                    "wrapper": "{:08X}".format(target),
+                    "wrapper_kind": REVIEWED_WRAPPERS[target]["kind"],
+                    "wrapper_layer": REVIEWED_WRAPPERS[target]["layer"],
+                    "caller_function": function["name"],
+                    "caller_function_address": "{:08X}".format(
+                        function["address"]
+                    ),
+                    "callsite": "{:08X}".format(instruction["address"]),
+                    "return_address": "{:08X}".format(
+                        instruction["address"] + 4
+                    ),
+                    "dispatch_edge": "tail_forwarded",
+                    "forwarder_function": "sub_{:08X}".format(
+                        forwarder_address
+                    ),
+                    "forwarder_function_address": "{:08X}".format(
+                        forwarder_address
+                    ),
+                    "forwarder_branch": "{:08X}".format(branch["address"]),
                 }
             )
     return sorted(calls, key=lambda item: (item["wrapper"], item["callsite"]))
@@ -365,6 +461,112 @@ def resolve_mode_writes(functions: list[dict]) -> list[dict]:
     return sites
 
 
+def query_owner_lifecycle(functions: list[dict]) -> dict:
+    owner_address = 0x82D951E0
+    begin_target = 0x829F21A0
+    end_target = 0x829F2280
+    function = next(
+        (item for item in functions if item["address"] == owner_address), None
+    )
+    if function is None:
+        return {}
+    calls = []
+    for instruction in function["instructions"]:
+        match = CALL_RE.fullmatch(instruction["text"])
+        if not match:
+            continue
+        calls.append(
+            {
+                "target": "{:08X}".format(int(match.group(1), 16)),
+                "callsite": "{:08X}".format(instruction["address"]),
+                "return_address": "{:08X}".format(
+                    instruction["address"] + 4
+                ),
+            }
+        )
+    begin_calls = [item for item in calls if item["target"] == "829F21A0"]
+    end_calls = [item for item in calls if item["target"] == "829F2280"]
+    if len(begin_calls) != 1 or len(end_calls) != 1:
+        raise ValueError("reviewed visibility-query owner lifecycle drifted")
+    begin_address = int(begin_calls[0]["callsite"], 16)
+    end_address = int(end_calls[0]["callsite"], 16)
+    if begin_address >= end_address:
+        raise ValueError("reviewed visibility-query owner order drifted")
+    work_calls = [
+        item
+        for item in calls
+        if begin_address < int(item["callsite"], 16) < end_address
+    ]
+    if not work_calls:
+        raise ValueError("reviewed visibility-query owner has no enclosed work")
+    return {
+        "owner": "82D951E0",
+        "owner_kind": "viz_query_owner",
+        "begin_wrapper": "829F21A0",
+        "begin_callsite": begin_calls[0]["callsite"],
+        "end_wrapper": "829F2280",
+        "end_callsite": end_calls[0]["callsite"],
+        "work_calls_between": work_calls,
+        "classification": "query_lifecycle_owner_proved_semantics_unknown",
+        "suppression_eligible": False,
+    }
+
+
+def reviewed_side_effect_packets(constructors: list[dict]) -> dict:
+    by_function = collections.defaultdict(list)
+    for constructor in constructors:
+        by_function[constructor["function_address"]].append(constructor)
+
+    controller = by_function["824587D8"]
+    setup = by_function["82458A88"]
+    expected_controller = collections.Counter(
+        {
+            "PM4_EVENT_WRITE": 1,
+            "PM4_MEM_WRITE": 2,
+            "PM4_WAIT_REG_MEM": 2,
+            "PM4_EVENT_WRITE_EXT": 1,
+        }
+    )
+    expected_setup = collections.Counter(
+        {
+            "PM4_SET_BIN_MASK_LO": 2,
+            "PM4_SET_BIN_MASK_HI": 2,
+            "PM4_EVENT_WRITE_ZPD": 1,
+        }
+    )
+    if collections.Counter(item["opcode"] for item in controller) != expected_controller:
+        raise ValueError("reviewed resolve-controller packet sequence drifted")
+    if collections.Counter(item["opcode"] for item in setup) != expected_setup:
+        raise ValueError("reviewed resolve-setup packet sequence drifted")
+
+    binning = {}
+    for address, expected in {
+        "82413AB8": {"PM4_SET_BIN_MASK_LO", "PM4_SET_BIN_MASK_HI"},
+        "824736F0": {
+            "PM4_SET_BIN_MASK_LO",
+            "PM4_SET_BIN_MASK_HI",
+            "PM4_SET_BIN_SELECT_LO",
+            "PM4_SET_BIN_SELECT_HI",
+        },
+    }.items():
+        observed = {item["opcode"] for item in by_function[address]}
+        if not expected.issubset(observed):
+            raise ValueError(
+                "reviewed binning-state packet evidence drifted: {}".format(
+                    address
+                )
+            )
+        binning[address] = by_function[address]
+
+    return {
+        "resolve_controller": controller,
+        "resolve_setup": setup,
+        "binning_state_wrappers": binning,
+        "semantic_identity": "unknown",
+        "suppression_eligible": False,
+    }
+
+
 def build(paths: list[pathlib.Path]) -> dict:
     functions = parse_functions(paths)
     functions_by_address = {item["address"]: item for item in functions}
@@ -385,11 +587,14 @@ def build(paths: list[pathlib.Path]) -> dict:
         (int(item["function_address"], 16), int(item["opcode_value"], 16))
         for item in constructors
     }
-    expected_packet_evidence = {
-        (address, int(wrapper["packet_opcode"]))
-        for address, wrapper in REVIEWED_WRAPPERS.items()
-        if "packet_opcode" in wrapper
-    }
+    expected_packet_evidence = set()
+    for address, wrapper in REVIEWED_WRAPPERS.items():
+        if "packet_opcode" in wrapper:
+            expected_packet_evidence.add((address, int(wrapper["packet_opcode"])))
+        expected_packet_evidence.update(
+            (address, int(opcode))
+            for opcode in wrapper.get("packet_opcodes", [])
+        )
     missing = expected_packet_evidence - constructor_evidence
     if missing:
         raise ValueError(
@@ -401,6 +606,13 @@ def build(paths: list[pathlib.Path]) -> dict:
             )
         )
     calls = direct_calls(functions, set(REVIEWED_WRAPPERS))
+    forwarded_calls = tail_forwarded_calls(
+        functions, set(REVIEWED_WRAPPERS)
+    )
+    correlation_calls = sorted(
+        [*calls, *forwarded_calls],
+        key=lambda item: (item["wrapper"], item["callsite"]),
+    )
     adapter_calls = [
         item
         for item in calls
@@ -437,6 +649,16 @@ def build(paths: list[pathlib.Path]) -> dict:
     resolve_writes = resolve_mode_writes(functions)
     if len(resolve_writes) != 1:
         raise ValueError("reviewed title resolve-mode write evidence drifted")
+    query_owner = query_owner_lifecycle(functions)
+    side_effect_packets = reviewed_side_effect_packets(constructors)
+    query_owner_callers = [
+        item
+        for item in calls
+        if item["wrapper_kind"] == "viz_query_owner"
+    ]
+    if len(query_owner_callers) != 2:
+        raise ValueError("reviewed visibility-query owner callers drifted")
+    query_owner["direct_callers"] = query_owner_callers
     return {
         "schema": SCHEMA,
         "input": {
@@ -452,7 +674,14 @@ def build(paths: list[pathlib.Path]) -> dict:
                 "evidence": (
                     wrapper["evidence"]
                     if "evidence" in wrapper
-                    else PACKET_OPCODES[wrapper["packet_opcode"]]
+                    else ",".join(
+                        PACKET_OPCODES[opcode]
+                        for opcode in (
+                            [wrapper["packet_opcode"]]
+                            if "packet_opcode" in wrapper
+                            else wrapper["packet_opcodes"]
+                        )
+                    )
                 ),
                 "runtime_trace": "entry_lr_and_bounded_r3_r10_metadata",
                 "hook_address": "{:08X}".format(wrapper["hook_address"]),
@@ -474,9 +703,13 @@ def build(paths: list[pathlib.Path]) -> dict:
             for address, wrapper in sorted(REVIEWED_WRAPPERS.items())
         ],
         "direct_calls": calls,
+        "tail_forwarded_calls": forwarded_calls,
+        "runtime_correlation_calls": correlation_calls,
         "dirty_state_clears": clears,
         "query_state_transitions": query_transitions,
+        "query_owner_lifecycle": query_owner,
         "resolve_mode_writes": resolve_writes,
+        "side_effect_packets": side_effect_packets,
         "resolve_boundary": {
             "backend": "IssueCopy",
             "trigger": "RB_MODECONTROL.edram_mode == kCopy during Xenos draw",
@@ -488,9 +721,12 @@ def build(paths: list[pathlib.Path]) -> dict:
             "packet_constructors": len(constructors),
             "reviewed_wrappers": len(REVIEWED_WRAPPERS),
             "direct_calls": len(calls),
+            "tail_forwarded_calls": len(forwarded_calls),
+            "runtime_correlation_calls": len(correlation_calls),
             "dirty_state_clears": len(clears),
             "query_state_transitions": len(query_transitions),
             "resolve_mode_writes": len(resolve_writes),
+            "query_owner_callers": len(query_owner_callers),
         },
         "safety": {
             "guest_payload_read": False,

--- a/tools/summarize-native-renderer-dispatch-scenes.py
+++ b/tools/summarize-native-renderer-dispatch-scenes.py
@@ -11,7 +11,7 @@ import sys
 
 
 SCHEMA = "pinyon-shift.native-renderer-dispatch-scenes.v1"
-RUNTIME_SCHEMA = "pinyon-shift.native-renderer-dispatch-runtime.v2"
+RUNTIME_SCHEMA = "pinyon-shift.native-renderer-dispatch-runtime.v3"
 SCENE_RE = re.compile(r"^[a-z_]{1,32}$")
 
 

--- a/tools/summarize-native-renderer-dispatch.py
+++ b/tools/summarize-native-renderer-dispatch.py
@@ -8,8 +8,8 @@ import pathlib
 import sys
 
 
-SCHEMA = "pinyon-shift.native-renderer-dispatch-runtime.v2"
-STATIC_SCHEMA = "pinyon-shift.native-renderer-dispatch-static.v2"
+SCHEMA = "pinyon-shift.native-renderer-dispatch-runtime.v3"
+STATIC_SCHEMA = "pinyon-shift.native-renderer-dispatch-static.v3"
 PREFIX = "native_renderer.discovery.dispatch_"
 
 
@@ -78,7 +78,9 @@ def build(events: list[dict], static: dict, requested: str | None = None) -> dic
 
     static_calls = {
         (item["wrapper"], item["return_address"]): item
-        for item in static.get("direct_calls", [])
+        for item in static.get(
+            "runtime_correlation_calls", static.get("direct_calls", [])
+        )
     }
     callers = []
     for event in selected:
@@ -109,6 +111,12 @@ def build(events: list[dict], static: dict, requested: str | None = None) -> dic
                         "callsite": callsite["callsite"],
                         "wrapper_layer": callsite.get(
                             "wrapper_layer", "unknown"
+                        ),
+                        "dispatch_edge": callsite.get(
+                            "dispatch_edge", "direct"
+                        ),
+                        "forwarder_function": callsite.get(
+                            "forwarder_function"
                         ),
                     }
                     if callsite
@@ -146,7 +154,11 @@ def build(events: list[dict], static: dict, requested: str | None = None) -> dic
             "overflow_calls": int(summary.get("overflow_calls", 0)),
         },
         "resolve_boundary": static.get("resolve_boundary"),
-        "qualification": "wrapper_layer_identity_and_frequency_only",
+        "query_owner_lifecycle": static.get("query_owner_lifecycle"),
+        "side_effect_packets": static.get("side_effect_packets"),
+        "qualification": (
+            "wrapper_layer_side_effect_boundary_and_frequency_only"
+        ),
         "safety": {
             "metadata_only": True,
             "guest_payload_read": False,

--- a/tools/summarize-native-renderer-side-effects.py
+++ b/tools/summarize-native-renderer-side-effects.py
@@ -1,0 +1,200 @@
+"""Summarize query, memexport, resolve, and binning census evidence."""
+
+from __future__ import annotations
+
+import argparse
+import collections
+import json
+import pathlib
+import sys
+
+
+SCHEMA = "pinyon-shift.native-renderer-side-effects.v1"
+STATIC_SCHEMA = "pinyon-shift.native-renderer-dispatch-static.v3"
+DISPATCH_PREFIX = "native_renderer.discovery.dispatch_"
+WINDOW_EVENT = "native_renderer.census.resolve_window"
+
+
+def read_events(paths: list[pathlib.Path]) -> list[dict]:
+    events = []
+    for path in paths:
+        for line_number, line in enumerate(
+            path.read_text(encoding="utf-8").splitlines(), 1
+        ):
+            if not line.strip():
+                continue
+            try:
+                event = json.loads(line)
+            except json.JSONDecodeError as error:
+                raise ValueError(
+                    f"{path}:{line_number}: invalid JSON: {error}"
+                ) from error
+            name = str(event.get("event", ""))
+            if name.startswith(DISPATCH_PREFIX) or name == WINDOW_EVENT:
+                events.append(event)
+    return events
+
+
+def select_session(events: list[dict], requested: str | None) -> str:
+    if requested:
+        if not any(event.get("session") == requested for event in events):
+            raise ValueError(f"side-effect session not found: {requested}")
+        return requested
+    armed = [
+        str(event.get("session", ""))
+        for event in events
+        if event.get("event") == f"{DISPATCH_PREFIX}config"
+        and event.get("status") == "armed"
+    ]
+    if not armed or not armed[-1]:
+        raise ValueError("no armed side-effect session found")
+    return armed[-1]
+
+
+def build(events: list[dict], static: dict, requested: str | None = None) -> dict:
+    if static.get("schema") != STATIC_SCHEMA:
+        raise ValueError("unsupported static side-effect inventory schema")
+    session = select_session(events, requested)
+    selected = [event for event in events if event.get("session") == session]
+    configs = [
+        event
+        for event in selected
+        if event.get("event") == f"{DISPATCH_PREFIX}config"
+        and event.get("status") == "armed"
+    ]
+    summaries = [
+        event
+        for event in selected
+        if event.get("event") == f"{DISPATCH_PREFIX}summary"
+    ]
+    if len(configs) != 1 or len(summaries) != 1:
+        raise ValueError("side-effect session requires one config and summary")
+    required_safety = {
+        "guest_payload_read": "false",
+        "guest_state_changed": "false",
+        "control_flow_changed": "false",
+        "xenos_authority": "true",
+        "suppression_allowed": "false",
+    }
+    if any(
+        str(summaries[0].get(key)).lower() != value
+        for key, value in required_safety.items()
+    ):
+        raise ValueError("side-effect summary does not prove passive safety")
+
+    windows = []
+    for event in selected:
+        if event.get("event") != WINDOW_EVENT:
+            continue
+        first_frame = int(event.get("first_frame", 0))
+        last_frame = int(event.get("last_frame", 0))
+        if first_frame <= 0 or last_frame < first_frame:
+            raise ValueError("invalid side-effect census window")
+        windows.append(
+            {
+                "first_frame": first_frame,
+                "last_frame": last_frame,
+                "resolves": int(event.get("resolves", 0)),
+                "resolve_bytes": int(event.get("resolve_bytes", 0)),
+                "query_draws": int(event.get("query_draws", 0)),
+                "memexport_draws": int(event.get("memexport_draws", 0)),
+                "target_overflow": int(event.get("target_overflow", 0)),
+                "page_overflow": int(event.get("page_overflow", 0)),
+            }
+        )
+    windows.sort(key=lambda item: (item["first_frame"], item["last_frame"]))
+    for previous, current in zip(windows, windows[1:]):
+        if current["first_frame"] <= previous["last_frame"]:
+            raise ValueError("overlapping side-effect census windows")
+
+    wrapper_calls = collections.Counter()
+    wrapper_callers = collections.Counter()
+    for event in selected:
+        if event.get("event") != f"{DISPATCH_PREFIX}caller":
+            continue
+        wrapper = str(event.get("wrapper", "unknown"))
+        wrapper_calls[wrapper] += int(event.get("calls", 0))
+        wrapper_callers[wrapper] += 1
+    reviewed = [
+        str(item["kind"]) for item in static.get("reviewed_wrappers", [])
+    ]
+    wrapper_summary = {
+        kind: {
+            "calls": wrapper_calls[kind],
+            "callers": wrapper_callers[kind],
+        }
+        for kind in reviewed
+    }
+
+    query_draws = sum(item["query_draws"] for item in windows)
+    memexport_draws = sum(item["memexport_draws"] for item in windows)
+    return {
+        "schema": SCHEMA,
+        "session": session,
+        "scene": str(configs[0].get("scene", "unmarked")),
+        "windows": windows,
+        "totals": {
+            "windows": len(windows),
+            "resolves": sum(item["resolves"] for item in windows),
+            "resolve_bytes": sum(item["resolve_bytes"] for item in windows),
+            "query_draws": query_draws,
+            "memexport_draws": memexport_draws,
+            "target_overflow": sum(
+                item["target_overflow"] for item in windows
+            ),
+            "page_overflow": sum(item["page_overflow"] for item in windows),
+        },
+        "wrapper_activity": wrapper_summary,
+        "query": {
+            "owner": static.get("query_owner_lifecycle"),
+            "draw_observation": (
+                "observed" if query_draws else "unobserved_not_absent"
+            ),
+            "semantic_identity": "unknown",
+            "guest_side_effect": "preserved_on_xenos",
+        },
+        "memexport": {
+            "draw_observation": (
+                "observed" if memexport_draws else "unobserved_not_absent"
+            ),
+            "semantic_identity": "unknown",
+            "guest_side_effect": "preserved_on_xenos",
+        },
+        "resolve_and_binning_packets": static.get("side_effect_packets"),
+        "safety": {
+            "metadata_only": True,
+            "guest_payload_read": False,
+            "guest_state_changed": False,
+            "control_flow_changed": False,
+            "xenos_authority": True,
+            "suppression_allowed": False,
+        },
+    }
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("logs", nargs="+", type=pathlib.Path)
+    parser.add_argument("--static", required=True, type=pathlib.Path)
+    parser.add_argument("--session")
+    parser.add_argument("--output", required=True, type=pathlib.Path)
+    args = parser.parse_args(argv)
+    try:
+        static = json.loads(args.static.read_text(encoding="utf-8"))
+        document = build(read_events(args.logs), static, args.session)
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(
+            json.dumps(document, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        return 0
+    except (OSError, ValueError, TypeError, json.JSONDecodeError) as error:
+        print(
+            "native renderer side-effect summary failed: {}".format(error),
+            file=sys.stderr,
+        )
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/tests/test_native_renderer_dispatch_discovery.py
+++ b/tools/tests/test_native_renderer_dispatch_discovery.py
@@ -51,6 +51,24 @@ def reviewed_fixtures(include_immediate=True):
             0x824587D8,
             [
                 "mflr r12",
+                "lis r20,-16384",
+                "ori r20,r20,17920",
+                "stwu r20,4(r3)",
+                "lis r21,-16383",
+                "ori r21,r21,15616",
+                "stwu r21,4(r3)",
+                "lis r22,-16383",
+                "ori r22,r22,15616",
+                "stwu r22,4(r3)",
+                "lis r23,-16380",
+                "ori r23,r23,15360",
+                "stwu r23,4(r3)",
+                "lis r24,-16380",
+                "ori r24,r24,15360",
+                "stwu r24,4(r3)",
+                "lis r25,-16383",
+                "ori r25,r25,23040",
+                "stwu r25,4(r3)",
                 "bl 0x82458a88",
                 "bl 0x82458a88",
             ],
@@ -64,6 +82,21 @@ def reviewed_fixtures(include_immediate=True):
                 "stwu r11,4(r3)",
                 "lis r11,1",
                 "stwu r10,4(r3)",
+                "lis r20,-16384",
+                "ori r20,r20,24576",
+                "stwu r20,4(r3)",
+                "lis r21,-16384",
+                "ori r21,r21,24832",
+                "stwu r21,4(r3)",
+                "lis r22,-16384",
+                "ori r22,r22,24576",
+                "stwu r22,4(r3)",
+                "lis r23,-16384",
+                "ori r23,r23,24832",
+                "stwu r23,4(r3)",
+                "lis r24,-16384",
+                "ori r24,r24,23296",
+                "stwu r24,4(r3)",
             ],
         ),
         fixture(
@@ -88,6 +121,50 @@ def reviewed_fixtures(include_immediate=True):
                 "std r11,12424(r31)",
             ],
         ),
+        fixture(
+            0x82D951E0,
+            [
+                "mflr r12",
+                "bl 0x829f21a0",
+                "bl 0x82415f68",
+                "bl 0x829f2280",
+            ],
+        ),
+        fixture(
+            0x82413AB8,
+            [
+                "mflr r12",
+                "lis r20,-16384",
+                "ori r20,r20,24576",
+                "stwu r20,4(r3)",
+                "lis r21,-16384",
+                "ori r21,r21,24832",
+                "stwu r21,4(r3)",
+            ],
+        ),
+        fixture(
+            0x824736F0,
+            [
+                "mflr r12",
+                "lis r20,-16384",
+                "ori r20,r20,24576",
+                "stwu r20,4(r3)",
+                "lis r21,-16384",
+                "ori r21,r21,24832",
+                "stwu r21,4(r3)",
+                "lis r22,-16384",
+                "ori r22,r22,25088",
+                "stwu r22,4(r3)",
+                "lis r23,-16384",
+                "ori r23,r23,25344",
+                "stwu r23,4(r3)",
+                "bl 0x82413ab8",
+            ],
+        ),
+        fixture(0x82D95408, ["bl 0x82d951e0"]),
+        fixture(0x82DA8CB0, ["bl 0x82d951e0"]),
+        fixture(0x829ED510, ["b 0x82413ab8"]),
+        fixture(0x8246FB90, ["bl 0x829ed510"]),
     ]
     if include_immediate:
         chunks.append(
@@ -120,21 +197,24 @@ class NativeRendererDispatchDiscoveryTests(unittest.TestCase):
                 "bl 0x829f21a0",
                 "bl 0x829f2280",
                 "bl 0x829f7c70",
+                "bl 0x82413ab8",
+                "bl 0x824736f0",
             ],
         )
         document = self.build([*reviewed_fixtures(), caller])
-        self.assertEqual(document["totals"]["reviewed_wrappers"], 7)
-        self.assertEqual(document["totals"]["direct_calls"], 8)
+        self.assertEqual(document["totals"]["reviewed_wrappers"], 10)
+        self.assertEqual(document["totals"]["direct_calls"], 15)
+        self.assertEqual(document["totals"]["tail_forwarded_calls"], 1)
+        self.assertEqual(document["totals"]["runtime_correlation_calls"], 16)
         self.assertEqual(document["totals"]["dirty_state_clears"], 6)
         self.assertEqual(document["totals"]["query_state_transitions"], 2)
-        self.assertEqual(
-            document["packet_constructors"][0]["header_source"],
-            "dynamic_type3_count",
+        indexed_packet = next(
+            item
+            for item in document["packet_constructors"]
+            if item["function_address"] == "8240F4D8"
+            and item["opcode"] == "PM4_DRAW_INDX_2"
         )
-        self.assertEqual(
-            document["packet_constructors"][1]["header_source"],
-            "fixed_type3_count_1",
-        )
+        self.assertEqual(indexed_packet["header_source"], "dynamic_type3_count")
         adapter_call = next(
             item
             for item in document["direct_calls"]
@@ -146,6 +226,18 @@ class NativeRendererDispatchDiscoveryTests(unittest.TestCase):
             "title_resolve_setup_and_backend_copy_proved",
         )
         self.assertEqual(document["totals"]["resolve_mode_writes"], 1)
+        self.assertEqual(document["totals"]["query_owner_callers"], 2)
+        self.assertEqual(
+            document["query_owner_lifecycle"]["classification"],
+            "query_lifecycle_owner_proved_semantics_unknown",
+        )
+        self.assertEqual(
+            len(document["side_effect_packets"]["resolve_controller"]), 6
+        )
+        forwarded = document["tail_forwarded_calls"][0]
+        self.assertEqual(forwarded["wrapper"], "82413AB8")
+        self.assertEqual(forwarded["return_address"], "8246FB94")
+        self.assertEqual(forwarded["forwarder_function"], "sub_829ED510")
         self.assertFalse(document["safety"]["suppression_allowed"])
 
     def test_rejects_missing_reviewed_packet_evidence(self):
@@ -210,6 +302,20 @@ class NativeRendererDispatchDiscoveryTests(unittest.TestCase):
             analysis.count('name = "PinyonShiftObserveResolveSetupDispatch"'),
             1,
         )
+        self.assertEqual(
+            analysis.count('name = "PinyonShiftObserveVizQueryOwnerDispatch"'),
+            1,
+        )
+        self.assertEqual(
+            analysis.count(
+                'name = "PinyonShiftObserveBinningScissorStateDispatch"'
+            ),
+            1,
+        )
+        self.assertEqual(
+            analysis.count('name = "PinyonShiftObserveBinningStateResetDispatch"'),
+            1,
+        )
         self.assertIn('address = 0x824079BC', analysis)
         self.assertIn('address = 0x8240F4DC', analysis)
         self.assertIn('address = 0x824587DC', analysis)
@@ -217,16 +323,20 @@ class NativeRendererDispatchDiscoveryTests(unittest.TestCase):
         self.assertIn('address = 0x829F21A4', analysis)
         self.assertIn('address = 0x829F2284', analysis)
         self.assertIn('address = 0x829F7C74', analysis)
+        self.assertIn('address = 0x82D951E4', analysis)
+        self.assertIn('address = 0x82413ABC', analysis)
+        self.assertIn('address = 0x824736F4', analysis)
         self.assertEqual(
             analysis.count(
                 'registers = ["r3", "r4", "r5", "r6", "r7", "r8", '
                 '"r9", "r10", "r12"]'
             ),
-            7,
+            10,
         )
         self.assertIn(
             "REX_PINYON_SHIFT_NATIVE_RENDERER_DISPATCH_DISCOVERY", capture
         )
+        self.assertIn("REX_PINYON_SHIFT_NATIVE_RENDERER_CENSUS", capture)
         self.assertIn("PINYON_SHIFT_NATIVE_RENDERER_SCENE", capture)
         self.assertIn("[string]$Scene = 'unmarked'", capture)
         self.assertIn("launch-preview.ps1", capture)

--- a/tools/tests/test_native_renderer_side_effects.py
+++ b/tools/tests/test_native_renderer_side_effects.py
@@ -1,0 +1,114 @@
+import importlib.util
+import sys
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+TOOL = ROOT / "tools" / "summarize-native-renderer-side-effects.py"
+SPEC = importlib.util.spec_from_file_location("native_side_effects", TOOL)
+assert SPEC and SPEC.loader
+MODULE = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = MODULE
+SPEC.loader.exec_module(MODULE)
+
+
+def static_inventory():
+    return {
+        "schema": MODULE.STATIC_SCHEMA,
+        "reviewed_wrappers": [
+            {"kind": "viz_query_owner"},
+            {"kind": "resolve_controller"},
+            {"kind": "binning_state_reset"},
+        ],
+        "query_owner_lifecycle": {"owner": "82D951E0"},
+        "side_effect_packets": {"semantic_identity": "unknown"},
+    }
+
+
+def events(safe=True):
+    return [
+        {
+            "event": "native_renderer.discovery.dispatch_config",
+            "session": "run",
+            "status": "armed",
+            "scene": "race",
+        },
+        {
+            "event": "native_renderer.census.resolve_window",
+            "session": "run",
+            "first_frame": "1",
+            "last_frame": "300",
+            "resolves": "40",
+            "resolve_bytes": "4096",
+            "query_draws": "3",
+            "memexport_draws": "2",
+            "target_overflow": "0",
+            "page_overflow": "0",
+        },
+        {
+            "event": "native_renderer.discovery.dispatch_caller",
+            "session": "run",
+            "wrapper": "viz_query_owner",
+            "calls": "9",
+        },
+        {
+            "event": "native_renderer.discovery.dispatch_summary",
+            "session": "run",
+            "guest_payload_read": "false",
+            "guest_state_changed": "false",
+            "control_flow_changed": "false",
+            "xenos_authority": "true",
+            "suppression_allowed": "false" if safe else "true",
+        },
+    ]
+
+
+class NativeRendererSideEffectTests(unittest.TestCase):
+    def test_summarizes_side_effects_without_promoting_semantics(self):
+        document = MODULE.build(events(), static_inventory())
+        self.assertEqual(document["scene"], "race")
+        self.assertEqual(document["totals"]["query_draws"], 3)
+        self.assertEqual(document["totals"]["memexport_draws"], 2)
+        self.assertEqual(
+            document["wrapper_activity"]["viz_query_owner"]["calls"], 9
+        )
+        self.assertEqual(document["query"]["semantic_identity"], "unknown")
+        self.assertEqual(
+            document["memexport"]["guest_side_effect"],
+            "preserved_on_xenos",
+        )
+        self.assertFalse(document["safety"]["suppression_allowed"])
+
+    def test_rejects_unsafe_or_overlapping_evidence(self):
+        with self.assertRaisesRegex(ValueError, "passive safety"):
+            MODULE.build(events(safe=False), static_inventory())
+        overlapping = events()
+        overlapping.insert(
+            2,
+            {
+                "event": "native_renderer.census.resolve_window",
+                "session": "run",
+                "first_frame": "300",
+                "last_frame": "600",
+            },
+        )
+        with self.assertRaisesRegex(ValueError, "overlapping"):
+            MODULE.build(overlapping, static_inventory())
+
+    def test_uses_unobserved_not_absent_for_zero_counts(self):
+        zero = events()
+        zero[1]["query_draws"] = "0"
+        zero[1]["memexport_draws"] = "0"
+        document = MODULE.build(zero, static_inventory())
+        self.assertEqual(
+            document["query"]["draw_observation"], "unobserved_not_absent"
+        )
+        self.assertEqual(
+            document["memexport"]["draw_observation"],
+            "unobserved_not_absent",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- prove visibility-query lifecycle ownership and exact resolve side-effect packet ordering
- add passive hooks for query ownership and Xenos binning/scissor-state boundaries
- add bounded side-effect reporting with explicit `unobserved_not_absent` semantics
- correlate tail-forwarded wrapper callers without promoting semantic identities

## Safety
- Xenos remains authoritative
- suppression remains disabled
- no guest payload reads, guest-state writes, or control-flow changes

## Validation
- `python -m unittest discover -s tools/tests -v` (253 passed)
- `tools/build-preview.ps1 -CleanGenerated -JsonEvents`
- AppData session `20260829T112833Z-p40656` (normal exit)
- 26/26 runtime callers matched; zero caller/target/page overflow
- median 30.463 FPS; simulation 29.716 Hz; presentation 59.984 Hz