### PR TITLE
feat(native-renderer): prove semantic draw packet lineage

### DIFF
--- a/config/rexglue/analysis/main-xex.toml
+++ b/config/rexglue/analysis/main-xex.toml
@@ -326,6 +326,20 @@ address = 0x82417B60
 name = "PinyonShiftObserveProceduralModelGeometrySubmission"
 registers = ["r20", "r22", "r24", "r25", "r26", "r27", "r28", "r31"]
 
+# Graphics slot 160 resolves to 0x82415CE0 and forwards into 0x82415F68.
+# These are its two exact PM4_DRAW_INDX (opcode 0x22) header stores. The hooks
+# publish only the effective packet address and the already-proved semantic
+# scope; Xenos still writes and executes every packet.
+[[midasm_hook]]
+address = 0x82416260
+name = "PinyonShiftObserveProceduralModelDirectDrawPacket"
+registers = ["r23", "r24", "r25", "r28", "r29", "r30"]
+
+[[midasm_hook]]
+address = 0x824162F4
+name = "PinyonShiftObserveProceduralModelAlternateDrawPacket"
+registers = ["r6", "r23", "r24", "r25", "r28", "r29"]
+
 [[midasm_hook]]
 address = 0x824095B4
 name = "PinyonShiftObserveIndirectPacket824095B4"

--- a/docs/native-renderer/HIGH_LEVEL_RENDER_HOOKS.md
+++ b/docs/native-renderer/HIGH_LEVEL_RENDER_HOOKS.md
@@ -321,8 +321,11 @@ table family, opaque runtime submission object, exact default/counted
 geometry-source tuple, graphics vtable, and byte-160 submission method. The
 first overlap census found no semantic submission at direct draw packet stores
 `82410328`/`829F7CB0`; those stores remained EDRAM-copy traffic. Prepared draw
-lineage therefore remains open at the actual byte-160 target. This is resolved
-structural submission identity, not a
+lineage therefore moved to the actual byte-160 target. Static decoding now
+resolves it through `82415CE0`/`82415F68` to exact `PM4_DRAW_INDX` stores
+`82416260` and `824162F4`. The passive hooks attach the active semantic key to
+those physical packet headers; runtime backend qualification remains pending.
+This is resolved structural submission identity, not a
 proved provider class, secondary-resolution semantic, texture, material,
 vertex, index, mesh, LOD, streaming, or lifetime ABI. See
 `PROCEDURAL_MODEL_SUBMISSION_CONTRACT.md`.

--- a/docs/native-renderer/PROCEDURAL_MODEL_DRAW_LINEAGE.md
+++ b/docs/native-renderer/PROCEDURAL_MODEL_DRAW_LINEAGE.md
@@ -1,10 +1,11 @@
-# Procedural-model draw-dispatch boundary
+# Procedural-model draw lineage
 
 This NR-05B investigation follows each accepted procedural-model semantic
-submission to graphics virtual slot 160 and tests whether that call directly
-uses either title `PM4_DRAW_INDX_2` constructor already covered by exact packet
-provenance. It is a boundary census, not yet submission-to-backend draw
-lineage. Native upload, native draw, and suppression remain disabled.
+submission through graphics virtual slot 160 to the physical `PM4_DRAW_INDX`
+header consumed by the backend. The first checkpoint was a negative overlap
+census against two unrelated `PM4_DRAW_INDX_2` constructors. The current
+bridge hooks slot 160's own exact packet stores. Native upload, native draw,
+and suppression remain disabled.
 
 ## Proven boundary
 
@@ -60,11 +61,18 @@ This proves rare scope overlap, not buffer ownership or prepared-draw lineage.
 Static inspection resolves `82415CE0` to a thin state/update wrapper around
 `82415F68`. The callee emits PM4 words directly into the graphics context's
 command stream through the packet sequence beginning at `824161EC`, and
-updates the stream cursor at `82416358`. This explains why the two previously tracked
-direct constructors saw no semantic origin: slot 160 is itself a distinct
-packet-emission path. The next ownership bridge must bracket this exact emitted
-range and join it to backend execution before any prepared draw is attributed
-to a semantic submission.
+updates the stream cursor at `82416350`. Its two branches construct
+`PM4_DRAW_INDX` opcode `0x22` at exact header stores `82416260` and
+`824162F4`. This explains why the two previously tracked direct constructors
+saw no semantic origin: slot 160 is itself a distinct packet-emission path.
+
+The current bridge observes those two stores before the title instruction
+executes, computes only the effective guest packet address, translates it to
+the physical address through the existing packet-provenance path, and attaches
+the active semantic key and scope generation. Backend consumption still uses
+the exact physical header address and oldest retained address generation. A
+large submission may emit multiple packets, so packet counts may exceed scope
+counts without weakening the join.
 
 ## Runtime accounting
 
@@ -86,21 +94,32 @@ python tools/summarize-native-renderer-semantic-draws.py `
   --output <semantic-draw-boundary.json>
 ```
 
-A `complete` report means the boundary and overlap census are fully accounted.
-`prepared_draw_lineage_proved` is a separate boolean and remains false when
-any semantic dispatch lacks a direct tracked packet origin.
+A `complete` report means the scope, packet-generation, physical-address, and
+backend accounting all reconcile. `physical_pm4_packet_correlation_proved`
+requires every accepted scope to emit at least one exact tracked packet.
+`prepared_draw_lineage_proved` additionally requires at least one prepared
+backend outcome and no matched unprepared outcome. Both remain runtime gates,
+not static assumptions.
 
-## Next correlation boundary
+## Qualification result
 
-The next milestone will instrument the exact `82415CE0`/`82415F68` command
-range and retain its start cursor, end cursor, semantic key, and scope
-generation in a bounded table. Backend correlation must consume that record
-only through exact buffer identity and packet address/range membership. It must
-also retain the exact indirect constructor store address for the four observed
-overlaps rather than treating all six constructors as one aggregate. Existing
-command-buffer lineage proves receiver context for part of the indirect draw
-set, but receiver context alone is not enough to assign an individual record
-or semantic submission key.
+Release/AppData session `20260829T202741Z-p30324` cleared the physical-packet
+and prepared-draw gates in one consolidated run. All 888,664 accepted semantic
+scopes emitted an exact `82416260` or `824162F4` packet. The backend consumed
+888,312 of those packet generations as prepared draws across 819 unique
+signatures; zero matched packets were unprepared. The remaining 352 packet
+generations were pending only at clean shutdown, and matched plus pending
+exactly reconciles the 888,664 recorded origins.
+
+Every match retained the same semantic receiver generation, record index, and
+key. Address failures, provenance-table overflow, scope mismatches, stack
+faults, backend-outcome mismatches, native admission, and suppression were
+zero. The report therefore proves both
+`physical_pm4_packet_correlation_proved` and
+`prepared_draw_lineage_proved`. This establishes an exact passive bridge from
+the procedural semantic submission to its physical PM4 header and prepared
+Xenos draw; it does not yet establish the resource ABI needed for native
+rendering.
 
 ## Safety boundary
 
@@ -110,10 +129,10 @@ state, or backend submission. Xenos remains authoritative. Mesh/material ABI,
 texture ownership, vertex/index formats, LOD meaning, streaming lifetime,
 prepared signatures, and native batching eligibility remain unproved.
 
-The expanded saved visual checkpoint is
-`.local/qualification/native-renderer-semantic-draw-expanded-runtime.jpg`; the
-live festival save rendered normally. Its 204.217-second capture measured
-29.652 median FPS, 18.768 FPS one-percent low, 59.985 Hz presentation cadence,
-zero present-deadline misses, and zero XMA stalls. All semantic-submission,
-semantic-instance, command-lineage, semantic-boundary, and performance reports
+The saved visual checkpoint is
+`.local/qualification/native-renderer-semantic-pm4-runtime.png`; the live
+festival save rendered normally. Its 193.692-second capture measured 29.701
+median FPS, 15.272 FPS one-percent low, 59.538 Hz presentation cadence, one
+present-deadline miss, and zero XMA stalls. All semantic-submission,
+semantic-instance, command-lineage, semantic-draw, and performance reports
 completed from this single saved session; no confirmation rerun was required.

--- a/docs/native-renderer/PROCEDURAL_MODEL_SUBMISSION_CONTRACT.md
+++ b/docs/native-renderer/PROCEDURAL_MODEL_SUBMISSION_CONTRACT.md
@@ -85,12 +85,15 @@ but exact texture/material class,
 vertex format, index format, mesh ownership, and streaming lifetime are still
 open.
 
-The next passive layer probes whether an accepted tuple overlaps either direct
-title draw-packet constructor already covered by physical packet provenance.
-The first consolidated run proved that it does not. See
-`docs/native-renderer/PROCEDURAL_MODEL_DRAW_LINEAGE.md`. Runtime slot-160 target
-identity now narrows the next command-buffer ownership search without claiming
-a packet, prepared signature, mesh, or material ABI.
+The first passive draw layer proved that an accepted tuple does not overlap the
+two previously tracked `PM4_DRAW_INDX_2` constructors. Runtime target identity
+then resolved slot 160 through `82415CE0` to emitter `82415F68`. Static decoding
+proves that emitter's two `PM4_DRAW_INDX` header stores at `82416260` and
+`824162F4`; the next bridge attaches the active semantic key to those exact
+physical packet headers. See
+`docs/native-renderer/PROCEDURAL_MODEL_DRAW_LINEAGE.md`. Backend prepared-draw
+qualification, mesh/material ABI, and native eligibility remain separate
+runtime gates.
 
 ## Bounded runtime join
 

--- a/src/native_renderer/graphics_hooks.cpp
+++ b/src/native_renderer/graphics_hooks.cpp
@@ -113,6 +113,7 @@ enum class DispatchWrapper : uint32_t {
   kVizQueryOwner = 8,
   kBinningScissorState = 9,
   kBinningStateReset = 10,
+  kProceduralModelDrawIndexed = 11,
 };
 
 struct DispatchCallerEntry {
@@ -676,6 +677,8 @@ const char *DispatchWrapperName(DispatchWrapper wrapper) {
     return "binning_scissor_state";
   case DispatchWrapper::kBinningStateReset:
     return "binning_state_reset";
+  case DispatchWrapper::kProceduralModelDrawIndexed:
+    return "procedural_model_draw_indexed";
   }
   return "unknown";
 }
@@ -702,6 +705,8 @@ const char *DispatchWrapperAddress(DispatchWrapper wrapper) {
     return "82413AB8";
   case DispatchWrapper::kBinningStateReset:
     return "824736F0";
+  case DispatchWrapper::kProceduralModelDrawIndexed:
+    return "82415F68";
   }
   return "00000000";
 }
@@ -1035,6 +1040,7 @@ void ConfigureTitleDrawProvenance(bool census_requested,
       {{"status", armed ? "armed" : "disabled"},
        {"scene", CensusSceneMarker()},
        {"title_packet_hooks", "82410328,829F7CB0"},
+       {"semantic_packet_hooks", "82416260,824162F4"},
        {"title_indirect_packet_hooks",
         "824095B4,82416EFC,8246FC1C,8263BD64,829E8E88,829EC49C"},
        {"packet_key", "physical_pm4_header_address"},
@@ -1111,12 +1117,9 @@ void CapturePacketWrapperOrigin(DispatchWrapper wrapper, uint32_t caller,
   ++g_title_origins_pushed;
 }
 
-void RecordTitleDrawPacket(uint32_t packet_guest_address) {
+void RecordTitleDrawPacketOrigin(uint32_t packet_guest_address,
+                                 const TitleDrawOrigin &origin) {
   if (!g_title_provenance_installed.load(std::memory_order_acquire)) {
-    return;
-  }
-  if (!g_title_origin_stack_depth) {
-    ++g_title_packets_without_origin;
     return;
   }
   rex::memory::Memory *memory =
@@ -1124,9 +1127,6 @@ void RecordTitleDrawPacket(uint32_t packet_guest_address) {
   if (!memory) {
     return;
   }
-  const TitleDrawOrigin origin =
-      g_title_origin_stack[--g_title_origin_stack_depth];
-  ++g_title_origins_consumed;
   const uint32_t packet_physical_address =
       memory->GetPhysicalAddress(packet_guest_address);
   std::scoped_lock lock(g_title_packet_provenance_mutex);
@@ -1173,6 +1173,49 @@ void RecordTitleDrawPacket(uint32_t packet_guest_address) {
                                                 std::memory_order_relaxed);
   }
   ++g_title_packets_recorded;
+}
+
+void RecordTitleDrawPacket(uint32_t packet_guest_address) {
+  if (!g_title_provenance_installed.load(std::memory_order_acquire)) {
+    return;
+  }
+  if (!g_title_provenance_memory.load(std::memory_order_acquire)) {
+    return;
+  }
+  if (!g_title_origin_stack_depth) {
+    ++g_title_packets_without_origin;
+    return;
+  }
+  const TitleDrawOrigin origin =
+      g_title_origin_stack[--g_title_origin_stack_depth];
+  ++g_title_origins_consumed;
+  RecordTitleDrawPacketOrigin(packet_guest_address, origin);
+}
+
+void RecordProceduralModelSemanticDrawPacket(
+    uint32_t packet_guest_address, uint32_t constructor_store_address,
+    std::array<uint32_t, 8> arguments) {
+  if (!g_title_provenance_installed.load(std::memory_order_acquire) ||
+      !g_semantic_render_item_stack_depth) {
+    return;
+  }
+  SemanticDrawIdentity &semantic_draw =
+      g_semantic_render_item_stack[g_semantic_render_item_stack_depth - 1];
+  if (!semantic_draw.valid) {
+    g_semantic_draw_scope_mismatches.fetch_add(1,
+                                                std::memory_order_relaxed);
+    return;
+  }
+  TitleDrawOrigin origin{};
+  origin.wrapper = DispatchWrapper::kProceduralModelDrawIndexed;
+  origin.caller = constructor_store_address;
+  origin.arguments = arguments;
+  origin.semantic_draw = semantic_draw;
+  origin.valid = true;
+  ++semantic_draw.direct_title_origins;
+  g_semantic_draw_origins_captured.fetch_add(1,
+                                              std::memory_order_relaxed);
+  RecordTitleDrawPacketOrigin(packet_guest_address, origin);
 }
 
 uint32_t ExpectedIndirectOwnerFunction(uint32_t constructor_function_address,
@@ -6861,7 +6904,7 @@ void EmitTitleDrawProvenanceSummary() {
   const bool semantic_draw_accounting_complete =
       semantic_draw_overlap_probe_accounting_complete &&
       !semantic_dispatches_without_direct_title_origin &&
-      semantic_origins == semantic_scope_joins &&
+      semantic_origins >= semantic_scope_joins &&
       semantic_packets == semantic_origins &&
       semantic_packets == semantic_packet_matches + semantic_pending_packets &&
       semantic_packet_matches ==
@@ -9253,13 +9296,17 @@ void InstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system,
        {"render_item_exit_hook", "82417B80"},
        {"geometry_submission_hook", "82417B60"},
        {"title_packet_hooks", "82410328,829F7CB0"},
+       {"semantic_packet_hooks", "82416260,824162F4"},
+       {"graphics_submission_wrapper", "82415CE0"},
+       {"graphics_submission_emitter", "82415F68"},
+       {"semantic_packet_opcode", "PM4_DRAW_INDX_0x22"},
        {"title_indirect_packet_hooks",
         "824095B4,82416EFC,8246FC1C,8263BD64,829E8E88,829EC49C"},
        {"render_item_stack_capacity",
         std::to_string(kSemanticRenderItemStackCapacity)},
        {"correlation",
-        "exact_render_item_scope_with_packet_constructor_overlap_probe"},
-       {"classification", "procedural_submission_dispatch_boundary"},
+        "exact_render_item_scope_to_emitted_and_backend_pm4_header"},
+       {"classification", "procedural_submission_pm4_packet_boundary"},
        {"guest_payload_read", "bounded_submission_identity_only"},
        {"guest_state_changed", "false"},
        {"native_upload", "false"},
@@ -10188,6 +10235,22 @@ void PinyonShiftObserveProceduralModelGeometrySubmission(
   RecordProceduralModelGeometrySubmission(
       r20.u32, r22.u32, r24.u32, r25.u32, r26.u32, r27.u32, r28.u32,
       r31.u32);
+}
+
+void PinyonShiftObserveProceduralModelDirectDrawPacket(
+    PPCRegister &r23, PPCRegister &r24, PPCRegister &r25, PPCRegister &r28,
+    PPCRegister &r29, PPCRegister &r30) {
+  RecordProceduralModelSemanticDrawPacket(
+      r30.u32 + sizeof(uint32_t), 0x82416260,
+      {r23.u32, r24.u32, r25.u32, r28.u32, r29.u32, r30.u32, 0, 0});
+}
+
+void PinyonShiftObserveProceduralModelAlternateDrawPacket(
+    PPCRegister &r6, PPCRegister &r23, PPCRegister &r24, PPCRegister &r25,
+    PPCRegister &r28, PPCRegister &r29) {
+  RecordProceduralModelSemanticDrawPacket(
+      r6.u32 + sizeof(uint32_t), 0x824162F4,
+      {r23.u32, r24.u32, r25.u32, r28.u32, r29.u32, r6.u32, 0, 0});
 }
 
 void PinyonShiftObserveIndirectPacket824095B4(PPCRegister &r11,

--- a/tools/discover-native-renderer-dispatch.py
+++ b/tools/discover-native-renderer-dispatch.py
@@ -206,6 +206,9 @@ PROCEDURAL_MODEL_RECEIVER = {
     "primary_resource_binding_hook": 0x82417A74,
     "secondary_resource_binding_hook": 0x82417A9C,
     "geometry_submission_hook": 0x82417B60,
+    "graphics_submission_wrapper": 0x82415CE0,
+    "graphics_submission_emitter": 0x82415F68,
+    "semantic_draw_packet_hooks": [0x82416260, 0x824162F4],
     "resource_binding_function": 0x82415BF8,
     "resource_resolution_function": 0x82415AD0,
     "resource_lookup_function": 0x82410A58,
@@ -826,6 +829,8 @@ def procedural_model_receiver_lifecycle(
         spec["resource_binding_function"],
         spec["resource_resolution_function"],
         spec["resource_lookup_function"],
+        spec["graphics_submission_wrapper"],
+        spec["graphics_submission_emitter"],
     }
     lifecycle_functions = required - {spec["dispatch_function"]}
     if not lifecycle_functions & set(functions_by_address):
@@ -890,6 +895,18 @@ def procedural_model_receiver_lifecycle(
     resource_lookup = {
         item["address"]: item["text"]
         for item in functions_by_address[spec["resource_lookup_function"]][
+            "instructions"
+        ]
+    }
+    graphics_submission_wrapper = {
+        item["address"]: item["text"]
+        for item in functions_by_address[spec["graphics_submission_wrapper"]][
+            "instructions"
+        ]
+    }
+    graphics_submission_emitter = {
+        item["address"]: item["text"]
+        for item in functions_by_address[spec["graphics_submission_emitter"]][
             "instructions"
         ]
     }
@@ -1039,6 +1056,37 @@ def procedural_model_receiver_lifecycle(
         for address, text in render_state_helper_expected.items()
     ):
         raise ValueError("procedural-model render-item call evidence drifted")
+
+    graphics_submission_wrapper_expected = {
+        spec["graphics_submission_wrapper"]: "mflr r12",
+        0x82415CFC: "mr r31,r3",
+        0x82415D00: "lwz r3,20(r3)",
+        0x82415D18: "bl 0x82415f68",
+        0x82415D1C: "addi r11,r31,172",
+    }
+    graphics_submission_emitter_expected = {
+        spec["graphics_submission_emitter"]: "mflr r12",
+        0x82415F80: "mr r31,r3",
+        0x824161D4: "lwz r3,48(r31)",
+        0x82416250: "lis r11,-16383",
+        0x82416258: "ori r11,r11,8705",
+        spec["semantic_draw_packet_hooks"][0]: "stwu r11,4(r30)",
+        0x824162C8: "lis r9,-16383",
+        0x824162D0: "ori r9,r9,8705",
+        spec["semantic_draw_packet_hooks"][1]: "stwu r9,4(r6)",
+        0x82416350: "stw r11,48(r31)",
+        0x82416370: "b 0x824161d4",
+    }
+    if any(
+        graphics_submission_wrapper.get(address) != text
+        for address, text in graphics_submission_wrapper_expected.items()
+    ):
+        raise ValueError("procedural-model graphics submission wrapper drifted")
+    if any(
+        graphics_submission_emitter.get(address) != text
+        for address, text in graphics_submission_emitter_expected.items()
+    ):
+        raise ValueError("procedural-model graphics packet emitter drifted")
 
     resource_binding_expected = {
         spec["resource_binding_function"]: "mflr r12",
@@ -1385,6 +1433,10 @@ def procedural_model_receiver_lifecycle(
                 spec["geometry_submission_hook"]
             ),
             "title_draw_packet_hook_addresses": ["82410328", "829F7CB0"],
+            "semantic_draw_packet_hook_addresses": [
+                "{:08X}".format(address)
+                for address in spec["semantic_draw_packet_hooks"]
+            ],
             "title_indirect_packet_hook_addresses": [
                 "824095B4",
                 "82416EFC",
@@ -1395,13 +1447,23 @@ def procedural_model_receiver_lifecycle(
             ],
             "graphics_submission_vtable_offset": 160,
             "graphics_submission_target_runtime_join_required": True,
+            "graphics_submission_wrapper_address": "{:08X}".format(
+                spec["graphics_submission_wrapper"]
+            ),
+            "graphics_submission_emitter_address": "{:08X}".format(
+                spec["graphics_submission_emitter"]
+            ),
+            "semantic_draw_packet_opcode": "PM4_DRAW_INDX",
+            "semantic_draw_packet_opcode_value": 0x22,
             "render_item_invocation_scope_proved": True,
             "submission_before_draw_dispatch_proved": True,
             "direct_title_packet_overlap_probe": True,
             "indirect_packet_constructor_overlap_probe": True,
+            "semantic_pm4_packet_construction_proved": True,
+            "semantic_pm4_backend_join_required": True,
             "physical_pm4_packet_correlation_proved": False,
             "prepared_draw_lineage_proved": False,
-            "classification": "procedural_submission_dispatch_boundary",
+            "classification": "procedural_submission_pm4_packet_boundary",
             "native_rendering_enabled": False,
             "suppression_eligible": False,
         },

--- a/tools/summarize-native-renderer-semantic-draws.py
+++ b/tools/summarize-native-renderer-semantic-draws.py
@@ -9,13 +9,13 @@ import pathlib
 import sys
 
 
-SCHEMA = "pinyon-shift.native-renderer-semantic-draw-boundary.v2"
+SCHEMA = "pinyon-shift.native-renderer-semantic-draw-lineage.v3"
 STATIC_SCHEMA = "pinyon-shift.native-renderer-dispatch-static.v3"
 SEMANTIC_DRAW_PREFIX = "native_renderer.discovery.semantic_draw_"
 SEMANTIC_SUBMISSION_PREFIX = "native_renderer.discovery.semantic_submission_"
 TITLE_PREFIX = "native_renderer.discovery.title_provenance_"
 EXPECTED_CLASS = "proceduralGeometry::CProceduralModels"
-EXPECTED_CORRELATION = "exact_render_item_scope_with_packet_constructor_overlap_probe"
+EXPECTED_CORRELATION = "exact_render_item_scope_to_emitted_and_backend_pm4_header"
 EXPECTED_DIRECT_ASSOCIATION = "exact_render_item_scope_and_physical_pm4_header"
 
 
@@ -81,6 +81,7 @@ def _validate_static(static: dict) -> dict:
         "render_item_exit_hook_address": "82417B80",
         "geometry_submission_hook_address": "82417B60",
         "title_draw_packet_hook_addresses": ["82410328", "829F7CB0"],
+        "semantic_draw_packet_hook_addresses": ["82416260", "824162F4"],
         "title_indirect_packet_hook_addresses": [
             "824095B4",
             "82416EFC",
@@ -91,11 +92,17 @@ def _validate_static(static: dict) -> dict:
         ],
         "graphics_submission_vtable_offset": 160,
         "graphics_submission_target_runtime_join_required": True,
+        "graphics_submission_wrapper_address": "82415CE0",
+        "graphics_submission_emitter_address": "82415F68",
+        "semantic_draw_packet_opcode": "PM4_DRAW_INDX",
+        "semantic_draw_packet_opcode_value": 0x22,
         "direct_title_packet_overlap_probe": True,
         "indirect_packet_constructor_overlap_probe": True,
+        "semantic_pm4_packet_construction_proved": True,
+        "semantic_pm4_backend_join_required": True,
         "physical_pm4_packet_correlation_proved": False,
         "prepared_draw_lineage_proved": False,
-        "classification": "procedural_submission_dispatch_boundary",
+        "classification": "procedural_submission_pm4_packet_boundary",
         "native_rendering_enabled": False,
         "suppression_eligible": False,
     }
@@ -149,6 +156,10 @@ def build(events: list[dict], static: dict, requested: str | None = None) -> dic
         or config.get("render_item_exit_hook") != "82417B80"
         or config.get("geometry_submission_hook") != "82417B60"
         or config.get("title_packet_hooks") != "82410328,829F7CB0"
+        or config.get("semantic_packet_hooks") != "82416260,824162F4"
+        or config.get("graphics_submission_wrapper") != "82415CE0"
+        or config.get("graphics_submission_emitter") != "82415F68"
+        or config.get("semantic_packet_opcode") != "PM4_DRAW_INDX_0x22"
         or config.get("title_indirect_packet_hooks")
         not in (
             None,
@@ -156,7 +167,7 @@ def build(events: list[dict], static: dict, requested: str | None = None) -> dic
         )
         or config.get("correlation") != EXPECTED_CORRELATION
         or config.get("classification")
-        != "procedural_submission_dispatch_boundary"
+        != "procedural_submission_pm4_packet_boundary"
     ):
         raise ValueError("semantic-draw runtime contract drifted")
     safety = {
@@ -213,6 +224,9 @@ def build(events: list[dict], static: dict, requested: str | None = None) -> dic
         record_index = _integer(event, "semantic_record_index")
         descriptor_address = _hex(event, "semantic_descriptor_address", 8)
         runtime_address = _hex(event, "semantic_runtime_address", 8)
+        origin_wrapper = str(event.get("origin_wrapper", ""))
+        origin_wrapper_address = _hex(event, "origin_wrapper_address", 8)
+        origin_caller = _hex(event, "origin_caller", 8)
         if (
             calls <= 0
             or event.get("semantic_draw_association") != EXPECTED_DIRECT_ASSOCIATION
@@ -222,6 +236,9 @@ def build(events: list[dict], static: dict, requested: str | None = None) -> dic
             or receiver_address != submission["receiver_address"]
             or receiver_generation != submission["receiver_generation"]
             or record_index != submission["record_index"]
+            or origin_wrapper != "procedural_model_draw_indexed"
+            or origin_wrapper_address != "82415F68"
+            or origin_caller not in {"82416260", "824162F4"}
         ):
             raise ValueError("semantic draw identity or safety evidence is inconsistent")
         if outcome == "prepared":
@@ -246,9 +263,9 @@ def build(events: list[dict], static: dict, requested: str | None = None) -> dic
                 "record_index": record_index,
                 "descriptor_address": descriptor_address,
                 "runtime_address": runtime_address,
-                "origin_wrapper": str(event.get("origin_wrapper", "unknown")),
-                "origin_wrapper_address": _hex(event, "origin_wrapper_address", 8),
-                "origin_caller": _hex(event, "origin_caller", 8),
+                "origin_wrapper": origin_wrapper,
+                "origin_wrapper_address": origin_wrapper_address,
+                "origin_caller": origin_caller,
                 "outcome": outcome,
                 "backend_outcome": str(event.get("backend_outcome", "")),
                 "backend_signature": backend_signature,
@@ -348,6 +365,16 @@ def build(events: list[dict], static: dict, requested: str | None = None) -> dic
     submission_lineage.sort(
         key=lambda item: (-item["calls"], item["semantic_submission_key"])
     )
+    physical_pm4_packet_correlation_proved = (
+        counters["semantic_draw_dispatches_without_direct_title_origin"] == 0
+        and counters["semantic_draw_packets_recorded"] > 0
+        and counters["semantic_draw_packets_recorded"] == associated_calls + pending
+    )
+    prepared_draw_lineage_proved = (
+        physical_pm4_packet_correlation_proved
+        and prepared_calls > 0
+        and unprepared_calls == 0
+    )
     return {
         "schema": SCHEMA,
         "session": session,
@@ -377,10 +404,11 @@ def build(events: list[dict], static: dict, requested: str | None = None) -> dic
             **faults,
         },
         "correlation": contract,
-        "qualification": "exact_semantic_submission_dispatch_boundary_and_direct_packet_overlap_census",
-        "prepared_draw_lineage_proved": (
-            counters["semantic_draw_dispatches_without_direct_title_origin"] == 0
+        "qualification": "exact_semantic_submission_to_pm4_and_backend_draw_lineage",
+        "physical_pm4_packet_correlation_proved": (
+            physical_pm4_packet_correlation_proved
         ),
+        "prepared_draw_lineage_proved": prepared_draw_lineage_proved,
         "safety": {
             "bounded_guest_read": True,
             "guest_state_changed": False,

--- a/tools/tests/test_native_renderer_contract.py
+++ b/tools/tests/test_native_renderer_contract.py
@@ -163,6 +163,8 @@ class NativeRendererContractTests(unittest.TestCase):
             "PinyonShiftObserveProceduralModelResourceResolutionResult": "0x82415C50",
             "PinyonShiftObserveProceduralModelResourceBindDispatch": "0x82415C6C",
             "PinyonShiftObserveProceduralModelGeometrySubmission": "0x82417B60",
+            "PinyonShiftObserveProceduralModelDirectDrawPacket": "0x82416260",
+            "PinyonShiftObserveProceduralModelAlternateDrawPacket": "0x824162F4",
         }
         for name, address in expected_hooks.items():
             self.assertEqual(analysis.count(f'name = "{name}"'), 1)

--- a/tools/tests/test_native_renderer_dispatch_discovery.py
+++ b/tools/tests/test_native_renderer_dispatch_discovery.py
@@ -740,6 +740,48 @@ def procedural_model_lifecycle_fixtures():
                 "b 0x82a7de34",
             ],
         ),
+        fixture(
+            0x82415CE0,
+            [
+                "mflr r12",
+                "loc_82415CFC:",
+                "mr r31,r3",
+                "loc_82415D00:",
+                "lwz r3,20(r3)",
+                "loc_82415D18:",
+                "bl 0x82415f68",
+                "loc_82415D1C:",
+                "addi r11,r31,172",
+                "blr",
+            ],
+        ),
+        fixture(
+            0x82415F68,
+            [
+                "mflr r12",
+                "loc_82415F80:",
+                "mr r31,r3",
+                "loc_824161D4:",
+                "lwz r3,48(r31)",
+                "loc_82416250:",
+                "lis r11,-16383",
+                "loc_82416258:",
+                "ori r11,r11,8705",
+                "loc_82416260:",
+                "stwu r11,4(r30)",
+                "loc_824162C8:",
+                "lis r9,-16383",
+                "loc_824162D0:",
+                "ori r9,r9,8705",
+                "loc_824162F4:",
+                "stwu r9,4(r6)",
+                "loc_82416350:",
+                "stw r11,48(r31)",
+                "loc_82416370:",
+                "b 0x824161d4",
+                "blr",
+            ],
+        ),
     ]
 
 
@@ -1118,6 +1160,20 @@ class NativeRendererDispatchDiscoveryTests(unittest.TestCase):
             ["82410328", "829F7CB0"],
             draw_association["title_draw_packet_hook_addresses"],
         )
+        self.assertEqual(
+            ["82416260", "824162F4"],
+            draw_association["semantic_draw_packet_hook_addresses"],
+        )
+        self.assertEqual(
+            "82415CE0", draw_association["graphics_submission_wrapper_address"]
+        )
+        self.assertEqual(
+            "82415F68", draw_association["graphics_submission_emitter_address"]
+        )
+        self.assertEqual(
+            "PM4_DRAW_INDX", draw_association["semantic_draw_packet_opcode"]
+        )
+        self.assertTrue(draw_association["semantic_pm4_packet_construction_proved"])
         self.assertTrue(draw_association["render_item_invocation_scope_proved"])
         self.assertTrue(draw_association["submission_before_draw_dispatch_proved"])
         self.assertEqual(160, draw_association["graphics_submission_vtable_offset"])

--- a/tools/tests/test_native_renderer_semantic_draws.py
+++ b/tools/tests/test_native_renderer_semantic_draws.py
@@ -23,19 +23,28 @@ def static_inventory():
                 "render_item_exit_hook_address": "82417B80",
                 "geometry_submission_hook_address": "82417B60",
                 "title_draw_packet_hook_addresses": ["82410328", "829F7CB0"],
+                "semantic_draw_packet_hook_addresses": [
+                    "82416260", "824162F4",
+                ],
                 "title_indirect_packet_hook_addresses": [
                     "824095B4", "82416EFC", "8246FC1C",
                     "8263BD64", "829E8E88", "829EC49C",
                 ],
                 "graphics_submission_vtable_offset": 160,
                 "graphics_submission_target_runtime_join_required": True,
+                "graphics_submission_wrapper_address": "82415CE0",
+                "graphics_submission_emitter_address": "82415F68",
+                "semantic_draw_packet_opcode": "PM4_DRAW_INDX",
+                "semantic_draw_packet_opcode_value": 0x22,
                 "render_item_invocation_scope_proved": True,
                 "submission_before_draw_dispatch_proved": True,
                 "direct_title_packet_overlap_probe": True,
                 "indirect_packet_constructor_overlap_probe": True,
+                "semantic_pm4_packet_construction_proved": True,
+                "semantic_pm4_backend_join_required": True,
                 "physical_pm4_packet_correlation_proved": False,
                 "prepared_draw_lineage_proved": False,
-                "classification": "procedural_submission_dispatch_boundary",
+                "classification": "procedural_submission_pm4_packet_boundary",
                 "native_rendering_enabled": False,
                 "suppression_eligible": False,
             }
@@ -62,10 +71,14 @@ def events():
             "render_item_exit_hook": "82417B80",
             "geometry_submission_hook": "82417B60",
             "title_packet_hooks": "82410328,829F7CB0",
+            "semantic_packet_hooks": "82416260,824162F4",
+            "graphics_submission_wrapper": "82415CE0",
+            "graphics_submission_emitter": "82415F68",
+            "semantic_packet_opcode": "PM4_DRAW_INDX_0x22",
             "title_indirect_packet_hooks":
                 "824095B4,82416EFC,8246FC1C,8263BD64,829E8E88,829EC49C",
-            "correlation": "exact_render_item_scope_with_packet_constructor_overlap_probe",
-            "classification": "procedural_submission_dispatch_boundary",
+            "correlation": "exact_render_item_scope_to_emitted_and_backend_pm4_header",
+            "classification": "procedural_submission_pm4_packet_boundary",
             "guest_state_changed": "false",
             "native_upload": "false",
             "native_draw": "false",
@@ -99,9 +112,9 @@ def events():
             "semantic_draw_association":
                 "exact_render_item_scope_and_physical_pm4_header",
             "semantic_identity": "procedural_model_submission",
-            "origin_wrapper": "draw_indexed",
-            "origin_wrapper_address": "8240F4D8",
-            "origin_caller": "82417B80",
+            "origin_wrapper": "procedural_model_draw_indexed",
+            "origin_wrapper_address": "82415F68",
+            "origin_caller": "82416260",
             "outcome": "prepared",
             "backend_outcome": "prepared_callback",
             "backend_signature": "AABBCCDDEEFF0011",
@@ -146,6 +159,8 @@ class SemanticDrawTests(unittest.TestCase):
         self.assertEqual(12, document["totals"]["semantic_submissions"])
         self.assertEqual(12, document["totals"]["prepared_draw_calls"])
         self.assertEqual(1, document["totals"]["unique_prepared_signatures"])
+        self.assertTrue(document["physical_pm4_packet_correlation_proved"])
+        self.assertTrue(document["prepared_draw_lineage_proved"])
         self.assertFalse(document["safety"]["native_draw"])
         self.assertFalse(document["safety"]["suppression_allowed"])
 
@@ -170,6 +185,19 @@ class SemanticDrawTests(unittest.TestCase):
                 "semantic_draw_dispatches_without_direct_title_origin"
             ],
         )
+
+    def test_accepts_multiple_exact_draw_packets_for_one_submission_scope(self):
+        observed = copy.deepcopy(events())
+        observed[3]["calls"] = "15"
+        summary = observed[-1]
+        summary["semantic_draw_origins_captured"] = "15"
+        summary["semantic_draw_packets_recorded"] = "15"
+        summary["semantic_draw_packet_matches"] = "15"
+        summary["semantic_draw_prepared_matches"] = "15"
+        document = MODULE.build(observed, static_inventory())
+        self.assertEqual(12, document["totals"]["semantic_submissions"])
+        self.assertEqual(15, document["totals"]["prepared_draw_calls"])
+        self.assertTrue(document["prepared_draw_lineage_proved"])
 
     def test_rejects_mismatched_submission_identity(self):
         observed = copy.deepcopy(events())


### PR DESCRIPTION
## Summary\n- map graphics slot 160 to its exact PM4_DRAW_INDX emitter and header stores\n- attach semantic submission identity to exact physical packet generations\n- prove prepared backend draw lineage while retaining Xenos authority\n- extend fail-closed reports, static discovery, tests, and qualification docs\n\n## Validation\n- 320 Python tests pass\n- Release build succeeds\n- AppData session \20260829T202741Z-p30324\ exits normally\n- 888,664 semantic scopes produce 888,664 exact packet origins\n- 888,312 prepared matches; 352 clean-shutdown pending; 0 unprepared\n- 0 address failures, table overflow, scope faults, native admission, or suppression\n- 29.701 median FPS, 59.538 Hz presentation, 0 XMA stalls\n\nNo confirmation rerun was performed; all runtime reports come from the same consolidated session.