### PR TITLE
feat(native-renderer): trace indirect constructor callers

### DIFF
--- a/config/rexglue/analysis/main-xex.toml
+++ b/config/rexglue/analysis/main-xex.toml
@@ -37,8 +37,65 @@ name = "PinyonShiftObserveDrawPacketSubmission"
 registers = ["r3"]
 
 # Record exact physical identities for the six stored indirect-buffer packet
-# sites. The original store executes after each hook; only its effective
-# address registers are observed.
+# sites. Each constructor entry runs after its opening mflr, preserving the
+# direct caller return address in r12 and the bounded r3-r10 entry metadata.
+# Its balanced exit hook runs before stack restoration. The original entry,
+# exit, and packet-store instructions execute after their hooks; no title state
+# or control flow is changed.
+[[midasm_hook]]
+address = 0x8240939C
+name = "PinyonShiftObserveIndirectConstructor82409398Entry"
+registers = ["r3", "r4", "r5", "r6", "r7", "r8", "r9", "r10", "r12"]
+
+[[midasm_hook]]
+address = 0x82409660
+name = "PinyonShiftObserveIndirectConstructor82409398Exit"
+
+[[midasm_hook]]
+address = 0x82416A04
+name = "PinyonShiftObserveIndirectConstructor82416A00Entry"
+registers = ["r3", "r4", "r5", "r6", "r7", "r8", "r9", "r10", "r12"]
+
+[[midasm_hook]]
+address = 0x82417054
+name = "PinyonShiftObserveIndirectConstructor82416A00Exit"
+
+[[midasm_hook]]
+address = 0x8246FB9C
+name = "PinyonShiftObserveIndirectConstructor8246FB98Entry"
+registers = ["r3", "r4", "r5", "r6", "r7", "r8", "r9", "r10", "r12"]
+
+[[midasm_hook]]
+address = 0x8246FC78
+name = "PinyonShiftObserveIndirectConstructor8246FB98Exit"
+
+[[midasm_hook]]
+address = 0x8263BCBC
+name = "PinyonShiftObserveIndirectConstructor8263BCB8Entry"
+registers = ["r3", "r4", "r5", "r6", "r7", "r8", "r9", "r10", "r12"]
+
+[[midasm_hook]]
+address = 0x8263BDF0
+name = "PinyonShiftObserveIndirectConstructor8263BCB8Exit"
+
+[[midasm_hook]]
+address = 0x829E8E04
+name = "PinyonShiftObserveIndirectConstructor829E8E00Entry"
+registers = ["r3", "r4", "r5", "r6", "r7", "r8", "r9", "r10", "r12"]
+
+[[midasm_hook]]
+address = 0x829E8ED4
+name = "PinyonShiftObserveIndirectConstructor829E8E00Exit"
+
+[[midasm_hook]]
+address = 0x829EC404
+name = "PinyonShiftObserveIndirectConstructor829EC400Entry"
+registers = ["r3", "r4", "r5", "r6", "r7", "r8", "r9", "r10", "r12"]
+
+[[midasm_hook]]
+address = 0x829EC5AC
+name = "PinyonShiftObserveIndirectConstructor829EC400Exit"
+
 [[midasm_hook]]
 address = 0x824095B4
 name = "PinyonShiftObserveIndirectPacket824095B4"

--- a/docs/native-renderer/COMMAND_BUFFER_LINEAGE.md
+++ b/docs/native-renderer/COMMAND_BUFFER_LINEAGE.md
@@ -51,8 +51,13 @@ fall within the reported current-buffer bounds or the lineage is invalid.
 
 Pinyon validates the exact addresses, current-buffer length, and packet offset
 on every draw, then aggregates a stable ownership-class key in a fixed
-4,096-entry table: nesting depth and exact constructor store when one is
-matched. Each class retains minimum and maximum current-buffer lengths, packet
+4,096-entry table: nesting depth, exact constructor store, and exact constructor
+return address when those are matched. Balanced entry/exit hooks on all six
+constructor functions carry the direct caller return address and bounded
+`r3-r10` entry metadata into the exact stored packet generation. Each class
+retains the statically resolved callsite and caller when proved, a sample
+constructor argument vector and varying mask, minimum and maximum current-buffer
+lengths, packet
 offsets, and parent-packet offsets from the first indirect root, plus a first
 prepared-signature sample and whether that signature varied. Absolute current,
 parent, and root addresses, buffer lengths, and individual offsets remain
@@ -124,3 +129,8 @@ overflow, plus exact constructor matches with unmatched producers retained
 explicitly. This qualifies dispatch ownership for the matched packet instances.
 Semantic identity remains unknown, and suppression remains disabled, until
 object and lifetime ownership are independently understood.
+
+The constructor/caller refinement and its additional fail-closed accounting are
+documented in `INDIRECT_CONSTRUCTOR_PROVENANCE.md`. Its runtime qualification is
+performed as a separate milestone gate; the evidence above remains the baseline
+for the original store-and-depth bridge.

--- a/docs/native-renderer/INDIRECT_CONSTRUCTOR_PROVENANCE.md
+++ b/docs/native-renderer/INDIRECT_CONSTRUCTOR_PROVENANCE.md
@@ -1,0 +1,100 @@
+# Indirect-constructor provenance
+
+This milestone refines command-buffer ownership from an exact packet store and
+nesting depth to the title function and direct callsite that created that packet
+generation. It remains a passive discovery bridge. It does not identify a mesh,
+material, render pass, or lifetime owner, and it does not authorize suppression.
+
+## Static call graph
+
+The dispatch scanner recognizes every direct `bl` targeting a function that
+stores `PM4_INDIRECT_BUFFER` or `PM4_INDIRECT_BUFFER_PFD`. Against the verified
+MS-2505 generated title it proves seven packet constructors in six functions
+and 38 direct callsites:
+
+| Constructor function | Store site(s) | Direct callsites | Distinct callers |
+| --- | --- | ---: | ---: |
+| `82409398` | `824095B4` | 7 | 6 |
+| `82416A00` | `82416EFC` | 3 | 3 |
+| `8246FB98` | `8246FC1C` | 21 | 14 |
+| `8263BCB8` | `8263BD64` | 1 | 1 |
+| `829E8E00` | `829E8E88` | 2 | 2 |
+| `829EC400` | `829EC49C` | 4 | 1 |
+
+Each inventory record contains the constructor function, stored packet opcode
+and store sites, caller function, callsite, and return address. The return
+address is the exact value available in `r12` after the constructor's opening
+`mflr`, so static and runtime evidence join without timing or address-range
+inference.
+
+## Runtime contract
+
+All six constructors have balanced entry and exit hooks. An entry hook runs
+after the opening `mflr`, captures the constructor function, direct caller
+return address, and bounded `r3-r10` entry metadata, and pushes it onto a
+32-entry thread-local stack. The exit hook runs before guest stack restoration
+and pops only the matching constructor. Overflow, underflow, mismatched exits,
+and invocations open at shutdown are counted explicitly.
+
+The existing packet-store hook copies the active constructor origin into the
+same bounded packet generation that carries its exact physical PM4 header
+address. Backend indirect-buffer execution still consumes only the oldest exact
+retained generation for that address. A prepared draw inherits constructor
+metadata only from the matching active indirect-buffer stack frame.
+
+The lineage ownership key is now:
+
+- exact constructor store, or `unknown`;
+- exact constructor return address, or `unknown`; and
+- indirect-buffer nesting depth.
+
+Each class reports the statically resolved callsite and caller function when
+available, a sample `r3-r10` vector, and an argument-varying mask. Unknown or
+uninstrumented paths remain unknown; they are never assigned to a nearby or
+recent caller.
+
+## Qualification gates
+
+The command-lineage report fails closed when a runtime constructor origin does
+not map to the function that owns its store. A return address outside the
+proved direct-call inventory remains exact runtime evidence but has an
+unresolved static caller; resolved and unresolved draw coverage are reported
+separately. The report also requires balanced constructor
+entry/exit/open-at-shutdown accounting and zero constructor-stack faults.
+Packets without a captured origin remain an explicit coverage metric, not an
+integrity failure.
+
+The static inventory passes with seven constructors, six functions, 38 direct
+callsites, and the unchanged safety contract. Release executable
+`346D15B8DF1E7D5D2AF97C93C711F021E5ABFC01B3B495F835778C94BE675A5C`
+loaded the installed `0.1.0` AppData save through the title and menu into the
+live festival scene. Session `20260829T150242Z-p23532` exited normally after a
+156.947-second performance capture covering 5,160 samples.
+
+The runtime report completed across 7,368,672 indirect draws and 7,144,490
+prepared draws. All 1,438,652 constructor entries matched 1,438,652 exits,
+with zero invocations open at shutdown and zero constructor-stack faults. The
+packet table recorded 1,451,713 generations; 1,434,662 indirect executions
+matched an exact retained generation, 10,486 generations were explicitly
+evicted, and 6,565 remained retained at shutdown. Address failures, table
+overflow, invalid lineage, and draw-stack faults were zero.
+
+Constructor origin covered 6,020,430 draws. Every captured origin resolved to
+a proved direct callsite, with zero unresolved constructor-origin draws and
+zero matched packets lacking an origin. The remaining 1,348,242 draws stayed
+in two explicit unknown-origin lineage classes rather than receiving inferred
+ownership. All 1,766,527 indirect enters reconciled with 1,766,526 exits plus
+one buffer open when the app was closed mid-frame.
+
+Xenos remained authoritative, suppression remained disabled, and the log
+contained no crash, fatal error, device loss, assertion failure, or unexpected
+shutdown marker. The visually inspected festival scene retained the expected
+car, crowd, structures, HUD, lighting, and sky. Median derived performance was
+30.56 FPS and the 1% low was 19.227 FPS.
+
+## Safety boundary
+
+The hooks observe registers and packet addresses only. They do not read guest
+resource payloads, mutate guest state, alter control flow, add a native draw,
+or expose a suppression API. Xenos remains authoritative and suppression
+remains disabled.

--- a/src/native_renderer/graphics_hooks.cpp
+++ b/src/native_renderer/graphics_hooks.cpp
@@ -82,6 +82,7 @@ constexpr size_t kTitleIndirectPacketWays = 4;
 constexpr size_t kTitleIndirectPacketCapacity =
     kTitleIndirectPacketBucketCount * kTitleIndirectPacketWays;
 constexpr size_t kTitleIndirectStackCapacity = 32;
+constexpr size_t kIndirectConstructorStackCapacity = 32;
 constexpr uint64_t kSkyHorizonAnchorSignature = UINT64_C(0x747837906D0BF484);
 constexpr uint64_t kSkyHorizonFollowerSignature = UINT64_C(0x1D253A52B55C9FB3);
 std::atomic<uint64_t> g_frame_sequence{};
@@ -151,8 +152,19 @@ struct TitleDrawProvenanceEntry {
 struct TitleIndirectPacketEntry {
   uint32_t packet_physical_address = UINT32_MAX;
   uint32_t constructor_store_address = 0;
+  uint32_t constructor_function_address = 0;
+  uint32_t constructor_return_address = 0;
+  std::array<uint32_t, 8> constructor_arguments{};
   uint64_t submission_sequence = 0;
+  bool constructor_origin_known = false;
   bool occupied = false;
+};
+
+struct IndirectConstructorOrigin {
+  uint32_t function_address = 0;
+  uint32_t return_address = 0;
+  std::array<uint32_t, 8> arguments{};
+  bool valid = false;
 };
 
 struct ActiveTitleIndirectBuffer {
@@ -161,6 +173,7 @@ struct ActiveTitleIndirectBuffer {
   uint32_t parent_packet_physical_address = UINT32_MAX;
   uint32_t root_buffer_physical_address = UINT32_MAX;
   uint32_t constructor_store_address = 0;
+  IndirectConstructorOrigin constructor_origin{};
   uint32_t depth = 0;
 };
 
@@ -206,7 +219,12 @@ uint64_t g_title_indirect_buffer_matches = 0;
 uint64_t g_title_indirect_buffer_unmatched = 0;
 uint64_t g_title_indirect_stack_faults = 0;
 uint64_t g_title_indirect_draw_stack_faults = 0;
+uint64_t g_indirect_constructor_entries = 0;
+uint64_t g_indirect_constructor_exits = 0;
+uint64_t g_indirect_constructor_stack_faults = 0;
+uint64_t g_indirect_packets_without_constructor_origin = 0;
 std::atomic<uint64_t> g_title_indirect_buffers_open{};
+std::atomic<uint64_t> g_indirect_constructor_invocations_open{};
 thread_local TitleDrawOrigin g_pending_adapter_origin;
 thread_local std::array<TitleDrawOrigin, kTitleOriginStackCapacity>
     g_title_origin_stack;
@@ -214,6 +232,11 @@ thread_local size_t g_title_origin_stack_depth = 0;
 thread_local std::array<ActiveTitleIndirectBuffer, kTitleIndirectStackCapacity>
     g_title_indirect_stack;
 thread_local size_t g_title_indirect_stack_depth = 0;
+thread_local std::array<IndirectConstructorOrigin,
+                        kIndirectConstructorStackCapacity>
+    g_indirect_constructor_stack;
+thread_local size_t g_indirect_constructor_stack_depth = 0;
+thread_local size_t g_indirect_constructor_stack_overflow_depth = 0;
 
 const char *DispatchWrapperName(DispatchWrapper wrapper) {
   switch (wrapper) {
@@ -366,12 +389,21 @@ void ResetTitleDrawProvenance() {
   g_title_indirect_buffer_unmatched = 0;
   g_title_indirect_stack_faults = 0;
   g_title_indirect_draw_stack_faults = 0;
+  g_indirect_constructor_entries = 0;
+  g_indirect_constructor_exits = 0;
+  g_indirect_constructor_stack_faults = 0;
+  g_indirect_packets_without_constructor_origin = 0;
   g_title_indirect_buffers_open.store(0, std::memory_order_relaxed);
+  g_indirect_constructor_invocations_open.store(0,
+                                                std::memory_order_relaxed);
   g_pending_adapter_origin = {};
   g_title_origin_stack = {};
   g_title_origin_stack_depth = 0;
   g_title_indirect_stack = {};
   g_title_indirect_stack_depth = 0;
+  g_indirect_constructor_stack = {};
+  g_indirect_constructor_stack_depth = 0;
+  g_indirect_constructor_stack_overflow_depth = 0;
 }
 
 void ConfigureTitleDrawProvenance(bool census_requested,
@@ -401,6 +433,8 @@ void ConfigureTitleDrawProvenance(bool census_requested,
        {"indirect_packet_ways", std::to_string(kTitleIndirectPacketWays)},
        {"indirect_stack_capacity",
         std::to_string(kTitleIndirectStackCapacity)},
+       {"constructor_stack_capacity",
+        std::to_string(kIndirectConstructorStackCapacity)},
        {"metadata",
         "origin_wrapper,entry_lr,r3-r10,outcome,backend_outcome,"
         "backend_signature"},
@@ -510,8 +544,75 @@ void RecordTitleDrawPacket(uint32_t packet_guest_address) {
   ++g_title_packets_recorded;
 }
 
+void PushIndirectConstructorOrigin(uint32_t function_address,
+                                   uint32_t return_address, uint32_t r3,
+                                   uint32_t r4, uint32_t r5, uint32_t r6,
+                                   uint32_t r7, uint32_t r8, uint32_t r9,
+                                   uint32_t r10) {
+  if (!g_command_buffer_lineage_installed.load(std::memory_order_acquire)) {
+    return;
+  }
+  ++g_indirect_constructor_entries;
+  if (g_indirect_constructor_stack_depth ==
+      kIndirectConstructorStackCapacity) {
+    ++g_indirect_constructor_stack_faults;
+    ++g_indirect_constructor_stack_overflow_depth;
+    return;
+  }
+  IndirectConstructorOrigin &origin =
+      g_indirect_constructor_stack[g_indirect_constructor_stack_depth++];
+  origin.function_address = function_address;
+  origin.return_address = return_address;
+  origin.arguments = {r3, r4, r5, r6, r7, r8, r9, r10};
+  origin.valid = true;
+  g_indirect_constructor_invocations_open.fetch_add(
+      1, std::memory_order_relaxed);
+}
+
+void PopIndirectConstructorOrigin(uint32_t function_address) {
+  if (!g_command_buffer_lineage_installed.load(std::memory_order_acquire)) {
+    return;
+  }
+  ++g_indirect_constructor_exits;
+  if (g_indirect_constructor_stack_overflow_depth) {
+    --g_indirect_constructor_stack_overflow_depth;
+    return;
+  }
+  if (!g_indirect_constructor_stack_depth) {
+    ++g_indirect_constructor_stack_faults;
+    return;
+  }
+  if (g_indirect_constructor_stack[g_indirect_constructor_stack_depth - 1]
+          .function_address != function_address) {
+    ++g_indirect_constructor_stack_faults;
+    g_indirect_constructor_invocations_open.fetch_sub(
+        g_indirect_constructor_stack_depth, std::memory_order_relaxed);
+    g_indirect_constructor_stack_depth = 0;
+    return;
+  }
+  --g_indirect_constructor_stack_depth;
+  g_indirect_constructor_invocations_open.fetch_sub(
+      1, std::memory_order_relaxed);
+}
+
+IndirectConstructorOrigin CurrentIndirectConstructorOrigin(
+    uint32_t function_address) {
+  if (!g_indirect_constructor_stack_depth) {
+    ++g_indirect_packets_without_constructor_origin;
+    return {};
+  }
+  const IndirectConstructorOrigin &origin =
+      g_indirect_constructor_stack[g_indirect_constructor_stack_depth - 1];
+  if (!origin.valid || origin.function_address != function_address) {
+    ++g_indirect_packets_without_constructor_origin;
+    return {};
+  }
+  return origin;
+}
+
 void RecordTitleIndirectPacket(uint32_t packet_guest_address,
-                               uint32_t constructor_store_address) {
+                               uint32_t constructor_store_address,
+                               uint32_t constructor_function_address) {
   if (!g_command_buffer_lineage_installed.load(std::memory_order_acquire)) {
     return;
   }
@@ -554,14 +655,21 @@ void RecordTitleIndirectPacket(uint32_t packet_guest_address,
     ++g_title_indirect_packet_evictions;
   }
   TitleIndirectPacketEntry &entry = g_title_indirect_packets[selected];
+  const IndirectConstructorOrigin origin =
+      CurrentIndirectConstructorOrigin(constructor_function_address);
   entry.packet_physical_address = packet_physical_address;
   entry.constructor_store_address = constructor_store_address;
+  entry.constructor_function_address = origin.function_address;
+  entry.constructor_return_address = origin.return_address;
+  entry.constructor_arguments = origin.arguments;
   entry.submission_sequence = ++g_title_indirect_packet_submission_sequence;
+  entry.constructor_origin_known = origin.valid;
   entry.occupied = true;
   ++g_title_indirect_packets_recorded;
 }
 
-uint32_t MatchTitleIndirectPacket(uint32_t packet_physical_address) {
+TitleIndirectPacketEntry MatchTitleIndirectPacket(
+    uint32_t packet_physical_address) {
   std::scoped_lock lock(g_title_packet_provenance_mutex);
   const size_t bucket =
       (packet_physical_address >> 2) % kTitleIndirectPacketBucketCount;
@@ -580,14 +688,13 @@ uint32_t MatchTitleIndirectPacket(uint32_t packet_physical_address) {
   }
   if (oldest_match != kTitleIndirectPacketCapacity) {
     TitleIndirectPacketEntry &entry = g_title_indirect_packets[oldest_match];
-    const uint32_t constructor_store_address =
-        entry.constructor_store_address;
+    const TitleIndirectPacketEntry matched = entry;
     entry.occupied = false;
     ++g_title_indirect_buffer_matches;
-    return constructor_store_address;
+    return matched;
   }
   ++g_title_indirect_buffer_unmatched;
-  return 0;
+  return {};
 }
 
 void ObserveIndirectBuffer(
@@ -611,8 +718,15 @@ void ObserveIndirectBuffer(
         observation.packet_physical_address;
     active.root_buffer_physical_address =
         observation.root_buffer_physical_address;
-    active.constructor_store_address =
+    const TitleIndirectPacketEntry matched =
         MatchTitleIndirectPacket(observation.packet_physical_address);
+    active.constructor_store_address = matched.constructor_store_address;
+    active.constructor_origin.function_address =
+        matched.constructor_function_address;
+    active.constructor_origin.return_address =
+        matched.constructor_return_address;
+    active.constructor_origin.arguments = matched.constructor_arguments;
+    active.constructor_origin.valid = matched.constructor_origin_known;
     active.depth = observation.depth;
     g_title_indirect_buffers_open.fetch_add(1, std::memory_order_relaxed);
     return;
@@ -636,17 +750,17 @@ void ObserveIndirectBuffer(
   g_title_indirect_buffers_open.fetch_sub(1, std::memory_order_relaxed);
 }
 
-uint32_t CurrentTitleIndirectConstructor(
+const ActiveTitleIndirectBuffer *CurrentTitleIndirectBuffer(
     const rex::system::GraphicsDrawObservation &observation) {
   if (!g_command_buffer_lineage_installed.load(std::memory_order_acquire)) {
-    return 0;
+    return nullptr;
   }
   if (!observation.command_buffer_depth) {
-    return 0;
+    return nullptr;
   }
   if (!g_title_indirect_stack_depth) {
     ++g_title_indirect_draw_stack_faults;
-    return 0;
+    return nullptr;
   }
   const ActiveTitleIndirectBuffer &active =
       g_title_indirect_stack[g_title_indirect_stack_depth - 1];
@@ -658,9 +772,9 @@ uint32_t CurrentTitleIndirectConstructor(
       active.root_buffer_physical_address !=
           observation.command_buffer_root_physical_address) {
     ++g_title_indirect_draw_stack_faults;
-    return 0;
+    return nullptr;
   }
-  return active.constructor_store_address;
+  return &active;
 }
 
 bool ConsumeTitleDrawPacket(uint32_t packet_physical_address,
@@ -1489,7 +1603,12 @@ struct CommandBufferLineageEntry {
   uint32_t min_parent_root_offset_bytes = UINT32_MAX;
   uint32_t max_parent_root_offset_bytes = 0;
   uint32_t constructor_store_address = 0;
+  uint32_t constructor_function_address = 0;
+  uint32_t constructor_return_address = 0;
+  std::array<uint32_t, 8> sample_constructor_arguments{};
+  uint32_t constructor_argument_varying_mask = 0;
   uint32_t depth = 0;
+  bool constructor_origin_known = false;
   bool prepared_signature_varied = false;
 };
 
@@ -2966,11 +3085,16 @@ void RecordPreparedCommandBufferLineage(
           ? observation.command_buffer_parent_packet_physical_address -
                 observation.command_buffer_root_physical_address
           : UINT32_MAX;
+  const ActiveTitleIndirectBuffer *active =
+      CurrentTitleIndirectBuffer(observation);
   const uint32_t constructor_store_address =
-      CurrentTitleIndirectConstructor(observation);
+      active ? active->constructor_store_address : 0;
+  const IndirectConstructorOrigin constructor_origin =
+      active ? active->constructor_origin : IndirectConstructorOrigin{};
   uint64_t key = 0xCBF29CE484222325ull;
   for (uint64_t value :
        {uint64_t(constructor_store_address),
+        uint64_t(constructor_origin.return_address),
         uint64_t(observation.command_buffer_depth)}) {
     key = HashCombine(key, value);
   }
@@ -3002,11 +3126,16 @@ void RecordPreparedCommandBufferLineage(
       entry.min_parent_root_offset_bytes = parent_root_offset_bytes;
       entry.max_parent_root_offset_bytes = parent_root_offset_bytes;
       entry.constructor_store_address = constructor_store_address;
+      entry.constructor_function_address = constructor_origin.function_address;
+      entry.constructor_return_address = constructor_origin.return_address;
+      entry.sample_constructor_arguments = constructor_origin.arguments;
+      entry.constructor_origin_known = constructor_origin.valid;
       entry.depth = observation.command_buffer_depth;
       ++g_command_buffer_lineage_entry_count;
       return;
     }
     if (entry.constructor_store_address == constructor_store_address &&
+        entry.constructor_return_address == constructor_origin.return_address &&
         entry.depth == observation.command_buffer_depth) {
       ++entry.calls;
       entry.last_frame = observation.frame_sequence;
@@ -3029,6 +3158,15 @@ void RecordPreparedCommandBufferLineage(
                    parent_root_offset_bytes);
       entry.prepared_signature_varied |=
           entry.sample_prepared_signature != prepared_signature;
+      if (entry.constructor_origin_known && constructor_origin.valid) {
+        for (size_t argument = 0;
+             argument < entry.sample_constructor_arguments.size(); ++argument) {
+          if (entry.sample_constructor_arguments[argument] !=
+              constructor_origin.arguments[argument]) {
+            entry.constructor_argument_varying_mask |= 1u << argument;
+          }
+        }
+      }
       return;
     }
     index = (index + 1) % kCommandBufferLineageCapacity;
@@ -3082,6 +3220,27 @@ void EmitCommandBufferLineageSummary() {
           entry.constructor_store_address
               ? fmt::format("{:08X}", entry.constructor_store_address)
               : "unknown"},
+         {"constructor_function_address",
+          entry.constructor_origin_known
+              ? fmt::format("{:08X}", entry.constructor_function_address)
+              : "unknown"},
+         {"constructor_return_address",
+          entry.constructor_origin_known
+              ? fmt::format("{:08X}", entry.constructor_return_address)
+              : "unknown"},
+         {"sample_constructor_arguments",
+          fmt::format(
+              "{:08X},{:08X},{:08X},{:08X},{:08X},{:08X},{:08X},{:08X}",
+              entry.sample_constructor_arguments[0],
+              entry.sample_constructor_arguments[1],
+              entry.sample_constructor_arguments[2],
+              entry.sample_constructor_arguments[3],
+              entry.sample_constructor_arguments[4],
+              entry.sample_constructor_arguments[5],
+              entry.sample_constructor_arguments[6],
+              entry.sample_constructor_arguments[7])},
+         {"constructor_argument_varying_mask",
+          fmt::format("{:02X}", entry.constructor_argument_varying_mask)},
          {"depth", std::to_string(entry.depth)},
          {"guest_payload_read", "false"},
          {"guest_state_changed", "false"},
@@ -3122,6 +3281,17 @@ void EmitCommandBufferLineageSummary() {
         std::to_string(g_title_indirect_stack_faults)},
        {"indirect_draw_stack_faults",
         std::to_string(g_title_indirect_draw_stack_faults)},
+       {"indirect_constructor_entries",
+        std::to_string(g_indirect_constructor_entries)},
+       {"indirect_constructor_exits",
+        std::to_string(g_indirect_constructor_exits)},
+       {"indirect_constructor_invocations_open_at_shutdown",
+        std::to_string(g_indirect_constructor_invocations_open.load(
+            std::memory_order_relaxed))},
+       {"indirect_constructor_stack_faults",
+        std::to_string(g_indirect_constructor_stack_faults)},
+       {"indirect_packets_without_constructor_origin",
+        std::to_string(g_indirect_packets_without_constructor_origin)},
        {"indirect_buffers_open_at_shutdown",
         std::to_string(g_title_indirect_buffers_open.load(
             std::memory_order_relaxed))},
@@ -5509,7 +5679,8 @@ void InstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system,
        {"scene", scene},
        {"capacity", std::to_string(kCommandBufferLineageCapacity)},
        {"source",
-        "title_store,backend_packet,current_buffer,parent_packet,root_buffer,depth"},
+        "title_store,constructor_function,constructor_return,r3-r10,"
+        "backend_packet,current_buffer,parent_packet,root_buffer,depth"},
        {"guest_payload_read", "false"},
        {"guest_state_changed", "false"},
        {"control_flow_changed", "false"},
@@ -6216,29 +6387,63 @@ void PinyonShiftObserveDrawPacketSubmission(PPCRegister &r3) {
   RecordTitleDrawPacket(r3.u32 + sizeof(uint32_t));
 }
 
+void ObserveIndirectConstructorEntry(
+    uint32_t function_address, PPCRegister &r3, PPCRegister &r4,
+    PPCRegister &r5, PPCRegister &r6, PPCRegister &r7, PPCRegister &r8,
+    PPCRegister &r9, PPCRegister &r10, PPCRegister &r12) {
+  PushIndirectConstructorOrigin(function_address, r12.u32, r3.u32, r4.u32,
+                                r5.u32, r6.u32, r7.u32, r8.u32, r9.u32,
+                                r10.u32);
+}
+
+#define PINYON_SHIFT_INDIRECT_CONSTRUCTOR_HOOKS(address)                       \
+  void PinyonShiftObserveIndirectConstructor##address##Entry(                  \
+      PPCRegister &r3, PPCRegister &r4, PPCRegister &r5, PPCRegister &r6,      \
+      PPCRegister &r7, PPCRegister &r8, PPCRegister &r9, PPCRegister &r10,     \
+      PPCRegister &r12) {                                                       \
+    ObserveIndirectConstructorEntry(0x##address, r3, r4, r5, r6, r7, r8, r9,  \
+                                    r10, r12);                                  \
+  }                                                                             \
+  void PinyonShiftObserveIndirectConstructor##address##Exit() {                \
+    PopIndirectConstructorOrigin(0x##address);                                  \
+  }
+
+PINYON_SHIFT_INDIRECT_CONSTRUCTOR_HOOKS(82409398)
+PINYON_SHIFT_INDIRECT_CONSTRUCTOR_HOOKS(82416A00)
+PINYON_SHIFT_INDIRECT_CONSTRUCTOR_HOOKS(8246FB98)
+PINYON_SHIFT_INDIRECT_CONSTRUCTOR_HOOKS(8263BCB8)
+PINYON_SHIFT_INDIRECT_CONSTRUCTOR_HOOKS(829E8E00)
+PINYON_SHIFT_INDIRECT_CONSTRUCTOR_HOOKS(829EC400)
+
+#undef PINYON_SHIFT_INDIRECT_CONSTRUCTOR_HOOKS
+
 void PinyonShiftObserveIndirectPacket824095B4(PPCRegister &r11,
                                                PPCRegister &r28) {
-  RecordTitleIndirectPacket(r11.u32 + r28.u32, 0x824095B4);
+  RecordTitleIndirectPacket(r11.u32 + r28.u32, 0x824095B4, 0x82409398);
 }
 
 void PinyonShiftObserveIndirectPacket82416EFC(PPCRegister &r30) {
-  RecordTitleIndirectPacket(r30.u32 + sizeof(uint32_t), 0x82416EFC);
+  RecordTitleIndirectPacket(r30.u32 + sizeof(uint32_t), 0x82416EFC,
+                            0x82416A00);
 }
 
 void PinyonShiftObserveIndirectPacket8246FC1C(PPCRegister &r11) {
-  RecordTitleIndirectPacket(r11.u32 + sizeof(uint32_t), 0x8246FC1C);
+  RecordTitleIndirectPacket(r11.u32 + sizeof(uint32_t), 0x8246FC1C,
+                            0x8246FB98);
 }
 
 void PinyonShiftObserveIndirectPacket8263BD64(PPCRegister &r9) {
-  RecordTitleIndirectPacket(r9.u32 + sizeof(uint32_t), 0x8263BD64);
+  RecordTitleIndirectPacket(r9.u32 + sizeof(uint32_t), 0x8263BD64,
+                            0x8263BCB8);
 }
 
 void PinyonShiftObserveIndirectPacket829E8E88(PPCRegister &r1) {
-  RecordTitleIndirectPacket(r1.u32 + 88, 0x829E8E88);
+  RecordTitleIndirectPacket(r1.u32 + 88, 0x829E8E88, 0x829E8E00);
 }
 
 void PinyonShiftObserveIndirectPacket829EC49C(PPCRegister &r11) {
-  RecordTitleIndirectPacket(r11.u32 + sizeof(uint32_t), 0x829EC49C);
+  RecordTitleIndirectPacket(r11.u32 + sizeof(uint32_t), 0x829EC49C,
+                            0x829EC400);
 }
 
 void PinyonShiftObserveResolveControllerDispatch(

--- a/tools/discover-native-renderer-dispatch.py
+++ b/tools/discover-native-renderer-dispatch.py
@@ -2,8 +2,8 @@
 
 This tool is intentionally payload-free.  It reads generated C++ instruction
 comments, identifies stored draw and visibility-query packet headers, records
-the direct title call graph, and proves the dirty-mask transitions that happen
-inside the indexed draw wrapper.
+the direct title and indirect-constructor call graphs, and proves the dirty-mask
+transitions that happen inside the indexed draw wrapper.
 """
 
 from __future__ import annotations
@@ -99,6 +99,14 @@ INITIALIZATION_CONSTRUCTORS = {
     0x829E82D0,
     0x829E8428,
     0x829EDB68,
+}
+INDIRECT_CONSTRUCTOR_RUNTIME_HOOKS = {
+    0x82409398: {"entry": 0x8240939C, "exit": 0x82409660},
+    0x82416A00: {"entry": 0x82416A04, "exit": 0x82417054},
+    0x8246FB98: {"entry": 0x8246FB9C, "exit": 0x8246FC78},
+    0x8263BCB8: {"entry": 0x8263BCBC, "exit": 0x8263BDF0},
+    0x829E8E00: {"entry": 0x829E8E04, "exit": 0x829E8ED4},
+    0x829EC400: {"entry": 0x829EC404, "exit": 0x829EC5AC},
 }
 
 FUNCTION_RE = re.compile(r"^DEFINE_REX_FUNC\(sub_([0-9A-F]{8})\) \{")
@@ -278,6 +286,118 @@ def direct_calls(functions: list[dict], targets: set[int]) -> list[dict]:
                 }
             )
     return sorted(calls, key=lambda item: (item["wrapper"], item["callsite"]))
+
+
+def indirect_constructor_calls(
+    functions: list[dict], constructors: list[dict]
+) -> list[dict]:
+    """Inventory direct callers of every stored indirect-buffer constructor."""
+    indirect_by_function: dict[int, list[dict]] = collections.defaultdict(list)
+    for constructor in constructors:
+        if constructor["opcode"] in {
+            "PM4_INDIRECT_BUFFER",
+            "PM4_INDIRECT_BUFFER_PFD",
+        }:
+            indirect_by_function[int(constructor["function_address"], 16)].append(
+                constructor
+            )
+
+    calls = []
+    for function in functions:
+        for instruction in function["instructions"]:
+            match = CALL_RE.fullmatch(instruction["text"])
+            if not match:
+                continue
+            target = int(match.group(1), 16)
+            target_constructors = indirect_by_function.get(target)
+            if not target_constructors:
+                continue
+            calls.append(
+                {
+                    "constructor_function": "sub_{:08X}".format(target),
+                    "constructor_function_address": "{:08X}".format(target),
+                    "constructor_opcodes": sorted(
+                        {item["opcode"] for item in target_constructors}
+                    ),
+                    "constructor_store_addresses": sorted(
+                        {item["store_address"] for item in target_constructors}
+                    ),
+                    "caller_function": function["name"],
+                    "caller_function_address": "{:08X}".format(
+                        function["address"]
+                    ),
+                    "callsite": "{:08X}".format(instruction["address"]),
+                    "return_address": "{:08X}".format(
+                        instruction["address"] + 4
+                    ),
+                    "classification": "direct_static_callsite",
+                    "semantic_identity": "unknown",
+                    "suppression_eligible": False,
+                }
+            )
+    return sorted(
+        calls,
+        key=lambda item: (
+            item["constructor_function_address"],
+            item["callsite"],
+        ),
+    )
+
+
+def indirect_constructor_runtime_hooks(
+    functions_by_address: dict[int, dict], constructors: list[dict]
+) -> list[dict]:
+    indirect_functions = {
+        int(item["function_address"], 16)
+        for item in constructors
+        if item["opcode"] in {
+            "PM4_INDIRECT_BUFFER",
+            "PM4_INDIRECT_BUFFER_PFD",
+        }
+    }
+    observed_known = indirect_functions & set(INDIRECT_CONSTRUCTOR_RUNTIME_HOOKS)
+    if observed_known and observed_known != set(INDIRECT_CONSTRUCTOR_RUNTIME_HOOKS):
+        raise ValueError("known indirect-constructor function set drifted")
+    result = []
+    for address in sorted(observed_known):
+        function = functions_by_address[address]
+        hooks = INDIRECT_CONSTRUCTOR_RUNTIME_HOOKS[address]
+        instructions = function["instructions"]
+        if (
+            not instructions
+            or instructions[0] != {"address": address, "text": "mflr r12"}
+            or hooks["entry"] != address + 4
+            or len(instructions) < 2
+            or instructions[-2]["address"] != hooks["exit"]
+            or not instructions[-2]["text"].startswith("addi r1,r1,")
+            or not BRANCH_RE.fullmatch(instructions[-1]["text"])
+        ):
+            raise ValueError(
+                "indirect-constructor balanced hook evidence drifted: "
+                "{:08X}".format(address)
+            )
+        result.append(
+            {
+                "function": function["name"],
+                "function_address": "{:08X}".format(address),
+                "entry_hook_address": "{:08X}".format(hooks["entry"]),
+                "exit_hook_address": "{:08X}".format(hooks["exit"]),
+                "caller_lr_register": "r12_after_opening_mflr",
+                "entry_metadata": [
+                    "r3",
+                    "r4",
+                    "r5",
+                    "r6",
+                    "r7",
+                    "r8",
+                    "r9",
+                    "r10",
+                ],
+                "classification": "balanced_passive_constructor_origin",
+                "suppression_eligible": False,
+            }
+        )
+    return result
 
 
 def adapter_argument_leads(functions: list[dict], calls: list[dict]) -> list[dict]:
@@ -742,6 +862,10 @@ def build(paths: list[pathlib.Path]) -> dict:
                 "reviewed wrapper entry LR evidence missing: {:08X}".format(address)
             )
     constructors = packet_constructors(functions)
+    constructor_calls = indirect_constructor_calls(functions, constructors)
+    constructor_hooks = indirect_constructor_runtime_hooks(
+        functions_by_address, constructors
+    )
     constructor_evidence = {
         (int(item["function_address"], 16), int(item["opcode_value"], 16))
         for item in constructors
@@ -827,6 +951,8 @@ def build(paths: list[pathlib.Path]) -> dict:
             "functions": len(functions),
         },
         "packet_constructors": constructors,
+        "indirect_constructor_calls": constructor_calls,
+        "indirect_constructor_runtime_hooks": constructor_hooks,
         "reviewed_wrappers": [
             {
                 "address": "{:08X}".format(address),
@@ -882,6 +1008,8 @@ def build(paths: list[pathlib.Path]) -> dict:
         },
         "totals": {
             "packet_constructors": len(constructors),
+            "indirect_constructor_calls": len(constructor_calls),
+            "indirect_constructor_runtime_hooks": len(constructor_hooks),
             "reviewed_wrappers": len(REVIEWED_WRAPPERS),
             "direct_calls": len(calls),
             "tail_forwarded_calls": len(forwarded_calls),

--- a/tools/summarize-native-renderer-command-lineage.py
+++ b/tools/summarize-native-renderer-command-lineage.py
@@ -70,6 +70,29 @@ def _hex(mapping: dict, key: str, width: int) -> str:
     return value
 
 
+def _optional_hex(mapping: dict, key: str, width: int) -> str | None:
+    value = str(mapping.get(key, "unknown")).upper()
+    if value == "UNKNOWN":
+        return None
+    return _hex({key: value}, key, width)
+
+
+def _hex_arguments(mapping: dict, key: str) -> list[str]:
+    values = str(mapping.get(key, "")).upper().split(",")
+    if len(values) != 8:
+        raise ValueError(f"invalid constructor argument vector: {key}")
+    for value in values:
+        if len(value) != 8:
+            raise ValueError(f"invalid constructor argument vector: {key}")
+        try:
+            int(value, 16)
+        except ValueError as error:
+            raise ValueError(
+                f"invalid constructor argument vector: {key}"
+            ) from error
+    return values
+
+
 def build(events: list[dict], static: dict, requested: str | None = None) -> dict:
     if static.get("schema") != STATIC_SCHEMA:
         raise ValueError("unsupported static dispatch inventory schema")
@@ -82,6 +105,20 @@ def build(events: list[dict], static: dict, requested: str | None = None) -> dic
         raise ValueError("static inventory has no stored indirect-buffer constructors")
     constructor_store_addresses = {
         str(item.get("store_address", "")).upper() for item in constructors
+    }
+    constructor_functions_by_store = {
+        str(item.get("store_address", "")).upper(): str(
+            item.get("function_address", "")
+        ).upper()
+        for item in constructors
+    }
+    static_constructor_calls = static.get("indirect_constructor_calls", [])
+    constructor_calls_by_return = {
+        (
+            str(item.get("constructor_function_address", "")).upper(),
+            str(item.get("return_address", "")).upper(),
+        ): item
+        for item in static_constructor_calls
     }
 
     session = select_session(events, requested)
@@ -181,6 +218,40 @@ def build(events: list[dict], static: dict, requested: str | None = None) -> dic
                     "lineage entry references an unproved constructor store"
                 )
             constructor_store_address = constructor_text
+        constructor_function_address = _optional_hex(
+            event, "constructor_function_address", 8
+        )
+        constructor_return_address = _optional_hex(
+            event, "constructor_return_address", 8
+        )
+        if (constructor_function_address is None) != (
+            constructor_return_address is None
+        ):
+            raise ValueError("lineage entry has a partial constructor origin")
+        constructor_call = None
+        constructor_arguments = None
+        constructor_argument_varying_mask = None
+        if constructor_function_address is not None:
+            if constructor_store_address is None:
+                raise ValueError(
+                    "lineage entry has an origin without a constructor store"
+                )
+            if (
+                constructor_functions_by_store[constructor_store_address]
+                != constructor_function_address
+            ):
+                raise ValueError(
+                    "lineage entry constructor function does not own its store"
+                )
+            constructor_call = constructor_calls_by_return.get(
+                (constructor_function_address, constructor_return_address)
+            )
+            constructor_arguments = _hex_arguments(
+                event, "sample_constructor_arguments"
+            )
+            constructor_argument_varying_mask = int(
+                _hex(event, "constructor_argument_varying_mask", 2), 16
+            )
         if depth:
             if parent_value >= PHYSICAL_APERTURE_SIZE or parent_value & 3:
                 raise ValueError("indirect lineage entry has no valid parent packet")
@@ -253,6 +324,28 @@ def build(events: list[dict], static: dict, requested: str | None = None) -> dic
                 "min_parent_root_offset_bytes": min_parent_root_offset,
                 "max_parent_root_offset_bytes": max_parent_root_offset,
                 "constructor_store_address": constructor_store_address,
+                "constructor_function_address": constructor_function_address,
+                "constructor_return_address": constructor_return_address,
+                "constructor_callsite": (
+                    constructor_call.get("callsite")
+                    if constructor_call is not None
+                    else None
+                ),
+                "constructor_caller_function": (
+                    constructor_call.get("caller_function")
+                    if constructor_call is not None
+                    else None
+                ),
+                "constructor_caller_function_address": (
+                    constructor_call.get("caller_function_address")
+                    if constructor_call is not None
+                    else None
+                ),
+                "constructor_callsite_proved": constructor_call is not None,
+                "sample_constructor_arguments": constructor_arguments,
+                "constructor_argument_varying_mask": (
+                    constructor_argument_varying_mask
+                ),
                 "depth": depth,
             }
         )
@@ -265,6 +358,7 @@ def build(events: list[dict], static: dict, requested: str | None = None) -> dic
             if item["min_parent_root_offset_bytes"] is None
             else item["min_parent_root_offset_bytes"],
             item["constructor_store_address"] or "",
+            item["constructor_return_address"] or "",
         )
     )
 
@@ -293,6 +387,17 @@ def build(events: list[dict], static: dict, requested: str | None = None) -> dic
     )
     indirect_stack_faults = _integer(summary, "indirect_buffer_stack_faults")
     draw_stack_faults = _integer(summary, "indirect_draw_stack_faults")
+    constructor_entries = _integer(summary, "indirect_constructor_entries")
+    constructor_exits = _integer(summary, "indirect_constructor_exits")
+    constructor_open = _integer(
+        summary, "indirect_constructor_invocations_open_at_shutdown"
+    )
+    constructor_stack_faults = _integer(
+        summary, "indirect_constructor_stack_faults"
+    )
+    packets_without_constructor_origin = _integer(
+        summary, "indirect_packets_without_constructor_origin"
+    )
     open_at_shutdown = _integer(
         summary, "indirect_buffers_open_at_shutdown"
     )
@@ -316,6 +421,18 @@ def build(events: list[dict], static: dict, requested: str | None = None) -> dic
         and not title_table_overflow
         and not indirect_stack_faults
         and not draw_stack_faults
+        and constructor_entries == constructor_exits + constructor_open
+        and not constructor_stack_faults
+        and (
+            not static_constructor_calls
+            or (
+                constructor_entries > 0
+                and any(
+                    item["constructor_return_address"] is not None
+                    for item in entries
+                )
+            )
+        )
     )
 
     shapes = []
@@ -343,6 +460,25 @@ def build(events: list[dict], static: dict, requested: str | None = None) -> dic
                 "constructor_store_address": entry[
                     "constructor_store_address"
                 ],
+                "constructor_function_address": entry[
+                    "constructor_function_address"
+                ],
+                "constructor_return_address": entry[
+                    "constructor_return_address"
+                ],
+                "constructor_callsite": entry["constructor_callsite"],
+                "constructor_caller_function": entry[
+                    "constructor_caller_function"
+                ],
+                "constructor_callsite_proved": entry[
+                    "constructor_callsite_proved"
+                ],
+                "sample_constructor_arguments": entry[
+                    "sample_constructor_arguments"
+                ],
+                "constructor_argument_varying_mask": entry[
+                    "constructor_argument_varying_mask"
+                ],
                 "depth": entry["depth"],
                 "sample_prepared_signature": entry[
                     "sample_prepared_signature"
@@ -362,6 +498,7 @@ def build(events: list[dict], static: dict, requested: str | None = None) -> dic
             if item["min_parent_root_offset_bytes"] is None
             else item["min_parent_root_offset_bytes"],
             item["constructor_store_address"] or "",
+            item["constructor_return_address"] or "",
         )
     )
 
@@ -373,6 +510,7 @@ def build(events: list[dict], static: dict, requested: str | None = None) -> dic
         "entries": entries,
         "shapes": shapes,
         "static_indirect_buffer_constructors": constructors,
+        "static_indirect_constructor_calls": static_constructor_calls,
         "totals": {
             "draws": draws,
             "primary_draws": primary_draws,
@@ -397,7 +535,32 @@ def build(events: list[dict], static: dict, requested: str | None = None) -> dic
             "indirect_buffer_constructor_unmatched": constructor_unmatched,
             "indirect_buffer_stack_faults": indirect_stack_faults,
             "indirect_draw_stack_faults": draw_stack_faults,
+            "indirect_constructor_entries": constructor_entries,
+            "indirect_constructor_exits": constructor_exits,
+            "indirect_constructor_invocations_open_at_shutdown": (
+                constructor_open
+            ),
+            "indirect_constructor_stack_faults": constructor_stack_faults,
+            "indirect_packets_without_constructor_origin": (
+                packets_without_constructor_origin
+            ),
             "indirect_buffers_open_at_shutdown": open_at_shutdown,
+            "constructor_origin_draws": sum(
+                item["calls"]
+                for item in entries
+                if item["constructor_return_address"] is not None
+            ),
+            "statically_resolved_constructor_origin_draws": sum(
+                item["calls"]
+                for item in entries
+                if item["constructor_callsite_proved"]
+            ),
+            "unresolved_constructor_origin_draws": sum(
+                item["calls"]
+                for item in entries
+                if item["constructor_return_address"] is not None
+                and not item["constructor_callsite_proved"]
+            ),
         },
         "qualification": "exact_title_store_to_backend_nested_command_buffer_lineage",
         "semantic_identity": "unknown",

--- a/tools/tests/test_native_renderer_command_lineage.py
+++ b/tools/tests/test_native_renderer_command_lineage.py
@@ -206,6 +206,87 @@ class NativeRendererCommandLineageTests(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "no stored indirect-buffer"):
             MODULE.build(events(), static)
 
+    def test_maps_runtime_constructor_origin_to_static_caller(self):
+        static = static_inventory()
+        static["indirect_constructor_calls"] = [
+            {
+                "constructor_function_address": "82409398",
+                "caller_function": "sub_829E9790",
+                "caller_function_address": "829E9790",
+                "callsite": "829E982C",
+                "return_address": "829E9830",
+            }
+        ]
+        traced = events()
+        traced[1].update(
+            {
+                "constructor_function_address": "82409398",
+                "constructor_return_address": "829E9830",
+                "sample_constructor_arguments": (
+                    "10000000,20000000,00000001,00000000,00000000,"
+                    "00000000,00000000,00000000"
+                ),
+                "constructor_argument_varying_mask": "03",
+            }
+        )
+        traced[-1].update(
+            {
+                "indirect_constructor_entries": "4",
+                "indirect_constructor_exits": "3",
+                "indirect_constructor_invocations_open_at_shutdown": "1",
+                "indirect_constructor_stack_faults": "0",
+                "indirect_packets_without_constructor_origin": "2",
+            }
+        )
+        document = MODULE.build(traced, static)
+        self.assertEqual("complete", document["status"])
+        shape = document["shapes"][0]
+        self.assertEqual("829E982C", shape["constructor_callsite"])
+        self.assertEqual("sub_829E9790", shape["constructor_caller_function"])
+        self.assertEqual(3, shape["constructor_argument_varying_mask"])
+        self.assertEqual(
+            2,
+            document["totals"]["indirect_packets_without_constructor_origin"],
+        )
+
+    def test_retains_exact_runtime_origin_when_static_caller_is_unresolved(self):
+        static = static_inventory()
+        static["indirect_constructor_calls"] = [
+            {
+                "constructor_function_address": "82409398",
+                "caller_function": "sub_829E9790",
+                "caller_function_address": "829E9790",
+                "callsite": "829E982C",
+                "return_address": "829E9830",
+            }
+        ]
+        traced = events()
+        traced[1].update(
+            {
+                "constructor_function_address": "82409398",
+                "constructor_return_address": "83000004",
+                "sample_constructor_arguments": (
+                    "00000000,00000000,00000000,00000000,00000000,"
+                    "00000000,00000000,00000000"
+                ),
+                "constructor_argument_varying_mask": "00",
+            }
+        )
+        traced[-1].update(
+            {
+                "indirect_constructor_entries": "1",
+                "indirect_constructor_exits": "1",
+                "indirect_constructor_invocations_open_at_shutdown": "0",
+                "indirect_constructor_stack_faults": "0",
+            }
+        )
+        document = MODULE.build(traced, static)
+        self.assertEqual("complete", document["status"])
+        self.assertFalse(document["shapes"][0]["constructor_callsite_proved"])
+        self.assertEqual(
+            12, document["totals"]["unresolved_constructor_origin_draws"]
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tools/tests/test_native_renderer_contract.py
+++ b/tools/tests/test_native_renderer_contract.py
@@ -332,7 +332,9 @@ class NativeRendererContractTests(unittest.TestCase):
         self.assertIn("g_command_buffer_lineage_installed", source)
         self.assertIn("g_command_buffer_lineage_memory", source)
         self.assertIn("constructor_store_address", source)
-        self.assertIn("CurrentTitleIndirectConstructor", source)
+        self.assertIn("CurrentTitleIndirectBuffer", source)
+        self.assertIn("constructor_return_address", source)
+        self.assertIn("indirect_constructor_stack_faults", source)
         self.assertIn("SetIndirectBufferObserver(&ObserveIndirectBuffer)", source)
         self.assertIn("SetIndirectBufferObserver(nullptr)", source)
         self.assertIn(

--- a/tools/tests/test_native_renderer_dispatch_discovery.py
+++ b/tools/tests/test_native_renderer_dispatch_discovery.py
@@ -319,7 +319,8 @@ class NativeRendererDispatchDiscoveryTests(unittest.TestCase):
                 "stw r10,16(r4)",
             ],
         )
-        document = self.build([indirect, *reviewed_fixtures()])
+        caller = fixture(0x83070000, ["bl 0x83060000"])
+        document = self.build([indirect, caller, *reviewed_fixtures()])
         packets = [
             item
             for item in document["packet_constructors"]
@@ -335,6 +336,18 @@ class NativeRendererDispatchDiscoveryTests(unittest.TestCase):
         )
         self.assertEqual(packets[0]["packet_register"], "r11")
         self.assertEqual(packets[0]["store_instruction"], "stwu r11,4(r3)")
+        self.assertEqual(document["totals"]["indirect_constructor_calls"], 1)
+        constructor_call = document["indirect_constructor_calls"][0]
+        self.assertEqual(
+            constructor_call["constructor_function_address"], "83060000"
+        )
+        self.assertEqual(constructor_call["callsite"], "83070000")
+        self.assertEqual(constructor_call["return_address"], "83070004")
+        self.assertEqual(
+            constructor_call["constructor_store_addresses"],
+            ["83060008", "83060014"],
+        )
+        self.assertFalse(constructor_call["suppression_eligible"])
 
     def test_runtime_hooks_are_default_off_bounded_and_passive(self):
         hooks = (ROOT / "src/native_renderer/graphics_hooks.cpp").read_text(
@@ -385,6 +398,28 @@ class NativeRendererDispatchDiscoveryTests(unittest.TestCase):
                 ),
                 1,
             )
+        for function, entry, exit_address in (
+            ("82409398", "8240939C", "82409660"),
+            ("82416A00", "82416A04", "82417054"),
+            ("8246FB98", "8246FB9C", "8246FC78"),
+            ("8263BCB8", "8263BCBC", "8263BDF0"),
+            ("829E8E00", "829E8E04", "829E8ED4"),
+            ("829EC400", "829EC404", "829EC5AC"),
+        ):
+            self.assertIn(f"address = 0x{entry}", analysis)
+            self.assertIn(f"address = 0x{exit_address}", analysis)
+            self.assertEqual(
+                analysis.count(
+                    f'name = "PinyonShiftObserveIndirectConstructor{function}Entry"'
+                ),
+                1,
+            )
+            self.assertEqual(
+                analysis.count(
+                    f'name = "PinyonShiftObserveIndirectConstructor{function}Exit"'
+                ),
+                1,
+            )
         self.assertEqual(
             analysis.count('name = "PinyonShiftObserveVizQueryBeginDispatch"'),
             1,
@@ -432,7 +467,7 @@ class NativeRendererDispatchDiscoveryTests(unittest.TestCase):
                 'registers = ["r3", "r4", "r5", "r6", "r7", "r8", '
                 '"r9", "r10", "r12"]'
             ),
-            10,
+            16,
         )
         self.assertIn(
             "REX_PINYON_SHIFT_NATIVE_RENDERER_DISPATCH_DISCOVERY", capture


### PR DESCRIPTION
## Summary
- inventory every direct caller of stored indirect-buffer constructors
- capture balanced constructor entry/exit provenance and attach it to exact packet generations
- resolve runtime lineage to statically proved callsites while preserving explicit unknown ownership
- document the AppData festival qualification evidence

## Validation
- 51 focused tests passed
- static scan: 7 constructors, 6 functions, 38 direct callsites
- Release build: 	ools/build-preview.ps1 -Parallel 16
- AppData festival run: 156.947 s, 5,160 samples, 30.56 median FPS, 19.227 FPS 1% low
- 6,020,430 constructor-origin draws; 100% resolved to proved direct callsites
- zero constructor stack faults, invalid lineages, overflow, or fatal/crash markers

Xenos remains authoritative and suppression remains disabled.