### PR TITLE
feat(native-renderer): trace indirect owner callers

### DIFF
--- a/config/rexglue/analysis/main-xex.toml
+++ b/config/rexglue/analysis/main-xex.toml
@@ -96,6 +96,46 @@ registers = ["r3", "r4", "r5", "r6", "r7", "r8", "r9", "r10", "r12"]
 address = 0x829EC5AC
 name = "PinyonShiftObserveIndirectConstructor829EC400Exit"
 
+# Trace the four immediate caller functions that accounted for every known-
+# origin draw in the constructor-provenance milestone. Entry hooks observe the
+# owner's direct caller LR and r3-r10; balanced exits run before stack restore.
+# This is one passive ownership layer only and does not assign semantic names.
+[[midasm_hook]]
+address = 0x8240966C
+name = "PinyonShiftObserveIndirectOwner82409668Entry"
+registers = ["r3", "r4", "r5", "r6", "r7", "r8", "r9", "r10", "r12"]
+
+[[midasm_hook]]
+address = 0x8240983C
+name = "PinyonShiftObserveIndirectOwner82409668Exit"
+
+[[midasm_hook]]
+address = 0x824167FC
+name = "PinyonShiftObserveIndirectOwner824167F8Entry"
+registers = ["r3", "r4", "r5", "r6", "r7", "r8", "r9", "r10", "r12"]
+
+[[midasm_hook]]
+address = 0x82416898
+name = "PinyonShiftObserveIndirectOwner824167F8Exit"
+
+[[midasm_hook]]
+address = 0x8246E8FC
+name = "PinyonShiftObserveIndirectOwner8246E8F8Entry"
+registers = ["r3", "r4", "r5", "r6", "r7", "r8", "r9", "r10", "r12"]
+
+[[midasm_hook]]
+address = 0x8246E938
+name = "PinyonShiftObserveIndirectOwner8246E8F8Exit"
+
+[[midasm_hook]]
+address = 0x829F5FF4
+name = "PinyonShiftObserveIndirectOwner829F5FF0Entry"
+registers = ["r3", "r4", "r5", "r6", "r7", "r8", "r9", "r10", "r12"]
+
+[[midasm_hook]]
+address = 0x829F6358
+name = "PinyonShiftObserveIndirectOwner829F5FF0Exit"
+
 [[midasm_hook]]
 address = 0x824095B4
 name = "PinyonShiftObserveIndirectPacket824095B4"

--- a/docs/native-renderer/COMMAND_BUFFER_LINEAGE.md
+++ b/docs/native-renderer/COMMAND_BUFFER_LINEAGE.md
@@ -51,13 +51,15 @@ fall within the reported current-buffer bounds or the lineage is invalid.
 
 Pinyon validates the exact addresses, current-buffer length, and packet offset
 on every draw, then aggregates a stable ownership-class key in a fixed
-4,096-entry table: nesting depth, exact constructor store, and exact constructor
-return address when those are matched. Balanced entry/exit hooks on all six
-constructor functions carry the direct caller return address and bounded
-`r3-r10` entry metadata into the exact stored packet generation. Each class
-retains the statically resolved callsite and caller when proved, a sample
-constructor argument vector and varying mask, minimum and maximum current-buffer
-lengths, packet
+4,096-entry table: nesting depth, exact constructor store and return address,
+plus the exact upstream owner function and return address when those are
+matched. Balanced entry/exit hooks on all six constructor functions carry the
+direct caller return address and bounded `r3-r10` entry metadata into the exact
+stored packet generation. A second balanced layer covers the four immediate
+constructor callers that produced every known-origin draw in the first
+qualification. Each class retains statically resolved constructor and owner
+callsites when proved, independent argument samples and varying masks, and
+minimum and maximum current-buffer lengths, packet
 offsets, and parent-packet offsets from the first indirect root, plus a first
 prepared-signature sample and whether that signature varied. Absolute current,
 parent, and root addresses, buffer lengths, and individual offsets remain
@@ -134,3 +136,8 @@ The constructor/caller refinement and its additional fail-closed accounting are
 documented in `INDIRECT_CONSTRUCTOR_PROVENANCE.md`. Its runtime qualification is
 performed as a separate milestone gate; the evidence above remains the baseline
 for the original store-and-depth bridge.
+
+The next exact upstream layer is documented in
+`INDIRECT_OWNER_PROVENANCE.md`. It remains unqualified until the batched
+AppData gate proves balanced owner accounting and resolves live owner
+callsites; it does not change the already-qualified constructor baseline.

--- a/docs/native-renderer/HIGH_LEVEL_RENDER_HOOKS.md
+++ b/docs/native-renderer/HIGH_LEVEL_RENDER_HOOKS.md
@@ -257,6 +257,15 @@ and semantic caller identities remain open title-side inventory work. Until
 those gates are met, all work stays on Xenos and no new draw family may be
 suppressed.
 
+The constructor-provenance qualification identified four immediate caller
+functions covering every known-origin prepared draw. Static analysis now
+proves five constructor edges inside those functions and 32 exact direct
+callsites into them. The passive second-layer bridge in
+`INDIRECT_OWNER_PROVENANCE.md` captures those upstream return addresses and
+bounded entry arguments. Runtime qualification is still required before any
+of those callsites becomes an object or lifetime lead; all semantic identities
+remain unknown.
+
 For all 38 direct adapter callsites, the same static inventory now records
 `r3-r10`'s last syntactic definition since the nearest intervening call. Simple
 loads retain base register, offset, and width; values crossing a call boundary

--- a/docs/native-renderer/INDIRECT_CONSTRUCTOR_PROVENANCE.md
+++ b/docs/native-renderer/INDIRECT_CONSTRUCTOR_PROVENANCE.md
@@ -98,3 +98,12 @@ The hooks observe registers and packet addresses only. They do not read guest
 resource payloads, mutate guest state, alter control flow, add a native draw,
 or expose a suppression API. Xenos remains authoritative and suppression
 remains disabled.
+
+## Next ownership layer
+
+The four immediate constructor callers that accounted for all known-origin
+draws are now traced one exact caller layer upward. Their 32 proved direct
+callsites, balanced runtime contract, and additional fail-closed gates are
+documented in `INDIRECT_OWNER_PROVENANCE.md`. That work remains passive and
+does not retroactively assign semantic identity to this qualified constructor
+evidence.

--- a/docs/native-renderer/INDIRECT_OWNER_PROVENANCE.md
+++ b/docs/native-renderer/INDIRECT_OWNER_PROVENANCE.md
@@ -1,0 +1,128 @@
+# Indirect-owner provenance
+
+This NR-05A milestone traces the four constructor-caller functions that
+accounted for every known-origin draw in the preceding AppData qualification.
+It adds one exact caller layer above packet construction. It remains passive
+engine-structure discovery: the layer is not yet a mesh, material, object,
+instance, streaming, or lifetime owner, and it does not authorize suppression.
+
+## Static owner graph
+
+The generated-title scanner proves five direct constructor edges inside the
+four selected functions:
+
+| Constructor caller | Constructor callsite(s) | Operational evidence |
+| --- | --- | --- |
+| `82409668` | `82409834` -> `82409398` | Builds or queues one indirect command list while updating device-side counters and synchronization state. |
+| `824167F8` | `82416894` -> `82416A00` | Selects one of two device-held command-list sources and forwards its buffer field. |
+| `8246E8F8` | `8246E92C` -> `82416A00` | Locks a context, submits the context's buffer field, then runs a follow-up operation. |
+| `829F5FF0` | `829F6304`, `829F6338` -> `82409398` | Walks a tagged command stream and emits indirect work for two command forms. |
+
+These names describe instruction-level behavior only. None proves a semantic
+Forza render family.
+
+The same scan proves 32 direct callsites into this layer:
+
+| Constructor caller | Direct callsites | Distinct callers |
+| --- | ---: | ---: |
+| `82409668` | 7 | 5 |
+| `824167F8` | 23 | 10 |
+| `8246E8F8` | 1 | 1 |
+| `829F5FF0` | 1 | 1 |
+
+Every edge carries its exact callsite and return address. The inventory also
+records bounded local `r3-r10` definitions at all 38 constructor callsites and
+all 32 owner callsites. Constructor calls expose 142 locally proved argument
+definitions, including 27 direct memory loads; 158 slots stop at an
+intervening call. Owner calls expose 112 locally proved definitions, including
+35 direct memory loads; 138 slots stop at an intervening call. The remaining
+slots are unchanged entry registers. These are object/context leads, not
+pointer, type, or lifetime proof.
+
+## Runtime contract
+
+Each selected function has a balanced entry and exit hook. Entry runs after
+the opening `mflr`, capturing the exact direct caller return address and
+`r3-r10` in a 32-entry thread-local stack. Exit runs before stack restoration
+and pops only the matching function. Entry, exit, open-at-shutdown, overflow,
+underflow, and mismatch accounting is independent from the existing
+constructor stack.
+
+When one of the five proved constructor callsites enters its constructor, the
+active owner is copied only if its exact function matches the static immediate
+caller for that constructor return address. Missing or mismatched selected
+owners are counted and fail closed. Other constructor callsites remain
+explicitly without owner origin; no nearby or recently active owner is used.
+
+The owner function, owner return address, and owner `r3-r10` sample follow the
+same exact physical packet generation through indirect-buffer execution into
+prepared-draw command-buffer lineage. The bounded lineage key now contains:
+
+- exact constructor store, or `unknown`;
+- exact constructor return address, or `unknown`;
+- exact owner function and return address, or `unknown`; and
+- indirect-buffer nesting depth.
+
+Each class reports independent constructor and owner argument-varying masks.
+This divides a constructor callsite only when its proved upstream owner
+callsite differs; it cannot merge or infer unknown ownership.
+
+## Promotion gate
+
+The deterministic report requires:
+
+- balanced owner `entries = exits + open at shutdown` accounting;
+- zero owner stack faults;
+- zero constructor-to-owner mismatches;
+- an exact static owner-callsite resolution for every resolved runtime owner;
+- the existing constructor, packet-generation, command-buffer, and safety
+  gates; and
+- explicit resolved, unresolved, and absent owner-origin coverage.
+
+## AppData qualification
+
+The completed batch was qualified once against the installed `0.1.0` AppData
+save in session `20260829T152644Z-p16152`, using Release executable SHA-256
+`077F1AE45FD5D4E1F353A456B620B8B3223C2C76D2693F1FFC43059D8FB40DE1`.
+The 214.05-second run entered the live festival autoshow scene and exited
+normally. Visual inspection confirmed the player car, crowd, stage structures,
+sky, lighting, HUD, and event prompt remained intact.
+
+The deterministic report completed with:
+
+- 2,401,715 indirect draws and 2,201,749 prepared draws;
+- 416,582 balanced constructor entries and exits, with zero open invocations
+  and zero constructor stack faults;
+- 390,818 balanced owner entries and exits, with zero open invocations and
+  zero owner stack faults;
+- zero constructor-to-owner mismatches;
+- 1,669,534 owner-origin draws, all resolved to exact static constructor and
+  owner callsites, with zero unresolved owner-origin draws; and
+- zero invalid lineages, capacity overflow, packet-address failures, or packet
+  table overflow.
+
+Ten of the 32 statically proved owner callsites fed live festival draws:
+
+| Owner function | Live direct caller return(s) | Owner-origin draws |
+| --- | --- | ---: |
+| `82409668` | `8240D1B0` | 372,058 |
+| `824167F8` | `823F6BAC`, `824170BC`, `8241A2A4`, `824399F0`, `8243CE0C`, `8244CBF4`, `8244DD5C`, `8244E2A8` | 711,558 |
+| `8246E8F8` | `824726F4` | 30,715 |
+| `829F5FF0` | `829F6608` | 555,203 |
+
+The performance capture contained 7,111 samples, with a 30.466 FPS median,
+19.469 FPS one-percent low, 59.977 Hz host presentation cadence, zero present
+deadline misses, and zero XMA stalls. The JSONL ended with
+`process.shutdown`; no fatal, crash, device-loss, assertion, unhandled
+exception, or unexpected-shutdown marker was present.
+
+This promotes owner-callsite provenance as an exact operational classifier.
+The observed argument variation supplies bounded leads for the next discovery
+batch, but still does not establish object identity or lifetime ownership.
+
+## Safety boundary
+
+The hooks observe registers and packet addresses only. They read no guest
+resource payload, mutate no guest state, alter no control flow, add no native
+draw, and expose no suppression API. Xenos remains authoritative and all
+semantic identities remain `unknown`.

--- a/src/native_renderer/graphics_hooks.cpp
+++ b/src/native_renderer/graphics_hooks.cpp
@@ -83,6 +83,7 @@ constexpr size_t kTitleIndirectPacketCapacity =
     kTitleIndirectPacketBucketCount * kTitleIndirectPacketWays;
 constexpr size_t kTitleIndirectStackCapacity = 32;
 constexpr size_t kIndirectConstructorStackCapacity = 32;
+constexpr size_t kIndirectOwnerStackCapacity = 32;
 constexpr uint64_t kSkyHorizonAnchorSignature = UINT64_C(0x747837906D0BF484);
 constexpr uint64_t kSkyHorizonFollowerSignature = UINT64_C(0x1D253A52B55C9FB3);
 std::atomic<uint64_t> g_frame_sequence{};
@@ -155,12 +156,22 @@ struct TitleIndirectPacketEntry {
   uint32_t constructor_function_address = 0;
   uint32_t constructor_return_address = 0;
   std::array<uint32_t, 8> constructor_arguments{};
+  uint32_t owner_function_address = 0;
+  uint32_t owner_return_address = 0;
+  std::array<uint32_t, 8> owner_arguments{};
   uint64_t submission_sequence = 0;
   bool constructor_origin_known = false;
+  bool owner_origin_known = false;
   bool occupied = false;
 };
 
 struct IndirectConstructorOrigin {
+  struct Owner {
+    uint32_t function_address = 0;
+    uint32_t return_address = 0;
+    std::array<uint32_t, 8> arguments{};
+    bool valid = false;
+  } owner{};
   uint32_t function_address = 0;
   uint32_t return_address = 0;
   std::array<uint32_t, 8> arguments{};
@@ -223,8 +234,14 @@ uint64_t g_indirect_constructor_entries = 0;
 uint64_t g_indirect_constructor_exits = 0;
 uint64_t g_indirect_constructor_stack_faults = 0;
 uint64_t g_indirect_packets_without_constructor_origin = 0;
+uint64_t g_indirect_owner_entries = 0;
+uint64_t g_indirect_owner_exits = 0;
+uint64_t g_indirect_owner_stack_faults = 0;
+uint64_t g_indirect_constructors_without_owner_origin = 0;
+uint64_t g_indirect_constructor_owner_mismatches = 0;
 std::atomic<uint64_t> g_title_indirect_buffers_open{};
 std::atomic<uint64_t> g_indirect_constructor_invocations_open{};
+std::atomic<uint64_t> g_indirect_owner_invocations_open{};
 thread_local TitleDrawOrigin g_pending_adapter_origin;
 thread_local std::array<TitleDrawOrigin, kTitleOriginStackCapacity>
     g_title_origin_stack;
@@ -237,6 +254,11 @@ thread_local std::array<IndirectConstructorOrigin,
     g_indirect_constructor_stack;
 thread_local size_t g_indirect_constructor_stack_depth = 0;
 thread_local size_t g_indirect_constructor_stack_overflow_depth = 0;
+thread_local std::array<IndirectConstructorOrigin::Owner,
+                        kIndirectOwnerStackCapacity>
+    g_indirect_owner_stack;
+thread_local size_t g_indirect_owner_stack_depth = 0;
+thread_local size_t g_indirect_owner_stack_overflow_depth = 0;
 
 const char *DispatchWrapperName(DispatchWrapper wrapper) {
   switch (wrapper) {
@@ -393,9 +415,15 @@ void ResetTitleDrawProvenance() {
   g_indirect_constructor_exits = 0;
   g_indirect_constructor_stack_faults = 0;
   g_indirect_packets_without_constructor_origin = 0;
+  g_indirect_owner_entries = 0;
+  g_indirect_owner_exits = 0;
+  g_indirect_owner_stack_faults = 0;
+  g_indirect_constructors_without_owner_origin = 0;
+  g_indirect_constructor_owner_mismatches = 0;
   g_title_indirect_buffers_open.store(0, std::memory_order_relaxed);
   g_indirect_constructor_invocations_open.store(0,
                                                 std::memory_order_relaxed);
+  g_indirect_owner_invocations_open.store(0, std::memory_order_relaxed);
   g_pending_adapter_origin = {};
   g_title_origin_stack = {};
   g_title_origin_stack_depth = 0;
@@ -404,6 +432,9 @@ void ResetTitleDrawProvenance() {
   g_indirect_constructor_stack = {};
   g_indirect_constructor_stack_depth = 0;
   g_indirect_constructor_stack_overflow_depth = 0;
+  g_indirect_owner_stack = {};
+  g_indirect_owner_stack_depth = 0;
+  g_indirect_owner_stack_overflow_depth = 0;
 }
 
 void ConfigureTitleDrawProvenance(bool census_requested,
@@ -435,6 +466,7 @@ void ConfigureTitleDrawProvenance(bool census_requested,
         std::to_string(kTitleIndirectStackCapacity)},
        {"constructor_stack_capacity",
         std::to_string(kIndirectConstructorStackCapacity)},
+       {"owner_stack_capacity", std::to_string(kIndirectOwnerStackCapacity)},
        {"metadata",
         "origin_wrapper,entry_lr,r3-r10,outcome,backend_outcome,"
         "backend_signature"},
@@ -544,6 +576,82 @@ void RecordTitleDrawPacket(uint32_t packet_guest_address) {
   ++g_title_packets_recorded;
 }
 
+uint32_t ExpectedIndirectOwnerFunction(uint32_t constructor_function_address,
+                                       uint32_t constructor_return_address) {
+  if (constructor_function_address == 0x82409398) {
+    switch (constructor_return_address) {
+    case 0x82409838:
+      return 0x82409668;
+    case 0x829F6308:
+    case 0x829F633C:
+      return 0x829F5FF0;
+    default:
+      return 0;
+    }
+  }
+  if (constructor_function_address == 0x82416A00) {
+    switch (constructor_return_address) {
+    case 0x82416898:
+      return 0x824167F8;
+    case 0x8246E930:
+      return 0x8246E8F8;
+    default:
+      return 0;
+    }
+  }
+  return 0;
+}
+
+void PushIndirectOwnerOrigin(uint32_t function_address,
+                             uint32_t return_address, uint32_t r3,
+                             uint32_t r4, uint32_t r5, uint32_t r6,
+                             uint32_t r7, uint32_t r8, uint32_t r9,
+                             uint32_t r10) {
+  if (!g_command_buffer_lineage_installed.load(std::memory_order_acquire)) {
+    return;
+  }
+  ++g_indirect_owner_entries;
+  if (g_indirect_owner_stack_depth == kIndirectOwnerStackCapacity) {
+    ++g_indirect_owner_stack_faults;
+    ++g_indirect_owner_stack_overflow_depth;
+    return;
+  }
+  IndirectConstructorOrigin::Owner &owner =
+      g_indirect_owner_stack[g_indirect_owner_stack_depth++];
+  owner.function_address = function_address;
+  owner.return_address = return_address;
+  owner.arguments = {r3, r4, r5, r6, r7, r8, r9, r10};
+  owner.valid = true;
+  g_indirect_owner_invocations_open.fetch_add(1,
+                                               std::memory_order_relaxed);
+}
+
+void PopIndirectOwnerOrigin(uint32_t function_address) {
+  if (!g_command_buffer_lineage_installed.load(std::memory_order_acquire)) {
+    return;
+  }
+  ++g_indirect_owner_exits;
+  if (g_indirect_owner_stack_overflow_depth) {
+    --g_indirect_owner_stack_overflow_depth;
+    return;
+  }
+  if (!g_indirect_owner_stack_depth) {
+    ++g_indirect_owner_stack_faults;
+    return;
+  }
+  if (g_indirect_owner_stack[g_indirect_owner_stack_depth - 1]
+          .function_address != function_address) {
+    ++g_indirect_owner_stack_faults;
+    g_indirect_owner_invocations_open.fetch_sub(
+        g_indirect_owner_stack_depth, std::memory_order_relaxed);
+    g_indirect_owner_stack_depth = 0;
+    return;
+  }
+  --g_indirect_owner_stack_depth;
+  g_indirect_owner_invocations_open.fetch_sub(1,
+                                               std::memory_order_relaxed);
+}
+
 void PushIndirectConstructorOrigin(uint32_t function_address,
                                    uint32_t return_address, uint32_t r3,
                                    uint32_t r4, uint32_t r5, uint32_t r6,
@@ -561,9 +669,26 @@ void PushIndirectConstructorOrigin(uint32_t function_address,
   }
   IndirectConstructorOrigin &origin =
       g_indirect_constructor_stack[g_indirect_constructor_stack_depth++];
+  origin = {};
   origin.function_address = function_address;
   origin.return_address = return_address;
   origin.arguments = {r3, r4, r5, r6, r7, r8, r9, r10};
+  const uint32_t expected_owner =
+      ExpectedIndirectOwnerFunction(function_address, return_address);
+  if (expected_owner && g_indirect_owner_stack_depth) {
+    const IndirectConstructorOrigin::Owner &owner =
+        g_indirect_owner_stack[g_indirect_owner_stack_depth - 1];
+    if (owner.valid && owner.function_address == expected_owner) {
+      origin.owner = owner;
+    } else {
+      ++g_indirect_constructor_owner_mismatches;
+    }
+  } else if (expected_owner) {
+    ++g_indirect_constructor_owner_mismatches;
+  }
+  if (!origin.owner.valid) {
+    ++g_indirect_constructors_without_owner_origin;
+  }
   origin.valid = true;
   g_indirect_constructor_invocations_open.fetch_add(
       1, std::memory_order_relaxed);
@@ -662,8 +787,12 @@ void RecordTitleIndirectPacket(uint32_t packet_guest_address,
   entry.constructor_function_address = origin.function_address;
   entry.constructor_return_address = origin.return_address;
   entry.constructor_arguments = origin.arguments;
+  entry.owner_function_address = origin.owner.function_address;
+  entry.owner_return_address = origin.owner.return_address;
+  entry.owner_arguments = origin.owner.arguments;
   entry.submission_sequence = ++g_title_indirect_packet_submission_sequence;
   entry.constructor_origin_known = origin.valid;
+  entry.owner_origin_known = origin.owner.valid;
   entry.occupied = true;
   ++g_title_indirect_packets_recorded;
 }
@@ -727,6 +856,12 @@ void ObserveIndirectBuffer(
         matched.constructor_return_address;
     active.constructor_origin.arguments = matched.constructor_arguments;
     active.constructor_origin.valid = matched.constructor_origin_known;
+    active.constructor_origin.owner.function_address =
+        matched.owner_function_address;
+    active.constructor_origin.owner.return_address =
+        matched.owner_return_address;
+    active.constructor_origin.owner.arguments = matched.owner_arguments;
+    active.constructor_origin.owner.valid = matched.owner_origin_known;
     active.depth = observation.depth;
     g_title_indirect_buffers_open.fetch_add(1, std::memory_order_relaxed);
     return;
@@ -1607,8 +1742,13 @@ struct CommandBufferLineageEntry {
   uint32_t constructor_return_address = 0;
   std::array<uint32_t, 8> sample_constructor_arguments{};
   uint32_t constructor_argument_varying_mask = 0;
+  uint32_t owner_function_address = 0;
+  uint32_t owner_return_address = 0;
+  std::array<uint32_t, 8> sample_owner_arguments{};
+  uint32_t owner_argument_varying_mask = 0;
   uint32_t depth = 0;
   bool constructor_origin_known = false;
+  bool owner_origin_known = false;
   bool prepared_signature_varied = false;
 };
 
@@ -3095,6 +3235,8 @@ void RecordPreparedCommandBufferLineage(
   for (uint64_t value :
        {uint64_t(constructor_store_address),
         uint64_t(constructor_origin.return_address),
+        uint64_t(constructor_origin.owner.function_address),
+        uint64_t(constructor_origin.owner.return_address),
         uint64_t(observation.command_buffer_depth)}) {
     key = HashCombine(key, value);
   }
@@ -3130,12 +3272,20 @@ void RecordPreparedCommandBufferLineage(
       entry.constructor_return_address = constructor_origin.return_address;
       entry.sample_constructor_arguments = constructor_origin.arguments;
       entry.constructor_origin_known = constructor_origin.valid;
+      entry.owner_function_address =
+          constructor_origin.owner.function_address;
+      entry.owner_return_address = constructor_origin.owner.return_address;
+      entry.sample_owner_arguments = constructor_origin.owner.arguments;
+      entry.owner_origin_known = constructor_origin.owner.valid;
       entry.depth = observation.command_buffer_depth;
       ++g_command_buffer_lineage_entry_count;
       return;
     }
     if (entry.constructor_store_address == constructor_store_address &&
         entry.constructor_return_address == constructor_origin.return_address &&
+        entry.owner_function_address ==
+            constructor_origin.owner.function_address &&
+        entry.owner_return_address == constructor_origin.owner.return_address &&
         entry.depth == observation.command_buffer_depth) {
       ++entry.calls;
       entry.last_frame = observation.frame_sequence;
@@ -3164,6 +3314,15 @@ void RecordPreparedCommandBufferLineage(
           if (entry.sample_constructor_arguments[argument] !=
               constructor_origin.arguments[argument]) {
             entry.constructor_argument_varying_mask |= 1u << argument;
+          }
+        }
+      }
+      if (entry.owner_origin_known && constructor_origin.owner.valid) {
+        for (size_t argument = 0;
+             argument < entry.sample_owner_arguments.size(); ++argument) {
+          if (entry.sample_owner_arguments[argument] !=
+              constructor_origin.owner.arguments[argument]) {
+            entry.owner_argument_varying_mask |= 1u << argument;
           }
         }
       }
@@ -3241,6 +3400,23 @@ void EmitCommandBufferLineageSummary() {
               entry.sample_constructor_arguments[7])},
          {"constructor_argument_varying_mask",
           fmt::format("{:02X}", entry.constructor_argument_varying_mask)},
+         {"owner_function_address",
+          entry.owner_origin_known
+              ? fmt::format("{:08X}", entry.owner_function_address)
+              : "unknown"},
+         {"owner_return_address",
+          entry.owner_origin_known
+              ? fmt::format("{:08X}", entry.owner_return_address)
+              : "unknown"},
+         {"sample_owner_arguments",
+          fmt::format(
+              "{:08X},{:08X},{:08X},{:08X},{:08X},{:08X},{:08X},{:08X}",
+              entry.sample_owner_arguments[0], entry.sample_owner_arguments[1],
+              entry.sample_owner_arguments[2], entry.sample_owner_arguments[3],
+              entry.sample_owner_arguments[4], entry.sample_owner_arguments[5],
+              entry.sample_owner_arguments[6], entry.sample_owner_arguments[7])},
+         {"owner_argument_varying_mask",
+          fmt::format("{:02X}", entry.owner_argument_varying_mask)},
          {"depth", std::to_string(entry.depth)},
          {"guest_payload_read", "false"},
          {"guest_state_changed", "false"},
@@ -3292,6 +3468,17 @@ void EmitCommandBufferLineageSummary() {
         std::to_string(g_indirect_constructor_stack_faults)},
        {"indirect_packets_without_constructor_origin",
         std::to_string(g_indirect_packets_without_constructor_origin)},
+       {"indirect_owner_entries", std::to_string(g_indirect_owner_entries)},
+       {"indirect_owner_exits", std::to_string(g_indirect_owner_exits)},
+       {"indirect_owner_invocations_open_at_shutdown",
+        std::to_string(g_indirect_owner_invocations_open.load(
+            std::memory_order_relaxed))},
+       {"indirect_owner_stack_faults",
+        std::to_string(g_indirect_owner_stack_faults)},
+       {"indirect_constructors_without_owner_origin",
+        std::to_string(g_indirect_constructors_without_owner_origin)},
+       {"indirect_constructor_owner_mismatches",
+        std::to_string(g_indirect_constructor_owner_mismatches)},
        {"indirect_buffers_open_at_shutdown",
         std::to_string(g_title_indirect_buffers_open.load(
             std::memory_order_relaxed))},
@@ -5680,7 +5867,8 @@ void InstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system,
        {"capacity", std::to_string(kCommandBufferLineageCapacity)},
        {"source",
         "title_store,constructor_function,constructor_return,r3-r10,"
-        "backend_packet,current_buffer,parent_packet,root_buffer,depth"},
+        "owner_function,owner_return,owner_r3-r10,backend_packet,"
+        "current_buffer,parent_packet,root_buffer,depth"},
        {"guest_payload_read", "false"},
        {"guest_state_changed", "false"},
        {"control_flow_changed", "false"},
@@ -6416,6 +6604,33 @@ PINYON_SHIFT_INDIRECT_CONSTRUCTOR_HOOKS(829E8E00)
 PINYON_SHIFT_INDIRECT_CONSTRUCTOR_HOOKS(829EC400)
 
 #undef PINYON_SHIFT_INDIRECT_CONSTRUCTOR_HOOKS
+
+void ObserveIndirectOwnerEntry(
+    uint32_t function_address, PPCRegister &r3, PPCRegister &r4,
+    PPCRegister &r5, PPCRegister &r6, PPCRegister &r7, PPCRegister &r8,
+    PPCRegister &r9, PPCRegister &r10, PPCRegister &r12) {
+  PushIndirectOwnerOrigin(function_address, r12.u32, r3.u32, r4.u32, r5.u32,
+                          r6.u32, r7.u32, r8.u32, r9.u32, r10.u32);
+}
+
+#define PINYON_SHIFT_INDIRECT_OWNER_HOOKS(address)                             \
+  void PinyonShiftObserveIndirectOwner##address##Entry(                        \
+      PPCRegister &r3, PPCRegister &r4, PPCRegister &r5, PPCRegister &r6,      \
+      PPCRegister &r7, PPCRegister &r8, PPCRegister &r9, PPCRegister &r10,     \
+      PPCRegister &r12) {                                                       \
+    ObserveIndirectOwnerEntry(0x##address, r3, r4, r5, r6, r7, r8, r9, r10,   \
+                              r12);                                            \
+  }                                                                             \
+  void PinyonShiftObserveIndirectOwner##address##Exit() {                      \
+    PopIndirectOwnerOrigin(0x##address);                                        \
+  }
+
+PINYON_SHIFT_INDIRECT_OWNER_HOOKS(82409668)
+PINYON_SHIFT_INDIRECT_OWNER_HOOKS(824167F8)
+PINYON_SHIFT_INDIRECT_OWNER_HOOKS(8246E8F8)
+PINYON_SHIFT_INDIRECT_OWNER_HOOKS(829F5FF0)
+
+#undef PINYON_SHIFT_INDIRECT_OWNER_HOOKS
 
 void PinyonShiftObserveIndirectPacket824095B4(PPCRegister &r11,
                                                PPCRegister &r28) {

--- a/tools/discover-native-renderer-dispatch.py
+++ b/tools/discover-native-renderer-dispatch.py
@@ -108,6 +108,12 @@ INDIRECT_CONSTRUCTOR_RUNTIME_HOOKS = {
     0x829E8E00: {"entry": 0x829E8E04, "exit": 0x829E8ED4},
     0x829EC400: {"entry": 0x829EC404, "exit": 0x829EC5AC},
 }
+INDIRECT_OWNER_RUNTIME_HOOKS = {
+    0x82409668: {"entry": 0x8240966C, "exit": 0x8240983C},
+    0x824167F8: {"entry": 0x824167FC, "exit": 0x82416898},
+    0x8246E8F8: {"entry": 0x8246E8FC, "exit": 0x8246E938},
+    0x829F5FF0: {"entry": 0x829F5FF4, "exit": 0x829F6358},
+}
 
 FUNCTION_RE = re.compile(r"^DEFINE_REX_FUNC\(sub_([0-9A-F]{8})\) \{")
 LABEL_RE = re.compile(r"^loc_([0-9A-F]{8}):")
@@ -398,6 +404,171 @@ def indirect_constructor_runtime_hooks(
             }
         )
     return result
+
+
+def indirect_owner_calls(functions: list[dict]) -> list[dict]:
+    """Inventory direct callers of the runtime-qualified constructor owners."""
+    calls = []
+    for function in functions:
+        for instruction in function["instructions"]:
+            match = CALL_RE.fullmatch(instruction["text"])
+            if not match:
+                continue
+            target = int(match.group(1), 16)
+            if target not in INDIRECT_OWNER_RUNTIME_HOOKS:
+                continue
+            calls.append(
+                {
+                    "owner_function": "sub_{:08X}".format(target),
+                    "owner_function_address": "{:08X}".format(target),
+                    "caller_function": function["name"],
+                    "caller_function_address": "{:08X}".format(
+                        function["address"]
+                    ),
+                    "callsite": "{:08X}".format(instruction["address"]),
+                    "return_address": "{:08X}".format(
+                        instruction["address"] + 4
+                    ),
+                    "classification": "direct_static_owner_callsite",
+                    "semantic_identity": "unknown",
+                    "suppression_eligible": False,
+                }
+            )
+    return sorted(
+        calls,
+        key=lambda item: (item["owner_function_address"], item["callsite"]),
+    )
+
+
+def indirect_owner_runtime_hooks(functions_by_address: dict[int, dict]) -> list[dict]:
+    """Prove balanced passive hooks for the selected constructor owners."""
+    observed_known = set(functions_by_address) & set(INDIRECT_OWNER_RUNTIME_HOOKS)
+    if observed_known and observed_known != set(INDIRECT_OWNER_RUNTIME_HOOKS):
+        raise ValueError("known indirect-owner function set drifted")
+    result = []
+    for address in sorted(observed_known):
+        hooks = INDIRECT_OWNER_RUNTIME_HOOKS[address]
+        function = functions_by_address[address]
+        instructions = function["instructions"]
+        exit_instruction = next(
+            (
+                item
+                for item in instructions
+                if item["address"] == hooks["exit"]
+            ),
+            None,
+        )
+        if (
+            not instructions
+            or instructions[0] != {"address": address, "text": "mflr r12"}
+            or hooks["entry"] != address + 4
+            or exit_instruction is None
+            or not exit_instruction["text"].startswith("addi r1,r1,")
+            or instructions[-1]["text"] not in {"blr", "blr "}
+            and not BRANCH_RE.fullmatch(instructions[-1]["text"])
+        ):
+            raise ValueError(
+                "indirect-owner balanced hook evidence drifted: "
+                "{:08X}".format(address)
+            )
+        result.append(
+            {
+                "function": function["name"],
+                "function_address": "{:08X}".format(address),
+                "entry_hook_address": "{:08X}".format(hooks["entry"]),
+                "exit_hook_address": "{:08X}".format(hooks["exit"]),
+                "caller_lr_register": "r12_after_opening_mflr",
+                "entry_metadata": [
+                    "r3", "r4", "r5", "r6", "r7", "r8", "r9", "r10"
+                ],
+                "classification": "balanced_passive_constructor_owner",
+                "semantic_identity": "unknown",
+                "suppression_eligible": False,
+            }
+        )
+    return result
+
+
+def argument_leads_for_calls(
+    functions: list[dict], calls: list[dict], target_key: str
+) -> list[dict]:
+    """Record bounded local r3-r10 definitions for an exact direct call."""
+    functions_by_address = {item["address"]: item for item in functions}
+    leads = []
+    for call in calls:
+        function = functions_by_address[int(call["caller_function_address"], 16)]
+        instructions = function["instructions"]
+        call_index = next(
+            index
+            for index, instruction in enumerate(instructions)
+            if instruction["address"] == int(call["callsite"], 16)
+        )
+        definitions = []
+        for register_index in range(3, 11):
+            register = f"r{register_index}"
+            definition = None
+            crossed_call = False
+            for instruction in reversed(instructions[:call_index]):
+                if CALL_BOUNDARY_RE.fullmatch(instruction["text"]):
+                    crossed_call = True
+                    break
+                match = REGISTER_DEFINITION_RE.match(instruction["text"])
+                if (
+                    not match
+                    or match.group(2) != register
+                    or match.group(1) not in DEFINITION_OPERATIONS
+                ):
+                    continue
+                definition = instruction
+                break
+            if definition is None:
+                definitions.append(
+                    {
+                        "register": register,
+                        "status": (
+                            "unknown_across_call_boundary"
+                            if crossed_call
+                            else "entry_register"
+                        ),
+                    }
+                )
+                continue
+            text = definition["text"]
+            operation = text.split(" ", 1)[0]
+            operands = text.split(" ", 1)[1].split(",")
+            source_registers = re.findall(r"r\d+", ",".join(operands[1:]))
+            item = {
+                "register": register,
+                "status": "bounded_syntactic_definition",
+                "address": "{:08X}".format(definition["address"]),
+                "operation": operation,
+                "instruction": text,
+                "source_registers": source_registers,
+            }
+            memory = MEMORY_LOAD_RE.fullmatch(text)
+            if memory:
+                item["memory_load"] = {
+                    "base_register": memory.group(4),
+                    "offset": int(memory.group(3)),
+                    "width": memory.group(1),
+                }
+            definitions.append(item)
+        leads.append(
+            {
+                target_key: call[target_key],
+                "caller_function": call["caller_function"],
+                "caller_function_address": call["caller_function_address"],
+                "callsite": call["callsite"],
+                "return_address": call["return_address"],
+                "arguments": definitions,
+                "classification": "bounded_syntactic_object_lead_only",
+                "interprocedural_dataflow": False,
+                "object_identity_proved": False,
+                "lifetime_proved": False,
+                "suppression_eligible": False,
+            }
+        )
+    return leads
 
 
 def adapter_argument_leads(functions: list[dict], calls: list[dict]) -> list[dict]:
@@ -866,6 +1037,14 @@ def build(paths: list[pathlib.Path]) -> dict:
     constructor_hooks = indirect_constructor_runtime_hooks(
         functions_by_address, constructors
     )
+    owner_calls = indirect_owner_calls(functions)
+    owner_hooks = indirect_owner_runtime_hooks(functions_by_address)
+    constructor_argument_leads = argument_leads_for_calls(
+        functions, constructor_calls, "constructor_function_address"
+    )
+    owner_argument_leads = argument_leads_for_calls(
+        functions, owner_calls, "owner_function_address"
+    )
     constructor_evidence = {
         (int(item["function_address"], 16), int(item["opcode_value"], 16))
         for item in constructors
@@ -953,6 +1132,10 @@ def build(paths: list[pathlib.Path]) -> dict:
         "packet_constructors": constructors,
         "indirect_constructor_calls": constructor_calls,
         "indirect_constructor_runtime_hooks": constructor_hooks,
+        "indirect_constructor_argument_leads": constructor_argument_leads,
+        "indirect_owner_calls": owner_calls,
+        "indirect_owner_runtime_hooks": owner_hooks,
+        "indirect_owner_argument_leads": owner_argument_leads,
         "reviewed_wrappers": [
             {
                 "address": "{:08X}".format(address),
@@ -1010,6 +1193,12 @@ def build(paths: list[pathlib.Path]) -> dict:
             "packet_constructors": len(constructors),
             "indirect_constructor_calls": len(constructor_calls),
             "indirect_constructor_runtime_hooks": len(constructor_hooks),
+            "indirect_constructor_argument_leads": len(
+                constructor_argument_leads
+            ),
+            "indirect_owner_calls": len(owner_calls),
+            "indirect_owner_runtime_hooks": len(owner_hooks),
+            "indirect_owner_argument_leads": len(owner_argument_leads),
             "reviewed_wrappers": len(REVIEWED_WRAPPERS),
             "direct_calls": len(calls),
             "tail_forwarded_calls": len(forwarded_calls),

--- a/tools/summarize-native-renderer-command-lineage.py
+++ b/tools/summarize-native-renderer-command-lineage.py
@@ -80,15 +80,15 @@ def _optional_hex(mapping: dict, key: str, width: int) -> str | None:
 def _hex_arguments(mapping: dict, key: str) -> list[str]:
     values = str(mapping.get(key, "")).upper().split(",")
     if len(values) != 8:
-        raise ValueError(f"invalid constructor argument vector: {key}")
+        raise ValueError(f"invalid argument vector: {key}")
     for value in values:
         if len(value) != 8:
-            raise ValueError(f"invalid constructor argument vector: {key}")
+            raise ValueError(f"invalid argument vector: {key}")
         try:
             int(value, 16)
         except ValueError as error:
             raise ValueError(
-                f"invalid constructor argument vector: {key}"
+                f"invalid argument vector: {key}"
             ) from error
     return values
 
@@ -119,6 +119,14 @@ def build(events: list[dict], static: dict, requested: str | None = None) -> dic
             str(item.get("return_address", "")).upper(),
         ): item
         for item in static_constructor_calls
+    }
+    static_owner_calls = static.get("indirect_owner_calls", [])
+    owner_calls_by_return = {
+        (
+            str(item.get("owner_function_address", "")).upper(),
+            str(item.get("return_address", "")).upper(),
+        ): item
+        for item in static_owner_calls
     }
 
     session = select_session(events, requested)
@@ -252,6 +260,36 @@ def build(events: list[dict], static: dict, requested: str | None = None) -> dic
             constructor_argument_varying_mask = int(
                 _hex(event, "constructor_argument_varying_mask", 2), 16
             )
+        owner_function_address = _optional_hex(
+            event, "owner_function_address", 8
+        )
+        owner_return_address = _optional_hex(
+            event, "owner_return_address", 8
+        )
+        if (owner_function_address is None) != (owner_return_address is None):
+            raise ValueError("lineage entry has a partial owner origin")
+        owner_call = None
+        owner_arguments = None
+        owner_argument_varying_mask = None
+        if owner_function_address is not None:
+            if constructor_call is None:
+                raise ValueError(
+                    "lineage entry has an owner without a proved constructor caller"
+                )
+            if (
+                str(constructor_call.get("caller_function_address", "")).upper()
+                != owner_function_address
+            ):
+                raise ValueError(
+                    "lineage owner does not contain the constructor callsite"
+                )
+            owner_call = owner_calls_by_return.get(
+                (owner_function_address, owner_return_address)
+            )
+            owner_arguments = _hex_arguments(event, "sample_owner_arguments")
+            owner_argument_varying_mask = int(
+                _hex(event, "owner_argument_varying_mask", 2), 16
+            )
         if depth:
             if parent_value >= PHYSICAL_APERTURE_SIZE or parent_value & 3:
                 raise ValueError("indirect lineage entry has no valid parent packet")
@@ -346,6 +384,24 @@ def build(events: list[dict], static: dict, requested: str | None = None) -> dic
                 "constructor_argument_varying_mask": (
                     constructor_argument_varying_mask
                 ),
+                "owner_function_address": owner_function_address,
+                "owner_return_address": owner_return_address,
+                "owner_callsite": (
+                    owner_call.get("callsite") if owner_call is not None else None
+                ),
+                "owner_caller_function": (
+                    owner_call.get("caller_function")
+                    if owner_call is not None
+                    else None
+                ),
+                "owner_caller_function_address": (
+                    owner_call.get("caller_function_address")
+                    if owner_call is not None
+                    else None
+                ),
+                "owner_callsite_proved": owner_call is not None,
+                "sample_owner_arguments": owner_arguments,
+                "owner_argument_varying_mask": owner_argument_varying_mask,
                 "depth": depth,
             }
         )
@@ -359,6 +415,7 @@ def build(events: list[dict], static: dict, requested: str | None = None) -> dic
             else item["min_parent_root_offset_bytes"],
             item["constructor_store_address"] or "",
             item["constructor_return_address"] or "",
+            item["owner_return_address"] or "",
         )
     )
 
@@ -398,6 +455,18 @@ def build(events: list[dict], static: dict, requested: str | None = None) -> dic
     packets_without_constructor_origin = _integer(
         summary, "indirect_packets_without_constructor_origin"
     )
+    owner_entries = _integer(summary, "indirect_owner_entries")
+    owner_exits = _integer(summary, "indirect_owner_exits")
+    owner_open = _integer(
+        summary, "indirect_owner_invocations_open_at_shutdown"
+    )
+    owner_stack_faults = _integer(summary, "indirect_owner_stack_faults")
+    constructors_without_owner_origin = _integer(
+        summary, "indirect_constructors_without_owner_origin"
+    )
+    constructor_owner_mismatches = _integer(
+        summary, "indirect_constructor_owner_mismatches"
+    )
     open_at_shutdown = _integer(
         summary, "indirect_buffers_open_at_shutdown"
     )
@@ -423,12 +492,25 @@ def build(events: list[dict], static: dict, requested: str | None = None) -> dic
         and not draw_stack_faults
         and constructor_entries == constructor_exits + constructor_open
         and not constructor_stack_faults
+        and owner_entries == owner_exits + owner_open
+        and not owner_stack_faults
+        and not constructor_owner_mismatches
         and (
             not static_constructor_calls
             or (
                 constructor_entries > 0
                 and any(
                     item["constructor_return_address"] is not None
+                    for item in entries
+                )
+            )
+        )
+        and (
+            not static_owner_calls
+            or (
+                owner_entries > 0
+                and any(
+                    item["owner_return_address"] is not None
                     for item in entries
                 )
             )
@@ -479,6 +561,15 @@ def build(events: list[dict], static: dict, requested: str | None = None) -> dic
                 "constructor_argument_varying_mask": entry[
                     "constructor_argument_varying_mask"
                 ],
+                "owner_function_address": entry["owner_function_address"],
+                "owner_return_address": entry["owner_return_address"],
+                "owner_callsite": entry["owner_callsite"],
+                "owner_caller_function": entry["owner_caller_function"],
+                "owner_callsite_proved": entry["owner_callsite_proved"],
+                "sample_owner_arguments": entry["sample_owner_arguments"],
+                "owner_argument_varying_mask": entry[
+                    "owner_argument_varying_mask"
+                ],
                 "depth": entry["depth"],
                 "sample_prepared_signature": entry[
                     "sample_prepared_signature"
@@ -499,6 +590,7 @@ def build(events: list[dict], static: dict, requested: str | None = None) -> dic
             else item["min_parent_root_offset_bytes"],
             item["constructor_store_address"] or "",
             item["constructor_return_address"] or "",
+            item["owner_return_address"] or "",
         )
     )
 
@@ -511,6 +603,7 @@ def build(events: list[dict], static: dict, requested: str | None = None) -> dic
         "shapes": shapes,
         "static_indirect_buffer_constructors": constructors,
         "static_indirect_constructor_calls": static_constructor_calls,
+        "static_indirect_owner_calls": static_owner_calls,
         "totals": {
             "draws": draws,
             "primary_draws": primary_draws,
@@ -544,6 +637,16 @@ def build(events: list[dict], static: dict, requested: str | None = None) -> dic
             "indirect_packets_without_constructor_origin": (
                 packets_without_constructor_origin
             ),
+            "indirect_owner_entries": owner_entries,
+            "indirect_owner_exits": owner_exits,
+            "indirect_owner_invocations_open_at_shutdown": owner_open,
+            "indirect_owner_stack_faults": owner_stack_faults,
+            "indirect_constructors_without_owner_origin": (
+                constructors_without_owner_origin
+            ),
+            "indirect_constructor_owner_mismatches": (
+                constructor_owner_mismatches
+            ),
             "indirect_buffers_open_at_shutdown": open_at_shutdown,
             "constructor_origin_draws": sum(
                 item["calls"]
@@ -560,6 +663,20 @@ def build(events: list[dict], static: dict, requested: str | None = None) -> dic
                 for item in entries
                 if item["constructor_return_address"] is not None
                 and not item["constructor_callsite_proved"]
+            ),
+            "owner_origin_draws": sum(
+                item["calls"]
+                for item in entries
+                if item["owner_return_address"] is not None
+            ),
+            "statically_resolved_owner_origin_draws": sum(
+                item["calls"] for item in entries if item["owner_callsite_proved"]
+            ),
+            "unresolved_owner_origin_draws": sum(
+                item["calls"]
+                for item in entries
+                if item["owner_return_address"] is not None
+                and not item["owner_callsite_proved"]
             ),
         },
         "qualification": "exact_title_store_to_backend_nested_command_buffer_lineage",

--- a/tools/tests/test_native_renderer_command_lineage.py
+++ b/tools/tests/test_native_renderer_command_lineage.py
@@ -287,6 +287,97 @@ class NativeRendererCommandLineageTests(unittest.TestCase):
             12, document["totals"]["unresolved_constructor_origin_draws"]
         )
 
+    def test_maps_balanced_owner_origin_to_static_caller(self):
+        static = static_inventory()
+        static["indirect_constructor_calls"] = [
+            {
+                "constructor_function_address": "82409398",
+                "caller_function": "sub_82409668",
+                "caller_function_address": "82409668",
+                "callsite": "82409834",
+                "return_address": "82409838",
+            }
+        ]
+        static["indirect_owner_calls"] = [
+            {
+                "owner_function_address": "82409668",
+                "caller_function": "sub_82469290",
+                "caller_function_address": "82469290",
+                "callsite": "824693E0",
+                "return_address": "824693E4",
+            }
+        ]
+        traced = events()
+        traced[1].update(
+            {
+                "constructor_function_address": "82409398",
+                "constructor_return_address": "82409838",
+                "sample_constructor_arguments": (
+                    "10000000,20000000,00000001,00000000,00000000,"
+                    "00000000,00000000,00000000"
+                ),
+                "constructor_argument_varying_mask": "03",
+                "owner_function_address": "82409668",
+                "owner_return_address": "824693E4",
+                "sample_owner_arguments": (
+                    "30000000,40000000,00000002,00000000,00000000,"
+                    "00000000,00000000,00000000"
+                ),
+                "owner_argument_varying_mask": "05",
+            }
+        )
+        traced[-1].update(
+            {
+                "indirect_constructor_entries": "4",
+                "indirect_constructor_exits": "4",
+                "indirect_constructor_invocations_open_at_shutdown": "0",
+                "indirect_constructor_stack_faults": "0",
+                "indirect_owner_entries": "4",
+                "indirect_owner_exits": "4",
+                "indirect_owner_invocations_open_at_shutdown": "0",
+                "indirect_owner_stack_faults": "0",
+                "indirect_constructors_without_owner_origin": "0",
+                "indirect_constructor_owner_mismatches": "0",
+            }
+        )
+        document = MODULE.build(traced, static)
+        self.assertEqual("complete", document["status"])
+        shape = document["shapes"][0]
+        self.assertEqual("824693E0", shape["owner_callsite"])
+        self.assertEqual("sub_82469290", shape["owner_caller_function"])
+        self.assertEqual(5, shape["owner_argument_varying_mask"])
+        self.assertEqual(12, document["totals"]["owner_origin_draws"])
+        self.assertEqual(
+            12, document["totals"]["statically_resolved_owner_origin_draws"]
+        )
+
+    def test_rejects_owner_that_does_not_contain_constructor_callsite(self):
+        static = static_inventory()
+        static["indirect_constructor_calls"] = [
+            {
+                "constructor_function_address": "82409398",
+                "caller_function": "sub_82409668",
+                "caller_function_address": "82409668",
+                "callsite": "82409834",
+                "return_address": "82409838",
+            }
+        ]
+        traced = events()
+        traced[1].update(
+            {
+                "constructor_function_address": "82409398",
+                "constructor_return_address": "82409838",
+                "sample_constructor_arguments": "00000000," * 7 + "00000000",
+                "constructor_argument_varying_mask": "00",
+                "owner_function_address": "824167F8",
+                "owner_return_address": "824170BC",
+                "sample_owner_arguments": "00000000," * 7 + "00000000",
+                "owner_argument_varying_mask": "00",
+            }
+        )
+        with self.assertRaisesRegex(ValueError, "does not contain"):
+            MODULE.build(traced, static)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tools/tests/test_native_renderer_contract.py
+++ b/tools/tests/test_native_renderer_contract.py
@@ -335,6 +335,10 @@ class NativeRendererContractTests(unittest.TestCase):
         self.assertIn("CurrentTitleIndirectBuffer", source)
         self.assertIn("constructor_return_address", source)
         self.assertIn("indirect_constructor_stack_faults", source)
+        self.assertIn("kIndirectOwnerStackCapacity = 32", source)
+        self.assertIn("owner_return_address", source)
+        self.assertIn("indirect_owner_stack_faults", source)
+        self.assertIn("indirect_constructor_owner_mismatches", source)
         self.assertIn("SetIndirectBufferObserver(&ObserveIndirectBuffer)", source)
         self.assertIn("SetIndirectBufferObserver(nullptr)", source)
         self.assertIn(

--- a/tools/tests/test_native_renderer_dispatch_discovery.py
+++ b/tools/tests/test_native_renderer_dispatch_discovery.py
@@ -193,6 +193,58 @@ def reviewed_fixtures(include_immediate=True):
     return chunks
 
 
+def owner_fixtures():
+    return [
+        fixture(
+            0x82409668,
+            [
+                "mflr r12",
+                "loc_82409834:",
+                "bl 0x82409398",
+                "mr r3,r29",
+                "addi r1,r1,176",
+                "b 0x82a7de40",
+            ],
+        ),
+        fixture(
+            0x824167F8,
+            [
+                "mflr r12",
+                "loc_82416894:",
+                "bl 0x82416a00",
+                "addi r1,r1,112",
+                "blr",
+            ],
+        ),
+        fixture(
+            0x8246E8F8,
+            [
+                "mflr r12",
+                "loc_8246E92C:",
+                "bl 0x82416a00",
+                "mr r3,r30",
+                "bl 0x82467468",
+                "addi r1,r1,112",
+                "blr",
+            ],
+        ),
+        fixture(
+            0x829F5FF0,
+            [
+                "mflr r12",
+                "loc_829F6304:",
+                "bl 0x82409398",
+                "loc_829F6338:",
+                "bl 0x82409398",
+                "loc_829F6354:",
+                "mr r3,r31",
+                "addi r1,r1,176",
+                "b 0x82a7de44",
+            ],
+        ),
+    ]
+
+
 class NativeRendererDispatchDiscoveryTests(unittest.TestCase):
     def build(self, chunks):
         with tempfile.TemporaryDirectory() as directory:
@@ -349,6 +401,41 @@ class NativeRendererDispatchDiscoveryTests(unittest.TestCase):
         )
         self.assertFalse(constructor_call["suppression_eligible"])
 
+    def test_inventories_balanced_constructor_owner_layer(self):
+        callers = [
+            fixture(0x83010000, ["lwz r3,40(r31)", "bl 0x82409668"]),
+            fixture(0x83020000, ["bl 0x824167f8"]),
+            fixture(0x83030000, ["bl 0x8246e8f8"]),
+            fixture(0x83040000, ["bl 0x829f5ff0"]),
+        ]
+        document = self.build(
+            [*reviewed_fixtures(), *owner_fixtures(), *callers]
+        )
+        self.assertEqual(4, document["totals"]["indirect_owner_runtime_hooks"])
+        self.assertEqual(4, document["totals"]["indirect_owner_calls"])
+        self.assertEqual(4, document["totals"]["indirect_owner_argument_leads"])
+        hooks = {
+            item["function_address"]: item
+            for item in document["indirect_owner_runtime_hooks"]
+        }
+        self.assertEqual("8240983C", hooks["82409668"]["exit_hook_address"])
+        call = next(
+            item
+            for item in document["indirect_owner_calls"]
+            if item["owner_function_address"] == "82409668"
+        )
+        self.assertEqual("83010004", call["callsite"])
+        lead = next(
+            item
+            for item in document["indirect_owner_argument_leads"]
+            if item["owner_function_address"] == "82409668"
+        )
+        self.assertEqual(
+            {"base_register": "r31", "offset": 40, "width": "lwz"},
+            lead["arguments"][0]["memory_load"],
+        )
+        self.assertFalse(lead["suppression_eligible"])
+
     def test_runtime_hooks_are_default_off_bounded_and_passive(self):
         hooks = (ROOT / "src/native_renderer/graphics_hooks.cpp").read_text(
             encoding="utf-8"
@@ -420,6 +507,26 @@ class NativeRendererDispatchDiscoveryTests(unittest.TestCase):
                 ),
                 1,
             )
+        for function, entry, exit_address in (
+            ("82409668", "8240966C", "8240983C"),
+            ("824167F8", "824167FC", "82416898"),
+            ("8246E8F8", "8246E8FC", "8246E938"),
+            ("829F5FF0", "829F5FF4", "829F6358"),
+        ):
+            self.assertIn(f"address = 0x{entry}", analysis)
+            self.assertIn(f"address = 0x{exit_address}", analysis)
+            self.assertEqual(
+                analysis.count(
+                    f'name = "PinyonShiftObserveIndirectOwner{function}Entry"'
+                ),
+                1,
+            )
+            self.assertEqual(
+                analysis.count(
+                    f'name = "PinyonShiftObserveIndirectOwner{function}Exit"'
+                ),
+                1,
+            )
         self.assertEqual(
             analysis.count('name = "PinyonShiftObserveVizQueryBeginDispatch"'),
             1,
@@ -467,7 +574,7 @@ class NativeRendererDispatchDiscoveryTests(unittest.TestCase):
                 'registers = ["r3", "r4", "r5", "r6", "r7", "r8", '
                 '"r9", "r10", "r12"]'
             ),
-            16,
+            20,
         )
         self.assertIn(
             "REX_PINYON_SHIFT_NATIVE_RENDERER_DISPATCH_DISCOVERY", capture


### PR DESCRIPTION
## Summary
- prove the dominant indirect-constructor owner call graph and hook four balanced owner functions
- propagate exact owner function, caller return, and argument samples through packet and prepared-draw lineage
- add fail-closed reporting, safety gates, focused tests, and AppData qualification evidence

## Validation
- 54 focused Python tests passed
- Python compileall and real static discovery scan passed
- Release preview build passed
- 214.05 s AppData gameplay capture exited normally
- report completed with 390,818 balanced owner entries/exits, zero owner mismatches or stack faults, and 1,669,534 statically resolved owner-origin draws
- median 30.466 FPS over 7,111 samples; visual festival scene intact