### PR TITLE
feat(native-renderer): prove procedural model receiver

### DIFF
--- a/config/rexglue/analysis/main-xex.toml
+++ b/config/rexglue/analysis/main-xex.toml
@@ -208,6 +208,49 @@ registers = ["r3", "r4", "r5", "r6", "r7", "r8", "r9", "r10", "r12"]
 address = 0x829F67B8
 name = "PinyonShiftObserveIndirectContext829F6620Exit"
 
+# RTTI-backed lifetime hooks for proceduralGeometry::CProceduralModels. The
+# constructor and destructor both write vtable 0x82002B5C; virtual slot 41 is
+# the context dispatch at 0x82417BC0. Runtime joins only the exact r3 receiver
+# address observed after completed construction and before destruction.
+[[midasm_hook]]
+address = 0x82E1C9A4
+name = "PinyonShiftObserveProceduralModelConstructorEntry"
+registers = ["r3"]
+
+[[midasm_hook]]
+address = 0x82E1CA0C
+name = "PinyonShiftObserveProceduralModelConstructorExit"
+
+[[midasm_hook]]
+address = 0x82E1CA2C
+name = "PinyonShiftObserveProceduralModelDestructorEntry"
+registers = ["r3"]
+
+[[midasm_hook]]
+address = 0x82E1CBD0
+name = "PinyonShiftObserveProceduralModelDestructorExit"
+
+# Vtable slots 14 and 40 bracket the exact visibility-preparation and render-
+# state preparation functions consumed by slot 41. These hooks record only the
+# live receiver generation and balanced invocation order.
+[[midasm_hook]]
+address = 0x82E1FD04
+name = "PinyonShiftObserveProceduralModelVisibilityEntry"
+registers = ["r3"]
+
+[[midasm_hook]]
+address = 0x82E208CC
+name = "PinyonShiftObserveProceduralModelVisibilityExit"
+
+[[midasm_hook]]
+address = 0x824170DC
+name = "PinyonShiftObserveProceduralModelRenderStateEntry"
+registers = ["r3"]
+
+[[midasm_hook]]
+address = 0x82417410
+name = "PinyonShiftObserveProceduralModelRenderStateExit"
+
 [[midasm_hook]]
 address = 0x824095B4
 name = "PinyonShiftObserveIndirectPacket824095B4"

--- a/docs/native-renderer/COMMAND_BUFFER_LINEAGE.md
+++ b/docs/native-renderer/COMMAND_BUFFER_LINEAGE.md
@@ -157,3 +157,14 @@ identity. Session `20260829T162653Z-p41196` runtime-qualified 5,311,650 exact
 context-origin draws with zero unresolved origins, stack faults, join faults,
 invalid lineages, or overflow. It remains metadata-only, Xenos-authoritative,
 and suppression-ineligible.
+
+`PROCEDURAL_MODEL_RECEIVER_LIFETIME.md` defines the first semantic receiver
+join. For `82417BC0` only, a prepared lineage may carry an exact live
+`proceduralGeometry::CProceduralModels` receiver address and generation.
+That lineage also carries the latest completed slot 14 visibility epoch, slot
+40 render-state epoch, and the visibility epoch consumed by slot 40. Runtime
+evidence shows those stages are optional histories, not universal dispatch
+prerequisites. Impossible or unbalanced stage history remains explicit
+fail-closed evidence, and alternate routes remain counted. Mesh,
+material, instance, LOD, and streaming semantics remain unknown, and the
+receiver join does not change Xenos authority.

--- a/docs/native-renderer/HIGH_LEVEL_RENDER_HOOKS.md
+++ b/docs/native-renderer/HIGH_LEVEL_RENDER_HOOKS.md
@@ -283,6 +283,18 @@ the entry-register-plus-offset root must all match producer `r3`. This narrows
 the next object/lifetime investigation without claiming a type, instance,
 registration, destruction, or suppression candidate.
 
+That receiver investigation now proves `82417BC0` as virtual slot 41 of
+`proceduralGeometry::CProceduralModels`, including its exact constructor,
+destructor, scalar-deleting destructor, and runtime address generations. The
+semantic receiver is entry `r3`; the command root remains the distinct
+`r6 + 59712` value. See `PROCEDURAL_MODEL_RECEIVER_LIFETIME.md`. No mesh,
+material, LOD, or streaming field is classified yet. The static proof now also
+identifies the 512-byte object extent, slot 14 visibility preparation, slot 40
+render-state preparation, 92/68-byte descriptor/runtime record strides, and
+three 64-byte transform/constant matrix ranges. Balanced runtime epochs carry
+the optional stage history to slot 41 without reading guest payload; the
+AppData capture refutes treating both stages as a universal prerequisite.
+
 For all 38 direct adapter callsites, the same static inventory now records
 `r3-r10`'s last syntactic definition since the nearest intervening call. Simple
 loads retain base register, offset, and width; values crossing a call boundary

--- a/docs/native-renderer/INDIRECT_CONTEXT_ROOTS.md
+++ b/docs/native-renderer/INDIRECT_CONTEXT_ROOTS.md
@@ -107,3 +107,12 @@ shutdown event. The visually inspected frame retained the car, crowd, stage,
 structures, sky, lighting, HUD, and interaction prompt. Median derived
 performance was 30.514 FPS, the 1% low was 19.185 FPS, present cadence was
 59.981 Hz, and present-deadline and XMA stall counters were zero.
+
+The first semantic refinement is documented in
+`PROCEDURAL_MODEL_RECEIVER_LIFETIME.md`. It identifies entry `r3` of
+`82417BC0` as a live `proceduralGeometry::CProceduralModels` receiver through
+RTTI, vtable, constructor, destructor, and exact runtime address-generation
+evidence. Slot 14 visibility and slot 40 render-state epochs now accompany
+that live generation into slot 41 when those optional stages have occurred.
+Alternate stage routes remain explicit in the report. It deliberately keeps
+the separate `r6 + 59712` command root non-semantic.

--- a/docs/native-renderer/PROCEDURAL_MODEL_RECEIVER_LIFETIME.md
+++ b/docs/native-renderer/PROCEDURAL_MODEL_RECEIVER_LIFETIME.md
@@ -1,0 +1,142 @@
+# Procedural-model receiver lifetime
+
+This NR-05A milestone identifies the first semantic title receiver behind the
+qualified indirect command-buffer lineage. It proves an engine class, its
+object lifetime, its exact object extent, and two observed render-related
+stages. Runtime evidence shows those stages are not universal prerequisites
+for its render dispatch. Individual mesh/material meaning, LOD policy, and
+streaming ownership remain unclassified.
+
+## Static identity
+
+The supported USA retail image proves this exact chain:
+
+| Evidence | Address or value |
+| --- | --- |
+| Complete-object locator | `82363C9C` |
+| Type descriptor | `832B9EDC` |
+| Decorated RTTI name | `.?AVCProceduralModels@proceduralGeometry@@` |
+| Reviewed class | `proceduralGeometry::CProceduralModels` |
+| Vtable | `82002B5C` |
+| Virtual dispatch slot | 41 |
+| Dispatch function | `82417BC0` |
+| Constructor | `82E1C9A0` |
+| Destructor | `82E1CA28` |
+| Scalar-deleting destructor | `82E1D9B0` |
+| Array constructor | `82E1CDC8` |
+| Object stride | 512 bytes |
+| Visibility-preparation virtual | slot 14, `82E1FD00` |
+| Render-state virtual | slot 40, `824170D8` |
+
+The constructor calls its base constructor, writes vtable `82002B5C`, and
+initializes the reviewed receiver fields before returning. The destructor
+writes the same vtable, releases its owned fields, and calls its base
+destructor. Vtable slot zero is the scalar-deleting destructor, which calls the
+reviewed destructor before optional deallocation. Slot 41 is exactly
+`82417BC0`.
+
+This identity is separate from the already-proved command root. At dispatch
+entry, receiver `r3` is the `CProceduralModels` instance while producer root
+`r6 + 59712` is a different address. The implementation never labels that
+command root as the procedural-model object.
+
+## Preparation and payload layout
+
+The array constructor advances exactly 512 bytes between constructed
+`CProceduralModels` objects. Within the derived portion, static instruction
+evidence proves these structural fields:
+
+| Offset | Structural role |
+| ---: | --- |
+| 124 | descriptor-owner pointer |
+| 128 | parallel runtime-record pointer |
+| 132 | auxiliary allocation pointer |
+| 136 | active/double-buffer index |
+| 140 | runtime-record capacity |
+| 320–383 | 64-byte transform/constant matrix |
+| 384–447 | 64-byte transform/constant matrix |
+| 448–511 | 64-byte transform/constant matrix |
+
+Virtual slot 14 walks 92-byte descriptor records and parallel 68-byte runtime
+records, performs the observed spatial/visibility tests, and writes the runtime
+selection state. Virtual slot 40 publishes the three 64-byte matrix ranges and
+invokes the per-record helper at `82417418`; slot 41 consumes the same record
+strides while producing the already-qualified command lineage.
+
+These are structural names, not claims about a shipping engine ABI. In
+particular, the exact mesh, material, LOD, and streaming meaning of individual
+record members is still unknown.
+
+## Runtime lifetime join
+
+Balanced constructor hooks retain entry `r3` and publish its address only
+after the constructor returns. Balanced destructor hooks change that exact
+address from live to destroying at entry and to destroyed at exit. A reused
+address receives a monotonically increasing local generation.
+
+The fixed 1,024-entry lifecycle table is lock-free on the hot dispatch path.
+The `82417BC0` context hook accepts a semantic receiver only when its exact
+entry `r3` address is currently live. Unregistered, destroying, destroyed,
+overflowed, or zero-generation receivers remain unknown and are counted.
+Each accepted address and generation then follows the existing exact
+producer, owner, constructor, packet, nested-buffer, and prepared-draw chain.
+
+Balanced hooks also bracket slot 14 and slot 40. A completed visibility call
+increments a receiver-generation visibility epoch. A completed render-state
+call records the visibility epoch it consumed and increments a render-state
+epoch. Slot 41 snapshots all three values into the exact packet lineage.
+
+The AppData capture proved that these are optional stage histories rather than
+a universal two-step prerequisite for slot 41: only six of 73 active receivers
+visited slot 40, and some valid dispatching receivers visited neither observed
+stage. Qualification therefore fails closed on an unregistered generation,
+an impossible epoch relationship, or an unbalanced stage stack, while
+reporting dispatches before both stages as an observed alternate route. It
+still requires at least one exact lineage that carries all three epochs so the
+full stage join itself is proved. The raw lifecycle event retains the older
+`with_preparation` field names for capture compatibility; report totals call
+them dispatches after or before both observed stages.
+
+Qualification requires balanced constructor and destructor stacks, exact
+published/destroyed/live accounting, zero table overflow, zero unknown or
+post-destruction dispatches, and at least one full-stage lineage carrying an
+exact live receiver generation. Per-address lifecycle summaries reconcile
+with the aggregate counters.
+
+## AppData qualification
+
+Release executable SHA-256
+`714DB33D4C139E0E50767163CDB1FEFB6D9841A5599CEA114E461B88C016076D`
+ran against the installed `0.1.0` preview save in session
+`20260829T171002Z-p39732`. The saved festival scene rendered correctly and the
+process exited cleanly after 7,983 measured frames (245.863 seconds).
+
+The final fail-closed stage-history report is `complete`:
+
+- 256 constructor entries and exits published 256 live generations;
+- 127,396 semantic dispatches all joined an exact live generation;
+- zero unregistered, destroying, destroyed, overflowed, unknown-stage, or
+  stack-fault cases;
+- 72,281 balanced visibility calls and 16,543 balanced render-state calls;
+- 43,401 dispatches followed both observed stages, while 83,995 preserved the
+  newly proved alternate-stage routes;
+- no guest payload reads, guest state/control changes, or suppression.
+
+Performance held a 30.228 FPS median with a 19.461 one-percent low, 49.526 ms
+p95 frame time, 59.952 Hz presentation cadence, and zero present-deadline
+misses. The captured gameplay frame is
+`native-renderer-procedural-model-preparation-open-world.jpg` (SHA-256
+`70492E7E9684401D05C55C4C9BB37CA9A69E3A99AAAE6719F4A43AD3BD87FD58`).
+
+## Safety and remaining semantic work
+
+The hooks observe registers only. They do not read the receiver or command-root
+payload, mutate guest memory, alter control flow, issue a native draw, or
+expose suppression. Xenos remains authoritative.
+
+This milestone proves the class, receiver address generation, observed
+construction-to-destruction interval, record strides, matrix ranges, and the
+visibility/render-state stage histories. It does not prove which record
+members own meshes or materials, which entries are world instances, the exact
+LOD policy, or how streaming registration maps to destruction. Those remain
+required before NR-05B semantic extraction.

--- a/src/native_renderer/graphics_hooks.cpp
+++ b/src/native_renderer/graphics_hooks.cpp
@@ -86,6 +86,8 @@ constexpr size_t kIndirectConstructorStackCapacity = 32;
 constexpr size_t kIndirectOwnerStackCapacity = 32;
 constexpr size_t kIndirectProducerStackCapacity = 32;
 constexpr size_t kIndirectContextStackCapacity = 32;
+constexpr size_t kSemanticReceiverLifecycleCapacity = 1024;
+constexpr size_t kSemanticReceiverStackCapacity = 32;
 constexpr uint64_t kSkyHorizonAnchorSignature = UINT64_C(0x747837906D0BF484);
 constexpr uint64_t kSkyHorizonFollowerSignature = UINT64_C(0x1D253A52B55C9FB3);
 std::atomic<uint64_t> g_frame_sequence{};
@@ -168,11 +170,17 @@ struct TitleIndirectPacketEntry {
   uint32_t context_return_address = 0;
   std::array<uint32_t, 8> context_arguments{};
   uint32_t context_root_address = 0;
+  uint32_t semantic_receiver_address = 0;
+  uint32_t semantic_receiver_generation = 0;
+  uint64_t semantic_visibility_epoch = 0;
+  uint64_t semantic_render_state_epoch = 0;
+  uint64_t semantic_render_state_visibility_epoch = 0;
   uint64_t submission_sequence = 0;
   bool constructor_origin_known = false;
   bool owner_origin_known = false;
   bool producer_origin_known = false;
   bool context_origin_known = false;
+  bool semantic_receiver_known = false;
   bool occupied = false;
 };
 
@@ -184,6 +192,12 @@ struct IndirectConstructorOrigin {
         uint32_t return_address = 0;
         std::array<uint32_t, 8> arguments{};
         uint32_t root_address = 0;
+        uint32_t semantic_receiver_address = 0;
+        uint32_t semantic_receiver_generation = 0;
+        uint64_t semantic_visibility_epoch = 0;
+        uint64_t semantic_render_state_epoch = 0;
+        uint64_t semantic_render_state_visibility_epoch = 0;
+        bool semantic_receiver_known = false;
         bool valid = false;
       } context{};
       uint32_t function_address = 0;
@@ -278,6 +292,60 @@ std::atomic<uint64_t> g_indirect_constructor_invocations_open{};
 std::atomic<uint64_t> g_indirect_owner_invocations_open{};
 std::atomic<uint64_t> g_indirect_producer_invocations_open{};
 std::atomic<uint64_t> g_indirect_context_invocations_open{};
+enum class SemanticReceiverState : uint32_t {
+  kEmpty = 0,
+  kLive = 1,
+  kDestroying = 2,
+  kDestroyed = 3,
+};
+
+struct SemanticReceiverLifecycleEntry {
+  std::atomic<uint32_t> address{};
+  std::atomic<uint32_t> generation{};
+  std::atomic<uint32_t> state{};
+  std::atomic<uint64_t> dispatches{};
+  std::atomic<uint64_t> visibility_preparations{};
+  std::atomic<uint64_t> render_state_preparations{};
+  std::atomic<uint64_t> visibility_epoch{};
+  std::atomic<uint64_t> render_state_epoch{};
+  std::atomic<uint64_t> render_state_visibility_epoch{};
+  // Legacy event field names retained for capture compatibility. These count
+  // whether both optional observed stages had history before a dispatch; they
+  // are not a universal slot-41 readiness predicate.
+  std::atomic<uint64_t> dispatches_with_preparation{};
+  std::atomic<uint64_t> dispatches_without_preparation{};
+  std::atomic<uint64_t> dispatches_without_visibility{};
+  std::atomic<uint64_t> dispatches_without_render_state{};
+};
+
+std::array<SemanticReceiverLifecycleEntry,
+           kSemanticReceiverLifecycleCapacity>
+    g_semantic_receiver_lifecycles{};
+std::atomic<uint64_t> g_semantic_receiver_constructor_entries{};
+std::atomic<uint64_t> g_semantic_receiver_constructor_exits{};
+std::atomic<uint64_t> g_semantic_receiver_constructor_open{};
+std::atomic<uint64_t> g_semantic_receiver_destructor_entries{};
+std::atomic<uint64_t> g_semantic_receiver_destructor_exits{};
+std::atomic<uint64_t> g_semantic_receiver_destructor_open{};
+std::atomic<uint64_t> g_semantic_receiver_stack_faults{};
+std::atomic<uint64_t> g_semantic_receiver_instances_published{};
+std::atomic<uint64_t> g_semantic_receiver_instances_destroyed{};
+std::atomic<uint64_t> g_semantic_receiver_address_reuses{};
+std::atomic<uint64_t> g_semantic_receiver_table_overflow{};
+std::atomic<uint64_t> g_semantic_receiver_dispatches{};
+std::atomic<uint64_t> g_semantic_receiver_live_dispatches{};
+std::atomic<uint64_t> g_semantic_receiver_unregistered_dispatches{};
+std::atomic<uint64_t> g_semantic_receiver_destroying_dispatches{};
+std::atomic<uint64_t> g_semantic_receiver_destroyed_dispatches{};
+std::atomic<uint64_t> g_semantic_receiver_destructors_without_instance{};
+std::atomic<uint64_t> g_semantic_visibility_entries{};
+std::atomic<uint64_t> g_semantic_visibility_exits{};
+std::atomic<uint64_t> g_semantic_visibility_open{};
+std::atomic<uint64_t> g_semantic_render_state_entries{};
+std::atomic<uint64_t> g_semantic_render_state_exits{};
+std::atomic<uint64_t> g_semantic_render_state_open{};
+std::atomic<uint64_t> g_semantic_stage_stack_faults{};
+std::atomic<uint64_t> g_semantic_stage_unknown_receivers{};
 thread_local TitleDrawOrigin g_pending_adapter_origin;
 thread_local std::array<TitleDrawOrigin, kTitleOriginStackCapacity>
     g_title_origin_stack;
@@ -305,6 +373,28 @@ thread_local std::array<IndirectConstructorOrigin::Owner::Producer::Context,
     g_indirect_context_stack;
 thread_local size_t g_indirect_context_stack_depth = 0;
 thread_local size_t g_indirect_context_stack_overflow_depth = 0;
+thread_local std::array<uint32_t, kSemanticReceiverStackCapacity>
+    g_semantic_receiver_constructor_stack{};
+thread_local size_t g_semantic_receiver_constructor_stack_depth = 0;
+thread_local size_t g_semantic_receiver_constructor_overflow_depth = 0;
+thread_local std::array<uint32_t, kSemanticReceiverStackCapacity>
+    g_semantic_receiver_destructor_stack{};
+thread_local size_t g_semantic_receiver_destructor_stack_depth = 0;
+thread_local size_t g_semantic_receiver_destructor_overflow_depth = 0;
+struct SemanticReceiverStageScope {
+  uint32_t address = 0;
+  uint32_t generation = 0;
+};
+thread_local std::array<SemanticReceiverStageScope,
+                        kSemanticReceiverStackCapacity>
+    g_semantic_visibility_stack{};
+thread_local size_t g_semantic_visibility_stack_depth = 0;
+thread_local size_t g_semantic_visibility_overflow_depth = 0;
+thread_local std::array<SemanticReceiverStageScope,
+                        kSemanticReceiverStackCapacity>
+    g_semantic_render_state_stack{};
+thread_local size_t g_semantic_render_state_stack_depth = 0;
+thread_local size_t g_semantic_render_state_overflow_depth = 0;
 
 const char *DispatchWrapperName(DispatchWrapper wrapper) {
   switch (wrapper) {
@@ -489,6 +579,65 @@ void ResetTitleDrawProvenance() {
   g_indirect_owner_invocations_open.store(0, std::memory_order_relaxed);
   g_indirect_producer_invocations_open.store(0, std::memory_order_relaxed);
   g_indirect_context_invocations_open.store(0, std::memory_order_relaxed);
+  for (SemanticReceiverLifecycleEntry &entry :
+       g_semantic_receiver_lifecycles) {
+    entry.address.store(0, std::memory_order_relaxed);
+    entry.generation.store(0, std::memory_order_relaxed);
+    entry.state.store(0, std::memory_order_relaxed);
+    entry.dispatches.store(0, std::memory_order_relaxed);
+    entry.visibility_preparations.store(0, std::memory_order_relaxed);
+    entry.render_state_preparations.store(0, std::memory_order_relaxed);
+    entry.visibility_epoch.store(0, std::memory_order_relaxed);
+    entry.render_state_epoch.store(0, std::memory_order_relaxed);
+    entry.render_state_visibility_epoch.store(0,
+                                               std::memory_order_relaxed);
+    entry.dispatches_with_preparation.store(0, std::memory_order_relaxed);
+    entry.dispatches_without_preparation.store(0,
+                                                std::memory_order_relaxed);
+    entry.dispatches_without_visibility.store(0,
+                                               std::memory_order_relaxed);
+    entry.dispatches_without_render_state.store(0,
+                                                 std::memory_order_relaxed);
+  }
+  g_semantic_receiver_constructor_entries.store(0,
+                                                 std::memory_order_relaxed);
+  g_semantic_receiver_constructor_exits.store(0,
+                                               std::memory_order_relaxed);
+  g_semantic_receiver_constructor_open.store(0,
+                                              std::memory_order_relaxed);
+  g_semantic_receiver_destructor_entries.store(0,
+                                                std::memory_order_relaxed);
+  g_semantic_receiver_destructor_exits.store(0,
+                                              std::memory_order_relaxed);
+  g_semantic_receiver_destructor_open.store(0,
+                                             std::memory_order_relaxed);
+  g_semantic_receiver_stack_faults.store(0, std::memory_order_relaxed);
+  g_semantic_receiver_instances_published.store(0,
+                                                 std::memory_order_relaxed);
+  g_semantic_receiver_instances_destroyed.store(0,
+                                                 std::memory_order_relaxed);
+  g_semantic_receiver_address_reuses.store(0, std::memory_order_relaxed);
+  g_semantic_receiver_table_overflow.store(0, std::memory_order_relaxed);
+  g_semantic_receiver_dispatches.store(0, std::memory_order_relaxed);
+  g_semantic_receiver_live_dispatches.store(0,
+                                             std::memory_order_relaxed);
+  g_semantic_receiver_unregistered_dispatches.store(
+      0, std::memory_order_relaxed);
+  g_semantic_receiver_destroying_dispatches.store(
+      0, std::memory_order_relaxed);
+  g_semantic_receiver_destroyed_dispatches.store(
+      0, std::memory_order_relaxed);
+  g_semantic_receiver_destructors_without_instance.store(
+      0, std::memory_order_relaxed);
+  g_semantic_visibility_entries.store(0, std::memory_order_relaxed);
+  g_semantic_visibility_exits.store(0, std::memory_order_relaxed);
+  g_semantic_visibility_open.store(0, std::memory_order_relaxed);
+  g_semantic_render_state_entries.store(0, std::memory_order_relaxed);
+  g_semantic_render_state_exits.store(0, std::memory_order_relaxed);
+  g_semantic_render_state_open.store(0, std::memory_order_relaxed);
+  g_semantic_stage_stack_faults.store(0, std::memory_order_relaxed);
+  g_semantic_stage_unknown_receivers.store(0,
+                                            std::memory_order_relaxed);
   g_pending_adapter_origin = {};
   g_title_origin_stack = {};
   g_title_origin_stack_depth = 0;
@@ -506,6 +655,18 @@ void ResetTitleDrawProvenance() {
   g_indirect_context_stack = {};
   g_indirect_context_stack_depth = 0;
   g_indirect_context_stack_overflow_depth = 0;
+  g_semantic_receiver_constructor_stack = {};
+  g_semantic_receiver_constructor_stack_depth = 0;
+  g_semantic_receiver_constructor_overflow_depth = 0;
+  g_semantic_receiver_destructor_stack = {};
+  g_semantic_receiver_destructor_stack_depth = 0;
+  g_semantic_receiver_destructor_overflow_depth = 0;
+  g_semantic_visibility_stack = {};
+  g_semantic_visibility_stack_depth = 0;
+  g_semantic_visibility_overflow_depth = 0;
+  g_semantic_render_state_stack = {};
+  g_semantic_render_state_stack_depth = 0;
+  g_semantic_render_state_overflow_depth = 0;
 }
 
 void ConfigureTitleDrawProvenance(bool census_requested,
@@ -731,6 +892,364 @@ uint32_t DeriveIndirectContextRoot(
   }
 }
 
+size_t SemanticReceiverLifecycleIndex(uint32_t address) {
+  return size_t((address >> 4) % kSemanticReceiverLifecycleCapacity);
+}
+
+SemanticReceiverLifecycleEntry *FindSemanticReceiverLifecycle(
+    uint32_t address) {
+  size_t index = SemanticReceiverLifecycleIndex(address);
+  for (size_t probe = 0; probe < kSemanticReceiverLifecycleCapacity;
+       ++probe) {
+    SemanticReceiverLifecycleEntry &entry =
+        g_semantic_receiver_lifecycles[index];
+    const uint32_t observed =
+        entry.address.load(std::memory_order_acquire);
+    if (observed == address) {
+      return &entry;
+    }
+    if (!observed) {
+      return nullptr;
+    }
+    index = (index + 1) % kSemanticReceiverLifecycleCapacity;
+  }
+  return nullptr;
+}
+
+SemanticReceiverLifecycleEntry *FindOrClaimSemanticReceiverLifecycle(
+    uint32_t address) {
+  size_t index = SemanticReceiverLifecycleIndex(address);
+  for (size_t probe = 0; probe < kSemanticReceiverLifecycleCapacity;
+       ++probe) {
+    SemanticReceiverLifecycleEntry &entry =
+        g_semantic_receiver_lifecycles[index];
+    uint32_t observed = entry.address.load(std::memory_order_acquire);
+    if (observed == address) {
+      return &entry;
+    }
+    if (!observed && entry.address.compare_exchange_strong(
+                         observed, address, std::memory_order_acq_rel,
+                         std::memory_order_acquire)) {
+      return &entry;
+    }
+    index = (index + 1) % kSemanticReceiverLifecycleCapacity;
+  }
+  g_semantic_receiver_table_overflow.fetch_add(1,
+                                                std::memory_order_relaxed);
+  return nullptr;
+}
+
+void PublishSemanticReceiver(uint32_t address) {
+  SemanticReceiverLifecycleEntry *entry =
+      FindOrClaimSemanticReceiverLifecycle(address);
+  if (!entry) {
+    return;
+  }
+  const auto previous = static_cast<SemanticReceiverState>(
+      entry->state.load(std::memory_order_acquire));
+  if (previous == SemanticReceiverState::kLive ||
+      previous == SemanticReceiverState::kDestroying) {
+    g_semantic_receiver_stack_faults.fetch_add(1,
+                                                std::memory_order_relaxed);
+    return;
+  }
+  uint32_t generation =
+      entry->generation.load(std::memory_order_relaxed) + 1;
+  if (!generation) {
+    generation = 1;
+  }
+  if (previous == SemanticReceiverState::kDestroyed) {
+    g_semantic_receiver_address_reuses.fetch_add(1,
+                                                  std::memory_order_relaxed);
+  }
+  entry->dispatches.store(0, std::memory_order_relaxed);
+  entry->visibility_preparations.store(0, std::memory_order_relaxed);
+  entry->render_state_preparations.store(0, std::memory_order_relaxed);
+  entry->visibility_epoch.store(0, std::memory_order_relaxed);
+  entry->render_state_epoch.store(0, std::memory_order_relaxed);
+  entry->render_state_visibility_epoch.store(0,
+                                              std::memory_order_relaxed);
+  entry->dispatches_with_preparation.store(0, std::memory_order_relaxed);
+  entry->dispatches_without_preparation.store(0,
+                                               std::memory_order_relaxed);
+  entry->dispatches_without_visibility.store(0,
+                                              std::memory_order_relaxed);
+  entry->dispatches_without_render_state.store(0,
+                                                std::memory_order_relaxed);
+  entry->generation.store(generation, std::memory_order_relaxed);
+  entry->state.store(uint32_t(SemanticReceiverState::kLive),
+                     std::memory_order_release);
+  g_semantic_receiver_instances_published.fetch_add(
+      1, std::memory_order_relaxed);
+}
+
+void BeginSemanticReceiverConstruction(uint32_t address) {
+  if (!g_command_buffer_lineage_installed.load(std::memory_order_acquire)) {
+    return;
+  }
+  g_semantic_receiver_constructor_entries.fetch_add(
+      1, std::memory_order_relaxed);
+  if (g_semantic_receiver_constructor_stack_depth ==
+      kSemanticReceiverStackCapacity) {
+    g_semantic_receiver_stack_faults.fetch_add(1,
+                                                std::memory_order_relaxed);
+    ++g_semantic_receiver_constructor_overflow_depth;
+    return;
+  }
+  g_semantic_receiver_constructor_stack
+      [g_semantic_receiver_constructor_stack_depth++] = address;
+  g_semantic_receiver_constructor_open.fetch_add(1,
+                                                  std::memory_order_relaxed);
+}
+
+void EndSemanticReceiverConstruction() {
+  if (!g_command_buffer_lineage_installed.load(std::memory_order_acquire)) {
+    return;
+  }
+  g_semantic_receiver_constructor_exits.fetch_add(
+      1, std::memory_order_relaxed);
+  if (g_semantic_receiver_constructor_overflow_depth) {
+    --g_semantic_receiver_constructor_overflow_depth;
+    return;
+  }
+  if (!g_semantic_receiver_constructor_stack_depth) {
+    g_semantic_receiver_stack_faults.fetch_add(1,
+                                                std::memory_order_relaxed);
+    return;
+  }
+  const uint32_t address = g_semantic_receiver_constructor_stack
+      [--g_semantic_receiver_constructor_stack_depth];
+  g_semantic_receiver_constructor_open.fetch_sub(1,
+                                                  std::memory_order_relaxed);
+  PublishSemanticReceiver(address);
+}
+
+void BeginSemanticReceiverDestruction(uint32_t address) {
+  if (!g_command_buffer_lineage_installed.load(std::memory_order_acquire)) {
+    return;
+  }
+  g_semantic_receiver_destructor_entries.fetch_add(
+      1, std::memory_order_relaxed);
+  if (g_semantic_receiver_destructor_stack_depth ==
+      kSemanticReceiverStackCapacity) {
+    g_semantic_receiver_stack_faults.fetch_add(1,
+                                                std::memory_order_relaxed);
+    ++g_semantic_receiver_destructor_overflow_depth;
+    return;
+  }
+  g_semantic_receiver_destructor_stack
+      [g_semantic_receiver_destructor_stack_depth++] = address;
+  g_semantic_receiver_destructor_open.fetch_add(1,
+                                                 std::memory_order_relaxed);
+  SemanticReceiverLifecycleEntry *entry =
+      FindSemanticReceiverLifecycle(address);
+  uint32_t expected_state = uint32_t(SemanticReceiverState::kLive);
+  if (!entry || !entry->state.compare_exchange_strong(
+                    expected_state,
+                    uint32_t(SemanticReceiverState::kDestroying),
+                    std::memory_order_acq_rel,
+                    std::memory_order_acquire)) {
+    g_semantic_receiver_destructors_without_instance.fetch_add(
+        1, std::memory_order_relaxed);
+  }
+}
+
+void EndSemanticReceiverDestruction() {
+  if (!g_command_buffer_lineage_installed.load(std::memory_order_acquire)) {
+    return;
+  }
+  g_semantic_receiver_destructor_exits.fetch_add(
+      1, std::memory_order_relaxed);
+  if (g_semantic_receiver_destructor_overflow_depth) {
+    --g_semantic_receiver_destructor_overflow_depth;
+    return;
+  }
+  if (!g_semantic_receiver_destructor_stack_depth) {
+    g_semantic_receiver_stack_faults.fetch_add(1,
+                                                std::memory_order_relaxed);
+    return;
+  }
+  const uint32_t address = g_semantic_receiver_destructor_stack
+      [--g_semantic_receiver_destructor_stack_depth];
+  g_semantic_receiver_destructor_open.fetch_sub(1,
+                                                 std::memory_order_relaxed);
+  SemanticReceiverLifecycleEntry *entry =
+      FindSemanticReceiverLifecycle(address);
+  uint32_t expected_state = uint32_t(SemanticReceiverState::kDestroying);
+  if (!entry || !entry->state.compare_exchange_strong(
+                    expected_state,
+                    uint32_t(SemanticReceiverState::kDestroyed),
+                    std::memory_order_acq_rel,
+                    std::memory_order_acquire)) {
+    g_semantic_receiver_stack_faults.fetch_add(1,
+                                                std::memory_order_relaxed);
+    return;
+  }
+  g_semantic_receiver_instances_destroyed.fetch_add(
+      1, std::memory_order_relaxed);
+}
+
+enum class SemanticReceiverStage {
+  kVisibility,
+  kRenderState,
+};
+
+void BeginSemanticReceiverStage(uint32_t address,
+                                SemanticReceiverStage stage) {
+  if (!g_command_buffer_lineage_installed.load(std::memory_order_acquire)) {
+    return;
+  }
+  auto &entries = stage == SemanticReceiverStage::kVisibility
+                      ? g_semantic_visibility_entries
+                      : g_semantic_render_state_entries;
+  auto &open = stage == SemanticReceiverStage::kVisibility
+                   ? g_semantic_visibility_open
+                   : g_semantic_render_state_open;
+  auto &stack = stage == SemanticReceiverStage::kVisibility
+                    ? g_semantic_visibility_stack
+                    : g_semantic_render_state_stack;
+  size_t &depth = stage == SemanticReceiverStage::kVisibility
+                      ? g_semantic_visibility_stack_depth
+                      : g_semantic_render_state_stack_depth;
+  size_t &overflow_depth = stage == SemanticReceiverStage::kVisibility
+                               ? g_semantic_visibility_overflow_depth
+                               : g_semantic_render_state_overflow_depth;
+  entries.fetch_add(1, std::memory_order_relaxed);
+  if (depth == kSemanticReceiverStackCapacity) {
+    g_semantic_stage_stack_faults.fetch_add(1,
+                                             std::memory_order_relaxed);
+    ++overflow_depth;
+    return;
+  }
+  SemanticReceiverStageScope &scope = stack[depth++];
+  scope = {};
+  scope.address = address;
+  SemanticReceiverLifecycleEntry *entry =
+      FindSemanticReceiverLifecycle(address);
+  if (!entry || entry->state.load(std::memory_order_acquire) !=
+                    uint32_t(SemanticReceiverState::kLive)) {
+    g_semantic_stage_unknown_receivers.fetch_add(
+        1, std::memory_order_relaxed);
+  } else {
+    scope.generation = entry->generation.load(std::memory_order_relaxed);
+  }
+  open.fetch_add(1, std::memory_order_relaxed);
+}
+
+void EndSemanticReceiverStage(SemanticReceiverStage stage) {
+  if (!g_command_buffer_lineage_installed.load(std::memory_order_acquire)) {
+    return;
+  }
+  auto &exits = stage == SemanticReceiverStage::kVisibility
+                    ? g_semantic_visibility_exits
+                    : g_semantic_render_state_exits;
+  auto &open = stage == SemanticReceiverStage::kVisibility
+                   ? g_semantic_visibility_open
+                   : g_semantic_render_state_open;
+  auto &stack = stage == SemanticReceiverStage::kVisibility
+                    ? g_semantic_visibility_stack
+                    : g_semantic_render_state_stack;
+  size_t &depth = stage == SemanticReceiverStage::kVisibility
+                      ? g_semantic_visibility_stack_depth
+                      : g_semantic_render_state_stack_depth;
+  size_t &overflow_depth = stage == SemanticReceiverStage::kVisibility
+                               ? g_semantic_visibility_overflow_depth
+                               : g_semantic_render_state_overflow_depth;
+  exits.fetch_add(1, std::memory_order_relaxed);
+  if (overflow_depth) {
+    --overflow_depth;
+    return;
+  }
+  if (!depth) {
+    g_semantic_stage_stack_faults.fetch_add(1,
+                                             std::memory_order_relaxed);
+    return;
+  }
+  const SemanticReceiverStageScope scope = stack[--depth];
+  open.fetch_sub(1, std::memory_order_relaxed);
+  SemanticReceiverLifecycleEntry *entry =
+      FindSemanticReceiverLifecycle(scope.address);
+  if (!scope.generation || !entry ||
+      entry->state.load(std::memory_order_acquire) !=
+          uint32_t(SemanticReceiverState::kLive) ||
+      entry->generation.load(std::memory_order_relaxed) != scope.generation) {
+    g_semantic_stage_unknown_receivers.fetch_add(
+        1, std::memory_order_relaxed);
+    return;
+  }
+  if (stage == SemanticReceiverStage::kVisibility) {
+    entry->visibility_preparations.fetch_add(1,
+                                              std::memory_order_relaxed);
+    entry->visibility_epoch.fetch_add(1, std::memory_order_release);
+  } else {
+    entry->render_state_visibility_epoch.store(
+        entry->visibility_epoch.load(std::memory_order_acquire),
+        std::memory_order_relaxed);
+    entry->render_state_preparations.fetch_add(1,
+                                                std::memory_order_relaxed);
+    entry->render_state_epoch.fetch_add(1, std::memory_order_release);
+  }
+}
+
+bool ResolveSemanticReceiver(uint32_t address, uint32_t *generation,
+                             uint64_t *visibility_epoch,
+                             uint64_t *render_state_epoch,
+                             uint64_t *render_state_visibility_epoch) {
+  g_semantic_receiver_dispatches.fetch_add(1, std::memory_order_relaxed);
+  SemanticReceiverLifecycleEntry *entry =
+      FindSemanticReceiverLifecycle(address);
+  if (!entry) {
+    g_semantic_receiver_unregistered_dispatches.fetch_add(
+        1, std::memory_order_relaxed);
+    return false;
+  }
+  const auto state = static_cast<SemanticReceiverState>(
+      entry->state.load(std::memory_order_acquire));
+  if (state != SemanticReceiverState::kLive) {
+    if (state == SemanticReceiverState::kDestroying) {
+      g_semantic_receiver_destroying_dispatches.fetch_add(
+          1, std::memory_order_relaxed);
+    } else {
+      g_semantic_receiver_destroyed_dispatches.fetch_add(
+          1, std::memory_order_relaxed);
+    }
+    return false;
+  }
+  *generation = entry->generation.load(std::memory_order_relaxed);
+  if (entry->state.load(std::memory_order_acquire) !=
+      uint32_t(SemanticReceiverState::kLive)) {
+    g_semantic_receiver_destroying_dispatches.fetch_add(
+        1, std::memory_order_relaxed);
+    return false;
+  }
+  entry->dispatches.fetch_add(1, std::memory_order_relaxed);
+  *visibility_epoch =
+      entry->visibility_epoch.load(std::memory_order_acquire);
+  *render_state_epoch =
+      entry->render_state_epoch.load(std::memory_order_acquire);
+  *render_state_visibility_epoch =
+      entry->render_state_visibility_epoch.load(std::memory_order_relaxed);
+  if (!*visibility_epoch) {
+    entry->dispatches_without_visibility.fetch_add(
+        1, std::memory_order_relaxed);
+  }
+  if (!*render_state_epoch) {
+    entry->dispatches_without_render_state.fetch_add(
+        1, std::memory_order_relaxed);
+  }
+  if (*visibility_epoch && *render_state_epoch &&
+      *render_state_visibility_epoch) {
+    entry->dispatches_with_preparation.fetch_add(
+        1, std::memory_order_relaxed);
+  } else {
+    entry->dispatches_without_preparation.fetch_add(
+        1, std::memory_order_relaxed);
+  }
+  g_semantic_receiver_live_dispatches.fetch_add(
+      1, std::memory_order_relaxed);
+  return *generation != 0;
+}
+
 void PushIndirectContextOrigin(uint32_t function_address,
                                uint32_t return_address, uint32_t r3,
                                uint32_t r4, uint32_t r5, uint32_t r6,
@@ -754,6 +1273,14 @@ void PushIndirectContextOrigin(uint32_t function_address,
   context.arguments = {r3, r4, r5, r6, r7, r8, r9, r10};
   context.root_address =
       DeriveIndirectContextRoot(function_address, context.arguments);
+  if (function_address == 0x82417BC0) {
+    context.semantic_receiver_address = r3;
+    context.semantic_receiver_known = ResolveSemanticReceiver(
+        r3, &context.semantic_receiver_generation,
+        &context.semantic_visibility_epoch,
+        &context.semantic_render_state_epoch,
+        &context.semantic_render_state_visibility_epoch);
+  }
   context.valid = true;
   g_indirect_context_invocations_open.fetch_add(1,
                                                  std::memory_order_relaxed);
@@ -1090,11 +1617,23 @@ void RecordTitleIndirectPacket(uint32_t packet_guest_address,
   entry.context_return_address = origin.owner.producer.context.return_address;
   entry.context_arguments = origin.owner.producer.context.arguments;
   entry.context_root_address = origin.owner.producer.context.root_address;
+  entry.semantic_receiver_address =
+      origin.owner.producer.context.semantic_receiver_address;
+  entry.semantic_receiver_generation =
+      origin.owner.producer.context.semantic_receiver_generation;
+  entry.semantic_visibility_epoch =
+      origin.owner.producer.context.semantic_visibility_epoch;
+  entry.semantic_render_state_epoch =
+      origin.owner.producer.context.semantic_render_state_epoch;
+  entry.semantic_render_state_visibility_epoch =
+      origin.owner.producer.context.semantic_render_state_visibility_epoch;
   entry.submission_sequence = ++g_title_indirect_packet_submission_sequence;
   entry.constructor_origin_known = origin.valid;
   entry.owner_origin_known = origin.owner.valid;
   entry.producer_origin_known = origin.owner.producer.valid;
   entry.context_origin_known = origin.owner.producer.context.valid;
+  entry.semantic_receiver_known =
+      origin.owner.producer.context.semantic_receiver_known;
   entry.occupied = true;
   ++g_title_indirect_packets_recorded;
 }
@@ -1180,6 +1719,19 @@ void ObserveIndirectBuffer(
         matched.context_arguments;
     active.constructor_origin.owner.producer.context.root_address =
         matched.context_root_address;
+    active.constructor_origin.owner.producer.context.semantic_receiver_address =
+        matched.semantic_receiver_address;
+    active.constructor_origin.owner.producer.context
+        .semantic_receiver_generation = matched.semantic_receiver_generation;
+    active.constructor_origin.owner.producer.context.semantic_visibility_epoch =
+        matched.semantic_visibility_epoch;
+    active.constructor_origin.owner.producer.context.semantic_render_state_epoch =
+        matched.semantic_render_state_epoch;
+    active.constructor_origin.owner.producer.context
+        .semantic_render_state_visibility_epoch =
+        matched.semantic_render_state_visibility_epoch;
+    active.constructor_origin.owner.producer.context.semantic_receiver_known =
+        matched.semantic_receiver_known;
     active.constructor_origin.owner.producer.context.valid =
         matched.context_origin_known;
     active.depth = observation.depth;
@@ -2076,11 +2628,18 @@ struct CommandBufferLineageEntry {
   uint32_t context_argument_varying_mask = 0;
   uint32_t sample_context_root_address = 0;
   bool context_root_address_varied = false;
+  uint32_t semantic_receiver_address = 0;
+  uint32_t semantic_receiver_generation = 0;
+  uint64_t semantic_visibility_epoch = 0;
+  uint64_t semantic_render_state_epoch = 0;
+  uint64_t semantic_render_state_visibility_epoch = 0;
   uint32_t depth = 0;
   bool constructor_origin_known = false;
   bool owner_origin_known = false;
   bool producer_origin_known = false;
   bool context_origin_known = false;
+  bool semantic_receiver_known = false;
+  bool semantic_preparation_epoch_varied = false;
   bool prepared_signature_varied = false;
 };
 
@@ -3573,6 +4132,10 @@ void RecordPreparedCommandBufferLineage(
         uint64_t(constructor_origin.owner.producer.return_address),
         uint64_t(constructor_origin.owner.producer.context.function_address),
         uint64_t(constructor_origin.owner.producer.context.return_address),
+        uint64_t(
+            constructor_origin.owner.producer.context.semantic_receiver_address),
+        uint64_t(constructor_origin.owner.producer.context
+                     .semantic_receiver_generation),
         uint64_t(observation.command_buffer_depth)}) {
     key = HashCombine(key, value);
   }
@@ -3631,6 +4194,20 @@ void RecordPreparedCommandBufferLineage(
           constructor_origin.owner.producer.context.root_address;
       entry.context_origin_known =
           constructor_origin.owner.producer.context.valid;
+      entry.semantic_receiver_address = constructor_origin.owner.producer
+                                            .context.semantic_receiver_address;
+      entry.semantic_receiver_generation =
+          constructor_origin.owner.producer.context
+              .semantic_receiver_generation;
+      entry.semantic_visibility_epoch = constructor_origin.owner.producer
+                                            .context.semantic_visibility_epoch;
+      entry.semantic_render_state_epoch = constructor_origin.owner.producer
+                                              .context.semantic_render_state_epoch;
+      entry.semantic_render_state_visibility_epoch =
+          constructor_origin.owner.producer.context
+              .semantic_render_state_visibility_epoch;
+      entry.semantic_receiver_known = constructor_origin.owner.producer.context
+                                          .semantic_receiver_known;
       entry.depth = observation.command_buffer_depth;
       ++g_command_buffer_lineage_entry_count;
       return;
@@ -3648,8 +4225,24 @@ void RecordPreparedCommandBufferLineage(
             constructor_origin.owner.producer.context.function_address &&
         entry.context_return_address ==
             constructor_origin.owner.producer.context.return_address &&
+        entry.semantic_receiver_address ==
+            constructor_origin.owner.producer.context
+                .semantic_receiver_address &&
+        entry.semantic_receiver_generation ==
+            constructor_origin.owner.producer.context
+                .semantic_receiver_generation &&
         entry.depth == observation.command_buffer_depth) {
       ++entry.calls;
+      entry.semantic_preparation_epoch_varied |=
+          entry.semantic_visibility_epoch !=
+              constructor_origin.owner.producer.context
+                  .semantic_visibility_epoch ||
+          entry.semantic_render_state_epoch !=
+              constructor_origin.owner.producer.context
+                  .semantic_render_state_epoch ||
+          entry.semantic_render_state_visibility_epoch !=
+              constructor_origin.owner.producer.context
+                  .semantic_render_state_visibility_epoch;
       entry.last_frame = observation.frame_sequence;
       entry.last_draw = observation.draw_sequence;
       entry.min_packet_offset_bytes =
@@ -3850,9 +4443,106 @@ void EmitCommandBufferLineageSummary() {
               : "unknown"},
          {"context_root_address_varied",
           entry.context_root_address_varied ? "true" : "false"},
+         {"semantic_receiver_class",
+          entry.semantic_receiver_known
+              ? "proceduralGeometry::CProceduralModels"
+              : "unknown"},
+         {"semantic_receiver_address",
+          entry.semantic_receiver_known
+              ? fmt::format("{:08X}", entry.semantic_receiver_address)
+              : "unknown"},
+         {"semantic_receiver_generation",
+          entry.semantic_receiver_known
+              ? std::to_string(entry.semantic_receiver_generation)
+              : "unknown"},
+         {"semantic_visibility_epoch",
+          entry.semantic_receiver_known
+              ? std::to_string(entry.semantic_visibility_epoch)
+              : "unknown"},
+         {"semantic_render_state_epoch",
+          entry.semantic_receiver_known
+              ? std::to_string(entry.semantic_render_state_epoch)
+              : "unknown"},
+         {"semantic_render_state_visibility_epoch",
+          entry.semantic_receiver_known
+              ? std::to_string(entry.semantic_render_state_visibility_epoch)
+              : "unknown"},
+         {"semantic_preparation_epoch_varied",
+          entry.semantic_preparation_epoch_varied ? "true" : "false"},
          {"depth", std::to_string(entry.depth)},
          {"guest_payload_read", "false"},
          {"guest_state_changed", "false"},
+         {"xenos_authority", "true"},
+         {"suppression_allowed", "false"}});
+  }
+  uint64_t semantic_receivers_tracked = 0;
+  uint64_t semantic_receivers_live = 0;
+  uint64_t semantic_receivers_destroying = 0;
+  uint64_t semantic_receivers_destroyed = 0;
+  for (const SemanticReceiverLifecycleEntry &entry :
+       g_semantic_receiver_lifecycles) {
+    const uint32_t address = entry.address.load(std::memory_order_acquire);
+    if (!address) {
+      continue;
+    }
+    ++semantic_receivers_tracked;
+    const auto state = static_cast<SemanticReceiverState>(
+        entry.state.load(std::memory_order_acquire));
+    const char *state_name = "empty";
+    switch (state) {
+    case SemanticReceiverState::kLive:
+      state_name = "live";
+      ++semantic_receivers_live;
+      break;
+    case SemanticReceiverState::kDestroying:
+      state_name = "destroying";
+      ++semantic_receivers_destroying;
+      break;
+    case SemanticReceiverState::kDestroyed:
+      state_name = "destroyed";
+      ++semantic_receivers_destroyed;
+      break;
+    case SemanticReceiverState::kEmpty:
+      break;
+    }
+    pinyon_shift::diagnostics::RecordEvent(
+        "native_renderer.discovery.semantic_receiver_lifecycle_entry",
+        {{"class", "proceduralGeometry::CProceduralModels"},
+         {"address", fmt::format("{:08X}", address)},
+         {"generation",
+          std::to_string(entry.generation.load(std::memory_order_relaxed))},
+         {"state", state_name},
+         {"dispatches",
+          std::to_string(entry.dispatches.load(std::memory_order_relaxed))},
+         {"visibility_preparations",
+          std::to_string(entry.visibility_preparations.load(
+              std::memory_order_relaxed))},
+         {"render_state_preparations",
+          std::to_string(entry.render_state_preparations.load(
+              std::memory_order_relaxed))},
+         {"visibility_epoch",
+          std::to_string(
+              entry.visibility_epoch.load(std::memory_order_relaxed))},
+         {"render_state_epoch",
+          std::to_string(
+              entry.render_state_epoch.load(std::memory_order_relaxed))},
+         {"render_state_visibility_epoch",
+          std::to_string(entry.render_state_visibility_epoch.load(
+              std::memory_order_relaxed))},
+         {"dispatches_with_preparation",
+          std::to_string(entry.dispatches_with_preparation.load(
+              std::memory_order_relaxed))},
+         {"dispatches_without_preparation",
+          std::to_string(entry.dispatches_without_preparation.load(
+              std::memory_order_relaxed))},
+         {"dispatches_without_visibility",
+          std::to_string(entry.dispatches_without_visibility.load(
+              std::memory_order_relaxed))},
+         {"dispatches_without_render_state",
+          std::to_string(entry.dispatches_without_render_state.load(
+              std::memory_order_relaxed))},
+         {"identity_join", "exact_constructor_receiver_address"},
+         {"guest_payload_read", "false"},
          {"xenos_authority", "true"},
          {"suppression_allowed", "false"}});
   }
@@ -3959,12 +4649,99 @@ void EmitCommandBufferLineageSummary() {
        {"indirect_producer_context_mismatches",
         std::to_string(g_indirect_producer_context_mismatches.load(
             std::memory_order_relaxed))},
+       {"semantic_receiver_class",
+        "proceduralGeometry::CProceduralModels"},
+       {"semantic_receiver_constructor_entries",
+        std::to_string(g_semantic_receiver_constructor_entries.load(
+            std::memory_order_relaxed))},
+       {"semantic_receiver_constructor_exits",
+        std::to_string(g_semantic_receiver_constructor_exits.load(
+            std::memory_order_relaxed))},
+       {"semantic_receiver_constructor_open_at_shutdown",
+        std::to_string(g_semantic_receiver_constructor_open.load(
+            std::memory_order_relaxed))},
+       {"semantic_receiver_destructor_entries",
+        std::to_string(g_semantic_receiver_destructor_entries.load(
+            std::memory_order_relaxed))},
+       {"semantic_receiver_destructor_exits",
+        std::to_string(g_semantic_receiver_destructor_exits.load(
+            std::memory_order_relaxed))},
+       {"semantic_receiver_destructor_open_at_shutdown",
+        std::to_string(g_semantic_receiver_destructor_open.load(
+            std::memory_order_relaxed))},
+       {"semantic_receiver_stack_faults",
+        std::to_string(g_semantic_receiver_stack_faults.load(
+            std::memory_order_relaxed))},
+       {"semantic_receiver_instances_published",
+        std::to_string(g_semantic_receiver_instances_published.load(
+            std::memory_order_relaxed))},
+       {"semantic_receiver_instances_destroyed",
+        std::to_string(g_semantic_receiver_instances_destroyed.load(
+            std::memory_order_relaxed))},
+       {"semantic_receiver_address_reuses",
+        std::to_string(g_semantic_receiver_address_reuses.load(
+            std::memory_order_relaxed))},
+       {"semantic_receiver_table_overflow",
+        std::to_string(g_semantic_receiver_table_overflow.load(
+            std::memory_order_relaxed))},
+       {"semantic_receiver_dispatches",
+        std::to_string(g_semantic_receiver_dispatches.load(
+            std::memory_order_relaxed))},
+       {"semantic_receiver_live_dispatches",
+        std::to_string(g_semantic_receiver_live_dispatches.load(
+            std::memory_order_relaxed))},
+       {"semantic_receiver_unregistered_dispatches",
+        std::to_string(g_semantic_receiver_unregistered_dispatches.load(
+            std::memory_order_relaxed))},
+       {"semantic_receiver_destroying_dispatches",
+        std::to_string(g_semantic_receiver_destroying_dispatches.load(
+            std::memory_order_relaxed))},
+       {"semantic_receiver_destroyed_dispatches",
+        std::to_string(g_semantic_receiver_destroyed_dispatches.load(
+            std::memory_order_relaxed))},
+       {"semantic_receiver_destructors_without_instance",
+        std::to_string(g_semantic_receiver_destructors_without_instance.load(
+            std::memory_order_relaxed))},
+       {"semantic_visibility_entries",
+        std::to_string(
+            g_semantic_visibility_entries.load(std::memory_order_relaxed))},
+       {"semantic_visibility_exits",
+        std::to_string(
+            g_semantic_visibility_exits.load(std::memory_order_relaxed))},
+       {"semantic_visibility_open_at_shutdown",
+        std::to_string(
+            g_semantic_visibility_open.load(std::memory_order_relaxed))},
+       {"semantic_render_state_entries",
+        std::to_string(g_semantic_render_state_entries.load(
+            std::memory_order_relaxed))},
+       {"semantic_render_state_exits",
+        std::to_string(
+            g_semantic_render_state_exits.load(std::memory_order_relaxed))},
+       {"semantic_render_state_open_at_shutdown",
+        std::to_string(
+            g_semantic_render_state_open.load(std::memory_order_relaxed))},
+       {"semantic_stage_stack_faults",
+        std::to_string(
+            g_semantic_stage_stack_faults.load(std::memory_order_relaxed))},
+       {"semantic_stage_unknown_receivers",
+        std::to_string(g_semantic_stage_unknown_receivers.load(
+            std::memory_order_relaxed))},
+       {"semantic_receivers_tracked",
+        std::to_string(semantic_receivers_tracked)},
+       {"semantic_receivers_live_at_shutdown",
+        std::to_string(semantic_receivers_live)},
+       {"semantic_receivers_destroying_at_shutdown",
+        std::to_string(semantic_receivers_destroying)},
+       {"semantic_receivers_destroyed",
+        std::to_string(semantic_receivers_destroyed)},
        {"indirect_buffers_open_at_shutdown",
         std::to_string(g_title_indirect_buffers_open.load(
             std::memory_order_relaxed))},
        {"correlation",
         "exact_title_store_to_backend_nested_command_buffer_shape"},
        {"semantic_identity", "unknown"},
+       {"semantic_receiver_identity",
+        "exact_rtti_lifetime_and_preparation_join"},
        {"guest_payload_read", "false"},
        {"guest_state_changed", "false"},
        {"control_flow_changed", "false"},
@@ -6335,6 +7112,7 @@ void InstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system,
                             {"resolve_summary_limit", "32"},
                             {"prepared_shader_pair_capacity", "1024"},
                             {"command_buffer_lineage_capacity", "4096"},
+                            {"semantic_receiver_lifecycle_capacity", "1024"},
                             {"guest_cpu_visibility_target_capacity", "64"},
                             {"scene", scene},
                             {"mode", g_sky_horizon_suppression.armed
@@ -6349,8 +7127,32 @@ void InstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system,
         "title_store,constructor_function,constructor_return,r3-r10,"
         "owner_function,owner_return,owner_r3-r10,producer_function,"
         "producer_return,producer_r3-r10,context_function,context_return,"
-        "context_r3-r10,context_root,backend_packet,"
+        "context_r3-r10,context_root,semantic_receiver_generation,"
+        "semantic_visibility_epoch,semantic_render_state_epoch,"
+        "backend_packet,"
         "current_buffer,parent_packet,root_buffer,depth"},
+       {"guest_payload_read", "false"},
+       {"guest_state_changed", "false"},
+       {"control_flow_changed", "false"},
+       {"xenos_authority", "true"},
+       {"suppression_allowed", "false"}});
+  diagnostics::RecordEvent(
+      "native_renderer.discovery.semantic_receiver_config",
+      {{"status", "armed"},
+       {"class", "proceduralGeometry::CProceduralModels"},
+       {"dispatch", "82417BC0"},
+       {"receiver", "entry_r3"},
+       {"command_root", "entry_r6_plus_59712"},
+       {"constructor", "82E1C9A0"},
+       {"destructor", "82E1CA28"},
+       {"deleting_destructor", "82E1D9B0"},
+       {"object_size", "512"},
+       {"visibility_function", "82E1FD00"},
+       {"render_state_function", "824170D8"},
+       {"descriptor_record_stride", "92"},
+       {"runtime_record_stride", "68"},
+       {"transform_matrix_ranges", "320:64,384:64,448:64"},
+       {"identity_join", "exact_constructor_receiver_address_generation"},
        {"guest_payload_read", "false"},
        {"guest_state_changed", "false"},
        {"control_flow_changed", "false"},
@@ -7168,6 +7970,38 @@ PINYON_SHIFT_INDIRECT_CONTEXT_HOOKS(824365B0)
 PINYON_SHIFT_INDIRECT_CONTEXT_HOOKS(829F6620)
 
 #undef PINYON_SHIFT_INDIRECT_CONTEXT_HOOKS
+
+void PinyonShiftObserveProceduralModelConstructorEntry(PPCRegister &r3) {
+  BeginSemanticReceiverConstruction(r3.u32);
+}
+
+void PinyonShiftObserveProceduralModelConstructorExit() {
+  EndSemanticReceiverConstruction();
+}
+
+void PinyonShiftObserveProceduralModelDestructorEntry(PPCRegister &r3) {
+  BeginSemanticReceiverDestruction(r3.u32);
+}
+
+void PinyonShiftObserveProceduralModelDestructorExit() {
+  EndSemanticReceiverDestruction();
+}
+
+void PinyonShiftObserveProceduralModelVisibilityEntry(PPCRegister &r3) {
+  BeginSemanticReceiverStage(r3.u32, SemanticReceiverStage::kVisibility);
+}
+
+void PinyonShiftObserveProceduralModelVisibilityExit() {
+  EndSemanticReceiverStage(SemanticReceiverStage::kVisibility);
+}
+
+void PinyonShiftObserveProceduralModelRenderStateEntry(PPCRegister &r3) {
+  BeginSemanticReceiverStage(r3.u32, SemanticReceiverStage::kRenderState);
+}
+
+void PinyonShiftObserveProceduralModelRenderStateExit() {
+  EndSemanticReceiverStage(SemanticReceiverStage::kRenderState);
+}
 
 void PinyonShiftObserveIndirectPacket824095B4(PPCRegister &r11,
                                                PPCRegister &r28) {

--- a/tools/capture-native-renderer-dispatch.ps1
+++ b/tools/capture-native-renderer-dispatch.ps1
@@ -58,8 +58,12 @@ if ($StaticOutput) {
         throw "StaticOutput must be below $localRoot"
     }
     $generatedRoot = Join-Path $repositoryRoot '.local\generated\default'
+    $imagePath = Join-Path $repositoryRoot '.local\analysis\default-image.bin'
+    if (-not (Test-Path -LiteralPath $imagePath -PathType Leaf)) {
+        throw "Static dispatch discovery image is missing: $imagePath"
+    }
     & python (Join-Path $PSScriptRoot 'discover-native-renderer-dispatch.py') `
-        $generatedRoot --output $resolvedStaticOutput
+        $generatedRoot --image $imagePath --output $resolvedStaticOutput
     if ($LASTEXITCODE -ne 0) {
         throw 'Static dispatch discovery failed.'
     }

--- a/tools/discover-native-renderer-dispatch.py
+++ b/tools/discover-native-renderer-dispatch.py
@@ -17,6 +17,7 @@ import sys
 
 
 SCHEMA = "pinyon-shift.native-renderer-dispatch-static.v3"
+IMAGE_BASE = 0x82000000
 PACKET_OPCODES = {
     0x3C: "PM4_WAIT_REG_MEM",
     0x3D: "PM4_MEM_WRITE",
@@ -175,6 +176,31 @@ INDIRECT_CONTEXT_RUNTIME_HOOKS = {
             (0x829F67A8, "mr r3,r28"),
         ],
     },
+}
+
+PROCEDURAL_MODEL_RECEIVER = {
+    "class_name": "proceduralGeometry::CProceduralModels",
+    "decorated_name": ".?AVCProceduralModels@proceduralGeometry@@",
+    "vtable_address": 0x82002B5C,
+    "vtable_slot": 41,
+    "dispatch_function": 0x82417BC0,
+    "constructor_function": 0x82E1C9A0,
+    "constructor_entry": 0x82E1C9A4,
+    "constructor_exit": 0x82E1CA0C,
+    "destructor_function": 0x82E1CA28,
+    "destructor_entry": 0x82E1CA2C,
+    "destructor_exit": 0x82E1CBD0,
+    "deleting_destructor_function": 0x82E1D9B0,
+    "array_constructor_function": 0x82E1CDC8,
+    "visibility_function": 0x82E1FD00,
+    "visibility_vtable_slot": 14,
+    "visibility_entry": 0x82E1FD04,
+    "visibility_exit": 0x82E208CC,
+    "render_state_function": 0x824170D8,
+    "render_state_vtable_slot": 40,
+    "render_state_entry": 0x824170DC,
+    "render_state_exit": 0x82417410,
+    "render_item_function": 0x82417418,
 }
 
 FUNCTION_RE = re.compile(r"^DEFINE_REX_FUNC\(sub_([0-9A-F]{8})\) \{")
@@ -743,6 +769,296 @@ def indirect_context_roots(functions_by_address: dict[int, dict]) -> list[dict]:
     return roots
 
 
+def _image_u32(image: bytes, address: int) -> int:
+    offset = address - IMAGE_BASE
+    if offset < 0 or offset + 4 > len(image):
+        raise ValueError(
+            "semantic receiver image address is out of range: {:08X}".format(
+                address
+            )
+        )
+    return int.from_bytes(image[offset : offset + 4], "big")
+
+
+def _image_c_string(image: bytes, address: int) -> str:
+    offset = address - IMAGE_BASE
+    if offset < 0 or offset >= len(image):
+        raise ValueError(
+            "semantic receiver type name is out of range: {:08X}".format(
+                address
+            )
+        )
+    end = image.find(b"\0", offset, min(len(image), offset + 256))
+    if end < 0:
+        raise ValueError("semantic receiver type name is not terminated")
+    return image[offset:end].decode("ascii")
+
+
+def procedural_model_receiver_lifecycle(
+    functions_by_address: dict[int, dict], image: bytes | None = None
+) -> dict:
+    """Prove the first semantic receiver and its construction lifetime."""
+    spec = PROCEDURAL_MODEL_RECEIVER
+    required = {
+        spec["dispatch_function"],
+        spec["constructor_function"],
+        spec["destructor_function"],
+        spec["deleting_destructor_function"],
+        spec["array_constructor_function"],
+        spec["visibility_function"],
+        spec["render_state_function"],
+        spec["render_item_function"],
+    }
+    lifecycle_functions = required - {spec["dispatch_function"]}
+    if not lifecycle_functions & set(functions_by_address):
+        return {}
+    if not required <= set(functions_by_address):
+        raise ValueError("procedural-model receiver function set drifted")
+
+    constructor = {
+        item["address"]: item["text"]
+        for item in functions_by_address[spec["constructor_function"]][
+            "instructions"
+        ]
+    }
+    destructor = {
+        item["address"]: item["text"]
+        for item in functions_by_address[spec["destructor_function"]][
+            "instructions"
+        ]
+    }
+    deleting_destructor = {
+        item["address"]: item["text"]
+        for item in functions_by_address[
+            spec["deleting_destructor_function"]
+        ]["instructions"]
+    }
+    array_constructor = {
+        item["address"]: item["text"]
+        for item in functions_by_address[spec["array_constructor_function"]][
+            "instructions"
+        ]
+    }
+    visibility = {
+        item["address"]: item["text"]
+        for item in functions_by_address[spec["visibility_function"]][
+            "instructions"
+        ]
+    }
+    render_state = {
+        item["address"]: item["text"]
+        for item in functions_by_address[spec["render_state_function"]][
+            "instructions"
+        ]
+    }
+    render_item = {
+        item["address"]: item["text"]
+        for item in functions_by_address[spec["render_item_function"]][
+            "instructions"
+        ]
+    }
+    expected = {
+        spec["constructor_function"]: "mflr r12",
+        0x82E1C9B8: "bl 0x82e19478",
+        0x82E1C9BC: "lis r11,-32256",
+        0x82E1C9C4: "addi r11,r11,11100",
+        0x82E1C9D0: "stw r11,0(r31)",
+        spec["constructor_exit"]: "addi r1,r1,112",
+    }
+    if any(constructor.get(address) != text for address, text in expected.items()):
+        raise ValueError("procedural-model constructor evidence drifted")
+    expected = {
+        spec["destructor_function"]: "mflr r12",
+        0x82E1CA3C: "lis r11,-32256",
+        0x82E1CA48: "addi r11,r11,11100",
+        0x82E1CA50: "stw r11,0(r3)",
+        0x82E1CBCC: "bl 0x82e1c0c0",
+        spec["destructor_exit"]: "addi r1,r1,112",
+    }
+    if any(destructor.get(address) != text for address, text in expected.items()):
+        raise ValueError("procedural-model destructor evidence drifted")
+    if deleting_destructor.get(0x82E1D9CC) != "bl 0x82e1ca28":
+        raise ValueError("procedural-model deleting destructor evidence drifted")
+
+    array_expected = {
+        0x82E1CDD8: "rlwinm r3,r3,9,0,22",
+        0x82E1CDFC: "bl 0x82e1c9a0",
+        0x82E1CE04: "addi r31,r31,512",
+    }
+    if any(
+        array_constructor.get(address) != text
+        for address, text in array_expected.items()
+    ):
+        raise ValueError("procedural-model object-size evidence drifted")
+
+    visibility_expected = {
+        spec["visibility_function"]: "mflr r12",
+        0x82E1FD20: "mr r20,r3",
+        0x82E1FD40: "lwz r11,124(r3)",
+        0x82E1FD4C: "lwz r11,136(r3)",
+        0x82E1FE10: "lwz r11,128(r20)",
+        0x82E1FEB8: "lwz r9,128(r20)",
+        0x82E20048: "lwz r11,124(r20)",
+        0x82E20854: "addi r18,r18,92",
+        0x82E20858: "addi r17,r17,68",
+        spec["visibility_exit"]: "addi r1,r1,704",
+    }
+    if any(
+        visibility.get(address) != text
+        for address, text in visibility_expected.items()
+    ):
+        raise ValueError("procedural-model visibility evidence drifted")
+
+    render_state_expected = {
+        spec["render_state_function"]: "mflr r12",
+        0x824172F8: "vmaddfp v1,v31,v0,v30",
+        0x82417304: "mr r3,r31",
+        0x82417410: "addi r1,r1,256",
+    }
+    render_item_expected = {
+        spec["render_item_function"]: "mflr r12",
+        0x82417494: "addi r30,r27,448",
+        0x824174D8: "addi r30,r27,320",
+        0x8241751C: "addi r30,r27,384",
+        0x82417668: "lwz r10,124(r27)",
+        0x824176AC: "lwz r10,128(r27)",
+        0x824176B0: "mulli r11,r9,68",
+    }
+    if any(
+        render_state.get(address) != text
+        for address, text in render_state_expected.items()
+    ):
+        raise ValueError("procedural-model render-state evidence drifted")
+    if any(
+        render_item.get(address) != text
+        for address, text in render_item_expected.items()
+    ):
+        raise ValueError("procedural-model render-item evidence drifted")
+
+    rtti_verified = False
+    complete_object_locator = None
+    type_descriptor = None
+    decorated_name = None
+    if image is not None:
+        vtable = spec["vtable_address"]
+        complete_object_locator = _image_u32(image, vtable - 4)
+        type_descriptor = _image_u32(image, complete_object_locator + 12)
+        decorated_name = _image_c_string(image, type_descriptor + 8)
+        slot_target = _image_u32(image, vtable + spec["vtable_slot"] * 4)
+        visibility_target = _image_u32(
+            image, vtable + spec["visibility_vtable_slot"] * 4
+        )
+        render_state_target = _image_u32(
+            image, vtable + spec["render_state_vtable_slot"] * 4
+        )
+        deleting_target = _image_u32(image, vtable)
+        if (
+            decorated_name != spec["decorated_name"]
+            or slot_target != spec["dispatch_function"]
+            or visibility_target != spec["visibility_function"]
+            or render_state_target != spec["render_state_function"]
+            or deleting_target != spec["deleting_destructor_function"]
+        ):
+            raise ValueError("procedural-model RTTI/vtable evidence drifted")
+        rtti_verified = True
+
+    return {
+        "class_name": spec["class_name"] if rtti_verified else "unknown",
+        "decorated_name": decorated_name or "unverified_without_image",
+        "complete_object_locator": (
+            "{:08X}".format(complete_object_locator)
+            if complete_object_locator is not None
+            else "unverified_without_image"
+        ),
+        "type_descriptor": (
+            "{:08X}".format(type_descriptor)
+            if type_descriptor is not None
+            else "unverified_without_image"
+        ),
+        "vtable_address": "{:08X}".format(spec["vtable_address"]),
+        "vtable_slot": spec["vtable_slot"],
+        "dispatch_function_address": "{:08X}".format(
+            spec["dispatch_function"]
+        ),
+        "receiver_entry_register": "r3",
+        "command_root_derivation": "r6+59712",
+        "receiver_is_command_root": False,
+        "constructor_function_address": "{:08X}".format(
+            spec["constructor_function"]
+        ),
+        "constructor_entry_hook_address": "{:08X}".format(
+            spec["constructor_entry"]
+        ),
+        "constructor_exit_hook_address": "{:08X}".format(
+            spec["constructor_exit"]
+        ),
+        "destructor_function_address": "{:08X}".format(
+            spec["destructor_function"]
+        ),
+        "destructor_entry_hook_address": "{:08X}".format(
+            spec["destructor_entry"]
+        ),
+        "destructor_exit_hook_address": "{:08X}".format(
+            spec["destructor_exit"]
+        ),
+        "deleting_destructor_function_address": "{:08X}".format(
+            spec["deleting_destructor_function"]
+        ),
+        "object_size": 512,
+        "visibility_function_address": "{:08X}".format(
+            spec["visibility_function"]
+        ),
+        "visibility_vtable_slot": spec["visibility_vtable_slot"],
+        "visibility_entry_hook_address": "{:08X}".format(
+            spec["visibility_entry"]
+        ),
+        "visibility_exit_hook_address": "{:08X}".format(
+            spec["visibility_exit"]
+        ),
+        "render_state_function_address": "{:08X}".format(
+            spec["render_state_function"]
+        ),
+        "render_state_vtable_slot": spec["render_state_vtable_slot"],
+        "render_state_entry_hook_address": "{:08X}".format(
+            spec["render_state_entry"]
+        ),
+        "render_state_exit_hook_address": "{:08X}".format(
+            spec["render_state_exit"]
+        ),
+        "render_item_function_address": "{:08X}".format(
+            spec["render_item_function"]
+        ),
+        "field_layout": {
+            "descriptor_owner_pointer_offset": 124,
+            "runtime_record_pointer_offset": 128,
+            "auxiliary_allocation_pointer_offset": 132,
+            "active_buffer_index_offset": 136,
+            "runtime_record_capacity_offset": 140,
+            "descriptor_record_stride": 92,
+            "runtime_record_stride": 68,
+            "matrix_ranges": [
+                {"offset": 320, "size": 64},
+                {"offset": 384, "size": 64},
+                {"offset": 448, "size": 64},
+            ],
+        },
+        "rtti_vtable_identity_proved": rtti_verified,
+        "constructor_destructor_pair_proved": True,
+        "object_extent_proved": True,
+        "visibility_preparation_boundary_proved": True,
+        "render_state_boundary_proved": True,
+        "render_item_layout_proved": True,
+        "runtime_address_join_required": True,
+        "mesh_material_ownership_proved": False,
+        "transform_matrix_ranges_proved": True,
+        "visibility_runtime_join_required": True,
+        "render_state_runtime_join_required": True,
+        "lod_meaning_proved": False,
+        "streaming_registration_proved": False,
+        "suppression_eligible": False,
+    }
+
+
 def argument_leads_for_calls(
     functions: list[dict], calls: list[dict], target_key: str
 ) -> list[dict]:
@@ -1271,7 +1587,7 @@ def draw_packet_provenance(constructors: list[dict], calls: list[dict]) -> dict:
     }
 
 
-def build(paths: list[pathlib.Path]) -> dict:
+def build(paths: list[pathlib.Path], image: bytes | None = None) -> dict:
     functions = parse_functions(paths)
     functions_by_address = {item["address"]: item for item in functions}
     for address, wrapper in REVIEWED_WRAPPERS.items():
@@ -1297,6 +1613,9 @@ def build(paths: list[pathlib.Path]) -> dict:
     producer_hooks = indirect_producer_runtime_hooks(functions_by_address)
     context_hooks = indirect_context_runtime_hooks(functions_by_address)
     context_roots = indirect_context_roots(functions_by_address)
+    semantic_receiver = procedural_model_receiver_lifecycle(
+        functions_by_address, image
+    )
     constructor_argument_leads = argument_leads_for_calls(
         functions, constructor_calls, "constructor_function_address"
     )
@@ -1402,6 +1721,7 @@ def build(paths: list[pathlib.Path]) -> dict:
         "indirect_producer_argument_leads": producer_argument_leads,
         "indirect_context_runtime_hooks": context_hooks,
         "indirect_context_roots": context_roots,
+        "procedural_model_receiver_lifecycle": semantic_receiver,
         "reviewed_wrappers": [
             {
                 "address": "{:08X}".format(address),
@@ -1472,6 +1792,7 @@ def build(paths: list[pathlib.Path]) -> dict:
             ),
             "indirect_context_runtime_hooks": len(context_hooks),
             "indirect_context_roots": len(context_roots),
+            "procedural_model_receiver_lifecycles": bool(semantic_receiver),
             "reviewed_wrappers": len(REVIEWED_WRAPPERS),
             "direct_calls": len(calls),
             "tail_forwarded_calls": len(forwarded_calls),
@@ -1495,13 +1816,15 @@ def build(paths: list[pathlib.Path]) -> dict:
 def main(argv=None) -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("generated_root", type=pathlib.Path)
+    parser.add_argument("--image", type=pathlib.Path)
     parser.add_argument("--output", required=True, type=pathlib.Path)
     args = parser.parse_args(argv)
     try:
         paths = list(args.generated_root.glob("pinyon_shift_recomp.*.cpp"))
         if not paths:
             raise ValueError("no generated AOT C++ files found")
-        document = build(paths)
+        image = args.image.read_bytes() if args.image else None
+        document = build(paths, image)
         args.output.parent.mkdir(parents=True, exist_ok=True)
         args.output.write_text(
             json.dumps(document, indent=2, sort_keys=True) + "\n",

--- a/tools/summarize-native-renderer-command-lineage.py
+++ b/tools/summarize-native-renderer-command-lineage.py
@@ -11,6 +11,7 @@ import sys
 SCHEMA = "pinyon-shift.native-renderer-command-lineage.v1"
 STATIC_SCHEMA = "pinyon-shift.native-renderer-dispatch-static.v3"
 PREFIX = "native_renderer.discovery.command_buffer_lineage_"
+SEMANTIC_RECEIVER_PREFIX = "native_renderer.discovery.semantic_receiver_"
 INDIRECT_OPCODES = {"PM4_INDIRECT_BUFFER", "PM4_INDIRECT_BUFFER_PFD"}
 PHYSICAL_APERTURE_SIZE = 0x20000000
 KNOWN_PREPARED_FAMILIES = {
@@ -31,7 +32,10 @@ def read_events(paths: list[pathlib.Path]) -> list[dict]:
                 event = json.loads(line)
             except json.JSONDecodeError as error:
                 raise ValueError(f"{path}:{line_number}: invalid JSON: {error}") from error
-            if str(event.get("event", "")).startswith(PREFIX):
+            event_name = str(event.get("event", ""))
+            if event_name.startswith(PREFIX) or event_name.startswith(
+                SEMANTIC_RECEIVER_PREFIX
+            ):
                 events.append(event)
     return events
 
@@ -137,6 +141,23 @@ def build(events: list[dict], static: dict, requested: str | None = None) -> dic
         for item in static_producer_calls
     }
     static_context_roots = static.get("indirect_context_roots", [])
+    static_semantic_receiver = static.get(
+        "procedural_model_receiver_lifecycle", {}
+    )
+    if static_semantic_receiver and not static_semantic_receiver.get(
+        "rtti_vtable_identity_proved"
+    ):
+        raise ValueError("procedural-model receiver RTTI identity is unproved")
+    if static_semantic_receiver and not all(
+        static_semantic_receiver.get(key)
+        for key in (
+            "object_extent_proved",
+            "visibility_preparation_boundary_proved",
+            "render_state_boundary_proved",
+            "transform_matrix_ranges_proved",
+        )
+    ):
+        raise ValueError("procedural-model preparation layout is unproved")
     context_roots_by_producer_return = {
         (
             str(item.get("producer_function_address", "")).upper(),
@@ -158,6 +179,14 @@ def build(events: list[dict], static: dict, requested: str | None = None) -> dic
     ]
     if len(configs) != 1 or len(summaries) != 1:
         raise ValueError("lineage session needs one armed config and summary")
+    semantic_configs = [
+        event
+        for event in selected
+        if event.get("event") == f"{SEMANTIC_RECEIVER_PREFIX}config"
+        and event.get("status") == "armed"
+    ]
+    if static_semantic_receiver and len(semantic_configs) != 1:
+        raise ValueError("lineage session needs one semantic receiver config")
     summary = summaries[0]
     required_safety = {
         "guest_payload_read": "false",
@@ -347,6 +376,13 @@ def build(events: list[dict], static: dict, requested: str | None = None) -> dic
         context_root_address = None
         context_root_address_varied = None
         context_root = None
+        semantic_receiver_class = None
+        semantic_receiver_address = None
+        semantic_receiver_generation = None
+        semantic_visibility_epoch = None
+        semantic_render_state_epoch = None
+        semantic_render_state_visibility_epoch = None
+        semantic_preparation_epoch_varied = None
         if static_context_roots:
             context_function_address = _optional_hex(
                 event, "context_function_address", 8
@@ -408,6 +444,76 @@ def build(events: list[dict], static: dict, requested: str | None = None) -> dic
                     raise ValueError(
                         "runtime context root does not match its static derivation"
                     )
+                if static_semantic_receiver and (
+                    context_function_address
+                    == static_semantic_receiver["dispatch_function_address"]
+                ):
+                    semantic_receiver_class = str(
+                        event.get("semantic_receiver_class", "unknown")
+                    )
+                    semantic_receiver_address = _optional_hex(
+                        event, "semantic_receiver_address", 8
+                    )
+                    generation_text = str(
+                        event.get("semantic_receiver_generation", "unknown")
+                    )
+                    if generation_text != "unknown":
+                        try:
+                            semantic_receiver_generation = int(generation_text)
+                        except ValueError as error:
+                            raise ValueError(
+                                "invalid semantic receiver generation"
+                            ) from error
+                    epoch_fields = []
+                    for key in (
+                        "semantic_visibility_epoch",
+                        "semantic_render_state_epoch",
+                        "semantic_render_state_visibility_epoch",
+                    ):
+                        text = str(event.get(key, "unknown"))
+                        try:
+                            epoch_fields.append(
+                                None if text == "unknown" else int(text)
+                            )
+                        except ValueError as error:
+                            raise ValueError(
+                                "invalid procedural-model preparation epoch"
+                            ) from error
+                    (
+                        semantic_visibility_epoch,
+                        semantic_render_state_epoch,
+                        semantic_render_state_visibility_epoch,
+                    ) = epoch_fields
+                    semantic_preparation_epoch_varied = (
+                        str(
+                            event.get(
+                                "semantic_preparation_epoch_varied", "false"
+                            )
+                        ).lower()
+                        == "true"
+                    )
+                    if (
+                        semantic_receiver_class
+                        != static_semantic_receiver["class_name"]
+                        or semantic_receiver_address is None
+                        or not semantic_receiver_generation
+                        or semantic_receiver_address != context_arguments[0]
+                        or (
+                            semantic_render_state_visibility_epoch
+                            and not semantic_render_state_epoch
+                        )
+                        or (
+                            semantic_render_state_visibility_epoch
+                            and (
+                                not semantic_visibility_epoch
+                                or semantic_render_state_visibility_epoch
+                                > semantic_visibility_epoch
+                            )
+                        )
+                    ):
+                        raise ValueError(
+                            "procedural-model receiver has no exact stage-history join"
+                        )
         if depth:
             if parent_value >= PHYSICAL_APERTURE_SIZE or parent_value & 3:
                 raise ValueError("indirect lineage entry has no valid parent packet")
@@ -556,6 +662,17 @@ def build(events: list[dict], static: dict, requested: str | None = None) -> dic
                 ),
                 "sample_context_root_address": context_root_address,
                 "context_root_address_varied": context_root_address_varied,
+                "semantic_receiver_class": semantic_receiver_class,
+                "semantic_receiver_address": semantic_receiver_address,
+                "semantic_receiver_generation": semantic_receiver_generation,
+                "semantic_visibility_epoch": semantic_visibility_epoch,
+                "semantic_render_state_epoch": semantic_render_state_epoch,
+                "semantic_render_state_visibility_epoch": (
+                    semantic_render_state_visibility_epoch
+                ),
+                "semantic_preparation_epoch_varied": (
+                    semantic_preparation_epoch_varied
+                ),
                 "depth": depth,
             }
         )
@@ -654,6 +771,219 @@ def build(events: list[dict], static: dict, requested: str | None = None) -> dic
     open_at_shutdown = _integer(
         summary, "indirect_buffers_open_at_shutdown"
     )
+    semantic_lifecycle_entries = []
+    semantic_constructor_entries = 0
+    semantic_constructor_exits = 0
+    semantic_constructor_open = 0
+    semantic_destructor_entries = 0
+    semantic_destructor_exits = 0
+    semantic_destructor_open = 0
+    semantic_stack_faults = 0
+    semantic_instances_published = 0
+    semantic_instances_destroyed = 0
+    semantic_address_reuses = 0
+    semantic_table_overflow = 0
+    semantic_dispatches = 0
+    semantic_live_dispatches = 0
+    semantic_unregistered_dispatches = 0
+    semantic_destroying_dispatches = 0
+    semantic_destroyed_dispatches = 0
+    semantic_destructors_without_instance = 0
+    semantic_receivers_tracked = 0
+    semantic_receivers_live = 0
+    semantic_receivers_destroying = 0
+    semantic_receivers_destroyed = 0
+    semantic_visibility_entries = 0
+    semantic_visibility_exits = 0
+    semantic_visibility_open = 0
+    semantic_render_state_entries = 0
+    semantic_render_state_exits = 0
+    semantic_render_state_open = 0
+    semantic_stage_stack_faults = 0
+    semantic_stage_unknown_receivers = 0
+    if static_semantic_receiver:
+        seen_receiver_addresses = set()
+        for event in selected:
+            if event.get("event") != f"{SEMANTIC_RECEIVER_PREFIX}lifecycle_entry":
+                continue
+            receiver_class = str(event.get("class", "unknown"))
+            address = _hex(event, "address", 8)
+            generation = _integer(event, "generation")
+            state = str(event.get("state", ""))
+            dispatches = _integer(event, "dispatches")
+            visibility_preparations = _integer(
+                event, "visibility_preparations"
+            )
+            render_state_preparations = _integer(
+                event, "render_state_preparations"
+            )
+            visibility_epoch = _integer(event, "visibility_epoch")
+            render_state_epoch = _integer(event, "render_state_epoch")
+            render_state_visibility_epoch = _integer(
+                event, "render_state_visibility_epoch"
+            )
+            dispatches_with_preparation = _integer(
+                event, "dispatches_with_preparation"
+            )
+            dispatches_without_preparation = _integer(
+                event, "dispatches_without_preparation"
+            )
+            dispatches_without_visibility = _integer(
+                event, "dispatches_without_visibility"
+            )
+            dispatches_without_render_state = _integer(
+                event, "dispatches_without_render_state"
+            )
+            if (
+                receiver_class != static_semantic_receiver["class_name"]
+                or address in seen_receiver_addresses
+                or not generation
+                or state not in {"live", "destroying", "destroyed"}
+                or dispatches < 0
+                or min(
+                    visibility_preparations,
+                    render_state_preparations,
+                    visibility_epoch,
+                    render_state_epoch,
+                    render_state_visibility_epoch,
+                    dispatches_with_preparation,
+                    dispatches_without_preparation,
+                    dispatches_without_visibility,
+                    dispatches_without_render_state,
+                )
+                < 0
+                or visibility_preparations != visibility_epoch
+                or render_state_preparations != render_state_epoch
+                or render_state_visibility_epoch > visibility_epoch
+                or dispatches
+                != dispatches_with_preparation
+                + dispatches_without_preparation
+                or str(event.get("identity_join"))
+                != "exact_constructor_receiver_address"
+                or str(event.get("guest_payload_read")).lower() != "false"
+                or str(event.get("xenos_authority")).lower() != "true"
+                or str(event.get("suppression_allowed")).lower() != "false"
+            ):
+                raise ValueError("invalid semantic receiver lifecycle entry")
+            seen_receiver_addresses.add(address)
+            semantic_lifecycle_entries.append(
+                {
+                    "class": receiver_class,
+                    "address": address,
+                    "generation": generation,
+                    "state": state,
+                    "dispatches": dispatches,
+                    "visibility_preparations": visibility_preparations,
+                    "render_state_preparations": render_state_preparations,
+                    "visibility_epoch": visibility_epoch,
+                    "render_state_epoch": render_state_epoch,
+                    "render_state_visibility_epoch": (
+                        render_state_visibility_epoch
+                    ),
+                    "dispatches_with_preparation": (
+                        dispatches_with_preparation
+                    ),
+                    "dispatches_without_preparation": (
+                        dispatches_without_preparation
+                    ),
+                    "dispatches_without_visibility": (
+                        dispatches_without_visibility
+                    ),
+                    "dispatches_without_render_state": (
+                        dispatches_without_render_state
+                    ),
+                }
+            )
+        semantic_constructor_entries = _integer(
+            summary, "semantic_receiver_constructor_entries"
+        )
+        semantic_constructor_exits = _integer(
+            summary, "semantic_receiver_constructor_exits"
+        )
+        semantic_constructor_open = _integer(
+            summary, "semantic_receiver_constructor_open_at_shutdown"
+        )
+        semantic_destructor_entries = _integer(
+            summary, "semantic_receiver_destructor_entries"
+        )
+        semantic_destructor_exits = _integer(
+            summary, "semantic_receiver_destructor_exits"
+        )
+        semantic_destructor_open = _integer(
+            summary, "semantic_receiver_destructor_open_at_shutdown"
+        )
+        semantic_stack_faults = _integer(
+            summary, "semantic_receiver_stack_faults"
+        )
+        semantic_instances_published = _integer(
+            summary, "semantic_receiver_instances_published"
+        )
+        semantic_instances_destroyed = _integer(
+            summary, "semantic_receiver_instances_destroyed"
+        )
+        semantic_address_reuses = _integer(
+            summary, "semantic_receiver_address_reuses"
+        )
+        semantic_table_overflow = _integer(
+            summary, "semantic_receiver_table_overflow"
+        )
+        semantic_dispatches = _integer(
+            summary, "semantic_receiver_dispatches"
+        )
+        semantic_live_dispatches = _integer(
+            summary, "semantic_receiver_live_dispatches"
+        )
+        semantic_unregistered_dispatches = _integer(
+            summary, "semantic_receiver_unregistered_dispatches"
+        )
+        semantic_destroying_dispatches = _integer(
+            summary, "semantic_receiver_destroying_dispatches"
+        )
+        semantic_destroyed_dispatches = _integer(
+            summary, "semantic_receiver_destroyed_dispatches"
+        )
+        semantic_destructors_without_instance = _integer(
+            summary, "semantic_receiver_destructors_without_instance"
+        )
+        semantic_receivers_tracked = _integer(
+            summary, "semantic_receivers_tracked"
+        )
+        semantic_receivers_live = _integer(
+            summary, "semantic_receivers_live_at_shutdown"
+        )
+        semantic_receivers_destroying = _integer(
+            summary, "semantic_receivers_destroying_at_shutdown"
+        )
+        semantic_receivers_destroyed = _integer(
+            summary, "semantic_receivers_destroyed"
+        )
+        semantic_visibility_entries = _integer(
+            summary, "semantic_visibility_entries"
+        )
+        semantic_visibility_exits = _integer(
+            summary, "semantic_visibility_exits"
+        )
+        semantic_visibility_open = _integer(
+            summary, "semantic_visibility_open_at_shutdown"
+        )
+        semantic_render_state_entries = _integer(
+            summary, "semantic_render_state_entries"
+        )
+        semantic_render_state_exits = _integer(
+            summary, "semantic_render_state_exits"
+        )
+        semantic_render_state_open = _integer(
+            summary, "semantic_render_state_open_at_shutdown"
+        )
+        semantic_stage_stack_faults = _integer(
+            summary, "semantic_stage_stack_faults"
+        )
+        semantic_stage_unknown_receivers = _integer(
+            summary, "semantic_stage_unknown_receivers"
+        )
+        semantic_lifecycle_entries.sort(
+            key=lambda item: (item["address"], item["generation"])
+        )
     retained_title_generations = (
         title_packets - constructor_matches - title_evictions
     )
@@ -721,6 +1051,74 @@ def build(events: list[dict], static: dict, requested: str | None = None) -> dic
                 context_entries > 0
                 and any(
                     item["context_return_address"] is not None
+                    for item in entries
+                )
+            )
+        )
+        and (
+            not static_semantic_receiver
+            or (
+                semantic_constructor_entries
+                == semantic_constructor_exits + semantic_constructor_open
+                and semantic_destructor_entries
+                == semantic_destructor_exits + semantic_destructor_open
+                and semantic_constructor_exits == semantic_instances_published
+                and semantic_destructor_exits == semantic_instances_destroyed
+                and semantic_instances_published
+                == semantic_instances_destroyed
+                + semantic_receivers_live
+                + semantic_receivers_destroying
+                and not semantic_stack_faults
+                and not semantic_table_overflow
+                and not semantic_unregistered_dispatches
+                and not semantic_destroying_dispatches
+                and not semantic_destroyed_dispatches
+                and not semantic_destructors_without_instance
+                and semantic_dispatches == semantic_live_dispatches
+                and semantic_live_dispatches > 0
+                and semantic_visibility_entries
+                == semantic_visibility_exits + semantic_visibility_open
+                and semantic_render_state_entries
+                == semantic_render_state_exits + semantic_render_state_open
+                and semantic_visibility_exits > 0
+                and semantic_render_state_exits > 0
+                and not semantic_stage_stack_faults
+                and not semantic_stage_unknown_receivers
+                and semantic_receivers_tracked == len(semantic_lifecycle_entries)
+                and semantic_receivers_live
+                == sum(
+                    item["state"] == "live"
+                    for item in semantic_lifecycle_entries
+                )
+                and semantic_receivers_destroying
+                == sum(
+                    item["state"] == "destroying"
+                    for item in semantic_lifecycle_entries
+                )
+                and semantic_receivers_destroyed
+                == sum(
+                    item["state"] == "destroyed"
+                    for item in semantic_lifecycle_entries
+                )
+                and semantic_live_dispatches
+                == sum(
+                    item["dispatches"] for item in semantic_lifecycle_entries
+                )
+                and semantic_visibility_exits
+                == sum(
+                    item["visibility_preparations"]
+                    for item in semantic_lifecycle_entries
+                )
+                and semantic_render_state_exits
+                == sum(
+                    item["render_state_preparations"]
+                    for item in semantic_lifecycle_entries
+                )
+                and any(
+                    item["semantic_receiver_address"] is not None
+                    and item["semantic_visibility_epoch"]
+                    and item["semantic_render_state_epoch"]
+                    and item["semantic_render_state_visibility_epoch"]
                     for item in entries
                 )
             )
@@ -817,6 +1215,27 @@ def build(events: list[dict], static: dict, requested: str | None = None) -> dic
                 "context_root_address_varied": entry[
                     "context_root_address_varied"
                 ],
+                "semantic_receiver_class": entry[
+                    "semantic_receiver_class"
+                ],
+                "semantic_receiver_address": entry[
+                    "semantic_receiver_address"
+                ],
+                "semantic_receiver_generation": entry[
+                    "semantic_receiver_generation"
+                ],
+                "semantic_visibility_epoch": entry[
+                    "semantic_visibility_epoch"
+                ],
+                "semantic_render_state_epoch": entry[
+                    "semantic_render_state_epoch"
+                ],
+                "semantic_render_state_visibility_epoch": entry[
+                    "semantic_render_state_visibility_epoch"
+                ],
+                "semantic_preparation_epoch_varied": entry[
+                    "semantic_preparation_epoch_varied"
+                ],
                 "depth": entry["depth"],
                 "sample_prepared_signature": entry[
                     "sample_prepared_signature"
@@ -855,6 +1274,10 @@ def build(events: list[dict], static: dict, requested: str | None = None) -> dic
         "static_indirect_owner_calls": static_owner_calls,
         "static_indirect_producer_calls": static_producer_calls,
         "static_indirect_context_roots": static_context_roots,
+        "static_procedural_model_receiver_lifecycle": (
+            static_semantic_receiver
+        ),
+        "semantic_receiver_lifecycles": semantic_lifecycle_entries,
         "totals": {
             "draws": draws,
             "primary_draws": primary_draws,
@@ -918,6 +1341,69 @@ def build(events: list[dict], static: dict, requested: str | None = None) -> dic
             "indirect_producer_context_mismatches": (
                 producer_context_mismatches
             ),
+            "semantic_receiver_constructor_entries": (
+                semantic_constructor_entries
+            ),
+            "semantic_receiver_constructor_exits": semantic_constructor_exits,
+            "semantic_receiver_constructor_open_at_shutdown": (
+                semantic_constructor_open
+            ),
+            "semantic_receiver_destructor_entries": semantic_destructor_entries,
+            "semantic_receiver_destructor_exits": semantic_destructor_exits,
+            "semantic_receiver_destructor_open_at_shutdown": (
+                semantic_destructor_open
+            ),
+            "semantic_receiver_stack_faults": semantic_stack_faults,
+            "semantic_receiver_instances_published": (
+                semantic_instances_published
+            ),
+            "semantic_receiver_instances_destroyed": (
+                semantic_instances_destroyed
+            ),
+            "semantic_receiver_address_reuses": semantic_address_reuses,
+            "semantic_receiver_table_overflow": semantic_table_overflow,
+            "semantic_receiver_dispatches": semantic_dispatches,
+            "semantic_receiver_live_dispatches": semantic_live_dispatches,
+            "semantic_receiver_unregistered_dispatches": (
+                semantic_unregistered_dispatches
+            ),
+            "semantic_receiver_destroying_dispatches": (
+                semantic_destroying_dispatches
+            ),
+            "semantic_receiver_destroyed_dispatches": (
+                semantic_destroyed_dispatches
+            ),
+            "semantic_receiver_destructors_without_instance": (
+                semantic_destructors_without_instance
+            ),
+            "semantic_receivers_tracked": semantic_receivers_tracked,
+            "semantic_receivers_live_at_shutdown": semantic_receivers_live,
+            "semantic_receivers_destroying_at_shutdown": (
+                semantic_receivers_destroying
+            ),
+            "semantic_receivers_destroyed": semantic_receivers_destroyed,
+            "semantic_visibility_entries": semantic_visibility_entries,
+            "semantic_visibility_exits": semantic_visibility_exits,
+            "semantic_visibility_open_at_shutdown": (
+                semantic_visibility_open
+            ),
+            "semantic_render_state_entries": semantic_render_state_entries,
+            "semantic_render_state_exits": semantic_render_state_exits,
+            "semantic_render_state_open_at_shutdown": (
+                semantic_render_state_open
+            ),
+            "semantic_stage_stack_faults": semantic_stage_stack_faults,
+            "semantic_stage_unknown_receivers": (
+                semantic_stage_unknown_receivers
+            ),
+            "semantic_dispatches_after_both_observed_stages": sum(
+                item["dispatches_with_preparation"]
+                for item in semantic_lifecycle_entries
+            ),
+            "semantic_dispatches_before_both_observed_stages": sum(
+                item["dispatches_without_preparation"]
+                for item in semantic_lifecycle_entries
+            ),
             "indirect_buffers_open_at_shutdown": open_at_shutdown,
             "constructor_origin_draws": sum(
                 item["calls"]
@@ -979,9 +1465,18 @@ def build(events: list[dict], static: dict, requested: str | None = None) -> dic
                 if item["context_return_address"] is not None
                 and not item["context_root_proved"]
             ),
+            "procedural_model_receiver_origin_draws": sum(
+                item["calls"]
+                for item in entries
+                if item["semantic_receiver_address"] is not None
+            ),
         },
         "qualification": "exact_title_store_to_backend_nested_command_buffer_lineage",
-        "semantic_identity": "unknown",
+        "semantic_identity": (
+            "procedural_model_receiver_stage_history"
+            if static_semantic_receiver
+            else "unknown"
+        ),
         "safety": {
             "guest_payload_read": False,
             "guest_state_changed": False,

--- a/tools/tests/test_native_renderer_command_lineage.py
+++ b/tools/tests/test_native_renderer_command_lineage.py
@@ -209,6 +209,160 @@ def context_root_events():
     return traced
 
 
+def procedural_model_inventory():
+    static = context_root_inventory()
+    static["indirect_constructor_calls"][0].update(
+        {
+            "caller_function": "sub_824167F8",
+            "caller_function_address": "824167F8",
+            "callsite": "82416894",
+            "return_address": "82416898",
+        }
+    )
+    static["indirect_owner_calls"][0].update(
+        {
+            "owner_function_address": "824167F8",
+            "caller_function": "sub_82417060",
+            "caller_function_address": "82417060",
+            "callsite": "824170B8",
+            "return_address": "824170BC",
+        }
+    )
+    static["indirect_producer_calls"][0].update(
+        {
+            "producer_function_address": "82417060",
+            "caller_function": "sub_82417BC0",
+            "caller_function_address": "82417BC0",
+            "callsite": "82418A24",
+            "return_address": "82418A28",
+        }
+    )
+    static["indirect_context_roots"][0].update(
+        {
+            "context_function": "sub_82417BC0",
+            "context_function_address": "82417BC0",
+            "producer_function": "sub_82417060",
+            "producer_function_address": "82417060",
+            "producer_return_address": "82418A28",
+            "root_entry_register": "r6",
+            "root_offset": 59712,
+            "derivation": "r6+59712",
+        }
+    )
+    static["procedural_model_receiver_lifecycle"] = {
+        "class_name": "proceduralGeometry::CProceduralModels",
+        "dispatch_function_address": "82417BC0",
+        "rtti_vtable_identity_proved": True,
+        "object_extent_proved": True,
+        "visibility_preparation_boundary_proved": True,
+        "render_state_boundary_proved": True,
+        "transform_matrix_ranges_proved": True,
+    }
+    return static
+
+
+def procedural_model_events():
+    traced = context_root_events()
+    traced[1].update(
+        {
+            "constructor_return_address": "82416898",
+            "owner_function_address": "824167F8",
+            "owner_return_address": "824170BC",
+            "producer_function_address": "82417060",
+            "producer_return_address": "82418A28",
+            "sample_producer_arguments": (
+                "1000E940,20000000,00000001,00000000,00000000,"
+                "00000000,00000000,00000000"
+            ),
+            "context_function_address": "82417BC0",
+            "sample_context_arguments": (
+                "20000000,30000000,00000002,10000000,00000000,"
+                "00000000,00000000,00000000"
+            ),
+            "sample_context_root_address": "1000E940",
+            "semantic_receiver_class": (
+                "proceduralGeometry::CProceduralModels"
+            ),
+            "semantic_receiver_address": "20000000",
+            "semantic_receiver_generation": "1",
+            "semantic_visibility_epoch": "2",
+            "semantic_render_state_epoch": "1",
+            "semantic_render_state_visibility_epoch": "2",
+            "semantic_preparation_epoch_varied": "true",
+        }
+    )
+    summary = traced.pop()
+    summary.update(
+        {
+            "semantic_receiver_constructor_entries": "1",
+            "semantic_receiver_constructor_exits": "1",
+            "semantic_receiver_constructor_open_at_shutdown": "0",
+            "semantic_receiver_destructor_entries": "0",
+            "semantic_receiver_destructor_exits": "0",
+            "semantic_receiver_destructor_open_at_shutdown": "0",
+            "semantic_receiver_stack_faults": "0",
+            "semantic_receiver_instances_published": "1",
+            "semantic_receiver_instances_destroyed": "0",
+            "semantic_receiver_address_reuses": "0",
+            "semantic_receiver_table_overflow": "0",
+            "semantic_receiver_dispatches": "1",
+            "semantic_receiver_live_dispatches": "1",
+            "semantic_receiver_unregistered_dispatches": "0",
+            "semantic_receiver_destroying_dispatches": "0",
+            "semantic_receiver_destroyed_dispatches": "0",
+            "semantic_receiver_destructors_without_instance": "0",
+            "semantic_receivers_tracked": "1",
+            "semantic_receivers_live_at_shutdown": "1",
+            "semantic_receivers_destroying_at_shutdown": "0",
+            "semantic_receivers_destroyed": "0",
+            "semantic_visibility_entries": "2",
+            "semantic_visibility_exits": "2",
+            "semantic_visibility_open_at_shutdown": "0",
+            "semantic_render_state_entries": "1",
+            "semantic_render_state_exits": "1",
+            "semantic_render_state_open_at_shutdown": "0",
+            "semantic_stage_stack_faults": "0",
+            "semantic_stage_unknown_receivers": "0",
+        }
+    )
+    traced.extend(
+        [
+            {
+                "session": "lineage-session",
+                "event": "native_renderer.discovery.semantic_receiver_config",
+                "status": "armed",
+            },
+            {
+                "session": "lineage-session",
+                "event": (
+                    "native_renderer.discovery."
+                    "semantic_receiver_lifecycle_entry"
+                ),
+                "class": "proceduralGeometry::CProceduralModels",
+                "address": "20000000",
+                "generation": "1",
+                "state": "live",
+                "dispatches": "1",
+                "visibility_preparations": "2",
+                "render_state_preparations": "1",
+                "visibility_epoch": "2",
+                "render_state_epoch": "1",
+                "render_state_visibility_epoch": "2",
+                "dispatches_with_preparation": "1",
+                "dispatches_without_preparation": "0",
+                "dispatches_without_visibility": "0",
+                "dispatches_without_render_state": "0",
+                "identity_join": "exact_constructor_receiver_address",
+                "guest_payload_read": "false",
+                "xenos_authority": "true",
+                "suppression_allowed": "false",
+            },
+            summary,
+        ]
+    )
+    return traced
+
+
 class NativeRendererCommandLineageTests(unittest.TestCase):
     def test_builds_complete_exact_lineage_report(self):
         document = MODULE.build(events(), static_inventory())
@@ -239,6 +393,48 @@ class NativeRendererCommandLineageTests(unittest.TestCase):
             "824095B4", document["shapes"][0]["constructor_store_address"]
         )
         self.assertFalse(document["safety"]["suppression_allowed"])
+
+    def test_proves_procedural_model_receiver_generation(self):
+        document = MODULE.build(
+            procedural_model_events(), procedural_model_inventory()
+        )
+        self.assertEqual("complete", document["status"])
+        self.assertEqual(
+            "procedural_model_receiver_stage_history",
+            document["semantic_identity"],
+        )
+        self.assertEqual(
+            "20000000", document["entries"][0]["semantic_receiver_address"]
+        )
+        self.assertEqual(
+            1, document["entries"][0]["semantic_receiver_generation"]
+        )
+        self.assertEqual(
+            12,
+            document["totals"]["procedural_model_receiver_origin_draws"],
+        )
+
+    def test_accepts_observed_alternate_procedural_model_stage_routes(self):
+        traced = procedural_model_events()
+        traced[-2]["dispatches_with_preparation"] = "0"
+        traced[-2]["dispatches_without_preparation"] = "1"
+        document = MODULE.build(traced, procedural_model_inventory())
+        self.assertEqual("complete", document["status"])
+        self.assertEqual(
+            1,
+            document["totals"][
+                "semantic_dispatches_before_both_observed_stages"
+            ],
+        )
+
+    def test_fails_closed_on_unregistered_procedural_model_dispatch(self):
+        traced = procedural_model_events()
+        traced[-1]["semantic_receiver_unregistered_dispatches"] = "1"
+        traced[-1]["semantic_receiver_live_dispatches"] = "0"
+        traced[-2]["dispatches"] = "0"
+        traced[-2]["dispatches_with_preparation"] = "0"
+        document = MODULE.build(traced, procedural_model_inventory())
+        self.assertEqual("incomplete_fail_closed", document["status"])
 
     def test_fails_closed_on_invalid_or_overflowed_lineage(self):
         broken = events()

--- a/tools/tests/test_native_renderer_contract.py
+++ b/tools/tests/test_native_renderer_contract.py
@@ -349,6 +349,17 @@ class NativeRendererContractTests(unittest.TestCase):
         self.assertIn("context_function_address", source)
         self.assertIn("sample_context_root_address", source)
         self.assertIn("indirect_context_stack_faults", source)
+        self.assertIn("kSemanticReceiverLifecycleCapacity = 1024", source)
+        self.assertIn("FindOrClaimSemanticReceiverLifecycle", source)
+        self.assertIn("ResolveSemanticReceiver", source)
+        self.assertIn("semantic_receiver_unregistered_dispatches", source)
+        self.assertIn("semantic_visibility_epoch", source)
+        self.assertIn("semantic_render_state_epoch", source)
+        self.assertIn("BeginSemanticReceiverStage", source)
+        self.assertIn("semantic_stage_unknown_receivers", source)
+        self.assertIn(
+            "proceduralGeometry::CProceduralModels", source
+        )
         self.assertIn("indirect_producer_context_mismatches", source)
         self.assertIn(
             "std::atomic<uint64_t> g_indirect_producer_entries", source

--- a/tools/tests/test_native_renderer_dispatch_discovery.py
+++ b/tools/tests/test_native_renderer_dispatch_discovery.py
@@ -360,12 +360,149 @@ def context_fixtures():
     ]
 
 
+def procedural_model_lifecycle_fixtures():
+    return [
+        fixture(
+            0x82E1C9A0,
+            [
+                "mflr r12",
+                "loc_82E1C9B8:",
+                "bl 0x82e19478",
+                "loc_82E1C9BC:",
+                "lis r11,-32256",
+                "loc_82E1C9C4:",
+                "addi r11,r11,11100",
+                "loc_82E1C9D0:",
+                "stw r11,0(r31)",
+                "loc_82E1CA0C:",
+                "addi r1,r1,112",
+                "blr",
+            ],
+        ),
+        fixture(
+            0x82E1CA28,
+            [
+                "mflr r12",
+                "loc_82E1CA3C:",
+                "lis r11,-32256",
+                "loc_82E1CA48:",
+                "addi r11,r11,11100",
+                "loc_82E1CA50:",
+                "stw r11,0(r3)",
+                "loc_82E1CBCC:",
+                "bl 0x82e1c0c0",
+                "loc_82E1CBD0:",
+                "addi r1,r1,112",
+                "blr",
+            ],
+        ),
+        fixture(
+            0x82E1D9B0,
+            [
+                "mflr r12",
+                "loc_82E1D9CC:",
+                "bl 0x82e1ca28",
+                "blr",
+            ],
+        ),
+        fixture(
+            0x82E1CDC8,
+            [
+                "mflr r12",
+                "loc_82E1CDD8:",
+                "rlwinm r3,r3,9,0,22",
+                "loc_82E1CDFC:",
+                "bl 0x82e1c9a0",
+                "loc_82E1CE04:",
+                "addi r31,r31,512",
+                "blr",
+            ],
+        ),
+        fixture(
+            0x82E1FD00,
+            [
+                "mflr r12",
+                "loc_82E1FD20:",
+                "mr r20,r3",
+                "loc_82E1FD40:",
+                "lwz r11,124(r3)",
+                "loc_82E1FD4C:",
+                "lwz r11,136(r3)",
+                "loc_82E1FE10:",
+                "lwz r11,128(r20)",
+                "loc_82E1FEB8:",
+                "lwz r9,128(r20)",
+                "loc_82E20048:",
+                "lwz r11,124(r20)",
+                "loc_82E20854:",
+                "addi r18,r18,92",
+                "loc_82E20858:",
+                "addi r17,r17,68",
+                "loc_82E208CC:",
+                "addi r1,r1,704",
+                "blr",
+            ],
+        ),
+        fixture(
+            0x824170D8,
+            [
+                "mflr r12",
+                "loc_824172F8:",
+                "vmaddfp v1,v31,v0,v30",
+                "loc_82417304:",
+                "mr r3,r31",
+                "loc_82417410:",
+                "addi r1,r1,256",
+                "blr",
+            ],
+        ),
+        fixture(
+            0x82417418,
+            [
+                "mflr r12",
+                "loc_82417494:",
+                "addi r30,r27,448",
+                "loc_824174D8:",
+                "addi r30,r27,320",
+                "loc_8241751C:",
+                "addi r30,r27,384",
+                "loc_82417668:",
+                "lwz r10,124(r27)",
+                "loc_824176AC:",
+                "lwz r10,128(r27)",
+                "loc_824176B0:",
+                "mulli r11,r9,68",
+                "blr",
+            ],
+        ),
+    ]
+
+
+def procedural_model_image():
+    decorated = b".?AVCProceduralModels@proceduralGeometry@@\0"
+    image = bytearray(0x12B9EE4 + len(decorated))
+
+    def store(address, value):
+        offset = address - MODULE.IMAGE_BASE
+        image[offset : offset + 4] = value.to_bytes(4, "big")
+
+    store(0x82002B58, 0x82363C9C)
+    store(0x82002B5C, 0x82E1D9B0)
+    store(0x82002B94, 0x82E1FD00)
+    store(0x82002BFC, 0x824170D8)
+    store(0x82002C00, 0x82417BC0)
+    store(0x82363CA8, 0x832B9EDC)
+    name_offset = 0x832B9EDC - MODULE.IMAGE_BASE + 8
+    image[name_offset : name_offset + len(decorated)] = decorated
+    return bytes(image)
+
+
 class NativeRendererDispatchDiscoveryTests(unittest.TestCase):
-    def build(self, chunks):
+    def build(self, chunks, image=None):
         with tempfile.TemporaryDirectory() as directory:
             path = Path(directory) / "pinyon_shift_recomp.1.cpp"
             path.write_text("\n\n".join(chunks), encoding="utf-8")
-            return MODULE.build([path])
+            return MODULE.build([path], image)
 
     def test_finds_reviewed_wrappers_and_direct_calls(self):
         caller = fixture(
@@ -639,6 +776,51 @@ class NativeRendererDispatchDiscoveryTests(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "producer edge drifted"):
             self.build([*reviewed_fixtures(), *producer_fixtures(), *contexts])
 
+    def test_proves_procedural_model_receiver_lifecycle(self):
+        document = self.build(
+            [
+                *reviewed_fixtures(),
+                *context_fixtures(),
+                *procedural_model_lifecycle_fixtures(),
+            ],
+            procedural_model_image(),
+        )
+        lifecycle = document["procedural_model_receiver_lifecycle"]
+        self.assertEqual(
+            "proceduralGeometry::CProceduralModels", lifecycle["class_name"]
+        )
+        self.assertEqual(41, lifecycle["vtable_slot"])
+        self.assertEqual("82417BC0", lifecycle["dispatch_function_address"])
+        self.assertEqual("r3", lifecycle["receiver_entry_register"])
+        self.assertEqual("r6+59712", lifecycle["command_root_derivation"])
+        self.assertFalse(lifecycle["receiver_is_command_root"])
+        self.assertTrue(lifecycle["rtti_vtable_identity_proved"])
+        self.assertTrue(lifecycle["constructor_destructor_pair_proved"])
+        self.assertEqual(512, lifecycle["object_size"])
+        self.assertTrue(lifecycle["visibility_preparation_boundary_proved"])
+        self.assertTrue(lifecycle["render_state_boundary_proved"])
+        self.assertEqual(
+            92, lifecycle["field_layout"]["descriptor_record_stride"]
+        )
+        self.assertEqual(
+            68, lifecycle["field_layout"]["runtime_record_stride"]
+        )
+        self.assertFalse(lifecycle["suppression_eligible"])
+
+    def test_rejects_drifted_procedural_model_vtable_slot(self):
+        image = bytearray(procedural_model_image())
+        offset = 0x82002C00 - MODULE.IMAGE_BASE
+        image[offset : offset + 4] = (0x824365B0).to_bytes(4, "big")
+        with self.assertRaisesRegex(ValueError, "RTTI/vtable evidence drifted"):
+            self.build(
+                [
+                    *reviewed_fixtures(),
+                    *context_fixtures(),
+                    *procedural_model_lifecycle_fixtures(),
+                ],
+                bytes(image),
+            )
+
     def test_runtime_hooks_are_default_off_bounded_and_passive(self):
         hooks = (ROOT / "src/native_renderer/graphics_hooks.cpp").read_text(
             encoding="utf-8"
@@ -707,6 +889,26 @@ class NativeRendererDispatchDiscoveryTests(unittest.TestCase):
             self.assertEqual(
                 analysis.count(
                     f'name = "PinyonShiftObserveIndirectConstructor{function}Exit"'
+                ),
+                1,
+            )
+        for name, entry, exit_address in (
+            ("Constructor", "82E1C9A4", "82E1CA0C"),
+            ("Destructor", "82E1CA2C", "82E1CBD0"),
+            ("Visibility", "82E1FD04", "82E208CC"),
+            ("RenderState", "824170DC", "82417410"),
+        ):
+            self.assertIn(f"address = 0x{entry}", analysis)
+            self.assertIn(f"address = 0x{exit_address}", analysis)
+            self.assertEqual(
+                analysis.count(
+                    f'name = "PinyonShiftObserveProceduralModel{name}Entry"'
+                ),
+                1,
+            )
+            self.assertEqual(
+                analysis.count(
+                    f'name = "PinyonShiftObserveProceduralModel{name}Exit"'
                 ),
                 1,
             )


### PR DESCRIPTION
## Summary
- prove `proceduralGeometry::CProceduralModels` through RTTI, vtable, constructor/destructor, and exact live address generations
- map its 512-byte extent, descriptor/runtime record strides, transform ranges, and optional visibility/render-state stage history
- propagate the semantic receiver through the existing exact command-buffer lineage without reading guest payload or changing Xenos authority
- qualify the batched change with one Release/AppData session and preserve alternate stage routes found by runtime evidence

## Validation
- `python -m unittest tools.tests.test_native_renderer_dispatch_discovery tools.tests.test_native_renderer_command_lineage tools.tests.test_native_renderer_contract` (67 passed)
- `python -m py_compile tools/discover-native-renderer-dispatch.py tools/summarize-native-renderer-command-lineage.py`
- `tools/build-preview.ps1 -JsonEvents`
- AppData session `20260829T171002Z-p39732`: complete fail-closed report, 127,396 live semantic dispatches, zero lifecycle/stage/overflow faults
- median 30.228 FPS, 59.952 Hz presentation cadence, zero present-deadline misses