### PR TITLE
feat(native-renderer): extract procedural model semantics

### DIFF
--- a/config/rexglue/analysis/main-xex.toml
+++ b/config/rexglue/analysis/main-xex.toml
@@ -230,9 +230,9 @@ registers = ["r3"]
 address = 0x82E1CBD0
 name = "PinyonShiftObserveProceduralModelDestructorExit"
 
-# Vtable slots 14 and 40 bracket the exact visibility-preparation and render-
-# state preparation functions consumed by slot 41. These hooks record only the
-# live receiver generation and balanced invocation order.
+# Vtable slots 14 and 40 bracket optional visibility and render-state history.
+# These hooks record only the live receiver generation and balanced invocation
+# order; the stages are not universal slot-41 prerequisites.
 [[midasm_hook]]
 address = 0x82E1FD04
 name = "PinyonShiftObserveProceduralModelVisibilityEntry"
@@ -250,6 +250,16 @@ registers = ["r3"]
 [[midasm_hook]]
 address = 0x82417410
 name = "PinyonShiftObserveProceduralModelRenderStateExit"
+
+# Static argument flow proves that render-state slot 40 passes a live
+# CProceduralModels receiver in r3 and stores its descriptor index at caller
+# stack offset 84 before calling per-record helper 0x82417418. The entry hook
+# performs bounded read-only semantic extraction and leaves every sample on
+# the Xenos replay fallback.
+[[midasm_hook]]
+address = 0x8241741C
+name = "PinyonShiftObserveProceduralModelRenderItem"
+registers = ["r1", "r3", "r4", "r5", "r6", "r7", "r8", "r9", "r10"]
 
 [[midasm_hook]]
 address = 0x824095B4

--- a/docs/native-renderer/HIGH_LEVEL_RENDER_HOOKS.md
+++ b/docs/native-renderer/HIGH_LEVEL_RENDER_HOOKS.md
@@ -295,6 +295,11 @@ three 64-byte transform/constant matrix ranges. Balanced runtime epochs carry
 the optional stage history to slot 41 without reading guest payload; the
 AppData capture refutes treating both stages as a universal prerequisite.
 
+The first NR-05B boundary now observes slot 40's per-record helper at
+`8241741C`, extracts an exact live receiver generation and bounded immutable
+descriptor/runtime/transform sample, and leaves every sample on Xenos replay.
+See `PROCEDURAL_MODEL_SEMANTIC_EXTRACTION.md`.
+
 For all 38 direct adapter callsites, the same static inventory now records
 `r3-r10`'s last syntactic definition since the nearest intervening call. Simple
 loads retain base register, offset, and width; values crossing a call boundary

--- a/docs/native-renderer/PROCEDURAL_MODEL_RECEIVER_LIFETIME.md
+++ b/docs/native-renderer/PROCEDURAL_MODEL_RECEIVER_LIFETIME.md
@@ -52,7 +52,7 @@ evidence proves these structural fields:
 | 128 | parallel runtime-record pointer |
 | 132 | auxiliary allocation pointer |
 | 136 | active/double-buffer index |
-| 140 | runtime-record capacity |
+| 140 | per-record resource capacity |
 | 320–383 | 64-byte transform/constant matrix |
 | 384–447 | 64-byte transform/constant matrix |
 | 448–511 | 64-byte transform/constant matrix |
@@ -139,4 +139,6 @@ construction-to-destruction interval, record strides, matrix ranges, and the
 visibility/render-state stage histories. It does not prove which record
 members own meshes or materials, which entries are world instances, the exact
 LOD policy, or how streaming registration maps to destruction. Those remain
-required before NR-05B semantic extraction.
+open after the first NR-05B extraction census and are required before native
+admission. The bounded extraction boundary is documented in
+`PROCEDURAL_MODEL_SEMANTIC_EXTRACTION.md`.

--- a/docs/native-renderer/PROCEDURAL_MODEL_SEMANTIC_EXTRACTION.md
+++ b/docs/native-renderer/PROCEDURAL_MODEL_SEMANTIC_EXTRACTION.md
@@ -1,0 +1,109 @@
+# Procedural-model semantic extraction
+
+This NR-05B slice establishes a bounded, immutable semantic-instance census
+at the first proved per-record helper of
+`proceduralGeometry::CProceduralModels`. It extracts title records without
+rendering them. Every observed instance stays on Xenos replay until mesh,
+material, LOD, and streaming semantics are classified.
+
+## Exact title boundary
+
+Virtual slot 40 (`824170D8`) loads the descriptor index from its work node,
+stores it at caller stack offset 84, keeps the live `CProceduralModels`
+receiver in `r3`, and calls helper `82417418`. The hook at `8241741C` observes
+the helper after its link-register save and before it changes the relevant
+entry arguments.
+
+The helper's 272-byte stack frame makes its later load at callee offset 356
+the same original caller offset 84. Static instructions then derive:
+
+| Semantic input | Exact derivation |
+| --- | --- |
+| Receiver generation | exact live constructor/destructor join for entry `r3` |
+| Record index | guest word at entry `r1 + 84` |
+| Descriptor count | guest word at `receiver[124][12]` |
+| Descriptor record | `receiver[124][0] + index * 92` |
+| Runtime record | `receiver[128] + index * 68` |
+| Structural kind | descriptor word at byte offset 36 |
+| Transform/constants | receiver byte ranges 320–511 |
+| Helper context | entry `r4-r10` |
+
+`tools/discover-native-renderer-dispatch.py` refuses to publish the extraction
+contract unless this argument flow and record-address derivation are present
+in the supported generated title source.
+
+## Immutable bounded census
+
+The runtime observer first requires an exact live receiver address and
+generation. It rejects zero, unaligned, overflowing, or out-of-range record
+layouts before reading a record. Each valid observation reads exactly:
+
+- 23 descriptor words (92 bytes);
+- 17 runtime words (68 bytes);
+- 48 transform/constant words (192 bytes);
+- seven helper registers and the structural scalar fields already listed.
+
+The guest payload bound is 380 bytes per live observation, including the
+index word and owner/base/count words. A fixed 4,096-entry open-addressed table
+is keyed by receiver address, generation, and record index. The first 88
+record/transform words are immutable samples. Later observations update only
+call/frame counts and hash-variation counters, so a changing runtime record or
+transform never rewrites the captured first instance.
+
+The runtime emits one `semantic_instance_entry` per retained key and one
+`semantic_instance_summary`. The fail-closed report tool is:
+
+```powershell
+python tools/summarize-native-renderer-semantic-instances.py `
+  <diagnostic-jsonl> `
+  --static <native-renderer-dispatch-static.json> `
+  --session <session> `
+  --output <semantic-instance-report.json>
+```
+
+A complete report requires exact accounting, at least one instance, zero
+unknown receivers, invalid layouts, invalid indices, table overflow, and
+native admissions. It also requires every live observation to retain
+`xenos_replay` and the 380-byte read bound.
+
+## Safety boundary
+
+This is semantic extraction with no rendering. The observer performs bounded
+guest reads only. It does not mutate guest memory, upload a native resource,
+issue a native draw, change title control flow, or suppress Xenos work. An
+unclassified material or state always uses Xenos replay.
+
+The census proves stable record identity and captures the inputs needed for
+the next classification batch. It does not yet identify mesh buffers,
+materials, textures, visibility bits, LOD policy, or streaming ownership.
+Those meanings must be proved before an instance is eligible for native
+admission or batching.
+
+## AppData qualification
+
+Release executable SHA-256
+`0A69A3D1C1E8DFE4625762F2A4F37B942441FC854BD047EA5BEF240066C751B0`
+ran against the installed `0.1.0` preview save in session
+`20260829T173833Z-p40812`. The save loaded into the festival world and the
+process exited cleanly after 6,636 measured frames (204.704 seconds).
+
+The semantic-instance and command-lineage reports are both `complete`:
+
+- 557,009 live helper observations resolved into 463 immutable instance keys;
+- all 557,009 retained Xenos replay, with zero native admissions;
+- zero unknown receivers, invalid layouts, invalid indices, or table overflow;
+- 211,663,420 bytes reconciled exactly at 380 bounded guest bytes per live
+  observation;
+- descriptor kinds 0, 4, 1, and 5 appeared across 308, 108, 43, and 4 keys;
+- immutable descriptor samples did not vary, while runtime and transform
+  hashes recorded 288,017 and 556,475 changes without rewriting first samples;
+- 6,367,265 prepared draws retained complete command lineage, with zero
+  invalid lineage or overflow.
+
+Performance held a 30.259 FPS median with a 19.294 FPS one-percent low,
+50.303 ms p95 frame time, 59.891 Hz presentation cadence, zero present-
+deadline misses, and zero XMA stalls. The AppData gameplay frame is
+`native-renderer-semantic-extraction-appdata.jpg` (SHA-256
+`F4E287C36689A19D7266310C9ADAC720D51D26A1FA60269B8569578E7A06CC62`).
+The semantic report SHA-256 is
+`1145C68AA778FCEEBDC81793163A8F99A78DEC0E14D9644CAA936CD2CE44BD6B`.

--- a/src/native_renderer/graphics_hooks.cpp
+++ b/src/native_renderer/graphics_hooks.cpp
@@ -88,6 +88,11 @@ constexpr size_t kIndirectProducerStackCapacity = 32;
 constexpr size_t kIndirectContextStackCapacity = 32;
 constexpr size_t kSemanticReceiverLifecycleCapacity = 1024;
 constexpr size_t kSemanticReceiverStackCapacity = 32;
+constexpr size_t kSemanticInstanceCapacity = 4096;
+constexpr size_t kSemanticDescriptorWordCount = 92 / sizeof(uint32_t);
+constexpr size_t kSemanticRuntimeWordCount = 68 / sizeof(uint32_t);
+constexpr size_t kSemanticTransformWordCount = 192 / sizeof(uint32_t);
+constexpr uint64_t kSemanticObservationPayloadBytes = 380;
 constexpr uint64_t kSkyHorizonAnchorSignature = UINT64_C(0x747837906D0BF484);
 constexpr uint64_t kSkyHorizonFollowerSignature = UINT64_C(0x1D253A52B55C9FB3);
 std::atomic<uint64_t> g_frame_sequence{};
@@ -346,6 +351,46 @@ std::atomic<uint64_t> g_semantic_render_state_exits{};
 std::atomic<uint64_t> g_semantic_render_state_open{};
 std::atomic<uint64_t> g_semantic_stage_stack_faults{};
 std::atomic<uint64_t> g_semantic_stage_unknown_receivers{};
+
+struct SemanticInstanceEntry {
+  uint64_t key = 0;
+  uint64_t calls = 0;
+  uint64_t first_frame = 0;
+  uint64_t last_frame = 0;
+  uint64_t descriptor_hash = 0;
+  uint64_t runtime_hash = 0;
+  uint64_t transform_hash = 0;
+  uint64_t descriptor_variations = 0;
+  uint64_t runtime_variations = 0;
+  uint64_t transform_variations = 0;
+  uint32_t receiver_address = 0;
+  uint32_t receiver_generation = 0;
+  uint32_t record_index = 0;
+  uint32_t descriptor_count = 0;
+  uint32_t descriptor_address = 0;
+  uint32_t runtime_address = 0;
+  uint32_t descriptor_kind = 0;
+  uint32_t active_buffer_index = 0;
+  uint32_t per_record_resource_capacity = 0;
+  std::array<uint32_t, 7> helper_arguments{};
+  std::array<uint32_t, kSemanticDescriptorWordCount> descriptor_words{};
+  std::array<uint32_t, kSemanticRuntimeWordCount> runtime_words{};
+  std::array<uint32_t, kSemanticTransformWordCount> transform_words{};
+};
+
+std::array<SemanticInstanceEntry, kSemanticInstanceCapacity>
+    g_semantic_instances{};
+std::mutex g_semantic_instance_mutex;
+uint64_t g_semantic_instance_observations = 0;
+uint64_t g_semantic_instance_live_observations = 0;
+uint64_t g_semantic_instance_unknown_receivers = 0;
+uint64_t g_semantic_instance_invalid_layouts = 0;
+uint64_t g_semantic_instance_invalid_indices = 0;
+uint64_t g_semantic_instance_payload_bytes = 0;
+uint64_t g_semantic_instance_replay_fallbacks = 0;
+uint64_t g_semantic_instance_native_admissions = 0;
+uint64_t g_semantic_instance_overflow = 0;
+uint64_t g_semantic_instance_count = 0;
 thread_local TitleDrawOrigin g_pending_adapter_origin;
 thread_local std::array<TitleDrawOrigin, kTitleOriginStackCapacity>
     g_title_origin_stack;
@@ -638,6 +683,20 @@ void ResetTitleDrawProvenance() {
   g_semantic_stage_stack_faults.store(0, std::memory_order_relaxed);
   g_semantic_stage_unknown_receivers.store(0,
                                             std::memory_order_relaxed);
+  {
+    std::scoped_lock lock(g_semantic_instance_mutex);
+    std::memset(g_semantic_instances.data(), 0, sizeof(g_semantic_instances));
+    g_semantic_instance_observations = 0;
+    g_semantic_instance_live_observations = 0;
+    g_semantic_instance_unknown_receivers = 0;
+    g_semantic_instance_invalid_layouts = 0;
+    g_semantic_instance_invalid_indices = 0;
+    g_semantic_instance_payload_bytes = 0;
+    g_semantic_instance_replay_fallbacks = 0;
+    g_semantic_instance_native_admissions = 0;
+    g_semantic_instance_overflow = 0;
+    g_semantic_instance_count = 0;
+  }
   g_pending_adapter_origin = {};
   g_title_origin_stack = {};
   g_title_origin_stack_depth = 0;
@@ -2924,6 +2983,242 @@ uint64_t HashCombine(uint64_t hash, uint64_t value) {
   return hash ^ value;
 }
 
+uint32_t LoadSemanticGuestU32(rex::memory::Memory *memory,
+                              uint32_t address) {
+  return static_cast<uint32_t>(
+      *rex::memory::GuestPtr<rex::be_u32 *>(memory->virtual_membase(),
+                                            address));
+}
+
+template <size_t N>
+void LoadSemanticGuestWords(rex::memory::Memory *memory, uint32_t address,
+                            std::array<uint32_t, N> &words) {
+  for (size_t i = 0; i < N; ++i) {
+    words[i] = LoadSemanticGuestU32(
+        memory, address + static_cast<uint32_t>(i * sizeof(uint32_t)));
+  }
+}
+
+template <size_t N>
+uint64_t HashSemanticWords(const std::array<uint32_t, N> &words) {
+  uint64_t hash = 0xCBF29CE484222325ull;
+  for (uint32_t word : words) {
+    hash = HashCombine(hash, word);
+  }
+  return hash ? hash : 1;
+}
+
+void RecordProceduralModelSemanticInstance(
+    uint32_t stack_pointer, uint32_t receiver_address,
+    std::array<uint32_t, 7> helper_arguments) {
+  if (!g_command_buffer_lineage_installed.load(std::memory_order_acquire)) {
+    return;
+  }
+  rex::memory::Memory *memory =
+      g_command_buffer_lineage_memory.load(std::memory_order_acquire);
+  if (!memory) {
+    return;
+  }
+
+  std::scoped_lock lock(g_semantic_instance_mutex);
+  ++g_semantic_instance_observations;
+  SemanticReceiverLifecycleEntry *lifecycle =
+      FindSemanticReceiverLifecycle(receiver_address);
+  if (!lifecycle ||
+      lifecycle->state.load(std::memory_order_acquire) !=
+          uint32_t(SemanticReceiverState::kLive)) {
+    ++g_semantic_instance_unknown_receivers;
+    return;
+  }
+  const uint32_t receiver_generation =
+      lifecycle->generation.load(std::memory_order_relaxed);
+  if (!receiver_generation || stack_pointer > UINT32_MAX - 84 ||
+      receiver_address > UINT32_MAX - 512) {
+    ++g_semantic_instance_invalid_layouts;
+    return;
+  }
+
+  const uint32_t record_index =
+      LoadSemanticGuestU32(memory, stack_pointer + 84);
+  const uint32_t owner =
+      LoadSemanticGuestU32(memory, receiver_address + 124);
+  const uint32_t runtime_base =
+      LoadSemanticGuestU32(memory, receiver_address + 128);
+  const uint32_t active_buffer_index =
+      LoadSemanticGuestU32(memory, receiver_address + 136);
+  const uint32_t per_record_resource_capacity =
+      LoadSemanticGuestU32(memory, receiver_address + 140);
+  if (!owner || !runtime_base || (owner & 3) || (runtime_base & 3) ||
+      owner > UINT32_MAX - 16) {
+    ++g_semantic_instance_invalid_layouts;
+    return;
+  }
+  const uint32_t descriptor_base = LoadSemanticGuestU32(memory, owner);
+  const uint32_t descriptor_count =
+      LoadSemanticGuestU32(memory, owner + 12);
+  if (!descriptor_base || (descriptor_base & 3) || !descriptor_count) {
+    ++g_semantic_instance_invalid_layouts;
+    return;
+  }
+  if (record_index >= descriptor_count) {
+    ++g_semantic_instance_invalid_indices;
+    return;
+  }
+  const uint64_t descriptor_address_64 =
+      uint64_t(descriptor_base) + uint64_t(record_index) * 92;
+  const uint64_t runtime_address_64 =
+      uint64_t(runtime_base) + uint64_t(record_index) * 68;
+  if (descriptor_address_64 + 92 > uint64_t(UINT32_MAX) + 1 ||
+      runtime_address_64 + 68 > uint64_t(UINT32_MAX) + 1) {
+    ++g_semantic_instance_invalid_layouts;
+    return;
+  }
+  const uint32_t descriptor_address = uint32_t(descriptor_address_64);
+  const uint32_t runtime_address = uint32_t(runtime_address_64);
+
+  std::array<uint32_t, kSemanticDescriptorWordCount> descriptor_words{};
+  std::array<uint32_t, kSemanticRuntimeWordCount> runtime_words{};
+  std::array<uint32_t, kSemanticTransformWordCount> transform_words{};
+  LoadSemanticGuestWords(memory, descriptor_address, descriptor_words);
+  LoadSemanticGuestWords(memory, runtime_address, runtime_words);
+  LoadSemanticGuestWords(memory, receiver_address + 320, transform_words);
+  const uint64_t descriptor_hash = HashSemanticWords(descriptor_words);
+  const uint64_t runtime_hash = HashSemanticWords(runtime_words);
+  const uint64_t transform_hash = HashSemanticWords(transform_words);
+  ++g_semantic_instance_live_observations;
+  g_semantic_instance_payload_bytes += kSemanticObservationPayloadBytes;
+  ++g_semantic_instance_replay_fallbacks;
+  uint64_t key = 0xCBF29CE484222325ull;
+  key = HashCombine(key, receiver_address);
+  key = HashCombine(key, receiver_generation);
+  key = HashCombine(key, record_index);
+  key = key ? key : 1;
+
+  size_t index = size_t(key % kSemanticInstanceCapacity);
+  for (size_t probe = 0; probe < kSemanticInstanceCapacity; ++probe) {
+    SemanticInstanceEntry &entry = g_semantic_instances[index];
+    if (!entry.key) {
+      entry.key = key;
+      entry.calls = 1;
+      entry.first_frame = g_frame_sequence.load(std::memory_order_relaxed);
+      entry.last_frame = entry.first_frame;
+      entry.descriptor_hash = descriptor_hash;
+      entry.runtime_hash = runtime_hash;
+      entry.transform_hash = transform_hash;
+      entry.receiver_address = receiver_address;
+      entry.receiver_generation = receiver_generation;
+      entry.record_index = record_index;
+      entry.descriptor_count = descriptor_count;
+      entry.descriptor_address = descriptor_address;
+      entry.runtime_address = runtime_address;
+      entry.descriptor_kind = descriptor_words[36 / sizeof(uint32_t)];
+      entry.active_buffer_index = active_buffer_index;
+      entry.per_record_resource_capacity = per_record_resource_capacity;
+      entry.helper_arguments = helper_arguments;
+      entry.descriptor_words = descriptor_words;
+      entry.runtime_words = runtime_words;
+      entry.transform_words = transform_words;
+      ++g_semantic_instance_count;
+      return;
+    }
+    if (entry.key == key && entry.receiver_address == receiver_address &&
+        entry.receiver_generation == receiver_generation &&
+        entry.record_index == record_index) {
+      ++entry.calls;
+      entry.last_frame = g_frame_sequence.load(std::memory_order_relaxed);
+      entry.descriptor_variations += entry.descriptor_hash != descriptor_hash;
+      entry.runtime_variations += entry.runtime_hash != runtime_hash;
+      entry.transform_variations += entry.transform_hash != transform_hash;
+      return;
+    }
+    index = (index + 1) % kSemanticInstanceCapacity;
+  }
+  ++g_semantic_instance_overflow;
+}
+
+void EmitProceduralModelSemanticInstances() {
+  std::scoped_lock lock(g_semantic_instance_mutex);
+  for (const SemanticInstanceEntry &entry : g_semantic_instances) {
+    if (!entry.key) {
+      continue;
+    }
+    pinyon_shift::diagnostics::RecordEvent(
+        "native_renderer.discovery.semantic_instance_entry",
+        {{"class", "proceduralGeometry::CProceduralModels"},
+         {"key", fmt::format("{:016X}", entry.key)},
+         {"calls", std::to_string(entry.calls)},
+         {"first_frame", std::to_string(entry.first_frame)},
+         {"last_frame", std::to_string(entry.last_frame)},
+         {"receiver_address",
+          fmt::format("{:08X}", entry.receiver_address)},
+         {"receiver_generation",
+          std::to_string(entry.receiver_generation)},
+         {"record_index", std::to_string(entry.record_index)},
+         {"descriptor_count", std::to_string(entry.descriptor_count)},
+         {"descriptor_address",
+          fmt::format("{:08X}", entry.descriptor_address)},
+         {"runtime_address", fmt::format("{:08X}", entry.runtime_address)},
+         {"descriptor_kind", std::to_string(entry.descriptor_kind)},
+         {"active_buffer_index",
+          std::to_string(entry.active_buffer_index)},
+         {"per_record_resource_capacity",
+          std::to_string(entry.per_record_resource_capacity)},
+         {"helper_arguments",
+          fmt::format(
+              "{:08X},{:08X},{:08X},{:08X},{:08X},{:08X},{:08X}",
+              entry.helper_arguments[0], entry.helper_arguments[1],
+              entry.helper_arguments[2], entry.helper_arguments[3],
+              entry.helper_arguments[4], entry.helper_arguments[5],
+              entry.helper_arguments[6])},
+         {"descriptor_hash", fmt::format("{:016X}", entry.descriptor_hash)},
+         {"runtime_hash", fmt::format("{:016X}", entry.runtime_hash)},
+         {"transform_hash", fmt::format("{:016X}", entry.transform_hash)},
+         {"descriptor_variations",
+          std::to_string(entry.descriptor_variations)},
+         {"runtime_variations", std::to_string(entry.runtime_variations)},
+         {"transform_variations",
+          std::to_string(entry.transform_variations)},
+         {"immutable_sample_words", "88"},
+         {"classification", "unclassified_material_or_state"},
+         {"fallback", "xenos_replay"},
+         {"guest_payload_read", "bounded_semantic_records_only"},
+         {"guest_state_changed", "false"},
+         {"native_upload", "false"},
+         {"native_draw", "false"},
+         {"xenos_authority", "true"},
+         {"suppression_allowed", "false"}});
+  }
+  pinyon_shift::diagnostics::RecordEvent(
+      "native_renderer.discovery.semantic_instance_summary",
+      {{"observations", std::to_string(g_semantic_instance_observations)},
+       {"live_observations",
+        std::to_string(g_semantic_instance_live_observations)},
+       {"unknown_receivers",
+        std::to_string(g_semantic_instance_unknown_receivers)},
+       {"invalid_layouts",
+        std::to_string(g_semantic_instance_invalid_layouts)},
+       {"invalid_indices",
+        std::to_string(g_semantic_instance_invalid_indices)},
+       {"payload_bytes",
+        std::to_string(g_semantic_instance_payload_bytes)},
+       {"replay_fallbacks",
+        std::to_string(g_semantic_instance_replay_fallbacks)},
+       {"native_admissions",
+        std::to_string(g_semantic_instance_native_admissions)},
+       {"entries", std::to_string(g_semantic_instance_count)},
+       {"capacity", std::to_string(kSemanticInstanceCapacity)},
+       {"overflow", std::to_string(g_semantic_instance_overflow)},
+       {"payload_bytes_per_live_observation",
+        std::to_string(kSemanticObservationPayloadBytes)},
+       {"fallback", "xenos_replay"},
+       {"guest_payload_read", "bounded_semantic_records_only"},
+       {"guest_state_changed", "false"},
+       {"native_upload", "false"},
+       {"native_draw", "false"},
+       {"xenos_authority", "true"},
+       {"suppression_allowed", "false"}});
+}
+
 uint64_t PreparedPipelineHash(
     const rex::system::GraphicsPreparedDrawObservation &prepared) {
   uint64_t hash = 0xCBF29CE484222325ull;
@@ -4312,6 +4607,7 @@ void RecordPreparedCommandBufferLineage(
 }
 
 void EmitCommandBufferLineageSummary() {
+  EmitProceduralModelSemanticInstances();
   for (const CommandBufferLineageEntry &entry : g_command_buffer_lineages) {
     if (!entry.calls) {
       continue;
@@ -7158,6 +7454,29 @@ void InstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system,
        {"control_flow_changed", "false"},
        {"xenos_authority", "true"},
        {"suppression_allowed", "false"}});
+  diagnostics::RecordEvent(
+      "native_renderer.discovery.semantic_instance_config",
+      {{"status", lineage_armed ? "armed" : "disabled"},
+       {"class", "proceduralGeometry::CProceduralModels"},
+       {"hook", "82417418"},
+       {"hook_address", "8241741C"},
+       {"receiver", "entry_r3"},
+       {"descriptor_index", "caller_stack_plus_84"},
+       {"descriptor_record", "owner[0]+index*92"},
+       {"runtime_record", "receiver[128]+index*68"},
+       {"transform_ranges", "receiver+320:192"},
+       {"capacity", std::to_string(kSemanticInstanceCapacity)},
+       {"immutable_sample_words", "88"},
+       {"payload_bytes_per_live_observation",
+        std::to_string(kSemanticObservationPayloadBytes)},
+       {"classification", "semantic_extraction_no_rendering"},
+       {"fallback", "xenos_replay_unclassified_material_or_state"},
+       {"guest_payload_read", "bounded_semantic_records_only"},
+       {"guest_state_changed", "false"},
+       {"native_upload", "false"},
+       {"native_draw", "false"},
+       {"xenos_authority", "true"},
+       {"suppression_allowed", "false"}});
   diagnostics::RecordEvent("native_renderer.census.scene_marker",
                            {{"scene", scene}, {"source", "operator"}});
   diagnostics::RecordEvent(
@@ -8001,6 +8320,15 @@ void PinyonShiftObserveProceduralModelRenderStateEntry(PPCRegister &r3) {
 
 void PinyonShiftObserveProceduralModelRenderStateExit() {
   EndSemanticReceiverStage(SemanticReceiverStage::kRenderState);
+}
+
+void PinyonShiftObserveProceduralModelRenderItem(
+    PPCRegister &r1, PPCRegister &r3, PPCRegister &r4, PPCRegister &r5,
+    PPCRegister &r6, PPCRegister &r7, PPCRegister &r8, PPCRegister &r9,
+    PPCRegister &r10) {
+  RecordProceduralModelSemanticInstance(
+      r1.u32, r3.u32,
+      {r4.u32, r5.u32, r6.u32, r7.u32, r8.u32, r9.u32, r10.u32});
 }
 
 void PinyonShiftObserveIndirectPacket824095B4(PPCRegister &r11,

--- a/tools/discover-native-renderer-dispatch.py
+++ b/tools/discover-native-renderer-dispatch.py
@@ -201,6 +201,7 @@ PROCEDURAL_MODEL_RECEIVER = {
     "render_state_entry": 0x824170DC,
     "render_state_exit": 0x82417410,
     "render_item_function": 0x82417418,
+    "render_item_entry_hook": 0x8241741C,
 }
 
 FUNCTION_RE = re.compile(r"^DEFINE_REX_FUNC\(sub_([0-9A-F]{8})\) \{")
@@ -917,12 +918,22 @@ def procedural_model_receiver_lifecycle(
     }
     render_item_expected = {
         spec["render_item_function"]: "mflr r12",
+        0x8241742C: "mr r27,r3",
         0x82417494: "addi r30,r27,448",
         0x824174D8: "addi r30,r27,320",
         0x8241751C: "addi r30,r27,384",
         0x82417668: "lwz r10,124(r27)",
+        0x8241766C: "lwz r9,356(r1)",
+        0x82417670: "mulli r11,r9,92",
+        0x82417674: "lwz r10,0(r10)",
         0x824176AC: "lwz r10,128(r27)",
         0x824176B0: "mulli r11,r9,68",
+    }
+    render_state_helper_expected = {
+        0x824171AC: "lwz r11,4(r30)",
+        0x824171C0: "lwz r3,0(r30)",
+        0x824171D0: "stw r11,84(r1)",
+        0x824171D4: "bl 0x82417418",
     }
     if any(
         render_state.get(address) != text
@@ -934,6 +945,11 @@ def procedural_model_receiver_lifecycle(
         for address, text in render_item_expected.items()
     ):
         raise ValueError("procedural-model render-item evidence drifted")
+    if any(
+        render_state.get(address) != text
+        for address, text in render_state_helper_expected.items()
+    ):
+        raise ValueError("procedural-model render-item call evidence drifted")
 
     rtti_verified = False
     complete_object_locator = None
@@ -1028,12 +1044,15 @@ def procedural_model_receiver_lifecycle(
         "render_item_function_address": "{:08X}".format(
             spec["render_item_function"]
         ),
+        "render_item_entry_hook_address": "{:08X}".format(
+            spec["render_item_entry_hook"]
+        ),
         "field_layout": {
             "descriptor_owner_pointer_offset": 124,
             "runtime_record_pointer_offset": 128,
             "auxiliary_allocation_pointer_offset": 132,
             "active_buffer_index_offset": 136,
-            "runtime_record_capacity_offset": 140,
+            "per_record_resource_capacity_offset": 140,
             "descriptor_record_stride": 92,
             "runtime_record_stride": 68,
             "matrix_ranges": [
@@ -1048,6 +1067,29 @@ def procedural_model_receiver_lifecycle(
         "visibility_preparation_boundary_proved": True,
         "render_state_boundary_proved": True,
         "render_item_layout_proved": True,
+        "semantic_instance_extraction": {
+            "hook_function_address": "{:08X}".format(
+                spec["render_item_function"]
+            ),
+            "hook_address": "{:08X}".format(
+                spec["render_item_entry_hook"]
+            ),
+            "receiver_register": "r3",
+            "descriptor_index_caller_stack_offset": 84,
+            "descriptor_index_callee_stack_offset": 356,
+            "descriptor_count_owner_offset": 12,
+            "descriptor_base_owner_offset": 0,
+            "descriptor_kind_offset": 36,
+            "descriptor_record_stride": 92,
+            "runtime_record_stride": 68,
+            "bounded_payload_bytes_per_observation": 380,
+            "immutable_sample_words": 88,
+            "fallback_policy": "replay_unclassified_material_or_state",
+            "argument_mapping_proved": True,
+            "record_address_derivation_proved": True,
+            "native_rendering_enabled": False,
+            "suppression_eligible": False,
+        },
         "runtime_address_join_required": True,
         "mesh_material_ownership_proved": False,
         "transform_matrix_ranges_proved": True,

--- a/tools/summarize-native-renderer-semantic-instances.py
+++ b/tools/summarize-native-renderer-semantic-instances.py
@@ -1,0 +1,286 @@
+"""Validate bounded procedural-model semantic-instance observations."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import pathlib
+import sys
+
+
+SCHEMA = "pinyon-shift.native-renderer-semantic-instances.v1"
+STATIC_SCHEMA = "pinyon-shift.native-renderer-dispatch-static.v3"
+PREFIX = "native_renderer.discovery.semantic_instance_"
+EXPECTED_CLASS = "proceduralGeometry::CProceduralModels"
+EXPECTED_WORDS = 88
+EXPECTED_PAYLOAD_BYTES = 380
+
+
+def read_events(paths: list[pathlib.Path]) -> list[dict]:
+    events = []
+    for path in paths:
+        for line_number, line in enumerate(
+            path.read_text(encoding="utf-8").splitlines(), 1
+        ):
+            if not line.strip():
+                continue
+            try:
+                event = json.loads(line)
+            except json.JSONDecodeError as error:
+                raise ValueError(f"{path}:{line_number}: invalid JSON: {error}") from error
+            if str(event.get("event", "")).startswith(PREFIX):
+                events.append(event)
+    return events
+
+
+def _integer(mapping: dict, key: str) -> int:
+    try:
+        return int(mapping.get(key, ""))
+    except (TypeError, ValueError) as error:
+        raise ValueError(f"invalid integer field: {key}") from error
+
+
+def _hex(mapping: dict, key: str, width: int) -> str:
+    value = str(mapping.get(key, "")).upper()
+    if len(value) != width:
+        raise ValueError(f"invalid hexadecimal field: {key}")
+    try:
+        int(value, 16)
+    except ValueError as error:
+        raise ValueError(f"invalid hexadecimal field: {key}") from error
+    return value
+
+
+def _hex_arguments(mapping: dict, key: str) -> list[str]:
+    values = str(mapping.get(key, "")).upper().split(",")
+    if len(values) != 7:
+        raise ValueError(f"invalid argument vector: {key}")
+    for value in values:
+        _hex({key: value}, key, 8)
+    return values
+
+
+def _require_safety(mapping: dict) -> None:
+    expected = {
+        "guest_payload_read": "bounded_semantic_records_only",
+        "guest_state_changed": "false",
+        "native_upload": "false",
+        "native_draw": "false",
+        "xenos_authority": "true",
+        "suppression_allowed": "false",
+        "fallback": "xenos_replay",
+    }
+    if any(str(mapping.get(key)).lower() != value for key, value in expected.items()):
+        raise ValueError("semantic-instance evidence violates the safety boundary")
+
+
+def _select_session(events: list[dict], requested: str | None) -> str:
+    if requested:
+        if not any(event.get("session") == requested for event in events):
+            raise ValueError(f"semantic-instance session not found: {requested}")
+        return requested
+    armed = [
+        str(event.get("session", ""))
+        for event in events
+        if event.get("event") == f"{PREFIX}config"
+        and event.get("status") == "armed"
+    ]
+    if not armed or not armed[-1]:
+        raise ValueError("no armed semantic-instance session found")
+    return armed[-1]
+
+
+def build(events: list[dict], static: dict, requested: str | None = None) -> dict:
+    if static.get("schema") != STATIC_SCHEMA:
+        raise ValueError("unsupported static dispatch inventory schema")
+    lifecycle = static.get("procedural_model_receiver_lifecycle", {})
+    extraction = lifecycle.get("semantic_instance_extraction", {})
+    if not lifecycle.get("rtti_vtable_identity_proved"):
+        raise ValueError("procedural-model receiver RTTI identity is unproved")
+    if not all(
+        extraction.get(key)
+        for key in ("argument_mapping_proved", "record_address_derivation_proved")
+    ):
+        raise ValueError("procedural-model semantic record derivation is unproved")
+    if (
+        extraction.get("hook_address") != "8241741C"
+        or extraction.get("bounded_payload_bytes_per_observation")
+        != EXPECTED_PAYLOAD_BYTES
+        or extraction.get("native_rendering_enabled") is not False
+        or extraction.get("suppression_eligible") is not False
+    ):
+        raise ValueError("unsupported semantic extraction contract")
+
+    session = _select_session(events, requested)
+    selected = [event for event in events if event.get("session") == session]
+    configs = [
+        event
+        for event in selected
+        if event.get("event") == f"{PREFIX}config"
+        and event.get("status") == "armed"
+    ]
+    summaries = [
+        event for event in selected if event.get("event") == f"{PREFIX}summary"
+    ]
+    if len(configs) != 1 or len(summaries) != 1:
+        raise ValueError("semantic-instance session needs one armed config and summary")
+
+    entries = []
+    entry_calls = 0
+    for event in selected:
+        if event.get("event") != f"{PREFIX}entry":
+            continue
+        _require_safety(event)
+        if event.get("class") != EXPECTED_CLASS:
+            raise ValueError("semantic-instance entry has an unexpected receiver class")
+        key = _hex(event, "key", 16)
+        receiver_address = _hex(event, "receiver_address", 8)
+        descriptor_address = _hex(event, "descriptor_address", 8)
+        runtime_address = _hex(event, "runtime_address", 8)
+        descriptor_hash = _hex(event, "descriptor_hash", 16)
+        runtime_hash = _hex(event, "runtime_hash", 16)
+        transform_hash = _hex(event, "transform_hash", 16)
+        helper_arguments = _hex_arguments(event, "helper_arguments")
+        calls = _integer(event, "calls")
+        first_frame = _integer(event, "first_frame")
+        last_frame = _integer(event, "last_frame")
+        generation = _integer(event, "receiver_generation")
+        record_index = _integer(event, "record_index")
+        descriptor_count = _integer(event, "descriptor_count")
+        if (
+            calls <= 0
+            or generation <= 0
+            or first_frame > last_frame
+            or record_index < 0
+            or descriptor_count <= record_index
+            or int(descriptor_address, 16) & 3
+            or int(runtime_address, 16) & 3
+            or _integer(event, "immutable_sample_words") != EXPECTED_WORDS
+            or event.get("classification") != "unclassified_material_or_state"
+        ):
+            raise ValueError("semantic-instance entry has invalid immutable evidence")
+        entry_calls += calls
+        entries.append(
+            {
+                "key": key,
+                "calls": calls,
+                "frames": [first_frame, last_frame],
+                "receiver_address": receiver_address,
+                "receiver_generation": generation,
+                "record_index": record_index,
+                "descriptor_count": descriptor_count,
+                "descriptor_address": descriptor_address,
+                "runtime_address": runtime_address,
+                "descriptor_kind": _integer(event, "descriptor_kind"),
+                "helper_arguments": helper_arguments,
+                "hashes": {
+                    "descriptor": descriptor_hash,
+                    "runtime": runtime_hash,
+                    "transform": transform_hash,
+                },
+                "variations": {
+                    "descriptor": _integer(event, "descriptor_variations"),
+                    "runtime": _integer(event, "runtime_variations"),
+                    "transform": _integer(event, "transform_variations"),
+                },
+                "fallback": "xenos_replay",
+            }
+        )
+
+    summary = summaries[0]
+    _require_safety(summary)
+    totals = {
+        key: _integer(summary, key)
+        for key in (
+            "observations",
+            "live_observations",
+            "unknown_receivers",
+            "invalid_layouts",
+            "invalid_indices",
+            "payload_bytes",
+            "replay_fallbacks",
+            "native_admissions",
+            "entries",
+            "capacity",
+            "overflow",
+            "payload_bytes_per_live_observation",
+        )
+    }
+    failures = []
+    if totals["observations"] != sum(
+        totals[key]
+        for key in (
+            "live_observations",
+            "unknown_receivers",
+            "invalid_layouts",
+            "invalid_indices",
+        )
+    ):
+        failures.append("observation accounting is incomplete")
+    if totals["live_observations"] != totals["replay_fallbacks"]:
+        failures.append("not every live observation retained Xenos replay")
+    if totals["payload_bytes_per_live_observation"] != EXPECTED_PAYLOAD_BYTES:
+        failures.append("bounded payload contract changed")
+    if totals["payload_bytes"] != totals["live_observations"] * EXPECTED_PAYLOAD_BYTES:
+        failures.append("payload accounting is inconsistent")
+    if entry_calls + totals["overflow"] != totals["live_observations"]:
+        failures.append("entry accounting is inconsistent")
+    if totals["entries"] != len(entries):
+        failures.append("entry count is inconsistent")
+    for key in (
+        "unknown_receivers",
+        "invalid_layouts",
+        "invalid_indices",
+        "overflow",
+        "native_admissions",
+    ):
+        if totals[key]:
+            failures.append(f"{key} is nonzero")
+    if not entries:
+        failures.append("no semantic instances were observed")
+
+    return {
+        "schema": SCHEMA,
+        "session": session,
+        "status": "complete" if not failures else "incomplete",
+        "failures": failures,
+        "entries": entries,
+        "totals": totals,
+        "safety": {
+            "bounded_guest_read": True,
+            "guest_state_changed": False,
+            "native_upload": False,
+            "native_draw": False,
+            "xenos_authority": True,
+            "suppression_allowed": False,
+        },
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("logs", nargs="+", type=pathlib.Path)
+    parser.add_argument("--static", required=True, type=pathlib.Path)
+    parser.add_argument("--session")
+    parser.add_argument("--output", type=pathlib.Path)
+    args = parser.parse_args(argv)
+    try:
+        report = build(
+            read_events(args.logs),
+            json.loads(args.static.read_text(encoding="utf-8")),
+            args.session,
+        )
+    except (OSError, ValueError, json.JSONDecodeError) as error:
+        print(f"error: {error}", file=sys.stderr)
+        return 2
+    payload = json.dumps(report, indent=2) + "\n"
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(payload, encoding="utf-8")
+    else:
+        print(payload, end="")
+    return 0 if report["status"] == "complete" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/tests/test_native_renderer_contract.py
+++ b/tools/tests/test_native_renderer_contract.py
@@ -14,11 +14,17 @@ class NativeRendererContractTests(unittest.TestCase):
 
         self.assertNotIn("g_draw_census = {};", source)
         self.assertNotIn("g_dependency_census = {};", source)
+        self.assertNotIn("g_semantic_instances = {};", source)
         self.assertIn(
             "std::memset(&g_draw_census, 0, sizeof(g_draw_census));", source
         )
         self.assertIn(
             "std::memset(&g_dependency_census, 0, sizeof(g_dependency_census));",
+            source,
+        )
+        self.assertIn(
+            "std::memset(g_semantic_instances.data(), 0, "
+            "sizeof(g_semantic_instances));",
             source,
         )
 
@@ -50,7 +56,37 @@ class NativeRendererContractTests(unittest.TestCase):
         self.assertIn("kRequiresRestart", source)
         self.assertIn('"mode", "pass_through"', source)
         self.assertNotIn("REX_STORE", source)
-        self.assertNotIn("GuestPtr", source)
+
+    def test_procedural_model_semantic_extraction_is_bounded_and_passive(self):
+        source = (ROOT / "src/native_renderer/graphics_hooks.cpp").read_text(
+            encoding="utf-8"
+        )
+        analysis = (ROOT / "config/rexglue/analysis/main-xex.toml").read_text(
+            encoding="utf-8"
+        )
+        summarizer = (
+            ROOT / "tools/summarize-native-renderer-semantic-instances.py"
+        ).read_text(encoding="utf-8")
+
+        self.assertEqual(
+            analysis.count('name = "PinyonShiftObserveProceduralModelRenderItem"'),
+            1,
+        )
+        hook = analysis.split(
+            'name = "PinyonShiftObserveProceduralModelRenderItem"', 1
+        )[0].rsplit("[[midasm_hook]]", 1)[1]
+        self.assertIn("address = 0x8241741C", hook)
+        self.assertIn("kSemanticInstanceCapacity = 4096", source)
+        self.assertIn("kSemanticObservationPayloadBytes = 380", source)
+        self.assertIn("LoadSemanticGuestWords", source)
+        self.assertIn('"classification", "unclassified_material_or_state"', source)
+        self.assertIn('{"fallback", "xenos_replay"}', source)
+        self.assertIn('{"native_upload", "false"}', source)
+        self.assertIn('{"native_draw", "false"}', source)
+        self.assertIn('{"suppression_allowed", "false"}', source)
+        self.assertNotIn("SetDrawSuppression", source)
+        self.assertIn('"bounded_guest_read": True', summarizer)
+        self.assertIn('"suppression_allowed": False', summarizer)
 
     def test_exact_pass_consumer_trace_is_bounded_and_fail_closed(self):
         source = (ROOT / "src/native_renderer/graphics_hooks.cpp").read_text(

--- a/tools/tests/test_native_renderer_dispatch_discovery.py
+++ b/tools/tests/test_native_renderer_dispatch_discovery.py
@@ -447,6 +447,14 @@ def procedural_model_lifecycle_fixtures():
             0x824170D8,
             [
                 "mflr r12",
+                "loc_824171AC:",
+                "lwz r11,4(r30)",
+                "loc_824171C0:",
+                "lwz r3,0(r30)",
+                "loc_824171D0:",
+                "stw r11,84(r1)",
+                "loc_824171D4:",
+                "bl 0x82417418",
                 "loc_824172F8:",
                 "vmaddfp v1,v31,v0,v30",
                 "loc_82417304:",
@@ -460,6 +468,8 @@ def procedural_model_lifecycle_fixtures():
             0x82417418,
             [
                 "mflr r12",
+                "loc_8241742C:",
+                "mr r27,r3",
                 "loc_82417494:",
                 "addi r30,r27,448",
                 "loc_824174D8:",
@@ -468,6 +478,12 @@ def procedural_model_lifecycle_fixtures():
                 "addi r30,r27,384",
                 "loc_82417668:",
                 "lwz r10,124(r27)",
+                "loc_8241766C:",
+                "lwz r9,356(r1)",
+                "loc_82417670:",
+                "mulli r11,r9,92",
+                "loc_82417674:",
+                "lwz r10,0(r10)",
                 "loc_824176AC:",
                 "lwz r10,128(r27)",
                 "loc_824176B0:",
@@ -805,6 +821,12 @@ class NativeRendererDispatchDiscoveryTests(unittest.TestCase):
         self.assertEqual(
             68, lifecycle["field_layout"]["runtime_record_stride"]
         )
+        extraction = lifecycle["semantic_instance_extraction"]
+        self.assertEqual("8241741C", extraction["hook_address"])
+        self.assertEqual(84, extraction["descriptor_index_caller_stack_offset"])
+        self.assertEqual(380, extraction["bounded_payload_bytes_per_observation"])
+        self.assertTrue(extraction["argument_mapping_proved"])
+        self.assertFalse(extraction["native_rendering_enabled"])
         self.assertFalse(lifecycle["suppression_eligible"])
 
     def test_rejects_drifted_procedural_model_vtable_slot(self):

--- a/tools/tests/test_native_renderer_semantic_instances.py
+++ b/tools/tests/test_native_renderer_semantic_instances.py
@@ -1,0 +1,136 @@
+import copy
+import importlib.util
+import sys
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+TOOL = ROOT / "tools" / "summarize-native-renderer-semantic-instances.py"
+SPEC = importlib.util.spec_from_file_location("semantic_instances", TOOL)
+assert SPEC and SPEC.loader
+MODULE = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = MODULE
+SPEC.loader.exec_module(MODULE)
+
+
+def static_inventory():
+    return {
+        "schema": "pinyon-shift.native-renderer-dispatch-static.v3",
+        "procedural_model_receiver_lifecycle": {
+            "rtti_vtable_identity_proved": True,
+            "semantic_instance_extraction": {
+                "argument_mapping_proved": True,
+                "record_address_derivation_proved": True,
+                "hook_address": "8241741C",
+                "bounded_payload_bytes_per_observation": 380,
+                "native_rendering_enabled": False,
+                "suppression_eligible": False,
+            },
+        },
+    }
+
+
+def events():
+    common = {"session": "semantic-session"}
+    safety = {
+        "fallback": "xenos_replay",
+        "guest_payload_read": "bounded_semantic_records_only",
+        "guest_state_changed": "false",
+        "native_upload": "false",
+        "native_draw": "false",
+        "xenos_authority": "true",
+        "suppression_allowed": "false",
+    }
+    return [
+        {
+            **common,
+            "event": "native_renderer.discovery.semantic_instance_config",
+            "status": "armed",
+        },
+        {
+            **common,
+            **safety,
+            "event": "native_renderer.discovery.semantic_instance_entry",
+            "class": "proceduralGeometry::CProceduralModels",
+            "key": "0123456789ABCDEF",
+            "calls": "12",
+            "first_frame": "10",
+            "last_frame": "30",
+            "receiver_address": "10000000",
+            "receiver_generation": "2",
+            "record_index": "3",
+            "descriptor_count": "8",
+            "descriptor_address": "20000114",
+            "runtime_address": "300000CC",
+            "descriptor_kind": "4",
+            "active_buffer_index": "1",
+            "per_record_resource_capacity": "8",
+            "helper_arguments": "00000001,00000002,00000003,00000004,00000005,00000006,00000007",
+            "descriptor_hash": "1111111111111111",
+            "runtime_hash": "2222222222222222",
+            "transform_hash": "3333333333333333",
+            "descriptor_variations": "0",
+            "runtime_variations": "2",
+            "transform_variations": "1",
+            "immutable_sample_words": "88",
+            "classification": "unclassified_material_or_state",
+        },
+        {
+            **common,
+            **safety,
+            "event": "native_renderer.discovery.semantic_instance_summary",
+            "observations": "12",
+            "live_observations": "12",
+            "unknown_receivers": "0",
+            "invalid_layouts": "0",
+            "invalid_indices": "0",
+            "payload_bytes": "4560",
+            "replay_fallbacks": "12",
+            "native_admissions": "0",
+            "entries": "1",
+            "capacity": "4096",
+            "overflow": "0",
+            "payload_bytes_per_live_observation": "380",
+        },
+    ]
+
+
+class SemanticInstanceTests(unittest.TestCase):
+    def test_complete_bounded_fallback_report(self):
+        report = MODULE.build(events(), static_inventory())
+        self.assertEqual(report["status"], "complete")
+        self.assertEqual(report["totals"]["live_observations"], 12)
+        self.assertEqual(report["entries"][0]["record_index"], 3)
+        self.assertFalse(report["safety"]["suppression_allowed"])
+
+    def test_unknown_receiver_keeps_report_incomplete(self):
+        sample = copy.deepcopy(events())
+        sample[-1]["observations"] = "13"
+        sample[-1]["unknown_receivers"] = "1"
+        report = MODULE.build(sample, static_inventory())
+        self.assertEqual(report["status"], "incomplete")
+        self.assertIn("unknown_receivers is nonzero", report["failures"])
+
+    def test_native_admission_is_rejected(self):
+        sample = copy.deepcopy(events())
+        sample[-1]["native_admissions"] = "1"
+        report = MODULE.build(sample, static_inventory())
+        self.assertEqual(report["status"], "incomplete")
+        self.assertIn("native_admissions is nonzero", report["failures"])
+
+    def test_suppression_claim_is_rejected(self):
+        sample = copy.deepcopy(events())
+        sample[1]["suppression_allowed"] = "true"
+        with self.assertRaisesRegex(ValueError, "safety boundary"):
+            MODULE.build(sample, static_inventory())
+
+    def test_record_index_must_be_in_descriptor_range(self):
+        sample = copy.deepcopy(events())
+        sample[1]["record_index"] = "8"
+        with self.assertRaisesRegex(ValueError, "immutable evidence"):
+            MODULE.build(sample, static_inventory())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- prove the procedural-model per-record helper argument and record-address flow
- capture a bounded immutable semantic-instance census keyed by live receiver generation and record index
- retain Xenos replay for every unclassified material or state, with no native upload, draw, or suppression
- add fail-closed report tooling, contract tests, and qualification documentation

## Validation
- 51 focused unit and contract tests
- pinned Release build
- AppData session \20260829T173833Z-p40812\: normal exit, 557,009 live observations, 463 keys, zero unknown/invalid/overflow/native-admission cases
- command lineage report complete for 6,367,265 prepared draws
- 30.259 FPS median, 19.294 FPS 1% low, 59.891 Hz present cadence, zero deadline misses and XMA stalls