### PR TITLE
feat(native-renderer): trace dominant producer callers

### DIFF
--- a/config/rexglue/analysis/main-xex.toml
+++ b/config/rexglue/analysis/main-xex.toml
@@ -136,6 +136,38 @@ registers = ["r3", "r4", "r5", "r6", "r7", "r8", "r9", "r10", "r12"]
 address = 0x829F6358
 name = "PinyonShiftObserveIndirectOwner829F5FF0Exit"
 
+# Trace the three dominant live functions that directly call the constructor
+# owners above. Together they accounted for most owner-origin draws in the
+# NR-05A owner-provenance qualification. Entry hooks capture their direct
+# caller LR and r3-r10; exits are the proved common stack-restoration points.
+# The metadata remains passive and does not assign semantic object identity.
+[[midasm_hook]]
+address = 0x8240D074
+name = "PinyonShiftObserveIndirectProducer8240D070Entry"
+registers = ["r3", "r4", "r5", "r6", "r7", "r8", "r9", "r10", "r12"]
+
+[[midasm_hook]]
+address = 0x8240D1F0
+name = "PinyonShiftObserveIndirectProducer8240D070Exit"
+
+[[midasm_hook]]
+address = 0x82417064
+name = "PinyonShiftObserveIndirectProducer82417060Entry"
+registers = ["r3", "r4", "r5", "r6", "r7", "r8", "r9", "r10", "r12"]
+
+[[midasm_hook]]
+address = 0x824170C0
+name = "PinyonShiftObserveIndirectProducer82417060Exit"
+
+[[midasm_hook]]
+address = 0x829F6364
+name = "PinyonShiftObserveIndirectProducer829F6360Entry"
+registers = ["r3", "r4", "r5", "r6", "r7", "r8", "r9", "r10", "r12"]
+
+[[midasm_hook]]
+address = 0x829F63FC
+name = "PinyonShiftObserveIndirectProducer829F6360Exit"
+
 [[midasm_hook]]
 address = 0x824095B4
 name = "PinyonShiftObserveIndirectPacket824095B4"

--- a/docs/native-renderer/COMMAND_BUFFER_LINEAGE.md
+++ b/docs/native-renderer/COMMAND_BUFFER_LINEAGE.md
@@ -52,12 +52,14 @@ fall within the reported current-buffer bounds or the lineage is invalid.
 Pinyon validates the exact addresses, current-buffer length, and packet offset
 on every draw, then aggregates a stable ownership-class key in a fixed
 4,096-entry table: nesting depth, exact constructor store and return address,
-plus the exact upstream owner function and return address when those are
-matched. Balanced entry/exit hooks on all six constructor functions carry the
-direct caller return address and bounded `r3-r10` entry metadata into the exact
-stored packet generation. A second balanced layer covers the four immediate
-constructor callers that produced every known-origin draw in the first
-qualification. Each class retains statically resolved constructor and owner
+plus the exact upstream owner and producer function and return addresses when
+those are matched. Balanced entry/exit hooks on all six constructor functions
+carry the direct caller return address and bounded `r3-r10` entry metadata into
+the exact stored packet generation. A second balanced layer covers the four
+immediate constructor callers that produced every known-origin draw in the first
+qualification. A third balanced layer covers the three producer functions
+responsible for 85.1% of the owner-origin draws in the owner qualification.
+Each class retains statically resolved constructor, owner, and producer
 callsites when proved, independent argument samples and varying masks, and
 minimum and maximum current-buffer lengths, packet
 offsets, and parent-packet offsets from the first indirect root, plus a first
@@ -137,7 +139,9 @@ documented in `INDIRECT_CONSTRUCTOR_PROVENANCE.md`. Its runtime qualification is
 performed as a separate milestone gate; the evidence above remains the baseline
 for the original store-and-depth bridge.
 
-The next exact upstream layer is documented in
-`INDIRECT_OWNER_PROVENANCE.md`. It remains unqualified until the batched
-AppData gate proves balanced owner accounting and resolves live owner
-callsites; it does not change the already-qualified constructor baseline.
+The exact owner layer is documented and runtime-qualified in
+`INDIRECT_OWNER_PROVENANCE.md`. The next producer layer is documented in
+`INDIRECT_PRODUCER_PROVENANCE.md`. Session `20260829T155036Z-p13876`
+runtime-qualified its balanced accounting and resolved 4,400,708 producer-
+origin draws to five exact live caller edges. Neither refinement changes the
+qualified constructor baseline.

--- a/docs/native-renderer/HIGH_LEVEL_RENDER_HOOKS.md
+++ b/docs/native-renderer/HIGH_LEVEL_RENDER_HOOKS.md
@@ -258,13 +258,23 @@ those gates are met, all work stays on Xenos and no new draw family may be
 suppressed.
 
 The constructor-provenance qualification identified four immediate caller
-functions covering every known-origin prepared draw. Static analysis now
-proves five constructor edges inside those functions and 32 exact direct
-callsites into them. The passive second-layer bridge in
-`INDIRECT_OWNER_PROVENANCE.md` captures those upstream return addresses and
-bounded entry arguments. Runtime qualification is still required before any
-of those callsites becomes an object or lifetime lead; all semantic identities
-remain unknown.
+functions covering every known-origin prepared draw. Static analysis proves
+five constructor edges inside those functions and 32 exact direct callsites
+into them. Session `20260829T152644Z-p16152` runtime-qualified the passive
+owner bridge with 390,818 balanced owner entries and exits, zero stack faults
+or constructor-to-owner mismatches, and 1,669,534 owner-origin draws resolved
+to ten live callsites. This is exact operational provenance, not object or
+lifetime identity; all semantic identities remain unknown.
+
+The next batched layer selects three producer functions behind 1,420,568 of
+those draws (85.1%). Static analysis proves seven direct calls into them and
+records bounded local argument leads. `INDIRECT_PRODUCER_PROVENANCE.md`
+defines the independent balanced stack, exact owner-to-producer join, and
+combined qualification gate. Session `20260829T155036Z-p13876` qualified that
+slice with 967,815 balanced producer entries and exits, zero stack faults or
+owner-to-producer mismatches, and 4,400,708 producer-origin draws resolved to
+five exact live caller edges. Semantic object and lifetime identity remains
+unknown.
 
 For all 38 direct adapter callsites, the same static inventory now records
 `r3-r10`'s last syntactic definition since the nearest intervening call. Simple

--- a/docs/native-renderer/INDIRECT_OWNER_PROVENANCE.md
+++ b/docs/native-renderer/INDIRECT_OWNER_PROVENANCE.md
@@ -120,6 +120,12 @@ This promotes owner-callsite provenance as an exact operational classifier.
 The observed argument variation supplies bounded leads for the next discovery
 batch, but still does not establish object identity or lifetime ownership.
 
+The next bounded layer selects the three producer functions responsible for
+85.1% of these owner-origin draws. Its seven direct caller edges and exact
+fail-closed propagation contract are documented in
+`INDIRECT_PRODUCER_PROVENANCE.md`. That layer does not reinterpret this
+qualified owner baseline or assign semantic identity.
+
 ## Safety boundary
 
 The hooks observe registers and packet addresses only. They read no guest

--- a/docs/native-renderer/INDIRECT_PRODUCER_PROVENANCE.md
+++ b/docs/native-renderer/INDIRECT_PRODUCER_PROVENANCE.md
@@ -1,0 +1,103 @@
+# Indirect-producer provenance
+
+This NR-05A milestone adds one exact upstream layer above the three dominant
+live indirect owners. In the preceding AppData qualification, those owner
+callsites accounted for 1,420,568 of 1,669,534 owner-origin draws (85.1%). The
+layer remains passive structural evidence: it does not identify a render
+family, object type, instance, resource lifetime, or suppression candidate.
+
+## Static producer graph
+
+The generated-title scanner proves seven direct calls into the selected
+producer functions:
+
+| Producer | Direct caller callsite(s) | Owner callsite | Prior draw coverage |
+| --- | --- | --- | ---: |
+| `8240D070` | `823EA6F0`, `8240CFFC` | `8240D1AC` -> `82409668` | 372,058 |
+| `82417060` | `82418A24`, `82418EC8`, `82437044`, `82DE8DBC` | `824170B8` -> `824167F8` | 493,307 |
+| `829F6360` | `829F67AC` | `829F6604` -> `829F5FF0` | 555,203 |
+
+Every edge records its exact callsite and return address. At each producer
+call, `r3` is copied from a nonvolatile register (`r31`, `r24`, `r25`, `r20`,
+or `r28`). Other locally visible `r4-r10` definitions are retained, while
+values crossing an intervening call remain explicitly unknown. These are
+bounded object/context leads only; no pointer validity, identity, type, or
+lifetime is inferred.
+
+## Runtime contract
+
+The selected producers have balanced entry and exit hooks. Entry captures the
+direct caller return address and `r3-r10` in an independent 32-entry
+thread-local stack. Exit pops only the matching producer. Entries, exits,
+open-at-shutdown invocations, overflow, underflow, and mismatches are counted.
+
+An owner inherits producer provenance only when its exact owner return address
+maps to one selected producer and the active producer function matches that
+static edge. Missing producer context remains absent; a wrong active producer
+is counted as a mismatch and fails closed. The producer function, return
+address, argument sample, and varying mask then follow the already exact
+owner, constructor, packet-generation, indirect-execution, and prepared-draw
+lineage. No recent or nearby context is substituted for an exact match.
+
+The bounded lineage key now contains constructor store and return, owner
+function and return, producer function and return, and indirect-buffer depth.
+Unknown values remain distinct and explicit.
+
+## Promotion gate
+
+The combined deterministic report requires:
+
+- balanced producer `entries = exits + open at shutdown` accounting;
+- zero producer stack faults and zero owner-to-producer mismatches;
+- exact static resolution for every runtime producer origin;
+- the existing owner, constructor, packet-generation, command-buffer, and
+  safety gates; and
+- explicit resolved, unresolved, and absent producer-origin coverage.
+
+## AppData qualification
+
+The completed batch was qualified once against the installed `0.1.0` AppData
+save in session `20260829T155036Z-p13876`, using Release executable SHA-256
+`6BF13B9169CC8EDA45661B51D27CA304CE311129FFF85500600FEF553B234B22`.
+The 380.52-second capture advanced through the title into the live festival
+scene and exited normally. Visual inspection confirmed the player car, crowd,
+stage structures, sky, lighting, HUD, and autoshow prompt remained intact.
+
+The deterministic report completed with:
+
+- 6,880,926 indirect draws and 6,463,454 prepared draws;
+- 967,815 balanced producer entries and exits, with zero open invocations and
+  zero producer stack faults;
+- zero owner-to-producer mismatches;
+- 4,400,708 producer-origin draws, all resolved to exact static constructor,
+  owner, producer, and producer-caller callsites;
+- zero unresolved producer-origin draws; and
+- zero invalid lineages, capacity overflow, packet-address failures, packet
+  table overflow, constructor faults, or owner faults.
+
+Five of the seven statically proved producer callsites fed live festival draws:
+
+| Producer | Live caller return | Static caller | Producer-origin draws |
+| --- | --- | --- | ---: |
+| `829F6360` | `829F67B0` | `829F6620` | 2,049,909 |
+| `82417060` | `82437048` | `824365B0` | 1,755,152 |
+| `8240D070` | `8240D000` | `8240CF68` | 499,163 |
+| `82417060` | `82418ECC` | `82417BC0` | 96,454 |
+| `82417060` | `82418A28` | `82417BC0` | 30 |
+
+The performance capture contained 11,968 samples, with a 30.143 FPS median,
+19.515 FPS one-percent low, 59.994 Hz host presentation cadence, one present
+deadline miss, and zero XMA stalls. The JSONL ended with `process.shutdown`;
+no fatal, crash, device-loss, assertion, unhandled-exception, or unexpected-
+shutdown marker was present.
+
+This qualifies producer-caller provenance as an exact operational classifier.
+The observed caller and argument variation can nominate a later object/lifetime
+investigation, but it does not establish semantic identity on its own.
+
+## Safety boundary
+
+The hooks observe registers and packet addresses only. They read no guest
+resource payload, mutate no guest state, alter no control flow, add no native
+draw, and expose no suppression API. Xenos remains authoritative and all
+semantic identities remain `unknown`.

--- a/src/native_renderer/graphics_hooks.cpp
+++ b/src/native_renderer/graphics_hooks.cpp
@@ -84,6 +84,7 @@ constexpr size_t kTitleIndirectPacketCapacity =
 constexpr size_t kTitleIndirectStackCapacity = 32;
 constexpr size_t kIndirectConstructorStackCapacity = 32;
 constexpr size_t kIndirectOwnerStackCapacity = 32;
+constexpr size_t kIndirectProducerStackCapacity = 32;
 constexpr uint64_t kSkyHorizonAnchorSignature = UINT64_C(0x747837906D0BF484);
 constexpr uint64_t kSkyHorizonFollowerSignature = UINT64_C(0x1D253A52B55C9FB3);
 std::atomic<uint64_t> g_frame_sequence{};
@@ -159,14 +160,24 @@ struct TitleIndirectPacketEntry {
   uint32_t owner_function_address = 0;
   uint32_t owner_return_address = 0;
   std::array<uint32_t, 8> owner_arguments{};
+  uint32_t producer_function_address = 0;
+  uint32_t producer_return_address = 0;
+  std::array<uint32_t, 8> producer_arguments{};
   uint64_t submission_sequence = 0;
   bool constructor_origin_known = false;
   bool owner_origin_known = false;
+  bool producer_origin_known = false;
   bool occupied = false;
 };
 
 struct IndirectConstructorOrigin {
   struct Owner {
+    struct Producer {
+      uint32_t function_address = 0;
+      uint32_t return_address = 0;
+      std::array<uint32_t, 8> arguments{};
+      bool valid = false;
+    } producer{};
     uint32_t function_address = 0;
     uint32_t return_address = 0;
     std::array<uint32_t, 8> arguments{};
@@ -239,9 +250,15 @@ uint64_t g_indirect_owner_exits = 0;
 uint64_t g_indirect_owner_stack_faults = 0;
 uint64_t g_indirect_constructors_without_owner_origin = 0;
 uint64_t g_indirect_constructor_owner_mismatches = 0;
+uint64_t g_indirect_producer_entries = 0;
+uint64_t g_indirect_producer_exits = 0;
+uint64_t g_indirect_producer_stack_faults = 0;
+uint64_t g_indirect_owners_without_producer_origin = 0;
+uint64_t g_indirect_owner_producer_mismatches = 0;
 std::atomic<uint64_t> g_title_indirect_buffers_open{};
 std::atomic<uint64_t> g_indirect_constructor_invocations_open{};
 std::atomic<uint64_t> g_indirect_owner_invocations_open{};
+std::atomic<uint64_t> g_indirect_producer_invocations_open{};
 thread_local TitleDrawOrigin g_pending_adapter_origin;
 thread_local std::array<TitleDrawOrigin, kTitleOriginStackCapacity>
     g_title_origin_stack;
@@ -259,6 +276,11 @@ thread_local std::array<IndirectConstructorOrigin::Owner,
     g_indirect_owner_stack;
 thread_local size_t g_indirect_owner_stack_depth = 0;
 thread_local size_t g_indirect_owner_stack_overflow_depth = 0;
+thread_local std::array<IndirectConstructorOrigin::Owner::Producer,
+                        kIndirectProducerStackCapacity>
+    g_indirect_producer_stack;
+thread_local size_t g_indirect_producer_stack_depth = 0;
+thread_local size_t g_indirect_producer_stack_overflow_depth = 0;
 
 const char *DispatchWrapperName(DispatchWrapper wrapper) {
   switch (wrapper) {
@@ -420,10 +442,16 @@ void ResetTitleDrawProvenance() {
   g_indirect_owner_stack_faults = 0;
   g_indirect_constructors_without_owner_origin = 0;
   g_indirect_constructor_owner_mismatches = 0;
+  g_indirect_producer_entries = 0;
+  g_indirect_producer_exits = 0;
+  g_indirect_producer_stack_faults = 0;
+  g_indirect_owners_without_producer_origin = 0;
+  g_indirect_owner_producer_mismatches = 0;
   g_title_indirect_buffers_open.store(0, std::memory_order_relaxed);
   g_indirect_constructor_invocations_open.store(0,
                                                 std::memory_order_relaxed);
   g_indirect_owner_invocations_open.store(0, std::memory_order_relaxed);
+  g_indirect_producer_invocations_open.store(0, std::memory_order_relaxed);
   g_pending_adapter_origin = {};
   g_title_origin_stack = {};
   g_title_origin_stack_depth = 0;
@@ -435,6 +463,9 @@ void ResetTitleDrawProvenance() {
   g_indirect_owner_stack = {};
   g_indirect_owner_stack_depth = 0;
   g_indirect_owner_stack_overflow_depth = 0;
+  g_indirect_producer_stack = {};
+  g_indirect_producer_stack_depth = 0;
+  g_indirect_producer_stack_overflow_depth = 0;
 }
 
 void ConfigureTitleDrawProvenance(bool census_requested,
@@ -467,6 +498,8 @@ void ConfigureTitleDrawProvenance(bool census_requested,
        {"constructor_stack_capacity",
         std::to_string(kIndirectConstructorStackCapacity)},
        {"owner_stack_capacity", std::to_string(kIndirectOwnerStackCapacity)},
+       {"producer_stack_capacity",
+        std::to_string(kIndirectProducerStackCapacity)},
        {"metadata",
         "origin_wrapper,entry_lr,r3-r10,outcome,backend_outcome,"
         "backend_signature"},
@@ -602,6 +635,74 @@ uint32_t ExpectedIndirectOwnerFunction(uint32_t constructor_function_address,
   return 0;
 }
 
+uint32_t ExpectedIndirectProducerFunction(uint32_t owner_function_address,
+                                          uint32_t owner_return_address) {
+  if (owner_function_address == 0x82409668 &&
+      owner_return_address == 0x8240D1B0) {
+    return 0x8240D070;
+  }
+  if (owner_function_address == 0x824167F8 &&
+      owner_return_address == 0x824170BC) {
+    return 0x82417060;
+  }
+  if (owner_function_address == 0x829F5FF0 &&
+      owner_return_address == 0x829F6608) {
+    return 0x829F6360;
+  }
+  return 0;
+}
+
+void PushIndirectProducerOrigin(uint32_t function_address,
+                                uint32_t return_address, uint32_t r3,
+                                uint32_t r4, uint32_t r5, uint32_t r6,
+                                uint32_t r7, uint32_t r8, uint32_t r9,
+                                uint32_t r10) {
+  if (!g_command_buffer_lineage_installed.load(std::memory_order_acquire)) {
+    return;
+  }
+  ++g_indirect_producer_entries;
+  if (g_indirect_producer_stack_depth == kIndirectProducerStackCapacity) {
+    ++g_indirect_producer_stack_faults;
+    ++g_indirect_producer_stack_overflow_depth;
+    return;
+  }
+  IndirectConstructorOrigin::Owner::Producer &producer =
+      g_indirect_producer_stack[g_indirect_producer_stack_depth++];
+  producer = {};
+  producer.function_address = function_address;
+  producer.return_address = return_address;
+  producer.arguments = {r3, r4, r5, r6, r7, r8, r9, r10};
+  producer.valid = true;
+  g_indirect_producer_invocations_open.fetch_add(
+      1, std::memory_order_relaxed);
+}
+
+void PopIndirectProducerOrigin(uint32_t function_address) {
+  if (!g_command_buffer_lineage_installed.load(std::memory_order_acquire)) {
+    return;
+  }
+  ++g_indirect_producer_exits;
+  if (g_indirect_producer_stack_overflow_depth) {
+    --g_indirect_producer_stack_overflow_depth;
+    return;
+  }
+  if (!g_indirect_producer_stack_depth) {
+    ++g_indirect_producer_stack_faults;
+    return;
+  }
+  if (g_indirect_producer_stack[g_indirect_producer_stack_depth - 1]
+          .function_address != function_address) {
+    ++g_indirect_producer_stack_faults;
+    g_indirect_producer_invocations_open.fetch_sub(
+        g_indirect_producer_stack_depth, std::memory_order_relaxed);
+    g_indirect_producer_stack_depth = 0;
+    return;
+  }
+  --g_indirect_producer_stack_depth;
+  g_indirect_producer_invocations_open.fetch_sub(
+      1, std::memory_order_relaxed);
+}
+
 void PushIndirectOwnerOrigin(uint32_t function_address,
                              uint32_t return_address, uint32_t r3,
                              uint32_t r4, uint32_t r5, uint32_t r6,
@@ -618,9 +719,26 @@ void PushIndirectOwnerOrigin(uint32_t function_address,
   }
   IndirectConstructorOrigin::Owner &owner =
       g_indirect_owner_stack[g_indirect_owner_stack_depth++];
+  owner = {};
   owner.function_address = function_address;
   owner.return_address = return_address;
   owner.arguments = {r3, r4, r5, r6, r7, r8, r9, r10};
+  const uint32_t expected_producer =
+      ExpectedIndirectProducerFunction(function_address, return_address);
+  if (expected_producer && g_indirect_producer_stack_depth) {
+    const IndirectConstructorOrigin::Owner::Producer &producer =
+        g_indirect_producer_stack[g_indirect_producer_stack_depth - 1];
+    if (producer.valid && producer.function_address == expected_producer) {
+      owner.producer = producer;
+    } else {
+      ++g_indirect_owner_producer_mismatches;
+    }
+  } else if (expected_producer) {
+    ++g_indirect_owner_producer_mismatches;
+  }
+  if (!owner.producer.valid) {
+    ++g_indirect_owners_without_producer_origin;
+  }
   owner.valid = true;
   g_indirect_owner_invocations_open.fetch_add(1,
                                                std::memory_order_relaxed);
@@ -790,9 +908,13 @@ void RecordTitleIndirectPacket(uint32_t packet_guest_address,
   entry.owner_function_address = origin.owner.function_address;
   entry.owner_return_address = origin.owner.return_address;
   entry.owner_arguments = origin.owner.arguments;
+  entry.producer_function_address = origin.owner.producer.function_address;
+  entry.producer_return_address = origin.owner.producer.return_address;
+  entry.producer_arguments = origin.owner.producer.arguments;
   entry.submission_sequence = ++g_title_indirect_packet_submission_sequence;
   entry.constructor_origin_known = origin.valid;
   entry.owner_origin_known = origin.owner.valid;
+  entry.producer_origin_known = origin.owner.producer.valid;
   entry.occupied = true;
   ++g_title_indirect_packets_recorded;
 }
@@ -862,6 +984,14 @@ void ObserveIndirectBuffer(
         matched.owner_return_address;
     active.constructor_origin.owner.arguments = matched.owner_arguments;
     active.constructor_origin.owner.valid = matched.owner_origin_known;
+    active.constructor_origin.owner.producer.function_address =
+        matched.producer_function_address;
+    active.constructor_origin.owner.producer.return_address =
+        matched.producer_return_address;
+    active.constructor_origin.owner.producer.arguments =
+        matched.producer_arguments;
+    active.constructor_origin.owner.producer.valid =
+        matched.producer_origin_known;
     active.depth = observation.depth;
     g_title_indirect_buffers_open.fetch_add(1, std::memory_order_relaxed);
     return;
@@ -1746,9 +1876,14 @@ struct CommandBufferLineageEntry {
   uint32_t owner_return_address = 0;
   std::array<uint32_t, 8> sample_owner_arguments{};
   uint32_t owner_argument_varying_mask = 0;
+  uint32_t producer_function_address = 0;
+  uint32_t producer_return_address = 0;
+  std::array<uint32_t, 8> sample_producer_arguments{};
+  uint32_t producer_argument_varying_mask = 0;
   uint32_t depth = 0;
   bool constructor_origin_known = false;
   bool owner_origin_known = false;
+  bool producer_origin_known = false;
   bool prepared_signature_varied = false;
 };
 
@@ -3237,6 +3372,8 @@ void RecordPreparedCommandBufferLineage(
         uint64_t(constructor_origin.return_address),
         uint64_t(constructor_origin.owner.function_address),
         uint64_t(constructor_origin.owner.return_address),
+        uint64_t(constructor_origin.owner.producer.function_address),
+        uint64_t(constructor_origin.owner.producer.return_address),
         uint64_t(observation.command_buffer_depth)}) {
     key = HashCombine(key, value);
   }
@@ -3277,6 +3414,14 @@ void RecordPreparedCommandBufferLineage(
       entry.owner_return_address = constructor_origin.owner.return_address;
       entry.sample_owner_arguments = constructor_origin.owner.arguments;
       entry.owner_origin_known = constructor_origin.owner.valid;
+      entry.producer_function_address =
+          constructor_origin.owner.producer.function_address;
+      entry.producer_return_address =
+          constructor_origin.owner.producer.return_address;
+      entry.sample_producer_arguments =
+          constructor_origin.owner.producer.arguments;
+      entry.producer_origin_known =
+          constructor_origin.owner.producer.valid;
       entry.depth = observation.command_buffer_depth;
       ++g_command_buffer_lineage_entry_count;
       return;
@@ -3286,6 +3431,10 @@ void RecordPreparedCommandBufferLineage(
         entry.owner_function_address ==
             constructor_origin.owner.function_address &&
         entry.owner_return_address == constructor_origin.owner.return_address &&
+        entry.producer_function_address ==
+            constructor_origin.owner.producer.function_address &&
+        entry.producer_return_address ==
+            constructor_origin.owner.producer.return_address &&
         entry.depth == observation.command_buffer_depth) {
       ++entry.calls;
       entry.last_frame = observation.frame_sequence;
@@ -3323,6 +3472,16 @@ void RecordPreparedCommandBufferLineage(
           if (entry.sample_owner_arguments[argument] !=
               constructor_origin.owner.arguments[argument]) {
             entry.owner_argument_varying_mask |= 1u << argument;
+          }
+        }
+      }
+      if (entry.producer_origin_known &&
+          constructor_origin.owner.producer.valid) {
+        for (size_t argument = 0;
+             argument < entry.sample_producer_arguments.size(); ++argument) {
+          if (entry.sample_producer_arguments[argument] !=
+              constructor_origin.owner.producer.arguments[argument]) {
+            entry.producer_argument_varying_mask |= 1u << argument;
           }
         }
       }
@@ -3417,6 +3576,27 @@ void EmitCommandBufferLineageSummary() {
               entry.sample_owner_arguments[6], entry.sample_owner_arguments[7])},
          {"owner_argument_varying_mask",
           fmt::format("{:02X}", entry.owner_argument_varying_mask)},
+         {"producer_function_address",
+          entry.producer_origin_known
+              ? fmt::format("{:08X}", entry.producer_function_address)
+              : "unknown"},
+         {"producer_return_address",
+          entry.producer_origin_known
+              ? fmt::format("{:08X}", entry.producer_return_address)
+              : "unknown"},
+         {"sample_producer_arguments",
+          fmt::format(
+              "{:08X},{:08X},{:08X},{:08X},{:08X},{:08X},{:08X},{:08X}",
+              entry.sample_producer_arguments[0],
+              entry.sample_producer_arguments[1],
+              entry.sample_producer_arguments[2],
+              entry.sample_producer_arguments[3],
+              entry.sample_producer_arguments[4],
+              entry.sample_producer_arguments[5],
+              entry.sample_producer_arguments[6],
+              entry.sample_producer_arguments[7])},
+         {"producer_argument_varying_mask",
+          fmt::format("{:02X}", entry.producer_argument_varying_mask)},
          {"depth", std::to_string(entry.depth)},
          {"guest_payload_read", "false"},
          {"guest_state_changed", "false"},
@@ -3479,6 +3659,19 @@ void EmitCommandBufferLineageSummary() {
         std::to_string(g_indirect_constructors_without_owner_origin)},
        {"indirect_constructor_owner_mismatches",
         std::to_string(g_indirect_constructor_owner_mismatches)},
+       {"indirect_producer_entries",
+        std::to_string(g_indirect_producer_entries)},
+       {"indirect_producer_exits",
+        std::to_string(g_indirect_producer_exits)},
+       {"indirect_producer_invocations_open_at_shutdown",
+        std::to_string(g_indirect_producer_invocations_open.load(
+            std::memory_order_relaxed))},
+       {"indirect_producer_stack_faults",
+        std::to_string(g_indirect_producer_stack_faults)},
+       {"indirect_owners_without_producer_origin",
+        std::to_string(g_indirect_owners_without_producer_origin)},
+       {"indirect_owner_producer_mismatches",
+        std::to_string(g_indirect_owner_producer_mismatches)},
        {"indirect_buffers_open_at_shutdown",
         std::to_string(g_title_indirect_buffers_open.load(
             std::memory_order_relaxed))},
@@ -5867,7 +6060,8 @@ void InstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system,
        {"capacity", std::to_string(kCommandBufferLineageCapacity)},
        {"source",
         "title_store,constructor_function,constructor_return,r3-r10,"
-        "owner_function,owner_return,owner_r3-r10,backend_packet,"
+        "owner_function,owner_return,owner_r3-r10,producer_function,"
+        "producer_return,producer_r3-r10,backend_packet,"
         "current_buffer,parent_packet,root_buffer,depth"},
        {"guest_payload_read", "false"},
        {"guest_state_changed", "false"},
@@ -6631,6 +6825,33 @@ PINYON_SHIFT_INDIRECT_OWNER_HOOKS(8246E8F8)
 PINYON_SHIFT_INDIRECT_OWNER_HOOKS(829F5FF0)
 
 #undef PINYON_SHIFT_INDIRECT_OWNER_HOOKS
+
+void ObserveIndirectProducerEntry(
+    uint32_t function_address, PPCRegister &r3, PPCRegister &r4,
+    PPCRegister &r5, PPCRegister &r6, PPCRegister &r7, PPCRegister &r8,
+    PPCRegister &r9, PPCRegister &r10, PPCRegister &r12) {
+  PushIndirectProducerOrigin(function_address, r12.u32, r3.u32, r4.u32,
+                             r5.u32, r6.u32, r7.u32, r8.u32, r9.u32,
+                             r10.u32);
+}
+
+#define PINYON_SHIFT_INDIRECT_PRODUCER_HOOKS(address)                          \
+  void PinyonShiftObserveIndirectProducer##address##Entry(                     \
+      PPCRegister &r3, PPCRegister &r4, PPCRegister &r5, PPCRegister &r6,      \
+      PPCRegister &r7, PPCRegister &r8, PPCRegister &r9, PPCRegister &r10,     \
+      PPCRegister &r12) {                                                       \
+    ObserveIndirectProducerEntry(0x##address, r3, r4, r5, r6, r7, r8, r9,     \
+                                 r10, r12);                                     \
+  }                                                                             \
+  void PinyonShiftObserveIndirectProducer##address##Exit() {                   \
+    PopIndirectProducerOrigin(0x##address);                                     \
+  }
+
+PINYON_SHIFT_INDIRECT_PRODUCER_HOOKS(8240D070)
+PINYON_SHIFT_INDIRECT_PRODUCER_HOOKS(82417060)
+PINYON_SHIFT_INDIRECT_PRODUCER_HOOKS(829F6360)
+
+#undef PINYON_SHIFT_INDIRECT_PRODUCER_HOOKS
 
 void PinyonShiftObserveIndirectPacket824095B4(PPCRegister &r11,
                                                PPCRegister &r28) {

--- a/tools/discover-native-renderer-dispatch.py
+++ b/tools/discover-native-renderer-dispatch.py
@@ -114,6 +114,11 @@ INDIRECT_OWNER_RUNTIME_HOOKS = {
     0x8246E8F8: {"entry": 0x8246E8FC, "exit": 0x8246E938},
     0x829F5FF0: {"entry": 0x829F5FF4, "exit": 0x829F6358},
 }
+INDIRECT_PRODUCER_RUNTIME_HOOKS = {
+    0x8240D070: {"entry": 0x8240D074, "exit": 0x8240D1F0},
+    0x82417060: {"entry": 0x82417064, "exit": 0x824170C0},
+    0x829F6360: {"entry": 0x829F6364, "exit": 0x829F63FC},
+}
 
 FUNCTION_RE = re.compile(r"^DEFINE_REX_FUNC\(sub_([0-9A-F]{8})\) \{")
 LABEL_RE = re.compile(r"^loc_([0-9A-F]{8}):")
@@ -483,6 +488,96 @@ def indirect_owner_runtime_hooks(functions_by_address: dict[int, dict]) -> list[
                 ],
                 "classification": "balanced_passive_constructor_owner",
                 "semantic_identity": "unknown",
+                "suppression_eligible": False,
+            }
+        )
+    return result
+
+
+def indirect_producer_calls(functions: list[dict]) -> list[dict]:
+    """Inventory direct callers of the dominant live owner-caller functions."""
+    calls = []
+    for function in functions:
+        for instruction in function["instructions"]:
+            match = CALL_RE.fullmatch(instruction["text"])
+            if not match:
+                continue
+            target = int(match.group(1), 16)
+            if target not in INDIRECT_PRODUCER_RUNTIME_HOOKS:
+                continue
+            calls.append(
+                {
+                    "producer_function": "sub_{:08X}".format(target),
+                    "producer_function_address": "{:08X}".format(target),
+                    "caller_function": function["name"],
+                    "caller_function_address": "{:08X}".format(
+                        function["address"]
+                    ),
+                    "callsite": "{:08X}".format(instruction["address"]),
+                    "return_address": "{:08X}".format(
+                        instruction["address"] + 4
+                    ),
+                    "classification": "direct_static_producer_callsite",
+                    "semantic_identity": "unknown",
+                    "object_identity_proved": False,
+                    "lifetime_proved": False,
+                    "suppression_eligible": False,
+                }
+            )
+    return sorted(
+        calls,
+        key=lambda item: (
+            item["producer_function_address"], item["callsite"]
+        ),
+    )
+
+
+def indirect_producer_runtime_hooks(
+    functions_by_address: dict[int, dict]
+) -> list[dict]:
+    """Prove balanced passive hooks for the dominant owner producers."""
+    observed_known = set(functions_by_address) & set(
+        INDIRECT_PRODUCER_RUNTIME_HOOKS
+    )
+    if observed_known and observed_known != set(INDIRECT_PRODUCER_RUNTIME_HOOKS):
+        raise ValueError("known indirect-producer function set drifted")
+    result = []
+    for address in sorted(observed_known):
+        hooks = INDIRECT_PRODUCER_RUNTIME_HOOKS[address]
+        function = functions_by_address[address]
+        instructions = function["instructions"]
+        exit_instruction = next(
+            (
+                item for item in instructions
+                if item["address"] == hooks["exit"]
+            ),
+            None,
+        )
+        if (
+            not instructions
+            or instructions[0] != {"address": address, "text": "mflr r12"}
+            or hooks["entry"] != address + 4
+            or exit_instruction is None
+            or not exit_instruction["text"].startswith("addi r1,r1,")
+        ):
+            raise ValueError(
+                "indirect-producer balanced hook evidence drifted: "
+                "{:08X}".format(address)
+            )
+        result.append(
+            {
+                "function": function["name"],
+                "function_address": "{:08X}".format(address),
+                "entry_hook_address": "{:08X}".format(hooks["entry"]),
+                "exit_hook_address": "{:08X}".format(hooks["exit"]),
+                "caller_lr_register": "r12_after_opening_mflr",
+                "entry_metadata": [
+                    "r3", "r4", "r5", "r6", "r7", "r8", "r9", "r10"
+                ],
+                "classification": "balanced_passive_owner_producer",
+                "semantic_identity": "unknown",
+                "object_identity_proved": False,
+                "lifetime_proved": False,
                 "suppression_eligible": False,
             }
         )
@@ -1039,11 +1134,16 @@ def build(paths: list[pathlib.Path]) -> dict:
     )
     owner_calls = indirect_owner_calls(functions)
     owner_hooks = indirect_owner_runtime_hooks(functions_by_address)
+    producer_calls = indirect_producer_calls(functions)
+    producer_hooks = indirect_producer_runtime_hooks(functions_by_address)
     constructor_argument_leads = argument_leads_for_calls(
         functions, constructor_calls, "constructor_function_address"
     )
     owner_argument_leads = argument_leads_for_calls(
         functions, owner_calls, "owner_function_address"
+    )
+    producer_argument_leads = argument_leads_for_calls(
+        functions, producer_calls, "producer_function_address"
     )
     constructor_evidence = {
         (int(item["function_address"], 16), int(item["opcode_value"], 16))
@@ -1136,6 +1236,9 @@ def build(paths: list[pathlib.Path]) -> dict:
         "indirect_owner_calls": owner_calls,
         "indirect_owner_runtime_hooks": owner_hooks,
         "indirect_owner_argument_leads": owner_argument_leads,
+        "indirect_producer_calls": producer_calls,
+        "indirect_producer_runtime_hooks": producer_hooks,
+        "indirect_producer_argument_leads": producer_argument_leads,
         "reviewed_wrappers": [
             {
                 "address": "{:08X}".format(address),
@@ -1199,6 +1302,11 @@ def build(paths: list[pathlib.Path]) -> dict:
             "indirect_owner_calls": len(owner_calls),
             "indirect_owner_runtime_hooks": len(owner_hooks),
             "indirect_owner_argument_leads": len(owner_argument_leads),
+            "indirect_producer_calls": len(producer_calls),
+            "indirect_producer_runtime_hooks": len(producer_hooks),
+            "indirect_producer_argument_leads": len(
+                producer_argument_leads
+            ),
             "reviewed_wrappers": len(REVIEWED_WRAPPERS),
             "direct_calls": len(calls),
             "tail_forwarded_calls": len(forwarded_calls),

--- a/tools/summarize-native-renderer-command-lineage.py
+++ b/tools/summarize-native-renderer-command-lineage.py
@@ -128,6 +128,14 @@ def build(events: list[dict], static: dict, requested: str | None = None) -> dic
         ): item
         for item in static_owner_calls
     }
+    static_producer_calls = static.get("indirect_producer_calls", [])
+    producer_calls_by_return = {
+        (
+            str(item.get("producer_function_address", "")).upper(),
+            str(item.get("return_address", "")).upper(),
+        ): item
+        for item in static_producer_calls
+    }
 
     session = select_session(events, requested)
     selected = [event for event in events if event.get("session") == session]
@@ -290,6 +298,40 @@ def build(events: list[dict], static: dict, requested: str | None = None) -> dic
             owner_argument_varying_mask = int(
                 _hex(event, "owner_argument_varying_mask", 2), 16
             )
+        producer_function_address = _optional_hex(
+            event, "producer_function_address", 8
+        )
+        producer_return_address = _optional_hex(
+            event, "producer_return_address", 8
+        )
+        if (producer_function_address is None) != (
+            producer_return_address is None
+        ):
+            raise ValueError("lineage entry has a partial producer origin")
+        producer_call = None
+        producer_arguments = None
+        producer_argument_varying_mask = None
+        if producer_function_address is not None:
+            if owner_call is None:
+                raise ValueError(
+                    "lineage entry has a producer without a proved owner caller"
+                )
+            if (
+                str(owner_call.get("caller_function_address", "")).upper()
+                != producer_function_address
+            ):
+                raise ValueError(
+                    "lineage producer does not contain the owner callsite"
+                )
+            producer_call = producer_calls_by_return.get(
+                (producer_function_address, producer_return_address)
+            )
+            producer_arguments = _hex_arguments(
+                event, "sample_producer_arguments"
+            )
+            producer_argument_varying_mask = int(
+                _hex(event, "producer_argument_varying_mask", 2), 16
+            )
         if depth:
             if parent_value >= PHYSICAL_APERTURE_SIZE or parent_value & 3:
                 raise ValueError("indirect lineage entry has no valid parent packet")
@@ -402,6 +444,28 @@ def build(events: list[dict], static: dict, requested: str | None = None) -> dic
                 "owner_callsite_proved": owner_call is not None,
                 "sample_owner_arguments": owner_arguments,
                 "owner_argument_varying_mask": owner_argument_varying_mask,
+                "producer_function_address": producer_function_address,
+                "producer_return_address": producer_return_address,
+                "producer_callsite": (
+                    producer_call.get("callsite")
+                    if producer_call is not None
+                    else None
+                ),
+                "producer_caller_function": (
+                    producer_call.get("caller_function")
+                    if producer_call is not None
+                    else None
+                ),
+                "producer_caller_function_address": (
+                    producer_call.get("caller_function_address")
+                    if producer_call is not None
+                    else None
+                ),
+                "producer_callsite_proved": producer_call is not None,
+                "sample_producer_arguments": producer_arguments,
+                "producer_argument_varying_mask": (
+                    producer_argument_varying_mask
+                ),
                 "depth": depth,
             }
         )
@@ -416,6 +480,7 @@ def build(events: list[dict], static: dict, requested: str | None = None) -> dic
             item["constructor_store_address"] or "",
             item["constructor_return_address"] or "",
             item["owner_return_address"] or "",
+            item["producer_return_address"] or "",
         )
     )
 
@@ -467,6 +532,20 @@ def build(events: list[dict], static: dict, requested: str | None = None) -> dic
     constructor_owner_mismatches = _integer(
         summary, "indirect_constructor_owner_mismatches"
     )
+    producer_entries = _integer(summary, "indirect_producer_entries")
+    producer_exits = _integer(summary, "indirect_producer_exits")
+    producer_open = _integer(
+        summary, "indirect_producer_invocations_open_at_shutdown"
+    )
+    producer_stack_faults = _integer(
+        summary, "indirect_producer_stack_faults"
+    )
+    owners_without_producer_origin = _integer(
+        summary, "indirect_owners_without_producer_origin"
+    )
+    owner_producer_mismatches = _integer(
+        summary, "indirect_owner_producer_mismatches"
+    )
     open_at_shutdown = _integer(
         summary, "indirect_buffers_open_at_shutdown"
     )
@@ -495,6 +574,9 @@ def build(events: list[dict], static: dict, requested: str | None = None) -> dic
         and owner_entries == owner_exits + owner_open
         and not owner_stack_faults
         and not constructor_owner_mismatches
+        and producer_entries == producer_exits + producer_open
+        and not producer_stack_faults
+        and not owner_producer_mismatches
         and (
             not static_constructor_calls
             or (
@@ -511,6 +593,16 @@ def build(events: list[dict], static: dict, requested: str | None = None) -> dic
                 owner_entries > 0
                 and any(
                     item["owner_return_address"] is not None
+                    for item in entries
+                )
+            )
+        )
+        and (
+            not static_producer_calls
+            or (
+                producer_entries > 0
+                and any(
+                    item["producer_return_address"] is not None
                     for item in entries
                 )
             )
@@ -570,6 +662,23 @@ def build(events: list[dict], static: dict, requested: str | None = None) -> dic
                 "owner_argument_varying_mask": entry[
                     "owner_argument_varying_mask"
                 ],
+                "producer_function_address": entry[
+                    "producer_function_address"
+                ],
+                "producer_return_address": entry["producer_return_address"],
+                "producer_callsite": entry["producer_callsite"],
+                "producer_caller_function": entry[
+                    "producer_caller_function"
+                ],
+                "producer_callsite_proved": entry[
+                    "producer_callsite_proved"
+                ],
+                "sample_producer_arguments": entry[
+                    "sample_producer_arguments"
+                ],
+                "producer_argument_varying_mask": entry[
+                    "producer_argument_varying_mask"
+                ],
                 "depth": entry["depth"],
                 "sample_prepared_signature": entry[
                     "sample_prepared_signature"
@@ -591,6 +700,7 @@ def build(events: list[dict], static: dict, requested: str | None = None) -> dic
             item["constructor_store_address"] or "",
             item["constructor_return_address"] or "",
             item["owner_return_address"] or "",
+            item["producer_return_address"] or "",
         )
     )
 
@@ -604,6 +714,7 @@ def build(events: list[dict], static: dict, requested: str | None = None) -> dic
         "static_indirect_buffer_constructors": constructors,
         "static_indirect_constructor_calls": static_constructor_calls,
         "static_indirect_owner_calls": static_owner_calls,
+        "static_indirect_producer_calls": static_producer_calls,
         "totals": {
             "draws": draws,
             "primary_draws": primary_draws,
@@ -647,6 +758,16 @@ def build(events: list[dict], static: dict, requested: str | None = None) -> dic
             "indirect_constructor_owner_mismatches": (
                 constructor_owner_mismatches
             ),
+            "indirect_producer_entries": producer_entries,
+            "indirect_producer_exits": producer_exits,
+            "indirect_producer_invocations_open_at_shutdown": producer_open,
+            "indirect_producer_stack_faults": producer_stack_faults,
+            "indirect_owners_without_producer_origin": (
+                owners_without_producer_origin
+            ),
+            "indirect_owner_producer_mismatches": (
+                owner_producer_mismatches
+            ),
             "indirect_buffers_open_at_shutdown": open_at_shutdown,
             "constructor_origin_draws": sum(
                 item["calls"]
@@ -677,6 +798,22 @@ def build(events: list[dict], static: dict, requested: str | None = None) -> dic
                 for item in entries
                 if item["owner_return_address"] is not None
                 and not item["owner_callsite_proved"]
+            ),
+            "producer_origin_draws": sum(
+                item["calls"]
+                for item in entries
+                if item["producer_return_address"] is not None
+            ),
+            "statically_resolved_producer_origin_draws": sum(
+                item["calls"]
+                for item in entries
+                if item["producer_callsite_proved"]
+            ),
+            "unresolved_producer_origin_draws": sum(
+                item["calls"]
+                for item in entries
+                if item["producer_return_address"] is not None
+                and not item["producer_callsite_proved"]
             ),
         },
         "qualification": "exact_title_store_to_backend_nested_command_buffer_lineage",

--- a/tools/tests/test_native_renderer_command_lineage.py
+++ b/tools/tests/test_native_renderer_command_lineage.py
@@ -351,6 +351,114 @@ class NativeRendererCommandLineageTests(unittest.TestCase):
             12, document["totals"]["statically_resolved_owner_origin_draws"]
         )
 
+    def test_maps_balanced_producer_origin_to_static_caller(self):
+        static = static_inventory()
+        static["indirect_constructor_calls"] = [
+            {
+                "constructor_function_address": "82409398",
+                "caller_function": "sub_82409668",
+                "caller_function_address": "82409668",
+                "callsite": "82409834",
+                "return_address": "82409838",
+            }
+        ]
+        static["indirect_owner_calls"] = [
+            {
+                "owner_function_address": "82409668",
+                "caller_function": "sub_8240D070",
+                "caller_function_address": "8240D070",
+                "callsite": "8240D1AC",
+                "return_address": "8240D1B0",
+            }
+        ]
+        static["indirect_producer_calls"] = [
+            {
+                "producer_function_address": "8240D070",
+                "caller_function": "sub_8240CF68",
+                "caller_function_address": "8240CF68",
+                "callsite": "8240CFFC",
+                "return_address": "8240D000",
+            }
+        ]
+        traced = events()
+        traced[1].update(
+            {
+                "constructor_function_address": "82409398",
+                "constructor_return_address": "82409838",
+                "sample_constructor_arguments": "00000000," * 7 + "00000000",
+                "constructor_argument_varying_mask": "00",
+                "owner_function_address": "82409668",
+                "owner_return_address": "8240D1B0",
+                "sample_owner_arguments": "00000000," * 7 + "00000000",
+                "owner_argument_varying_mask": "00",
+                "producer_function_address": "8240D070",
+                "producer_return_address": "8240D000",
+                "sample_producer_arguments": (
+                    "10000000,20000000,00000001,00000000,00000000,"
+                    "00000000,00000000,00000000"
+                ),
+                "producer_argument_varying_mask": "03",
+            }
+        )
+        traced[-1].update(
+            {
+                "indirect_constructor_entries": "1",
+                "indirect_constructor_exits": "1",
+                "indirect_owner_entries": "1",
+                "indirect_owner_exits": "1",
+                "indirect_producer_entries": "1",
+                "indirect_producer_exits": "1",
+                "indirect_owner_producer_mismatches": "0",
+            }
+        )
+        document = MODULE.build(traced, static)
+        self.assertEqual("complete", document["status"])
+        shape = document["shapes"][0]
+        self.assertEqual("8240CFFC", shape["producer_callsite"])
+        self.assertEqual("sub_8240CF68", shape["producer_caller_function"])
+        self.assertEqual(3, shape["producer_argument_varying_mask"])
+        self.assertEqual(12, document["totals"]["producer_origin_draws"])
+        self.assertEqual(
+            12,
+            document["totals"]["statically_resolved_producer_origin_draws"],
+        )
+
+    def test_rejects_producer_that_does_not_contain_owner_callsite(self):
+        static = static_inventory()
+        static["indirect_constructor_calls"] = [
+            {
+                "constructor_function_address": "82409398",
+                "caller_function_address": "82409668",
+                "return_address": "82409838",
+            }
+        ]
+        static["indirect_owner_calls"] = [
+            {
+                "owner_function_address": "82409668",
+                "caller_function_address": "8240D070",
+                "return_address": "8240D1B0",
+            }
+        ]
+        traced = events()
+        traced[1].update(
+            {
+                "constructor_function_address": "82409398",
+                "constructor_return_address": "82409838",
+                "sample_constructor_arguments": "00000000," * 7 + "00000000",
+                "constructor_argument_varying_mask": "00",
+                "owner_function_address": "82409668",
+                "owner_return_address": "8240D1B0",
+                "sample_owner_arguments": "00000000," * 7 + "00000000",
+                "owner_argument_varying_mask": "00",
+                "producer_function_address": "829F6360",
+                "producer_return_address": "829F67B0",
+                "sample_producer_arguments": "00000000," * 7 + "00000000",
+                "producer_argument_varying_mask": "00",
+            }
+        )
+        with self.assertRaisesRegex(ValueError, "does not contain"):
+            MODULE.build(traced, static)
+
     def test_rejects_owner_that_does_not_contain_constructor_callsite(self):
         static = static_inventory()
         static["indirect_constructor_calls"] = [

--- a/tools/tests/test_native_renderer_contract.py
+++ b/tools/tests/test_native_renderer_contract.py
@@ -339,6 +339,10 @@ class NativeRendererContractTests(unittest.TestCase):
         self.assertIn("owner_return_address", source)
         self.assertIn("indirect_owner_stack_faults", source)
         self.assertIn("indirect_constructor_owner_mismatches", source)
+        self.assertIn("kIndirectProducerStackCapacity = 32", source)
+        self.assertIn("producer_return_address", source)
+        self.assertIn("indirect_producer_stack_faults", source)
+        self.assertIn("indirect_owner_producer_mismatches", source)
         self.assertIn("SetIndirectBufferObserver(&ObserveIndirectBuffer)", source)
         self.assertIn("SetIndirectBufferObserver(nullptr)", source)
         self.assertIn(

--- a/tools/tests/test_native_renderer_dispatch_discovery.py
+++ b/tools/tests/test_native_renderer_dispatch_discovery.py
@@ -245,6 +245,41 @@ def owner_fixtures():
     ]
 
 
+def producer_fixtures():
+    return [
+        fixture(
+            0x8240D070,
+            [
+                "mflr r12",
+                "bl 0x82409668",
+                "loc_8240D1F0:",
+                "addi r1,r1,128",
+                "b 0x82a7de58",
+            ],
+        ),
+        fixture(
+            0x82417060,
+            [
+                "mflr r12",
+                "bl 0x824167f8",
+                "loc_824170C0:",
+                "addi r1,r1,96",
+                "blr",
+            ],
+        ),
+        fixture(
+            0x829F6360,
+            [
+                "mflr r12",
+                "bl 0x829f5ff0",
+                "loc_829F63FC:",
+                "addi r1,r1,128",
+                "b 0x82a7de54",
+            ],
+        ),
+    ]
+
+
 class NativeRendererDispatchDiscoveryTests(unittest.TestCase):
     def build(self, chunks):
         with tempfile.TemporaryDirectory() as directory:
@@ -436,6 +471,43 @@ class NativeRendererDispatchDiscoveryTests(unittest.TestCase):
         )
         self.assertFalse(lead["suppression_eligible"])
 
+    def test_inventories_balanced_dominant_producer_layer(self):
+        callers = [
+            fixture(0x83010000, ["lwz r3,40(r31)", "bl 0x8240d070"]),
+            fixture(0x83020000, ["bl 0x82417060"]),
+            fixture(0x83030000, ["bl 0x829f6360"]),
+        ]
+        document = self.build(
+            [*reviewed_fixtures(), *producer_fixtures(), *callers]
+        )
+        self.assertEqual(3, document["totals"]["indirect_producer_runtime_hooks"])
+        self.assertEqual(3, document["totals"]["indirect_producer_calls"])
+        self.assertEqual(
+            3, document["totals"]["indirect_producer_argument_leads"]
+        )
+        hooks = {
+            item["function_address"]: item
+            for item in document["indirect_producer_runtime_hooks"]
+        }
+        self.assertEqual("829F63FC", hooks["829F6360"]["exit_hook_address"])
+        call = next(
+            item
+            for item in document["indirect_producer_calls"]
+            if item["producer_function_address"] == "8240D070"
+        )
+        self.assertEqual("83010004", call["callsite"])
+        lead = next(
+            item
+            for item in document["indirect_producer_argument_leads"]
+            if item["producer_function_address"] == "8240D070"
+        )
+        self.assertEqual(
+            {"base_register": "r31", "offset": 40, "width": "lwz"},
+            lead["arguments"][0]["memory_load"],
+        )
+        self.assertFalse(call["object_identity_proved"])
+        self.assertFalse(call["lifetime_proved"])
+
     def test_runtime_hooks_are_default_off_bounded_and_passive(self):
         hooks = (ROOT / "src/native_renderer/graphics_hooks.cpp").read_text(
             encoding="utf-8"
@@ -527,6 +599,25 @@ class NativeRendererDispatchDiscoveryTests(unittest.TestCase):
                 ),
                 1,
             )
+        for function, entry, exit_address in (
+            ("8240D070", "8240D074", "8240D1F0"),
+            ("82417060", "82417064", "824170C0"),
+            ("829F6360", "829F6364", "829F63FC"),
+        ):
+            self.assertIn(f"address = 0x{entry}", analysis)
+            self.assertIn(f"address = 0x{exit_address}", analysis)
+            self.assertEqual(
+                analysis.count(
+                    f'name = "PinyonShiftObserveIndirectProducer{function}Entry"'
+                ),
+                1,
+            )
+            self.assertEqual(
+                analysis.count(
+                    f'name = "PinyonShiftObserveIndirectProducer{function}Exit"'
+                ),
+                1,
+            )
         self.assertEqual(
             analysis.count('name = "PinyonShiftObserveVizQueryBeginDispatch"'),
             1,
@@ -574,7 +665,7 @@ class NativeRendererDispatchDiscoveryTests(unittest.TestCase):
                 'registers = ["r3", "r4", "r5", "r6", "r7", "r8", '
                 '"r9", "r10", "r12"]'
             ),
-            20,
+            23,
         )
         self.assertIn(
             "REX_PINYON_SHIFT_NATIVE_RENDERER_DISPATCH_DISCOVERY", capture


### PR DESCRIPTION
## Summary
- trace the exact caller layer above the three dominant indirect-owner producers
- propagate producer function, return, and bounded argument metadata through exact packet and command-buffer lineage
- preserve Xenos authority, explicit unknown provenance, and no-suppression safety gates

## Validation
- 57 focused tests pass
- Release preview build succeeds
- AppData session \20260829T155036Z-p13876\ exits normally after a 380.5 s capture
- 967,815 producer entries/exits balance with zero stack faults or owner-to-producer mismatches
- 4,400,708 producer-origin draws resolve to five exact live caller edges, with zero unresolved origins
- median 30.143 FPS; 19.515 FPS 1% low
- live festival visual inspection retains car, crowd, structures, HUD, lighting, sky, and event prompt