### PR TITLE
feat(native-renderer): trace procedural resource providers

### DIFF
--- a/config/rexglue/analysis/main-xex.toml
+++ b/config/rexglue/analysis/main-xex.toml
@@ -280,6 +280,35 @@ address = 0x82415C50
 name = "PinyonShiftObserveProceduralModelResourceResolutionResult"
 registers = ["r3", "r30", "r31"]
 
+# The resolver's cache-miss path exposes the opaque lookup provider, both
+# provider predicates/method routes, and the opaque secondary-resolution
+# result. The runtime joins this provenance to the final bound object without
+# changing the title call or suppressing Xenos replay.
+[[midasm_hook]]
+address = 0x82415B64
+name = "PinyonShiftObserveProceduralModelResourceProviderLookup"
+registers = ["r3", "r29", "r31"]
+
+[[midasm_hook]]
+address = 0x82415B80
+name = "PinyonShiftObserveProceduralModelResourceProviderPrimaryPredicate"
+registers = ["r3", "r30"]
+
+[[midasm_hook]]
+address = 0x82415BA4
+name = "PinyonShiftObserveProceduralModelResourceProviderFallbackPredicate"
+registers = ["r3", "r30"]
+
+[[midasm_hook]]
+address = 0x82415BC0
+name = "PinyonShiftObserveProceduralModelResourceProviderMethodResult"
+registers = ["r3", "r30", "r31"]
+
+[[midasm_hook]]
+address = 0x82415BE4
+name = "PinyonShiftObserveProceduralModelResourceSecondaryResolutionResult"
+registers = ["r3", "r30", "r31"]
+
 [[midasm_hook]]
 address = 0x82415C6C
 name = "PinyonShiftObserveProceduralModelResourceBindDispatch"

--- a/docs/native-renderer/HIGH_LEVEL_RENDER_HOOKS.md
+++ b/docs/native-renderer/HIGH_LEVEL_RENDER_HOOKS.md
@@ -302,14 +302,40 @@ See `PROCEDURAL_MODEL_SEMANTIC_EXTRACTION.md`.
 
 The next boundary follows the same record to resource-binding helper
 `82415BF8` and graphics-context submission. Hooks at `82417A74`, `82417A9C`,
-`82415C50`, `82415C6C`, and `82417B60` now join receiver-table resource keys
+`82415C50`, `82415C6C`, and `82417B60` join receiver-table resource keys
 in slots 0/1 to the exact opaque objects returned by resolver `82415AD0` and
-dispatched through graphics virtual slot 88. The submission also retains the
-proved descriptor-kind group, helper-state table family, opaque runtime
-submission object, and exact default/counted geometry-source tuple. This is
-resolved structural submission identity, not a proved texture, material,
-vertex, index, mesh, LOD, or streaming ABI. See
+dispatched through graphics virtual slot 88.
+
+The provider-chain extension proves resolver lookup `82410A58`, its shared
+five-entry key/object/usage cache, provider predicates at vtable bytes 24 and
+44, selected methods at bytes 36 and 40, and opaque secondary-resolution call
+`823E58D8`. Hooks at `82415B64`, `82415B80`, `82415BA4`, `82415BC0`, and
+`82415BE4` retain the exact provider, vtable, four method identities, selected
+route, object source, and final object. Separate mirrors follow the binding
+helper's per-slot unchanged-key cache and the resolver's actual shared guest
+cache-slot addresses, so either form of exact-key reuse cannot lose or
+substitute provenance.
+
+The submission also retains the proved descriptor-kind group, helper-state
+table family, opaque runtime submission object, and exact default/counted
+geometry-source tuple. This is resolved structural submission identity, not a
+proved provider class, secondary-resolution semantic, texture, material,
+vertex, index, mesh, LOD, streaming, or lifetime ABI. See
 `PROCEDURAL_MODEL_SUBMISSION_CONTRACT.md`.
+
+AppData session `20260829T192106Z-p37612` runtime-qualified the provider chain
+across 695,696 exact submissions and 34 unique chains. Its 599,423 resolver
+operations comprised 422,946 shared-cache hits and 176,477 direct lookups;
+164,879 lookups selected provider method byte 36 and 11,598 used opaque
+secondary resolution after both predicates declined. Another 96,273 calls
+used the binding helper's per-slot exact-key cache. The runtime reconciles that
+cache against the title's actual shared key array at `834AD4CC` because other
+callers may update it. Lookup/resolution misses, null method results, protocol
+faults, unresolved joins, native admission, and suppression were all zero.
+Xenos remained authoritative at 29.334 median FPS with 59.983 Hz presentation
+and no deadline or XMA stalls.
+
+The two sessions below remain the pre-provider-chain structural baselines.
 
 AppData session `20260829T180132Z-p42336` qualified this contract across
 463,613 exact submissions and 605 retained tuples. All observations stayed on

--- a/docs/native-renderer/PROCEDURAL_MODEL_SEMANTIC_EXTRACTION.md
+++ b/docs/native-renderer/PROCEDURAL_MODEL_SEMANTIC_EXTRACTION.md
@@ -80,9 +80,12 @@ Those meanings must be proved before an instance is eligible for native
 admission or batching.
 
 The next static and runtime contract now follows these same records through
-their exact resource-binding and geometry-submission operations. It classifies
-structural resource keys, binding slots, an opaque runtime submission object,
-and the two geometry-source paths without claiming a mesh/material ABI. See
+their exact resource-provider lookup, shared resolver cache, reconciled
+resource-binding key cache, and geometry-submission operations. It classifies
+structural resource keys,
+opaque provider/vtable/method identities and selection routes, binding slots,
+an opaque runtime submission object, and the two geometry-source paths without
+claiming a provider class, secondary-resolution semantic, or mesh/material ABI. See
 `PROCEDURAL_MODEL_SUBMISSION_CONTRACT.md`.
 
 ## AppData qualification

--- a/docs/native-renderer/PROCEDURAL_MODEL_SUBMISSION_CONTRACT.md
+++ b/docs/native-renderer/PROCEDURAL_MODEL_SUBMISSION_CONTRACT.md
@@ -12,12 +12,17 @@ Helper `82417418` keeps the live receiver in `r27`, the descriptor record in
 `r28`, the parallel runtime record in `r26`, the graphics context in `r31`, and
 the resource-lookup context in `r20`.
 
-The static inventory proves five observation points:
+The static inventory proves ten observation points:
 
 | Hook | Structural operation |
 | --- | --- |
 | `82417A74` | bind descriptor word 0's receiver-table key to slot 0 |
 | `82417A9C` | conditionally bind descriptor word 4's key to slot 1 |
+| `82415B64` | observe the opaque provider returned by lookup `82410A58` |
+| `82415B80` | observe the provider byte-24 predicate result |
+| `82415BA4` | observe the provider byte-44 fallback predicate result |
+| `82415BC0` | observe the selected byte-36 or byte-40 method result |
+| `82415BE4` | observe the opaque secondary-resolution result |
 | `82415C50` | observe the opaque object returned by resolver `82415AD0` |
 | `82415C6C` | prove that exact object reaches graphics virtual slot 88 |
 | `82417B60` | submit the runtime object and geometry source tuple |
@@ -27,9 +32,36 @@ receiver-table stride of eight, added to the table at receiver offset 8, and
 passed to helper `82415BF8`. That helper accepts a binding slot below five,
 caches the resource key, resolves it through `82415AD0`, and calls the graphics
 context's virtual slot at byte offset 88. The observed uses are exactly slots
-0 and 1. A five-slot mirror follows the title helper's key cache so unchanged
-keys reuse only an object identity previously proved at the bind dispatch.
-Resolver misses and protocol discontinuities remain explicit failures.
+0 and 1. Its first cache is a five-key array at `834AD4CC`, indexed by
+graphics binding slot:
+an unchanged key skips both resolution and rebinding, so the runtime preserves
+the previously dispatched object and provenance for that exact binding slot.
+
+Resolver `82415AD0` owns a five-entry cache shared across binding roles. Each
+12-byte entry contains bound object, resource key, and usage count at offsets
+0, 4, and 8. On a cache miss it calls `82410A58`, which indexes the lookup
+context's byte-2812 table with the pointed-to key and returns an opaque
+provider. The resolver then follows one of these exact structural routes:
+
+- provider predicate byte 24 succeeds, then provider method byte 36 runs;
+- byte 24 declines and predicate byte 44 succeeds, then method byte 40 runs;
+- byte 44 also declines, so no provider method runs.
+
+A null selected-method result and the declined-provider path both call opaque
+secondary-resolution function `823E58D8`. The final result is stored in the
+selected cache entry and returned to the binding helper. The static proof does
+not assign class, allocation, texture, material, or lifetime semantics to that
+secondary function.
+
+The runtime maintains a separate mirror for each title cache. The binding-
+helper mirror is indexed by graphics binding slot and reconciled against the
+exact guest key at `834AD4CC + slot * 4` before deciding whether the shared
+helper will skip resolution. The resolver mirror is keyed by the exact guest
+resolver-cache slot address and searched by resource key. A key can therefore
+cross primary and secondary binding roles only with
+the provider, route, object source, and final bound-object identity previously
+proved at a bind dispatch. Resolver misses and protocol discontinuities remain
+explicit failures.
 
 The same helper also proves two structural partitions without assigning a
 material ABI. Descriptor kinds form `kind_4_5`, `kind_1_3`, and `other` groups.
@@ -46,7 +78,8 @@ slot 124. Virtual slot 160 receives primitive 13, byte count
   at runtime byte offset 32.
 
 These are structural resource keys, binding slots, an opaque runtime
-submission object, and a geometry source tuple. Exact texture/material class,
+submission object, and a geometry source tuple. Exact provider and virtual-
+method identities are retained structurally, but exact texture/material class,
 vertex format, index format, mesh ownership, and streaming lifetime are still
 open.
 
@@ -54,6 +87,7 @@ open.
 
 The resource hooks retain only the pending receiver, descriptor/runtime
 record addresses, graphics and lookup contexts, binding keys, exact opaque
+provider/vtable/method identities, selected provider route, object source,
 bound objects, and which slots were observed. The geometry hook consumes that
 pending tuple and accepts it
 only when all of the following hold:
@@ -66,16 +100,21 @@ only when all of the following hold:
   helper;
 - each required key joins to a nonzero opaque object observed at virtual bind
   slot 88, either directly or through the exact key cache;
+- each nonzero object retains a nonzero provider, vtable, all four proved
+  method identities, a primary/fallback/unavailable route, and either the
+  selected provider method or opaque secondary resolution as its exact source;
 - secondary binding presence exactly follows descriptor word 4's signed
   sentinel;
 - runtime object, count, and source reproduce one of the two proved geometry
   source paths.
 
-Each accepted observation reads 52 bytes, or 56 bytes when the optional
+Each accepted geometry observation reads 52 bytes, or 56 bytes when the optional
 secondary resource is present. A fixed 8,192-entry table aggregates exact
-receiver generation, record, key/object resource pair, state-variant pair,
-runtime-object, and geometry-source tuples. Mismatches remain separately
-accountable and fail qualification.
+receiver generation, record, key/provider/vtable/method/route/source/object
+chain, state-variant pair, runtime-object, and geometry-source tuples. A direct
+non-null provider lookup reads 20 additional bounded metadata bytes: one
+provider vtable pointer and four vtable method pointers. Mismatches remain
+separately accountable and fail qualification.
 
 The runtime emits `semantic_submission_entry` records and one
 `semantic_submission_summary`. Validate them with:
@@ -89,9 +128,12 @@ python tools/summarize-native-renderer-semantic-submissions.py `
 ```
 
 The report requires complete observation, binding, payload, entry, and replay
-accounting. Unknown receivers, mismatched bindings, invalid or unresolved
-resource joins, resolver misses, bind-protocol faults, invalid geometry,
-capacity overflow, native admission, or suppression claims make it incomplete.
+accounting. It also reconciles lookup outcomes, provider selections and null
+results, secondary-resolution outcomes, final resolver successes/misses, and
+the 20-byte provider metadata budget. Unknown receivers, mismatched bindings,
+invalid or unresolved resource joins, resolver misses, bind-protocol faults,
+invalid geometry, capacity overflow, native admission, or suppression claims
+make it incomplete.
 
 ## Safety boundary
 
@@ -101,6 +143,40 @@ work. Every accepted tuple is classified as
 `resolved_resource_and_state_variant_submission` and retains `xenos_replay`.
 
 ## AppData qualification
+
+Release executable SHA-256
+`902C2694E66BA1F929DE308BEC870B94C99AD5D6E6212A04E228931B9A720881`
+ran against the installed `0.1.0` preview save in session
+`20260829T192106Z-p37612`. The save loaded into the live festival world and
+the process exited normally after 3,540 measured frames (129.354 seconds).
+
+The provider-chain, semantic-instance, and command-lineage reports are all
+`complete`:
+
+- all 695,696 geometry submissions joined to an exact bound object and
+  provider chain while retaining Xenos replay;
+- 599,423 resolver/bind operations comprised 422,946 shared resolver-cache
+  hits and 176,477 direct provider lookups; another 96,273 calls used the
+  binding helper's exact per-slot key cache;
+- 164,879 direct lookups selected provider method byte 36, while 11,598 took
+  the declined-provider route and succeeded through opaque secondary
+  resolution; the byte-40 fallback route was not observed;
+- 34 unique provider chains covered every retained resource pair;
+- zero lookup/resolution misses, null provider-method results, unresolved
+  resources, protocol faults, bad joins, overflow, native admission, or
+  suppression;
+- 754,656 immutable semantic-instance observations and 8,114,562 prepared
+  draws retained complete fallback and lineage accounting.
+
+Performance measured 29.334 median FPS with an 18.902 FPS one-percent low,
+50.990 ms p95 frame time, 59.983 Hz presentation cadence, zero present-
+deadline misses, and zero XMA stalls. The semantic-submission report SHA-256
+is `E6A8C430EA771DE44ED09ADC72CF30C77C5BDBCE589AB956E3D28157B6B83821`.
+The 3072x1728 live screenshot is
+`native-renderer-provider-chain-open-world.jpg`, SHA-256
+`9C0168C242FE85E09C39B523A85B4487F55B6D187E2093A00B8300BC54A41657`.
+
+## Previous resolved-object baseline
 
 Release executable SHA-256
 `87B00D70EEDED7DC0547C4F8E848AB754FD597EBBF0DECC652415E985AF19C57`

--- a/src/native_renderer/graphics_hooks.cpp
+++ b/src/native_renderer/graphics_hooks.cpp
@@ -38,7 +38,8 @@ REXCVAR_DEFINE_BOOL(
     .lifecycle(rex::cvar::Lifecycle::kRequiresRestart);
 REXCVAR_DEFINE_BOOL(
     pinyon_shift_native_renderer_dispatch_discovery, false, "Pinyon Shift",
-    "Record bounded title graphics-wrapper caller metadata without changing rendering")
+                    "Record bounded title graphics-wrapper caller metadata "
+                    "without changing rendering")
     .lifecycle(rex::cvar::Lifecycle::kRequiresRestart);
 REXCVAR_DEFINE_BOOL(
     pinyon_shift_native_renderer_sky_horizon_suppression, false,
@@ -95,6 +96,7 @@ constexpr size_t kSemanticRuntimeWordCount = 68 / sizeof(uint32_t);
 constexpr size_t kSemanticTransformWordCount = 192 / sizeof(uint32_t);
 constexpr uint64_t kSemanticObservationPayloadBytes = 380;
 constexpr uint64_t kSemanticSubmissionMaximumPayloadBytes = 56;
+constexpr uint32_t kResourceBindingKeyCacheAddress = 0x834AD4CC;
 constexpr uint64_t kSkyHorizonAnchorSignature = UINT64_C(0x747837906D0BF484);
 constexpr uint64_t kSkyHorizonFollowerSignature = UINT64_C(0x1D253A52B55C9FB3);
 std::atomic<uint64_t> g_frame_sequence{};
@@ -409,9 +411,25 @@ struct SemanticSubmissionEntry {
   uint32_t primary_resource_index = 0;
   uint32_t primary_resource_key = 0;
   uint32_t primary_bound_resource_object = 0;
+  uint32_t primary_resource_provider_object = 0;
+  uint32_t primary_resource_provider_vtable = 0;
+  uint32_t primary_resource_predicate_24_method = 0;
+  uint32_t primary_resource_primary_36_method = 0;
+  uint32_t primary_resource_fallback_40_method = 0;
+  uint32_t primary_resource_predicate_44_method = 0;
+  uint32_t primary_resource_provider_selection = 0;
+  uint32_t primary_resource_object_source = 0;
   int32_t secondary_resource_index = -1;
   uint32_t secondary_resource_key = 0;
   uint32_t secondary_bound_resource_object = 0;
+  uint32_t secondary_resource_provider_object = 0;
+  uint32_t secondary_resource_provider_vtable = 0;
+  uint32_t secondary_resource_predicate_24_method = 0;
+  uint32_t secondary_resource_primary_36_method = 0;
+  uint32_t secondary_resource_fallback_40_method = 0;
+  uint32_t secondary_resource_predicate_44_method = 0;
+  uint32_t secondary_resource_provider_selection = 0;
+  uint32_t secondary_resource_object_source = 0;
   uint32_t runtime_submission_object = 0;
   uint32_t primitive_type = 13;
   uint32_t count_units = 0;
@@ -419,6 +437,34 @@ struct SemanticSubmissionEntry {
   uint32_t source_address = 0;
   bool secondary_resource_present = false;
   bool counted_runtime_source = false;
+};
+
+enum class SemanticResourceProviderSelection : uint32_t {
+  kUnknown = 0,
+  kLookupMissing = 1,
+  kPrimaryMethod = 2,
+  kFallbackMethod = 3,
+  kUnavailable = 4,
+};
+
+enum class SemanticResourceObjectSource : uint32_t {
+  kUnknown = 0,
+  kProviderMethod = 1,
+  kSecondaryResolution = 2,
+  kNone = 3,
+};
+
+struct SemanticResourceProviderProvenance {
+  uint32_t provider_object = 0;
+  uint32_t provider_vtable = 0;
+  uint32_t predicate_24_method = 0;
+  uint32_t primary_36_method = 0;
+  uint32_t fallback_40_method = 0;
+  uint32_t predicate_44_method = 0;
+  SemanticResourceProviderSelection selection =
+      SemanticResourceProviderSelection::kUnknown;
+  SemanticResourceObjectSource object_source =
+      SemanticResourceObjectSource::kUnknown;
 };
 
 struct PendingSemanticResourceBindings {
@@ -429,17 +475,28 @@ struct PendingSemanticResourceBindings {
   uint32_t resource_lookup_context = 0;
   uint32_t primary_resource_key = 0;
   uint32_t primary_bound_resource_object = 0;
+  SemanticResourceProviderProvenance primary_provider{};
   uint32_t secondary_resource_key = 0;
   uint32_t secondary_bound_resource_object = 0;
+  SemanticResourceProviderProvenance secondary_provider{};
   bool primary_seen = false;
   bool primary_resolution_known = false;
   bool secondary_seen = false;
   bool secondary_resolution_known = false;
 };
 
-struct SemanticResolvedResourceSlot {
+struct SemanticBindingCacheSlot {
   uint32_t resource_key = 0;
   uint32_t bound_resource_object = 0;
+  SemanticResourceProviderProvenance provider{};
+  bool key_known = false;
+};
+
+struct SemanticResolverCacheSlot {
+  uint32_t resolver_cache_slot = 0;
+  uint32_t resource_key = 0;
+  uint32_t bound_resource_object = 0;
+  SemanticResourceProviderProvenance provider{};
   bool key_known = false;
 };
 
@@ -448,9 +505,20 @@ struct PendingSemanticResourceResolution {
   uint32_t binding_slot = 0;
   uint32_t graphics_context = 0;
   uint32_t resolved_resource_object = 0;
+  SemanticResourceProviderProvenance provider{};
+  uint32_t provider_method_result = 0;
+  uint32_t secondary_resolution_result = 0;
+  uint32_t resolver_cache_slot = 0;
+  int32_t resolver_cache_index = -1;
   bool active = false;
   bool result_seen = false;
   bool cache_candidate = false;
+  bool resolver_cache_candidate = false;
+  bool provider_lookup_seen = false;
+  bool primary_predicate_seen = false;
+  bool fallback_predicate_seen = false;
+  bool provider_method_result_seen = false;
+  bool secondary_resolution_result_seen = false;
 };
 
 std::array<SemanticSubmissionEntry, kSemanticSubmissionCapacity>
@@ -476,8 +544,21 @@ uint64_t g_semantic_resource_resolution_misses = 0;
 uint64_t g_semantic_resource_resolution_cache_hits = 0;
 uint64_t g_semantic_resource_bind_dispatches = 0;
 uint64_t g_semantic_resource_resolution_protocol_faults = 0;
+uint64_t g_semantic_provider_lookup_observations = 0;
+uint64_t g_semantic_provider_cache_hits = 0;
+uint64_t g_semantic_provider_lookup_misses = 0;
+uint64_t g_semantic_provider_primary_selections = 0;
+uint64_t g_semantic_provider_fallback_selections = 0;
+uint64_t g_semantic_provider_unavailable_selections = 0;
+uint64_t g_semantic_provider_method_results = 0;
+uint64_t g_semantic_provider_method_null_results = 0;
+uint64_t g_semantic_secondary_resolution_attempts = 0;
+uint64_t g_semantic_secondary_resolution_successes = 0;
+uint64_t g_semantic_secondary_resolution_misses = 0;
+uint64_t g_semantic_provider_metadata_bytes = 0;
 uint64_t g_semantic_submission_unresolved_resource_joins = 0;
-std::array<SemanticResolvedResourceSlot, 5> g_semantic_resolved_resource_slots{};
+std::array<SemanticBindingCacheSlot, 5> g_semantic_binding_cache_slots{};
+std::array<SemanticResolverCacheSlot, 5> g_semantic_resolver_cache_slots{};
 thread_local PendingSemanticResourceBindings g_pending_semantic_bindings{};
 thread_local PendingSemanticResourceResolution
     g_pending_semantic_resource_resolution{};
@@ -811,8 +892,21 @@ void ResetTitleDrawProvenance() {
     g_semantic_resource_resolution_cache_hits = 0;
     g_semantic_resource_bind_dispatches = 0;
     g_semantic_resource_resolution_protocol_faults = 0;
+    g_semantic_provider_lookup_observations = 0;
+    g_semantic_provider_cache_hits = 0;
+    g_semantic_provider_lookup_misses = 0;
+    g_semantic_provider_primary_selections = 0;
+    g_semantic_provider_fallback_selections = 0;
+    g_semantic_provider_unavailable_selections = 0;
+    g_semantic_provider_method_results = 0;
+    g_semantic_provider_method_null_results = 0;
+    g_semantic_secondary_resolution_attempts = 0;
+    g_semantic_secondary_resolution_successes = 0;
+    g_semantic_secondary_resolution_misses = 0;
+    g_semantic_provider_metadata_bytes = 0;
     g_semantic_submission_unresolved_resource_joins = 0;
-    g_semantic_resolved_resource_slots = {};
+    g_semantic_binding_cache_slots = {};
+    g_semantic_resolver_cache_slots = {};
   }
   g_pending_semantic_bindings = {};
   g_pending_semantic_resource_resolution = {};
@@ -3338,6 +3432,86 @@ void EmitProceduralModelSemanticInstances() {
        {"suppression_allowed", "false"}});
 }
 
+const char *SemanticResourceProviderSelectionName(
+    SemanticResourceProviderSelection selection) {
+  switch (selection) {
+  case SemanticResourceProviderSelection::kLookupMissing:
+    return "lookup_missing";
+  case SemanticResourceProviderSelection::kPrimaryMethod:
+    return "primary_method_36";
+  case SemanticResourceProviderSelection::kFallbackMethod:
+    return "fallback_method_40";
+  case SemanticResourceProviderSelection::kUnavailable:
+    return "provider_unavailable";
+  default:
+    return "unknown";
+  }
+}
+
+const char *SemanticResourceObjectSourceName(
+    SemanticResourceObjectSource source) {
+  switch (source) {
+  case SemanticResourceObjectSource::kProviderMethod:
+    return "provider_method";
+  case SemanticResourceObjectSource::kSecondaryResolution:
+    return "secondary_resolution";
+  case SemanticResourceObjectSource::kNone:
+    return "none";
+  default:
+    return "unknown";
+  }
+}
+
+bool IsResolvedSemanticResourceProviderProvenance(
+    const SemanticResourceProviderProvenance &provider) {
+  const bool selected_provider_path =
+      provider.selection == SemanticResourceProviderSelection::kPrimaryMethod ||
+      provider.selection ==
+          SemanticResourceProviderSelection::kFallbackMethod ||
+      provider.selection == SemanticResourceProviderSelection::kUnavailable;
+  const bool produced_object =
+      provider.object_source == SemanticResourceObjectSource::kProviderMethod ||
+      provider.object_source ==
+          SemanticResourceObjectSource::kSecondaryResolution;
+  return provider.provider_object && provider.provider_vtable &&
+         provider.predicate_24_method && provider.primary_36_method &&
+         provider.fallback_40_method && provider.predicate_44_method &&
+         selected_provider_path && produced_object;
+}
+
+void PublishProceduralModelResourceBinding(
+    uint32_t binding_slot, uint32_t bound_resource_object,
+    const SemanticResourceProviderProvenance &provider) {
+  if (binding_slot == 0) {
+    g_pending_semantic_bindings.primary_bound_resource_object =
+        bound_resource_object;
+    g_pending_semantic_bindings.primary_provider = provider;
+    g_pending_semantic_bindings.primary_resolution_known = true;
+  } else if (binding_slot == 1) {
+    g_pending_semantic_bindings.secondary_bound_resource_object =
+        bound_resource_object;
+    g_pending_semantic_bindings.secondary_provider = provider;
+    g_pending_semantic_bindings.secondary_resolution_known = true;
+  }
+}
+
+void InvalidateProceduralModelResolverCacheCandidate(
+    PendingSemanticResourceResolution &resolution) {
+  if (!resolution.resolver_cache_candidate) {
+    return;
+  }
+  if (resolution.resolver_cache_index >= 0 &&
+      size_t(resolution.resolver_cache_index) <
+          g_semantic_resolver_cache_slots.size()) {
+    g_semantic_resolver_cache_slots[size_t(resolution.resolver_cache_index)] =
+        {};
+  }
+  resolution.resolved_resource_object = 0;
+  resolution.provider = {};
+  resolution.resolver_cache_candidate = false;
+  resolution.resolver_cache_index = -1;
+}
+
 bool FinalizeProceduralModelResourceCacheCandidate() {
   PendingSemanticResourceResolution &resolution =
       g_pending_semantic_resource_resolution;
@@ -3347,17 +3521,18 @@ bool FinalizeProceduralModelResourceCacheCandidate() {
     return false;
   }
   ++g_semantic_resource_resolution_cache_hits;
-  if (resolution.binding_slot == 0) {
-    g_pending_semantic_bindings.primary_bound_resource_object =
-        resolution.resolved_resource_object;
-    g_pending_semantic_bindings.primary_resolution_known = true;
-  } else if (resolution.binding_slot == 1) {
-    g_pending_semantic_bindings.secondary_bound_resource_object =
-        resolution.resolved_resource_object;
-    g_pending_semantic_bindings.secondary_resolution_known = true;
-  } else {
+  if (resolution.binding_slot > 1) {
     return false;
   }
+  g_semantic_binding_cache_slots[resolution.binding_slot] = {
+      .resource_key = resolution.resource_key,
+      .bound_resource_object = resolution.resolved_resource_object,
+      .provider = resolution.provider,
+      .key_known = true,
+  };
+  PublishProceduralModelResourceBinding(resolution.binding_slot,
+                                        resolution.resolved_resource_object,
+                                        resolution.provider);
   resolution = {};
   return true;
 }
@@ -3413,11 +3588,57 @@ void RecordProceduralModelResourceBinding(
     g_pending_semantic_bindings.secondary_seen = true;
   }
 
-  const SemanticResolvedResourceSlot &cached =
-      g_semantic_resolved_resource_slots[binding_slot];
+  auto *kernel_state = rex::system::kernel_state();
+  auto *memory = kernel_state ? kernel_state->memory() : nullptr;
+  const uint32_t guest_cached_key =
+      memory ? LoadSemanticGuestU32(
+                   memory, kResourceBindingKeyCacheAddress + binding_slot * 4)
+             : ~resource_key;
+  const bool title_binding_cache_hit = int32_t(resource_key) >= 0 &&
+                                       guest_cached_key == resource_key;
+  SemanticBindingCacheSlot &cached_binding =
+      g_semantic_binding_cache_slots[binding_slot];
+  if (cached_binding.key_known &&
+      cached_binding.resource_key != guest_cached_key) {
+    cached_binding = {};
+  }
+  int32_t resolver_cache_index = -1;
+  for (size_t index = 0; index < g_semantic_resolver_cache_slots.size();
+       ++index) {
+    const SemanticResolverCacheSlot &candidate =
+        g_semantic_resolver_cache_slots[index];
+    if (candidate.key_known && candidate.resource_key == resource_key &&
+        candidate.bound_resource_object) {
+      resolver_cache_index = int32_t(index);
+      break;
+    }
+  }
+  const bool resolver_cache_candidate = resolver_cache_index >= 0;
+  const bool binding_mirror_candidate =
+      cached_binding.key_known && cached_binding.resource_key == resource_key &&
+      cached_binding.bound_resource_object;
   const bool cache_candidate =
-      cached.key_known && cached.resource_key == resource_key &&
-      cached.bound_resource_object;
+      title_binding_cache_hit &&
+      (binding_mirror_candidate || resolver_cache_candidate);
+  const SemanticResourceProviderProvenance cached_provider =
+      binding_mirror_candidate
+          ? cached_binding.provider
+          : resolver_cache_candidate
+                ? g_semantic_resolver_cache_slots[size_t(resolver_cache_index)]
+                      .provider
+                : SemanticResourceProviderProvenance{};
+  const uint32_t cached_object =
+      binding_mirror_candidate
+          ? cached_binding.bound_resource_object
+          : resolver_cache_candidate
+                ? g_semantic_resolver_cache_slots[size_t(resolver_cache_index)]
+                      .bound_resource_object
+                : 0;
+  const uint32_t cached_resolver_slot =
+      resolver_cache_candidate
+          ? g_semantic_resolver_cache_slots[size_t(resolver_cache_index)]
+                .resolver_cache_slot
+          : 0;
   if (!cache_candidate) {
     ++g_semantic_resource_resolution_attempts;
   }
@@ -3425,11 +3646,225 @@ void RecordProceduralModelResourceBinding(
       .resource_key = resource_key,
       .binding_slot = binding_slot,
       .graphics_context = graphics_context,
-      .resolved_resource_object =
-          cache_candidate ? cached.bound_resource_object : 0,
+      .resolved_resource_object = cached_object,
+      .provider = cached_provider,
+      .resolver_cache_slot = cached_resolver_slot,
+      .resolver_cache_index = resolver_cache_index,
       .active = true,
       .cache_candidate = cache_candidate,
+      .resolver_cache_candidate =
+          !title_binding_cache_hit && resolver_cache_candidate,
   };
+}
+
+void RecordProceduralModelResourceProviderLookup(uint32_t provider_object,
+                                                 uint32_t lookup_context,
+                                                 uint32_t resolver_cache_slot) {
+  if (!g_command_buffer_lineage_installed.load(std::memory_order_acquire) ||
+      !g_pending_semantic_resource_resolution.active) {
+    return;
+  }
+  std::scoped_lock lock(g_semantic_submission_mutex);
+  PendingSemanticResourceResolution &resolution =
+      g_pending_semantic_resource_resolution;
+  if (!resolution.active || resolution.provider_lookup_seen ||
+      lookup_context != g_pending_semantic_bindings.resource_lookup_context ||
+      !resolver_cache_slot || (resolver_cache_slot & 3)) {
+    ++g_semantic_resource_resolution_protocol_faults;
+    resolution = {};
+    return;
+  }
+  if (resolution.cache_candidate) {
+    ++g_semantic_resource_resolution_protocol_faults;
+    resolution = {};
+    return;
+  }
+  InvalidateProceduralModelResolverCacheCandidate(resolution);
+  ++g_semantic_provider_lookup_observations;
+  resolution.provider_lookup_seen = true;
+  resolution.resolver_cache_slot = resolver_cache_slot;
+  int32_t cache_index = -1;
+  int32_t empty_index = -1;
+  for (size_t index = 0; index < g_semantic_resolver_cache_slots.size();
+       ++index) {
+    const SemanticResolverCacheSlot &candidate =
+        g_semantic_resolver_cache_slots[index];
+    if (candidate.resolver_cache_slot == resolver_cache_slot) {
+      cache_index = int32_t(index);
+      break;
+    }
+    if (!candidate.resolver_cache_slot && empty_index < 0) {
+      empty_index = int32_t(index);
+    }
+  }
+  if (cache_index < 0) {
+    cache_index = empty_index;
+  }
+  if (cache_index < 0) {
+    ++g_semantic_resource_resolution_protocol_faults;
+    resolution = {};
+    return;
+  }
+  resolution.resolver_cache_index = cache_index;
+  g_semantic_resolver_cache_slots[size_t(cache_index)] = {
+      .resolver_cache_slot = resolver_cache_slot,
+  };
+  if (!provider_object) {
+    ++g_semantic_provider_lookup_misses;
+    resolution.provider.selection =
+        SemanticResourceProviderSelection::kLookupMissing;
+    return;
+  }
+  auto *kernel_state = rex::system::kernel_state();
+  if (!kernel_state || !kernel_state->memory() || (provider_object & 3)) {
+    ++g_semantic_resource_resolution_protocol_faults;
+    resolution = {};
+    return;
+  }
+  auto *memory = kernel_state->memory();
+  const uint32_t provider_vtable =
+      LoadSemanticGuestU32(memory, provider_object);
+  if (!provider_vtable || (provider_vtable & 3) ||
+      provider_vtable > UINT32_MAX - 44) {
+    ++g_semantic_resource_resolution_protocol_faults;
+    resolution = {};
+    return;
+  }
+  SemanticResourceProviderProvenance provider = {
+      .provider_object = provider_object,
+      .provider_vtable = provider_vtable,
+      .predicate_24_method = LoadSemanticGuestU32(memory, provider_vtable + 24),
+      .primary_36_method = LoadSemanticGuestU32(memory, provider_vtable + 36),
+      .fallback_40_method = LoadSemanticGuestU32(memory, provider_vtable + 40),
+      .predicate_44_method = LoadSemanticGuestU32(memory, provider_vtable + 44),
+  };
+  if (!provider.predicate_24_method || !provider.primary_36_method ||
+      !provider.fallback_40_method || !provider.predicate_44_method ||
+      (provider.predicate_24_method & 3) || (provider.primary_36_method & 3) ||
+      (provider.fallback_40_method & 3) || (provider.predicate_44_method & 3)) {
+    ++g_semantic_resource_resolution_protocol_faults;
+    resolution = {};
+    return;
+  }
+  resolution.provider = provider;
+  g_semantic_provider_metadata_bytes += 20;
+}
+
+void RecordProceduralModelResourceProviderPrimaryPredicate(
+    uint32_t predicate_result, uint32_t provider_object) {
+  if (!g_command_buffer_lineage_installed.load(std::memory_order_acquire) ||
+      !g_pending_semantic_resource_resolution.active) {
+    return;
+  }
+  std::scoped_lock lock(g_semantic_submission_mutex);
+  PendingSemanticResourceResolution &resolution =
+      g_pending_semantic_resource_resolution;
+  if (!resolution.active || !resolution.provider_lookup_seen ||
+      !resolution.provider.provider_object ||
+      resolution.provider.provider_object != provider_object ||
+      resolution.primary_predicate_seen) {
+    ++g_semantic_resource_resolution_protocol_faults;
+    resolution = {};
+    return;
+  }
+  resolution.primary_predicate_seen = true;
+  if (predicate_result & 0xFF) {
+    resolution.provider.selection =
+        SemanticResourceProviderSelection::kPrimaryMethod;
+    ++g_semantic_provider_primary_selections;
+  }
+}
+
+void RecordProceduralModelResourceProviderFallbackPredicate(
+    uint32_t predicate_result, uint32_t provider_object) {
+  if (!g_command_buffer_lineage_installed.load(std::memory_order_acquire) ||
+      !g_pending_semantic_resource_resolution.active) {
+    return;
+  }
+  std::scoped_lock lock(g_semantic_submission_mutex);
+  PendingSemanticResourceResolution &resolution =
+      g_pending_semantic_resource_resolution;
+  if (!resolution.active || !resolution.primary_predicate_seen ||
+      resolution.provider.selection !=
+          SemanticResourceProviderSelection::kUnknown ||
+      resolution.provider.provider_object != provider_object ||
+      resolution.fallback_predicate_seen) {
+    ++g_semantic_resource_resolution_protocol_faults;
+    resolution = {};
+    return;
+  }
+  resolution.fallback_predicate_seen = true;
+  if (predicate_result & 0xFF) {
+    resolution.provider.selection =
+        SemanticResourceProviderSelection::kFallbackMethod;
+    ++g_semantic_provider_fallback_selections;
+  } else {
+    resolution.provider.selection =
+        SemanticResourceProviderSelection::kUnavailable;
+    ++g_semantic_provider_unavailable_selections;
+  }
+}
+
+void RecordProceduralModelResourceProviderMethodResult(
+    uint32_t provider_method_result, uint32_t provider_object,
+    uint32_t resolver_cache_slot) {
+  if (!g_command_buffer_lineage_installed.load(std::memory_order_acquire) ||
+      !g_pending_semantic_resource_resolution.active) {
+    return;
+  }
+  std::scoped_lock lock(g_semantic_submission_mutex);
+  PendingSemanticResourceResolution &resolution =
+      g_pending_semantic_resource_resolution;
+  if (!resolution.active || resolution.provider_method_result_seen ||
+      resolution.provider.provider_object != provider_object ||
+      resolution.resolver_cache_slot != resolver_cache_slot ||
+      (resolution.provider.selection !=
+           SemanticResourceProviderSelection::kPrimaryMethod &&
+       resolution.provider.selection !=
+           SemanticResourceProviderSelection::kFallbackMethod)) {
+    ++g_semantic_resource_resolution_protocol_faults;
+    resolution = {};
+    return;
+  }
+  ++g_semantic_provider_method_results;
+  if (!provider_method_result) {
+    ++g_semantic_provider_method_null_results;
+  }
+  resolution.provider_method_result_seen = true;
+  resolution.provider_method_result = provider_method_result;
+}
+
+void RecordProceduralModelResourceSecondaryResolutionResult(
+    uint32_t secondary_resolution_result, uint32_t provider_object,
+    uint32_t resolver_cache_slot) {
+  if (!g_command_buffer_lineage_installed.load(std::memory_order_acquire) ||
+      !g_pending_semantic_resource_resolution.active) {
+    return;
+  }
+  std::scoped_lock lock(g_semantic_submission_mutex);
+  PendingSemanticResourceResolution &resolution =
+      g_pending_semantic_resource_resolution;
+  const bool secondary_resolution_expected =
+      resolution.provider.selection ==
+          SemanticResourceProviderSelection::kUnavailable ||
+      (resolution.provider_method_result_seen &&
+       !resolution.provider_method_result);
+  if (!resolution.active || !secondary_resolution_expected ||
+      resolution.secondary_resolution_result_seen ||
+      resolution.provider.provider_object != provider_object ||
+      resolution.resolver_cache_slot != resolver_cache_slot) {
+    ++g_semantic_resource_resolution_protocol_faults;
+    resolution = {};
+    return;
+  }
+  ++g_semantic_secondary_resolution_attempts;
+  if (secondary_resolution_result) {
+    ++g_semantic_secondary_resolution_successes;
+  } else {
+    ++g_semantic_secondary_resolution_misses;
+  }
+  resolution.secondary_resolution_result_seen = true;
+  resolution.secondary_resolution_result = secondary_resolution_result;
 }
 
 void RecordProceduralModelResourceResolutionResult(
@@ -3450,9 +3885,62 @@ void RecordProceduralModelResourceResolutionResult(
     return;
   }
   if (resolution.cache_candidate) {
-    ++g_semantic_resource_resolution_attempts;
-    g_semantic_resolved_resource_slots[binding_slot] = {};
-    resolution.cache_candidate = false;
+    ++g_semantic_resource_resolution_protocol_faults;
+    resolution = {};
+    return;
+  }
+  if (resolution.resolver_cache_candidate) {
+    if (resolution.provider_lookup_seen || !resolved_resource_object ||
+        resolved_resource_object != resolution.resolved_resource_object ||
+        !IsResolvedSemanticResourceProviderProvenance(resolution.provider)) {
+      ++g_semantic_resource_resolution_protocol_faults;
+      resolution = {};
+      return;
+    }
+    ++g_semantic_provider_cache_hits;
+    resolution.result_seen = true;
+    return;
+  }
+  bool provider_chain_valid = resolution.provider_lookup_seen;
+  if (resolution.provider.selection ==
+      SemanticResourceProviderSelection::kLookupMissing) {
+    provider_chain_valid = provider_chain_valid && !resolved_resource_object;
+    resolution.provider.object_source = SemanticResourceObjectSource::kNone;
+  } else if (resolution.provider.selection ==
+                 SemanticResourceProviderSelection::kPrimaryMethod ||
+             resolution.provider.selection ==
+                 SemanticResourceProviderSelection::kFallbackMethod) {
+    provider_chain_valid =
+        provider_chain_valid && resolution.provider_method_result_seen;
+    if (resolution.provider_method_result) {
+      provider_chain_valid =
+          provider_chain_valid &&
+          !resolution.secondary_resolution_result_seen &&
+          resolved_resource_object == resolution.provider_method_result;
+      resolution.provider.object_source =
+          SemanticResourceObjectSource::kProviderMethod;
+    } else {
+      provider_chain_valid =
+          provider_chain_valid && resolution.secondary_resolution_result_seen &&
+          resolved_resource_object == resolution.secondary_resolution_result;
+      resolution.provider.object_source =
+          SemanticResourceObjectSource::kSecondaryResolution;
+    }
+  } else if (resolution.provider.selection ==
+             SemanticResourceProviderSelection::kUnavailable) {
+    provider_chain_valid =
+        provider_chain_valid && !resolution.provider_method_result_seen &&
+        resolution.secondary_resolution_result_seen &&
+        resolved_resource_object == resolution.secondary_resolution_result;
+    resolution.provider.object_source =
+        SemanticResourceObjectSource::kSecondaryResolution;
+  } else {
+    provider_chain_valid = false;
+  }
+  if (!provider_chain_valid) {
+    ++g_semantic_resource_resolution_protocol_faults;
+    resolution = {};
+    return;
   }
   resolution.result_seen = true;
   resolution.resolved_resource_object = resolved_resource_object;
@@ -3461,9 +3949,18 @@ void RecordProceduralModelResourceResolutionResult(
   }
 
   ++g_semantic_resource_resolution_misses;
-  g_semantic_resolved_resource_slots[binding_slot] = {
+  if (resolution.resolver_cache_index < 0 ||
+      size_t(resolution.resolver_cache_index) >=
+          g_semantic_resolver_cache_slots.size()) {
+    ++g_semantic_resource_resolution_protocol_faults;
+    resolution = {};
+    return;
+  }
+  g_semantic_resolver_cache_slots[size_t(resolution.resolver_cache_index)] = {
+      .resolver_cache_slot = resolution.resolver_cache_slot,
       .resource_key = resolution.resource_key,
       .bound_resource_object = 0,
+      .provider = resolution.provider,
       .key_known = true,
   };
   if (binding_slot == 0) {
@@ -3498,20 +3995,28 @@ void RecordProceduralModelResourceBindDispatch(
 
   ++g_semantic_resource_resolution_successes;
   ++g_semantic_resource_bind_dispatches;
-  g_semantic_resolved_resource_slots[binding_slot] = {
+  if (resolution.resolver_cache_index < 0 ||
+      size_t(resolution.resolver_cache_index) >=
+          g_semantic_resolver_cache_slots.size()) {
+    ++g_semantic_resource_resolution_protocol_faults;
+    resolution = {};
+    return;
+  }
+  g_semantic_resolver_cache_slots[size_t(resolution.resolver_cache_index)] = {
+      .resolver_cache_slot = resolution.resolver_cache_slot,
       .resource_key = resolution.resource_key,
       .bound_resource_object = bound_resource_object,
+      .provider = resolution.provider,
       .key_known = true,
   };
-  if (binding_slot == 0) {
-    g_pending_semantic_bindings.primary_bound_resource_object =
-        bound_resource_object;
-    g_pending_semantic_bindings.primary_resolution_known = true;
-  } else {
-    g_pending_semantic_bindings.secondary_bound_resource_object =
-        bound_resource_object;
-    g_pending_semantic_bindings.secondary_resolution_known = true;
-  }
+  g_semantic_binding_cache_slots[binding_slot] = {
+      .resource_key = resolution.resource_key,
+      .bound_resource_object = bound_resource_object,
+      .provider = resolution.provider,
+      .key_known = true,
+  };
+  PublishProceduralModelResourceBinding(
+      binding_slot, bound_resource_object, resolution.provider);
   resolution = {};
 }
 
@@ -3651,7 +4156,8 @@ void RecordProceduralModelGeometrySubmission(
     return;
   }
   if (!pending.primary_resolution_known ||
-      !pending.primary_bound_resource_object) {
+      !pending.primary_bound_resource_object ||
+      !IsResolvedSemanticResourceProviderProvenance(pending.primary_provider)) {
     ++g_semantic_submission_unresolved_resource_joins;
     return;
   }
@@ -3675,7 +4181,9 @@ void RecordProceduralModelGeometrySubmission(
       return;
     }
     if (!pending.secondary_resolution_known ||
-        !pending.secondary_bound_resource_object) {
+        !pending.secondary_bound_resource_object ||
+        !IsResolvedSemanticResourceProviderProvenance(
+            pending.secondary_provider)) {
       ++g_semantic_submission_unresolved_resource_joins;
       return;
     }
@@ -3710,9 +4218,25 @@ void RecordProceduralModelGeometrySubmission(
         uint64_t(record_index), uint64_t(descriptor_kind),
         uint64_t(helper_state), uint64_t(primary_resource_key),
         uint64_t(pending.primary_bound_resource_object),
+        uint64_t(pending.primary_provider.provider_object),
+        uint64_t(pending.primary_provider.provider_vtable),
+        uint64_t(pending.primary_provider.predicate_24_method),
+        uint64_t(pending.primary_provider.primary_36_method),
+        uint64_t(pending.primary_provider.fallback_40_method),
+        uint64_t(pending.primary_provider.predicate_44_method),
+        uint64_t(pending.primary_provider.selection),
+        uint64_t(pending.primary_provider.object_source),
         uint64_t(secondary_resource_present),
         uint64_t(secondary_resource_key),
         uint64_t(pending.secondary_bound_resource_object),
+        uint64_t(pending.secondary_provider.provider_object),
+        uint64_t(pending.secondary_provider.provider_vtable),
+        uint64_t(pending.secondary_provider.predicate_24_method),
+        uint64_t(pending.secondary_provider.primary_36_method),
+        uint64_t(pending.secondary_provider.fallback_40_method),
+        uint64_t(pending.secondary_provider.predicate_44_method),
+        uint64_t(pending.secondary_provider.selection),
+        uint64_t(pending.secondary_provider.object_source),
         uint64_t(runtime_submission_object), uint64_t(count_bytes),
         uint64_t(source_address)}) {
     key = HashCombine(key, value);
@@ -3739,10 +4263,42 @@ void RecordProceduralModelGeometrySubmission(
           .primary_resource_key = primary_resource_key,
           .primary_bound_resource_object =
               pending.primary_bound_resource_object,
+          .primary_resource_provider_object =
+              pending.primary_provider.provider_object,
+          .primary_resource_provider_vtable =
+              pending.primary_provider.provider_vtable,
+          .primary_resource_predicate_24_method =
+              pending.primary_provider.predicate_24_method,
+          .primary_resource_primary_36_method =
+              pending.primary_provider.primary_36_method,
+          .primary_resource_fallback_40_method =
+              pending.primary_provider.fallback_40_method,
+          .primary_resource_predicate_44_method =
+              pending.primary_provider.predicate_44_method,
+          .primary_resource_provider_selection =
+              uint32_t(pending.primary_provider.selection),
+          .primary_resource_object_source =
+              uint32_t(pending.primary_provider.object_source),
           .secondary_resource_index = secondary_resource_index,
           .secondary_resource_key = secondary_resource_key,
           .secondary_bound_resource_object =
               pending.secondary_bound_resource_object,
+          .secondary_resource_provider_object =
+              pending.secondary_provider.provider_object,
+          .secondary_resource_provider_vtable =
+              pending.secondary_provider.provider_vtable,
+          .secondary_resource_predicate_24_method =
+              pending.secondary_provider.predicate_24_method,
+          .secondary_resource_primary_36_method =
+              pending.secondary_provider.primary_36_method,
+          .secondary_resource_fallback_40_method =
+              pending.secondary_provider.fallback_40_method,
+          .secondary_resource_predicate_44_method =
+              pending.secondary_provider.predicate_44_method,
+          .secondary_resource_provider_selection =
+              uint32_t(pending.secondary_provider.selection),
+          .secondary_resource_object_source =
+              uint32_t(pending.secondary_provider.object_source),
           .runtime_submission_object = runtime_submission_object,
           .primitive_type = 13,
           .count_units = count_units,
@@ -3765,11 +4321,43 @@ void RecordProceduralModelGeometrySubmission(
         entry.primary_resource_key == primary_resource_key &&
         entry.primary_bound_resource_object ==
             pending.primary_bound_resource_object &&
+        entry.primary_resource_provider_object ==
+            pending.primary_provider.provider_object &&
+        entry.primary_resource_provider_vtable ==
+            pending.primary_provider.provider_vtable &&
+        entry.primary_resource_predicate_24_method ==
+            pending.primary_provider.predicate_24_method &&
+        entry.primary_resource_primary_36_method ==
+            pending.primary_provider.primary_36_method &&
+        entry.primary_resource_fallback_40_method ==
+            pending.primary_provider.fallback_40_method &&
+        entry.primary_resource_predicate_44_method ==
+            pending.primary_provider.predicate_44_method &&
+        entry.primary_resource_provider_selection ==
+            uint32_t(pending.primary_provider.selection) &&
+        entry.primary_resource_object_source ==
+            uint32_t(pending.primary_provider.object_source) &&
         entry.secondary_resource_present == secondary_resource_present &&
         entry.secondary_resource_index == secondary_resource_index &&
         entry.secondary_resource_key == secondary_resource_key &&
         entry.secondary_bound_resource_object ==
             pending.secondary_bound_resource_object &&
+        entry.secondary_resource_provider_object ==
+            pending.secondary_provider.provider_object &&
+        entry.secondary_resource_provider_vtable ==
+            pending.secondary_provider.provider_vtable &&
+        entry.secondary_resource_predicate_24_method ==
+            pending.secondary_provider.predicate_24_method &&
+        entry.secondary_resource_primary_36_method ==
+            pending.secondary_provider.primary_36_method &&
+        entry.secondary_resource_fallback_40_method ==
+            pending.secondary_provider.fallback_40_method &&
+        entry.secondary_resource_predicate_44_method ==
+            pending.secondary_provider.predicate_44_method &&
+        entry.secondary_resource_provider_selection ==
+            uint32_t(pending.secondary_provider.selection) &&
+        entry.secondary_resource_object_source ==
+            uint32_t(pending.secondary_provider.object_source) &&
         entry.runtime_submission_object == runtime_submission_object &&
         entry.count_units == count_units &&
         entry.count_bytes == count_bytes &&
@@ -3811,6 +4399,25 @@ void EmitProceduralModelSemanticSubmissions() {
           fmt::format("{:08X}", entry.primary_resource_key)},
          {"primary_bound_resource_object",
           fmt::format("{:08X}", entry.primary_bound_resource_object)},
+         {"primary_resource_provider_object",
+          fmt::format("{:08X}", entry.primary_resource_provider_object)},
+         {"primary_resource_provider_vtable",
+          fmt::format("{:08X}", entry.primary_resource_provider_vtable)},
+         {"primary_resource_predicate_24_method",
+          fmt::format("{:08X}", entry.primary_resource_predicate_24_method)},
+         {"primary_resource_primary_36_method",
+          fmt::format("{:08X}", entry.primary_resource_primary_36_method)},
+         {"primary_resource_fallback_40_method",
+          fmt::format("{:08X}", entry.primary_resource_fallback_40_method)},
+         {"primary_resource_predicate_44_method",
+          fmt::format("{:08X}", entry.primary_resource_predicate_44_method)},
+         {"primary_resource_provider_selection",
+          SemanticResourceProviderSelectionName(
+              SemanticResourceProviderSelection(
+                  entry.primary_resource_provider_selection))},
+         {"primary_resource_object_source",
+          SemanticResourceObjectSourceName(SemanticResourceObjectSource(
+              entry.primary_resource_object_source))},
          {"secondary_resource_present",
           entry.secondary_resource_present ? "true" : "false"},
          {"secondary_resource_index",
@@ -3819,6 +4426,25 @@ void EmitProceduralModelSemanticSubmissions() {
           fmt::format("{:08X}", entry.secondary_resource_key)},
          {"secondary_bound_resource_object",
           fmt::format("{:08X}", entry.secondary_bound_resource_object)},
+         {"secondary_resource_provider_object",
+          fmt::format("{:08X}", entry.secondary_resource_provider_object)},
+         {"secondary_resource_provider_vtable",
+          fmt::format("{:08X}", entry.secondary_resource_provider_vtable)},
+         {"secondary_resource_predicate_24_method",
+          fmt::format("{:08X}", entry.secondary_resource_predicate_24_method)},
+         {"secondary_resource_primary_36_method",
+          fmt::format("{:08X}", entry.secondary_resource_primary_36_method)},
+         {"secondary_resource_fallback_40_method",
+          fmt::format("{:08X}", entry.secondary_resource_fallback_40_method)},
+         {"secondary_resource_predicate_44_method",
+          fmt::format("{:08X}", entry.secondary_resource_predicate_44_method)},
+         {"secondary_resource_provider_selection",
+          SemanticResourceProviderSelectionName(
+              SemanticResourceProviderSelection(
+                  entry.secondary_resource_provider_selection))},
+         {"secondary_resource_object_source",
+          SemanticResourceObjectSourceName(SemanticResourceObjectSource(
+              entry.secondary_resource_object_source))},
          {"runtime_submission_object",
           fmt::format("{:08X}", entry.runtime_submission_object)},
          {"primitive_type", std::to_string(entry.primitive_type)},
@@ -3870,10 +4496,36 @@ void EmitProceduralModelSemanticSubmissions() {
         std::to_string(g_semantic_resource_resolution_misses)},
        {"resource_resolution_cache_hits",
         std::to_string(g_semantic_resource_resolution_cache_hits)},
+       {"resource_binding_key_cache_hits",
+        std::to_string(g_semantic_resource_resolution_cache_hits)},
        {"resource_bind_dispatches",
         std::to_string(g_semantic_resource_bind_dispatches)},
        {"resource_resolution_protocol_faults",
         std::to_string(g_semantic_resource_resolution_protocol_faults)},
+       {"provider_lookup_observations",
+        std::to_string(g_semantic_provider_lookup_observations)},
+       {"provider_cache_hits", std::to_string(g_semantic_provider_cache_hits)},
+       {"provider_lookup_misses",
+        std::to_string(g_semantic_provider_lookup_misses)},
+       {"provider_primary_selections",
+        std::to_string(g_semantic_provider_primary_selections)},
+       {"provider_fallback_selections",
+        std::to_string(g_semantic_provider_fallback_selections)},
+       {"provider_unavailable_selections",
+        std::to_string(g_semantic_provider_unavailable_selections)},
+       {"provider_method_results",
+        std::to_string(g_semantic_provider_method_results)},
+       {"provider_method_null_results",
+        std::to_string(g_semantic_provider_method_null_results)},
+       {"secondary_resolution_attempts",
+        std::to_string(g_semantic_secondary_resolution_attempts)},
+       {"secondary_resolution_successes",
+        std::to_string(g_semantic_secondary_resolution_successes)},
+       {"secondary_resolution_misses",
+        std::to_string(g_semantic_secondary_resolution_misses)},
+       {"provider_metadata_bytes",
+        std::to_string(g_semantic_provider_metadata_bytes)},
+       {"provider_metadata_bytes_per_lookup", "20"},
        {"payload_bytes",
         std::to_string(g_semantic_submission_payload_bytes)},
        {"maximum_payload_bytes_per_live_observation",
@@ -8162,6 +8814,12 @@ void InstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system,
        {"secondary_resource_binding_hook", "82417A9C"},
        {"geometry_submission_hook", "82417B60"},
        {"resource_binding_helper", "82415BF8"},
+       {"resource_lookup_function", "82410A58"},
+       {"resource_provider_lookup_hook", "82415B64"},
+       {"resource_provider_primary_predicate_hook", "82415B80"},
+       {"resource_provider_fallback_predicate_hook", "82415BA4"},
+       {"resource_provider_method_result_hook", "82415BC0"},
+       {"resource_secondary_resolution_result_hook", "82415BE4"},
        {"resource_resolution_result_hook", "82415C50"},
        {"resource_bind_dispatch_hook", "82415C6C"},
        {"resource_binding_slots", "0,1"},
@@ -9061,6 +9719,33 @@ void PinyonShiftObserveProceduralModelSecondaryResourceBinding(
 void PinyonShiftObserveProceduralModelResourceResolutionResult(
     PPCRegister &r3, PPCRegister &r30, PPCRegister &r31) {
   RecordProceduralModelResourceResolutionResult(r3.u32, r30.u32, r31.u32);
+}
+
+void PinyonShiftObserveProceduralModelResourceProviderLookup(PPCRegister &r3,
+                                                             PPCRegister &r29,
+                                                             PPCRegister &r31) {
+  RecordProceduralModelResourceProviderLookup(r3.u32, r29.u32, r31.u32);
+}
+
+void PinyonShiftObserveProceduralModelResourceProviderPrimaryPredicate(
+    PPCRegister &r3, PPCRegister &r30) {
+  RecordProceduralModelResourceProviderPrimaryPredicate(r3.u32, r30.u32);
+}
+
+void PinyonShiftObserveProceduralModelResourceProviderFallbackPredicate(
+    PPCRegister &r3, PPCRegister &r30) {
+  RecordProceduralModelResourceProviderFallbackPredicate(r3.u32, r30.u32);
+}
+
+void PinyonShiftObserveProceduralModelResourceProviderMethodResult(
+    PPCRegister &r3, PPCRegister &r30, PPCRegister &r31) {
+  RecordProceduralModelResourceProviderMethodResult(r3.u32, r30.u32, r31.u32);
+}
+
+void PinyonShiftObserveProceduralModelResourceSecondaryResolutionResult(
+    PPCRegister &r3, PPCRegister &r30, PPCRegister &r31) {
+  RecordProceduralModelResourceSecondaryResolutionResult(r3.u32, r30.u32,
+                                                         r31.u32);
 }
 
 void PinyonShiftObserveProceduralModelResourceBindDispatch(

--- a/tools/discover-native-renderer-dispatch.py
+++ b/tools/discover-native-renderer-dispatch.py
@@ -206,6 +206,13 @@ PROCEDURAL_MODEL_RECEIVER = {
     "secondary_resource_binding_hook": 0x82417A9C,
     "geometry_submission_hook": 0x82417B60,
     "resource_binding_function": 0x82415BF8,
+    "resource_resolution_function": 0x82415AD0,
+    "resource_lookup_function": 0x82410A58,
+    "resource_provider_lookup_hook": 0x82415B64,
+    "resource_provider_primary_predicate_hook": 0x82415B80,
+    "resource_provider_fallback_predicate_hook": 0x82415BA4,
+    "resource_provider_method_result_hook": 0x82415BC0,
+    "resource_secondary_resolution_result_hook": 0x82415BE4,
     "resource_resolution_result_hook": 0x82415C50,
     "resource_bind_dispatch_hook": 0x82415C6C,
 }
@@ -816,6 +823,8 @@ def procedural_model_receiver_lifecycle(
         spec["render_state_function"],
         spec["render_item_function"],
         spec["resource_binding_function"],
+        spec["resource_resolution_function"],
+        spec["resource_lookup_function"],
     }
     lifecycle_functions = required - {spec["dispatch_function"]}
     if not lifecycle_functions & set(functions_by_address):
@@ -868,6 +877,18 @@ def procedural_model_receiver_lifecycle(
     resource_binding = {
         item["address"]: item["text"]
         for item in functions_by_address[spec["resource_binding_function"]][
+            "instructions"
+        ]
+    }
+    resource_resolution = {
+        item["address"]: item["text"]
+        for item in functions_by_address[spec["resource_resolution_function"]][
+            "instructions"
+        ]
+    }
+    resource_lookup = {
+        item["address"]: item["text"]
+        for item in functions_by_address[spec["resource_lookup_function"]][
             "instructions"
         ]
     }
@@ -1040,6 +1061,57 @@ def procedural_model_receiver_lifecycle(
     ):
         raise ValueError("procedural-model resource resolution evidence drifted")
 
+    resource_lookup_expected = {
+        spec["resource_lookup_function"]: "lwz r11,0(r4)",
+        0x82410A5C: "lwz r10,2812(r3)",
+        0x82410A60: "rlwinm r11,r11,2,0,29",
+        0x82410A64: "lwzx r3,r11,r10",
+        0x82410A68: "blr",
+    }
+    resource_resolution_expected = {
+        spec["resource_resolution_function"]: "mflr r12",
+        0x82415AE4: "mr r29,r5",
+        0x82415AF8: "lwz r10,0(r11)",
+        0x82415AFC: "lwz r8,-4(r11)",
+        0x82415B04: "cmpw cr6,r8,r4",
+        0x82415B10: "addi r9,r11,-8",
+        0x82415B40: "lwz r3,0(r9)",
+        0x82415B4C: "stw r4,4(r31)",
+        0x82415B50: "mr r3,r29",
+        0x82415B58: "addi r4,r1,80",
+        0x82415B60: "bl 0x82410a58",
+        spec["resource_provider_lookup_hook"]: "mr. r30,r3",
+        0x82415B6C: "lwz r11,0(r30)",
+        0x82415B74: "lwz r11,24(r11)",
+        0x82415B7C: "bctrl",
+        spec["resource_provider_primary_predicate_hook"]:
+            "clrlwi. r11,r3,24",
+        0x82415B90: "lwz r11,36(r11)",
+        0x82415B98: "lwz r11,44(r11)",
+        0x82415BA0: "bctrl",
+        spec["resource_provider_fallback_predicate_hook"]:
+            "clrlwi. r11,r3,24",
+        0x82415BB4: "lwz r11,40(r11)",
+        0x82415BBC: "bctrl",
+        spec["resource_provider_method_result_hook"]: "stw r3,0(r31)",
+        0x82415BC4: "lwz r11,0(r31)",
+        0x82415BD0: "lwz r11,8(r30)",
+        0x82415BE0: "bl 0x823e58d8",
+        spec["resource_secondary_resolution_result_hook"]:
+            "stw r3,0(r31)",
+        0x82415BE8: "lwz r3,0(r31)",
+    }
+    if any(
+        resource_lookup.get(address) != text
+        for address, text in resource_lookup_expected.items()
+    ):
+        raise ValueError("procedural-model resource lookup evidence drifted")
+    if any(
+        resource_resolution.get(address) != text
+        for address, text in resource_resolution_expected.items()
+    ):
+        raise ValueError("procedural-model provider chain evidence drifted")
+
     rtti_verified = False
     complete_object_locator = None
     type_descriptor = None
@@ -1199,7 +1271,54 @@ def procedural_model_receiver_lifecycle(
             "receiver_resource_table_offset": 8,
             "receiver_resource_table_stride": 8,
             "resource_binding_helper_function_address": "82415BF8",
-            "resource_resolution_function_address": "82415AD0",
+            "resource_resolution_function_address": "{:08X}".format(
+                spec["resource_resolution_function"]
+            ),
+            "resource_lookup_function_address": "{:08X}".format(
+                spec["resource_lookup_function"]
+            ),
+            "resource_provider_lookup_hook_address": "{:08X}".format(
+                spec["resource_provider_lookup_hook"]
+            ),
+            "resource_provider_primary_predicate_hook_address":
+                "{:08X}".format(
+                    spec["resource_provider_primary_predicate_hook"]
+                ),
+            "resource_provider_fallback_predicate_hook_address":
+                "{:08X}".format(
+                    spec["resource_provider_fallback_predicate_hook"]
+                ),
+            "resource_provider_method_result_hook_address": "{:08X}".format(
+                spec["resource_provider_method_result_hook"]
+            ),
+            "resource_secondary_resolution_result_hook_address":
+                "{:08X}".format(
+                    spec["resource_secondary_resolution_result_hook"]
+                ),
+            "resource_provider_vtable_method_offsets": [24, 36, 40, 44],
+            "resource_resolution_cache_entry_count": 5,
+            "resource_resolution_cache_entry_stride": 12,
+            "resource_resolution_cache_bound_object_offset": 0,
+            "resource_resolution_cache_key_offset": 4,
+            "resource_resolution_cache_usage_offset": 8,
+            "resource_resolution_cache_shared_across_binding_slots": True,
+            "resource_provider_routes": {
+                "primary_method_36": {
+                    "predicate_offset": 24,
+                    "method_offset": 36,
+                },
+                "fallback_method_40": {
+                    "predicate_offset": 44,
+                    "method_offset": 40,
+                },
+                "provider_unavailable": {
+                    "predicate_offset": 44,
+                    "secondary_resolution_function_address": "823E58D8",
+                },
+                "null_provider_method_result": {
+                    "secondary_resolution_function_address": "823E58D8",
+                },
+            },
             "resource_resolution_result_hook_address": "{:08X}".format(
                 spec["resource_resolution_result_hook"]
             ),
@@ -1208,6 +1327,11 @@ def procedural_model_receiver_lifecycle(
             ),
             "resource_bind_dispatch_vtable_offset": 88,
             "resource_binding_slots": [0, 1],
+            "resource_binding_key_cache_address": "834AD4CC",
+            "resource_binding_key_cache_entry_count": 5,
+            "resource_binding_key_cache_entry_stride": 4,
+            "resource_binding_key_cache_indexed_by_binding_slot": True,
+            "resource_binding_key_cache_skips_unchanged_bind": True,
             "runtime_submission_object_offset": 0,
             "runtime_default_source_address_offset": 24,
             "runtime_count_units_offset": 28,
@@ -1231,6 +1355,9 @@ def procedural_model_receiver_lifecycle(
             "runtime_scalar_offsets": [40],
             "resource_binding_derivation_proved": True,
             "resolved_resource_object_derivation_proved": True,
+            "resource_provider_chain_derivation_proved": True,
+            "resource_provider_method_identity_runtime_join_required": True,
+            "secondary_resolution_semantics_proved": False,
             "descriptor_kind_partition_proved": True,
             "helper_state_partition_proved": True,
             "record_join_proved": True,

--- a/tools/summarize-native-renderer-semantic-submissions.py
+++ b/tools/summarize-native-renderer-semantic-submissions.py
@@ -9,7 +9,7 @@ import pathlib
 import sys
 
 
-SCHEMA = "pinyon-shift.native-renderer-semantic-submissions.v2"
+SCHEMA = "pinyon-shift.native-renderer-semantic-submissions.v3"
 STATIC_SCHEMA = "pinyon-shift.native-renderer-dispatch-static.v3"
 PREFIX = "native_renderer.discovery.semantic_submission_"
 EXPECTED_CLASS = "proceduralGeometry::CProceduralModels"
@@ -17,6 +17,11 @@ EXPECTED_CLASSIFICATION = "resolved_resource_and_state_variant_submission"
 EXPECTED_HOOKS = (
     "82417A74",
     "82417A9C",
+    "82415B64",
+    "82415B80",
+    "82415BA4",
+    "82415BC0",
+    "82415BE4",
     "82415C50",
     "82415C6C",
     "82417B60",
@@ -108,6 +113,7 @@ def _validate_static(static: dict) -> None:
         for key in (
             "resource_binding_derivation_proved",
             "resolved_resource_object_derivation_proved",
+            "resource_provider_chain_derivation_proved",
             "record_join_proved",
             "geometry_submission_derivation_proved",
             "descriptor_kind_partition_proved",
@@ -120,6 +126,11 @@ def _validate_static(static: dict) -> None:
         for key in (
             "primary_resource_binding_hook_address",
             "secondary_resource_binding_hook_address",
+            "resource_provider_lookup_hook_address",
+            "resource_provider_primary_predicate_hook_address",
+            "resource_provider_fallback_predicate_hook_address",
+            "resource_provider_method_result_hook_address",
+            "resource_secondary_resolution_result_hook_address",
             "resource_resolution_result_hook_address",
             "resource_bind_dispatch_hook_address",
             "geometry_submission_hook_address",
@@ -129,6 +140,27 @@ def _validate_static(static: dict) -> None:
         hooks != EXPECTED_HOOKS
         or extraction.get("resource_binding_helper_function_address") != "82415BF8"
         or extraction.get("resource_binding_slots") != [0, 1]
+        or extraction.get("resource_binding_key_cache_address") != "834AD4CC"
+        or extraction.get("resource_binding_key_cache_entry_count") != 5
+        or extraction.get("resource_binding_key_cache_entry_stride") != 4
+        or extraction.get(
+            "resource_binding_key_cache_indexed_by_binding_slot"
+        ) is not True
+        or extraction.get(
+            "resource_binding_key_cache_skips_unchanged_bind"
+        ) is not True
+        or extraction.get("resource_lookup_function_address") != "82410A58"
+        or extraction.get("resource_provider_vtable_method_offsets")
+        != [24, 36, 40, 44]
+        or extraction.get("resource_resolution_cache_entry_count") != 5
+        or extraction.get("resource_resolution_cache_entry_stride") != 12
+        or extraction.get("resource_resolution_cache_bound_object_offset") != 0
+        or extraction.get("resource_resolution_cache_key_offset") != 4
+        or extraction.get("resource_resolution_cache_usage_offset") != 8
+        or extraction.get(
+            "resource_resolution_cache_shared_across_binding_slots"
+        ) is not True
+        or extraction.get("secondary_resolution_semantics_proved") is not False
         or extraction.get("graphics_submission_primitive") != 13
         or extraction.get("graphics_submission_count_scale") != 4
         or extraction.get("classification") != EXPECTED_CLASSIFICATION
@@ -153,6 +185,21 @@ def build(events: list[dict], static: dict, requested: str | None = None) -> dic
     ]
     if len(configs) != 1 or len(summaries) != 1:
         raise ValueError("semantic-submission session needs one armed config and summary")
+    expected_runtime_hooks = {
+        "primary_resource_binding_hook": "82417A74",
+        "secondary_resource_binding_hook": "82417A9C",
+        "resource_lookup_function": "82410A58",
+        "resource_provider_lookup_hook": "82415B64",
+        "resource_provider_primary_predicate_hook": "82415B80",
+        "resource_provider_fallback_predicate_hook": "82415BA4",
+        "resource_provider_method_result_hook": "82415BC0",
+        "resource_secondary_resolution_result_hook": "82415BE4",
+        "resource_resolution_result_hook": "82415C50",
+        "resource_bind_dispatch_hook": "82415C6C",
+        "geometry_submission_hook": "82417B60",
+    }
+    if any(configs[0].get(key) != value for key, value in expected_runtime_hooks.items()):
+        raise ValueError("semantic-submission runtime hook contract drifted")
 
     entries = []
     entry_calls = 0
@@ -164,6 +211,9 @@ def build(events: list[dict], static: dict, requested: str | None = None) -> dic
     helper_state_families: collections.Counter[str] = collections.Counter()
     source_contracts: collections.Counter[str] = collections.Counter()
     resource_pairs: set[tuple[str, str, str, str]] = set()
+    provider_chains: set[tuple[str, ...]] = set()
+    provider_selections: collections.Counter[str] = collections.Counter()
+    object_sources: collections.Counter[str] = collections.Counter()
     for event in selected:
         if event.get("event") != f"{PREFIX}entry":
             continue
@@ -181,9 +231,43 @@ def build(events: list[dict], static: dict, requested: str | None = None) -> dic
         primary_bound_resource_object = _hex(
             event, "primary_bound_resource_object", 8
         )
+        primary_provider_fields = tuple(
+            _hex(event, key, 8)
+            for key in (
+                "primary_resource_provider_object",
+                "primary_resource_provider_vtable",
+                "primary_resource_predicate_24_method",
+                "primary_resource_primary_36_method",
+                "primary_resource_fallback_40_method",
+                "primary_resource_predicate_44_method",
+            )
+        )
+        primary_provider_selection = str(
+            event.get("primary_resource_provider_selection", "")
+        )
+        primary_object_source = str(
+            event.get("primary_resource_object_source", "")
+        )
         secondary_resource_key = _hex(event, "secondary_resource_key", 8)
         secondary_bound_resource_object = _hex(
             event, "secondary_bound_resource_object", 8
+        )
+        secondary_provider_fields = tuple(
+            _hex(event, key, 8)
+            for key in (
+                "secondary_resource_provider_object",
+                "secondary_resource_provider_vtable",
+                "secondary_resource_predicate_24_method",
+                "secondary_resource_primary_36_method",
+                "secondary_resource_fallback_40_method",
+                "secondary_resource_predicate_44_method",
+            )
+        )
+        secondary_provider_selection = str(
+            event.get("secondary_resource_provider_selection", "")
+        )
+        secondary_object_source = str(
+            event.get("secondary_resource_object_source", "")
         )
         runtime_submission_object = _hex(event, "runtime_submission_object", 8)
         source_address = _hex(event, "source_address", 8)
@@ -236,6 +320,10 @@ def build(events: list[dict], static: dict, requested: str | None = None) -> dic
             or int(graphics_context, 16) == 0
             or int(resource_lookup_context, 16) == 0
             or int(primary_bound_resource_object, 16) == 0
+            or any(int(value, 16) == 0 for value in primary_provider_fields)
+            or primary_provider_selection
+            not in ("primary_method_36", "fallback_method_40", "provider_unavailable")
+            or primary_object_source not in ("provider_method", "secondary_resolution")
             or int(runtime_submission_object, 16) == 0
             or int(source_address, 16) == 0
             or descriptor_kind_group != expected_kind_group
@@ -246,6 +334,28 @@ def build(events: list[dict], static: dict, requested: str | None = None) -> dic
             raise ValueError("semantic-submission secondary resource presence is inconsistent")
         if secondary_present != (int(secondary_bound_resource_object, 16) != 0):
             raise ValueError("semantic-submission resolved secondary resource is inconsistent")
+        if secondary_present:
+            if (
+                any(int(value, 16) == 0 for value in secondary_provider_fields)
+                or secondary_provider_selection
+                not in ("primary_method_36", "fallback_method_40", "provider_unavailable")
+                or secondary_object_source
+                not in ("provider_method", "secondary_resolution")
+            ):
+                raise ValueError("semantic-submission secondary provider chain is incomplete")
+        elif (
+            any(int(value, 16) != 0 for value in secondary_provider_fields)
+            or secondary_provider_selection != "unknown"
+            or secondary_object_source != "unknown"
+        ):
+            raise ValueError("semantic-submission absent secondary provider is inconsistent")
+        for selection, source in (
+            (primary_provider_selection, primary_object_source),
+            *(([(secondary_provider_selection, secondary_object_source)])
+              if secondary_present else []),
+        ):
+            if selection == "provider_unavailable" and source != "secondary_resolution":
+                raise ValueError("unavailable provider cannot be the object source")
         if source_contract == "runtime_record_24_default":
             if count_units != 0:
                 raise ValueError("default geometry source has a nonzero count")
@@ -260,12 +370,31 @@ def build(events: list[dict], static: dict, requested: str | None = None) -> dic
         descriptor_kind_groups[descriptor_kind_group] += calls
         helper_state_families[helper_state_family] += calls
         source_contracts[source_contract] += calls
+        provider_selections[primary_provider_selection] += calls
+        object_sources[primary_object_source] += calls
+        if secondary_present:
+            provider_selections[secondary_provider_selection] += calls
+            object_sources[secondary_object_source] += calls
         resource_pairs.add(
             (
                 primary_resource_key,
                 primary_bound_resource_object,
                 secondary_resource_key,
                 secondary_bound_resource_object,
+            )
+        )
+        provider_chains.add(
+            (
+                primary_resource_key,
+                primary_bound_resource_object,
+                *primary_provider_fields,
+                primary_provider_selection,
+                primary_object_source,
+                secondary_resource_key,
+                secondary_bound_resource_object,
+                *secondary_provider_fields,
+                secondary_provider_selection,
+                secondary_object_source,
             )
         )
         entries.append(
@@ -284,10 +413,30 @@ def build(events: list[dict], static: dict, requested: str | None = None) -> dic
                     "primary_index": primary_index,
                     "primary_key": primary_resource_key,
                     "primary_bound_object": primary_bound_resource_object,
+                    "primary_provider": {
+                        "object": primary_provider_fields[0],
+                        "vtable": primary_provider_fields[1],
+                        "predicate_24_method": primary_provider_fields[2],
+                        "primary_36_method": primary_provider_fields[3],
+                        "fallback_40_method": primary_provider_fields[4],
+                        "predicate_44_method": primary_provider_fields[5],
+                        "selection": primary_provider_selection,
+                        "object_source": primary_object_source,
+                    },
                     "secondary_present": secondary_present,
                     "secondary_index": secondary_index,
                     "secondary_key": secondary_resource_key,
                     "secondary_bound_object": secondary_bound_resource_object,
+                    "secondary_provider": {
+                        "object": secondary_provider_fields[0],
+                        "vtable": secondary_provider_fields[1],
+                        "predicate_24_method": secondary_provider_fields[2],
+                        "primary_36_method": secondary_provider_fields[3],
+                        "fallback_40_method": secondary_provider_fields[4],
+                        "predicate_44_method": secondary_provider_fields[5],
+                        "selection": secondary_provider_selection,
+                        "object_source": secondary_object_source,
+                    },
                 },
                 "state_variant": {
                     "descriptor_kind_group": descriptor_kind_group,
@@ -326,8 +475,22 @@ def build(events: list[dict], static: dict, requested: str | None = None) -> dic
             "resource_resolution_successes",
             "resource_resolution_misses",
             "resource_resolution_cache_hits",
+            "resource_binding_key_cache_hits",
             "resource_bind_dispatches",
             "resource_resolution_protocol_faults",
+            "provider_lookup_observations",
+            "provider_cache_hits",
+            "provider_lookup_misses",
+            "provider_primary_selections",
+            "provider_fallback_selections",
+            "provider_unavailable_selections",
+            "provider_method_results",
+            "provider_method_null_results",
+            "secondary_resolution_attempts",
+            "secondary_resolution_successes",
+            "secondary_resolution_misses",
+            "provider_metadata_bytes",
+            "provider_metadata_bytes_per_lookup",
             "payload_bytes",
             "maximum_payload_bytes_per_live_observation",
             "replay_fallbacks",
@@ -374,6 +537,11 @@ def build(events: list[dict], static: dict, requested: str | None = None) -> dic
         + totals["resource_resolution_cache_hits"]
     ):
         failures.append("resource resolution observation accounting is inconsistent")
+    if (
+        totals["resource_binding_key_cache_hits"]
+        != totals["resource_resolution_cache_hits"]
+    ):
+        failures.append("binding key cache accounting is inconsistent")
     if totals["resource_resolution_attempts"] != (
         totals["resource_resolution_successes"]
         + totals["resource_resolution_misses"]
@@ -381,6 +549,58 @@ def build(events: list[dict], static: dict, requested: str | None = None) -> dic
         failures.append("resource resolution result accounting is inconsistent")
     if totals["resource_bind_dispatches"] != totals["resource_resolution_successes"]:
         failures.append("resource bind dispatch accounting is inconsistent")
+    if (
+        totals["provider_lookup_observations"]
+        + totals["provider_cache_hits"]
+        != totals["resource_resolution_attempts"]
+    ):
+        failures.append("provider lookup accounting is inconsistent")
+    if totals["provider_lookup_observations"] != sum(
+        totals[key]
+        for key in (
+            "provider_lookup_misses",
+            "provider_primary_selections",
+            "provider_fallback_selections",
+            "provider_unavailable_selections",
+        )
+    ):
+        failures.append("provider selection accounting is inconsistent")
+    if totals["provider_method_results"] != (
+        totals["provider_primary_selections"]
+        + totals["provider_fallback_selections"]
+    ):
+        failures.append("provider method result accounting is inconsistent")
+    if totals["provider_method_null_results"] > totals["provider_method_results"]:
+        failures.append("provider null result accounting is inconsistent")
+    if totals["secondary_resolution_attempts"] != (
+        totals["provider_unavailable_selections"]
+        + totals["provider_method_null_results"]
+    ):
+        failures.append("secondary resolution route accounting is inconsistent")
+    if totals["secondary_resolution_attempts"] != (
+        totals["secondary_resolution_successes"]
+        + totals["secondary_resolution_misses"]
+    ):
+        failures.append("secondary resolution result accounting is inconsistent")
+    if totals["resource_resolution_successes"] != (
+        totals["provider_cache_hits"]
+        + totals["provider_method_results"]
+        - totals["provider_method_null_results"]
+        + totals["secondary_resolution_successes"]
+    ):
+        failures.append("resolved object source accounting is inconsistent")
+    if totals["resource_resolution_misses"] != (
+        totals["provider_lookup_misses"]
+        + totals["secondary_resolution_misses"]
+    ):
+        failures.append("resource miss source accounting is inconsistent")
+    if (
+        totals["provider_metadata_bytes_per_lookup"] != 20
+        or totals["provider_metadata_bytes"]
+        != (totals["provider_lookup_observations"] - totals["provider_lookup_misses"])
+        * 20
+    ):
+        failures.append("provider metadata accounting is inconsistent")
     for key in (
         "unknown_receivers",
         "binding_mismatches",
@@ -411,7 +631,10 @@ def build(events: list[dict], static: dict, requested: str | None = None) -> dic
             "descriptor_kind_groups": dict(sorted(descriptor_kind_groups.items())),
             "helper_state_families": dict(sorted(helper_state_families.items())),
             "source_contracts": dict(sorted(source_contracts.items())),
+            "provider_selections": dict(sorted(provider_selections.items())),
+            "object_sources": dict(sorted(object_sources.items())),
             "unique_resource_pairs": len(resource_pairs),
+            "unique_provider_chains": len(provider_chains),
         },
         "safety": {
             "bounded_guest_read": True,

--- a/tools/tests/test_native_renderer_contract.py
+++ b/tools/tests/test_native_renderer_contract.py
@@ -143,6 +143,11 @@ class NativeRendererContractTests(unittest.TestCase):
         expected_hooks = {
             "PinyonShiftObserveProceduralModelPrimaryResourceBinding": "0x82417A74",
             "PinyonShiftObserveProceduralModelSecondaryResourceBinding": "0x82417A9C",
+            "PinyonShiftObserveProceduralModelResourceProviderLookup": "0x82415B64",
+            "PinyonShiftObserveProceduralModelResourceProviderPrimaryPredicate": "0x82415B80",
+            "PinyonShiftObserveProceduralModelResourceProviderFallbackPredicate": "0x82415BA4",
+            "PinyonShiftObserveProceduralModelResourceProviderMethodResult": "0x82415BC0",
+            "PinyonShiftObserveProceduralModelResourceSecondaryResolutionResult": "0x82415BE4",
             "PinyonShiftObserveProceduralModelResourceResolutionResult": "0x82415C50",
             "PinyonShiftObserveProceduralModelResourceBindDispatch": "0x82415C6C",
             "PinyonShiftObserveProceduralModelGeometrySubmission": "0x82417B60",
@@ -159,6 +164,9 @@ class NativeRendererContractTests(unittest.TestCase):
         self.assertIn("runtime_record_28_32", source)
         self.assertIn('"classification", "resolved_resource_and_state_variant_submission"', source)
         self.assertIn("primary_bound_resource_object", source)
+        self.assertIn("SemanticResourceProviderProvenance", source)
+        self.assertIn("provider_metadata_bytes_per_lookup", source)
+        self.assertIn("resource_provider_chain_derivation_proved", summarizer)
         self.assertIn("ProceduralModelHelperStateFamily", source)
         self.assertIn('{"fallback", "xenos_replay"}', source)
         self.assertIn('{"native_upload", "false"}', source)

--- a/tools/tests/test_native_renderer_dispatch_discovery.py
+++ b/tools/tests/test_native_renderer_dispatch_discovery.py
@@ -465,6 +465,111 @@ def procedural_model_lifecycle_fixtures():
             ],
         ),
         fixture(
+            0x82410A58,
+            [
+                "lwz r11,0(r4)",
+                "lwz r10,2812(r3)",
+                "rlwinm r11,r11,2,0,29",
+                "lwzx r3,r11,r10",
+                "blr",
+            ],
+        ),
+        fixture(
+            0x82415AD0,
+            [
+                "mflr r12",
+                "bl 0x82a7de08",
+                "loc_82415AD8:",
+                "stwu r1,-128(r1)",
+                "li r10,5",
+                "li r28,0",
+                "mr r29,r5",
+                "addi r11,r3,8",
+                "mr r9,r28",
+                "mr r31,r28",
+                "mtctr r10",
+                "loc_82415AF8:",
+                "lwz r10,0(r11)",
+                "lwz r8,-4(r11)",
+                "addi r10,r10,1",
+                "cmpw cr6,r8,r4",
+                "stw r10,0(r11)",
+                "bne cr6,0x82415b18",
+                "addi r9,r11,-8",
+                "b 0x82415b30",
+                "loc_82415B18:",
+                "cmplwi cr6,r31,0",
+                "beq cr6,0x82415b2c",
+                "lwz r8,8(r31)",
+                "cmpw cr6,r10,r8",
+                "ble cr6,0x82415b30",
+                "loc_82415B2C:",
+                "addi r31,r11,-8",
+                "loc_82415B30:",
+                "addi r11,r11,12",
+                "bdnz 0x82415af8",
+                "cmplwi cr6,r9,0",
+                "beq cr6,0x82415b4c",
+                "lwz r3,0(r9)",
+                "stw r28,8(r9)",
+                "b 0x82415bf0",
+                "loc_82415B4C:",
+                "stw r4,4(r31)",
+                "mr r3,r29",
+                "stw r4,80(r1)",
+                "addi r4,r1,80",
+                "stw r28,0(r31)",
+                "bl 0x82410a58",
+                "loc_82415B64:",
+                "mr. r30,r3",
+                "beq 0x82415be8",
+                "lwz r11,0(r30)",
+                "mr r3,r30",
+                "lwz r11,24(r11)",
+                "mtctr r11",
+                "bctrl",
+                "loc_82415B80:",
+                "clrlwi. r11,r3,24",
+                "lwz r11,0(r30)",
+                "mr r3,r30",
+                "beq 0x82415b98",
+                "lwz r11,36(r11)",
+                "b 0x82415bb8",
+                "loc_82415B98:",
+                "lwz r11,44(r11)",
+                "mtctr r11",
+                "bctrl",
+                "loc_82415BA4:",
+                "clrlwi. r11,r3,24",
+                "beq 0x82415bc4",
+                "lwz r11,0(r30)",
+                "mr r3,r30",
+                "lwz r11,40(r11)",
+                "loc_82415BB8:",
+                "mtctr r11",
+                "bctrl",
+                "loc_82415BC0:",
+                "stw r3,0(r31)",
+                "loc_82415BC4:",
+                "lwz r11,0(r31)",
+                "cmplwi cr6,r11,0",
+                "bne cr6,0x82415be8",
+                "lwz r11,8(r30)",
+                "addis r3,r29,1",
+                "addi r3,r3,-18544",
+                "rlwinm r4,r11,19,13,31",
+                "bl 0x823e58d8",
+                "loc_82415BE4:",
+                "stw r3,0(r31)",
+                "loc_82415BE8:",
+                "lwz r3,0(r31)",
+                "stw r28,8(r31)",
+                "loc_82415BF0:",
+                "addi r1,r1,128",
+                "b 0x82a7de58",
+            ],
+        ),
+        fixture(
             0x82415BF8,
             [
                 "mflr r12",
@@ -974,10 +1079,25 @@ class NativeRendererDispatchDiscoveryTests(unittest.TestCase):
         self.assertEqual("82417B60", submission["geometry_submission_hook_address"])
         self.assertEqual("82415C50", submission["resource_resolution_result_hook_address"])
         self.assertEqual("82415C6C", submission["resource_bind_dispatch_hook_address"])
+        self.assertEqual("82410A58", submission["resource_lookup_function_address"])
+        self.assertEqual("82415B64", submission["resource_provider_lookup_hook_address"])
+        self.assertEqual("82415B80", submission["resource_provider_primary_predicate_hook_address"])
+        self.assertEqual("82415BA4", submission["resource_provider_fallback_predicate_hook_address"])
+        self.assertEqual("82415BC0", submission["resource_provider_method_result_hook_address"])
+        self.assertEqual("82415BE4", submission["resource_secondary_resolution_result_hook_address"])
+        self.assertEqual([24, 36, 40, 44], submission["resource_provider_vtable_method_offsets"])
+        self.assertEqual(5, submission["resource_resolution_cache_entry_count"])
+        self.assertEqual(12, submission["resource_resolution_cache_entry_stride"])
+        self.assertTrue(submission["resource_resolution_cache_shared_across_binding_slots"])
+        self.assertTrue(submission["resource_provider_chain_derivation_proved"])
+        self.assertFalse(submission["secondary_resolution_semantics_proved"])
         self.assertTrue(submission["resolved_resource_object_derivation_proved"])
         self.assertTrue(submission["descriptor_kind_partition_proved"])
         self.assertTrue(submission["helper_state_partition_proved"])
         self.assertEqual([0, 1], submission["resource_binding_slots"])
+        self.assertEqual("834AD4CC", submission["resource_binding_key_cache_address"])
+        self.assertEqual(5, submission["resource_binding_key_cache_entry_count"])
+        self.assertTrue(submission["resource_binding_key_cache_skips_unchanged_bind"])
         self.assertEqual(13, submission["graphics_submission_primitive"])
         self.assertEqual(4, submission["graphics_submission_count_scale"])
         self.assertTrue(submission["resource_binding_derivation_proved"])
@@ -997,6 +1117,17 @@ class NativeRendererDispatchDiscoveryTests(unittest.TestCase):
                     *procedural_model_lifecycle_fixtures(),
                 ],
                 bytes(image),
+            )
+
+    def test_rejects_drifted_resource_provider_route(self):
+        lifecycle = [
+            chunk.replace("lwz r11,40(r11)", "lwz r11,48(r11)")
+            for chunk in procedural_model_lifecycle_fixtures()
+        ]
+        with self.assertRaisesRegex(ValueError, "provider chain evidence drifted"):
+            self.build(
+                [*reviewed_fixtures(), *context_fixtures(), *lifecycle],
+                procedural_model_image(),
             )
 
     def test_runtime_hooks_are_default_off_bounded_and_passive(self):

--- a/tools/tests/test_native_renderer_semantic_submissions.py
+++ b/tools/tests/test_native_renderer_semantic_submissions.py
@@ -22,15 +22,35 @@ def static_inventory():
             "semantic_submission_extraction": {
                 "primary_resource_binding_hook_address": "82417A74",
                 "secondary_resource_binding_hook_address": "82417A9C",
+                "resource_provider_lookup_hook_address": "82415B64",
+                "resource_provider_primary_predicate_hook_address": "82415B80",
+                "resource_provider_fallback_predicate_hook_address": "82415BA4",
+                "resource_provider_method_result_hook_address": "82415BC0",
+                "resource_secondary_resolution_result_hook_address": "82415BE4",
                 "resource_resolution_result_hook_address": "82415C50",
                 "resource_bind_dispatch_hook_address": "82415C6C",
                 "geometry_submission_hook_address": "82417B60",
                 "resource_binding_helper_function_address": "82415BF8",
                 "resource_binding_slots": [0, 1],
+                "resource_binding_key_cache_address": "834AD4CC",
+                "resource_binding_key_cache_entry_count": 5,
+                "resource_binding_key_cache_entry_stride": 4,
+                "resource_binding_key_cache_indexed_by_binding_slot": True,
+                "resource_binding_key_cache_skips_unchanged_bind": True,
+                "resource_lookup_function_address": "82410A58",
+                "resource_provider_vtable_method_offsets": [24, 36, 40, 44],
+                "resource_resolution_cache_entry_count": 5,
+                "resource_resolution_cache_entry_stride": 12,
+                "resource_resolution_cache_bound_object_offset": 0,
+                "resource_resolution_cache_key_offset": 4,
+                "resource_resolution_cache_usage_offset": 8,
+                "resource_resolution_cache_shared_across_binding_slots": True,
                 "graphics_submission_primitive": 13,
                 "graphics_submission_count_scale": 4,
                 "resource_binding_derivation_proved": True,
                 "resolved_resource_object_derivation_proved": True,
+                "resource_provider_chain_derivation_proved": True,
+                "secondary_resolution_semantics_proved": False,
                 "record_join_proved": True,
                 "geometry_submission_derivation_proved": True,
                 "descriptor_kind_partition_proved": True,
@@ -59,6 +79,17 @@ def events():
             **common,
             "event": "native_renderer.discovery.semantic_submission_config",
             "status": "armed",
+            "primary_resource_binding_hook": "82417A74",
+            "secondary_resource_binding_hook": "82417A9C",
+            "resource_lookup_function": "82410A58",
+            "resource_provider_lookup_hook": "82415B64",
+            "resource_provider_primary_predicate_hook": "82415B80",
+            "resource_provider_fallback_predicate_hook": "82415BA4",
+            "resource_provider_method_result_hook": "82415BC0",
+            "resource_secondary_resolution_result_hook": "82415BE4",
+            "resource_resolution_result_hook": "82415C50",
+            "resource_bind_dispatch_hook": "82415C6C",
+            "geometry_submission_hook": "82417B60",
         },
         {
             **common,
@@ -79,10 +110,26 @@ def events():
             "primary_resource_index": "9",
             "primary_resource_key": "40000000",
             "primary_bound_resource_object": "41000000",
+            "primary_resource_provider_object": "42000000",
+            "primary_resource_provider_vtable": "43000000",
+            "primary_resource_predicate_24_method": "82420018",
+            "primary_resource_primary_36_method": "82420024",
+            "primary_resource_fallback_40_method": "82420028",
+            "primary_resource_predicate_44_method": "8242002C",
+            "primary_resource_provider_selection": "primary_method_36",
+            "primary_resource_object_source": "provider_method",
             "secondary_resource_present": "true",
             "secondary_resource_index": "10",
             "secondary_resource_key": "50000000",
             "secondary_bound_resource_object": "51000000",
+            "secondary_resource_provider_object": "52000000",
+            "secondary_resource_provider_vtable": "53000000",
+            "secondary_resource_predicate_24_method": "82430018",
+            "secondary_resource_primary_36_method": "82430024",
+            "secondary_resource_fallback_40_method": "82430028",
+            "secondary_resource_predicate_44_method": "8243002C",
+            "secondary_resource_provider_selection": "fallback_method_40",
+            "secondary_resource_object_source": "provider_method",
             "runtime_submission_object": "60000000",
             "primitive_type": "13",
             "count_units": "16",
@@ -111,8 +158,22 @@ def events():
             "resource_resolution_successes": "2",
             "resource_resolution_misses": "0",
             "resource_resolution_cache_hits": "22",
+            "resource_binding_key_cache_hits": "22",
             "resource_bind_dispatches": "2",
             "resource_resolution_protocol_faults": "0",
+            "provider_lookup_observations": "2",
+            "provider_cache_hits": "0",
+            "provider_lookup_misses": "0",
+            "provider_primary_selections": "1",
+            "provider_fallback_selections": "1",
+            "provider_unavailable_selections": "0",
+            "provider_method_results": "2",
+            "provider_method_null_results": "0",
+            "secondary_resolution_attempts": "0",
+            "secondary_resolution_successes": "0",
+            "secondary_resolution_misses": "0",
+            "provider_metadata_bytes": "40",
+            "provider_metadata_bytes_per_lookup": "20",
             "payload_bytes": "672",
             "maximum_payload_bytes_per_live_observation": "56",
             "replay_fallbacks": "12",
@@ -140,6 +201,11 @@ class SemanticSubmissionTests(unittest.TestCase):
             report["entries"][0]["resources"]["primary_bound_object"],
             "41000000",
         )
+        self.assertEqual(
+            report["entries"][0]["resources"]["primary_provider"]["selection"],
+            "primary_method_36",
+        )
+        self.assertEqual(report["coverage"]["unique_provider_chains"], 1)
         self.assertFalse(report["safety"]["suppression_allowed"])
 
     def test_binding_mismatch_keeps_report_incomplete(self):
@@ -191,6 +257,44 @@ class SemanticSubmissionTests(unittest.TestCase):
         self.assertIn(
             "resource_resolution_protocol_faults is nonzero", report["failures"]
         )
+
+    def test_provider_chain_is_required(self):
+        sample = copy.deepcopy(events())
+        sample[1]["primary_resource_provider_object"] = "00000000"
+        with self.assertRaisesRegex(ValueError, "structural evidence"):
+            MODULE.build(sample, static_inventory())
+
+    def test_runtime_provider_hook_contract_is_required(self):
+        sample = copy.deepcopy(events())
+        sample[0]["resource_provider_method_result_hook"] = "82415BC4"
+        with self.assertRaisesRegex(ValueError, "runtime hook contract drifted"):
+            MODULE.build(sample, static_inventory())
+
+    def test_provider_accounting_is_enforced(self):
+        sample = copy.deepcopy(events())
+        sample[-1]["provider_primary_selections"] = "0"
+        report = MODULE.build(sample, static_inventory())
+        self.assertEqual(report["status"], "incomplete")
+        self.assertIn("provider selection accounting is inconsistent", report["failures"])
+
+    def test_secondary_resolution_source_is_reconciled(self):
+        sample = copy.deepcopy(events())
+        sample[1]["primary_resource_object_source"] = "secondary_resolution"
+        sample[-1]["provider_method_null_results"] = "1"
+        sample[-1]["secondary_resolution_attempts"] = "1"
+        sample[-1]["secondary_resolution_successes"] = "1"
+        report = MODULE.build(sample, static_inventory())
+        self.assertEqual(report["status"], "complete")
+
+    def test_shared_provider_cache_hit_is_reconciled(self):
+        sample = copy.deepcopy(events())
+        sample[-1]["provider_lookup_observations"] = "1"
+        sample[-1]["provider_cache_hits"] = "1"
+        sample[-1]["provider_fallback_selections"] = "0"
+        sample[-1]["provider_method_results"] = "1"
+        sample[-1]["provider_metadata_bytes"] = "20"
+        report = MODULE.build(sample, static_inventory())
+        self.assertEqual(report["status"], "complete")
 
     def test_suppression_claim_is_rejected(self):
         sample = copy.deepcopy(events())


### PR DESCRIPTION
Summary: proves the exact procedural resource lookup, provider predicate/method routes, opaque secondary-resolution path, both title caches, and final graphics bind provenance while leaving Xenos authoritative. Validation: 314 Python tests; Release build 902C2694E66BA1F929DE308BEC870B94C99AD5D6E6212A04E228931B9A720881; AppData session 20260829T192106Z-p37612 exited normally; 695,696 exact submissions and 34 unique provider chains; zero misses, unresolved joins, protocol faults, native admissions, or suppression; 29.334 median FPS, 18.902 FPS 1% low, 59.983 Hz presentation, zero deadline misses and XMA stalls.