### PR TITLE
feat(native-renderer): prove indirect context roots

### DIFF
--- a/config/rexglue/analysis/main-xex.toml
+++ b/config/rexglue/analysis/main-xex.toml
@@ -168,6 +168,46 @@ registers = ["r3", "r4", "r5", "r6", "r7", "r8", "r9", "r10", "r12"]
 address = 0x829F63FC
 name = "PinyonShiftObserveIndirectProducer829F6360Exit"
 
+# Balanced passive context scopes for the four functions behind the five live
+# producer callsites. Entries retain the caller LR and r3-r10; exits are the
+# proved common stack-restoration points. Runtime checks verify only the exact
+# statically derived producer root. Object lifetime and semantics remain unknown.
+[[midasm_hook]]
+address = 0x8240CF6C
+name = "PinyonShiftObserveIndirectContext8240CF68Entry"
+registers = ["r3", "r4", "r5", "r6", "r7", "r8", "r9", "r10", "r12"]
+
+[[midasm_hook]]
+address = 0x8240D054
+name = "PinyonShiftObserveIndirectContext8240CF68Exit"
+
+[[midasm_hook]]
+address = 0x82417BC4
+name = "PinyonShiftObserveIndirectContext82417BC0Entry"
+registers = ["r3", "r4", "r5", "r6", "r7", "r8", "r9", "r10", "r12"]
+
+[[midasm_hook]]
+address = 0x82418F38
+name = "PinyonShiftObserveIndirectContext82417BC0Exit"
+
+[[midasm_hook]]
+address = 0x824365B4
+name = "PinyonShiftObserveIndirectContext824365B0Entry"
+registers = ["r3", "r4", "r5", "r6", "r7", "r8", "r9", "r10", "r12"]
+
+[[midasm_hook]]
+address = 0x82437048
+name = "PinyonShiftObserveIndirectContext824365B0Exit"
+
+[[midasm_hook]]
+address = 0x829F6624
+name = "PinyonShiftObserveIndirectContext829F6620Entry"
+registers = ["r3", "r4", "r5", "r6", "r7", "r8", "r9", "r10", "r12"]
+
+[[midasm_hook]]
+address = 0x829F67B8
+name = "PinyonShiftObserveIndirectContext829F6620Exit"
+
 [[midasm_hook]]
 address = 0x824095B4
 name = "PinyonShiftObserveIndirectPacket824095B4"

--- a/docs/native-renderer/COMMAND_BUFFER_LINEAGE.md
+++ b/docs/native-renderer/COMMAND_BUFFER_LINEAGE.md
@@ -52,15 +52,19 @@ fall within the reported current-buffer bounds or the lineage is invalid.
 Pinyon validates the exact addresses, current-buffer length, and packet offset
 on every draw, then aggregates a stable ownership-class key in a fixed
 4,096-entry table: nesting depth, exact constructor store and return address,
-plus the exact upstream owner and producer function and return addresses when
-those are matched. Balanced entry/exit hooks on all six constructor functions
+plus the exact upstream owner, producer, and context function and return
+addresses when those are matched. Balanced entry/exit hooks on all six
+constructor functions
 carry the direct caller return address and bounded `r3-r10` entry metadata into
 the exact stored packet generation. A second balanced layer covers the four
 immediate constructor callers that produced every known-origin draw in the first
 qualification. A third balanced layer covers the three producer functions
 responsible for 85.1% of the owner-origin draws in the owner qualification.
-Each class retains statically resolved constructor, owner, and producer
-callsites when proved, independent argument samples and varying masks, and
+The fourth layer covers the four functions behind the five live producer
+caller edges. It verifies an exact entry-register-plus-offset equation for
+producer `r3` before retaining context provenance. Each class retains
+statically resolved constructor, owner, producer, and context roots when
+proved, independent argument samples and varying masks, and
 minimum and maximum current-buffer lengths, packet
 offsets, and parent-packet offsets from the first indirect root, plus a first
 prepared-signature sample and whether that signature varied. Absolute current,
@@ -145,3 +149,11 @@ The exact owner layer is documented and runtime-qualified in
 runtime-qualified its balanced accounting and resolved 4,400,708 producer-
 origin draws to five exact live caller edges. Neither refinement changes the
 qualified constructor baseline.
+
+The exact live caller-root refinement is documented in
+`INDIRECT_CONTEXT_ROOTS.md`. It adds balanced context accounting and exact
+static/runtime root-equation gates without interpreting the root as an object
+identity. Session `20260829T162653Z-p41196` runtime-qualified 5,311,650 exact
+context-origin draws with zero unresolved origins, stack faults, join faults,
+invalid lineages, or overflow. It remains metadata-only, Xenos-authoritative,
+and suppression-ineligible.

--- a/docs/native-renderer/HIGH_LEVEL_RENDER_HOOKS.md
+++ b/docs/native-renderer/HIGH_LEVEL_RENDER_HOOKS.md
@@ -276,6 +276,13 @@ owner-to-producer mismatches, and 4,400,708 producer-origin draws resolved to
 five exact live caller edges. Semantic object and lifetime identity remains
 unknown.
 
+Those five live edges now have four proved caller scopes and exact producer
+root equations. `INDIRECT_CONTEXT_ROOTS.md` specifies the balanced passive
+hooks and the fail-closed runtime join: context function, producer return, and
+the entry-register-plus-offset root must all match producer `r3`. This narrows
+the next object/lifetime investigation without claiming a type, instance,
+registration, destruction, or suppression candidate.
+
 For all 38 direct adapter callsites, the same static inventory now records
 `r3-r10`'s last syntactic definition since the nearest intervening call. Simple
 loads retain base register, offset, and width; values crossing a call boundary

--- a/docs/native-renderer/INDIRECT_CONTEXT_ROOTS.md
+++ b/docs/native-renderer/INDIRECT_CONTEXT_ROOTS.md
@@ -1,0 +1,109 @@
+# Indirect context roots
+
+This NR-05A milestone turns the five live producer-caller leads into exact
+invocation-root evidence. It does not identify an engine object, class,
+render family, owner, registration, or lifetime. The new layer is passive,
+Xenos-authoritative, and suppression-ineligible.
+
+## Static root equations
+
+The generated-title scanner proves four balanced caller scopes and five exact
+edges into the selected indirect producers:
+
+| Context function | Producer return | Producer | Exact producer `r3` root |
+| --- | --- | --- | --- |
+| `8240CF68` | `8240D000` | `8240D070` | context-entry `r3` |
+| `82417BC0` | `82418A28` | `82417060` | context-entry `r6 + 59712` |
+| `82417BC0` | `82418ECC` | `82417060` | context-entry `r6 + 59712` |
+| `824365B0` | `82437048` | `82417060` | context-entry `r3 + 59712` |
+| `829F6620` | `829F67B0` | `829F6360` | context-entry `r3` |
+
+Every row is tied to an exact `bl` instruction immediately before the listed
+producer return address. The scanner also verifies the instructions that
+preserve the entry register, apply the offset, and restore the value into
+producer `r3`. A changed call target, preservation sequence, stack restore,
+entry ABI, or root equation rejects the static inventory.
+
+The `59712` offset is the exact PowerPC result of `addis ...,1` followed by
+`addi ...,-5824`. It is structural address evidence only. Naming the base or
+derived address as a particular engine type would require independent
+constructor, registration, use, and destruction evidence.
+
+## Runtime contract
+
+The four context functions have independent 32-entry thread-local stacks.
+Entry captures caller `LR` and `r3-r10`; exit pops only the same function at
+its proved common stack-restoration point. The runtime derives the expected
+root from the captured entry register and offset.
+
+A selected producer inherits a context only when all of these facts match:
+
+- its exact producer function and return address map to a static root row;
+- the active context function equals that row's function; and
+- producer-entry `r3` equals the derived context root.
+
+Missing, wrong, partial, unbalanced, or overflowed context stays absent and is
+counted. No recent invocation, nearby address, or frequency heuristic can
+substitute for the exact join.
+
+All constructor, owner, producer, and context aggregate counters use relaxed
+atomics. Their per-invocation stacks remain thread-local. This prevents lost
+cross-thread increments from manufacturing an unbalanced qualification result
+without adding ordering or control-flow semantics to the observer.
+
+Matched context function, caller return, `r3-r10` sample, varying mask, and
+derived root follow the existing producer, owner, constructor, exact packet
+generation, nested command-buffer execution, and prepared-draw lineage. The
+bounded lineage key includes context function and caller return, but excludes
+the absolute root address because frame-local instances may rotate. The report
+still retains one root sample and whether it varied.
+
+## Qualification gate
+
+The combined deterministic report requires:
+
+- balanced context `entries = exits + open at shutdown` accounting;
+- zero context stack faults and zero producer-to-context mismatches;
+- at least one exact runtime context origin when static context roots exist;
+- equality between the static root equation, captured context arguments,
+  captured root, and producer-entry `r3`;
+- exact static resolution for every reported context origin; and
+- every existing producer, owner, constructor, packet-generation,
+  command-buffer, Xenos-authority, and no-suppression gate.
+
+Resolved, unresolved, and absent context-origin draw coverage is reported
+separately. A visually correct frame cannot override a failed structural gate.
+
+## Safety and semantic boundary
+
+The hooks observe registers and already-tracked packet addresses only. They
+read no guest resource payload, mutate no guest state, change no control flow,
+issue no native draw, and expose no suppression API. Xenos performs and
+presents the authoritative work.
+
+This milestone proves an invocation scope and an exact root derivation for the
+five live producer edges. It does **not** prove pointer validity, object type,
+object identity, ownership, construction, registration, destruction, or
+cross-frame lifetime. NR-05A must establish those independently before any
+semantic extraction or native batching decision.
+
+## Runtime qualification — 2026-08-29
+
+Release executable
+`FEC1BECD5E05ED7C4B89FEF55CBED8D6D53D5418F35F6D15883345979FCCCD1D`
+loaded the installed `0.1.0` AppData save into the live festival scene. Session
+`20260829T162653Z-p41196` exited normally after a 162.653-second capture with
+5,335 performance samples.
+
+The report completed with 1,257,138 context entries, 1,257,137 exits, and one
+invocation open at shutdown. All 1,202,457 producer entries and exits matched.
+Context and producer stack faults, producer-to-context mismatches, invalid
+lineages, and bounded-table overflow were zero. All 5,311,650 context-origin
+draws resolved to one of the five exact static roots; none remained unresolved.
+
+Xenos remained authoritative and suppression remained disabled. The log had no
+crash, fatal error, device-loss, assertion, unhandled exception, or unexpected
+shutdown event. The visually inspected frame retained the car, crowd, stage,
+structures, sky, lighting, HUD, and interaction prompt. Median derived
+performance was 30.514 FPS, the 1% low was 19.185 FPS, present cadence was
+59.981 Hz, and present-deadline and XMA stall counters were zero.

--- a/docs/native-renderer/INDIRECT_PRODUCER_PROVENANCE.md
+++ b/docs/native-renderer/INDIRECT_PRODUCER_PROVENANCE.md
@@ -95,6 +95,11 @@ This qualifies producer-caller provenance as an exact operational classifier.
 The observed caller and argument variation can nominate a later object/lifetime
 investigation, but it does not establish semantic identity on its own.
 
+The five live producer edges are refined one bounded layer further in
+`INDIRECT_CONTEXT_ROOTS.md`. That milestone proves exact equations from four
+caller-entry register sets to producer `r3`; it still does not assign an engine
+type, instance identity, ownership, or lifetime.
+
 ## Safety boundary
 
 The hooks observe registers and packet addresses only. They read no guest

--- a/src/native_renderer/graphics_hooks.cpp
+++ b/src/native_renderer/graphics_hooks.cpp
@@ -85,6 +85,7 @@ constexpr size_t kTitleIndirectStackCapacity = 32;
 constexpr size_t kIndirectConstructorStackCapacity = 32;
 constexpr size_t kIndirectOwnerStackCapacity = 32;
 constexpr size_t kIndirectProducerStackCapacity = 32;
+constexpr size_t kIndirectContextStackCapacity = 32;
 constexpr uint64_t kSkyHorizonAnchorSignature = UINT64_C(0x747837906D0BF484);
 constexpr uint64_t kSkyHorizonFollowerSignature = UINT64_C(0x1D253A52B55C9FB3);
 std::atomic<uint64_t> g_frame_sequence{};
@@ -163,16 +164,28 @@ struct TitleIndirectPacketEntry {
   uint32_t producer_function_address = 0;
   uint32_t producer_return_address = 0;
   std::array<uint32_t, 8> producer_arguments{};
+  uint32_t context_function_address = 0;
+  uint32_t context_return_address = 0;
+  std::array<uint32_t, 8> context_arguments{};
+  uint32_t context_root_address = 0;
   uint64_t submission_sequence = 0;
   bool constructor_origin_known = false;
   bool owner_origin_known = false;
   bool producer_origin_known = false;
+  bool context_origin_known = false;
   bool occupied = false;
 };
 
 struct IndirectConstructorOrigin {
   struct Owner {
     struct Producer {
+      struct Context {
+        uint32_t function_address = 0;
+        uint32_t return_address = 0;
+        std::array<uint32_t, 8> arguments{};
+        uint32_t root_address = 0;
+        bool valid = false;
+      } context{};
       uint32_t function_address = 0;
       uint32_t return_address = 0;
       std::array<uint32_t, 8> arguments{};
@@ -241,24 +254,30 @@ uint64_t g_title_indirect_buffer_matches = 0;
 uint64_t g_title_indirect_buffer_unmatched = 0;
 uint64_t g_title_indirect_stack_faults = 0;
 uint64_t g_title_indirect_draw_stack_faults = 0;
-uint64_t g_indirect_constructor_entries = 0;
-uint64_t g_indirect_constructor_exits = 0;
-uint64_t g_indirect_constructor_stack_faults = 0;
-uint64_t g_indirect_packets_without_constructor_origin = 0;
-uint64_t g_indirect_owner_entries = 0;
-uint64_t g_indirect_owner_exits = 0;
-uint64_t g_indirect_owner_stack_faults = 0;
-uint64_t g_indirect_constructors_without_owner_origin = 0;
-uint64_t g_indirect_constructor_owner_mismatches = 0;
-uint64_t g_indirect_producer_entries = 0;
-uint64_t g_indirect_producer_exits = 0;
-uint64_t g_indirect_producer_stack_faults = 0;
-uint64_t g_indirect_owners_without_producer_origin = 0;
-uint64_t g_indirect_owner_producer_mismatches = 0;
+std::atomic<uint64_t> g_indirect_constructor_entries{};
+std::atomic<uint64_t> g_indirect_constructor_exits{};
+std::atomic<uint64_t> g_indirect_constructor_stack_faults{};
+std::atomic<uint64_t> g_indirect_packets_without_constructor_origin{};
+std::atomic<uint64_t> g_indirect_owner_entries{};
+std::atomic<uint64_t> g_indirect_owner_exits{};
+std::atomic<uint64_t> g_indirect_owner_stack_faults{};
+std::atomic<uint64_t> g_indirect_constructors_without_owner_origin{};
+std::atomic<uint64_t> g_indirect_constructor_owner_mismatches{};
+std::atomic<uint64_t> g_indirect_producer_entries{};
+std::atomic<uint64_t> g_indirect_producer_exits{};
+std::atomic<uint64_t> g_indirect_producer_stack_faults{};
+std::atomic<uint64_t> g_indirect_owners_without_producer_origin{};
+std::atomic<uint64_t> g_indirect_owner_producer_mismatches{};
+std::atomic<uint64_t> g_indirect_context_entries{};
+std::atomic<uint64_t> g_indirect_context_exits{};
+std::atomic<uint64_t> g_indirect_context_stack_faults{};
+std::atomic<uint64_t> g_indirect_producers_without_context_origin{};
+std::atomic<uint64_t> g_indirect_producer_context_mismatches{};
 std::atomic<uint64_t> g_title_indirect_buffers_open{};
 std::atomic<uint64_t> g_indirect_constructor_invocations_open{};
 std::atomic<uint64_t> g_indirect_owner_invocations_open{};
 std::atomic<uint64_t> g_indirect_producer_invocations_open{};
+std::atomic<uint64_t> g_indirect_context_invocations_open{};
 thread_local TitleDrawOrigin g_pending_adapter_origin;
 thread_local std::array<TitleDrawOrigin, kTitleOriginStackCapacity>
     g_title_origin_stack;
@@ -281,6 +300,11 @@ thread_local std::array<IndirectConstructorOrigin::Owner::Producer,
     g_indirect_producer_stack;
 thread_local size_t g_indirect_producer_stack_depth = 0;
 thread_local size_t g_indirect_producer_stack_overflow_depth = 0;
+thread_local std::array<IndirectConstructorOrigin::Owner::Producer::Context,
+                        kIndirectContextStackCapacity>
+    g_indirect_context_stack;
+thread_local size_t g_indirect_context_stack_depth = 0;
+thread_local size_t g_indirect_context_stack_overflow_depth = 0;
 
 const char *DispatchWrapperName(DispatchWrapper wrapper) {
   switch (wrapper) {
@@ -433,25 +457,38 @@ void ResetTitleDrawProvenance() {
   g_title_indirect_buffer_unmatched = 0;
   g_title_indirect_stack_faults = 0;
   g_title_indirect_draw_stack_faults = 0;
-  g_indirect_constructor_entries = 0;
-  g_indirect_constructor_exits = 0;
-  g_indirect_constructor_stack_faults = 0;
-  g_indirect_packets_without_constructor_origin = 0;
-  g_indirect_owner_entries = 0;
-  g_indirect_owner_exits = 0;
-  g_indirect_owner_stack_faults = 0;
-  g_indirect_constructors_without_owner_origin = 0;
-  g_indirect_constructor_owner_mismatches = 0;
-  g_indirect_producer_entries = 0;
-  g_indirect_producer_exits = 0;
-  g_indirect_producer_stack_faults = 0;
-  g_indirect_owners_without_producer_origin = 0;
-  g_indirect_owner_producer_mismatches = 0;
+  g_indirect_constructor_entries.store(0, std::memory_order_relaxed);
+  g_indirect_constructor_exits.store(0, std::memory_order_relaxed);
+  g_indirect_constructor_stack_faults.store(0, std::memory_order_relaxed);
+  g_indirect_packets_without_constructor_origin.store(
+      0, std::memory_order_relaxed);
+  g_indirect_owner_entries.store(0, std::memory_order_relaxed);
+  g_indirect_owner_exits.store(0, std::memory_order_relaxed);
+  g_indirect_owner_stack_faults.store(0, std::memory_order_relaxed);
+  g_indirect_constructors_without_owner_origin.store(
+      0, std::memory_order_relaxed);
+  g_indirect_constructor_owner_mismatches.store(
+      0, std::memory_order_relaxed);
+  g_indirect_producer_entries.store(0, std::memory_order_relaxed);
+  g_indirect_producer_exits.store(0, std::memory_order_relaxed);
+  g_indirect_producer_stack_faults.store(0, std::memory_order_relaxed);
+  g_indirect_owners_without_producer_origin.store(
+      0, std::memory_order_relaxed);
+  g_indirect_owner_producer_mismatches.store(
+      0, std::memory_order_relaxed);
+  g_indirect_context_entries.store(0, std::memory_order_relaxed);
+  g_indirect_context_exits.store(0, std::memory_order_relaxed);
+  g_indirect_context_stack_faults.store(0, std::memory_order_relaxed);
+  g_indirect_producers_without_context_origin.store(
+      0, std::memory_order_relaxed);
+  g_indirect_producer_context_mismatches.store(
+      0, std::memory_order_relaxed);
   g_title_indirect_buffers_open.store(0, std::memory_order_relaxed);
   g_indirect_constructor_invocations_open.store(0,
                                                 std::memory_order_relaxed);
   g_indirect_owner_invocations_open.store(0, std::memory_order_relaxed);
   g_indirect_producer_invocations_open.store(0, std::memory_order_relaxed);
+  g_indirect_context_invocations_open.store(0, std::memory_order_relaxed);
   g_pending_adapter_origin = {};
   g_title_origin_stack = {};
   g_title_origin_stack_depth = 0;
@@ -466,6 +503,9 @@ void ResetTitleDrawProvenance() {
   g_indirect_producer_stack = {};
   g_indirect_producer_stack_depth = 0;
   g_indirect_producer_stack_overflow_depth = 0;
+  g_indirect_context_stack = {};
+  g_indirect_context_stack_depth = 0;
+  g_indirect_context_stack_overflow_depth = 0;
 }
 
 void ConfigureTitleDrawProvenance(bool census_requested,
@@ -500,6 +540,8 @@ void ConfigureTitleDrawProvenance(bool census_requested,
        {"owner_stack_capacity", std::to_string(kIndirectOwnerStackCapacity)},
        {"producer_stack_capacity",
         std::to_string(kIndirectProducerStackCapacity)},
+       {"context_stack_capacity",
+        std::to_string(kIndirectContextStackCapacity)},
        {"metadata",
         "origin_wrapper,entry_lr,r3-r10,outcome,backend_outcome,"
         "backend_signature"},
@@ -652,6 +694,99 @@ uint32_t ExpectedIndirectProducerFunction(uint32_t owner_function_address,
   return 0;
 }
 
+uint32_t ExpectedIndirectContextFunction(uint32_t producer_function_address,
+                                         uint32_t producer_return_address) {
+  if (producer_function_address == 0x8240D070 &&
+      producer_return_address == 0x8240D000) {
+    return 0x8240CF68;
+  }
+  if (producer_function_address == 0x82417060 &&
+      (producer_return_address == 0x82418A28 ||
+       producer_return_address == 0x82418ECC)) {
+    return 0x82417BC0;
+  }
+  if (producer_function_address == 0x82417060 &&
+      producer_return_address == 0x82437048) {
+    return 0x824365B0;
+  }
+  if (producer_function_address == 0x829F6360 &&
+      producer_return_address == 0x829F67B0) {
+    return 0x829F6620;
+  }
+  return 0;
+}
+
+uint32_t DeriveIndirectContextRoot(
+    uint32_t function_address, const std::array<uint32_t, 8> &arguments) {
+  switch (function_address) {
+  case 0x8240CF68:
+  case 0x829F6620:
+    return arguments[0];
+  case 0x82417BC0:
+    return arguments[3] + 59712;
+  case 0x824365B0:
+    return arguments[0] + 59712;
+  default:
+    return 0;
+  }
+}
+
+void PushIndirectContextOrigin(uint32_t function_address,
+                               uint32_t return_address, uint32_t r3,
+                               uint32_t r4, uint32_t r5, uint32_t r6,
+                               uint32_t r7, uint32_t r8, uint32_t r9,
+                               uint32_t r10) {
+  if (!g_command_buffer_lineage_installed.load(std::memory_order_acquire)) {
+    return;
+  }
+  g_indirect_context_entries.fetch_add(1, std::memory_order_relaxed);
+  if (g_indirect_context_stack_depth == kIndirectContextStackCapacity) {
+    g_indirect_context_stack_faults.fetch_add(1,
+                                               std::memory_order_relaxed);
+    ++g_indirect_context_stack_overflow_depth;
+    return;
+  }
+  IndirectConstructorOrigin::Owner::Producer::Context &context =
+      g_indirect_context_stack[g_indirect_context_stack_depth++];
+  context = {};
+  context.function_address = function_address;
+  context.return_address = return_address;
+  context.arguments = {r3, r4, r5, r6, r7, r8, r9, r10};
+  context.root_address =
+      DeriveIndirectContextRoot(function_address, context.arguments);
+  context.valid = true;
+  g_indirect_context_invocations_open.fetch_add(1,
+                                                 std::memory_order_relaxed);
+}
+
+void PopIndirectContextOrigin(uint32_t function_address) {
+  if (!g_command_buffer_lineage_installed.load(std::memory_order_acquire)) {
+    return;
+  }
+  g_indirect_context_exits.fetch_add(1, std::memory_order_relaxed);
+  if (g_indirect_context_stack_overflow_depth) {
+    --g_indirect_context_stack_overflow_depth;
+    return;
+  }
+  if (!g_indirect_context_stack_depth) {
+    g_indirect_context_stack_faults.fetch_add(1,
+                                               std::memory_order_relaxed);
+    return;
+  }
+  if (g_indirect_context_stack[g_indirect_context_stack_depth - 1]
+          .function_address != function_address) {
+    g_indirect_context_stack_faults.fetch_add(1,
+                                               std::memory_order_relaxed);
+    g_indirect_context_invocations_open.fetch_sub(
+        g_indirect_context_stack_depth, std::memory_order_relaxed);
+    g_indirect_context_stack_depth = 0;
+    return;
+  }
+  --g_indirect_context_stack_depth;
+  g_indirect_context_invocations_open.fetch_sub(1,
+                                                 std::memory_order_relaxed);
+}
+
 void PushIndirectProducerOrigin(uint32_t function_address,
                                 uint32_t return_address, uint32_t r3,
                                 uint32_t r4, uint32_t r5, uint32_t r6,
@@ -660,9 +795,10 @@ void PushIndirectProducerOrigin(uint32_t function_address,
   if (!g_command_buffer_lineage_installed.load(std::memory_order_acquire)) {
     return;
   }
-  ++g_indirect_producer_entries;
+  g_indirect_producer_entries.fetch_add(1, std::memory_order_relaxed);
   if (g_indirect_producer_stack_depth == kIndirectProducerStackCapacity) {
-    ++g_indirect_producer_stack_faults;
+    g_indirect_producer_stack_faults.fetch_add(1,
+                                                std::memory_order_relaxed);
     ++g_indirect_producer_stack_overflow_depth;
     return;
   }
@@ -672,6 +808,26 @@ void PushIndirectProducerOrigin(uint32_t function_address,
   producer.function_address = function_address;
   producer.return_address = return_address;
   producer.arguments = {r3, r4, r5, r6, r7, r8, r9, r10};
+  const uint32_t expected_context =
+      ExpectedIndirectContextFunction(function_address, return_address);
+  if (expected_context && g_indirect_context_stack_depth) {
+    const IndirectConstructorOrigin::Owner::Producer::Context &context =
+        g_indirect_context_stack[g_indirect_context_stack_depth - 1];
+    if (context.valid && context.function_address == expected_context &&
+        context.root_address == r3) {
+      producer.context = context;
+    } else {
+      g_indirect_producer_context_mismatches.fetch_add(
+          1, std::memory_order_relaxed);
+    }
+  } else if (expected_context) {
+    g_indirect_producer_context_mismatches.fetch_add(
+        1, std::memory_order_relaxed);
+  }
+  if (!producer.context.valid) {
+    g_indirect_producers_without_context_origin.fetch_add(
+        1, std::memory_order_relaxed);
+  }
   producer.valid = true;
   g_indirect_producer_invocations_open.fetch_add(
       1, std::memory_order_relaxed);
@@ -681,18 +837,20 @@ void PopIndirectProducerOrigin(uint32_t function_address) {
   if (!g_command_buffer_lineage_installed.load(std::memory_order_acquire)) {
     return;
   }
-  ++g_indirect_producer_exits;
+  g_indirect_producer_exits.fetch_add(1, std::memory_order_relaxed);
   if (g_indirect_producer_stack_overflow_depth) {
     --g_indirect_producer_stack_overflow_depth;
     return;
   }
   if (!g_indirect_producer_stack_depth) {
-    ++g_indirect_producer_stack_faults;
+    g_indirect_producer_stack_faults.fetch_add(1,
+                                                std::memory_order_relaxed);
     return;
   }
   if (g_indirect_producer_stack[g_indirect_producer_stack_depth - 1]
           .function_address != function_address) {
-    ++g_indirect_producer_stack_faults;
+    g_indirect_producer_stack_faults.fetch_add(1,
+                                                std::memory_order_relaxed);
     g_indirect_producer_invocations_open.fetch_sub(
         g_indirect_producer_stack_depth, std::memory_order_relaxed);
     g_indirect_producer_stack_depth = 0;
@@ -711,9 +869,10 @@ void PushIndirectOwnerOrigin(uint32_t function_address,
   if (!g_command_buffer_lineage_installed.load(std::memory_order_acquire)) {
     return;
   }
-  ++g_indirect_owner_entries;
+  g_indirect_owner_entries.fetch_add(1, std::memory_order_relaxed);
   if (g_indirect_owner_stack_depth == kIndirectOwnerStackCapacity) {
-    ++g_indirect_owner_stack_faults;
+    g_indirect_owner_stack_faults.fetch_add(1,
+                                             std::memory_order_relaxed);
     ++g_indirect_owner_stack_overflow_depth;
     return;
   }
@@ -731,13 +890,16 @@ void PushIndirectOwnerOrigin(uint32_t function_address,
     if (producer.valid && producer.function_address == expected_producer) {
       owner.producer = producer;
     } else {
-      ++g_indirect_owner_producer_mismatches;
+      g_indirect_owner_producer_mismatches.fetch_add(
+          1, std::memory_order_relaxed);
     }
   } else if (expected_producer) {
-    ++g_indirect_owner_producer_mismatches;
+    g_indirect_owner_producer_mismatches.fetch_add(
+        1, std::memory_order_relaxed);
   }
   if (!owner.producer.valid) {
-    ++g_indirect_owners_without_producer_origin;
+    g_indirect_owners_without_producer_origin.fetch_add(
+        1, std::memory_order_relaxed);
   }
   owner.valid = true;
   g_indirect_owner_invocations_open.fetch_add(1,
@@ -748,18 +910,20 @@ void PopIndirectOwnerOrigin(uint32_t function_address) {
   if (!g_command_buffer_lineage_installed.load(std::memory_order_acquire)) {
     return;
   }
-  ++g_indirect_owner_exits;
+  g_indirect_owner_exits.fetch_add(1, std::memory_order_relaxed);
   if (g_indirect_owner_stack_overflow_depth) {
     --g_indirect_owner_stack_overflow_depth;
     return;
   }
   if (!g_indirect_owner_stack_depth) {
-    ++g_indirect_owner_stack_faults;
+    g_indirect_owner_stack_faults.fetch_add(1,
+                                             std::memory_order_relaxed);
     return;
   }
   if (g_indirect_owner_stack[g_indirect_owner_stack_depth - 1]
           .function_address != function_address) {
-    ++g_indirect_owner_stack_faults;
+    g_indirect_owner_stack_faults.fetch_add(1,
+                                             std::memory_order_relaxed);
     g_indirect_owner_invocations_open.fetch_sub(
         g_indirect_owner_stack_depth, std::memory_order_relaxed);
     g_indirect_owner_stack_depth = 0;
@@ -778,10 +942,12 @@ void PushIndirectConstructorOrigin(uint32_t function_address,
   if (!g_command_buffer_lineage_installed.load(std::memory_order_acquire)) {
     return;
   }
-  ++g_indirect_constructor_entries;
+  g_indirect_constructor_entries.fetch_add(1,
+                                             std::memory_order_relaxed);
   if (g_indirect_constructor_stack_depth ==
       kIndirectConstructorStackCapacity) {
-    ++g_indirect_constructor_stack_faults;
+    g_indirect_constructor_stack_faults.fetch_add(
+        1, std::memory_order_relaxed);
     ++g_indirect_constructor_stack_overflow_depth;
     return;
   }
@@ -799,13 +965,16 @@ void PushIndirectConstructorOrigin(uint32_t function_address,
     if (owner.valid && owner.function_address == expected_owner) {
       origin.owner = owner;
     } else {
-      ++g_indirect_constructor_owner_mismatches;
+      g_indirect_constructor_owner_mismatches.fetch_add(
+          1, std::memory_order_relaxed);
     }
   } else if (expected_owner) {
-    ++g_indirect_constructor_owner_mismatches;
+    g_indirect_constructor_owner_mismatches.fetch_add(
+        1, std::memory_order_relaxed);
   }
   if (!origin.owner.valid) {
-    ++g_indirect_constructors_without_owner_origin;
+    g_indirect_constructors_without_owner_origin.fetch_add(
+        1, std::memory_order_relaxed);
   }
   origin.valid = true;
   g_indirect_constructor_invocations_open.fetch_add(
@@ -816,18 +985,21 @@ void PopIndirectConstructorOrigin(uint32_t function_address) {
   if (!g_command_buffer_lineage_installed.load(std::memory_order_acquire)) {
     return;
   }
-  ++g_indirect_constructor_exits;
+  g_indirect_constructor_exits.fetch_add(1,
+                                          std::memory_order_relaxed);
   if (g_indirect_constructor_stack_overflow_depth) {
     --g_indirect_constructor_stack_overflow_depth;
     return;
   }
   if (!g_indirect_constructor_stack_depth) {
-    ++g_indirect_constructor_stack_faults;
+    g_indirect_constructor_stack_faults.fetch_add(
+        1, std::memory_order_relaxed);
     return;
   }
   if (g_indirect_constructor_stack[g_indirect_constructor_stack_depth - 1]
           .function_address != function_address) {
-    ++g_indirect_constructor_stack_faults;
+    g_indirect_constructor_stack_faults.fetch_add(
+        1, std::memory_order_relaxed);
     g_indirect_constructor_invocations_open.fetch_sub(
         g_indirect_constructor_stack_depth, std::memory_order_relaxed);
     g_indirect_constructor_stack_depth = 0;
@@ -841,13 +1013,15 @@ void PopIndirectConstructorOrigin(uint32_t function_address) {
 IndirectConstructorOrigin CurrentIndirectConstructorOrigin(
     uint32_t function_address) {
   if (!g_indirect_constructor_stack_depth) {
-    ++g_indirect_packets_without_constructor_origin;
+    g_indirect_packets_without_constructor_origin.fetch_add(
+        1, std::memory_order_relaxed);
     return {};
   }
   const IndirectConstructorOrigin &origin =
       g_indirect_constructor_stack[g_indirect_constructor_stack_depth - 1];
   if (!origin.valid || origin.function_address != function_address) {
-    ++g_indirect_packets_without_constructor_origin;
+    g_indirect_packets_without_constructor_origin.fetch_add(
+        1, std::memory_order_relaxed);
     return {};
   }
   return origin;
@@ -911,10 +1085,16 @@ void RecordTitleIndirectPacket(uint32_t packet_guest_address,
   entry.producer_function_address = origin.owner.producer.function_address;
   entry.producer_return_address = origin.owner.producer.return_address;
   entry.producer_arguments = origin.owner.producer.arguments;
+  entry.context_function_address =
+      origin.owner.producer.context.function_address;
+  entry.context_return_address = origin.owner.producer.context.return_address;
+  entry.context_arguments = origin.owner.producer.context.arguments;
+  entry.context_root_address = origin.owner.producer.context.root_address;
   entry.submission_sequence = ++g_title_indirect_packet_submission_sequence;
   entry.constructor_origin_known = origin.valid;
   entry.owner_origin_known = origin.owner.valid;
   entry.producer_origin_known = origin.owner.producer.valid;
+  entry.context_origin_known = origin.owner.producer.context.valid;
   entry.occupied = true;
   ++g_title_indirect_packets_recorded;
 }
@@ -992,6 +1172,16 @@ void ObserveIndirectBuffer(
         matched.producer_arguments;
     active.constructor_origin.owner.producer.valid =
         matched.producer_origin_known;
+    active.constructor_origin.owner.producer.context.function_address =
+        matched.context_function_address;
+    active.constructor_origin.owner.producer.context.return_address =
+        matched.context_return_address;
+    active.constructor_origin.owner.producer.context.arguments =
+        matched.context_arguments;
+    active.constructor_origin.owner.producer.context.root_address =
+        matched.context_root_address;
+    active.constructor_origin.owner.producer.context.valid =
+        matched.context_origin_known;
     active.depth = observation.depth;
     g_title_indirect_buffers_open.fetch_add(1, std::memory_order_relaxed);
     return;
@@ -1880,10 +2070,17 @@ struct CommandBufferLineageEntry {
   uint32_t producer_return_address = 0;
   std::array<uint32_t, 8> sample_producer_arguments{};
   uint32_t producer_argument_varying_mask = 0;
+  uint32_t context_function_address = 0;
+  uint32_t context_return_address = 0;
+  std::array<uint32_t, 8> sample_context_arguments{};
+  uint32_t context_argument_varying_mask = 0;
+  uint32_t sample_context_root_address = 0;
+  bool context_root_address_varied = false;
   uint32_t depth = 0;
   bool constructor_origin_known = false;
   bool owner_origin_known = false;
   bool producer_origin_known = false;
+  bool context_origin_known = false;
   bool prepared_signature_varied = false;
 };
 
@@ -3374,6 +3571,8 @@ void RecordPreparedCommandBufferLineage(
         uint64_t(constructor_origin.owner.return_address),
         uint64_t(constructor_origin.owner.producer.function_address),
         uint64_t(constructor_origin.owner.producer.return_address),
+        uint64_t(constructor_origin.owner.producer.context.function_address),
+        uint64_t(constructor_origin.owner.producer.context.return_address),
         uint64_t(observation.command_buffer_depth)}) {
     key = HashCombine(key, value);
   }
@@ -3422,6 +3621,16 @@ void RecordPreparedCommandBufferLineage(
           constructor_origin.owner.producer.arguments;
       entry.producer_origin_known =
           constructor_origin.owner.producer.valid;
+      entry.context_function_address =
+          constructor_origin.owner.producer.context.function_address;
+      entry.context_return_address =
+          constructor_origin.owner.producer.context.return_address;
+      entry.sample_context_arguments =
+          constructor_origin.owner.producer.context.arguments;
+      entry.sample_context_root_address =
+          constructor_origin.owner.producer.context.root_address;
+      entry.context_origin_known =
+          constructor_origin.owner.producer.context.valid;
       entry.depth = observation.command_buffer_depth;
       ++g_command_buffer_lineage_entry_count;
       return;
@@ -3435,6 +3644,10 @@ void RecordPreparedCommandBufferLineage(
             constructor_origin.owner.producer.function_address &&
         entry.producer_return_address ==
             constructor_origin.owner.producer.return_address &&
+        entry.context_function_address ==
+            constructor_origin.owner.producer.context.function_address &&
+        entry.context_return_address ==
+            constructor_origin.owner.producer.context.return_address &&
         entry.depth == observation.command_buffer_depth) {
       ++entry.calls;
       entry.last_frame = observation.frame_sequence;
@@ -3484,6 +3697,19 @@ void RecordPreparedCommandBufferLineage(
             entry.producer_argument_varying_mask |= 1u << argument;
           }
         }
+      }
+      if (entry.context_origin_known &&
+          constructor_origin.owner.producer.context.valid) {
+        for (size_t argument = 0;
+             argument < entry.sample_context_arguments.size(); ++argument) {
+          if (entry.sample_context_arguments[argument] !=
+              constructor_origin.owner.producer.context.arguments[argument]) {
+            entry.context_argument_varying_mask |= 1u << argument;
+          }
+        }
+        entry.context_root_address_varied |=
+            entry.sample_context_root_address !=
+            constructor_origin.owner.producer.context.root_address;
       }
       return;
     }
@@ -3597,6 +3823,33 @@ void EmitCommandBufferLineageSummary() {
               entry.sample_producer_arguments[7])},
          {"producer_argument_varying_mask",
           fmt::format("{:02X}", entry.producer_argument_varying_mask)},
+         {"context_function_address",
+          entry.context_origin_known
+              ? fmt::format("{:08X}", entry.context_function_address)
+              : "unknown"},
+         {"context_return_address",
+          entry.context_origin_known
+              ? fmt::format("{:08X}", entry.context_return_address)
+              : "unknown"},
+         {"sample_context_arguments",
+          fmt::format(
+              "{:08X},{:08X},{:08X},{:08X},{:08X},{:08X},{:08X},{:08X}",
+              entry.sample_context_arguments[0],
+              entry.sample_context_arguments[1],
+              entry.sample_context_arguments[2],
+              entry.sample_context_arguments[3],
+              entry.sample_context_arguments[4],
+              entry.sample_context_arguments[5],
+              entry.sample_context_arguments[6],
+              entry.sample_context_arguments[7])},
+         {"context_argument_varying_mask",
+          fmt::format("{:02X}", entry.context_argument_varying_mask)},
+         {"sample_context_root_address",
+          entry.context_origin_known
+              ? fmt::format("{:08X}", entry.sample_context_root_address)
+              : "unknown"},
+         {"context_root_address_varied",
+          entry.context_root_address_varied ? "true" : "false"},
          {"depth", std::to_string(entry.depth)},
          {"guest_payload_read", "false"},
          {"guest_state_changed", "false"},
@@ -3638,40 +3891,74 @@ void EmitCommandBufferLineageSummary() {
        {"indirect_draw_stack_faults",
         std::to_string(g_title_indirect_draw_stack_faults)},
        {"indirect_constructor_entries",
-        std::to_string(g_indirect_constructor_entries)},
+        std::to_string(g_indirect_constructor_entries.load(
+            std::memory_order_relaxed))},
        {"indirect_constructor_exits",
-        std::to_string(g_indirect_constructor_exits)},
+        std::to_string(g_indirect_constructor_exits.load(
+            std::memory_order_relaxed))},
        {"indirect_constructor_invocations_open_at_shutdown",
         std::to_string(g_indirect_constructor_invocations_open.load(
             std::memory_order_relaxed))},
        {"indirect_constructor_stack_faults",
-        std::to_string(g_indirect_constructor_stack_faults)},
+        std::to_string(g_indirect_constructor_stack_faults.load(
+            std::memory_order_relaxed))},
        {"indirect_packets_without_constructor_origin",
-        std::to_string(g_indirect_packets_without_constructor_origin)},
-       {"indirect_owner_entries", std::to_string(g_indirect_owner_entries)},
-       {"indirect_owner_exits", std::to_string(g_indirect_owner_exits)},
+        std::to_string(g_indirect_packets_without_constructor_origin.load(
+            std::memory_order_relaxed))},
+       {"indirect_owner_entries",
+        std::to_string(
+            g_indirect_owner_entries.load(std::memory_order_relaxed))},
+       {"indirect_owner_exits",
+        std::to_string(
+            g_indirect_owner_exits.load(std::memory_order_relaxed))},
        {"indirect_owner_invocations_open_at_shutdown",
         std::to_string(g_indirect_owner_invocations_open.load(
             std::memory_order_relaxed))},
        {"indirect_owner_stack_faults",
-        std::to_string(g_indirect_owner_stack_faults)},
+        std::to_string(
+            g_indirect_owner_stack_faults.load(std::memory_order_relaxed))},
        {"indirect_constructors_without_owner_origin",
-        std::to_string(g_indirect_constructors_without_owner_origin)},
+        std::to_string(g_indirect_constructors_without_owner_origin.load(
+            std::memory_order_relaxed))},
        {"indirect_constructor_owner_mismatches",
-        std::to_string(g_indirect_constructor_owner_mismatches)},
+        std::to_string(g_indirect_constructor_owner_mismatches.load(
+            std::memory_order_relaxed))},
        {"indirect_producer_entries",
-        std::to_string(g_indirect_producer_entries)},
+        std::to_string(g_indirect_producer_entries.load(
+            std::memory_order_relaxed))},
        {"indirect_producer_exits",
-        std::to_string(g_indirect_producer_exits)},
+        std::to_string(
+            g_indirect_producer_exits.load(std::memory_order_relaxed))},
        {"indirect_producer_invocations_open_at_shutdown",
         std::to_string(g_indirect_producer_invocations_open.load(
             std::memory_order_relaxed))},
        {"indirect_producer_stack_faults",
-        std::to_string(g_indirect_producer_stack_faults)},
+        std::to_string(g_indirect_producer_stack_faults.load(
+            std::memory_order_relaxed))},
        {"indirect_owners_without_producer_origin",
-        std::to_string(g_indirect_owners_without_producer_origin)},
+        std::to_string(g_indirect_owners_without_producer_origin.load(
+            std::memory_order_relaxed))},
        {"indirect_owner_producer_mismatches",
-        std::to_string(g_indirect_owner_producer_mismatches)},
+        std::to_string(g_indirect_owner_producer_mismatches.load(
+            std::memory_order_relaxed))},
+       {"indirect_context_entries",
+        std::to_string(
+            g_indirect_context_entries.load(std::memory_order_relaxed))},
+       {"indirect_context_exits",
+        std::to_string(
+            g_indirect_context_exits.load(std::memory_order_relaxed))},
+       {"indirect_context_invocations_open_at_shutdown",
+        std::to_string(g_indirect_context_invocations_open.load(
+            std::memory_order_relaxed))},
+       {"indirect_context_stack_faults",
+        std::to_string(g_indirect_context_stack_faults.load(
+            std::memory_order_relaxed))},
+       {"indirect_producers_without_context_origin",
+        std::to_string(g_indirect_producers_without_context_origin.load(
+            std::memory_order_relaxed))},
+       {"indirect_producer_context_mismatches",
+        std::to_string(g_indirect_producer_context_mismatches.load(
+            std::memory_order_relaxed))},
        {"indirect_buffers_open_at_shutdown",
         std::to_string(g_title_indirect_buffers_open.load(
             std::memory_order_relaxed))},
@@ -6061,7 +6348,8 @@ void InstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system,
        {"source",
         "title_store,constructor_function,constructor_return,r3-r10,"
         "owner_function,owner_return,owner_r3-r10,producer_function,"
-        "producer_return,producer_r3-r10,backend_packet,"
+        "producer_return,producer_r3-r10,context_function,context_return,"
+        "context_r3-r10,context_root,backend_packet,"
         "current_buffer,parent_packet,root_buffer,depth"},
        {"guest_payload_read", "false"},
        {"guest_state_changed", "false"},
@@ -6852,6 +7140,34 @@ PINYON_SHIFT_INDIRECT_PRODUCER_HOOKS(82417060)
 PINYON_SHIFT_INDIRECT_PRODUCER_HOOKS(829F6360)
 
 #undef PINYON_SHIFT_INDIRECT_PRODUCER_HOOKS
+
+void ObserveIndirectContextEntry(
+    uint32_t function_address, PPCRegister &r3, PPCRegister &r4,
+    PPCRegister &r5, PPCRegister &r6, PPCRegister &r7, PPCRegister &r8,
+    PPCRegister &r9, PPCRegister &r10, PPCRegister &r12) {
+  PushIndirectContextOrigin(function_address, r12.u32, r3.u32, r4.u32,
+                            r5.u32, r6.u32, r7.u32, r8.u32, r9.u32,
+                            r10.u32);
+}
+
+#define PINYON_SHIFT_INDIRECT_CONTEXT_HOOKS(address)                           \
+  void PinyonShiftObserveIndirectContext##address##Entry(                      \
+      PPCRegister &r3, PPCRegister &r4, PPCRegister &r5, PPCRegister &r6,      \
+      PPCRegister &r7, PPCRegister &r8, PPCRegister &r9, PPCRegister &r10,     \
+      PPCRegister &r12) {                                                       \
+    ObserveIndirectContextEntry(0x##address, r3, r4, r5, r6, r7, r8, r9,      \
+                                r10, r12);                                     \
+  }                                                                             \
+  void PinyonShiftObserveIndirectContext##address##Exit() {                    \
+    PopIndirectContextOrigin(0x##address);                                      \
+  }
+
+PINYON_SHIFT_INDIRECT_CONTEXT_HOOKS(8240CF68)
+PINYON_SHIFT_INDIRECT_CONTEXT_HOOKS(82417BC0)
+PINYON_SHIFT_INDIRECT_CONTEXT_HOOKS(824365B0)
+PINYON_SHIFT_INDIRECT_CONTEXT_HOOKS(829F6620)
+
+#undef PINYON_SHIFT_INDIRECT_CONTEXT_HOOKS
 
 void PinyonShiftObserveIndirectPacket824095B4(PPCRegister &r11,
                                                PPCRegister &r28) {

--- a/tools/discover-native-renderer-dispatch.py
+++ b/tools/discover-native-renderer-dispatch.py
@@ -119,6 +119,63 @@ INDIRECT_PRODUCER_RUNTIME_HOOKS = {
     0x82417060: {"entry": 0x82417064, "exit": 0x824170C0},
     0x829F6360: {"entry": 0x829F6364, "exit": 0x829F63FC},
 }
+INDIRECT_CONTEXT_RUNTIME_HOOKS = {
+    0x8240CF68: {
+        "entry": 0x8240CF6C,
+        "exit": 0x8240D054,
+        "root_entry_register": "r3",
+        "root_offset": 0,
+        "producer_edges": [(0x8240D070, 0x8240D000)],
+        "proof": [
+            (0x8240CF80, "mr r31,r3"),
+            (0x8240CFF8, "mr r3,r31"),
+        ],
+    },
+    0x82417BC0: {
+        "entry": 0x82417BC4,
+        "exit": 0x82418F38,
+        "root_entry_register": "r6",
+        "root_offset": 59712,
+        "producer_edges": [
+            (0x82417060, 0x82418A28),
+            (0x82417060, 0x82418ECC),
+        ],
+        "proof": [
+            (0x82417BF0, "stw r6,2156(r1)"),
+            (0x82418058, "lwz r8,2156(r1)"),
+            (0x82418068, "addis r24,r8,1"),
+            (0x8241807C, "addi r24,r24,-5824"),
+            (0x82418A20, "mr r3,r24"),
+            (0x82418EC4, "mr r3,r24"),
+        ],
+    },
+    0x824365B0: {
+        "entry": 0x824365B4,
+        "exit": 0x82437048,
+        "root_entry_register": "r3",
+        "root_offset": 59712,
+        "producer_edges": [(0x82417060, 0x82437048)],
+        "proof": [
+            (0x824365C0, "mr r29,r3"),
+            (0x8243667C, "addis r25,r29,1"),
+            (0x82436688, "addi r25,r25,-5824"),
+            (0x82436690, "stw r25,84(r1)"),
+            (0x82437030, "lwz r25,84(r1)"),
+            (0x82437040, "mr r3,r25"),
+        ],
+    },
+    0x829F6620: {
+        "entry": 0x829F6624,
+        "exit": 0x829F67B8,
+        "root_entry_register": "r3",
+        "root_offset": 0,
+        "producer_edges": [(0x829F6360, 0x829F67B0)],
+        "proof": [
+            (0x829F662C, "mr r28,r3"),
+            (0x829F67A8, "mr r3,r28"),
+        ],
+    },
+}
 
 FUNCTION_RE = re.compile(r"^DEFINE_REX_FUNC\(sub_([0-9A-F]{8})\) \{")
 LABEL_RE = re.compile(r"^loc_([0-9A-F]{8}):")
@@ -582,6 +639,108 @@ def indirect_producer_runtime_hooks(
             }
         )
     return result
+
+
+def indirect_context_runtime_hooks(
+    functions_by_address: dict[int, dict]
+) -> list[dict]:
+    """Prove balanced scopes for the four live producer contexts."""
+    observed_known = set(functions_by_address) & set(
+        INDIRECT_CONTEXT_RUNTIME_HOOKS
+    )
+    if observed_known and observed_known != set(INDIRECT_CONTEXT_RUNTIME_HOOKS):
+        raise ValueError("known indirect-context function set drifted")
+    result = []
+    for address in sorted(observed_known):
+        hooks = INDIRECT_CONTEXT_RUNTIME_HOOKS[address]
+        function = functions_by_address[address]
+        by_address = {
+            item["address"]: item["text"] for item in function["instructions"]
+        }
+        if (
+            not function["instructions"]
+            or function["instructions"][0]
+            != {"address": address, "text": "mflr r12"}
+            or hooks["entry"] != address + 4
+            or not by_address.get(hooks["exit"], "").startswith("addi r1,r1,")
+            or any(
+                by_address.get(proof_address) != proof_text
+                for proof_address, proof_text in hooks["proof"]
+            )
+        ):
+            raise ValueError(
+                "indirect-context root evidence drifted: {:08X}".format(address)
+            )
+        result.append(
+            {
+                "function": function["name"],
+                "function_address": "{:08X}".format(address),
+                "entry_hook_address": "{:08X}".format(hooks["entry"]),
+                "exit_hook_address": "{:08X}".format(hooks["exit"]),
+                "caller_lr_register": "r12_after_opening_mflr",
+                "entry_metadata": [
+                    "r3", "r4", "r5", "r6", "r7", "r8", "r9", "r10"
+                ],
+                "root_entry_register": hooks["root_entry_register"],
+                "root_offset": hooks["root_offset"],
+                "classification": "balanced_passive_producer_context",
+                "semantic_identity": "unknown",
+                "object_identity_proved": False,
+                "object_lifetime_proved": False,
+                "invocation_scope_proved": True,
+                "suppression_eligible": False,
+            }
+        )
+    return result
+
+
+def indirect_context_roots(functions_by_address: dict[int, dict]) -> list[dict]:
+    """Describe exact entry-register roots for the five live producer edges."""
+    if not set(functions_by_address) & set(INDIRECT_CONTEXT_RUNTIME_HOOKS):
+        return []
+    roots = []
+    for address, hooks in sorted(INDIRECT_CONTEXT_RUNTIME_HOOKS.items()):
+        function = functions_by_address[address]
+        by_address = {
+            item["address"]: item["text"] for item in function["instructions"]
+        }
+        for producer_function, producer_return in hooks["producer_edges"]:
+            expected_call = "bl 0x{:08x}".format(producer_function)
+            if by_address.get(producer_return - 4) != expected_call:
+                raise ValueError(
+                    "indirect-context producer edge drifted: "
+                    "{:08X}->{:08X}".format(address, producer_return)
+                )
+            roots.append(
+                {
+                    "context_function": "sub_{:08X}".format(address),
+                    "context_function_address": "{:08X}".format(address),
+                    "producer_function": "sub_{:08X}".format(
+                        producer_function
+                    ),
+                    "producer_function_address": "{:08X}".format(
+                        producer_function
+                    ),
+                    "producer_return_address": "{:08X}".format(
+                        producer_return
+                    ),
+                    "root_entry_register": hooks["root_entry_register"],
+                    "root_offset": hooks["root_offset"],
+                    "derivation": (
+                        hooks["root_entry_register"]
+                        if not hooks["root_offset"]
+                        else "{}+{}".format(
+                            hooks["root_entry_register"], hooks["root_offset"]
+                        )
+                    ),
+                    "classification": "exact_producer_context_root",
+                    "semantic_identity": "unknown",
+                    "object_identity_proved": False,
+                    "object_lifetime_proved": False,
+                    "suppression_eligible": False,
+                }
+            )
+    return roots
 
 
 def argument_leads_for_calls(
@@ -1136,6 +1295,8 @@ def build(paths: list[pathlib.Path]) -> dict:
     owner_hooks = indirect_owner_runtime_hooks(functions_by_address)
     producer_calls = indirect_producer_calls(functions)
     producer_hooks = indirect_producer_runtime_hooks(functions_by_address)
+    context_hooks = indirect_context_runtime_hooks(functions_by_address)
+    context_roots = indirect_context_roots(functions_by_address)
     constructor_argument_leads = argument_leads_for_calls(
         functions, constructor_calls, "constructor_function_address"
     )
@@ -1239,6 +1400,8 @@ def build(paths: list[pathlib.Path]) -> dict:
         "indirect_producer_calls": producer_calls,
         "indirect_producer_runtime_hooks": producer_hooks,
         "indirect_producer_argument_leads": producer_argument_leads,
+        "indirect_context_runtime_hooks": context_hooks,
+        "indirect_context_roots": context_roots,
         "reviewed_wrappers": [
             {
                 "address": "{:08X}".format(address),
@@ -1307,6 +1470,8 @@ def build(paths: list[pathlib.Path]) -> dict:
             "indirect_producer_argument_leads": len(
                 producer_argument_leads
             ),
+            "indirect_context_runtime_hooks": len(context_hooks),
+            "indirect_context_roots": len(context_roots),
             "reviewed_wrappers": len(REVIEWED_WRAPPERS),
             "direct_calls": len(calls),
             "tail_forwarded_calls": len(forwarded_calls),

--- a/tools/summarize-native-renderer-command-lineage.py
+++ b/tools/summarize-native-renderer-command-lineage.py
@@ -136,6 +136,14 @@ def build(events: list[dict], static: dict, requested: str | None = None) -> dic
         ): item
         for item in static_producer_calls
     }
+    static_context_roots = static.get("indirect_context_roots", [])
+    context_roots_by_producer_return = {
+        (
+            str(item.get("producer_function_address", "")).upper(),
+            str(item.get("producer_return_address", "")).upper(),
+        ): item
+        for item in static_context_roots
+    }
 
     session = select_session(events, requested)
     selected = [event for event in events if event.get("session") == session]
@@ -332,6 +340,74 @@ def build(events: list[dict], static: dict, requested: str | None = None) -> dic
             producer_argument_varying_mask = int(
                 _hex(event, "producer_argument_varying_mask", 2), 16
             )
+        context_function_address = None
+        context_return_address = None
+        context_arguments = None
+        context_argument_varying_mask = None
+        context_root_address = None
+        context_root_address_varied = None
+        context_root = None
+        if static_context_roots:
+            context_function_address = _optional_hex(
+                event, "context_function_address", 8
+            )
+            context_return_address = _optional_hex(
+                event, "context_return_address", 8
+            )
+            context_root_address = _optional_hex(
+                event, "sample_context_root_address", 8
+            )
+            if (
+                (context_function_address is None)
+                != (context_return_address is None)
+                or (context_function_address is None)
+                != (context_root_address is None)
+            ):
+                raise ValueError("lineage entry has a partial context origin")
+            if context_function_address is not None:
+                if producer_call is None or producer_arguments is None:
+                    raise ValueError(
+                        "lineage entry has a context without a proved producer caller"
+                    )
+                context_root = context_roots_by_producer_return.get(
+                    (producer_function_address, producer_return_address)
+                )
+                if context_root is None:
+                    raise ValueError(
+                        "lineage context has no proved producer-root edge"
+                    )
+                if (
+                    str(context_root.get("context_function_address", "")).upper()
+                    != context_function_address
+                ):
+                    raise ValueError(
+                        "lineage context does not contain the producer callsite"
+                    )
+                context_arguments = _hex_arguments(
+                    event, "sample_context_arguments"
+                )
+                context_argument_varying_mask = int(
+                    _hex(event, "context_argument_varying_mask", 2), 16
+                )
+                context_root_address_varied = (
+                    str(event.get("context_root_address_varied", "")).lower()
+                    == "true"
+                )
+                register = str(context_root.get("root_entry_register", ""))
+                if register not in {f"r{index}" for index in range(3, 11)}:
+                    raise ValueError("static context root has an invalid register")
+                argument_index = int(register[1:]) - 3
+                expected_root = (
+                    int(context_arguments[argument_index], 16)
+                    + int(context_root.get("root_offset", 0))
+                ) & 0xFFFFFFFF
+                if (
+                    int(context_root_address, 16) != expected_root
+                    or int(producer_arguments[0], 16) != expected_root
+                ):
+                    raise ValueError(
+                        "runtime context root does not match its static derivation"
+                    )
         if depth:
             if parent_value >= PHYSICAL_APERTURE_SIZE or parent_value & 3:
                 raise ValueError("indirect lineage entry has no valid parent packet")
@@ -466,6 +542,20 @@ def build(events: list[dict], static: dict, requested: str | None = None) -> dic
                 "producer_argument_varying_mask": (
                     producer_argument_varying_mask
                 ),
+                "context_function_address": context_function_address,
+                "context_return_address": context_return_address,
+                "context_root_derivation": (
+                    context_root.get("derivation")
+                    if context_root is not None
+                    else None
+                ),
+                "context_root_proved": context_root is not None,
+                "sample_context_arguments": context_arguments,
+                "context_argument_varying_mask": (
+                    context_argument_varying_mask
+                ),
+                "sample_context_root_address": context_root_address,
+                "context_root_address_varied": context_root_address_varied,
                 "depth": depth,
             }
         )
@@ -481,6 +571,7 @@ def build(events: list[dict], static: dict, requested: str | None = None) -> dic
             item["constructor_return_address"] or "",
             item["owner_return_address"] or "",
             item["producer_return_address"] or "",
+            item["context_return_address"] or "",
         )
     )
 
@@ -546,6 +637,20 @@ def build(events: list[dict], static: dict, requested: str | None = None) -> dic
     owner_producer_mismatches = _integer(
         summary, "indirect_owner_producer_mismatches"
     )
+    context_entries = _integer(summary, "indirect_context_entries")
+    context_exits = _integer(summary, "indirect_context_exits")
+    context_open = _integer(
+        summary, "indirect_context_invocations_open_at_shutdown"
+    )
+    context_stack_faults = _integer(
+        summary, "indirect_context_stack_faults"
+    )
+    producers_without_context_origin = _integer(
+        summary, "indirect_producers_without_context_origin"
+    )
+    producer_context_mismatches = _integer(
+        summary, "indirect_producer_context_mismatches"
+    )
     open_at_shutdown = _integer(
         summary, "indirect_buffers_open_at_shutdown"
     )
@@ -577,6 +682,9 @@ def build(events: list[dict], static: dict, requested: str | None = None) -> dic
         and producer_entries == producer_exits + producer_open
         and not producer_stack_faults
         and not owner_producer_mismatches
+        and context_entries == context_exits + context_open
+        and not context_stack_faults
+        and not producer_context_mismatches
         and (
             not static_constructor_calls
             or (
@@ -603,6 +711,16 @@ def build(events: list[dict], static: dict, requested: str | None = None) -> dic
                 producer_entries > 0
                 and any(
                     item["producer_return_address"] is not None
+                    for item in entries
+                )
+            )
+        )
+        and (
+            not static_context_roots
+            or (
+                context_entries > 0
+                and any(
+                    item["context_return_address"] is not None
                     for item in entries
                 )
             )
@@ -679,6 +797,26 @@ def build(events: list[dict], static: dict, requested: str | None = None) -> dic
                 "producer_argument_varying_mask": entry[
                     "producer_argument_varying_mask"
                 ],
+                "context_function_address": entry[
+                    "context_function_address"
+                ],
+                "context_return_address": entry["context_return_address"],
+                "context_root_derivation": entry[
+                    "context_root_derivation"
+                ],
+                "context_root_proved": entry["context_root_proved"],
+                "sample_context_arguments": entry[
+                    "sample_context_arguments"
+                ],
+                "context_argument_varying_mask": entry[
+                    "context_argument_varying_mask"
+                ],
+                "sample_context_root_address": entry[
+                    "sample_context_root_address"
+                ],
+                "context_root_address_varied": entry[
+                    "context_root_address_varied"
+                ],
                 "depth": entry["depth"],
                 "sample_prepared_signature": entry[
                     "sample_prepared_signature"
@@ -701,6 +839,7 @@ def build(events: list[dict], static: dict, requested: str | None = None) -> dic
             item["constructor_return_address"] or "",
             item["owner_return_address"] or "",
             item["producer_return_address"] or "",
+            item["context_return_address"] or "",
         )
     )
 
@@ -715,6 +854,7 @@ def build(events: list[dict], static: dict, requested: str | None = None) -> dic
         "static_indirect_constructor_calls": static_constructor_calls,
         "static_indirect_owner_calls": static_owner_calls,
         "static_indirect_producer_calls": static_producer_calls,
+        "static_indirect_context_roots": static_context_roots,
         "totals": {
             "draws": draws,
             "primary_draws": primary_draws,
@@ -768,6 +908,16 @@ def build(events: list[dict], static: dict, requested: str | None = None) -> dic
             "indirect_owner_producer_mismatches": (
                 owner_producer_mismatches
             ),
+            "indirect_context_entries": context_entries,
+            "indirect_context_exits": context_exits,
+            "indirect_context_invocations_open_at_shutdown": context_open,
+            "indirect_context_stack_faults": context_stack_faults,
+            "indirect_producers_without_context_origin": (
+                producers_without_context_origin
+            ),
+            "indirect_producer_context_mismatches": (
+                producer_context_mismatches
+            ),
             "indirect_buffers_open_at_shutdown": open_at_shutdown,
             "constructor_origin_draws": sum(
                 item["calls"]
@@ -814,6 +964,20 @@ def build(events: list[dict], static: dict, requested: str | None = None) -> dic
                 for item in entries
                 if item["producer_return_address"] is not None
                 and not item["producer_callsite_proved"]
+            ),
+            "context_origin_draws": sum(
+                item["calls"]
+                for item in entries
+                if item["context_return_address"] is not None
+            ),
+            "statically_resolved_context_origin_draws": sum(
+                item["calls"] for item in entries if item["context_root_proved"]
+            ),
+            "unresolved_context_origin_draws": sum(
+                item["calls"]
+                for item in entries
+                if item["context_return_address"] is not None
+                and not item["context_root_proved"]
             ),
         },
         "qualification": "exact_title_store_to_backend_nested_command_buffer_lineage",

--- a/tools/tests/test_native_renderer_command_lineage.py
+++ b/tools/tests/test_native_renderer_command_lineage.py
@@ -115,6 +115,100 @@ def nested_events():
     return result
 
 
+def context_root_inventory():
+    static = static_inventory()
+    static["indirect_constructor_calls"] = [
+        {
+            "constructor_function_address": "82409398",
+            "caller_function": "sub_82409668",
+            "caller_function_address": "82409668",
+            "callsite": "82409834",
+            "return_address": "82409838",
+        }
+    ]
+    static["indirect_owner_calls"] = [
+        {
+            "owner_function_address": "82409668",
+            "caller_function": "sub_8240D070",
+            "caller_function_address": "8240D070",
+            "callsite": "8240D1AC",
+            "return_address": "8240D1B0",
+        }
+    ]
+    static["indirect_producer_calls"] = [
+        {
+            "producer_function_address": "8240D070",
+            "caller_function": "sub_8240CF68",
+            "caller_function_address": "8240CF68",
+            "callsite": "8240CFFC",
+            "return_address": "8240D000",
+        }
+    ]
+    static["indirect_context_roots"] = [
+        {
+            "context_function": "sub_8240CF68",
+            "context_function_address": "8240CF68",
+            "producer_function": "sub_8240D070",
+            "producer_function_address": "8240D070",
+            "producer_return_address": "8240D000",
+            "root_entry_register": "r3",
+            "root_offset": 0,
+            "derivation": "r3",
+        }
+    ]
+    return static
+
+
+def context_root_events():
+    traced = events()
+    traced[1].update(
+        {
+            "constructor_function_address": "82409398",
+            "constructor_return_address": "82409838",
+            "sample_constructor_arguments": "00000000," * 7 + "00000000",
+            "constructor_argument_varying_mask": "00",
+            "owner_function_address": "82409668",
+            "owner_return_address": "8240D1B0",
+            "sample_owner_arguments": "00000000," * 7 + "00000000",
+            "owner_argument_varying_mask": "00",
+            "producer_function_address": "8240D070",
+            "producer_return_address": "8240D000",
+            "sample_producer_arguments": (
+                "10000000,20000000,00000001,00000000,00000000,"
+                "00000000,00000000,00000000"
+            ),
+            "producer_argument_varying_mask": "03",
+            "context_function_address": "8240CF68",
+            "context_return_address": "83000000",
+            "sample_context_arguments": (
+                "10000000,30000000,00000002,00000000,00000000,"
+                "00000000,00000000,00000000"
+            ),
+            "context_argument_varying_mask": "05",
+            "sample_context_root_address": "10000000",
+            "context_root_address_varied": "false",
+        }
+    )
+    traced[-1].update(
+        {
+            "indirect_constructor_entries": "1",
+            "indirect_constructor_exits": "1",
+            "indirect_owner_entries": "1",
+            "indirect_owner_exits": "1",
+            "indirect_producer_entries": "1",
+            "indirect_producer_exits": "1",
+            "indirect_owner_producer_mismatches": "0",
+            "indirect_context_entries": "1",
+            "indirect_context_exits": "1",
+            "indirect_context_invocations_open_at_shutdown": "0",
+            "indirect_context_stack_faults": "0",
+            "indirect_producers_without_context_origin": "0",
+            "indirect_producer_context_mismatches": "0",
+        }
+    )
+    return traced
+
+
 class NativeRendererCommandLineageTests(unittest.TestCase):
     def test_builds_complete_exact_lineage_report(self):
         document = MODULE.build(events(), static_inventory())
@@ -422,6 +516,33 @@ class NativeRendererCommandLineageTests(unittest.TestCase):
             12,
             document["totals"]["statically_resolved_producer_origin_draws"],
         )
+
+    def test_proves_balanced_runtime_context_root(self):
+        document = MODULE.build(context_root_events(), context_root_inventory())
+        self.assertEqual("complete", document["status"])
+        shape = document["shapes"][0]
+        self.assertEqual("8240CF68", shape["context_function_address"])
+        self.assertEqual("r3", shape["context_root_derivation"])
+        self.assertTrue(shape["context_root_proved"])
+        self.assertEqual("10000000", shape["sample_context_root_address"])
+        self.assertEqual(5, shape["context_argument_varying_mask"])
+        self.assertEqual(12, document["totals"]["context_origin_draws"])
+        self.assertEqual(
+            12,
+            document["totals"]["statically_resolved_context_origin_draws"],
+        )
+
+    def test_rejects_runtime_context_root_derivation_mismatch(self):
+        traced = context_root_events()
+        traced[1]["sample_context_root_address"] = "10000004"
+        with self.assertRaisesRegex(ValueError, "static derivation"):
+            MODULE.build(traced, context_root_inventory())
+
+    def test_fails_closed_on_context_producer_mismatch(self):
+        traced = context_root_events()
+        traced[-1]["indirect_producer_context_mismatches"] = "1"
+        document = MODULE.build(traced, context_root_inventory())
+        self.assertEqual("incomplete_fail_closed", document["status"])
 
     def test_rejects_producer_that_does_not_contain_owner_callsite(self):
         static = static_inventory()

--- a/tools/tests/test_native_renderer_contract.py
+++ b/tools/tests/test_native_renderer_contract.py
@@ -343,6 +343,16 @@ class NativeRendererContractTests(unittest.TestCase):
         self.assertIn("producer_return_address", source)
         self.assertIn("indirect_producer_stack_faults", source)
         self.assertIn("indirect_owner_producer_mismatches", source)
+        self.assertIn("kIndirectContextStackCapacity = 32", source)
+        self.assertIn("ExpectedIndirectContextFunction", source)
+        self.assertIn("DeriveIndirectContextRoot", source)
+        self.assertIn("context_function_address", source)
+        self.assertIn("sample_context_root_address", source)
+        self.assertIn("indirect_context_stack_faults", source)
+        self.assertIn("indirect_producer_context_mismatches", source)
+        self.assertIn(
+            "std::atomic<uint64_t> g_indirect_producer_entries", source
+        )
         self.assertIn("SetIndirectBufferObserver(&ObserveIndirectBuffer)", source)
         self.assertIn("SetIndirectBufferObserver(nullptr)", source)
         self.assertIn(

--- a/tools/tests/test_native_renderer_dispatch_discovery.py
+++ b/tools/tests/test_native_renderer_dispatch_discovery.py
@@ -280,6 +280,86 @@ def producer_fixtures():
     ]
 
 
+def context_fixtures():
+    return [
+        fixture(
+            0x8240CF68,
+            [
+                "mflr r12",
+                "loc_8240CF80:",
+                "mr r31,r3",
+                "loc_8240CFF8:",
+                "mr r3,r31",
+                "bl 0x8240d070",
+                "loc_8240D054:",
+                "addi r1,r1,112",
+                "blr",
+            ],
+        ),
+        fixture(
+            0x82417BC0,
+            [
+                "mflr r12",
+                "loc_82417BF0:",
+                "stw r6,2156(r1)",
+                "loc_82418058:",
+                "lwz r8,2156(r1)",
+                "loc_82418068:",
+                "addis r24,r8,1",
+                "loc_8241807C:",
+                "addi r24,r24,-5824",
+                "loc_82418A20:",
+                "mr r3,r24",
+                "bl 0x82417060",
+                "loc_82418EC4:",
+                "mr r3,r24",
+                "bl 0x82417060",
+                "loc_82418F38:",
+                "addi r1,r1,2112",
+                "b 0x82a7de20",
+            ],
+        ),
+        fixture(
+            0x824365B0,
+            [
+                "mflr r12",
+                "loc_824365C0:",
+                "mr r29,r3",
+                "loc_8243667C:",
+                "addis r25,r29,1",
+                "loc_82436688:",
+                "addi r25,r25,-5824",
+                "loc_82436690:",
+                "stw r25,84(r1)",
+                "loc_82437030:",
+                "lwz r25,84(r1)",
+                "loc_82437040:",
+                "mr r3,r25",
+                "bl 0x82417060",
+                "loc_82437048:",
+                "addi r1,r1,1472",
+                "b 0x82a7de20",
+            ],
+        ),
+        fixture(
+            0x829F6620,
+            [
+                "mflr r12",
+                "loc_829F662C:",
+                "mr r28,r3",
+                "loc_829F67A8:",
+                "mr r3,r28",
+                "bl 0x829f6360",
+                "loc_829F67B4:",
+                "li r3,0",
+                "loc_829F67B8:",
+                "addi r1,r1,176",
+                "b 0x82a7de44",
+            ],
+        ),
+    ]
+
+
 class NativeRendererDispatchDiscoveryTests(unittest.TestCase):
     def build(self, chunks):
         with tempfile.TemporaryDirectory() as directory:
@@ -508,6 +588,57 @@ class NativeRendererDispatchDiscoveryTests(unittest.TestCase):
         self.assertFalse(call["object_identity_proved"])
         self.assertFalse(call["lifetime_proved"])
 
+    def test_proves_live_producer_context_roots(self):
+        document = self.build(
+            [
+                *reviewed_fixtures(),
+                *producer_fixtures(),
+                *context_fixtures(),
+            ]
+        )
+        self.assertEqual(4, document["totals"]["indirect_context_runtime_hooks"])
+        self.assertEqual(5, document["totals"]["indirect_context_roots"])
+        hooks = {
+            item["function_address"]: item
+            for item in document["indirect_context_runtime_hooks"]
+        }
+        self.assertEqual("82418F38", hooks["82417BC0"]["exit_hook_address"])
+        self.assertEqual("829F67B8", hooks["829F6620"]["exit_hook_address"])
+        self.assertTrue(hooks["82417BC0"]["invocation_scope_proved"])
+        roots = {
+            (
+                item["context_function_address"],
+                item["producer_return_address"],
+            ): item
+            for item in document["indirect_context_roots"]
+        }
+        self.assertEqual(
+            "r3", roots[("8240CF68", "8240D000")]["derivation"]
+        )
+        self.assertEqual(
+            "r6+59712", roots[("82417BC0", "82418A28")]["derivation"]
+        )
+        self.assertEqual(
+            "r3+59712", roots[("824365B0", "82437048")]["derivation"]
+        )
+        self.assertEqual(
+            "r3", roots[("829F6620", "829F67B0")]["derivation"]
+        )
+        self.assertFalse(
+            roots[("824365B0", "82437048")]["object_lifetime_proved"]
+        )
+        self.assertFalse(
+            roots[("824365B0", "82437048")]["suppression_eligible"]
+        )
+
+    def test_rejects_drifted_context_producer_edge(self):
+        contexts = context_fixtures()
+        contexts[-1] = contexts[-1].replace(
+            "bl 0x829f6360", "bl 0x829f5ff0"
+        )
+        with self.assertRaisesRegex(ValueError, "producer edge drifted"):
+            self.build([*reviewed_fixtures(), *producer_fixtures(), *contexts])
+
     def test_runtime_hooks_are_default_off_bounded_and_passive(self):
         hooks = (ROOT / "src/native_renderer/graphics_hooks.cpp").read_text(
             encoding="utf-8"
@@ -665,7 +796,7 @@ class NativeRendererDispatchDiscoveryTests(unittest.TestCase):
                 'registers = ["r3", "r4", "r5", "r6", "r7", "r8", '
                 '"r9", "r10", "r12"]'
             ),
-            23,
+            27,
         )
         self.assertIn(
             "REX_PINYON_SHIFT_NATIVE_RENDERER_DISPATCH_DISCOVERY", capture


### PR DESCRIPTION
## Summary
- derive five live indirect-producer roots from four balanced caller scopes
- propagate exact context evidence through producer, owner, constructor, packet, and draw lineage
- make cross-thread aggregate qualification counters relaxed-atomic
- fail closed on unresolved roots while keeping Xenos authoritative and suppression disabled

## Validation
- 62 focused native-renderer tests pass
- Release build passes
- AppData session \20260829T162653Z-p41196\ exits normally
- 5,311,650 context-origin draws resolve statically with zero faults, mismatches, invalid lineages, overflow, or unresolved origins
- median 30.514 FPS; 19.185 FPS 1% low; 59.981 Hz present; zero deadline/XMA stalls