### PR TITLE
feat(native-renderer): trace exact title draw provenance

### DIFF
--- a/config/rexglue/analysis/main-xex.toml
+++ b/config/rexglue/analysis/main-xex.toml
@@ -29,6 +29,13 @@ address = 0x8240F4DC
 name = "PinyonShiftObserveDrawIndexedDispatch"
 registers = ["r3", "r4", "r5", "r6", "r7", "r8", "r9", "r10", "r12"]
 
+# Record the physical identity of the exact PM4_DRAW_INDX_2 header without
+# reading or changing the packet. The original stwu executes after the hook.
+[[midasm_hook]]
+address = 0x82410328
+name = "PinyonShiftObserveDrawPacketSubmission"
+registers = ["r3"]
+
 [[midasm_hook]]
 address = 0x82413ABC
 name = "PinyonShiftObserveBinningScissorStateDispatch"
@@ -63,6 +70,11 @@ registers = ["r3", "r4", "r5", "r6", "r7", "r8", "r9", "r10", "r12"]
 address = 0x829F7C74
 name = "PinyonShiftObserveDrawImmediateDispatch"
 registers = ["r3", "r4", "r5", "r6", "r7", "r8", "r9", "r10", "r12"]
+
+[[midasm_hook]]
+address = 0x829F7CB0
+name = "PinyonShiftObserveDrawPacketSubmission"
+registers = ["r3"]
 
 [[midasm_hook]]
 address = 0x82D951E4

--- a/docs/native-renderer/HIGH_LEVEL_RENDER_HOOKS.md
+++ b/docs/native-renderer/HIGH_LEVEL_RENDER_HOOKS.md
@@ -8,7 +8,7 @@ scene evidence supports a family name.
 The dispatch extension starts from Pinyon Shift `dev` merge
 `38bc3a2239b5c3d1689d0810ab2349e0527cadc6`, ReXGlue `v0.10.0` at
 `f5337cdc947ff6d4c4196737e2c807a48f2a1fc2`, and patch stack `0001` through
-`0079`. The supported `default.xex` SHA-256 remains
+`0080`. The supported `default.xex` SHA-256 remains
 `DB40DF605ADE49A612B35A7A24C38F6004BCB17A88ED6B48288DE16DF9E3987C`.
 
 ## Safety boundary
@@ -22,6 +22,13 @@ not read guest resource payloads or write guest state. The original wrapper,
 PM4 packet, Xenos work, arguments, registers, and control flow are preserved.
 Discovery records are never suppression evidence.
 
+The NR-05A packet-provenance extension adds exact header-store hooks at
+`0x82410328` and `0x829F7CB0`. It correlates title metadata with backend draws
+by physical PM4 header address, not by timing or FIFO order. Its fixed
+16,384-packet and 4,096-aggregate capacities, failure accounting, and
+promotion gate are documented in
+[`TITLE_DRAW_PROVENANCE.md`](TITLE_DRAW_PROVENANCE.md).
+
 ## Proved wrapper layers
 
 The generated AOT instruction inventory establishes ten runtime wrapper
@@ -30,7 +37,7 @@ families:
 | Entry | Static evidence | Reviewed identity | Runtime observation |
 | --- | --- | --- | --- |
 | `0x824079B8` | Directly adapts its entry arguments and calls `0x8240F4D8` at `0x824079F8` | Title draw adapter; semantic family unknown | Hook `0x824079BC`: entry `LR` and `r3-r10` |
-| `0x8240F4D8` | At `0x82410320`, stores a dynamic-count Type-3 `PM4_DRAW_INDX_2` (`0x36`) header | Indexed draw packet wrapper | Hook `0x8240F4DC`: entry `LR` and `r3-r10` |
+| `0x8240F4D8` | Constructs a dynamic-count Type-3 `PM4_DRAW_INDX_2` (`0x36`) header at `0x82410320` and stores it at `0x82410328` | Indexed draw packet wrapper | Entry hook `0x8240F4DC`; exact packet-address hook `0x82410328` |
 | `0x824587D8` | Calls `0x82458A88` at `0x82458828` and `0x824589E4` while managing resolve state | Title resolve controller | Hook `0x824587DC`: entry `LR` and `r3-r10` |
 | `0x82458A88` | Writes register `0x2208` (`RB_MODECONTROL`) followed by value 6 (`EdramMode::kCopy`) at `0x82458AC0`/`0x82458AD4` | Resolve state-packet setup wrapper | Hook `0x82458A8C`: entry `LR` and `r3-r10` |
 | `0x82413AB8` | Stores `PM4_SET_BIN_MASK_LO` and `PM4_SET_BIN_MASK_HI` packet headers | Xenos binning/scissor-state wrapper; semantic tiled-pass role unknown | Hook `0x82413ABC`: entry `LR` and `r3-r10` |
@@ -38,7 +45,7 @@ families:
 | `0x829F21A0` | At `0x829F225C`, stores `0xC0002300`; then marks the query ID active at `0x829F2270` | Visibility-query begin wrapper | Hook `0x829F21A4`: entry `LR` and `r3-r10` |
 | `0x829F2280` | At `0x829F22E4`, stores `0xC0002300`; then clears the active query ID at `0x829F2308` | Visibility-query end wrapper | Hook `0x829F2284`: entry `LR` and `r3-r10` |
 | `0x82D951E0` | Calls query begin at `0x82D95230`, performs five intervening work calls, then calls query end at `0x82D95378` | Visibility-query lifecycle owner; result semantics unknown | Hook `0x82D951E4`: entry `LR` and `r3-r10` |
-| `0x829F7C70` | At `0x829F7CA8`, stores fixed Type-3 count-one `PM4_DRAW_INDX_2` (`0x36`) header | Immediate/embedded-index draw wrapper | Hook `0x829F7C74`: entry `LR` and `r3-r10` |
+| `0x829F7C70` | Constructs fixed Type-3 count-one `PM4_DRAW_INDX_2` (`0x36`) at `0x829F7CA8` and stores it at `0x829F7CB0` | Immediate/embedded-index draw wrapper | Entry hook `0x829F7C74`; exact packet-address hook `0x829F7CB0` |
 
 Three additional opcode-`0x36` constructors at `0x829E82D0`, `0x829E8428`,
 and `0x829EDB68` build initialization templates. They are inventoried but are
@@ -245,6 +252,31 @@ query-result consumption, semantic tiled-pass ownership, resource lifetime,
 and semantic caller identities remain open title-side inventory work. Until
 those gates are met, all work stays on Xenos and no new draw family may be
 suppressed.
+
+For all 38 direct adapter callsites, the same static inventory now records
+`r3-r10`'s last syntactic definition since the nearest intervening call. Simple
+loads retain base register, offset, and width; values crossing a call boundary
+remain unknown. The exact runtime provenance report joins these leads with
+per-signature argument stability, but neither source alone proves an object
+type or lifetime.
+
+The packet-provenance bridge replaces “next draw” inference with an exact
+address match. The first consolidated runtime capture proved 232,506 exact
+title-to-backend matches, but all matched draws ended before the prepared
+callback and 40 live address generations reused an address. The bridge now
+retains those generations oldest-first for the same exact address, aggregates
+unprepared backend signatures instead of discarding them, and treats clean
+shutdown packets as accounted when `recorded = matched + pending` holds. The
+next milestone capture must show zero address, forwarding, origin, and capacity
+faults before any caller association is accepted; prepared semantic coverage
+remains unproved until a prepared outcome is actually observed.
+
+That follow-up capture, session `20260829T123251Z-p12356`, completed the exact
+accounting contract with 107,455 backend matches, 105 shutdown-pending packets,
+40 handled live-address reuses, 66 statically joined unprepared aggregates, and
+zero attribution faults. This qualifies the exact title-to-backend bridge. It
+does not qualify title-to-prepared provenance: every exact match retained the
+explicit `not_prepared` outcome.
 
 ## Side-effect-boundary qualification — 2026-08-29
 

--- a/docs/native-renderer/RENDER_PASS_CENSUS.md
+++ b/docs/native-renderer/RENDER_PASS_CENSUS.md
@@ -34,13 +34,14 @@ Xenos suppression, or presentation changes. Its setting,
 | System command-buffer request | `0x829EFD80` | `sub_829EFB30` calls `VdGetSystemCommandBuffer`; output pointers are passed in `r3` and `r4` | The returned buffer cursor is subsequently written into the graphics-device object | Verified, not hooked |
 | Frame submission | `0x829EFEB8` | `sub_829EFB30` calls the sole `VdSwap` import; continuation is `0x829EFEBC` | Device command-buffer cursor is updated after return | Verified, pass-through hook |
 | Xenos swap packet | ReXGlue `CommandProcessor::ExecutePacketType3_XE_SWAP` | Consumes the `VdSwap` packet and calls backend `IssueSwap` | ReXGlue snapshots/reset per-frame counters before decoding the packet payload | Verified runtime boundary |
-| Title draw adapter | `0x824079B8` | Direct call to indexed wrapper at `0x824079F8`; 38 call sites across 25 caller functions | Entry `r3-r10` and caller `LR` are observed only when discovery is enabled; stack arguments remain unread | Verified, bounded pass-through hook; semantic family unknown |
+| Title draw adapter | `0x824079B8` | Direct call to indexed wrapper at `0x824079F8`; 38 call sites across 25 caller functions | Entry `r3-r10` and caller `LR` are observed only when discovery is enabled; exact packet store is keyed at `0x82410328`; stack arguments remain unread | Verified, bounded pass-through hook; exact backend provenance qualified, prepared provenance not observed |
 | Indexed draw wrapper | `0x8240F4D8` | Stored `PM4_DRAW_INDX_2` header at `0x82410320`; dynamic Type-3 count | Entry `r3-r10` and caller `LR` are observed; six consume-then-clear dirty-mask sites are statically proved | Verified, bounded pass-through hook |
 | Immediate draw wrapper | `0x829F7C70` | Stored count-one `PM4_DRAW_INDX_2` header at `0x829F7CA8` | Entry `r3-r10` and caller `LR` are observed only when discovery is enabled | Verified, bounded pass-through hook |
 | Visibility-query begin | `0x829F21A0` | Stored count-one `PM4_VIZ_QUERY` header at `0x829F225C`; active-query bit set at `0x829F2270` | Entry `r3-r10` and caller `LR` are observed only when discovery is enabled | Verified, bounded pass-through hook |
 | Visibility-query end | `0x829F2280` | Stored count-one `PM4_VIZ_QUERY` header at `0x829F22E4`; active-query bit cleared at `0x829F2308` | Entry `r3-r10` and caller `LR` are observed only when discovery is enabled | Verified, bounded pass-through hook |
 | Visibility-query owner | `0x82D951E0` | Calls begin at `0x82D95230`, performs five work calls, then calls end at `0x82D95378`; two direct callers | Entry `r3-r10` and caller `LR` are observed only when discovery is enabled | Lifecycle owner verified; result consumer and semantics unknown |
 | Draw packet backend | ReXGlue `PM4_DRAW_INDX` / `PM4_DRAW_INDX_2` | Generic command processor decodes the packet before backend `IssueDraw` | Register-derived draw state is consumed by the backend | Verified runtime boundary |
+| Draw packet provenance | Title stores `0x82410328` / `0x829F7CB0`; ReXGlue patch `0080` | Both sides normalize the same PM4 header to a physical address | Fixed outstanding table is consumed only on exact address equality; same-address generations are retained oldest-first | Runtime-qualified, passive: 107,455 exact matches and zero attribution faults; no prepared callback observed |
 | Resolve controller | `0x824587D8` | Two direct calls to setup wrapper `0x82458A88`; three direct controller callers | Entry `r3-r10` and caller `LR` are observed only when discovery is enabled | Verified, bounded pass-through hook |
 | Resolve setup | `0x82458A88` | Emits `RB_MODECONTROL` register index `0x2208` followed by `EdramMode::kCopy` value 6 | Entry `r3-r10` and caller `LR` are observed only when discovery is enabled | Title setup verified; subsequent resolve draw ownership unknown |
 | Binning/scissor state | `0x82413AB8` | Stores `PM4_SET_BIN_MASK_LO/HI` headers; ten direct calls | Entry `r3-r10` and caller `LR` are observed only when discovery is enabled | Xenos state boundary verified; semantic tiled role unknown |
@@ -103,6 +104,8 @@ read or serialize guest memory.
 - Inventory memexport-producing draws and guest-visible resolve destinations.
 - Map high-level world, vehicle, road, HUD, garage, mirror, shadow, exposure,
   livery, thumbnail, and rewind dispatch families.
+- Use exact title-packet provenance to associate those callers with prepared
+  signatures before reading object/lifetime structures.
 
 The ten proved wrapper entries, all 72 static direct calls, one proved tail-
 forwarded correlation edge, and explicit semantic unknowns are recorded in

--- a/docs/native-renderer/TITLE_DRAW_PROVENANCE.md
+++ b/docs/native-renderer/TITLE_DRAW_PROVENANCE.md
@@ -1,0 +1,144 @@
+# Title draw provenance
+
+This NR-05A bridge connects a title-level draw caller to the exact backend draw
+without relying on thread timing, global FIFO position, resolution, or
+shader-only heuristics. When that draw reaches pipeline preparation, the bridge
+also records the exact prepared signature. It remains passive and default-off.
+Xenos still parses and executes every packet, and no result produced here
+permits suppression.
+
+## Why a FIFO is insufficient
+
+The title writes command buffers on a guest CPU thread while ReXGlue decodes
+them later on the graphics command-processor thread. A wrapper invocation and
+the next prepared draw are therefore not a safe pair: indirect buffers,
+direct packet-wrapper callers, predication, unsupported packets, or a draw
+that does not reach pipeline preparation can shift either sequence.
+
+The bridge instead uses the identity already shared by both sides: the
+physical address of the stored PM4 header.
+
+## Exact correlation path
+
+1. The entry hook on `0x824079B8` retains the adapter caller `LR` and unchanged
+   `r3-r10` metadata in thread-local host state.
+2. The indexed-wrapper hook at `0x8240F4DC` proves the forwarding edge when its
+   caller is `0x824079FC`; direct indexed-wrapper callers retain their own LR.
+3. Immediately before the original header store at `0x82410328`, the packet
+   hook records `physical(r3 + 4)`. The original `stwu` still executes.
+4. The immediate wrapper uses the same contract at its header store
+   `0x829F7CB0`.
+5. ReXGlue patch `0080` records the physical address of every packet before
+   decoding it and includes that address in `GraphicsDrawObservation`.
+6. The draw observer consumes title metadata only when the two physical packet
+   addresses match exactly. Reused live addresses retain each submission and
+   are consumed oldest-first for that exact address. This is a per-address
+   generation rule, not attribution to the next global draw.
+7. The synchronous prepared-draw callback adds the existing exact prepared
+   signature. If no callback occurs before the next draw, the bridge records
+   the exact backend draw signature with `outcome=not_prepared` instead of
+   discarding the caller evidence.
+
+This preserves direct evidence across producer/consumer threads without
+serializing guest payloads or modifying the command stream.
+
+## Object/context leads
+
+The static dispatch inventory now records a bounded syntactic definition for
+each `r3-r10` argument at every direct adapter callsite. It scans backward only
+to the nearest intervening call, reports entry registers and call-clobbered
+unknowns explicitly, and decodes simple memory loads into base register,
+offset, and width. The runtime provenance report joins that record with the
+observed argument variation and exact prepared signature.
+
+This deliberately is not interprocedural dataflow. A stable `r3`, a load such
+as `lwz r3,40(r31)`, or a narrow numeric range is only an object/context lead.
+It does not establish pointerness, type, ownership, registration, destruction,
+or lifetime.
+
+The current deterministic MS-2505 inventory covers all 38 direct adapter
+callsites: 288 of 304 argument slots have a bounded local definition, 16 stop
+as unknown at an intervening call, and 32 are direct `lwz` field loads with an
+explicit base register and offset. Runtime evidence is still required to
+select which of these callsites owns a recurring prepared family.
+
+## Bounded failure model
+
+The outstanding packet table has 16,384 fixed entries. Provenance is aggregated
+into 4,096 fixed `(outcome, origin wrapper, caller LR, backend signature)`
+entries. Each aggregate retains first and last `r3-r10`, per-register numeric
+bounds, and a variation mask. Prepared outcomes use the exact prepared
+signature; unprepared outcomes use the existing draw signature. This is a
+bounded lead for distinguishing stable owner/context candidates from per-draw
+inputs; it is not proof that any value is a valid object pointer or that its
+numeric range represents a lifetime.
+The summary keeps separate counts for:
+
+- title packets recorded and exact backend matches;
+- matched packets whose draw never reached prepared-pipeline observation;
+- packets still outstanding at shutdown;
+- physical-address translation failures;
+- live packet-address reuse handled by ordered per-address generations;
+- packet-table and aggregate overflow;
+- bounded per-thread origin-stack overflow or a packet hook with no origin;
+- adapter-to-indexed forwarding mismatches; and
+- backend draws that have no instrumented title packet, which is expected for
+  unreviewed constructors and is not treated as an attribution.
+
+Address translation, table/stack/aggregate overflow, forwarding, or origin
+faults leave the deterministic report `status=incomplete_fail_closed`. A
+nonzero pending count at clean shutdown is valid only when the exact accounting
+identity `recorded = matched + pending` holds. Live address reuse is diagnostic,
+not a fault, because every generation is retained. Unmatched data is never
+assigned to the next caller or signature.
+
+## Deterministic report
+
+Generate the static inventory and run the existing AppData capture once at the
+milestone boundary:
+
+```powershell
+$stateRoot = Join-Path $env:LOCALAPPDATA `
+    'PinyonShift\source\0.1.0\.local\preview'
+.\tools\capture-native-renderer-dispatch.ps1 `
+    -StateRoot $stateRoot `
+    -Scene open_world `
+    -StaticOutput .local\qualification\native-dispatch-static.json
+```
+
+After clean exit, build the exact provenance report from that same diagnostics
+stream:
+
+```powershell
+python .\tools\summarize-native-renderer-title-provenance.py `
+    <diagnostics.jsonl> `
+    --static .local\qualification\native-dispatch-static.json `
+    --output .local\qualification\native-title-provenance.json
+```
+
+Milestone session `20260829T123251Z-p12356` closed with complete exact
+accounting: 107,560 title packets recorded, 107,455 exact backend matches, and
+105 packets still outstanding at clean shutdown. Forty live same-address
+generations were retained and consumed without loss. The 107,455 matched draws
+formed 66 statically joined unprepared aggregates, with zero address,
+forwarding, origin, table, stack, or aggregate faults. No matched title draw
+reached the prepared callback in this scene, so `prepared_coverage` correctly
+remains `none_observed` and no semantic promotion follows from this capture.
+
+The report recognizes only the two prepared signatures already qualified by
+independent visual evidence: retained sky/horizon anchor
+`747837906D0BF484` and follower `1D253A52B55C9FB3`. Every other signature
+remains `unknown`. Even a known signature has `native_coverage=false` and
+`suppression_eligible=false`; an unprepared outcome always remains semantically
+unknown. This bridge proves dispatch provenance, not
+object lifetime, material ownership, transforms, LOD, visibility, streaming,
+destruction, or a semantic replacement boundary.
+
+## Promotion gate
+
+A caller may become an NR-05 semantic extraction hook only after repeated
+scene captures reproduce its exact signature association and title-side
+analysis proves the owning object and lifetime contract. Terrain/roads and
+static world retain priority over the already-known sky family. This bridge
+supplies the dispatch-to-draw evidence needed to investigate those owners; it
+does not reorder the NR-05 priority list.

--- a/patches/rexglue/0080-graphics-draw-packet-provenance.patch
+++ b/patches/rexglue/0080-graphics-draw-packet-provenance.patch
@@ -1,0 +1,54 @@
+diff --git a/include/rex/graphics/command_processor.h b/include/rex/graphics/command_processor.h
+index 96dfb59..41bf91f 100644
+--- a/include/rex/graphics/command_processor.h
++++ b/include/rex/graphics/command_processor.h
+@@ -278,6 +278,7 @@ class CommandProcessor {
+   uint64_t observation_frame_sequence_ = 1;
+   uint64_t observation_draw_sequence_ = 0;
+   uint64_t observation_copy_sequence_ = 0;
++  uint32_t observation_packet_physical_address_ = UINT32_MAX;
+ 
+   bool paused_ = false;
+ 
+diff --git a/include/rex/system/interfaces/graphics.h b/include/rex/system/interfaces/graphics.h
+index 3540c35..b276361 100644
+--- a/include/rex/system/interfaces/graphics.h
++++ b/include/rex/system/interfaces/graphics.h
+@@ -222,6 +222,7 @@ struct GraphicsDrawObservation {
+   uint64_t draw_sequence = 0;
+   uint64_t vertex_shader_hash = 0;
+   uint64_t pixel_shader_hash = 0;
++  uint32_t packet_physical_address = UINT32_MAX;
+   uint32_t packet = 0;
+   uint32_t initiator = 0;
+   uint32_t primitive_type = 0;
+diff --git a/src/graphics/command_processor.cpp b/src/graphics/command_processor.cpp
+index f3fcfbe..1e7eb06 100644
+--- a/src/graphics/command_processor.cpp
++++ b/src/graphics/command_processor.cpp
+@@ -683,6 +683,16 @@ void CommandProcessor::ExecutePacket(uint32_t ptr, uint32_t count) {
+ }
+ 
+ bool CommandProcessor::ExecutePacket(memory::RingBuffer* reader) {
++  const uintptr_t packet_host_address =
++      reinterpret_cast<uintptr_t>(reader->buffer()) + reader->read_offset();
++  const uintptr_t physical_host_base =
++      reinterpret_cast<uintptr_t>(memory_->physical_membase());
++  const uintptr_t physical_offset = packet_host_address - physical_host_base;
++  observation_packet_physical_address_ =
++      packet_host_address >= physical_host_base &&
++              physical_offset < UINT32_C(0x20000000)
++          ? uint32_t(physical_offset)
++          : UINT32_MAX;
+   const uint32_t packet = reader->ReadAndSwap<uint32_t>();
+   const uint32_t packet_type = packet >> 30;
+   if (packet == 0) {
+@@ -1485,6 +1495,8 @@ bool CommandProcessor::ExecutePacketType3Draw(memory::RingBuffer* reader, uint32
+             active_vertex_shader_ ? active_vertex_shader_->ucode_data_hash() : 0;
+         observation.pixel_shader_hash =
+             active_pixel_shader_ ? active_pixel_shader_->ucode_data_hash() : 0;
++        observation.packet_physical_address =
++            observation_packet_physical_address_;
+         observation.packet = packet;
+         observation.initiator = vgt_draw_initiator.value;
+         observation.primitive_type = uint32_t(vgt_draw_initiator.prim_type);

--- a/src/native_renderer/graphics_hooks.cpp
+++ b/src/native_renderer/graphics_hooks.cpp
@@ -12,6 +12,7 @@
 #include <fstream>
 #include <iterator>
 #include <limits>
+#include <mutex>
 #include <span>
 #include <string>
 #include <thread>
@@ -72,6 +73,9 @@ constexpr uint64_t kSuppressionWarmupFrameCount = 8;
 constexpr uint64_t kSuppressionFailureCooldownFrameCount = 120;
 constexpr uint64_t kSuppressionStateDetailLimit = 32;
 constexpr size_t kDispatchCallerCapacity = 256;
+constexpr size_t kTitlePacketProvenanceCapacity = 16384;
+constexpr size_t kTitleDrawProvenanceCapacity = 4096;
+constexpr size_t kTitleOriginStackCapacity = 32;
 constexpr uint64_t kSkyHorizonAnchorSignature = UINT64_C(0x747837906D0BF484);
 constexpr uint64_t kSkyHorizonFollowerSignature = UINT64_C(0x1D253A52B55C9FB3);
 std::atomic<uint64_t> g_frame_sequence{};
@@ -106,6 +110,63 @@ struct DispatchCallerEntry {
 std::array<DispatchCallerEntry, kDispatchCallerCapacity> g_dispatch_callers;
 std::atomic<uint64_t> g_dispatch_caller_overflow{};
 std::atomic<bool> g_dispatch_discovery_installed{};
+
+struct TitleDrawOrigin {
+  DispatchWrapper wrapper = DispatchWrapper::kDrawIndexed;
+  uint32_t caller = 0;
+  std::array<uint32_t, 8> arguments{};
+  bool valid = false;
+};
+
+struct TitlePacketProvenanceEntry {
+  uint32_t packet_physical_address = 0;
+  uint64_t submission_sequence = 0;
+  TitleDrawOrigin origin{};
+  bool ever_used = false;
+  bool occupied = false;
+};
+
+struct TitleDrawProvenanceEntry {
+  uint64_t backend_signature = 0;
+  uint64_t calls = 0;
+  uint64_t first_frame = 0;
+  uint64_t last_frame = 0;
+  uint64_t first_draw = 0;
+  uint32_t first_packet_physical_address = 0;
+  TitleDrawOrigin origin{};
+  std::array<uint32_t, 8> last_arguments{};
+  std::array<uint32_t, 8> minimum_arguments{};
+  std::array<uint32_t, 8> maximum_arguments{};
+  uint32_t varying_argument_mask = 0;
+  bool prepared = false;
+};
+
+std::array<TitlePacketProvenanceEntry, kTitlePacketProvenanceCapacity>
+    g_title_packet_provenance{};
+std::array<TitleDrawProvenanceEntry, kTitleDrawProvenanceCapacity>
+    g_title_draw_provenance{};
+std::mutex g_title_packet_provenance_mutex;
+std::atomic<bool> g_title_provenance_installed{};
+std::atomic<rex::memory::Memory *> g_title_provenance_memory{};
+uint64_t g_title_packets_recorded = 0;
+uint64_t g_title_packets_matched = 0;
+uint64_t g_title_packet_address_failures = 0;
+uint64_t g_title_packet_reused_live_addresses = 0;
+uint64_t g_title_packet_table_overflow = 0;
+uint64_t g_title_backend_unattributed_draws = 0;
+uint64_t g_title_matched_unprepared_draws = 0;
+std::atomic<uint64_t> g_title_forwarding_mismatches{};
+std::atomic<uint64_t> g_title_origins_pushed{};
+std::atomic<uint64_t> g_title_origins_consumed{};
+std::atomic<uint64_t> g_title_origin_stack_overflow{};
+std::atomic<uint64_t> g_title_packets_without_origin{};
+uint64_t g_title_draw_provenance_count = 0;
+uint64_t g_title_draw_provenance_overflow = 0;
+uint64_t g_title_packet_submission_sequence = 0;
+thread_local TitleDrawOrigin g_pending_adapter_origin;
+thread_local std::array<TitleDrawOrigin, kTitleOriginStackCapacity>
+    g_title_origin_stack;
+thread_local size_t g_title_origin_stack_depth = 0;
 
 const char *DispatchWrapperName(DispatchWrapper wrapper) {
   switch (wrapper) {
@@ -159,6 +220,213 @@ const char *DispatchWrapperAddress(DispatchWrapper wrapper) {
   return "00000000";
 }
 
+std::string CensusSceneMarker();
+
+TitleDrawOrigin MakeTitleDrawOrigin(DispatchWrapper wrapper, uint32_t caller,
+                                    uint32_t r3, uint32_t r4, uint32_t r5,
+                                    uint32_t r6, uint32_t r7, uint32_t r8,
+                                    uint32_t r9, uint32_t r10) {
+  TitleDrawOrigin origin;
+  origin.wrapper = wrapper;
+  origin.caller = caller;
+  origin.arguments = {r3, r4, r5, r6, r7, r8, r9, r10};
+  origin.valid = true;
+  return origin;
+}
+
+void ResetTitleDrawProvenance() {
+  std::scoped_lock lock(g_title_packet_provenance_mutex);
+  for (TitlePacketProvenanceEntry &entry : g_title_packet_provenance) {
+    entry = {};
+  }
+  for (TitleDrawProvenanceEntry &entry : g_title_draw_provenance) {
+    entry = {};
+  }
+  g_title_packets_recorded = 0;
+  g_title_packets_matched = 0;
+  g_title_packet_address_failures = 0;
+  g_title_packet_reused_live_addresses = 0;
+  g_title_packet_table_overflow = 0;
+  g_title_backend_unattributed_draws = 0;
+  g_title_matched_unprepared_draws = 0;
+  g_title_forwarding_mismatches.store(0, std::memory_order_relaxed);
+  g_title_origins_pushed.store(0, std::memory_order_relaxed);
+  g_title_origins_consumed.store(0, std::memory_order_relaxed);
+  g_title_origin_stack_overflow.store(0, std::memory_order_relaxed);
+  g_title_packets_without_origin.store(0, std::memory_order_relaxed);
+  g_title_draw_provenance_count = 0;
+  g_title_draw_provenance_overflow = 0;
+  g_title_packet_submission_sequence = 0;
+  g_pending_adapter_origin = {};
+  g_title_origin_stack = {};
+  g_title_origin_stack_depth = 0;
+}
+
+void ConfigureTitleDrawProvenance(bool census_requested,
+                                  rex::memory::Memory *memory) {
+  ResetTitleDrawProvenance();
+  const bool dispatch_requested =
+      REXCVAR_GET(pinyon_shift_native_renderer_dispatch_discovery);
+  const bool armed = dispatch_requested && census_requested && memory;
+  g_title_provenance_memory.store(armed ? memory : nullptr,
+                                  std::memory_order_release);
+  g_title_provenance_installed.store(armed, std::memory_order_release);
+  pinyon_shift::diagnostics::RecordEvent(
+      "native_renderer.discovery.title_provenance_config",
+      {{"status", armed ? "armed" : "disabled"},
+       {"scene", CensusSceneMarker()},
+       {"title_packet_hooks", "82410328,829F7CB0"},
+       {"packet_key", "physical_pm4_header_address"},
+       {"packet_capacity", std::to_string(kTitlePacketProvenanceCapacity)},
+       {"aggregate_capacity", std::to_string(kTitleDrawProvenanceCapacity)},
+       {"origin_stack_capacity", std::to_string(kTitleOriginStackCapacity)},
+       {"metadata",
+        "origin_wrapper,entry_lr,r3-r10,outcome,backend_signature"},
+       {"guest_payload_read", "false"},
+       {"guest_state_changed", "false"},
+       {"control_flow_changed", "false"},
+       {"xenos_authority", "true"},
+       {"suppression_allowed", "false"}});
+}
+
+void CaptureAdapterOrigin(uint32_t caller, uint32_t r3, uint32_t r4,
+                          uint32_t r5, uint32_t r6, uint32_t r7,
+                          uint32_t r8, uint32_t r9, uint32_t r10) {
+  if (!g_title_provenance_installed.load(std::memory_order_acquire)) {
+    return;
+  }
+  g_pending_adapter_origin = MakeTitleDrawOrigin(
+      DispatchWrapper::kDrawAdapter, caller, r3, r4, r5, r6, r7, r8, r9,
+      r10);
+}
+
+void CapturePacketWrapperOrigin(DispatchWrapper wrapper, uint32_t caller,
+                                uint32_t r3, uint32_t r4, uint32_t r5,
+                                uint32_t r6, uint32_t r7, uint32_t r8,
+                                uint32_t r9, uint32_t r10) {
+  if (!g_title_provenance_installed.load(std::memory_order_acquire)) {
+    return;
+  }
+  TitleDrawOrigin origin;
+  if (wrapper == DispatchWrapper::kDrawIndexed && caller == 0x824079FC) {
+    if (g_pending_adapter_origin.valid) {
+      origin = g_pending_adapter_origin;
+      g_pending_adapter_origin = {};
+    } else {
+      ++g_title_forwarding_mismatches;
+    }
+  }
+  if (!origin.valid) {
+    origin = MakeTitleDrawOrigin(wrapper, caller, r3, r4, r5, r6, r7, r8,
+                                 r9, r10);
+  }
+  if (g_title_origin_stack_depth == kTitleOriginStackCapacity) {
+    ++g_title_origin_stack_overflow;
+    return;
+  }
+  g_title_origin_stack[g_title_origin_stack_depth++] = origin;
+  ++g_title_origins_pushed;
+}
+
+void RecordTitleDrawPacket(uint32_t packet_guest_address) {
+  if (!g_title_provenance_installed.load(std::memory_order_acquire)) {
+    return;
+  }
+  if (!g_title_origin_stack_depth) {
+    ++g_title_packets_without_origin;
+    return;
+  }
+  rex::memory::Memory *memory =
+      g_title_provenance_memory.load(std::memory_order_acquire);
+  if (!memory) {
+    return;
+  }
+  const TitleDrawOrigin origin =
+      g_title_origin_stack[--g_title_origin_stack_depth];
+  ++g_title_origins_consumed;
+  const uint32_t packet_physical_address =
+      memory->GetPhysicalAddress(packet_guest_address);
+  std::scoped_lock lock(g_title_packet_provenance_mutex);
+  if (!g_title_provenance_installed.load(std::memory_order_acquire)) {
+    return;
+  }
+  if (packet_physical_address == UINT32_MAX) {
+    ++g_title_packet_address_failures;
+    return;
+  }
+  const size_t initial =
+      (packet_physical_address >> 2) % kTitlePacketProvenanceCapacity;
+  size_t available = kTitlePacketProvenanceCapacity;
+  bool reused_live_address = false;
+  for (size_t probe = 0; probe < kTitlePacketProvenanceCapacity; ++probe) {
+    const size_t index = (initial + probe) % kTitlePacketProvenanceCapacity;
+    TitlePacketProvenanceEntry &entry = g_title_packet_provenance[index];
+    if (entry.occupied &&
+        entry.packet_physical_address == packet_physical_address) {
+      reused_live_address = true;
+    }
+    if (!entry.occupied && available == kTitlePacketProvenanceCapacity) {
+      available = index;
+    }
+    if (!entry.ever_used) {
+      break;
+    }
+  }
+  if (available == kTitlePacketProvenanceCapacity) {
+    ++g_title_packet_table_overflow;
+    return;
+  }
+  TitlePacketProvenanceEntry &entry = g_title_packet_provenance[available];
+  entry.packet_physical_address = packet_physical_address;
+  entry.submission_sequence = ++g_title_packet_submission_sequence;
+  entry.origin = origin;
+  entry.ever_used = true;
+  entry.occupied = true;
+  if (reused_live_address) {
+    ++g_title_packet_reused_live_addresses;
+  }
+  ++g_title_packets_recorded;
+}
+
+bool ConsumeTitleDrawPacket(uint32_t packet_physical_address,
+                            TitleDrawOrigin &origin) {
+  if (!g_title_provenance_installed.load(std::memory_order_acquire) ||
+      packet_physical_address == UINT32_MAX) {
+    return false;
+  }
+  std::scoped_lock lock(g_title_packet_provenance_mutex);
+  if (!g_title_provenance_installed.load(std::memory_order_acquire)) {
+    return false;
+  }
+  const size_t initial =
+      (packet_physical_address >> 2) % kTitlePacketProvenanceCapacity;
+  size_t oldest_match = kTitlePacketProvenanceCapacity;
+  uint64_t oldest_sequence = UINT64_MAX;
+  for (size_t probe = 0; probe < kTitlePacketProvenanceCapacity; ++probe) {
+    const size_t index = (initial + probe) % kTitlePacketProvenanceCapacity;
+    TitlePacketProvenanceEntry &entry = g_title_packet_provenance[index];
+    if (!entry.ever_used) {
+      break;
+    }
+    if (entry.occupied &&
+        entry.packet_physical_address == packet_physical_address &&
+        entry.submission_sequence < oldest_sequence) {
+      oldest_match = index;
+      oldest_sequence = entry.submission_sequence;
+    }
+  }
+  if (oldest_match != kTitlePacketProvenanceCapacity) {
+    TitlePacketProvenanceEntry &entry =
+        g_title_packet_provenance[oldest_match];
+    origin = entry.origin;
+    entry.occupied = false;
+    ++g_title_packets_matched;
+    return true;
+  }
+  ++g_title_backend_unattributed_draws;
+  return false;
+}
+
 void ResetDispatchDiscovery() {
   for (DispatchCallerEntry &entry : g_dispatch_callers) {
     entry.key.store(0, std::memory_order_relaxed);
@@ -175,8 +443,6 @@ void ResetDispatchDiscovery() {
   }
   g_dispatch_caller_overflow.store(0, std::memory_order_relaxed);
 }
-
-std::string CensusSceneMarker();
 
 void ConfigureDispatchDiscovery() {
   ResetDispatchDiscovery();
@@ -955,6 +1221,7 @@ std::atomic<uint64_t> g_guest_cpu_visibility_target_overflow{};
 
 struct PendingCandidateObservation {
   rex::system::GraphicsDrawObservation sample;
+  TitleDrawOrigin title_origin{};
   std::array<size_t, 64> family_targets{};
   size_t family_target_count = 0;
   uint64_t family_base_fetch_mask = 0;
@@ -2310,6 +2577,197 @@ CandidateSignature(const rex::system::GraphicsDrawObservation &observation,
   return hash ? hash : 1;
 }
 
+void RecordTitleDrawProvenance(
+    uint64_t backend_signature, bool prepared,
+    const rex::system::GraphicsDrawObservation &observation,
+    const TitleDrawOrigin &origin) {
+  if (!origin.valid) {
+    return;
+  }
+  const uint64_t key = backend_signature ^
+                       (uint64_t(origin.caller) << 17) ^
+                       (uint64_t(origin.wrapper) << 57) ^
+                       (prepared ? uint64_t(1) << 63 : 0);
+  size_t index = size_t(key % kTitleDrawProvenanceCapacity);
+  for (size_t probe = 0; probe < kTitleDrawProvenanceCapacity; ++probe) {
+    TitleDrawProvenanceEntry &entry = g_title_draw_provenance[index];
+    if (!entry.calls) {
+      entry.backend_signature = backend_signature;
+      entry.calls = 1;
+      entry.first_frame = observation.frame_sequence;
+      entry.last_frame = observation.frame_sequence;
+      entry.first_draw = observation.draw_sequence;
+      entry.first_packet_physical_address =
+          observation.packet_physical_address;
+      entry.origin = origin;
+      entry.last_arguments = origin.arguments;
+      entry.minimum_arguments = origin.arguments;
+      entry.maximum_arguments = origin.arguments;
+      entry.prepared = prepared;
+      ++g_title_draw_provenance_count;
+      return;
+    }
+    if (entry.backend_signature == backend_signature &&
+        entry.prepared == prepared &&
+        entry.origin.wrapper == origin.wrapper &&
+        entry.origin.caller == origin.caller) {
+      ++entry.calls;
+      entry.last_frame = observation.frame_sequence;
+      for (size_t i = 0; i < origin.arguments.size(); ++i) {
+        if (entry.last_arguments[i] != origin.arguments[i]) {
+          entry.varying_argument_mask |= uint32_t(1) << i;
+        }
+        entry.last_arguments[i] = origin.arguments[i];
+        entry.minimum_arguments[i] =
+            std::min(entry.minimum_arguments[i], origin.arguments[i]);
+        entry.maximum_arguments[i] =
+            std::max(entry.maximum_arguments[i], origin.arguments[i]);
+      }
+      return;
+    }
+    index = (index + 1) % kTitleDrawProvenanceCapacity;
+  }
+  ++g_title_draw_provenance_overflow;
+}
+
+void EmitTitleDrawProvenanceSummary() {
+  if (!g_title_provenance_installed.exchange(false,
+                                              std::memory_order_acq_rel)) {
+    g_title_provenance_memory.store(nullptr, std::memory_order_release);
+    return;
+  }
+  uint64_t prepared_matches = 0;
+  uint64_t unprepared_matches = 0;
+  uint64_t prepared_aggregate_count = 0;
+  uint64_t unprepared_aggregate_count = 0;
+  for (const TitleDrawProvenanceEntry &entry : g_title_draw_provenance) {
+    if (!entry.calls) {
+      continue;
+    }
+    if (entry.prepared) {
+      prepared_matches += entry.calls;
+      ++prepared_aggregate_count;
+    } else {
+      unprepared_matches += entry.calls;
+      ++unprepared_aggregate_count;
+    }
+    pinyon_shift::diagnostics::RecordEvent(
+        "native_renderer.discovery.title_provenance_entry",
+        {{"origin_wrapper", DispatchWrapperName(entry.origin.wrapper)},
+         {"origin_wrapper_address",
+          DispatchWrapperAddress(entry.origin.wrapper)},
+         {"origin_caller", fmt::format("{:08X}", entry.origin.caller)},
+         {"outcome", entry.prepared ? "prepared" : "not_prepared"},
+         {"backend_signature",
+          fmt::format("{:016X}", entry.backend_signature)},
+         {"prepared_signature",
+          entry.prepared ? fmt::format("{:016X}", entry.backend_signature)
+                         : ""},
+         {"calls", std::to_string(entry.calls)},
+         {"first_frame", std::to_string(entry.first_frame)},
+         {"last_frame", std::to_string(entry.last_frame)},
+         {"first_draw", std::to_string(entry.first_draw)},
+         {"first_packet_physical_address",
+          fmt::format("{:08X}", entry.first_packet_physical_address)},
+         {"first_r3", fmt::format("{:08X}", entry.origin.arguments[0])},
+         {"first_r4", fmt::format("{:08X}", entry.origin.arguments[1])},
+         {"first_r5", fmt::format("{:08X}", entry.origin.arguments[2])},
+         {"first_r6", fmt::format("{:08X}", entry.origin.arguments[3])},
+         {"first_r7", fmt::format("{:08X}", entry.origin.arguments[4])},
+         {"first_r8", fmt::format("{:08X}", entry.origin.arguments[5])},
+         {"first_r9", fmt::format("{:08X}", entry.origin.arguments[6])},
+         {"first_r10", fmt::format("{:08X}", entry.origin.arguments[7])},
+         {"last_arguments",
+          fmt::format("{:08X}:{:08X}:{:08X}:{:08X}:{:08X}:{:08X}:{:08X}:{:08X}",
+                      entry.last_arguments[0], entry.last_arguments[1],
+                      entry.last_arguments[2], entry.last_arguments[3],
+                      entry.last_arguments[4], entry.last_arguments[5],
+                      entry.last_arguments[6], entry.last_arguments[7])},
+         {"minimum_arguments",
+          fmt::format("{:08X}:{:08X}:{:08X}:{:08X}:{:08X}:{:08X}:{:08X}:{:08X}",
+                      entry.minimum_arguments[0], entry.minimum_arguments[1],
+                      entry.minimum_arguments[2], entry.minimum_arguments[3],
+                      entry.minimum_arguments[4], entry.minimum_arguments[5],
+                      entry.minimum_arguments[6], entry.minimum_arguments[7])},
+         {"maximum_arguments",
+          fmt::format("{:08X}:{:08X}:{:08X}:{:08X}:{:08X}:{:08X}:{:08X}:{:08X}",
+                      entry.maximum_arguments[0], entry.maximum_arguments[1],
+                      entry.maximum_arguments[2], entry.maximum_arguments[3],
+                      entry.maximum_arguments[4], entry.maximum_arguments[5],
+                      entry.maximum_arguments[6], entry.maximum_arguments[7])},
+         {"varying_argument_mask",
+          fmt::format("{:02X}", entry.varying_argument_mask)},
+         {"semantic_identity", "unknown"},
+         {"xenos_draw", "preserved"},
+         {"suppression_eligible", "false"}});
+  }
+  uint64_t pending_packets = 0;
+  {
+    std::scoped_lock lock(g_title_packet_provenance_mutex);
+    for (const TitlePacketProvenanceEntry &entry :
+         g_title_packet_provenance) {
+      pending_packets += entry.occupied ? 1 : 0;
+    }
+  }
+  const bool packet_accounting_complete =
+      g_title_packets_recorded == g_title_packets_matched + pending_packets;
+  const uint64_t origins_pushed =
+      g_title_origins_pushed.load(std::memory_order_relaxed);
+  const uint64_t origins_consumed =
+      g_title_origins_consumed.load(std::memory_order_relaxed);
+  pinyon_shift::diagnostics::RecordEvent(
+      "native_renderer.discovery.title_provenance_summary",
+      {{"title_packets_recorded", std::to_string(g_title_packets_recorded)},
+       {"backend_packet_matches", std::to_string(g_title_packets_matched)},
+       {"prepared_matches", std::to_string(prepared_matches)},
+       {"matched_unprepared_draws",
+        std::to_string(g_title_matched_unprepared_draws)},
+       {"pending_packets", std::to_string(pending_packets)},
+       {"backend_draws_without_title_packet",
+        std::to_string(g_title_backend_unattributed_draws)},
+       {"packet_address_failures",
+        std::to_string(g_title_packet_address_failures)},
+       {"reused_live_packet_addresses",
+        std::to_string(g_title_packet_reused_live_addresses)},
+       {"packet_table_overflow",
+        std::to_string(g_title_packet_table_overflow)},
+       {"forwarding_mismatches",
+        std::to_string(
+            g_title_forwarding_mismatches.load(std::memory_order_relaxed))},
+       {"origins_pushed", std::to_string(origins_pushed)},
+       {"origins_consumed", std::to_string(origins_consumed)},
+       {"origin_stack_overflow",
+        std::to_string(
+            g_title_origin_stack_overflow.load(std::memory_order_relaxed))},
+       {"packets_without_origin",
+        std::to_string(
+            g_title_packets_without_origin.load(std::memory_order_relaxed))},
+       {"origin_accounting_complete",
+        origins_pushed == origins_consumed ? "true" : "false"},
+       {"aggregate_count", std::to_string(g_title_draw_provenance_count)},
+       {"prepared_aggregate_count",
+        std::to_string(prepared_aggregate_count)},
+       {"unprepared_aggregate_count",
+        std::to_string(unprepared_aggregate_count)},
+       {"unprepared_aggregate_matches",
+        std::to_string(unprepared_matches)},
+       {"aggregate_overflow",
+        std::to_string(g_title_draw_provenance_overflow)},
+       {"packet_capacity", std::to_string(kTitlePacketProvenanceCapacity)},
+       {"aggregate_capacity", std::to_string(kTitleDrawProvenanceCapacity)},
+       {"origin_stack_capacity", std::to_string(kTitleOriginStackCapacity)},
+       {"packet_accounting_complete",
+        packet_accounting_complete ? "true" : "false"},
+       {"correlation", "exact_physical_pm4_header_address"},
+       {"semantic_identity", "unknown"},
+       {"guest_payload_read", "false"},
+       {"guest_state_changed", "false"},
+       {"control_flow_changed", "false"},
+       {"xenos_authority", "true"},
+       {"suppression_allowed", "false"}});
+  g_title_provenance_memory.store(nullptr, std::memory_order_release);
+}
+
 bool IsOpaqueColorState(
     const rex::system::GraphicsDrawObservation &observation) {
   bool writes_color = false;
@@ -2394,6 +2852,8 @@ void ObservePreparedDraw(
     CommitPassConsumer(sample, observation, g_pending_candidate);
     const uint64_t prepared_signature = CandidateSignature(
         sample, g_pending_candidate.samples_resolved_target, observation);
+    RecordTitleDrawProvenance(prepared_signature, true, sample,
+                              g_pending_candidate.title_origin);
     g_isolated_draw.prepared_signature = prepared_signature;
     g_isolated_draw.frame = sample.frame_sequence;
     g_isolated_draw.draw = sample.draw_sequence;
@@ -4269,6 +4729,8 @@ void ObserveDraw(const rex::system::GraphicsDrawObservation &observation) {
   size_t sampled_target_count = 0;
   PendingCandidateObservation candidate;
   candidate.sample = observation;
+  ConsumeTitleDrawPacket(observation.packet_physical_address,
+                         candidate.title_origin);
   for (uint32_t fetch_index = 0; fetch_index < 32; ++fetch_index) {
     if (!(observation.texture_fetch_mask & (uint32_t(1) << fetch_index))) {
       continue;
@@ -4302,6 +4764,12 @@ void ObserveDraw(const rex::system::GraphicsDrawObservation &observation) {
   const bool samples_resolved_target = sampled_target_count != 0;
   if (g_pending_candidate.valid) {
     ++g_candidate_unprepared_draw_count;
+    if (g_pending_candidate.title_origin.valid) {
+      ++g_title_matched_unprepared_draws;
+      RecordTitleDrawProvenance(DrawSignature(g_pending_candidate.sample),
+                                false, g_pending_candidate.sample,
+                                g_pending_candidate.title_origin);
+    }
     DiscardPendingPassConsumer();
   }
   candidate.samples_resolved_target = samples_resolved_target;
@@ -4346,6 +4814,7 @@ void InstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system,
       REXCVAR_GET(pinyon_shift_native_renderer_sky_horizon_suppression);
   const bool census_requested =
       REXCVAR_GET(pinyon_shift_native_renderer_census);
+  ConfigureTitleDrawProvenance(census_requested, memory);
   if (!census_requested && !g_sky_horizon_suppression.requested) {
     EmitSkyHorizonSuppressionControl();
     return;
@@ -4580,9 +5049,16 @@ void UninstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system) {
   }
   if (g_pending_candidate.valid) {
     ++g_candidate_unprepared_draw_count;
+    if (g_pending_candidate.title_origin.valid) {
+      ++g_title_matched_unprepared_draws;
+      RecordTitleDrawProvenance(DrawSignature(g_pending_candidate.sample),
+                                false, g_pending_candidate.sample,
+                                g_pending_candidate.title_origin);
+    }
     DiscardPendingPassConsumer();
     g_pending_candidate.valid = false;
   }
+  EmitTitleDrawProvenanceSummary();
   if (g_pass_consumer_trace.pending) {
     ++g_pass_consumer_trace.superseded_without_resolve;
     g_pass_consumer_trace.pending = false;
@@ -5047,6 +5523,9 @@ void PinyonShiftObserveDrawIndexedDispatch(
     PPCRegister &r12) {
   ObserveTitleDispatch(DispatchWrapper::kDrawIndexed, r12.u32, r3.u32, r4.u32,
                        r5.u32, r6.u32, r7.u32, r8.u32, r9.u32, r10.u32);
+  CapturePacketWrapperOrigin(DispatchWrapper::kDrawIndexed, r12.u32, r3.u32,
+                             r4.u32, r5.u32, r6.u32, r7.u32, r8.u32,
+                             r9.u32, r10.u32);
 }
 
 void PinyonShiftObserveDrawImmediateDispatch(
@@ -5055,6 +5534,9 @@ void PinyonShiftObserveDrawImmediateDispatch(
     PPCRegister &r12) {
   ObserveTitleDispatch(DispatchWrapper::kDrawImmediate, r12.u32, r3.u32, r4.u32,
                        r5.u32, r6.u32, r7.u32, r8.u32, r9.u32, r10.u32);
+  CapturePacketWrapperOrigin(DispatchWrapper::kDrawImmediate, r12.u32, r3.u32,
+                             r4.u32, r5.u32, r6.u32, r7.u32, r8.u32,
+                             r9.u32, r10.u32);
 }
 
 void PinyonShiftObserveDrawAdapterDispatch(
@@ -5063,6 +5545,12 @@ void PinyonShiftObserveDrawAdapterDispatch(
     PPCRegister &r12) {
   ObserveTitleDispatch(DispatchWrapper::kDrawAdapter, r12.u32, r3.u32, r4.u32,
                        r5.u32, r6.u32, r7.u32, r8.u32, r9.u32, r10.u32);
+  CaptureAdapterOrigin(r12.u32, r3.u32, r4.u32, r5.u32, r6.u32, r7.u32,
+                       r8.u32, r9.u32, r10.u32);
+}
+
+void PinyonShiftObserveDrawPacketSubmission(PPCRegister &r3) {
+  RecordTitleDrawPacket(r3.u32 + sizeof(uint32_t));
 }
 
 void PinyonShiftObserveResolveControllerDispatch(

--- a/tools/create-crash-report.ps1
+++ b/tools/create-crash-report.ps1
@@ -273,6 +273,31 @@ try {
             status = 'not_observed'
             suppression_allowed = $false
         }
+        title_draw_provenance = [ordered]@{
+            status = 'not_observed'
+            correlation = $null
+            title_packets_recorded = [uint64]0
+            backend_packet_matches = [uint64]0
+            prepared_matches = [uint64]0
+            matched_unprepared_draws = [uint64]0
+            pending_packets = [uint64]0
+            backend_draws_without_title_packet = [uint64]0
+            packet_address_failures = [uint64]0
+            reused_live_packet_addresses = [uint64]0
+            packet_table_overflow = [uint64]0
+            forwarding_mismatches = [uint64]0
+            origin_stack_overflow = [uint64]0
+            packets_without_origin = [uint64]0
+            aggregate_count = [uint64]0
+            prepared_aggregate_count = [uint64]0
+            unprepared_aggregate_count = [uint64]0
+            unprepared_aggregate_matches = [uint64]0
+            aggregate_overflow = [uint64]0
+            packet_accounting_complete = $false
+            origin_accounting_complete = $false
+            xenos_authority = $true
+            suppression_allowed = $false
+        }
     }
     $nativeShaderPack = [ordered]@{
         status = 'not_configured'
@@ -314,6 +339,37 @@ try {
                     $nativeRenderer.sky_horizon_suppression.status =
                         [string]$event.status
                     $nativeRenderer.sky_horizon_suppression.suppression_allowed =
+                        [string]$event.suppression_allowed -eq 'true'
+                }
+                'native_renderer.discovery.title_provenance_config' {
+                    $nativeRenderer.title_draw_provenance.status =
+                        [string]$event.status
+                }
+                'native_renderer.discovery.title_provenance_summary' {
+                    $provenance = $nativeRenderer.title_draw_provenance
+                    $provenance.status = 'summary_observed'
+                    $provenance.correlation = [string]$event.correlation
+                    foreach ($field in @(
+                            'title_packets_recorded', 'backend_packet_matches',
+                            'prepared_matches', 'matched_unprepared_draws',
+                            'pending_packets', 'backend_draws_without_title_packet',
+                            'packet_address_failures',
+                            'reused_live_packet_addresses', 'packet_table_overflow',
+                            'forwarding_mismatches', 'origin_stack_overflow',
+                            'packets_without_origin', 'aggregate_count',
+                            'prepared_aggregate_count',
+                            'unprepared_aggregate_count',
+                            'unprepared_aggregate_matches',
+                            'aggregate_overflow')) {
+                        $provenance[$field] = [uint64]$event.$field
+                    }
+                    $provenance.packet_accounting_complete =
+                        [string]$event.packet_accounting_complete -eq 'true'
+                    $provenance.origin_accounting_complete =
+                        [string]$event.origin_accounting_complete -eq 'true'
+                    $provenance.xenos_authority =
+                        [string]$event.xenos_authority -eq 'true'
+                    $provenance.suppression_allowed =
                         [string]$event.suppression_allowed -eq 'true'
                 }
                 'native_renderer.shader_pack.ready' {

--- a/tools/discover-native-renderer-dispatch.py
+++ b/tools/discover-native-renderer-dispatch.py
@@ -107,9 +107,20 @@ STORE_RE = re.compile(r"stw(?:u|x|ux)? (r\d+),.*$")
 LIS_RE = re.compile(r"lis (r\d+),(-?\d+)$")
 ORIS_RE = re.compile(r"oris (r\d+),\1,(\d+)$")
 CALL_RE = re.compile(r"bl 0x([0-9a-fA-F]{8})$")
+CALL_BOUNDARY_RE = re.compile(r"(?:bl 0x[0-9a-fA-F]{8}|bctrl|blrl)$")
 BRANCH_RE = re.compile(r"b 0x([0-9a-fA-F]{8})$")
 DIRTY_STORE_RE = re.compile(r"std (r\d+),(16|24|32)\(r31\)$")
 QUERY_STATE_STORE_RE = re.compile(r"std (r\d+),12424\(r31\)$")
+REGISTER_DEFINITION_RE = re.compile(r"([a-z0-9.]+) (r(?:[3-9]|10))(?:,|$)")
+MEMORY_LOAD_RE = re.compile(
+    r"(lbz|lhz|lwz|ld|lfs) (r(?:[3-9]|10)),(-?\d+)\((r\d+)\)$"
+)
+DEFINITION_OPERATIONS = {
+    "mr", "li", "lis", "mflr", "lbz", "lhz", "lwz", "ld", "lfs",
+    "addi", "addis", "add", "subf", "neg", "extsw", "or", "ori",
+    "oris", "and", "andc", "andi.", "andis.", "xor", "xori", "rlwinm",
+    "rlwimi", "rldicr", "clrlwi", "slwi", "srwi", "srawi",
+}
 
 
 def parse_functions(paths: list[pathlib.Path]) -> list[dict]:
@@ -262,6 +273,85 @@ def direct_calls(functions: list[dict], targets: set[int]) -> list[dict]:
                 }
             )
     return sorted(calls, key=lambda item: (item["wrapper"], item["callsite"]))
+
+
+def adapter_argument_leads(functions: list[dict], calls: list[dict]) -> list[dict]:
+    functions_by_address = {item["address"]: item for item in functions}
+    leads = []
+    for call in calls:
+        if call["wrapper"] != "824079B8":
+            continue
+        function = functions_by_address[int(call["caller_function_address"], 16)]
+        instructions = function["instructions"]
+        call_index = next(
+            index
+            for index, instruction in enumerate(instructions)
+            if instruction["address"] == int(call["callsite"], 16)
+        )
+        definitions = []
+        for register_index in range(3, 11):
+            register = f"r{register_index}"
+            definition = None
+            crossed_call = False
+            for instruction in reversed(instructions[:call_index]):
+                if CALL_BOUNDARY_RE.fullmatch(instruction["text"]):
+                    crossed_call = True
+                    break
+                match = REGISTER_DEFINITION_RE.match(instruction["text"])
+                if not match or match.group(2) != register:
+                    continue
+                if match.group(1) not in DEFINITION_OPERATIONS:
+                    continue
+                definition = instruction
+                break
+            if definition is None:
+                definitions.append(
+                    {
+                        "register": register,
+                        "status": (
+                            "unknown_across_call_boundary"
+                            if crossed_call
+                            else "entry_register"
+                        ),
+                    }
+                )
+                continue
+            text = definition["text"]
+            operation = text.split(" ", 1)[0]
+            operands = text.split(" ", 1)[1].split(",")
+            source_registers = re.findall(r"r\d+", ",".join(operands[1:]))
+            item = {
+                "register": register,
+                "status": "bounded_syntactic_definition",
+                "address": "{:08X}".format(definition["address"]),
+                "operation": operation,
+                "instruction": text,
+                "source_registers": source_registers,
+            }
+            memory = MEMORY_LOAD_RE.fullmatch(text)
+            if memory:
+                item["memory_load"] = {
+                    "base_register": memory.group(4),
+                    "offset": int(memory.group(3)),
+                    "width": memory.group(1),
+                }
+            definitions.append(item)
+        leads.append(
+            {
+                "wrapper": call["wrapper"],
+                "caller_function": call["caller_function"],
+                "caller_function_address": call["caller_function_address"],
+                "callsite": call["callsite"],
+                "return_address": call["return_address"],
+                "arguments": definitions,
+                "classification": "bounded_syntactic_object_lead_only",
+                "interprocedural_dataflow": False,
+                "object_identity_proved": False,
+                "lifetime_proved": False,
+                "suppression_eligible": False,
+            }
+        )
+    return leads
 
 
 def tail_forwarded_calls(
@@ -567,6 +657,70 @@ def reviewed_side_effect_packets(constructors: list[dict]) -> dict:
     }
 
 
+def draw_packet_provenance(constructors: list[dict], calls: list[dict]) -> dict:
+    expected = {
+        "8240F4D8": {
+            "constructor_address": "82410320",
+            "store_address": "82410328",
+            "packet_hook_address": "82410328",
+        },
+        "829F7C70": {
+            "constructor_address": "829F7CA8",
+            "store_address": "829F7CB0",
+            "packet_hook_address": "829F7CB0",
+        },
+    }
+    packet_sites = []
+    for wrapper, required in expected.items():
+        matches = [
+            item
+            for item in constructors
+            if item["function_address"] == wrapper
+            and item["opcode"] == "PM4_DRAW_INDX_2"
+            and item["role"] == "runtime_wrapper"
+        ]
+        if len(matches) != 1:
+            raise ValueError(
+                "reviewed draw wrapper must have one runtime packet store: {}".format(
+                    wrapper
+                )
+            )
+        packet = matches[0]
+        for field in ("constructor_address", "store_address"):
+            if packet[field] != required[field]:
+                raise ValueError(
+                    "reviewed draw packet {} drifted for {}".format(field, wrapper)
+                )
+        packet_sites.append(
+            {
+                "wrapper": wrapper,
+                "wrapper_kind": REVIEWED_WRAPPERS[int(wrapper, 16)]["kind"],
+                **required,
+                "packet_opcode": "PM4_DRAW_INDX_2",
+                "packet_address_expression": "physical(r3_plus_4_before_stwu)",
+            }
+        )
+    adapter_forward = [
+        item
+        for item in calls
+        if item["caller_function_address"] == "824079B8"
+        and item["wrapper"] == "8240F4D8"
+    ]
+    if len(adapter_forward) != 1 or adapter_forward[0]["return_address"] != "824079FC":
+        raise ValueError("draw adapter forwarding return address drifted")
+    return {
+        "packet_sites": packet_sites,
+        "adapter_forward_return_address": "824079FC",
+        "backend_observation_field": "packet_physical_address",
+        "correlation": "exact_physical_pm4_header_address",
+        "guest_payload_read": False,
+        "guest_state_changed": False,
+        "control_flow_changed": False,
+        "xenos_authority": True,
+        "suppression_allowed": False,
+    }
+
+
 def build(paths: list[pathlib.Path]) -> dict:
     functions = parse_functions(paths)
     functions_by_address = {item["address"]: item for item in functions}
@@ -606,6 +760,7 @@ def build(paths: list[pathlib.Path]) -> dict:
             )
         )
     calls = direct_calls(functions, set(REVIEWED_WRAPPERS))
+    argument_leads = adapter_argument_leads(functions, calls)
     forwarded_calls = tail_forwarded_calls(
         functions, set(REVIEWED_WRAPPERS)
     )
@@ -651,6 +806,7 @@ def build(paths: list[pathlib.Path]) -> dict:
         raise ValueError("reviewed title resolve-mode write evidence drifted")
     query_owner = query_owner_lifecycle(functions)
     side_effect_packets = reviewed_side_effect_packets(constructors)
+    packet_provenance = draw_packet_provenance(constructors, calls)
     query_owner_callers = [
         item
         for item in calls
@@ -705,11 +861,13 @@ def build(paths: list[pathlib.Path]) -> dict:
         "direct_calls": calls,
         "tail_forwarded_calls": forwarded_calls,
         "runtime_correlation_calls": correlation_calls,
+        "adapter_argument_leads": argument_leads,
         "dirty_state_clears": clears,
         "query_state_transitions": query_transitions,
         "query_owner_lifecycle": query_owner,
         "resolve_mode_writes": resolve_writes,
         "side_effect_packets": side_effect_packets,
+        "draw_packet_provenance": packet_provenance,
         "resolve_boundary": {
             "backend": "IssueCopy",
             "trigger": "RB_MODECONTROL.edram_mode == kCopy during Xenos draw",
@@ -723,6 +881,7 @@ def build(paths: list[pathlib.Path]) -> dict:
             "direct_calls": len(calls),
             "tail_forwarded_calls": len(forwarded_calls),
             "runtime_correlation_calls": len(correlation_calls),
+            "adapter_argument_leads": len(argument_leads),
             "dirty_state_clears": len(clears),
             "query_state_transitions": len(query_transitions),
             "resolve_mode_writes": len(resolve_writes),

--- a/tools/summarize-native-renderer-title-provenance.py
+++ b/tools/summarize-native-renderer-title-provenance.py
@@ -1,0 +1,377 @@
+"""Correlate exact title PM4 packet origins with prepared backend draws."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import pathlib
+import sys
+
+
+SCHEMA = "pinyon-shift.native-renderer-title-provenance.v2"
+STATIC_SCHEMA = "pinyon-shift.native-renderer-dispatch-static.v3"
+PREFIX = "native_renderer.discovery.title_provenance_"
+KNOWN_PREPARED_FAMILIES = {
+    "747837906D0BF484": "retained_sky_horizon_anchor",
+    "1D253A52B55C9FB3": "retained_sky_horizon_follower",
+}
+
+
+def read_events(paths: list[pathlib.Path]) -> list[dict]:
+    events = []
+    for path in paths:
+        for line_number, line in enumerate(
+            path.read_text(encoding="utf-8").splitlines(), 1
+        ):
+            if not line.strip():
+                continue
+            try:
+                event = json.loads(line)
+            except json.JSONDecodeError as error:
+                raise ValueError(f"{path}:{line_number}: invalid JSON: {error}") from error
+            if str(event.get("event", "")).startswith(PREFIX):
+                events.append(event)
+    return events
+
+
+def select_session(events: list[dict], requested: str | None) -> str:
+    if requested:
+        if not any(event.get("session") == requested for event in events):
+            raise ValueError(f"title provenance session not found: {requested}")
+        return requested
+    armed = [
+        str(event.get("session", ""))
+        for event in events
+        if event.get("event") == f"{PREFIX}config"
+        and event.get("status") == "armed"
+    ]
+    if not armed or not armed[-1]:
+        raise ValueError("no armed title provenance session found")
+    return armed[-1]
+
+
+def _integer(mapping: dict, key: str) -> int:
+    try:
+        return int(mapping.get(key, 0))
+    except (TypeError, ValueError) as error:
+        raise ValueError(f"invalid integer field: {key}") from error
+
+
+def _argument_vector(mapping: dict, key: str) -> dict[str, str]:
+    values = str(mapping.get(key, "")).upper().split(":")
+    if len(values) != 8 or any(len(value) != 8 for value in values):
+        raise ValueError(f"invalid title provenance argument vector: {key}")
+    return {f"r{index}": values[index - 3] for index in range(3, 11)}
+
+
+def build(events: list[dict], static: dict, requested: str | None = None) -> dict:
+    if static.get("schema") != STATIC_SCHEMA:
+        raise ValueError("unsupported static dispatch inventory schema")
+    provenance_contract = static.get("draw_packet_provenance")
+    if not isinstance(provenance_contract, dict):
+        raise ValueError("static inventory has no draw packet provenance contract")
+    packet_sites = provenance_contract.get("packet_sites", [])
+    if {
+        (item.get("wrapper"), item.get("packet_hook_address"))
+        for item in packet_sites
+    } != {("8240F4D8", "82410328"), ("829F7C70", "829F7CB0")}:
+        raise ValueError("static draw packet provenance sites drifted")
+
+    session = select_session(events, requested)
+    selected = [event for event in events if event.get("session") == session]
+    configs = [
+        event
+        for event in selected
+        if event.get("event") == f"{PREFIX}config"
+        and event.get("status") == "armed"
+    ]
+    summaries = [
+        event for event in selected if event.get("event") == f"{PREFIX}summary"
+    ]
+    if len(configs) != 1 or len(summaries) != 1:
+        raise ValueError("title provenance session needs one armed config and summary")
+    summary = summaries[0]
+    required_safety = {
+        "guest_payload_read": "false",
+        "guest_state_changed": "false",
+        "control_flow_changed": "false",
+        "xenos_authority": "true",
+        "suppression_allowed": "false",
+    }
+    if any(str(summary.get(key)).lower() != value for key, value in required_safety.items()):
+        raise ValueError("title provenance summary does not prove the safety boundary")
+    if str(summary.get("correlation")) != "exact_physical_pm4_header_address":
+        raise ValueError("title provenance summary uses an unsupported correlation key")
+
+    static_calls = {
+        (item["wrapper"], item["return_address"]): item
+        for item in static.get("runtime_correlation_calls", static.get("direct_calls", []))
+    }
+    static_argument_leads = {
+        (item["wrapper"], item["return_address"]): item
+        for item in static.get("adapter_argument_leads", [])
+    }
+    entries = []
+    for event in selected:
+        if event.get("event") != f"{PREFIX}entry":
+            continue
+        wrapper = str(event.get("origin_wrapper_address", "")).upper()
+        caller = str(event.get("origin_caller", "")).upper()
+        outcome = str(event.get("outcome", ""))
+        if outcome not in {"prepared", "not_prepared"}:
+            raise ValueError("invalid backend outcome in title provenance entry")
+        backend_signature = str(event.get("backend_signature", "")).upper()
+        if len(backend_signature) != 16:
+            raise ValueError("invalid backend signature in title provenance entry")
+        signature = str(event.get("prepared_signature", "")).upper()
+        if outcome == "prepared" and len(signature) != 16:
+            raise ValueError("invalid prepared signature in title provenance entry")
+        if outcome == "not_prepared" and signature:
+            raise ValueError("unprepared title provenance entry has a prepared signature")
+        callsite = static_calls.get((wrapper, caller))
+        argument_lead = static_argument_leads.get((wrapper, caller))
+        family = (
+            KNOWN_PREPARED_FAMILIES.get(signature, "unknown")
+            if outcome == "prepared"
+            else "not_prepared"
+        )
+        varying_mask = int(str(event.get("varying_argument_mask", "")), 16)
+        if varying_mask & ~0xFF:
+            raise ValueError("invalid varying argument mask")
+        minimums = _argument_vector(event, "minimum_arguments")
+        maximums = _argument_vector(event, "maximum_arguments")
+        entries.append(
+            {
+                "origin_wrapper": str(event.get("origin_wrapper", "unknown")),
+                "origin_wrapper_address": wrapper,
+                "origin_caller": caller,
+                "outcome": outcome,
+                "backend_signature": backend_signature,
+                "prepared_signature": signature or None,
+                "prepared_family": family,
+                "calls": _integer(event, "calls"),
+                "first_frame": _integer(event, "first_frame"),
+                "last_frame": _integer(event, "last_frame"),
+                "first_draw": _integer(event, "first_draw"),
+                "first_packet_physical_address": str(
+                    event.get("first_packet_physical_address", "")
+                ).upper(),
+                "first_arguments": {
+                    f"r{index}": str(event.get(f"first_r{index}", "")).upper()
+                    for index in range(3, 11)
+                },
+                "last_arguments": _argument_vector(event, "last_arguments"),
+                "argument_ranges": {
+                    register: {
+                        "minimum": minimums[register],
+                        "maximum": maximums[register],
+                    }
+                    for register in minimums
+                },
+                "varying_registers": [
+                    f"r{index}"
+                    for index in range(3, 11)
+                    if varying_mask & (1 << (index - 3))
+                ],
+                "stable_registers": [
+                    f"r{index}"
+                    for index in range(3, 11)
+                    if not (varying_mask & (1 << (index - 3)))
+                ],
+                "static_match": (
+                    {
+                        "caller_function": callsite["caller_function"],
+                        "caller_function_address": callsite["caller_function_address"],
+                        "callsite": callsite["callsite"],
+                        "wrapper_layer": callsite.get("wrapper_layer", "unknown"),
+                    }
+                    if callsite
+                    else None
+                ),
+                "static_argument_lead": argument_lead,
+                "semantic_identity": (
+                    family
+                    if outcome == "prepared" and family != "unknown"
+                    else "unknown"
+                ),
+                "semantic_evidence": (
+                    "existing_exact_prepared_signature_family"
+                    if family != "unknown"
+                    and outcome == "prepared"
+                    else (
+                        "exact_backend_draw_observed_without_prepared_callback"
+                        if outcome == "not_prepared"
+                        else "none"
+                    )
+                ),
+                "native_coverage": False,
+                "suppression_eligible": False,
+            }
+        )
+    entries.sort(
+        key=lambda item: (
+            -item["calls"],
+            item["origin_wrapper_address"],
+            item["origin_caller"],
+            item["backend_signature"],
+        )
+    )
+    prepared_entries = [item for item in entries if item["outcome"] == "prepared"]
+    unprepared_entries = [
+        item for item in entries if item["outcome"] == "not_prepared"
+    ]
+    prepared_matches = sum(item["calls"] for item in prepared_entries)
+    unprepared_aggregate_matches = sum(item["calls"] for item in unprepared_entries)
+    if prepared_matches != _integer(summary, "prepared_matches"):
+        raise ValueError("title provenance entry counts do not match the summary")
+    if len(entries) != _integer(summary, "aggregate_count"):
+        raise ValueError("title provenance aggregate count does not match the summary")
+    if len(prepared_entries) != _integer(summary, "prepared_aggregate_count"):
+        raise ValueError("prepared aggregate count does not match the summary")
+    if len(unprepared_entries) != _integer(summary, "unprepared_aggregate_count"):
+        raise ValueError("unprepared aggregate count does not match the summary")
+    if unprepared_aggregate_matches != _integer(
+        summary, "unprepared_aggregate_matches"
+    ):
+        raise ValueError("unprepared aggregate calls do not match the summary")
+
+    recorded = _integer(summary, "title_packets_recorded")
+    backend_matches = _integer(summary, "backend_packet_matches")
+    unprepared = _integer(summary, "matched_unprepared_draws")
+    pending = _integer(summary, "pending_packets")
+    unattributed_backend = _integer(summary, "backend_draws_without_title_packet")
+    origins_pushed = _integer(summary, "origins_pushed")
+    origins_consumed = _integer(summary, "origins_consumed")
+    fault_fields = (
+        "packet_address_failures",
+        "packet_table_overflow",
+        "forwarding_mismatches",
+        "origin_stack_overflow",
+        "packets_without_origin",
+        "aggregate_overflow",
+    )
+    faults = {field: _integer(summary, field) for field in fault_fields}
+    reused_live_addresses = _integer(summary, "reused_live_packet_addresses")
+    complete = (
+        recorded > 0
+        and str(summary.get("packet_accounting_complete")).lower() == "true"
+        and str(summary.get("origin_accounting_complete")).lower() == "true"
+        and recorded == backend_matches + pending
+        and backend_matches == prepared_matches + unprepared
+        and unprepared == unprepared_aggregate_matches
+        and origins_pushed == origins_consumed
+        and not any(faults.values())
+    )
+    callers = {}
+    for entry in entries:
+        key = (entry["origin_wrapper_address"], entry["origin_caller"])
+        aggregate = callers.setdefault(
+            key,
+            {
+                "origin_wrapper": entry["origin_wrapper"],
+                "origin_wrapper_address": key[0],
+                "origin_caller": key[1],
+                "calls": 0,
+                "prepared_signatures": 0,
+                "unprepared_signatures": 0,
+                "known_family_calls": 0,
+                "static_match": entry["static_match"],
+                "static_argument_lead": entry["static_argument_lead"],
+                "stable_argument_candidates": set(entry["stable_registers"]),
+                "varying_registers": set(entry["varying_registers"]),
+                "prepared_families": set(),
+            },
+        )
+        aggregate["calls"] += entry["calls"]
+        if entry["outcome"] == "prepared":
+            aggregate["prepared_signatures"] += 1
+            aggregate["prepared_families"].add(entry["prepared_family"])
+        else:
+            aggregate["unprepared_signatures"] += 1
+        aggregate["stable_argument_candidates"].intersection_update(
+            entry["stable_registers"]
+        )
+        aggregate["varying_registers"].update(entry["varying_registers"])
+        if entry["outcome"] == "prepared" and entry["prepared_family"] != "unknown":
+            aggregate["known_family_calls"] += entry["calls"]
+
+    caller_summaries = []
+    for aggregate in callers.values():
+        aggregate["stable_argument_candidates"] = sorted(
+            aggregate["stable_argument_candidates"]
+        )
+        aggregate["varying_registers"] = sorted(aggregate["varying_registers"])
+        aggregate["prepared_families"] = sorted(aggregate["prepared_families"])
+        caller_summaries.append(aggregate)
+
+    return {
+        "schema": SCHEMA,
+        "session": session,
+        "scene": str(configs[0].get("scene", "unmarked")),
+        "status": "complete" if complete else "incomplete_fail_closed",
+        "entries": entries,
+        "callers": sorted(
+            caller_summaries,
+            key=lambda item: (-item["calls"], item["origin_caller"]),
+        ),
+        "totals": {
+            "title_packets_recorded": recorded,
+            "backend_packet_matches": backend_matches,
+            "prepared_matches": prepared_matches,
+            "matched_unprepared_draws": unprepared,
+            "pending_packets": pending,
+            "backend_draws_without_title_packet": unattributed_backend,
+            "aggregate_count": len(entries),
+            "prepared_aggregate_count": len(prepared_entries),
+            "unprepared_aggregate_count": len(unprepared_entries),
+            "origins_pushed": origins_pushed,
+            "origins_consumed": origins_consumed,
+            "static_matches": sum(item["static_match"] is not None for item in entries),
+            "unknown_callers": sum(item["static_match"] is None for item in entries),
+            "known_family_calls": sum(
+                item["calls"]
+                for item in entries
+                if item["outcome"] == "prepared"
+                and item["prepared_family"] != "unknown"
+            ),
+            "reused_live_packet_addresses": reused_live_addresses,
+            **faults,
+        },
+        "correlation": provenance_contract,
+        "qualification": "exact_title_packet_to_backend_draw_provenance",
+        "prepared_coverage": (
+            "observed" if prepared_matches else "none_observed"
+        ),
+        "safety": {
+            "guest_payload_read": False,
+            "guest_state_changed": False,
+            "control_flow_changed": False,
+            "xenos_authority": True,
+            "suppression_allowed": False,
+        },
+    }
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("logs", nargs="+", type=pathlib.Path)
+    parser.add_argument("--static", required=True, type=pathlib.Path)
+    parser.add_argument("--session")
+    parser.add_argument("--output", required=True, type=pathlib.Path)
+    args = parser.parse_args(argv)
+    try:
+        static = json.loads(args.static.read_text(encoding="utf-8"))
+        document = build(read_events(args.logs), static, args.session)
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(
+            json.dumps(document, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        return 0
+    except (OSError, ValueError, TypeError, json.JSONDecodeError) as error:
+        print(f"native renderer title provenance summary failed: {error}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/tests/test_native_renderer_contract.py
+++ b/tools/tests/test_native_renderer_contract.py
@@ -214,6 +214,48 @@ class NativeRendererContractTests(unittest.TestCase):
         self.assertNotIn("observation.rb_blendcontrol", signature)
         self.assertNotIn("samples_resolved_target", signature)
 
+    def test_draw_packet_provenance_is_exact_bounded_and_passive(self):
+        patch = (
+            ROOT
+            / "patches/rexglue/0080-graphics-draw-packet-provenance.patch"
+        ).read_text(encoding="utf-8")
+        source = (ROOT / "src/native_renderer/graphics_hooks.cpp").read_text(
+            encoding="utf-8"
+        )
+        analysis = (ROOT / "config/rexglue/analysis/main-xex.toml").read_text(
+            encoding="utf-8"
+        )
+        self.assertIn("packet_physical_address", patch)
+        self.assertIn("reader->buffer()", patch)
+        self.assertIn("reader->read_offset()", patch)
+        self.assertIn("memory_->physical_membase()", patch)
+        self.assertIn("observation.packet_physical_address =", patch)
+        self.assertIn("observation_packet_physical_address_", patch)
+        self.assertIn("kTitlePacketProvenanceCapacity = 16384", source)
+        self.assertIn("kTitleDrawProvenanceCapacity = 4096", source)
+        self.assertIn("kTitleOriginStackCapacity = 32", source)
+        self.assertIn("exact_physical_pm4_header_address", source)
+        self.assertIn("GetPhysicalAddress(packet_guest_address)", source)
+        self.assertIn("packet_accounting_complete", source)
+        self.assertNotIn("g_title_packet_provenance = {};", source)
+        self.assertNotIn("g_title_draw_provenance = {};", source)
+        report = (ROOT / "tools/create-crash-report.ps1").read_text(
+            encoding="utf-8"
+        )
+        self.assertIn("title_draw_provenance", report)
+        self.assertIn(
+            "native_renderer.discovery.title_provenance_summary", report
+        )
+        self.assertIn("packet_address_failures", report)
+        self.assertIn('address = 0x82410328', analysis)
+        self.assertIn('address = 0x829F7CB0', analysis)
+        for forbidden in (
+            "SetDrawSuppression",
+            "SetCopySuppression",
+            "guest_payload_read\", \"true",
+        ):
+            self.assertNotIn(forbidden, patch + source + analysis)
+
     def test_census_has_no_native_renderer_or_suppression_api(self):
         source = (ROOT / "src/native_renderer/graphics_hooks.cpp").read_text(
             encoding="utf-8"

--- a/tools/tests/test_native_renderer_dispatch_discovery.py
+++ b/tools/tests/test_native_renderer_dispatch_discovery.py
@@ -19,7 +19,10 @@ def fixture(address, body):
         [
             "DEFINE_REX_FUNC(sub_{:08X}) {{".format(address),
             "\tREX_FUNC_PROLOGUE();",
-            *["\t// {}".format(line) for line in body],
+            *[
+                line if line.startswith("loc_") else "\t// {}".format(line)
+                for line in body
+            ],
             "}",
         ]
     )
@@ -36,13 +39,19 @@ def reviewed_fixtures(include_immediate=True):
             ]
         )
     chunks = [
-        fixture(0x824079B8, ["mflr r12", "bl 0x8240f4d8"]),
+        fixture(
+            0x824079B8,
+            ["mflr r12", "loc_824079F8:", "bl 0x8240f4d8"],
+        ),
         fixture(
             0x8240F4D8,
             [
                 "mflr r12",
+                "loc_82410318:",
                 "oris r11,r11,49152",
+                "rlwimi r10,r29,16,0,15",
                 "ori r11,r11,13824",
+                "cmpwi cr6,r22,0",
                 "stwu r11,4(r3)",
                 *dirty_clears,
             ],
@@ -172,8 +181,11 @@ def reviewed_fixtures(include_immediate=True):
                 0x829F7C70,
                 [
                     "mflr r12",
+                    "loc_829F7CA0:",
                     "lis r11,-16384",
+                    "rlwinm r10,r29,16,0,15",
                     "ori r11,r11,13824",
+                    "or r10,r10,r30",
                     "stwu r11,4(r3)",
                 ],
             )
@@ -206,6 +218,7 @@ class NativeRendererDispatchDiscoveryTests(unittest.TestCase):
         self.assertEqual(document["totals"]["direct_calls"], 15)
         self.assertEqual(document["totals"]["tail_forwarded_calls"], 1)
         self.assertEqual(document["totals"]["runtime_correlation_calls"], 16)
+        self.assertEqual(document["totals"]["adapter_argument_leads"], 1)
         self.assertEqual(document["totals"]["dirty_state_clears"], 6)
         self.assertEqual(document["totals"]["query_state_transitions"], 2)
         indexed_packet = next(
@@ -215,6 +228,17 @@ class NativeRendererDispatchDiscoveryTests(unittest.TestCase):
             and item["opcode"] == "PM4_DRAW_INDX_2"
         )
         self.assertEqual(indexed_packet["header_source"], "dynamic_type3_count")
+        provenance = document["draw_packet_provenance"]
+        self.assertEqual(
+            provenance["correlation"], "exact_physical_pm4_header_address"
+        )
+        self.assertEqual(
+            [item["packet_hook_address"] for item in provenance["packet_sites"]],
+            ["82410328", "829F7CB0"],
+        )
+        self.assertEqual(
+            provenance["adapter_forward_return_address"], "824079FC"
+        )
         adapter_call = next(
             item
             for item in document["direct_calls"]
@@ -239,6 +263,33 @@ class NativeRendererDispatchDiscoveryTests(unittest.TestCase):
         self.assertEqual(forwarded["return_address"], "8246FB94")
         self.assertEqual(forwarded["forwarder_function"], "sub_829ED510")
         self.assertFalse(document["safety"]["suppression_allowed"])
+
+    def test_adapter_argument_leads_stop_at_calls_and_decode_loads(self):
+        caller = fixture(
+            0x82B00000,
+            [
+                "bl 0x82415f68",
+                "lwz r3,40(r31)",
+                "mr r4,r30",
+                "bl 0x824079b8",
+            ],
+        )
+        document = self.build([*reviewed_fixtures(), caller])
+        lead = document["adapter_argument_leads"][0]
+        by_register = {item["register"]: item for item in lead["arguments"]}
+        self.assertEqual(
+            by_register["r3"]["status"], "bounded_syntactic_definition"
+        )
+        self.assertEqual(
+            by_register["r3"]["memory_load"],
+            {"base_register": "r31", "offset": 40, "width": "lwz"},
+        )
+        self.assertEqual(by_register["r4"]["source_registers"], ["r30"])
+        self.assertEqual(
+            by_register["r5"]["status"], "unknown_across_call_boundary"
+        )
+        self.assertFalse(lead["object_identity_proved"])
+        self.assertFalse(lead["lifetime_proved"])
 
     def test_rejects_missing_reviewed_packet_evidence(self):
         incomplete = reviewed_fixtures(include_immediate=False)
@@ -287,6 +338,10 @@ class NativeRendererDispatchDiscoveryTests(unittest.TestCase):
             1,
         )
         self.assertEqual(
+            analysis.count('name = "PinyonShiftObserveDrawPacketSubmission"'),
+            2,
+        )
+        self.assertEqual(
             analysis.count('name = "PinyonShiftObserveVizQueryBeginDispatch"'),
             1,
         )
@@ -318,11 +373,13 @@ class NativeRendererDispatchDiscoveryTests(unittest.TestCase):
         )
         self.assertIn('address = 0x824079BC', analysis)
         self.assertIn('address = 0x8240F4DC', analysis)
+        self.assertIn('address = 0x82410328', analysis)
         self.assertIn('address = 0x824587DC', analysis)
         self.assertIn('address = 0x82458A8C', analysis)
         self.assertIn('address = 0x829F21A4', analysis)
         self.assertIn('address = 0x829F2284', analysis)
         self.assertIn('address = 0x829F7C74', analysis)
+        self.assertIn('address = 0x829F7CB0', analysis)
         self.assertIn('address = 0x82D951E4', analysis)
         self.assertIn('address = 0x82413ABC', analysis)
         self.assertIn('address = 0x824736F4', analysis)

--- a/tools/tests/test_native_renderer_title_provenance.py
+++ b/tools/tests/test_native_renderer_title_provenance.py
@@ -1,0 +1,217 @@
+import importlib.util
+import sys
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+TOOL = ROOT / "tools" / "summarize-native-renderer-title-provenance.py"
+SPEC = importlib.util.spec_from_file_location("native_title_provenance", TOOL)
+assert SPEC and SPEC.loader
+MODULE = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = MODULE
+SPEC.loader.exec_module(MODULE)
+
+
+def static_inventory():
+    return {
+        "schema": MODULE.STATIC_SCHEMA,
+        "runtime_correlation_calls": [
+            {
+                "wrapper": "824079B8",
+                "return_address": "823E6F50",
+                "caller_function": "sub_823E6EF0",
+                "caller_function_address": "823E6EF0",
+                "callsite": "823E6F4C",
+                "wrapper_layer": "title_adapter",
+            }
+        ],
+        "draw_packet_provenance": {
+            "packet_sites": [
+                {
+                    "wrapper": "8240F4D8",
+                    "packet_hook_address": "82410328",
+                },
+                {
+                    "wrapper": "829F7C70",
+                    "packet_hook_address": "829F7CB0",
+                },
+            ],
+            "correlation": "exact_physical_pm4_header_address",
+        },
+        "adapter_argument_leads": [
+            {
+                "wrapper": "824079B8",
+                "return_address": "823E6F50",
+                "callsite": "823E6F4C",
+                "arguments": [
+                    {
+                        "register": "r3",
+                        "status": "bounded_syntactic_definition",
+                        "instruction": "lwz r3,40(r31)",
+                    }
+                ],
+                "classification": "bounded_syntactic_object_lead_only",
+                "object_identity_proved": False,
+                "lifetime_proved": False,
+            }
+        ],
+    }
+
+
+def events(safe=True, fault=False):
+    return [
+        {
+            "event": "native_renderer.discovery.title_provenance_config",
+            "session": "run",
+            "status": "armed",
+            "scene": "open_world",
+        },
+        {
+            "event": "native_renderer.discovery.title_provenance_entry",
+            "session": "run",
+            "origin_wrapper": "draw_adapter",
+            "origin_wrapper_address": "824079B8",
+            "origin_caller": "823E6F50",
+            "outcome": "prepared",
+            "backend_signature": "747837906D0BF484",
+            "prepared_signature": "747837906D0BF484",
+            "calls": "12",
+            "first_frame": "4",
+            "last_frame": "20",
+            "first_draw": "8",
+            "first_packet_physical_address": "00102000",
+            **{f"first_r{index}": f"{index:08X}" for index in range(3, 11)},
+            "last_arguments": ":".join(
+                f"{index + 1:08X}" for index in range(3, 11)
+            ),
+            "minimum_arguments": ":".join(
+                f"{index:08X}" for index in range(3, 11)
+            ),
+            "maximum_arguments": ":".join(
+                f"{index + 1:08X}" for index in range(3, 11)
+            ),
+            "varying_argument_mask": "05",
+        },
+        {
+            "event": "native_renderer.discovery.title_provenance_summary",
+            "session": "run",
+            "title_packets_recorded": "12",
+            "backend_packet_matches": "12",
+            "prepared_matches": "12",
+            "matched_unprepared_draws": "0",
+            "pending_packets": "0",
+            "backend_draws_without_title_packet": "25",
+            "packet_address_failures": "0",
+            "reused_live_packet_addresses": "0",
+            "packet_table_overflow": "0",
+            "forwarding_mismatches": "0",
+            "origins_pushed": "12",
+            "origins_consumed": "12",
+            "origin_stack_overflow": "0",
+            "packets_without_origin": "0",
+            "origin_accounting_complete": "true",
+            "aggregate_count": "1",
+            "prepared_aggregate_count": "1",
+            "unprepared_aggregate_count": "0",
+            "unprepared_aggregate_matches": "0",
+            "aggregate_overflow": "1" if fault else "0",
+            "packet_accounting_complete": "true",
+            "correlation": "exact_physical_pm4_header_address",
+            "guest_payload_read": "false",
+            "guest_state_changed": "false",
+            "control_flow_changed": "false",
+            "xenos_authority": "true",
+            "suppression_allowed": "false" if safe else "true",
+        },
+    ]
+
+
+class NativeRendererTitleProvenanceTests(unittest.TestCase):
+    def test_correlates_exact_known_family_with_title_caller(self):
+        document = MODULE.build(events(), static_inventory())
+        self.assertEqual(document["status"], "complete")
+        self.assertEqual(document["totals"]["prepared_matches"], 12)
+        self.assertEqual(document["totals"]["known_family_calls"], 12)
+        self.assertEqual(
+            document["entries"][0]["prepared_family"],
+            "retained_sky_horizon_anchor",
+        )
+        self.assertEqual(
+            document["entries"][0]["static_match"]["callsite"], "823E6F4C"
+        )
+        self.assertEqual(
+            document["entries"][0]["static_argument_lead"]["classification"],
+            "bounded_syntactic_object_lead_only",
+        )
+        self.assertFalse(document["entries"][0]["native_coverage"])
+        self.assertEqual(document["entries"][0]["varying_registers"], ["r3", "r5"])
+        self.assertIn("r4", document["entries"][0]["stable_registers"])
+        self.assertEqual(
+            document["entries"][0]["argument_ranges"]["r3"]["minimum"],
+            "00000003",
+        )
+        self.assertEqual(
+            document["callers"][0]["stable_argument_candidates"],
+            ["r10", "r4", "r6", "r7", "r8", "r9"],
+        )
+        self.assertEqual(
+            document["callers"][0]["prepared_families"],
+            ["retained_sky_horizon_anchor"],
+        )
+        self.assertFalse(document["safety"]["suppression_allowed"])
+
+    def test_faults_remain_incomplete_without_discarding_evidence(self):
+        document = MODULE.build(events(fault=True), static_inventory())
+        self.assertEqual(document["status"], "incomplete_fail_closed")
+        self.assertEqual(document["totals"]["aggregate_overflow"], 1)
+        self.assertEqual(len(document["entries"]), 1)
+
+    def test_accounts_pending_and_reused_addresses_with_unprepared_evidence(self):
+        capture = events()
+        entry = capture[1]
+        entry["outcome"] = "not_prepared"
+        entry["backend_signature"] = "0123456789ABCDEF"
+        entry["prepared_signature"] = ""
+        entry["calls"] = "10"
+        summary = capture[-1]
+        summary["title_packets_recorded"] = "12"
+        summary["backend_packet_matches"] = "10"
+        summary["prepared_matches"] = "0"
+        summary["matched_unprepared_draws"] = "10"
+        summary["pending_packets"] = "2"
+        summary["reused_live_packet_addresses"] = "3"
+        summary["prepared_aggregate_count"] = "0"
+        summary["unprepared_aggregate_count"] = "1"
+        summary["unprepared_aggregate_matches"] = "10"
+
+        document = MODULE.build(capture, static_inventory())
+
+        self.assertEqual(document["status"], "complete")
+        self.assertEqual(document["prepared_coverage"], "none_observed")
+        self.assertEqual(document["totals"]["pending_packets"], 2)
+        self.assertEqual(document["totals"]["reused_live_packet_addresses"], 3)
+        self.assertEqual(document["entries"][0]["outcome"], "not_prepared")
+        self.assertIsNone(document["entries"][0]["prepared_signature"])
+        self.assertEqual(document["entries"][0]["semantic_identity"], "unknown")
+        self.assertEqual(document["callers"][0]["unprepared_signatures"], 1)
+
+    def test_rejects_unsafe_or_drifted_contracts(self):
+        with self.assertRaisesRegex(ValueError, "safety"):
+            MODULE.build(events(safe=False), static_inventory())
+        drifted = static_inventory()
+        drifted["draw_packet_provenance"]["packet_sites"][0][
+            "packet_hook_address"
+        ] = "82410320"
+        with self.assertRaisesRegex(ValueError, "drifted"):
+            MODULE.build(events(), drifted)
+
+    def test_rejects_count_mismatch(self):
+        mismatched = events()
+        mismatched[-1]["prepared_matches"] = "13"
+        with self.assertRaisesRegex(ValueError, "counts"):
+            MODULE.build(mismatched, static_inventory())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/tests/test_release_contract.py
+++ b/tools/tests/test_release_contract.py
@@ -43,10 +43,10 @@ class ReleaseContractTests(unittest.TestCase):
 
     def test_rexglue_patches_have_stable_order_and_no_binary_payload(self):
         patches = sorted((ROOT / "patches/rexglue").glob("*.patch"))
-        self.assertEqual(len(patches), 79)
+        self.assertEqual(len(patches), 80)
         self.assertEqual(
             patches[-1].name,
-            "0079-d3d12-fail-closed-retained-pass-suppression.patch",
+            "0080-graphics-draw-packet-provenance.patch",
         )
         self.assertEqual(len(patches), len({path.name[:4] for path in patches}))
         for path in patches:


### PR DESCRIPTION
## Summary

- correlate title draw constructors with backend draws using the exact physical PM4 header address
- retain repeated live address generations and preserve unprepared caller/signature evidence
- add deterministic static/runtime reports, crash-report fields, documentation, and contract tests

## Runtime evidence

AppData session \20260829T123251Z-p12356\ exited normally.

- 107,560 title packets recorded
- 107,455 exact backend matches
- 105 packets accounted as pending at clean shutdown
- 40 repeated live addresses handled without attribution loss
- 66 statically joined unprepared aggregates
- zero address, forwarding, origin, stack, table, or aggregate faults
- prepared coverage remains explicitly \
one_observed\`n- median 30.73 FPS, simulation 29.60 Hz, present 59.98 Hz

## Validation

- \python -m unittest discover -s tools/tests -p 'test_*.py'\ (260 passed)
- focused provenance/contract suite (36 passed)
- incremental Release build
- real AppData save load and clean exit