### PR TITLE
feat(native-renderer): trace indirect buffer ownership

### DIFF
--- a/config/rexglue/analysis/main-xex.toml
+++ b/config/rexglue/analysis/main-xex.toml
@@ -36,6 +36,39 @@ address = 0x82410328
 name = "PinyonShiftObserveDrawPacketSubmission"
 registers = ["r3"]
 
+# Record exact physical identities for the six stored indirect-buffer packet
+# sites. The original store executes after each hook; only its effective
+# address registers are observed.
+[[midasm_hook]]
+address = 0x824095B4
+name = "PinyonShiftObserveIndirectPacket824095B4"
+registers = ["r11", "r28"]
+
+[[midasm_hook]]
+address = 0x82416EFC
+name = "PinyonShiftObserveIndirectPacket82416EFC"
+registers = ["r30"]
+
+[[midasm_hook]]
+address = 0x8246FC1C
+name = "PinyonShiftObserveIndirectPacket8246FC1C"
+registers = ["r11"]
+
+[[midasm_hook]]
+address = 0x8263BD64
+name = "PinyonShiftObserveIndirectPacket8263BD64"
+registers = ["r9"]
+
+[[midasm_hook]]
+address = 0x829E8E88
+name = "PinyonShiftObserveIndirectPacket829E8E88"
+registers = ["r1"]
+
+[[midasm_hook]]
+address = 0x829EC49C
+name = "PinyonShiftObserveIndirectPacket829EC49C"
+registers = ["r11"]
+
 [[midasm_hook]]
 address = 0x82413ABC
 name = "PinyonShiftObserveBinningScissorStateDispatch"

--- a/docs/native-renderer/COMMAND_BUFFER_LINEAGE.md
+++ b/docs/native-renderer/COMMAND_BUFFER_LINEAGE.md
@@ -1,0 +1,126 @@
+# Command-buffer lineage
+
+This milestone connects every observed backend draw to the exact command
+buffer that contains its PM4 packet. It is an ownership-discovery bridge, not
+a native rendering path and not evidence that any draw may be suppressed.
+
+## Why this bridge is needed
+
+The exact title-wrapper provenance bridge proved that the currently reviewed
+title draw wrapper feeds EDRAM copies. Prepared world draws therefore enter
+the backend through other command streams. ReXGlue already executes those
+streams exactly, including nested `PM4_INDIRECT_BUFFER` packets, so the
+backend command processor is the strongest passive point from which to recover
+their submission lineage.
+
+The static dispatch scanner now recognizes stored `PM4_INDIRECT_BUFFER`
+(`0x3F`) and `PM4_INDIRECT_BUFFER_PFD` (`0x37`) headers. The supported title
+contains seven such constructors across six functions. This inventory proves
+where packet headers are stored, but it does not yet prove the semantic owner
+of each constructed buffer.
+
+The title now observes the exact effective address at all six store sites:
+`0x824095B4`, `0x82416EFC`, `0x8246FC1C`, `0x8263BD64`, `0x829E8E88`, and
+`0x829EC49C`. ReXGlue patch `0083` emits balanced enter/exit observations
+around synchronous indirect-buffer execution. The active GPU-thread stack
+joins an execution to a store site only when the physical parent-packet
+address matches exactly; a prepared draw inherits that constructor only while
+the matching target/root/depth context remains active. Copied packet templates
+and uninstrumented producers remain explicitly `unknown`.
+
+Title-side packet generations live in a fixed 4,096-bucket, four-way cache.
+Each store creates one generation; an exact backend address consumes the oldest
+retained matching generation. A full bucket evicts its oldest generation and
+counts that eviction explicitly. Eviction can reduce constructor coverage, but
+it cannot create a match: evicted, copied, repeated, and uninstrumented packets
+remain unknown unless a retained generation matches the exact backend address.
+
+## Exact runtime contract
+
+ReXGlue patch `0082` carries five fields with each draw observation:
+
+- the current command-buffer physical address and length;
+- the exact parent indirect-buffer packet address;
+- the first indirect-buffer root address; and
+- the nesting depth.
+
+Primary or directly executed buffers have depth zero and no parent packet. An
+indirect buffer has a nonzero depth and an exact parent packet. Nested buffers
+preserve the first indirect root while increasing depth. The draw packet must
+fall within the reported current-buffer bounds or the lineage is invalid.
+
+Pinyon validates the exact addresses, current-buffer length, and packet offset
+on every draw, then aggregates a stable ownership-class key in a fixed
+4,096-entry table: nesting depth and exact constructor store when one is
+matched. Each class retains minimum and maximum current-buffer lengths, packet
+offsets, and parent-packet offsets from the first indirect root, plus a first
+prepared-signature sample and whether that signature varied. Absolute current,
+parent, and root addresses, buffer lengths, and individual offsets remain
+samples or ranges rather than key fields because frame-local command buffers
+and their parent packets rotate through guest memory. Prepared signatures are
+also excluded because they describe draw state rather than command-buffer
+ownership.
+Invalid relationships, unbalanced stacks, address failures, replacement
+evictions, and table overflow are counted explicitly. Replacement keeps the
+cache bounded without treating lost coverage as false ownership evidence.
+The report is complete only when draw accounting balances, all prepared calls
+are represented, and both invalid and overflow counts are zero. A clean
+shutdown may interrupt synchronous indirect execution after its enter callback;
+the summary therefore records the number of open buffers and requires
+`enters = exits + open_at_shutdown`. Any other result fails closed.
+
+Create the report from the same diagnostics stream used by the renderer census:
+
+```powershell
+python .\tools\summarize-native-renderer-command-lineage.py `
+    <diagnostics.jsonl> `
+    --static .local\qualification\native-dispatch-static-command-lineage.json `
+    --output .local\qualification\native-command-buffer-lineage.json
+```
+
+## Safety boundary
+
+The bridge observes packet addresses and register-derived draw metadata only.
+It reads no guest resource payload, changes no guest state or control flow,
+and does not add a renderer or suppression API. Xenos remains authoritative.
+Crash reports include only the bounded lineage summary, not individual packet
+records.
+
+Command-buffer lineage is armed with the renderer census itself. The broader
+title draw-provenance bridge remains independently gated by the optional
+dispatch-discovery setting; disabling that setting cannot disable indirect-
+buffer enter/exit accounting or the six exact indirect-packet store hooks.
+
+## Runtime qualification — 2026-08-29
+
+Release executable
+`167AB428979C2116880667D7888F7EDD3CA2022939A4C0EC2A9585DC0DA46948`
+loaded the installed `0.1.0` AppData save through the title and menu into the
+live festival scene. Session `20260829T143627Z-p19532` exited normally after a
+169.308-second performance capture covering 5,383 samples.
+
+The lineage report completed across 9,016,083 backend draws, including
+8,758,586 prepared draws, and collapsed them into four bounded ownership
+classes. Invalid lineage and ownership-table overflow were both zero. The six
+title hooks recorded 1,813,273 packet generations; 1,792,929 executions matched
+an exact retained generation, 14,438 generations were explicitly evicted, and
+5,906 remained retained at shutdown. Another 411,033 indirect executions
+remained unknown rather than being inferred.
+
+All 2,203,962 indirect enters reconciled with 2,203,961 exits plus one buffer
+open at shutdown. Address failures, table overflow, indirect stack faults, and
+draw-stack mismatches were zero. Xenos remained authoritative, suppression
+remained disabled, and the diagnostics contained no crash, fatal error, device
+loss, assertion failure, or unexpected shutdown marker. The visually inspected
+festival scene retained the expected car, crowd, structures, HUD, lighting,
+and sky. Median derived performance was 30.342 FPS and the 1% low was 19.017
+FPS.
+
+## Promotion gate
+
+Runtime qualification demonstrated zero invalid lineages, reconciled
+indirect enter/exit/open-at-shutdown accounting, zero stack faults, and zero
+overflow, plus exact constructor matches with unmatched producers retained
+explicitly. This qualifies dispatch ownership for the matched packet instances.
+Semantic identity remains unknown, and suppression remains disabled, until
+object and lifetime ownership are independently understood.

--- a/docs/native-renderer/HIGH_LEVEL_RENDER_HOOKS.md
+++ b/docs/native-renderer/HIGH_LEVEL_RENDER_HOOKS.md
@@ -52,8 +52,12 @@ and `0x829EDB68` build initialization templates. They are inventoried but are
 not runtime draw hooks.
 
 No `PM4_DRAW_INDX` (`0x22`) title constructor has yet passed the same stored-
-header proof. The scanner reports 91 proved stored packet constructors across
-the draw, query, resolve side-effect, and binning-state opcodes it recognizes.
+header proof. The scanner reports 98 proved stored packet constructors across
+the draw, query, resolve side-effect, binning-state, and indirect-buffer
+opcodes it recognizes. Seven are `PM4_INDIRECT_BUFFER` or
+`PM4_INDIRECT_BUFFER_PFD` constructors across six functions. Their exact
+backend draw lineage contract is documented in
+[`COMMAND_BUFFER_LINEAGE.md`](COMMAND_BUFFER_LINEAGE.md).
 It explicitly rejects a matching numeric operation in `sub_83051E48` because
 its result is not stored as a command packet.
 
@@ -270,6 +274,38 @@ shutdown packets as accounted when `recorded = matched + pending` holds. The
 next milestone capture must show zero address, forwarding, origin, and capacity
 faults before any caller association is accepted; prepared semantic coverage
 remains unproved until a prepared outcome is actually observed.
+
+The next ownership bridge validates exact current, parent, and root
+command-buffer lineage for each prepared backend draw, then aggregates bounded
+ownership classes by nesting depth and exact constructor store. Current-buffer
+lengths plus packet and parent/root offsets remain bounded evidence ranges.
+Prepared signatures remain samples because they describe draw state, not
+buffer ownership. Its
+milestone capture must show zero invalid relationships and zero capacity
+overflow before any ownership-class association is accepted. Static
+constructor identity remains separate until an exact title-to-buffer join is
+proved.
+
+That join is now implemented for the six stored indirect-buffer packet sites.
+Title hooks record only each store's effective physical address. ReXGlue patch
+`0083` brackets synchronous indirect execution with balanced observations, so
+the active stack can attach a store address to a prepared draw only through an
+exact parent-packet, target-buffer, root, and depth match. Copied templates and
+other producers remain unknown; no guest payload is read.
+This ownership bridge follows the renderer-census lifecycle directly and does
+not depend on the optional title dispatch-discovery toggle.
+Its constructor join uses a bounded four-way generational cache: exact backend
+addresses consume the oldest retained title generation, while collision
+evictions and all unmatched producers remain explicit unknowns.
+
+Session `20260829T143627Z-p19532` runtime-qualified this bridge on the installed
+AppData save. It covered 9,016,083 draws and 8,758,586 prepared draws in four
+ownership classes, with 1,792,929 exact constructor matches. The run had zero
+invalid lineages, aggregation overflow, address failures, table overflow, stack
+faults, or draw-stack mismatches. All 2,203,962 enters reconciled with
+2,203,961 exits and one buffer open at shutdown. The bounded cache reported
+14,438 evictions and retained 411,033 executions as unknown rather than
+guessing ownership. Xenos remained authoritative and suppression stayed off.
 
 That follow-up capture, session `20260829T123251Z-p12356`, completed the exact
 accounting contract with 107,455 backend matches, 105 shutdown-pending packets,

--- a/docs/native-renderer/RENDER_PASS_CENSUS.md
+++ b/docs/native-renderer/RENDER_PASS_CENSUS.md
@@ -43,6 +43,7 @@ Xenos suppression, or presentation changes. Its setting,
 | Draw packet backend | ReXGlue `PM4_DRAW_INDX` / `PM4_DRAW_INDX_2` | Generic command processor decodes the packet before backend `IssueDraw` | Register-derived draw state is consumed by the backend | Verified runtime boundary |
 | Draw packet provenance | Title stores `0x82410328` / `0x829F7CB0`; ReXGlue patch `0080` | Both sides normalize the same PM4 header to a physical address | Fixed outstanding table is consumed only on exact address equality; same-address generations are retained oldest-first | Runtime-qualified, passive: 107,455 exact matches and zero attribution faults; no prepared callback observed |
 | Draw backend outcome | D3D12 `IssueDraw`; ReXGlue patch `0081` | One callback at every backend return carries frame, draw, and exact packet identity | 18 bounded outcomes separate prepared completion, EDRAM copy, no-effect paths, pending pipelines, and failures | Runtime-qualified, passive: 8,478,174 outcomes, zero callback faults; all 132,568 exact title matches were EDRAM copies |
+| Draw command-buffer lineage | ReXGlue command processor; patches `0082`/`0083`; six exact title store hooks | Draw packet is bounded by its current buffer and carries exact parent packet, first indirect root, nesting depth, and exact constructor store when matched | Census-lifecycle enter/exit stack; bounded four-way title generations; fixed 4,096-entry ownership classes by depth/constructor with buffer-length, packet-offset, and parent/root ranges; faults and overflow fail closed | Runtime-qualified, passive: 9,016,083 draws, four ownership classes, 1,792,929 exact constructor matches, zero lineage/stack/overflow faults |
 | Resolve controller | `0x824587D8` | Two direct calls to setup wrapper `0x82458A88`; three direct controller callers | Entry `r3-r10` and caller `LR` are observed only when discovery is enabled | Verified, bounded pass-through hook |
 | Resolve setup | `0x82458A88` | Emits `RB_MODECONTROL` register index `0x2208` followed by `EdramMode::kCopy` value 6 | Entry `r3-r10` and caller `LR` are observed only when discovery is enabled | Title setup verified; subsequent resolve draw ownership unknown |
 | Binning/scissor state | `0x82413AB8` | Stores `PM4_SET_BIN_MASK_LO/HI` headers; ten direct calls | Entry `r3-r10` and caller `LR` are observed only when discovery is enabled | Xenos state boundary verified; semantic tiled role unknown |
@@ -107,6 +108,8 @@ read or serialize guest memory.
   livery, thumbnail, and rewind dispatch families.
 - Use exact title-packet provenance to associate those callers with prepared
   signatures before reading object/lifetime structures.
+- Use the qualified stored-packet-to-indirect-execution join to identify
+  semantic object and lifetime ownership without inferring unmatched producers.
 
 The ten proved wrapper entries, all 72 static direct calls, one proved tail-
 forwarded correlation edge, and explicit semantic unknowns are recorded in

--- a/patches/rexglue/0082-graphics-command-buffer-lineage.patch
+++ b/patches/rexglue/0082-graphics-command-buffer-lineage.patch
@@ -1,0 +1,118 @@
+diff --git a/include/rex/graphics/command_processor.h b/include/rex/graphics/command_processor.h
+index 41bf91f..8234329 100644
+--- a/include/rex/graphics/command_processor.h
++++ b/include/rex/graphics/command_processor.h
+@@ -279,6 +279,14 @@ class CommandProcessor {
+   uint64_t observation_draw_sequence_ = 0;
+   uint64_t observation_copy_sequence_ = 0;
+   uint32_t observation_packet_physical_address_ = UINT32_MAX;
++  struct ObservationCommandBufferContext {
++    uint32_t physical_address = UINT32_MAX;
++    uint32_t length_dwords = 0;
++    uint32_t parent_packet_physical_address = UINT32_MAX;
++    uint32_t root_physical_address = UINT32_MAX;
++    uint32_t depth = 0;
++  };
++  ObservationCommandBufferContext observation_command_buffer_{};
+ 
+   bool paused_ = false;
+ 
+diff --git a/include/rex/system/interfaces/graphics.h b/include/rex/system/interfaces/graphics.h
+index 5a16193..3477ac1 100644
+--- a/include/rex/system/interfaces/graphics.h
++++ b/include/rex/system/interfaces/graphics.h
+@@ -223,6 +223,11 @@ struct GraphicsDrawObservation {
+   uint64_t vertex_shader_hash = 0;
+   uint64_t pixel_shader_hash = 0;
+   uint32_t packet_physical_address = UINT32_MAX;
++  uint32_t command_buffer_physical_address = UINT32_MAX;
++  uint32_t command_buffer_length_dwords = 0;
++  uint32_t command_buffer_parent_packet_physical_address = UINT32_MAX;
++  uint32_t command_buffer_root_physical_address = UINT32_MAX;
++  uint32_t command_buffer_depth = 0;
+   uint32_t packet = 0;
+   uint32_t initiator = 0;
+   uint32_t primitive_type = 0;
+diff --git a/src/graphics/command_processor.cpp b/src/graphics/command_processor.cpp
+index 1e7eb06..4bd73cd 100644
+--- a/src/graphics/command_processor.cpp
++++ b/src/graphics/command_processor.cpp
+@@ -635,6 +635,13 @@ void CommandProcessor::ReturnFromWait() {}
+ uint32_t CommandProcessor::ExecutePrimaryBuffer(uint32_t read_index, uint32_t write_index) {
+   SCOPE_profile_cpu_f("gpu");
+ 
++  const ObservationCommandBufferContext previous_observation_command_buffer =
++      observation_command_buffer_;
++  observation_command_buffer_ = {primary_buffer_ptr_,
++                                 uint32_t(primary_buffer_size_ /
++                                          sizeof(uint32_t)),
++                                 UINT32_MAX, primary_buffer_ptr_, 0};
++
+   // Execute commands!
+   memory::RingBuffer reader(memory_->TranslatePhysical(primary_buffer_ptr_), primary_buffer_size_);
+   reader.set_read_offset(read_index * sizeof(uint32_t));
+@@ -650,12 +657,25 @@ uint32_t CommandProcessor::ExecutePrimaryBuffer(uint32_t read_index, uint32_t wr
+ 
+   OnPrimaryBufferEnd();
+ 
++  observation_command_buffer_ = previous_observation_command_buffer;
++
+   return write_index;
+ }
+ 
+ void CommandProcessor::ExecuteIndirectBuffer(uint32_t ptr, uint32_t count) {
+   SCOPE_profile_cpu_f("gpu");
+ 
++  const ObservationCommandBufferContext previous_observation_command_buffer =
++      observation_command_buffer_;
++  const uint32_t depth = previous_observation_command_buffer.depth + 1;
++  const uint32_t root_physical_address =
++      previous_observation_command_buffer.depth
++          ? previous_observation_command_buffer.root_physical_address
++          : ptr;
++  observation_command_buffer_ = {ptr, count,
++                                 observation_packet_physical_address_,
++                                 root_physical_address, depth};
++
+   // Execute commands!
+   memory::RingBuffer reader(memory_->TranslatePhysical(ptr), count * sizeof(uint32_t));
+   reader.set_write_offset(count * sizeof(uint32_t));
+@@ -667,9 +687,14 @@ void CommandProcessor::ExecuteIndirectBuffer(uint32_t ptr, uint32_t count) {
+       break;
+     }
+   } while (reader.read_count());
++
++  observation_command_buffer_ = previous_observation_command_buffer;
+ }
+ 
+ void CommandProcessor::ExecutePacket(uint32_t ptr, uint32_t count) {
++  const ObservationCommandBufferContext previous_observation_command_buffer =
++      observation_command_buffer_;
++  observation_command_buffer_ = {ptr, count, UINT32_MAX, ptr, 0};
+   // Execute commands!
+   memory::RingBuffer reader(memory_->TranslatePhysical(ptr), count * sizeof(uint32_t));
+   reader.set_write_offset(count * sizeof(uint32_t));
+@@ -680,6 +705,7 @@ void CommandProcessor::ExecutePacket(uint32_t ptr, uint32_t count) {
+       break;
+     }
+   } while (reader.read_count());
++  observation_command_buffer_ = previous_observation_command_buffer;
+ }
+ 
+ bool CommandProcessor::ExecutePacket(memory::RingBuffer* reader) {
+@@ -1497,6 +1523,15 @@ bool CommandProcessor::ExecutePacketType3Draw(memory::RingBuffer* reader, uint32
+             active_pixel_shader_ ? active_pixel_shader_->ucode_data_hash() : 0;
+         observation.packet_physical_address =
+             observation_packet_physical_address_;
++        observation.command_buffer_physical_address =
++            observation_command_buffer_.physical_address;
++        observation.command_buffer_length_dwords =
++            observation_command_buffer_.length_dwords;
++        observation.command_buffer_parent_packet_physical_address =
++            observation_command_buffer_.parent_packet_physical_address;
++        observation.command_buffer_root_physical_address =
++            observation_command_buffer_.root_physical_address;
++        observation.command_buffer_depth = observation_command_buffer_.depth;
+         observation.packet = packet;
+         observation.initiator = vgt_draw_initiator.value;
+         observation.primitive_type = uint32_t(vgt_draw_initiator.prim_type);

--- a/patches/rexglue/0083-graphics-indirect-buffer-observer.patch
+++ b/patches/rexglue/0083-graphics-indirect-buffer-observer.patch
@@ -1,0 +1,102 @@
+diff --git a/include/rex/system/interfaces/graphics.h b/include/rex/system/interfaces/graphics.h
+index 3477ac1..887a91a 100644
+--- a/include/rex/system/interfaces/graphics.h
++++ b/include/rex/system/interfaces/graphics.h
+@@ -292,6 +292,21 @@ struct GraphicsDrawObservation {
+ 
+ using GraphicsDrawObserver = void (*)(const GraphicsDrawObservation& observation);
+ 
++struct GraphicsIndirectBufferObservation {
++  uint32_t packet_physical_address = UINT32_MAX;
++  uint32_t parent_buffer_physical_address = UINT32_MAX;
++  uint32_t parent_buffer_length_dwords = 0;
++  uint32_t target_buffer_physical_address = UINT32_MAX;
++  uint32_t target_buffer_length_dwords = 0;
++  uint32_t root_buffer_physical_address = UINT32_MAX;
++  uint32_t depth = 0;
++  uint32_t opcode = 0;
++  bool entering = false;
++};
++
++using GraphicsIndirectBufferObserver = void (*)(
++    const GraphicsIndirectBufferObservation& observation);
++
+ struct GraphicsCopyObservation {
+   uint64_t frame_sequence = 0;
+   uint64_t copy_sequence = 0;
+@@ -550,6 +565,10 @@ class IGraphicsSystem {
+   virtual void SetDrawObserver(GraphicsDrawObserver observer) {
+     (void)observer;
+   }
++  virtual void SetIndirectBufferObserver(
++      GraphicsIndirectBufferObserver observer) {
++    (void)observer;
++  }
+   virtual void SetCopyObserver(GraphicsCopyObserver observer) {
+     (void)observer;
+   }
+diff --git a/include/rex/graphics/graphics_system.h b/include/rex/graphics/graphics_system.h
+index 1b48063..3ae6a8b 100644
+--- a/include/rex/graphics/graphics_system.h
++++ b/include/rex/graphics/graphics_system.h
+@@ -76,6 +76,13 @@ class GraphicsSystem : public system::IGraphicsSystem {
+   system::GraphicsDrawObserver draw_observer() const {
+     return draw_observer_.load(std::memory_order_acquire);
+   }
++  void SetIndirectBufferObserver(
++      system::GraphicsIndirectBufferObserver observer) override {
++    indirect_buffer_observer_.store(observer, std::memory_order_release);
++  }
++  system::GraphicsIndirectBufferObserver indirect_buffer_observer() const {
++    return indirect_buffer_observer_.load(std::memory_order_acquire);
++  }
+   void SetCopyObserver(system::GraphicsCopyObserver observer) override {
+     copy_observer_.store(observer, std::memory_order_release);
+   }
+@@ -196,6 +203,8 @@ class GraphicsSystem : public system::IGraphicsSystem {
+   std::unique_ptr<::rex::ui::Presenter> presenter_;
+ 
+   std::atomic<system::GraphicsDrawObserver> draw_observer_{nullptr};
++  std::atomic<system::GraphicsIndirectBufferObserver>
++      indirect_buffer_observer_{nullptr};
+   std::atomic<system::GraphicsCopyObserver> copy_observer_{nullptr};
+   std::atomic<system::GraphicsShaderTranslationObserver>
+       shader_translation_observer_{nullptr};
+diff --git a/src/graphics/command_processor.cpp b/src/graphics/command_processor.cpp
+index 02df215..5563447 100644
+--- a/src/graphics/command_processor.cpp
++++ b/src/graphics/command_processor.cpp
+@@ -1031,7 +1031,32 @@ bool CommandProcessor::ExecutePacketType3_INDIRECT_BUFFER(memory::RingBuffer* re
+   uint32_t list_length = reader->ReadAndSwap<uint32_t>();
+   assert_zero(list_length & ~0xFFFFF);
+   list_length &= 0xFFFFF;
+-  ExecuteIndirectBuffer(GpuToCpu(list_ptr), list_length);
++  const uint32_t target_physical_address = GpuToCpu(list_ptr);
++  auto observer = graphics_system_->indirect_buffer_observer();
++  system::GraphicsIndirectBufferObservation observation;
++  if (observer) {
++    observation.packet_physical_address =
++        observation_packet_physical_address_;
++    observation.parent_buffer_physical_address =
++        observation_command_buffer_.physical_address;
++    observation.parent_buffer_length_dwords =
++        observation_command_buffer_.length_dwords;
++    observation.target_buffer_physical_address = target_physical_address;
++    observation.target_buffer_length_dwords = list_length;
++    observation.root_buffer_physical_address =
++        observation_command_buffer_.depth
++            ? observation_command_buffer_.root_physical_address
++            : target_physical_address;
++    observation.depth = observation_command_buffer_.depth + 1;
++    observation.opcode = (packet >> 8) & 0x7F;
++    observation.entering = true;
++    observer(observation);
++  }
++  ExecuteIndirectBuffer(target_physical_address, list_length);
++  if (observer) {
++    observation.entering = false;
++    observer(observation);
++  }
+   return true;
+ }
+ 

--- a/src/native_renderer/graphics_hooks.cpp
+++ b/src/native_renderer/graphics_hooks.cpp
@@ -53,6 +53,7 @@ constexpr size_t kSignatureCapacity = 4096;
 constexpr size_t kSummaryLimit = 16;
 constexpr size_t kCandidateSummaryLimit = 32;
 constexpr size_t kPreparedShaderPairCapacity = 1024;
+constexpr size_t kCommandBufferLineageCapacity = 4096;
 constexpr size_t kResolveTargetCapacity = 4096;
 constexpr size_t kResolvePageCapacity = 32768;
 constexpr size_t kResolveSummaryLimit = 32;
@@ -76,6 +77,11 @@ constexpr size_t kDispatchCallerCapacity = 256;
 constexpr size_t kTitlePacketProvenanceCapacity = 16384;
 constexpr size_t kTitleDrawProvenanceCapacity = 4096;
 constexpr size_t kTitleOriginStackCapacity = 32;
+constexpr size_t kTitleIndirectPacketBucketCount = 4096;
+constexpr size_t kTitleIndirectPacketWays = 4;
+constexpr size_t kTitleIndirectPacketCapacity =
+    kTitleIndirectPacketBucketCount * kTitleIndirectPacketWays;
+constexpr size_t kTitleIndirectStackCapacity = 32;
 constexpr uint64_t kSkyHorizonAnchorSignature = UINT64_C(0x747837906D0BF484);
 constexpr uint64_t kSkyHorizonFollowerSignature = UINT64_C(0x1D253A52B55C9FB3);
 std::atomic<uint64_t> g_frame_sequence{};
@@ -142,13 +148,33 @@ struct TitleDrawProvenanceEntry {
   bool prepared = false;
 };
 
+struct TitleIndirectPacketEntry {
+  uint32_t packet_physical_address = UINT32_MAX;
+  uint32_t constructor_store_address = 0;
+  uint64_t submission_sequence = 0;
+  bool occupied = false;
+};
+
+struct ActiveTitleIndirectBuffer {
+  uint32_t packet_physical_address = UINT32_MAX;
+  uint32_t target_buffer_physical_address = UINT32_MAX;
+  uint32_t parent_packet_physical_address = UINT32_MAX;
+  uint32_t root_buffer_physical_address = UINT32_MAX;
+  uint32_t constructor_store_address = 0;
+  uint32_t depth = 0;
+};
+
 std::array<TitlePacketProvenanceEntry, kTitlePacketProvenanceCapacity>
     g_title_packet_provenance{};
 std::array<TitleDrawProvenanceEntry, kTitleDrawProvenanceCapacity>
     g_title_draw_provenance{};
+std::array<TitleIndirectPacketEntry, kTitleIndirectPacketCapacity>
+    g_title_indirect_packets{};
 std::mutex g_title_packet_provenance_mutex;
 std::atomic<bool> g_title_provenance_installed{};
 std::atomic<rex::memory::Memory *> g_title_provenance_memory{};
+std::atomic<bool> g_command_buffer_lineage_installed{};
+std::atomic<rex::memory::Memory *> g_command_buffer_lineage_memory{};
 uint64_t g_title_packets_recorded = 0;
 uint64_t g_title_packets_matched = 0;
 uint64_t g_title_packet_address_failures = 0;
@@ -169,10 +195,25 @@ std::atomic<uint64_t> g_title_packets_without_origin{};
 uint64_t g_title_draw_provenance_count = 0;
 uint64_t g_title_draw_provenance_overflow = 0;
 uint64_t g_title_packet_submission_sequence = 0;
+uint64_t g_title_indirect_packets_recorded = 0;
+uint64_t g_title_indirect_packet_address_failures = 0;
+uint64_t g_title_indirect_packet_table_overflow = 0;
+uint64_t g_title_indirect_packet_evictions = 0;
+uint64_t g_title_indirect_packet_submission_sequence = 0;
+uint64_t g_title_indirect_buffer_enters = 0;
+uint64_t g_title_indirect_buffer_exits = 0;
+uint64_t g_title_indirect_buffer_matches = 0;
+uint64_t g_title_indirect_buffer_unmatched = 0;
+uint64_t g_title_indirect_stack_faults = 0;
+uint64_t g_title_indirect_draw_stack_faults = 0;
+std::atomic<uint64_t> g_title_indirect_buffers_open{};
 thread_local TitleDrawOrigin g_pending_adapter_origin;
 thread_local std::array<TitleDrawOrigin, kTitleOriginStackCapacity>
     g_title_origin_stack;
 thread_local size_t g_title_origin_stack_depth = 0;
+thread_local std::array<ActiveTitleIndirectBuffer, kTitleIndirectStackCapacity>
+    g_title_indirect_stack;
+thread_local size_t g_title_indirect_stack_depth = 0;
 
 const char *DispatchWrapperName(DispatchWrapper wrapper) {
   switch (wrapper) {
@@ -291,6 +332,9 @@ void ResetTitleDrawProvenance() {
   for (TitleDrawProvenanceEntry &entry : g_title_draw_provenance) {
     entry = {};
   }
+  for (TitleIndirectPacketEntry &entry : g_title_indirect_packets) {
+    entry = {};
+  }
   g_title_packets_recorded = 0;
   g_title_packets_matched = 0;
   g_title_packet_address_failures = 0;
@@ -311,9 +355,23 @@ void ResetTitleDrawProvenance() {
   g_title_draw_provenance_count = 0;
   g_title_draw_provenance_overflow = 0;
   g_title_packet_submission_sequence = 0;
+  g_title_indirect_packets_recorded = 0;
+  g_title_indirect_packet_address_failures = 0;
+  g_title_indirect_packet_table_overflow = 0;
+  g_title_indirect_packet_evictions = 0;
+  g_title_indirect_packet_submission_sequence = 0;
+  g_title_indirect_buffer_enters = 0;
+  g_title_indirect_buffer_exits = 0;
+  g_title_indirect_buffer_matches = 0;
+  g_title_indirect_buffer_unmatched = 0;
+  g_title_indirect_stack_faults = 0;
+  g_title_indirect_draw_stack_faults = 0;
+  g_title_indirect_buffers_open.store(0, std::memory_order_relaxed);
   g_pending_adapter_origin = {};
   g_title_origin_stack = {};
   g_title_origin_stack_depth = 0;
+  g_title_indirect_stack = {};
+  g_title_indirect_stack_depth = 0;
 }
 
 void ConfigureTitleDrawProvenance(bool census_requested,
@@ -330,10 +388,19 @@ void ConfigureTitleDrawProvenance(bool census_requested,
       {{"status", armed ? "armed" : "disabled"},
        {"scene", CensusSceneMarker()},
        {"title_packet_hooks", "82410328,829F7CB0"},
+       {"title_indirect_packet_hooks",
+        "824095B4,82416EFC,8246FC1C,8263BD64,829E8E88,829EC49C"},
        {"packet_key", "physical_pm4_header_address"},
        {"packet_capacity", std::to_string(kTitlePacketProvenanceCapacity)},
        {"aggregate_capacity", std::to_string(kTitleDrawProvenanceCapacity)},
        {"origin_stack_capacity", std::to_string(kTitleOriginStackCapacity)},
+       {"indirect_packet_capacity",
+        std::to_string(kTitleIndirectPacketCapacity)},
+       {"indirect_packet_bucket_count",
+        std::to_string(kTitleIndirectPacketBucketCount)},
+       {"indirect_packet_ways", std::to_string(kTitleIndirectPacketWays)},
+       {"indirect_stack_capacity",
+        std::to_string(kTitleIndirectStackCapacity)},
        {"metadata",
         "origin_wrapper,entry_lr,r3-r10,outcome,backend_outcome,"
         "backend_signature"},
@@ -441,6 +508,159 @@ void RecordTitleDrawPacket(uint32_t packet_guest_address) {
     ++g_title_packet_reused_live_addresses;
   }
   ++g_title_packets_recorded;
+}
+
+void RecordTitleIndirectPacket(uint32_t packet_guest_address,
+                               uint32_t constructor_store_address) {
+  if (!g_command_buffer_lineage_installed.load(std::memory_order_acquire)) {
+    return;
+  }
+  rex::memory::Memory *memory =
+      g_command_buffer_lineage_memory.load(std::memory_order_acquire);
+  if (!memory) {
+    return;
+  }
+  const uint32_t packet_physical_address =
+      memory->GetPhysicalAddress(packet_guest_address);
+  std::scoped_lock lock(g_title_packet_provenance_mutex);
+  if (!g_command_buffer_lineage_installed.load(std::memory_order_acquire)) {
+    return;
+  }
+  if (packet_physical_address == UINT32_MAX ||
+      (packet_physical_address & 3)) {
+    ++g_title_indirect_packet_address_failures;
+    return;
+  }
+  const size_t bucket =
+      (packet_physical_address >> 2) % kTitleIndirectPacketBucketCount;
+  const size_t first = bucket * kTitleIndirectPacketWays;
+  size_t selected = first;
+  uint64_t oldest_sequence = UINT64_MAX;
+  bool found_free = false;
+  for (size_t way = 0; way < kTitleIndirectPacketWays; ++way) {
+    const size_t index = first + way;
+    const TitleIndirectPacketEntry &entry = g_title_indirect_packets[index];
+    if (!entry.occupied) {
+      selected = index;
+      found_free = true;
+      break;
+    }
+    if (entry.submission_sequence < oldest_sequence) {
+      selected = index;
+      oldest_sequence = entry.submission_sequence;
+    }
+  }
+  if (!found_free) {
+    ++g_title_indirect_packet_evictions;
+  }
+  TitleIndirectPacketEntry &entry = g_title_indirect_packets[selected];
+  entry.packet_physical_address = packet_physical_address;
+  entry.constructor_store_address = constructor_store_address;
+  entry.submission_sequence = ++g_title_indirect_packet_submission_sequence;
+  entry.occupied = true;
+  ++g_title_indirect_packets_recorded;
+}
+
+uint32_t MatchTitleIndirectPacket(uint32_t packet_physical_address) {
+  std::scoped_lock lock(g_title_packet_provenance_mutex);
+  const size_t bucket =
+      (packet_physical_address >> 2) % kTitleIndirectPacketBucketCount;
+  const size_t first = bucket * kTitleIndirectPacketWays;
+  size_t oldest_match = kTitleIndirectPacketCapacity;
+  uint64_t oldest_sequence = UINT64_MAX;
+  for (size_t way = 0; way < kTitleIndirectPacketWays; ++way) {
+    const size_t index = first + way;
+    const TitleIndirectPacketEntry &entry = g_title_indirect_packets[index];
+    if (entry.occupied &&
+        entry.packet_physical_address == packet_physical_address &&
+        entry.submission_sequence < oldest_sequence) {
+      oldest_match = index;
+      oldest_sequence = entry.submission_sequence;
+    }
+  }
+  if (oldest_match != kTitleIndirectPacketCapacity) {
+    TitleIndirectPacketEntry &entry = g_title_indirect_packets[oldest_match];
+    const uint32_t constructor_store_address =
+        entry.constructor_store_address;
+    entry.occupied = false;
+    ++g_title_indirect_buffer_matches;
+    return constructor_store_address;
+  }
+  ++g_title_indirect_buffer_unmatched;
+  return 0;
+}
+
+void ObserveIndirectBuffer(
+    const rex::system::GraphicsIndirectBufferObservation &observation) {
+  if (!g_command_buffer_lineage_installed.load(std::memory_order_acquire)) {
+    return;
+  }
+  if (observation.entering) {
+    ++g_title_indirect_buffer_enters;
+    if (g_title_indirect_stack_depth == kTitleIndirectStackCapacity ||
+        observation.depth != g_title_indirect_stack_depth + 1) {
+      ++g_title_indirect_stack_faults;
+      return;
+    }
+    ActiveTitleIndirectBuffer &active =
+        g_title_indirect_stack[g_title_indirect_stack_depth++];
+    active.packet_physical_address = observation.packet_physical_address;
+    active.target_buffer_physical_address =
+        observation.target_buffer_physical_address;
+    active.parent_packet_physical_address =
+        observation.packet_physical_address;
+    active.root_buffer_physical_address =
+        observation.root_buffer_physical_address;
+    active.constructor_store_address =
+        MatchTitleIndirectPacket(observation.packet_physical_address);
+    active.depth = observation.depth;
+    g_title_indirect_buffers_open.fetch_add(1, std::memory_order_relaxed);
+    return;
+  }
+
+  ++g_title_indirect_buffer_exits;
+  if (!g_title_indirect_stack_depth) {
+    ++g_title_indirect_stack_faults;
+    return;
+  }
+  const ActiveTitleIndirectBuffer &active =
+      g_title_indirect_stack[g_title_indirect_stack_depth - 1];
+  if (active.packet_physical_address != observation.packet_physical_address ||
+      active.target_buffer_physical_address !=
+          observation.target_buffer_physical_address ||
+      active.depth != observation.depth) {
+    ++g_title_indirect_stack_faults;
+    return;
+  }
+  --g_title_indirect_stack_depth;
+  g_title_indirect_buffers_open.fetch_sub(1, std::memory_order_relaxed);
+}
+
+uint32_t CurrentTitleIndirectConstructor(
+    const rex::system::GraphicsDrawObservation &observation) {
+  if (!g_command_buffer_lineage_installed.load(std::memory_order_acquire)) {
+    return 0;
+  }
+  if (!observation.command_buffer_depth) {
+    return 0;
+  }
+  if (!g_title_indirect_stack_depth) {
+    ++g_title_indirect_draw_stack_faults;
+    return 0;
+  }
+  const ActiveTitleIndirectBuffer &active =
+      g_title_indirect_stack[g_title_indirect_stack_depth - 1];
+  if (active.depth != observation.command_buffer_depth ||
+      active.target_buffer_physical_address !=
+          observation.command_buffer_physical_address ||
+      active.parent_packet_physical_address !=
+          observation.command_buffer_parent_packet_physical_address ||
+      active.root_buffer_physical_address !=
+          observation.command_buffer_root_physical_address) {
+    ++g_title_indirect_draw_stack_faults;
+    return 0;
+  }
+  return active.constructor_store_address;
 }
 
 bool ConsumeTitleDrawPacket(uint32_t packet_physical_address,
@@ -1249,6 +1469,39 @@ uint64_t g_prepared_shader_pair_count = 0;
 uint64_t g_prepared_shader_pair_overflow = 0;
 uint64_t g_candidate_unprepared_draw_count = 0;
 uint64_t g_candidate_prepared_without_observation_count = 0;
+
+struct CommandBufferLineageEntry {
+  uint64_t sample_prepared_signature = 0;
+  uint64_t calls = 0;
+  uint64_t first_frame = 0;
+  uint64_t last_frame = 0;
+  uint64_t first_draw = 0;
+  uint64_t last_draw = 0;
+  uint32_t packet_physical_address = UINT32_MAX;
+  uint32_t command_buffer_physical_address = UINT32_MAX;
+  uint32_t sample_command_buffer_length_dwords = 0;
+  uint32_t min_command_buffer_length_dwords = UINT32_MAX;
+  uint32_t max_command_buffer_length_dwords = 0;
+  uint32_t min_packet_offset_bytes = UINT32_MAX;
+  uint32_t max_packet_offset_bytes = 0;
+  uint32_t parent_packet_physical_address = UINT32_MAX;
+  uint32_t root_physical_address = UINT32_MAX;
+  uint32_t min_parent_root_offset_bytes = UINT32_MAX;
+  uint32_t max_parent_root_offset_bytes = 0;
+  uint32_t constructor_store_address = 0;
+  uint32_t depth = 0;
+  bool prepared_signature_varied = false;
+};
+
+std::array<CommandBufferLineageEntry, kCommandBufferLineageCapacity>
+    g_command_buffer_lineages{};
+uint64_t g_command_buffer_lineage_draws = 0;
+uint64_t g_command_buffer_lineage_primary_draws = 0;
+uint64_t g_command_buffer_lineage_indirect_draws = 0;
+uint64_t g_command_buffer_lineage_invalid = 0;
+uint64_t g_command_buffer_lineage_prepared_draws = 0;
+uint64_t g_command_buffer_lineage_entry_count = 0;
+uint64_t g_command_buffer_lineage_overflow = 0;
 bool g_graphics_census_installed = false;
 rex::memory::Memory *g_graphics_census_memory = nullptr;
 void *g_guest_cpu_access_callback = nullptr;
@@ -1402,6 +1655,18 @@ void ResetPreparedShaderPairs() {
   g_candidate_unprepared_draw_count = 0;
   g_candidate_prepared_without_observation_count = 0;
   g_pending_candidate.valid = false;
+}
+
+void ResetCommandBufferLineage() {
+  std::memset(g_command_buffer_lineages.data(), 0,
+              sizeof(g_command_buffer_lineages));
+  g_command_buffer_lineage_draws = 0;
+  g_command_buffer_lineage_primary_draws = 0;
+  g_command_buffer_lineage_indirect_draws = 0;
+  g_command_buffer_lineage_invalid = 0;
+  g_command_buffer_lineage_prepared_draws = 0;
+  g_command_buffer_lineage_entry_count = 0;
+  g_command_buffer_lineage_overflow = 0;
 }
 
 void ResetDependencyCensus() {
@@ -2632,6 +2897,244 @@ CandidateSignature(const rex::system::GraphicsDrawObservation &observation,
   return hash ? hash : 1;
 }
 
+bool HasValidCommandBufferLineage(
+    const rex::system::GraphicsDrawObservation &observation) {
+  if (observation.packet_physical_address == UINT32_MAX ||
+      observation.command_buffer_physical_address == UINT32_MAX ||
+      observation.command_buffer_root_physical_address == UINT32_MAX ||
+      !observation.command_buffer_length_dwords) {
+    return false;
+  }
+  const uint64_t buffer_begin =
+      observation.command_buffer_physical_address;
+  const uint64_t buffer_end =
+      buffer_begin + uint64_t(observation.command_buffer_length_dwords) * 4;
+  if ((buffer_begin & 3) ||
+      observation.command_buffer_root_physical_address >=
+          kPhysicalApertureSize ||
+      (observation.command_buffer_root_physical_address & 3) ||
+      buffer_end > kPhysicalApertureSize ||
+      observation.packet_physical_address < buffer_begin ||
+      observation.packet_physical_address >= buffer_end ||
+      (observation.packet_physical_address & 3)) {
+    return false;
+  }
+  if (!observation.command_buffer_depth) {
+    return observation.command_buffer_parent_packet_physical_address ==
+               UINT32_MAX &&
+           observation.command_buffer_root_physical_address ==
+               observation.command_buffer_physical_address;
+  }
+  if (observation.command_buffer_parent_packet_physical_address >=
+          kPhysicalApertureSize ||
+      (observation.command_buffer_parent_packet_physical_address & 3)) {
+    return false;
+  }
+  if (observation.command_buffer_depth == 1) {
+    return observation.command_buffer_root_physical_address ==
+           observation.command_buffer_physical_address;
+  }
+  return observation.command_buffer_parent_packet_physical_address >=
+         observation.command_buffer_root_physical_address;
+}
+
+void ObserveCommandBufferLineage(
+    const rex::system::GraphicsDrawObservation &observation) {
+  ++g_command_buffer_lineage_draws;
+  if (observation.command_buffer_depth) {
+    ++g_command_buffer_lineage_indirect_draws;
+  } else {
+    ++g_command_buffer_lineage_primary_draws;
+  }
+  if (!HasValidCommandBufferLineage(observation)) {
+    ++g_command_buffer_lineage_invalid;
+  }
+}
+
+void RecordPreparedCommandBufferLineage(
+    uint64_t prepared_signature,
+    const rex::system::GraphicsDrawObservation &observation) {
+  if (!HasValidCommandBufferLineage(observation)) {
+    return;
+  }
+  ++g_command_buffer_lineage_prepared_draws;
+  const uint32_t packet_offset_bytes =
+      observation.packet_physical_address -
+      observation.command_buffer_physical_address;
+  const uint32_t parent_root_offset_bytes =
+      observation.command_buffer_depth > 1
+          ? observation.command_buffer_parent_packet_physical_address -
+                observation.command_buffer_root_physical_address
+          : UINT32_MAX;
+  const uint32_t constructor_store_address =
+      CurrentTitleIndirectConstructor(observation);
+  uint64_t key = 0xCBF29CE484222325ull;
+  for (uint64_t value :
+       {uint64_t(constructor_store_address),
+        uint64_t(observation.command_buffer_depth)}) {
+    key = HashCombine(key, value);
+  }
+  size_t index = size_t(key % kCommandBufferLineageCapacity);
+  for (size_t probe = 0; probe < kCommandBufferLineageCapacity; ++probe) {
+    CommandBufferLineageEntry &entry = g_command_buffer_lineages[index];
+    if (!entry.calls) {
+      entry.sample_prepared_signature = prepared_signature;
+      entry.calls = 1;
+      entry.first_frame = observation.frame_sequence;
+      entry.last_frame = observation.frame_sequence;
+      entry.first_draw = observation.draw_sequence;
+      entry.last_draw = observation.draw_sequence;
+      entry.packet_physical_address = observation.packet_physical_address;
+      entry.command_buffer_physical_address =
+          observation.command_buffer_physical_address;
+      entry.sample_command_buffer_length_dwords =
+          observation.command_buffer_length_dwords;
+      entry.min_command_buffer_length_dwords =
+          observation.command_buffer_length_dwords;
+      entry.max_command_buffer_length_dwords =
+          observation.command_buffer_length_dwords;
+      entry.min_packet_offset_bytes = packet_offset_bytes;
+      entry.max_packet_offset_bytes = packet_offset_bytes;
+      entry.parent_packet_physical_address =
+          observation.command_buffer_parent_packet_physical_address;
+      entry.root_physical_address =
+          observation.command_buffer_root_physical_address;
+      entry.min_parent_root_offset_bytes = parent_root_offset_bytes;
+      entry.max_parent_root_offset_bytes = parent_root_offset_bytes;
+      entry.constructor_store_address = constructor_store_address;
+      entry.depth = observation.command_buffer_depth;
+      ++g_command_buffer_lineage_entry_count;
+      return;
+    }
+    if (entry.constructor_store_address == constructor_store_address &&
+        entry.depth == observation.command_buffer_depth) {
+      ++entry.calls;
+      entry.last_frame = observation.frame_sequence;
+      entry.last_draw = observation.draw_sequence;
+      entry.min_packet_offset_bytes =
+          std::min(entry.min_packet_offset_bytes, packet_offset_bytes);
+      entry.max_packet_offset_bytes =
+          std::max(entry.max_packet_offset_bytes, packet_offset_bytes);
+      entry.min_command_buffer_length_dwords =
+          std::min(entry.min_command_buffer_length_dwords,
+                   observation.command_buffer_length_dwords);
+      entry.max_command_buffer_length_dwords =
+          std::max(entry.max_command_buffer_length_dwords,
+                   observation.command_buffer_length_dwords);
+      entry.min_parent_root_offset_bytes =
+          std::min(entry.min_parent_root_offset_bytes,
+                   parent_root_offset_bytes);
+      entry.max_parent_root_offset_bytes =
+          std::max(entry.max_parent_root_offset_bytes,
+                   parent_root_offset_bytes);
+      entry.prepared_signature_varied |=
+          entry.sample_prepared_signature != prepared_signature;
+      return;
+    }
+    index = (index + 1) % kCommandBufferLineageCapacity;
+  }
+  ++g_command_buffer_lineage_overflow;
+}
+
+void EmitCommandBufferLineageSummary() {
+  for (const CommandBufferLineageEntry &entry : g_command_buffer_lineages) {
+    if (!entry.calls) {
+      continue;
+    }
+    pinyon_shift::diagnostics::RecordEvent(
+        "native_renderer.discovery.command_buffer_lineage_entry",
+        {{"sample_prepared_signature",
+          fmt::format("{:016X}", entry.sample_prepared_signature)},
+         {"prepared_signature_varied",
+          entry.prepared_signature_varied ? "true" : "false"},
+         {"calls", std::to_string(entry.calls)},
+         {"first_frame", std::to_string(entry.first_frame)},
+         {"last_frame", std::to_string(entry.last_frame)},
+         {"first_draw", std::to_string(entry.first_draw)},
+         {"last_draw", std::to_string(entry.last_draw)},
+         {"sample_packet_physical_address",
+          fmt::format("{:08X}", entry.packet_physical_address)},
+         {"sample_command_buffer_physical_address",
+          fmt::format("{:08X}", entry.command_buffer_physical_address)},
+         {"sample_command_buffer_length_dwords",
+          std::to_string(entry.sample_command_buffer_length_dwords)},
+         {"min_command_buffer_length_dwords",
+          std::to_string(entry.min_command_buffer_length_dwords)},
+         {"max_command_buffer_length_dwords",
+          std::to_string(entry.max_command_buffer_length_dwords)},
+         {"min_packet_offset_bytes",
+          std::to_string(entry.min_packet_offset_bytes)},
+         {"max_packet_offset_bytes",
+          std::to_string(entry.max_packet_offset_bytes)},
+         {"sample_parent_packet_physical_address",
+          fmt::format("{:08X}", entry.parent_packet_physical_address)},
+         {"sample_root_physical_address",
+          fmt::format("{:08X}", entry.root_physical_address)},
+         {"min_parent_root_offset_bytes",
+          entry.min_parent_root_offset_bytes == UINT32_MAX
+              ? "none"
+              : std::to_string(entry.min_parent_root_offset_bytes)},
+         {"max_parent_root_offset_bytes",
+          entry.max_parent_root_offset_bytes == UINT32_MAX
+              ? "none"
+              : std::to_string(entry.max_parent_root_offset_bytes)},
+         {"constructor_store_address",
+          entry.constructor_store_address
+              ? fmt::format("{:08X}", entry.constructor_store_address)
+              : "unknown"},
+         {"depth", std::to_string(entry.depth)},
+         {"guest_payload_read", "false"},
+         {"guest_state_changed", "false"},
+         {"xenos_authority", "true"},
+         {"suppression_allowed", "false"}});
+  }
+  pinyon_shift::diagnostics::RecordEvent(
+      "native_renderer.discovery.command_buffer_lineage_summary",
+      {{"draws", std::to_string(g_command_buffer_lineage_draws)},
+       {"primary_draws",
+        std::to_string(g_command_buffer_lineage_primary_draws)},
+       {"indirect_draws",
+        std::to_string(g_command_buffer_lineage_indirect_draws)},
+       {"invalid_lineages",
+        std::to_string(g_command_buffer_lineage_invalid)},
+       {"prepared_draws",
+        std::to_string(g_command_buffer_lineage_prepared_draws)},
+       {"entries", std::to_string(g_command_buffer_lineage_entry_count)},
+       {"overflow", std::to_string(g_command_buffer_lineage_overflow)},
+       {"capacity", std::to_string(kCommandBufferLineageCapacity)},
+       {"title_indirect_packets_recorded",
+        std::to_string(g_title_indirect_packets_recorded)},
+       {"title_indirect_packet_address_failures",
+        std::to_string(g_title_indirect_packet_address_failures)},
+       {"title_indirect_packet_table_overflow",
+        std::to_string(g_title_indirect_packet_table_overflow)},
+       {"title_indirect_packet_evictions",
+        std::to_string(g_title_indirect_packet_evictions)},
+       {"indirect_buffer_enters",
+        std::to_string(g_title_indirect_buffer_enters)},
+       {"indirect_buffer_exits",
+        std::to_string(g_title_indirect_buffer_exits)},
+       {"indirect_buffer_constructor_matches",
+        std::to_string(g_title_indirect_buffer_matches)},
+       {"indirect_buffer_constructor_unmatched",
+        std::to_string(g_title_indirect_buffer_unmatched)},
+       {"indirect_buffer_stack_faults",
+        std::to_string(g_title_indirect_stack_faults)},
+       {"indirect_draw_stack_faults",
+        std::to_string(g_title_indirect_draw_stack_faults)},
+       {"indirect_buffers_open_at_shutdown",
+        std::to_string(g_title_indirect_buffers_open.load(
+            std::memory_order_relaxed))},
+       {"correlation",
+        "exact_title_store_to_backend_nested_command_buffer_shape"},
+       {"semantic_identity", "unknown"},
+       {"guest_payload_read", "false"},
+       {"guest_state_changed", "false"},
+       {"control_flow_changed", "false"},
+       {"xenos_authority", "true"},
+       {"suppression_allowed", "false"}});
+}
+
 void RecordTitleDrawProvenance(
     uint64_t backend_signature, bool prepared, uint32_t backend_outcome,
     const rex::system::GraphicsDrawObservation &observation,
@@ -2938,6 +3441,7 @@ void ObservePreparedDraw(
     CommitPassConsumer(sample, observation, g_pending_candidate);
     const uint64_t prepared_signature = CandidateSignature(
         sample, g_pending_candidate.samples_resolved_target, observation);
+    RecordPreparedCommandBufferLineage(prepared_signature, sample);
     RecordTitleDrawProvenance(prepared_signature, true, 0, sample,
                               g_pending_candidate.title_origin);
     g_isolated_draw.prepared_signature = prepared_signature;
@@ -4844,6 +5348,7 @@ void RecordCandidate(
 
 void ObserveDraw(const rex::system::GraphicsDrawObservation &observation) {
   AdvanceDependencyWindow(observation.frame_sequence);
+  ObserveCommandBufferLineage(observation);
   const bool query_draw =
       observation.viz_query_condition || (observation.pa_sc_viz_query & 1);
   if (query_draw) {
@@ -4944,12 +5449,16 @@ void InstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system,
   const bool census_requested =
       REXCVAR_GET(pinyon_shift_native_renderer_census);
   ConfigureTitleDrawProvenance(census_requested, memory);
+  const bool lineage_armed = census_requested && memory;
+  g_command_buffer_lineage_installed.store(false, std::memory_order_release);
+  g_command_buffer_lineage_memory.store(nullptr, std::memory_order_release);
   if (!census_requested && !g_sky_horizon_suppression.requested) {
     EmitSkyHorizonSuppressionControl();
     return;
   }
   ResetDrawCensus();
   ResetPreparedShaderPairs();
+  ResetCommandBufferLineage();
   ResetDependencyCensus();
   ResetGuestCpuVisibility();
   ConfigureIndexScan();
@@ -4962,6 +5471,10 @@ void InstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system,
   EmitSkyHorizonSuppressionControl();
   ConfigureConsumerFamilyMarker();
   g_graphics_census_memory = memory;
+  g_command_buffer_lineage_memory.store(lineage_armed ? memory : nullptr,
+                                        std::memory_order_release);
+  g_command_buffer_lineage_installed.store(lineage_armed,
+                                           std::memory_order_release);
   if (g_pass_follower.requested && g_pass_follower.valid &&
       g_isolated_draw.requested && g_isolated_draw.valid) {
     g_guest_cpu_access_callback =
@@ -4970,6 +5483,7 @@ void InstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system,
   }
   g_graphics_census_installed = true;
   graphics_system->SetDrawObserver(&ObserveDraw);
+  graphics_system->SetIndirectBufferObserver(&ObserveIndirectBuffer);
   graphics_system->SetCopyObserver(&ObserveCopy);
   graphics_system->SetPreparedDrawObserver(&ObservePreparedDraw);
   graphics_system->SetDrawOutcomeObserver(&ObserveDrawOutcome);
@@ -4983,11 +5497,24 @@ void InstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system,
                             {"resolve_page_capacity", "32768"},
                             {"resolve_summary_limit", "32"},
                             {"prepared_shader_pair_capacity", "1024"},
+                            {"command_buffer_lineage_capacity", "4096"},
                             {"guest_cpu_visibility_target_capacity", "64"},
                             {"scene", scene},
                             {"mode", g_sky_horizon_suppression.armed
                                          ? "experimental_suppression"
                                          : "pass_through"}});
+  diagnostics::RecordEvent(
+      "native_renderer.discovery.command_buffer_lineage_config",
+      {{"status", "armed"},
+       {"scene", scene},
+       {"capacity", std::to_string(kCommandBufferLineageCapacity)},
+       {"source",
+        "title_store,backend_packet,current_buffer,parent_packet,root_buffer,depth"},
+       {"guest_payload_read", "false"},
+       {"guest_state_changed", "false"},
+       {"control_flow_changed", "false"},
+       {"xenos_authority", "true"},
+       {"suppression_allowed", "false"}});
   diagnostics::RecordEvent("native_renderer.census.scene_marker",
                            {{"scene", scene}, {"source", "operator"}});
   diagnostics::RecordEvent(
@@ -5144,11 +5671,14 @@ void InstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system,
 void UninstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system) {
   if (graphics_system) {
     graphics_system->SetDrawObserver(nullptr);
+    graphics_system->SetIndirectBufferObserver(nullptr);
     graphics_system->SetCopyObserver(nullptr);
     graphics_system->SetPreparedDrawObserver(nullptr);
     graphics_system->SetDrawOutcomeObserver(nullptr);
     graphics_system->SetIsolatedDrawRequestObserver(nullptr);
   }
+  g_command_buffer_lineage_installed.store(false, std::memory_order_release);
+  g_command_buffer_lineage_memory.store(nullptr, std::memory_order_release);
   EmitDispatchDiscoverySummary();
   if (!g_graphics_census_installed) {
     return;
@@ -5191,6 +5721,7 @@ void UninstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system) {
     g_pending_candidate.valid = false;
   }
   EmitTitleDrawProvenanceSummary();
+  EmitCommandBufferLineageSummary();
   if (g_pass_consumer_trace.pending) {
     ++g_pass_consumer_trace.superseded_without_resolve;
     g_pass_consumer_trace.pending = false;
@@ -5683,6 +6214,31 @@ void PinyonShiftObserveDrawAdapterDispatch(
 
 void PinyonShiftObserveDrawPacketSubmission(PPCRegister &r3) {
   RecordTitleDrawPacket(r3.u32 + sizeof(uint32_t));
+}
+
+void PinyonShiftObserveIndirectPacket824095B4(PPCRegister &r11,
+                                               PPCRegister &r28) {
+  RecordTitleIndirectPacket(r11.u32 + r28.u32, 0x824095B4);
+}
+
+void PinyonShiftObserveIndirectPacket82416EFC(PPCRegister &r30) {
+  RecordTitleIndirectPacket(r30.u32 + sizeof(uint32_t), 0x82416EFC);
+}
+
+void PinyonShiftObserveIndirectPacket8246FC1C(PPCRegister &r11) {
+  RecordTitleIndirectPacket(r11.u32 + sizeof(uint32_t), 0x8246FC1C);
+}
+
+void PinyonShiftObserveIndirectPacket8263BD64(PPCRegister &r9) {
+  RecordTitleIndirectPacket(r9.u32 + sizeof(uint32_t), 0x8263BD64);
+}
+
+void PinyonShiftObserveIndirectPacket829E8E88(PPCRegister &r1) {
+  RecordTitleIndirectPacket(r1.u32 + 88, 0x829E8E88);
+}
+
+void PinyonShiftObserveIndirectPacket829EC49C(PPCRegister &r11) {
+  RecordTitleIndirectPacket(r11.u32 + sizeof(uint32_t), 0x829EC49C);
 }
 
 void PinyonShiftObserveResolveControllerDispatch(

--- a/tools/create-crash-report.ps1
+++ b/tools/create-crash-report.ps1
@@ -302,6 +302,31 @@ try {
             xenos_authority = $true
             suppression_allowed = $false
         }
+        command_buffer_lineage = [ordered]@{
+            status = 'not_observed'
+            correlation = $null
+            draws = [uint64]0
+            primary_draws = [uint64]0
+            indirect_draws = [uint64]0
+            invalid_lineages = [uint64]0
+            prepared_draws = [uint64]0
+            entries = [uint64]0
+            overflow = [uint64]0
+            capacity = [uint64]0
+            title_indirect_packets_recorded = [uint64]0
+            title_indirect_packet_address_failures = [uint64]0
+            title_indirect_packet_table_overflow = [uint64]0
+            title_indirect_packet_evictions = [uint64]0
+            indirect_buffer_enters = [uint64]0
+            indirect_buffer_exits = [uint64]0
+            indirect_buffers_open_at_shutdown = [uint64]0
+            indirect_buffer_constructor_matches = [uint64]0
+            indirect_buffer_constructor_unmatched = [uint64]0
+            indirect_buffer_stack_faults = [uint64]0
+            indirect_draw_stack_faults = [uint64]0
+            xenos_authority = $true
+            suppression_allowed = $false
+        }
     }
     $nativeShaderPack = [ordered]@{
         status = 'not_configured'
@@ -378,6 +403,35 @@ try {
                     $provenance.xenos_authority =
                         [string]$event.xenos_authority -eq 'true'
                     $provenance.suppression_allowed =
+                        [string]$event.suppression_allowed -eq 'true'
+                }
+                'native_renderer.discovery.command_buffer_lineage_config' {
+                    $nativeRenderer.command_buffer_lineage.status =
+                        [string]$event.status
+                }
+                'native_renderer.discovery.command_buffer_lineage_summary' {
+                    $lineage = $nativeRenderer.command_buffer_lineage
+                    $lineage.status = 'summary_observed'
+                    $lineage.correlation = [string]$event.correlation
+                    foreach ($field in @(
+                            'draws', 'primary_draws', 'indirect_draws',
+                            'invalid_lineages', 'prepared_draws', 'entries',
+                            'overflow', 'capacity',
+                            'title_indirect_packets_recorded',
+                            'title_indirect_packet_address_failures',
+                            'title_indirect_packet_table_overflow',
+                            'title_indirect_packet_evictions',
+                            'indirect_buffer_enters', 'indirect_buffer_exits',
+                            'indirect_buffers_open_at_shutdown',
+                            'indirect_buffer_constructor_matches',
+                            'indirect_buffer_constructor_unmatched',
+                            'indirect_buffer_stack_faults',
+                            'indirect_draw_stack_faults')) {
+                        $lineage[$field] = [uint64]$event.$field
+                    }
+                    $lineage.xenos_authority =
+                        [string]$event.xenos_authority -eq 'true'
+                    $lineage.suppression_allowed =
                         [string]$event.suppression_allowed -eq 'true'
                 }
                 'native_renderer.shader_pack.ready' {

--- a/tools/discover-native-renderer-dispatch.py
+++ b/tools/discover-native-renderer-dispatch.py
@@ -29,6 +29,8 @@ PACKET_OPCODES = {
     0x63: "PM4_SET_BIN_SELECT_HI",
     0x23: "PM4_VIZ_QUERY",
     0x36: "PM4_DRAW_INDX_2",
+    0x37: "PM4_INDIRECT_BUFFER_PFD",
+    0x3F: "PM4_INDIRECT_BUFFER",
 }
 REVIEWED_WRAPPERS = {
     0x824079B8: {
@@ -230,9 +232,12 @@ def packet_constructors(functions: list[dict]) -> list[dict]:
                     "constructor_address": "{:08X}".format(
                         instruction["address"]
                     ),
+                    "constructor_instruction": instruction["text"],
                     "store_address": "{:08X}".format(
                         store_instruction["address"]
                     ),
+                    "store_instruction": store_instruction["text"],
+                    "packet_register": register,
                     "opcode": PACKET_OPCODES[opcode_value],
                     "opcode_value": "{:02X}".format(opcode_value),
                     "header_source": header_source,

--- a/tools/summarize-native-renderer-command-lineage.py
+++ b/tools/summarize-native-renderer-command-lineage.py
@@ -1,0 +1,436 @@
+"""Summarize exact backend draw-to-command-buffer lineage evidence."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import pathlib
+import sys
+
+
+SCHEMA = "pinyon-shift.native-renderer-command-lineage.v1"
+STATIC_SCHEMA = "pinyon-shift.native-renderer-dispatch-static.v3"
+PREFIX = "native_renderer.discovery.command_buffer_lineage_"
+INDIRECT_OPCODES = {"PM4_INDIRECT_BUFFER", "PM4_INDIRECT_BUFFER_PFD"}
+PHYSICAL_APERTURE_SIZE = 0x20000000
+KNOWN_PREPARED_FAMILIES = {
+    "747837906D0BF484": "retained_sky_horizon_anchor",
+    "1D253A52B55C9FB3": "retained_sky_horizon_follower",
+}
+
+
+def read_events(paths: list[pathlib.Path]) -> list[dict]:
+    events = []
+    for path in paths:
+        for line_number, line in enumerate(
+            path.read_text(encoding="utf-8").splitlines(), 1
+        ):
+            if not line.strip():
+                continue
+            try:
+                event = json.loads(line)
+            except json.JSONDecodeError as error:
+                raise ValueError(f"{path}:{line_number}: invalid JSON: {error}") from error
+            if str(event.get("event", "")).startswith(PREFIX):
+                events.append(event)
+    return events
+
+
+def select_session(events: list[dict], requested: str | None) -> str:
+    if requested:
+        if not any(event.get("session") == requested for event in events):
+            raise ValueError(f"command-buffer lineage session not found: {requested}")
+        return requested
+    armed = [
+        str(event.get("session", ""))
+        for event in events
+        if event.get("event") == f"{PREFIX}config"
+        and event.get("status") == "armed"
+    ]
+    if not armed or not armed[-1]:
+        raise ValueError("no armed command-buffer lineage session found")
+    return armed[-1]
+
+
+def _integer(mapping: dict, key: str) -> int:
+    try:
+        return int(mapping.get(key, 0))
+    except (TypeError, ValueError) as error:
+        raise ValueError(f"invalid integer field: {key}") from error
+
+
+def _hex(mapping: dict, key: str, width: int) -> str:
+    value = str(mapping.get(key, "")).upper()
+    if len(value) != width:
+        raise ValueError(f"invalid hexadecimal field: {key}")
+    try:
+        int(value, 16)
+    except ValueError as error:
+        raise ValueError(f"invalid hexadecimal field: {key}") from error
+    return value
+
+
+def build(events: list[dict], static: dict, requested: str | None = None) -> dict:
+    if static.get("schema") != STATIC_SCHEMA:
+        raise ValueError("unsupported static dispatch inventory schema")
+    constructors = [
+        item
+        for item in static.get("packet_constructors", [])
+        if item.get("opcode") in INDIRECT_OPCODES
+    ]
+    if not constructors:
+        raise ValueError("static inventory has no stored indirect-buffer constructors")
+    constructor_store_addresses = {
+        str(item.get("store_address", "")).upper() for item in constructors
+    }
+
+    session = select_session(events, requested)
+    selected = [event for event in events if event.get("session") == session]
+    configs = [
+        event
+        for event in selected
+        if event.get("event") == f"{PREFIX}config"
+        and event.get("status") == "armed"
+    ]
+    summaries = [
+        event for event in selected if event.get("event") == f"{PREFIX}summary"
+    ]
+    if len(configs) != 1 or len(summaries) != 1:
+        raise ValueError("lineage session needs one armed config and summary")
+    summary = summaries[0]
+    required_safety = {
+        "guest_payload_read": "false",
+        "guest_state_changed": "false",
+        "control_flow_changed": "false",
+        "xenos_authority": "true",
+        "suppression_allowed": "false",
+    }
+    if any(
+        str(summary.get(key)).lower() != value
+        for key, value in required_safety.items()
+    ):
+        raise ValueError("lineage summary does not prove the safety boundary")
+    if (
+        str(summary.get("correlation"))
+        != "exact_title_store_to_backend_nested_command_buffer_shape"
+    ):
+        raise ValueError("lineage summary uses an unsupported correlation key")
+
+    entries = []
+    for event in selected:
+        if event.get("event") != f"{PREFIX}entry":
+            continue
+        signature = _hex(event, "sample_prepared_signature", 16)
+        packet = _hex(event, "sample_packet_physical_address", 8)
+        current = _hex(event, "sample_command_buffer_physical_address", 8)
+        parent = _hex(event, "sample_parent_packet_physical_address", 8)
+        root = _hex(event, "sample_root_physical_address", 8)
+        calls = _integer(event, "calls")
+        sample_length = _integer(
+            event, "sample_command_buffer_length_dwords"
+        )
+        min_length = _integer(event, "min_command_buffer_length_dwords")
+        max_length = _integer(event, "max_command_buffer_length_dwords")
+        min_packet_offset = _integer(event, "min_packet_offset_bytes")
+        max_packet_offset = _integer(event, "max_packet_offset_bytes")
+        depth = _integer(event, "depth")
+        if (
+            not calls
+            or not sample_length
+            or not min_length
+            or not min_length <= sample_length <= max_length
+            or depth < 0
+        ):
+            raise ValueError("lineage entry has invalid count, length, or depth")
+        packet_value = int(packet, 16)
+        current_value = int(current, 16)
+        parent_value = int(parent, 16)
+        root_value = int(root, 16)
+        buffer_end = current_value + sample_length * 4
+        if (
+            current_value & 3
+            or packet_value & 3
+            or root_value & 3
+            or buffer_end > PHYSICAL_APERTURE_SIZE
+            or root_value >= PHYSICAL_APERTURE_SIZE
+        ):
+            raise ValueError("lineage entry has an invalid physical address")
+        if not current_value <= packet_value < buffer_end:
+            raise ValueError("lineage packet is outside its command buffer")
+        sample_packet_offset = packet_value - current_value
+        if not 0 <= min_packet_offset <= sample_packet_offset <= max_packet_offset:
+            raise ValueError("lineage packet-offset bounds exclude their sample")
+        if max_packet_offset >= max_length * 4:
+            raise ValueError(
+                "lineage packet-offset bounds exceed their maximum buffer"
+            )
+        min_parent_root_text = str(
+            event.get("min_parent_root_offset_bytes", "")
+        )
+        max_parent_root_text = str(
+            event.get("max_parent_root_offset_bytes", "")
+        )
+        constructor_text = str(
+            event.get("constructor_store_address", "unknown")
+        ).upper()
+        if constructor_text == "UNKNOWN":
+            constructor_store_address = None
+        else:
+            if constructor_text not in constructor_store_addresses:
+                raise ValueError(
+                    "lineage entry references an unproved constructor store"
+                )
+            constructor_store_address = constructor_text
+        if depth:
+            if parent_value >= PHYSICAL_APERTURE_SIZE or parent_value & 3:
+                raise ValueError("indirect lineage entry has no valid parent packet")
+            if depth == 1 and root != current:
+                raise ValueError("first indirect lineage root differs from its buffer")
+            if depth == 1:
+                if (
+                    min_parent_root_text != "none"
+                    or max_parent_root_text != "none"
+                ):
+                    raise ValueError(
+                        "first indirect lineage has parent-root offset bounds"
+                    )
+                min_parent_root_offset = None
+                max_parent_root_offset = None
+            else:
+                if parent_value < root_value:
+                    raise ValueError("nested parent packet precedes its root buffer")
+                try:
+                    min_parent_root_offset = int(min_parent_root_text)
+                    max_parent_root_offset = int(max_parent_root_text)
+                except ValueError as error:
+                    raise ValueError(
+                        "invalid nested parent-root offset bounds"
+                    ) from error
+                sample_parent_root_offset = parent_value - root_value
+                if not (
+                    0
+                    <= min_parent_root_offset
+                    <= sample_parent_root_offset
+                    <= max_parent_root_offset
+                ):
+                    raise ValueError(
+                        "nested parent-root offset bounds exclude their sample"
+                    )
+        elif parent != "FFFFFFFF" or root != current:
+            raise ValueError("direct lineage entry has invalid root or parent")
+        else:
+            if (
+                min_parent_root_text != "none"
+                or max_parent_root_text != "none"
+            ):
+                raise ValueError("direct lineage has parent-root offset bounds")
+            min_parent_root_offset = None
+            max_parent_root_offset = None
+        entries.append(
+            {
+                "sample_prepared_signature": signature,
+                "sample_prepared_family": KNOWN_PREPARED_FAMILIES.get(
+                    signature, "unknown"
+                ),
+                "prepared_signature_varied": str(
+                    event.get("prepared_signature_varied", "")
+                ).lower()
+                == "true",
+                "calls": calls,
+                "first_frame": _integer(event, "first_frame"),
+                "last_frame": _integer(event, "last_frame"),
+                "first_draw": _integer(event, "first_draw"),
+                "last_draw": _integer(event, "last_draw"),
+                "sample_packet_physical_address": packet,
+                "sample_command_buffer_physical_address": current,
+                "sample_command_buffer_length_dwords": sample_length,
+                "min_command_buffer_length_dwords": min_length,
+                "max_command_buffer_length_dwords": max_length,
+                "min_packet_offset_bytes": min_packet_offset,
+                "max_packet_offset_bytes": max_packet_offset,
+                "sample_parent_packet_physical_address": parent,
+                "sample_root_physical_address": root,
+                "min_parent_root_offset_bytes": min_parent_root_offset,
+                "max_parent_root_offset_bytes": max_parent_root_offset,
+                "constructor_store_address": constructor_store_address,
+                "depth": depth,
+            }
+        )
+    entries.sort(
+        key=lambda item: (
+            -item["calls"],
+            item["depth"],
+            item["min_command_buffer_length_dwords"],
+            -1
+            if item["min_parent_root_offset_bytes"] is None
+            else item["min_parent_root_offset_bytes"],
+            item["constructor_store_address"] or "",
+        )
+    )
+
+    draws = _integer(summary, "draws")
+    primary_draws = _integer(summary, "primary_draws")
+    indirect_draws = _integer(summary, "indirect_draws")
+    invalid = _integer(summary, "invalid_lineages")
+    prepared_draws = _integer(summary, "prepared_draws")
+    overflow = _integer(summary, "overflow")
+    capacity = _integer(summary, "capacity")
+    title_packets = _integer(summary, "title_indirect_packets_recorded")
+    title_address_failures = _integer(
+        summary, "title_indirect_packet_address_failures"
+    )
+    title_table_overflow = _integer(
+        summary, "title_indirect_packet_table_overflow"
+    )
+    title_evictions = _integer(summary, "title_indirect_packet_evictions")
+    indirect_enters = _integer(summary, "indirect_buffer_enters")
+    indirect_exits = _integer(summary, "indirect_buffer_exits")
+    constructor_matches = _integer(
+        summary, "indirect_buffer_constructor_matches"
+    )
+    constructor_unmatched = _integer(
+        summary, "indirect_buffer_constructor_unmatched"
+    )
+    indirect_stack_faults = _integer(summary, "indirect_buffer_stack_faults")
+    draw_stack_faults = _integer(summary, "indirect_draw_stack_faults")
+    open_at_shutdown = _integer(
+        summary, "indirect_buffers_open_at_shutdown"
+    )
+    retained_title_generations = (
+        title_packets - constructor_matches - title_evictions
+    )
+    if retained_title_generations < 0:
+        raise ValueError("title indirect-buffer generation accounting underflow")
+    complete = (
+        draws == primary_draws + indirect_draws
+        and prepared_draws == sum(item["calls"] for item in entries)
+        and len(entries) == _integer(summary, "entries")
+        and len(entries) <= capacity
+        and not invalid
+        and not overflow
+        and title_packets > 0
+        and constructor_matches > 0
+        and indirect_enters == indirect_exits + open_at_shutdown
+        and indirect_enters == constructor_matches + constructor_unmatched
+        and not title_address_failures
+        and not title_table_overflow
+        and not indirect_stack_faults
+        and not draw_stack_faults
+    )
+
+    shapes = []
+    for entry in entries:
+        shapes.append(
+            {
+                "calls": entry["calls"],
+                "sample_command_buffer_length_dwords": entry[
+                    "sample_command_buffer_length_dwords"
+                ],
+                "min_command_buffer_length_dwords": entry[
+                    "min_command_buffer_length_dwords"
+                ],
+                "max_command_buffer_length_dwords": entry[
+                    "max_command_buffer_length_dwords"
+                ],
+                "min_packet_offset_bytes": entry["min_packet_offset_bytes"],
+                "max_packet_offset_bytes": entry["max_packet_offset_bytes"],
+                "min_parent_root_offset_bytes": entry[
+                    "min_parent_root_offset_bytes"
+                ],
+                "max_parent_root_offset_bytes": entry[
+                    "max_parent_root_offset_bytes"
+                ],
+                "constructor_store_address": entry[
+                    "constructor_store_address"
+                ],
+                "depth": entry["depth"],
+                "sample_prepared_signature": entry[
+                    "sample_prepared_signature"
+                ],
+                "sample_prepared_family": entry["sample_prepared_family"],
+                "prepared_signature_varied": entry[
+                    "prepared_signature_varied"
+                ],
+            }
+        )
+    shapes.sort(
+        key=lambda item: (
+            -item["calls"],
+            item["depth"],
+            item["min_command_buffer_length_dwords"],
+            -1
+            if item["min_parent_root_offset_bytes"] is None
+            else item["min_parent_root_offset_bytes"],
+            item["constructor_store_address"] or "",
+        )
+    )
+
+    return {
+        "schema": SCHEMA,
+        "session": session,
+        "scene": str(configs[0].get("scene", "unmarked")),
+        "status": "complete" if complete else "incomplete_fail_closed",
+        "entries": entries,
+        "shapes": shapes,
+        "static_indirect_buffer_constructors": constructors,
+        "totals": {
+            "draws": draws,
+            "primary_draws": primary_draws,
+            "indirect_draws": indirect_draws,
+            "invalid_lineages": invalid,
+            "prepared_draws": prepared_draws,
+            "entries": len(entries),
+            "shapes": len(shapes),
+            "overflow": overflow,
+            "capacity": capacity,
+            "static_constructors": len(constructors),
+            "title_indirect_packets_recorded": title_packets,
+            "title_indirect_packet_address_failures": title_address_failures,
+            "title_indirect_packet_table_overflow": title_table_overflow,
+            "title_indirect_packet_evictions": title_evictions,
+            "title_indirect_packets_retained_at_shutdown": (
+                retained_title_generations
+            ),
+            "indirect_buffer_enters": indirect_enters,
+            "indirect_buffer_exits": indirect_exits,
+            "indirect_buffer_constructor_matches": constructor_matches,
+            "indirect_buffer_constructor_unmatched": constructor_unmatched,
+            "indirect_buffer_stack_faults": indirect_stack_faults,
+            "indirect_draw_stack_faults": draw_stack_faults,
+            "indirect_buffers_open_at_shutdown": open_at_shutdown,
+        },
+        "qualification": "exact_title_store_to_backend_nested_command_buffer_lineage",
+        "semantic_identity": "unknown",
+        "safety": {
+            "guest_payload_read": False,
+            "guest_state_changed": False,
+            "control_flow_changed": False,
+            "xenos_authority": True,
+            "suppression_allowed": False,
+        },
+    }
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("logs", nargs="+", type=pathlib.Path)
+    parser.add_argument("--static", required=True, type=pathlib.Path)
+    parser.add_argument("--session")
+    parser.add_argument("--output", required=True, type=pathlib.Path)
+    args = parser.parse_args(argv)
+    try:
+        static = json.loads(args.static.read_text(encoding="utf-8"))
+        document = build(read_events(args.logs), static, args.session)
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(
+            json.dumps(document, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        return 0
+    except (OSError, ValueError, TypeError, json.JSONDecodeError) as error:
+        print(f"native renderer command lineage summary failed: {error}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/tests/test_native_renderer_command_lineage.py
+++ b/tools/tests/test_native_renderer_command_lineage.py
@@ -1,0 +1,211 @@
+import importlib.util
+import sys
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+TOOL = ROOT / "tools" / "summarize-native-renderer-command-lineage.py"
+SPEC = importlib.util.spec_from_file_location("native_command_lineage", TOOL)
+assert SPEC and SPEC.loader
+MODULE = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = MODULE
+SPEC.loader.exec_module(MODULE)
+
+
+def static_inventory():
+    return {
+        "schema": "pinyon-shift.native-renderer-dispatch-static.v3",
+        "packet_constructors": [
+            {
+                "function": "sub_82409398",
+                "function_address": "82409398",
+                "constructor_address": "824095AC",
+                "constructor_instruction": "ori r10,r10,16128",
+                "store_address": "824095B4",
+                "store_instruction": "stwx r10,r11,r28",
+                "packet_register": "r10",
+                "opcode": "PM4_INDIRECT_BUFFER",
+                "opcode_value": "3F",
+                "header_source": "fixed_type3_count_2",
+                "role": "unreviewed",
+            }
+        ],
+    }
+
+
+def events():
+    common = {"session": "lineage-session"}
+    return [
+        {
+            **common,
+            "event": "native_renderer.discovery.command_buffer_lineage_config",
+            "status": "armed",
+            "scene": "open_world",
+        },
+        {
+            **common,
+            "event": "native_renderer.discovery.command_buffer_lineage_entry",
+            "sample_prepared_signature": "747837906D0BF484",
+            "prepared_signature_varied": "true",
+            "calls": "12",
+            "first_frame": "10",
+            "last_frame": "20",
+            "first_draw": "3",
+            "last_draw": "7",
+            "sample_packet_physical_address": "00102040",
+            "sample_command_buffer_physical_address": "00102000",
+            "sample_command_buffer_length_dwords": "64",
+            "min_command_buffer_length_dwords": "48",
+            "max_command_buffer_length_dwords": "96",
+            "min_packet_offset_bytes": "32",
+            "max_packet_offset_bytes": "96",
+            "sample_parent_packet_physical_address": "00004020",
+            "sample_root_physical_address": "00102000",
+            "min_parent_root_offset_bytes": "none",
+            "max_parent_root_offset_bytes": "none",
+            "constructor_store_address": "824095B4",
+            "depth": "1",
+        },
+        {
+            **common,
+            "event": "native_renderer.discovery.command_buffer_lineage_summary",
+            "draws": "14",
+            "primary_draws": "2",
+            "indirect_draws": "12",
+            "invalid_lineages": "0",
+            "prepared_draws": "12",
+            "entries": "1",
+            "overflow": "0",
+            "capacity": "4096",
+            "title_indirect_packets_recorded": "37",
+            "title_indirect_packet_address_failures": "0",
+            "title_indirect_packet_table_overflow": "0",
+            "title_indirect_packet_evictions": "7",
+            "indirect_buffer_enters": "30",
+            "indirect_buffer_exits": "28",
+            "indirect_buffers_open_at_shutdown": "2",
+            "indirect_buffer_constructor_matches": "20",
+            "indirect_buffer_constructor_unmatched": "10",
+            "indirect_buffer_stack_faults": "0",
+            "indirect_draw_stack_faults": "0",
+            "correlation": "exact_title_store_to_backend_nested_command_buffer_shape",
+            "guest_payload_read": "false",
+            "guest_state_changed": "false",
+            "control_flow_changed": "false",
+            "xenos_authority": "true",
+            "suppression_allowed": "false",
+        },
+    ]
+
+
+def nested_events():
+    result = events()
+    result[1].update(
+        {
+            "sample_packet_physical_address": "00103040",
+            "sample_command_buffer_physical_address": "00103000",
+            "sample_parent_packet_physical_address": "00102020",
+            "sample_root_physical_address": "00102000",
+            "min_parent_root_offset_bytes": "16",
+            "max_parent_root_offset_bytes": "48",
+            "depth": "2",
+        }
+    )
+    return result
+
+
+class NativeRendererCommandLineageTests(unittest.TestCase):
+    def test_builds_complete_exact_lineage_report(self):
+        document = MODULE.build(events(), static_inventory())
+        self.assertEqual("complete", document["status"])
+        self.assertEqual(12, document["totals"]["indirect_draws"])
+        self.assertEqual(1, document["totals"]["static_constructors"])
+        self.assertEqual(
+            "retained_sky_horizon_anchor",
+            document["shapes"][0]["sample_prepared_family"],
+        )
+        self.assertEqual(1, document["shapes"][0]["depth"])
+        self.assertEqual(
+            48, document["shapes"][0]["min_command_buffer_length_dwords"]
+        )
+        self.assertEqual(
+            96, document["shapes"][0]["max_command_buffer_length_dwords"]
+        )
+        self.assertEqual(2, document["totals"]["indirect_buffers_open_at_shutdown"])
+        self.assertEqual(7, document["totals"]["title_indirect_packet_evictions"])
+        self.assertEqual(
+            10,
+            document["totals"][
+                "title_indirect_packets_retained_at_shutdown"
+            ],
+        )
+        self.assertTrue(document["shapes"][0]["prepared_signature_varied"])
+        self.assertEqual(
+            "824095B4", document["shapes"][0]["constructor_store_address"]
+        )
+        self.assertFalse(document["safety"]["suppression_allowed"])
+
+    def test_fails_closed_on_invalid_or_overflowed_lineage(self):
+        broken = events()
+        broken[-1]["invalid_lineages"] = "1"
+        broken[-1]["overflow"] = "2"
+        document = MODULE.build(broken, static_inventory())
+        self.assertEqual("incomplete_fail_closed", document["status"])
+
+    def test_accepts_stable_nested_parent_root_shape(self):
+        document = MODULE.build(nested_events(), static_inventory())
+        entry = document["entries"][0]
+        self.assertEqual(2, entry["depth"])
+        self.assertEqual(16, entry["min_parent_root_offset_bytes"])
+        self.assertEqual(48, entry["max_parent_root_offset_bytes"])
+        self.assertEqual(
+            16, document["shapes"][0]["min_parent_root_offset_bytes"]
+        )
+
+    def test_rejects_nested_parent_root_offset_mismatch(self):
+        broken = nested_events()
+        broken[1]["min_parent_root_offset_bytes"] = "36"
+        with self.assertRaisesRegex(ValueError, "exclude their sample"):
+            MODULE.build(broken, static_inventory())
+
+    def test_fails_closed_without_an_exact_constructor_match(self):
+        broken = events()
+        broken[-1]["indirect_buffer_constructor_matches"] = "0"
+        broken[-1]["indirect_buffer_constructor_unmatched"] = "30"
+        document = MODULE.build(broken, static_inventory())
+        self.assertEqual("incomplete_fail_closed", document["status"])
+
+    def test_fails_closed_when_shutdown_open_buffers_do_not_balance(self):
+        broken = events()
+        broken[-1]["indirect_buffers_open_at_shutdown"] = "1"
+        document = MODULE.build(broken, static_inventory())
+        self.assertEqual("incomplete_fail_closed", document["status"])
+
+    def test_rejects_unproved_constructor_store(self):
+        broken = events()
+        broken[1]["constructor_store_address"] = "82400000"
+        with self.assertRaisesRegex(ValueError, "unproved constructor"):
+            MODULE.build(broken, static_inventory())
+
+    def test_rejects_indirect_entry_without_parent_packet(self):
+        broken = events()
+        broken[1]["sample_parent_packet_physical_address"] = "FFFFFFFF"
+        with self.assertRaisesRegex(ValueError, "no valid parent packet"):
+            MODULE.build(broken, static_inventory())
+
+    def test_rejects_invalid_first_indirect_root(self):
+        broken = events()
+        broken[1]["sample_root_physical_address"] = "00103000"
+        with self.assertRaisesRegex(ValueError, "root differs"):
+            MODULE.build(broken, static_inventory())
+
+    def test_requires_statically_proved_indirect_constructor(self):
+        static = static_inventory()
+        static["packet_constructors"] = []
+        with self.assertRaisesRegex(ValueError, "no stored indirect-buffer"):
+            MODULE.build(events(), static)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/tests/test_native_renderer_contract.py
+++ b/tools/tests/test_native_renderer_contract.py
@@ -281,6 +281,76 @@ class NativeRendererContractTests(unittest.TestCase):
         self.assertIn("SetDrawOutcomeObserver(nullptr)", source)
         self.assertNotIn("suppression_allowed\", \"true", patch + source)
 
+    def test_draw_command_buffer_lineage_is_exact_bounded_and_passive(self):
+        patch = (
+            ROOT
+            / "patches/rexglue/0082-graphics-command-buffer-lineage.patch"
+        ).read_text(encoding="utf-8")
+        patch += (
+            ROOT
+            / "patches/rexglue/0083-graphics-indirect-buffer-observer.patch"
+        ).read_text(encoding="utf-8")
+        source = (ROOT / "src/native_renderer/graphics_hooks.cpp").read_text(
+            encoding="utf-8"
+        )
+        report = (ROOT / "tools/create-crash-report.ps1").read_text(
+            encoding="utf-8"
+        )
+        for token in (
+            "command_buffer_physical_address",
+            "command_buffer_length_dwords",
+            "command_buffer_parent_packet_physical_address",
+            "command_buffer_root_physical_address",
+            "command_buffer_depth",
+            "ObservationCommandBufferContext",
+            "ExecutePrimaryBuffer",
+            "ExecuteIndirectBuffer",
+            "ExecutePacket(uint32_t ptr, uint32_t count)",
+            "GraphicsIndirectBufferObservation",
+            "SetIndirectBufferObserver",
+            "indirect_buffer_observer",
+            "entering = true",
+            "entering = false",
+        ):
+            self.assertIn(token, patch)
+        self.assertGreaterEqual(
+            patch.count("previous_observation_command_buffer"), 6
+        )
+        self.assertIn("kCommandBufferLineageCapacity = 4096", source)
+        self.assertIn("HasValidCommandBufferLineage", source)
+        self.assertIn("packet_offset_bytes", source)
+        self.assertIn("sample_command_buffer_length_dwords", source)
+        self.assertIn("min_command_buffer_length_dwords", source)
+        self.assertIn("max_command_buffer_length_dwords", source)
+        self.assertIn("min_parent_root_offset_bytes", source)
+        self.assertIn("max_parent_root_offset_bytes", source)
+        self.assertIn("g_title_indirect_buffers_open", source)
+        self.assertIn("indirect_buffers_open_at_shutdown", source)
+        self.assertIn("kTitleIndirectPacketWays = 4", source)
+        self.assertIn("title_indirect_packet_evictions", source)
+        self.assertIn("entry.occupied = false", source)
+        self.assertIn("g_command_buffer_lineage_installed", source)
+        self.assertIn("g_command_buffer_lineage_memory", source)
+        self.assertIn("constructor_store_address", source)
+        self.assertIn("CurrentTitleIndirectConstructor", source)
+        self.assertIn("SetIndirectBufferObserver(&ObserveIndirectBuffer)", source)
+        self.assertIn("SetIndirectBufferObserver(nullptr)", source)
+        self.assertIn(
+            "exact_title_store_to_backend_nested_command_buffer_shape", source
+        )
+        self.assertIn(
+            "native_renderer.discovery.command_buffer_lineage_summary",
+            source,
+        )
+        self.assertIn("command_buffer_lineage", report)
+        for forbidden in (
+            "SetDrawSuppression",
+            "SetCopySuppression",
+            'guest_payload_read\", \"true',
+            'suppression_allowed\", \"true',
+        ):
+            self.assertNotIn(forbidden, patch + source)
+
     def test_census_has_no_native_renderer_or_suppression_api(self):
         source = (ROOT / "src/native_renderer/graphics_hooks.cpp").read_text(
             encoding="utf-8"

--- a/tools/tests/test_native_renderer_dispatch_discovery.py
+++ b/tools/tests/test_native_renderer_dispatch_discovery.py
@@ -307,6 +307,35 @@ class NativeRendererDispatchDiscoveryTests(unittest.TestCase):
         }
         self.assertNotIn("83051E48", addresses)
 
+    def test_inventories_stored_indirect_buffer_packets(self):
+        indirect = fixture(
+            0x83060000,
+            [
+                "lis r11,-16382",
+                "ori r11,r11,16128",
+                "stwu r11,4(r3)",
+                "lis r10,-16382",
+                "ori r10,r10,14080",
+                "stw r10,16(r4)",
+            ],
+        )
+        document = self.build([indirect, *reviewed_fixtures()])
+        packets = [
+            item
+            for item in document["packet_constructors"]
+            if item["function_address"] == "83060000"
+        ]
+        self.assertEqual(
+            [item["opcode"] for item in packets],
+            ["PM4_INDIRECT_BUFFER", "PM4_INDIRECT_BUFFER_PFD"],
+        )
+        self.assertEqual(
+            [item["header_source"] for item in packets],
+            ["fixed_type3_count_3", "fixed_type3_count_3"],
+        )
+        self.assertEqual(packets[0]["packet_register"], "r11")
+        self.assertEqual(packets[0]["store_instruction"], "stwu r11,4(r3)")
+
     def test_runtime_hooks_are_default_off_bounded_and_passive(self):
         hooks = (ROOT / "src/native_renderer/graphics_hooks.cpp").read_text(
             encoding="utf-8"
@@ -341,6 +370,21 @@ class NativeRendererDispatchDiscoveryTests(unittest.TestCase):
             analysis.count('name = "PinyonShiftObserveDrawPacketSubmission"'),
             2,
         )
+        for address in (
+            "824095B4",
+            "82416EFC",
+            "8246FC1C",
+            "8263BD64",
+            "829E8E88",
+            "829EC49C",
+        ):
+            self.assertIn(f"address = 0x{address}", analysis)
+            self.assertEqual(
+                analysis.count(
+                    f'name = "PinyonShiftObserveIndirectPacket{address}"'
+                ),
+                1,
+            )
         self.assertEqual(
             analysis.count('name = "PinyonShiftObserveVizQueryBeginDispatch"'),
             1,

--- a/tools/tests/test_release_contract.py
+++ b/tools/tests/test_release_contract.py
@@ -43,10 +43,10 @@ class ReleaseContractTests(unittest.TestCase):
 
     def test_rexglue_patches_have_stable_order_and_no_binary_payload(self):
         patches = sorted((ROOT / "patches/rexglue").glob("*.patch"))
-        self.assertEqual(len(patches), 81)
+        self.assertEqual(len(patches), 83)
         self.assertEqual(
             patches[-1].name,
-            "0081-d3d12-draw-outcome-observer.patch",
+            "0083-graphics-indirect-buffer-observer.patch",
         )
         self.assertEqual(len(patches), len({path.name[:4] for path in patches}))
         for path in patches:


### PR DESCRIPTION
## Summary
- carry exact current, parent, and root command-buffer lineage through passive ReXGlue observations
- join six title indirect-buffer constructors through a bounded generational cache and aggregate stable ownership classes
- add fail-closed reporting, crash-report counters, static discovery, tests, and runtime qualification evidence

## Safety
- Xenos remains authoritative
- no guest payload is read or guest state/control flow changed
- suppression remains disabled
- unmatched and evicted constructor generations stay unknown

## Validation
- 67 focused tests passed
- 83-patch incremental Release build passed
- AppData save loaded into live festival gameplay and exited normally
- session 20260829T143627Z-p19532: 9,016,083 draws, 4 ownership classes, 1,792,929 exact constructor matches, zero invalid lineage/stack/overflow faults
- median 30.342 FPS; 1% low 19.017 FPS; no crash/fatal/device-loss/assertion markers