### PR TITLE
feat(native-renderer): catalog semantic draw instances

### DIFF
--- a/docs/native-renderer/HIGH_LEVEL_RENDER_HOOKS.md
+++ b/docs/native-renderer/HIGH_LEVEL_RENDER_HOOKS.md
@@ -324,7 +324,13 @@ first overlap census found no semantic submission at direct draw packet stores
 lineage therefore moved to the actual byte-160 target. Static decoding now
 resolves it through `82415CE0`/`82415F68` to exact `PM4_DRAW_INDX` stores
 `82416260` and `824162F4`. The passive hooks attach the active semantic key to
-those physical packet headers; runtime backend qualification remains pending.
+those physical packet headers. Session `20260829T202741Z-p30324` proved
+888,312 prepared matches across 819 signatures with zero unprepared outcomes.
+The compact layer now joins those exact outcomes to immutable semantic records,
+separates prepared templates from dynamic geometry/texture resources, and
+emits conservative batch groups. Session `20260829T210122Z-p37672` qualified
+900 composite templates and 1,067 groups across 403,015 prepared associations.
+See `SEMANTIC_INSTANCE_CATALOG.md`.
 This is resolved structural submission identity, not a
 proved provider class, secondary-resolution semantic, texture, material,
 vertex, index, mesh, LOD, streaming, or lifetime ABI. See

--- a/docs/native-renderer/PROCEDURAL_MODEL_DRAW_LINEAGE.md
+++ b/docs/native-renderer/PROCEDURAL_MODEL_DRAW_LINEAGE.md
@@ -121,6 +121,13 @@ the procedural semantic submission to its physical PM4 header and prepared
 Xenos draw; it does not yet establish the resource ABI needed for native
 rendering.
 
+The next NR-05B layer now uses that exact bridge to separate immutable prepared
+templates from dynamic semantic instances and conservative batch groups. See
+`SEMANTIC_INSTANCE_CATALOG.md`. Session `20260829T210122Z-p37672` proved the
+compact catalog across 403,015 prepared associations, 900 composite templates,
+and 1,067 conservative batch groups, with bounded layouts and zero hidden
+template or resource variation. Native batching and admission remain disabled.
+
 ## Safety boundary
 
 All observations are passive and bounded. The implementation does not alter

--- a/docs/native-renderer/PROCEDURAL_MODEL_SUBMISSION_CONTRACT.md
+++ b/docs/native-renderer/PROCEDURAL_MODEL_SUBMISSION_CONTRACT.md
@@ -95,6 +95,12 @@ physical packet headers. See
 qualification, mesh/material ABI, and native eligibility remain separate
 runtime gates.
 
+The prepared backend association now feeds the catalog described in
+`SEMANTIC_INSTANCE_CATALOG.md`. It joins this submission key back to the
+immutable semantic-instance record, keeps decoded geometry/texture resource
+identity separate from the prepared layout, and builds only conservative
+batch keys. This is a classification boundary, not native admission.
+
 ## Bounded runtime join
 
 The resource hooks retain only the pending receiver, descriptor/runtime

--- a/docs/native-renderer/SEMANTIC_INSTANCE_CATALOG.md
+++ b/docs/native-renderer/SEMANTIC_INSTANCE_CATALOG.md
@@ -1,0 +1,127 @@
+# Procedural-model semantic instance catalog
+
+This NR-05B checkpoint converts the proved procedural submission-to-prepared-
+draw lineage into a compact, fail-closed catalog. It separates immutable draw
+templates, dynamic resource instances, and conservative batch groups without
+uploading or drawing anything natively. Xenos remains authoritative for every
+entry.
+
+## Three exact identities
+
+The catalog joins three independently bounded runtime records:
+
+1. The semantic-instance key identifies one live
+   `CProceduralModels` receiver generation and record index. It retains the
+   first descriptor, runtime, and transform hashes plus explicit variation
+   counts.
+2. The semantic-submission key adds the resolved primary and optional
+   secondary resource chains, state family, runtime submission object, count,
+   source address, and exact graphics dispatch target.
+3. The prepared template key is a composite hash of the prepared pipeline,
+   shader/specialization pair, vertex declaration, texture instruction layout,
+   render-state layout, and primitive/index metadata reached through the exact
+   physical `PM4_DRAW_INDX` header generation. The backend candidate signature
+   remains a separate correlation identity because one signature can cover
+   multiple immutable layouts.
+
+The report rejects a submission unless its receiver generation and record
+index join exactly to one immutable semantic-instance record. It rejects a
+prepared association unless its nonzero template key retains one exact
+immutable identity. The prepared signature must still match the backend
+signature independently.
+
+## Template and resource split
+
+Each prepared association records bounded hashes and the scalar fields needed
+to audit the split:
+
+- prepared pipeline, vertex and pixel shader, and specialization masks;
+- guest primitive, source selection, indexed mode, index format, and
+  endianness;
+- vertex-binding and vertex-attribute layout;
+- texture fetch/instruction layout and layout-valid mask;
+- render-state layout without dynamic constant values;
+- index, vertex, and texture resource identities separately from the layout;
+- minimum and maximum observed index count;
+- explicit template and resource variation counters.
+
+The immutable template excludes guest resource addresses and dynamic constant
+values. The dynamic instance retains the semantic record hashes and the exact
+geometry, texture, and title resource identities. A conservative batch key is
+the tuple of template key, geometry-resource hash, texture-resource hash, and
+the primary/secondary title resource keys.
+
+An association is batchable only when geometry and texture layouts are
+bounded and neither its template nor its resource identity varied inside the
+aggregate. A non-batchable association remains in the catalog with its reason
+visible; it never falls through to an inferred identity.
+
+## Fail-closed report
+
+Run the existing lineage report after the semantic-instance and submission
+summaries have been emitted:
+
+```powershell
+python tools/summarize-native-renderer-semantic-draws.py `
+  <diagnostic-jsonl> `
+  --static <native-renderer-dispatch-static.json> `
+  --session <session> `
+  --output <semantic-draw-catalog.json>
+```
+
+Schema `pinyon-shift.native-renderer-semantic-draw-catalog.v4` publishes:
+
+- exact submission-to-draw associations;
+- immutable prepared templates;
+- joined dynamic semantic instances;
+- conservative batch groups and batchable call coverage;
+- physical-packet, prepared-draw, and compact-catalog gates.
+
+`compact_semantic_catalog_proved` requires complete prepared lineage, one
+contract for every prepared semantic draw, bounded geometry and texture
+layouts, and zero template or resource variation hidden by aggregation. A
+failed catalog gate does not weaken the already-proved PM4 lineage; it keeps
+the affected entries on Xenos and provides the next classification target.
+
+## Safety boundary
+
+This checkpoint observes decoded backend metadata that already exists for the
+prepared Xenos draw. It performs no additional guest payload reads, writes no
+guest memory, uploads no native resource, issues no native draw, enables no
+native batch, and suppresses no Xenos work. Native admission remains false
+even for a stable, bounded batch group.
+
+## AppData qualification
+
+Release executable SHA-256
+`F506BD779EEC86E36A91C175002ADE299818E268EE5EAA2476B29914D2E19314`
+ran the installed `0.1.0` preview save in session
+`20260829T210122Z-p37672`. The save loaded into live festival gameplay and the
+process exited normally after 2,906 measured frames (101.369 seconds).
+
+The submission, semantic-instance, command-lineage, semantic-catalog, and
+performance reports all completed from that one session. The catalog proves:
+
+- 403,325 accepted semantic submissions across 842 submission keys and 447
+  immutable instance keys;
+- 403,015 exact prepared associations across 820 backend signatures and 900
+  composite immutable templates;
+- 1,067 conservative batch groups covering all 403,015 prepared calls;
+- all prepared calls had bounded geometry and texture layouts, stable template
+  identity, and stable resource identity, with zero hidden variation;
+- 310 packet generations remained pending only at clean shutdown, while zero
+  matched packets were unprepared;
+- physical PM4 correlation, prepared-draw lineage, and the compact semantic
+  catalog gate are all proved;
+- Xenos remained authoritative, with no native upload, native draw, native
+  batching, guest-state change, or suppression.
+
+Performance held 29.672 median FPS, 15.266 FPS one-percent low, 59.959 Hz
+presentation cadence, zero present-deadline misses, and zero XMA stalls. No
+crash, fatal error, device loss, assertion failure, or unexpected shutdown was
+found in the logs. The catalog report SHA-256 is
+`6828395FDF838BB66146AD43F7E32331310F64858C5DA982B2FDFDBC12726040`.
+The live 3072x1728 screenshot is
+`.local/qualification/native-renderer-semantic-instance-catalog-progress.png`,
+SHA-256
+`F792181CBF2A11251259D1F54A79F0F22CE0161098FAEE6643BC0E5007AF1941`.

--- a/src/native_renderer/graphics_hooks.cpp
+++ b/src/native_renderer/graphics_hooks.cpp
@@ -92,6 +92,8 @@ constexpr size_t kSemanticReceiverStackCapacity = 32;
 constexpr size_t kSemanticInstanceCapacity = 4096;
 constexpr size_t kSemanticSubmissionCapacity = 8192;
 constexpr size_t kSemanticRenderItemStackCapacity = 32;
+constexpr size_t kSemanticPreparedTemplateCapacity =
+    kTitleDrawProvenanceCapacity;
 constexpr size_t kSemanticDescriptorWordCount = 92 / sizeof(uint32_t);
 constexpr size_t kSemanticRuntimeWordCount = 68 / sizeof(uint32_t);
 constexpr size_t kSemanticTransformWordCount = 192 / sizeof(uint32_t);
@@ -162,6 +164,43 @@ struct TitlePacketProvenanceEntry {
   bool occupied = false;
 };
 
+struct SemanticPreparedDrawContract {
+  uint64_t template_key = 0;
+  uint64_t prepared_pipeline_hash = 0;
+  uint64_t geometry_layout_hash = 0;
+  uint64_t texture_layout_hash = 0;
+  uint64_t render_state_hash = 0;
+  uint64_t geometry_resource_hash = 0;
+  uint64_t texture_resource_hash = 0;
+  uint64_t vertex_shader_hash = 0;
+  uint64_t pixel_shader_hash = 0;
+  uint64_t vertex_specialization_mask = 0;
+  uint64_t pixel_specialization_mask = 0;
+  uint64_t template_variations = 0;
+  uint64_t resource_variations = 0;
+  uint32_t primitive_type = 0;
+  uint32_t source_select = 0;
+  uint32_t minimum_index_count = 0;
+  uint32_t maximum_index_count = 0;
+  uint32_t index_buffer_address = 0;
+  uint32_t index_buffer_length = 0;
+  uint32_t index_format = 0;
+  uint32_t index_endianness = 0;
+  uint32_t vertex_binding_count = 0;
+  uint32_t vertex_attribute_count = 0;
+  uint32_t first_vertex_address = 0;
+  uint32_t first_vertex_size = 0;
+  uint32_t first_vertex_stride_words = 0;
+  uint32_t first_vertex_endianness = 0;
+  uint32_t texture_fetch_mask = 0;
+  uint32_t texture_layout_valid_mask = 0;
+  uint32_t texture_state_count = 0;
+  bool indexed = false;
+  bool geometry_bounded = false;
+  bool texture_layout_bounded = false;
+  bool valid = false;
+};
+
 struct TitleDrawProvenanceEntry {
   uint64_t backend_signature = 0;
   uint32_t backend_outcome = 0;
@@ -175,6 +214,7 @@ struct TitleDrawProvenanceEntry {
   std::array<uint32_t, 8> minimum_arguments{};
   std::array<uint32_t, 8> maximum_arguments{};
   uint32_t varying_argument_mask = 0;
+  SemanticPreparedDrawContract semantic_contract{};
   bool prepared = false;
 };
 
@@ -6657,10 +6697,269 @@ void EmitCommandBufferLineageSummary() {
        {"suppression_allowed", "false"}});
 }
 
+uint64_t SemanticGeometryLayoutHash(
+    const rex::system::GraphicsDrawObservation &observation) {
+  uint64_t hash = UINT64_C(0xCBF29CE484222325);
+  for (uint64_t value :
+       {uint64_t(observation.primitive_type),
+        uint64_t(observation.source_select), uint64_t(observation.indexed),
+        uint64_t(observation.index_format),
+        uint64_t(observation.index_endianness),
+        uint64_t(observation.index_reset_enabled),
+        uint64_t(observation.index_reset),
+        uint64_t(observation.vertex_index_offset),
+        uint64_t(observation.vertex_index_min),
+        uint64_t(observation.vertex_index_max),
+        uint64_t(observation.vertex_binding_count),
+        uint64_t(observation.vertex_binding_overflow),
+        uint64_t(observation.vertex_attribute_count),
+        uint64_t(observation.vertex_attribute_overflow)}) {
+    hash = HashCombine(hash, value);
+  }
+  const uint32_t binding_count = std::min(
+      observation.vertex_binding_count,
+      rex::system::kGraphicsVertexBindingObservationLimit);
+  for (uint32_t i = 0; i < binding_count; ++i) {
+    const auto &binding = observation.vertex_bindings[i];
+    for (uint32_t value : {binding.fetch_constant, binding.size,
+                           binding.stride_words, binding.endianness}) {
+      hash = HashCombine(hash, value);
+    }
+  }
+  const uint32_t attribute_count = std::min(
+      observation.vertex_attribute_count,
+      rex::system::kGraphicsVertexAttributeObservationLimit);
+  for (uint32_t i = 0; i < attribute_count; ++i) {
+    const auto &attribute = observation.vertex_attributes[i];
+    for (uint64_t value :
+         {uint64_t(attribute.binding_index),
+          uint64_t(attribute.fetch_constant),
+          uint64_t(uint32_t(attribute.offset_words)),
+          uint64_t(attribute.stride_words), uint64_t(attribute.data_format),
+          uint64_t(attribute.fetch_word_mask),
+          uint64_t(uint32_t(attribute.exp_adjust)),
+          uint64_t(attribute.signed_rf_mode),
+          uint64_t(attribute.result_storage_target),
+          uint64_t(attribute.result_storage_index),
+          uint64_t(attribute.result_write_mask),
+          uint64_t(attribute.result_components), uint64_t(attribute.flags)}) {
+      hash = HashCombine(hash, value);
+    }
+  }
+  return hash ? hash : 1;
+}
+
+uint64_t SemanticTextureLayoutHash(
+    const rex::system::GraphicsDrawObservation &observation) {
+  uint64_t hash = UINT64_C(0xCBF29CE484222325);
+  hash = HashCombine(hash, observation.texture_fetch_mask);
+  hash = HashCombine(hash, observation.texture_fetch_layout_valid_mask);
+  hash = HashCombine(hash, observation.texture_state_count);
+  hash = HashCombine(hash, observation.texture_state_overflow);
+  const uint32_t texture_count = std::min(
+      observation.texture_state_count,
+      rex::system::kGraphicsTextureFetchObservationLimit);
+  for (uint32_t i = 0; i < texture_count; ++i) {
+    const auto &state = observation.texture_states[i];
+    for (uint32_t value :
+         {state.stage, state.fetch_constant, state.opcode, state.dimension,
+          state.filters, state.flags, state.lod_bias, state.offsets,
+          state.result_storage_target, state.result_storage_index,
+          state.result_write_mask, state.result_components}) {
+      hash = HashCombine(hash, value);
+    }
+    for (uint32_t value : state.dwords) {
+      hash = HashCombine(hash, value);
+    }
+  }
+  return hash ? hash : 1;
+}
+
+uint64_t SemanticRenderStateHash(
+    const rex::system::GraphicsDrawObservation &observation) {
+  uint64_t hash = UINT64_C(0xCBF29CE484222325);
+  for (uint64_t value :
+       {observation.vertex_shader_hash, observation.pixel_shader_hash,
+        uint64_t(observation.surface_info),
+        uint64_t(observation.color_info[0]),
+        uint64_t(observation.color_info[1]),
+        uint64_t(observation.color_info[2]),
+        uint64_t(observation.color_info[3]),
+        uint64_t(observation.depth_info),
+        uint64_t(observation.rb_modecontrol),
+        uint64_t(observation.rb_color_mask),
+        uint64_t(observation.rb_blendcontrol[0]),
+        uint64_t(observation.rb_blendcontrol[1]),
+        uint64_t(observation.rb_blendcontrol[2]),
+        uint64_t(observation.rb_blendcontrol[3]),
+        uint64_t(observation.rb_depthcontrol),
+        uint64_t(observation.pa_su_sc_mode_cntl),
+        uint64_t(observation.pa_su_vtx_cntl),
+        uint64_t(observation.vertex_float_constant_count),
+        uint64_t(observation.vertex_float_constant_overflow),
+        uint64_t(observation.pixel_float_constant_count),
+        uint64_t(observation.pixel_float_constant_overflow),
+        uint64_t(observation.loop_constant_bitmap)}) {
+    hash = HashCombine(hash, value);
+  }
+  for (uint32_t value : observation.bool_constant_bitmap) {
+    hash = HashCombine(hash, value);
+  }
+  return hash ? hash : 1;
+}
+
+uint64_t SemanticGeometryResourceHash(
+    const rex::system::GraphicsDrawObservation &observation) {
+  uint64_t hash = UINT64_C(0xCBF29CE484222325);
+  hash = HashCombine(hash, observation.index_buffer_address);
+  hash = HashCombine(hash, observation.index_buffer_length);
+  const uint32_t binding_count = std::min(
+      observation.vertex_binding_count,
+      rex::system::kGraphicsVertexBindingObservationLimit);
+  for (uint32_t i = 0; i < binding_count; ++i) {
+    const auto &binding = observation.vertex_bindings[i];
+    hash = HashCombine(hash, binding.address);
+    hash = HashCombine(hash, binding.size);
+  }
+  return hash ? hash : 1;
+}
+
+uint64_t SemanticTextureResourceHash(
+    const rex::system::GraphicsDrawObservation &observation) {
+  uint64_t hash = UINT64_C(0xCBF29CE484222325);
+  for (uint32_t fetch = 0; fetch < 32; ++fetch) {
+    if (!(observation.texture_fetch_mask & (uint32_t(1) << fetch))) {
+      continue;
+    }
+    hash = HashCombine(hash, fetch);
+    hash = HashCombine(hash, observation.texture_fetch_addresses[fetch]);
+    hash = HashCombine(hash, observation.texture_fetch_base_lengths[fetch]);
+    hash = HashCombine(hash, observation.texture_fetch_mip_addresses[fetch]);
+    hash = HashCombine(hash, observation.texture_fetch_mip_lengths[fetch]);
+  }
+  return hash ? hash : 1;
+}
+
+SemanticPreparedDrawContract BuildSemanticPreparedDrawContract(
+    const rex::system::GraphicsDrawObservation &observation,
+    const rex::system::GraphicsPreparedDrawObservation &prepared) {
+  const uint32_t binding_count = std::min(
+      observation.vertex_binding_count,
+      rex::system::kGraphicsVertexBindingObservationLimit);
+  const bool geometry_bounded =
+      observation.index_count && observation.vertex_binding_count &&
+      !observation.vertex_binding_overflow &&
+      !observation.vertex_attribute_overflow &&
+      (!observation.indexed ||
+       (observation.index_buffer_address && observation.index_buffer_length));
+  const bool texture_layout_bounded =
+      !observation.texture_state_overflow &&
+      (observation.texture_fetch_layout_valid_mask &
+       observation.texture_fetch_mask) == observation.texture_fetch_mask;
+  SemanticPreparedDrawContract contract{
+      .prepared_pipeline_hash = PreparedPipelineHash(prepared),
+      .geometry_layout_hash = SemanticGeometryLayoutHash(observation),
+      .texture_layout_hash = SemanticTextureLayoutHash(observation),
+      .render_state_hash = SemanticRenderStateHash(observation),
+      .geometry_resource_hash = SemanticGeometryResourceHash(observation),
+      .texture_resource_hash = SemanticTextureResourceHash(observation),
+      .vertex_shader_hash = prepared.vertex_shader_hash,
+      .pixel_shader_hash = prepared.pixel_shader_hash,
+      .vertex_specialization_mask = prepared.vertex_specialization_mask,
+      .pixel_specialization_mask = prepared.pixel_specialization_mask,
+      .primitive_type = observation.primitive_type,
+      .source_select = observation.source_select,
+      .minimum_index_count = observation.index_count,
+      .maximum_index_count = observation.index_count,
+      .index_buffer_address = observation.index_buffer_address,
+      .index_buffer_length = observation.index_buffer_length,
+      .index_format = observation.index_format,
+      .index_endianness = observation.index_endianness,
+      .vertex_binding_count = observation.vertex_binding_count,
+      .vertex_attribute_count = observation.vertex_attribute_count,
+      .texture_fetch_mask = observation.texture_fetch_mask,
+      .texture_layout_valid_mask =
+          observation.texture_fetch_layout_valid_mask,
+      .texture_state_count = observation.texture_state_count,
+      .indexed = observation.indexed,
+      .geometry_bounded = geometry_bounded,
+      .texture_layout_bounded = texture_layout_bounded,
+      .valid = true,
+  };
+  if (binding_count) {
+    const auto &binding = observation.vertex_bindings[0];
+    contract.first_vertex_address = binding.address;
+    contract.first_vertex_size = binding.size;
+    contract.first_vertex_stride_words = binding.stride_words;
+    contract.first_vertex_endianness = binding.endianness;
+  }
+  uint64_t template_key = UINT64_C(0xCBF29CE484222325);
+  template_key = HashCombine(template_key, contract.prepared_pipeline_hash);
+  template_key = HashCombine(template_key, contract.geometry_layout_hash);
+  template_key = HashCombine(template_key, contract.texture_layout_hash);
+  template_key = HashCombine(template_key, contract.render_state_hash);
+  template_key = HashCombine(template_key, contract.vertex_shader_hash);
+  template_key = HashCombine(template_key, contract.pixel_shader_hash);
+  template_key =
+      HashCombine(template_key, contract.vertex_specialization_mask);
+  template_key = HashCombine(template_key, contract.pixel_specialization_mask);
+  template_key = HashCombine(template_key, contract.primitive_type);
+  template_key = HashCombine(template_key, contract.source_select);
+  template_key = HashCombine(template_key, contract.indexed ? 1 : 0);
+  template_key = HashCombine(template_key, contract.index_format);
+  template_key = HashCombine(template_key, contract.index_endianness);
+  template_key = HashCombine(template_key, contract.vertex_binding_count);
+  template_key = HashCombine(template_key, contract.vertex_attribute_count);
+  template_key = HashCombine(template_key, contract.first_vertex_stride_words);
+  template_key = HashCombine(template_key, contract.first_vertex_endianness);
+  template_key = HashCombine(template_key, contract.texture_fetch_mask);
+  template_key = HashCombine(template_key, contract.texture_layout_valid_mask);
+  template_key = HashCombine(template_key, contract.texture_state_count);
+  contract.template_key = template_key ? template_key : 1;
+  return contract;
+}
+
+void UpdateSemanticPreparedDrawContract(
+    SemanticPreparedDrawContract &contract,
+    const rex::system::GraphicsDrawObservation &observation,
+    const rex::system::GraphicsPreparedDrawObservation &prepared) {
+  const SemanticPreparedDrawContract current =
+      BuildSemanticPreparedDrawContract(observation, prepared);
+  if (!contract.valid) {
+    contract = current;
+    return;
+  }
+  if (contract.template_key != current.template_key ||
+      contract.prepared_pipeline_hash != current.prepared_pipeline_hash ||
+      contract.geometry_layout_hash != current.geometry_layout_hash ||
+      contract.texture_layout_hash != current.texture_layout_hash ||
+      contract.render_state_hash != current.render_state_hash ||
+      contract.vertex_shader_hash != current.vertex_shader_hash ||
+      contract.pixel_shader_hash != current.pixel_shader_hash ||
+      contract.vertex_specialization_mask !=
+          current.vertex_specialization_mask ||
+      contract.pixel_specialization_mask !=
+          current.pixel_specialization_mask) {
+    ++contract.template_variations;
+  }
+  if (contract.geometry_resource_hash != current.geometry_resource_hash ||
+      contract.texture_resource_hash != current.texture_resource_hash) {
+    ++contract.resource_variations;
+  }
+  contract.minimum_index_count =
+      std::min(contract.minimum_index_count, current.minimum_index_count);
+  contract.maximum_index_count =
+      std::max(contract.maximum_index_count, current.maximum_index_count);
+  contract.geometry_bounded &= current.geometry_bounded;
+  contract.texture_layout_bounded &= current.texture_layout_bounded;
+}
+
 void RecordTitleDrawProvenance(
     uint64_t backend_signature, bool prepared, uint32_t backend_outcome,
     const rex::system::GraphicsDrawObservation &observation,
-    const TitleDrawOrigin &origin) {
+    const TitleDrawOrigin &origin,
+    const rex::system::GraphicsPreparedDrawObservation *prepared_observation =
+        nullptr) {
   if (!origin.valid) {
     return;
   }
@@ -6669,11 +6968,17 @@ void RecordTitleDrawProvenance(
               : g_semantic_draw_unprepared_matches)
         .fetch_add(1, std::memory_order_relaxed);
   }
+  const SemanticPreparedDrawContract current_semantic_contract =
+      origin.semantic_draw.valid && prepared_observation
+          ? BuildSemanticPreparedDrawContract(observation,
+                                              *prepared_observation)
+          : SemanticPreparedDrawContract{};
   uint64_t key = backend_signature ^ (uint64_t(origin.caller) << 17) ^
                  (uint64_t(origin.wrapper) << 57) ^
                  (uint64_t(backend_outcome) << 41) ^
                  (prepared ? uint64_t(1) << 63 : 0);
   key = HashCombine(key, origin.semantic_draw.submission_key);
+  key = HashCombine(key, current_semantic_contract.template_key);
   size_t index = size_t(key % kTitleDrawProvenanceCapacity);
   for (size_t probe = 0; probe < kTitleDrawProvenanceCapacity; ++probe) {
     TitleDrawProvenanceEntry &entry = g_title_draw_provenance[index];
@@ -6691,6 +6996,9 @@ void RecordTitleDrawProvenance(
       entry.minimum_arguments = origin.arguments;
       entry.maximum_arguments = origin.arguments;
       entry.prepared = prepared;
+      if (current_semantic_contract.valid) {
+        entry.semantic_contract = current_semantic_contract;
+      }
       ++g_title_draw_provenance_count;
       return;
     }
@@ -6706,7 +7014,9 @@ void RecordTitleDrawProvenance(
         entry.origin.semantic_draw.receiver_generation ==
             origin.semantic_draw.receiver_generation &&
         entry.origin.semantic_draw.record_index ==
-            origin.semantic_draw.record_index) {
+            origin.semantic_draw.record_index &&
+        entry.semantic_contract.template_key ==
+            current_semantic_contract.template_key) {
       ++entry.calls;
       entry.last_frame = observation.frame_sequence;
       for (size_t i = 0; i < origin.arguments.size(); ++i) {
@@ -6718,6 +7028,11 @@ void RecordTitleDrawProvenance(
             std::min(entry.minimum_arguments[i], origin.arguments[i]);
         entry.maximum_arguments[i] =
             std::max(entry.maximum_arguments[i], origin.arguments[i]);
+      }
+      if (origin.semantic_draw.valid && prepared_observation) {
+        UpdateSemanticPreparedDrawContract(entry.semantic_contract,
+                                           observation,
+                                           *prepared_observation);
       }
       return;
     }
@@ -6736,6 +7051,14 @@ void EmitTitleDrawProvenanceSummary() {
   uint64_t unprepared_matches = 0;
   uint64_t prepared_aggregate_count = 0;
   uint64_t unprepared_aggregate_count = 0;
+  uint64_t semantic_contract_entries = 0;
+  uint64_t semantic_contract_calls = 0;
+  uint64_t semantic_bounded_geometry_calls = 0;
+  uint64_t semantic_bounded_texture_calls = 0;
+  uint64_t semantic_stable_template_calls = 0;
+  uint64_t semantic_stable_resource_calls = 0;
+  uint64_t semantic_template_variations = 0;
+  uint64_t semantic_resource_variations = 0;
   for (const TitleDrawProvenanceEntry &entry : g_title_draw_provenance) {
     if (!entry.calls) {
       continue;
@@ -6746,6 +7069,22 @@ void EmitTitleDrawProvenanceSummary() {
     } else {
       unprepared_matches += entry.calls;
       ++unprepared_aggregate_count;
+    }
+    const SemanticPreparedDrawContract &semantic_contract =
+        entry.semantic_contract;
+    if (semantic_contract.valid) {
+      ++semantic_contract_entries;
+      semantic_contract_calls += entry.calls;
+      semantic_bounded_geometry_calls +=
+          semantic_contract.geometry_bounded ? entry.calls : 0;
+      semantic_bounded_texture_calls +=
+          semantic_contract.texture_layout_bounded ? entry.calls : 0;
+      semantic_stable_template_calls +=
+          !semantic_contract.template_variations ? entry.calls : 0;
+      semantic_stable_resource_calls +=
+          !semantic_contract.resource_variations ? entry.calls : 0;
+      semantic_template_variations += semantic_contract.template_variations;
+      semantic_resource_variations += semantic_contract.resource_variations;
     }
     pinyon_shift::diagnostics::RecordEvent(
         "native_renderer.discovery.title_provenance_entry",
@@ -6762,6 +7101,152 @@ void EmitTitleDrawProvenanceSummary() {
          {"prepared_signature",
           entry.prepared ? fmt::format("{:016X}", entry.backend_signature)
                          : ""},
+         {"semantic_template_key",
+          semantic_contract.valid
+              ? fmt::format("{:016X}", semantic_contract.template_key)
+              : ""},
+         {"semantic_prepared_pipeline_hash",
+          semantic_contract.valid
+              ? fmt::format("{:016X}",
+                            semantic_contract.prepared_pipeline_hash)
+              : ""},
+         {"semantic_geometry_layout_hash",
+          semantic_contract.valid
+              ? fmt::format("{:016X}", semantic_contract.geometry_layout_hash)
+              : ""},
+         {"semantic_texture_layout_hash",
+          semantic_contract.valid
+              ? fmt::format("{:016X}", semantic_contract.texture_layout_hash)
+              : ""},
+         {"semantic_render_state_hash",
+          semantic_contract.valid
+              ? fmt::format("{:016X}", semantic_contract.render_state_hash)
+              : ""},
+         {"semantic_geometry_resource_hash",
+          semantic_contract.valid
+              ? fmt::format("{:016X}",
+                            semantic_contract.geometry_resource_hash)
+              : ""},
+         {"semantic_texture_resource_hash",
+          semantic_contract.valid
+              ? fmt::format("{:016X}",
+                            semantic_contract.texture_resource_hash)
+              : ""},
+         {"semantic_vertex_shader",
+          semantic_contract.valid
+              ? fmt::format("{:016X}", semantic_contract.vertex_shader_hash)
+              : ""},
+         {"semantic_pixel_shader",
+          semantic_contract.valid
+              ? fmt::format("{:016X}", semantic_contract.pixel_shader_hash)
+              : ""},
+         {"semantic_vertex_specialization",
+          semantic_contract.valid
+              ? fmt::format("{:016X}",
+                            semantic_contract.vertex_specialization_mask)
+              : ""},
+         {"semantic_pixel_specialization",
+          semantic_contract.valid
+              ? fmt::format("{:016X}",
+                            semantic_contract.pixel_specialization_mask)
+              : ""},
+         {"semantic_primitive_type",
+          semantic_contract.valid
+              ? std::to_string(semantic_contract.primitive_type)
+              : ""},
+         {"semantic_source_select",
+          semantic_contract.valid
+              ? std::to_string(semantic_contract.source_select)
+              : ""},
+         {"semantic_indexed",
+          semantic_contract.valid
+              ? (semantic_contract.indexed ? "true" : "false")
+              : ""},
+         {"semantic_minimum_index_count",
+          semantic_contract.valid
+              ? std::to_string(semantic_contract.minimum_index_count)
+              : ""},
+         {"semantic_maximum_index_count",
+          semantic_contract.valid
+              ? std::to_string(semantic_contract.maximum_index_count)
+              : ""},
+         {"semantic_index_buffer_address",
+          semantic_contract.valid
+              ? fmt::format("{:08X}",
+                            semantic_contract.index_buffer_address)
+              : ""},
+         {"semantic_index_buffer_length",
+          semantic_contract.valid
+              ? std::to_string(semantic_contract.index_buffer_length)
+              : ""},
+         {"semantic_index_format",
+          semantic_contract.valid
+              ? std::to_string(semantic_contract.index_format)
+              : ""},
+         {"semantic_index_endianness",
+          semantic_contract.valid
+              ? std::to_string(semantic_contract.index_endianness)
+              : ""},
+         {"semantic_vertex_binding_count",
+          semantic_contract.valid
+              ? std::to_string(semantic_contract.vertex_binding_count)
+              : ""},
+         {"semantic_vertex_attribute_count",
+          semantic_contract.valid
+              ? std::to_string(semantic_contract.vertex_attribute_count)
+              : ""},
+         {"semantic_first_vertex_address",
+          semantic_contract.valid
+              ? fmt::format("{:08X}",
+                            semantic_contract.first_vertex_address)
+              : ""},
+         {"semantic_first_vertex_size",
+          semantic_contract.valid
+              ? std::to_string(semantic_contract.first_vertex_size)
+              : ""},
+         {"semantic_first_vertex_stride_words",
+          semantic_contract.valid
+              ? std::to_string(
+                    semantic_contract.first_vertex_stride_words)
+              : ""},
+         {"semantic_first_vertex_endianness",
+          semantic_contract.valid
+              ? std::to_string(semantic_contract.first_vertex_endianness)
+              : ""},
+         {"semantic_texture_fetch_mask",
+          semantic_contract.valid
+              ? fmt::format("{:08X}",
+                            semantic_contract.texture_fetch_mask)
+              : ""},
+         {"semantic_texture_layout_valid_mask",
+          semantic_contract.valid
+              ? fmt::format("{:08X}",
+                            semantic_contract.texture_layout_valid_mask)
+              : ""},
+         {"semantic_texture_state_count",
+          semantic_contract.valid
+              ? std::to_string(semantic_contract.texture_state_count)
+              : ""},
+         {"semantic_geometry_bounded",
+          semantic_contract.valid
+              ? (semantic_contract.geometry_bounded ? "true" : "false")
+              : ""},
+         {"semantic_texture_layout_bounded",
+          semantic_contract.valid
+              ? (semantic_contract.texture_layout_bounded ? "true" : "false")
+              : ""},
+         {"semantic_template_variations",
+          semantic_contract.valid
+              ? std::to_string(semantic_contract.template_variations)
+              : ""},
+         {"semantic_resource_variations",
+          semantic_contract.valid
+              ? std::to_string(semantic_contract.resource_variations)
+              : ""},
+         {"semantic_catalog_classification",
+          semantic_contract.valid
+              ? "immutable_template_and_dynamic_resource_instance"
+              : "unavailable"},
          {"calls", std::to_string(entry.calls)},
          {"first_frame", std::to_string(entry.first_frame)},
          {"last_frame", std::to_string(entry.last_frame)},
@@ -6991,6 +7476,24 @@ void EmitTitleDrawProvenanceSummary() {
         std::to_string(semantic_pending_packets)},
        {"semantic_draw_accounting_complete",
         semantic_draw_accounting_complete ? "true" : "false"},
+       {"semantic_contract_entries",
+        std::to_string(semantic_contract_entries)},
+       {"semantic_contract_calls", std::to_string(semantic_contract_calls)},
+       {"semantic_bounded_geometry_calls",
+        std::to_string(semantic_bounded_geometry_calls)},
+       {"semantic_bounded_texture_calls",
+        std::to_string(semantic_bounded_texture_calls)},
+       {"semantic_stable_template_calls",
+        std::to_string(semantic_stable_template_calls)},
+       {"semantic_stable_resource_calls",
+        std::to_string(semantic_stable_resource_calls)},
+       {"semantic_template_variations",
+        std::to_string(semantic_template_variations)},
+       {"semantic_resource_variations",
+        std::to_string(semantic_resource_variations)},
+       {"semantic_catalog_accounting_complete",
+        semantic_contract_calls == semantic_prepared_matches ? "true"
+                                                              : "false"},
        {"backend_draws_without_title_packet",
         std::to_string(g_title_backend_unattributed_draws)},
        {"packet_address_failures",
@@ -7122,7 +7625,8 @@ void ObservePreparedDraw(
         sample, g_pending_candidate.samples_resolved_target, observation);
     RecordPreparedCommandBufferLineage(prepared_signature, sample);
     RecordTitleDrawProvenance(prepared_signature, true, 0, sample,
-                              g_pending_candidate.title_origin);
+                              g_pending_candidate.title_origin,
+                              &observation);
     g_isolated_draw.prepared_signature = prepared_signature;
     g_isolated_draw.frame = sample.frame_sequence;
     g_isolated_draw.draw = sample.draw_sequence;
@@ -9300,6 +9804,10 @@ void InstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system,
        {"graphics_submission_wrapper", "82415CE0"},
        {"graphics_submission_emitter", "82415F68"},
        {"semantic_packet_opcode", "PM4_DRAW_INDX_0x22"},
+       {"semantic_catalog",
+        "prepared_template_dynamic_resource_instance_and_batch_key"},
+       {"semantic_catalog_capacity",
+        std::to_string(kSemanticPreparedTemplateCapacity)},
        {"title_indirect_packet_hooks",
         "824095B4,82416EFC,8246FC1C,8263BD64,829E8E88,829EC49C"},
        {"render_item_stack_capacity",

--- a/tools/discover-native-renderer-dispatch.py
+++ b/tools/discover-native-renderer-dispatch.py
@@ -1461,6 +1461,10 @@ def procedural_model_receiver_lifecycle(
             "indirect_packet_constructor_overlap_probe": True,
             "semantic_pm4_packet_construction_proved": True,
             "semantic_pm4_backend_join_required": True,
+            "semantic_prepared_contract_runtime_join_required": True,
+            "semantic_catalog_classification": (
+                "immutable_template_and_dynamic_resource_instance"
+            ),
             "physical_pm4_packet_correlation_proved": False,
             "prepared_draw_lineage_proved": False,
             "classification": "procedural_submission_pm4_packet_boundary",

--- a/tools/summarize-native-renderer-semantic-draws.py
+++ b/tools/summarize-native-renderer-semantic-draws.py
@@ -9,10 +9,11 @@ import pathlib
 import sys
 
 
-SCHEMA = "pinyon-shift.native-renderer-semantic-draw-lineage.v3"
+SCHEMA = "pinyon-shift.native-renderer-semantic-draw-catalog.v4"
 STATIC_SCHEMA = "pinyon-shift.native-renderer-dispatch-static.v3"
 SEMANTIC_DRAW_PREFIX = "native_renderer.discovery.semantic_draw_"
 SEMANTIC_SUBMISSION_PREFIX = "native_renderer.discovery.semantic_submission_"
+SEMANTIC_INSTANCE_PREFIX = "native_renderer.discovery.semantic_instance_"
 TITLE_PREFIX = "native_renderer.discovery.title_provenance_"
 EXPECTED_CLASS = "proceduralGeometry::CProceduralModels"
 EXPECTED_CORRELATION = "exact_render_item_scope_to_emitted_and_backend_pm4_header"
@@ -21,7 +22,12 @@ EXPECTED_DIRECT_ASSOCIATION = "exact_render_item_scope_and_physical_pm4_header"
 
 def read_events(paths: list[pathlib.Path]) -> list[dict]:
     events = []
-    prefixes = (SEMANTIC_DRAW_PREFIX, SEMANTIC_SUBMISSION_PREFIX, TITLE_PREFIX)
+    prefixes = (
+        SEMANTIC_DRAW_PREFIX,
+        SEMANTIC_SUBMISSION_PREFIX,
+        SEMANTIC_INSTANCE_PREFIX,
+        TITLE_PREFIX,
+    )
     for path in paths:
         for line_number, line in enumerate(
             path.read_text(encoding="utf-8").splitlines(), 1
@@ -53,6 +59,13 @@ def _hex(mapping: dict, key: str, width: int) -> str:
     except ValueError as error:
         raise ValueError(f"invalid hexadecimal field: {key}") from error
     return value
+
+
+def _boolean(mapping: dict, key: str) -> bool:
+    value = str(mapping.get(key, "")).lower()
+    if value not in {"true", "false"}:
+        raise ValueError(f"invalid boolean field: {key}")
+    return value == "true"
 
 
 def _select_session(events: list[dict], requested: str | None) -> str:
@@ -100,6 +113,10 @@ def _validate_static(static: dict) -> dict:
         "indirect_packet_constructor_overlap_probe": True,
         "semantic_pm4_packet_construction_proved": True,
         "semantic_pm4_backend_join_required": True,
+        "semantic_prepared_contract_runtime_join_required": True,
+        "semantic_catalog_classification": (
+            "immutable_template_and_dynamic_resource_instance"
+        ),
         "physical_pm4_packet_correlation_proved": False,
         "prepared_draw_lineage_proved": False,
         "classification": "procedural_submission_pm4_packet_boundary",
@@ -145,9 +162,19 @@ def build(events: list[dict], static: dict, requested: str | None = None) -> dic
         for event in selected
         if event.get("event") == f"{SEMANTIC_SUBMISSION_PREFIX}summary"
     ]
-    if len(configs) != 1 or len(title_summaries) != 1 or len(submission_summaries) != 1:
+    instance_summaries = [
+        event
+        for event in selected
+        if event.get("event") == f"{SEMANTIC_INSTANCE_PREFIX}summary"
+    ]
+    if (
+        len(configs) != 1
+        or len(title_summaries) != 1
+        or len(submission_summaries) != 1
+        or len(instance_summaries) != 1
+    ):
         raise ValueError(
-            "semantic-draw session needs one config, title summary, and submission summary"
+            "semantic-draw session needs one config and all three summaries"
         )
     config = configs[0]
     if (
@@ -160,6 +187,9 @@ def build(events: list[dict], static: dict, requested: str | None = None) -> dic
         or config.get("graphics_submission_wrapper") != "82415CE0"
         or config.get("graphics_submission_emitter") != "82415F68"
         or config.get("semantic_packet_opcode") != "PM4_DRAW_INDX_0x22"
+        or config.get("semantic_catalog")
+        != "prepared_template_dynamic_resource_instance_and_batch_key"
+        or _integer(config, "semantic_catalog_capacity") != 4096
         or config.get("title_indirect_packet_hooks")
         not in (
             None,
@@ -180,6 +210,42 @@ def build(events: list[dict], static: dict, requested: str | None = None) -> dic
     if any(str(config.get(key)).lower() != value for key, value in safety.items()):
         raise ValueError("semantic-draw config violates the safety boundary")
 
+    instances_by_identity: dict[tuple[str, int, int], dict] = {}
+    for event in selected:
+        if event.get("event") != f"{SEMANTIC_INSTANCE_PREFIX}entry":
+            continue
+        identity = (
+            _hex(event, "receiver_address", 8),
+            _integer(event, "receiver_generation"),
+            _integer(event, "record_index"),
+        )
+        instance = {
+            "semantic_instance_key": _hex(event, "key", 16),
+            "descriptor_address": _hex(event, "descriptor_address", 8),
+            "runtime_address": _hex(event, "runtime_address", 8),
+            "descriptor_hash": _hex(event, "descriptor_hash", 16),
+            "runtime_hash": _hex(event, "runtime_hash", 16),
+            "transform_hash": _hex(event, "transform_hash", 16),
+            "descriptor_variations": _integer(event, "descriptor_variations"),
+            "runtime_variations": _integer(event, "runtime_variations"),
+            "transform_variations": _integer(event, "transform_variations"),
+        }
+        if (
+            identity in instances_by_identity
+            or identity[1] <= 0
+            or min(
+                instance["descriptor_variations"],
+                instance["runtime_variations"],
+                instance["transform_variations"],
+            )
+            < 0
+            or str(event.get("fallback", "")).lower() != "xenos_replay"
+            or str(event.get("native_draw", "")).lower() != "false"
+            or str(event.get("suppression_allowed", "")).lower() != "false"
+        ):
+            raise ValueError("invalid or duplicate semantic instance entry")
+        instances_by_identity[identity] = instance
+
     submissions: dict[str, dict] = {}
     submission_calls = 0
     for event in selected:
@@ -191,18 +257,41 @@ def build(events: list[dict], static: dict, requested: str | None = None) -> dic
             "receiver_address": _hex(event, "receiver_address", 8),
             "receiver_generation": _integer(event, "receiver_generation"),
             "record_index": _integer(event, "record_index"),
+            "descriptor_kind": _integer(event, "descriptor_kind"),
+            "helper_state": _integer(event, "helper_state"),
             "graphics_submission_method": _hex(
                 event, "graphics_submission_method", 8
             ),
+            "primary_resource_key": _hex(event, "primary_resource_key", 8),
+            "secondary_resource_present": str(
+                event.get("secondary_resource_present", "")
+            ).lower()
+            == "true",
+            "secondary_resource_key": _hex(event, "secondary_resource_key", 8),
+            "runtime_submission_object": _hex(
+                event, "runtime_submission_object", 8
+            ),
+            "count_bytes": _integer(event, "count_bytes"),
+            "source_address": _hex(event, "source_address", 8),
         }
         if key in submissions or calls <= 0 or identity["receiver_generation"] <= 0:
             raise ValueError("invalid or duplicate semantic submission entry")
-        submissions[key] = {"calls": calls, **identity}
+        instance_identity = (
+            identity["receiver_address"],
+            identity["receiver_generation"],
+            identity["record_index"],
+        )
+        instance = instances_by_identity.get(instance_identity)
+        if instance is None:
+            raise ValueError("semantic submission has no immutable instance")
+        submissions[key] = {"calls": calls, **identity, "instance": instance}
         submission_calls += calls
 
     associations = []
     associated_calls_by_key: collections.Counter[str] = collections.Counter()
     prepared_signatures_by_key: dict[str, set[str]] = collections.defaultdict(set)
+    templates: dict[str, dict] = {}
+    batch_groups: dict[tuple[str, str, str, str, str], dict] = {}
     prepared_calls = 0
     unprepared_calls = 0
     for event in selected:
@@ -241,10 +330,206 @@ def build(events: list[dict], static: dict, requested: str | None = None) -> dic
             or origin_caller not in {"82416260", "824162F4"}
         ):
             raise ValueError("semantic draw identity or safety evidence is inconsistent")
+        catalog = None
         if outcome == "prepared":
             if len(signature) != 16 or signature != backend_signature:
                 raise ValueError("semantic prepared draw signature is invalid")
             int(signature, 16)
+            template_key = _hex(event, "semantic_template_key", 16)
+            if int(template_key, 16) == 0:
+                raise ValueError("semantic template key is zero")
+            catalog = {
+                "prepared_pipeline_hash": _hex(
+                    event, "semantic_prepared_pipeline_hash", 16
+                ),
+                "geometry_layout_hash": _hex(
+                    event, "semantic_geometry_layout_hash", 16
+                ),
+                "texture_layout_hash": _hex(
+                    event, "semantic_texture_layout_hash", 16
+                ),
+                "render_state_hash": _hex(
+                    event, "semantic_render_state_hash", 16
+                ),
+                "geometry_resource_hash": _hex(
+                    event, "semantic_geometry_resource_hash", 16
+                ),
+                "texture_resource_hash": _hex(
+                    event, "semantic_texture_resource_hash", 16
+                ),
+                "vertex_shader": _hex(event, "semantic_vertex_shader", 16),
+                "pixel_shader": _hex(event, "semantic_pixel_shader", 16),
+                "vertex_specialization": _hex(
+                    event, "semantic_vertex_specialization", 16
+                ),
+                "pixel_specialization": _hex(
+                    event, "semantic_pixel_specialization", 16
+                ),
+                "primitive_type": _integer(event, "semantic_primitive_type"),
+                "source_select": _integer(event, "semantic_source_select"),
+                "indexed": _boolean(event, "semantic_indexed"),
+                "minimum_index_count": _integer(
+                    event, "semantic_minimum_index_count"
+                ),
+                "maximum_index_count": _integer(
+                    event, "semantic_maximum_index_count"
+                ),
+                "index_buffer_address": _hex(
+                    event, "semantic_index_buffer_address", 8
+                ),
+                "index_buffer_length": _integer(
+                    event, "semantic_index_buffer_length"
+                ),
+                "index_format": _integer(event, "semantic_index_format"),
+                "index_endianness": _integer(
+                    event, "semantic_index_endianness"
+                ),
+                "vertex_binding_count": _integer(
+                    event, "semantic_vertex_binding_count"
+                ),
+                "vertex_attribute_count": _integer(
+                    event, "semantic_vertex_attribute_count"
+                ),
+                "first_vertex_address": _hex(
+                    event, "semantic_first_vertex_address", 8
+                ),
+                "first_vertex_size": _integer(
+                    event, "semantic_first_vertex_size"
+                ),
+                "first_vertex_stride_words": _integer(
+                    event, "semantic_first_vertex_stride_words"
+                ),
+                "first_vertex_endianness": _integer(
+                    event, "semantic_first_vertex_endianness"
+                ),
+                "texture_fetch_mask": _hex(
+                    event, "semantic_texture_fetch_mask", 8
+                ),
+                "texture_layout_valid_mask": _hex(
+                    event, "semantic_texture_layout_valid_mask", 8
+                ),
+                "texture_state_count": _integer(
+                    event, "semantic_texture_state_count"
+                ),
+                "geometry_bounded": _boolean(
+                    event, "semantic_geometry_bounded"
+                ),
+                "texture_layout_bounded": _boolean(
+                    event, "semantic_texture_layout_bounded"
+                ),
+                "template_variations": _integer(
+                    event, "semantic_template_variations"
+                ),
+                "resource_variations": _integer(
+                    event, "semantic_resource_variations"
+                ),
+            }
+            if (
+                event.get("semantic_catalog_classification")
+                != "immutable_template_and_dynamic_resource_instance"
+                or catalog["minimum_index_count"] <= 0
+                or catalog["maximum_index_count"]
+                < catalog["minimum_index_count"]
+                or catalog["vertex_binding_count"] <= 0
+                or catalog["template_variations"] < 0
+                or catalog["resource_variations"] < 0
+            ):
+                raise ValueError("semantic prepared contract is invalid")
+            template_identity = {
+                key: catalog[key]
+                for key in (
+                    "prepared_pipeline_hash",
+                    "geometry_layout_hash",
+                    "texture_layout_hash",
+                    "render_state_hash",
+                    "vertex_shader",
+                    "pixel_shader",
+                    "vertex_specialization",
+                    "pixel_specialization",
+                    "primitive_type",
+                    "source_select",
+                    "indexed",
+                    "index_format",
+                    "index_endianness",
+                    "vertex_binding_count",
+                    "vertex_attribute_count",
+                    "first_vertex_stride_words",
+                    "first_vertex_endianness",
+                    "texture_fetch_mask",
+                    "texture_layout_valid_mask",
+                    "texture_state_count",
+                )
+            }
+            template = templates.get(template_key)
+            if template is None:
+                template = {
+                    "template_key": template_key,
+                    **template_identity,
+                    "calls": 0,
+                    "submission_keys": set(),
+                    "geometry_resource_hashes": set(),
+                    "texture_resource_hashes": set(),
+                    "geometry_bounded": True,
+                    "texture_layout_bounded": True,
+                    "template_variations": 0,
+                    "resource_variations": 0,
+                }
+                templates[template_key] = template
+            elif any(
+                template[name] != value
+                for name, value in template_identity.items()
+            ):
+                raise ValueError("semantic template identity changed across entries")
+            template["calls"] += calls
+            template["submission_keys"].add(key)
+            template["geometry_resource_hashes"].add(
+                catalog["geometry_resource_hash"]
+            )
+            template["texture_resource_hashes"].add(
+                catalog["texture_resource_hash"]
+            )
+            template["geometry_bounded"] &= catalog["geometry_bounded"]
+            template["texture_layout_bounded"] &= catalog[
+                "texture_layout_bounded"
+            ]
+            template["template_variations"] += catalog["template_variations"]
+            template["resource_variations"] += catalog["resource_variations"]
+            batch_key = (
+                template_key,
+                catalog["geometry_resource_hash"],
+                catalog["texture_resource_hash"],
+                submission["primary_resource_key"],
+                submission["secondary_resource_key"],
+            )
+            batch = batch_groups.setdefault(
+                batch_key,
+                {
+                    "template_key": template_key,
+                    "geometry_resource_hash": catalog[
+                        "geometry_resource_hash"
+                    ],
+                    "texture_resource_hash": catalog[
+                        "texture_resource_hash"
+                    ],
+                    "primary_resource_key": submission[
+                        "primary_resource_key"
+                    ],
+                    "secondary_resource_key": submission[
+                        "secondary_resource_key"
+                    ],
+                    "calls": 0,
+                    "submission_keys": set(),
+                    "batchable": True,
+                },
+            )
+            batch["calls"] += calls
+            batch["submission_keys"].add(key)
+            batch["batchable"] &= (
+                catalog["geometry_bounded"]
+                and catalog["texture_layout_bounded"]
+                and catalog["template_variations"] == 0
+                and catalog["resource_variations"] == 0
+            )
             prepared_signatures_by_key[key].add(signature)
             prepared_calls += calls
         elif outcome == "not_prepared":
@@ -270,18 +555,81 @@ def build(events: list[dict], static: dict, requested: str | None = None) -> dic
                 "backend_outcome": str(event.get("backend_outcome", "")),
                 "backend_signature": backend_signature,
                 "prepared_signature": signature or None,
+                "catalog": catalog if outcome == "prepared" else None,
                 "xenos_draw": "preserved",
                 "suppression_eligible": False,
             }
         )
 
     submission_summary = submission_summaries[0]
+    instance_summary = instance_summaries[0]
     title_summary = title_summaries[0]
     live_submissions = _integer(submission_summary, "live_observations")
+    instance_totals = {
+        key: _integer(instance_summary, key)
+        for key in (
+            "live_observations",
+            "unknown_receivers",
+            "invalid_layouts",
+            "invalid_indices",
+            "replay_fallbacks",
+            "native_admissions",
+            "entries",
+            "overflow",
+        )
+    }
     pending = _integer(title_summary, "semantic_draw_pending_packets")
     semantic_prepared = _integer(title_summary, "semantic_draw_prepared_matches")
     semantic_unprepared = _integer(title_summary, "semantic_draw_unprepared_matches")
     associated_calls = sum(associated_calls_by_key.values())
+    prepared_associations = [
+        item for item in associations if item["outcome"] == "prepared"
+    ]
+    catalog_counters = {
+        key: _integer(title_summary, key)
+        for key in (
+            "semantic_contract_entries",
+            "semantic_contract_calls",
+            "semantic_bounded_geometry_calls",
+            "semantic_bounded_texture_calls",
+            "semantic_stable_template_calls",
+            "semantic_stable_resource_calls",
+            "semantic_template_variations",
+            "semantic_resource_variations",
+        )
+    }
+    expected_catalog_counters = {
+        "semantic_contract_entries": len(prepared_associations),
+        "semantic_contract_calls": prepared_calls,
+        "semantic_bounded_geometry_calls": sum(
+            item["calls"]
+            for item in prepared_associations
+            if item["catalog"]["geometry_bounded"]
+        ),
+        "semantic_bounded_texture_calls": sum(
+            item["calls"]
+            for item in prepared_associations
+            if item["catalog"]["texture_layout_bounded"]
+        ),
+        "semantic_stable_template_calls": sum(
+            item["calls"]
+            for item in prepared_associations
+            if item["catalog"]["template_variations"] == 0
+        ),
+        "semantic_stable_resource_calls": sum(
+            item["calls"]
+            for item in prepared_associations
+            if item["catalog"]["resource_variations"] == 0
+        ),
+        "semantic_template_variations": sum(
+            item["catalog"]["template_variations"]
+            for item in prepared_associations
+        ),
+        "semantic_resource_variations": sum(
+            item["catalog"]["resource_variations"]
+            for item in prepared_associations
+        ),
+    }
     fault_fields = (
         "semantic_render_item_stack_faults",
         "semantic_draw_scope_mismatches",
@@ -308,6 +656,20 @@ def build(events: list[dict], static: dict, requested: str | None = None) -> dic
     }
     if (
         not submissions
+        or not instances_by_identity
+        or instance_totals["entries"] != len(instances_by_identity)
+        or instance_totals["live_observations"]
+        != instance_totals["replay_fallbacks"]
+        or any(
+            instance_totals[key]
+            for key in (
+                "unknown_receivers",
+                "invalid_layouts",
+                "invalid_indices",
+                "native_admissions",
+                "overflow",
+            )
+        )
         or submission_calls != live_submissions
         or counters["semantic_submission_live_observations"] != live_submissions
         or counters["semantic_draw_scope_joins"] != live_submissions
@@ -327,6 +689,9 @@ def build(events: list[dict], static: dict, requested: str | None = None) -> dic
         or associated_calls != prepared_calls + unprepared_calls
         or prepared_calls != semantic_prepared
         or unprepared_calls != semantic_unprepared
+        or catalog_counters != expected_catalog_counters
+        or str(title_summary.get("semantic_catalog_accounting_complete")).lower()
+        != "true"
         or counters["semantic_draw_packets_recorded"]
         != associated_calls + pending
         or counters["semantic_render_item_entries"]
@@ -375,6 +740,55 @@ def build(events: list[dict], static: dict, requested: str | None = None) -> dic
         and prepared_calls > 0
         and unprepared_calls == 0
     )
+    template_entries = []
+    for template in templates.values():
+        template_entries.append(
+            {
+                **{
+                    key: value
+                    for key, value in template.items()
+                    if key
+                    not in {
+                        "submission_keys",
+                        "geometry_resource_hashes",
+                        "texture_resource_hashes",
+                    }
+                },
+                "submission_keys": sorted(template["submission_keys"]),
+                "geometry_resource_hashes": sorted(
+                    template["geometry_resource_hashes"]
+                ),
+                "texture_resource_hashes": sorted(
+                    template["texture_resource_hashes"]
+                ),
+            }
+        )
+    template_entries.sort(key=lambda item: (-item["calls"], item["template_key"]))
+    batch_entries = [
+        {
+            **{key: value for key, value in batch.items() if key != "submission_keys"},
+            "submission_keys": sorted(batch["submission_keys"]),
+        }
+        for batch in batch_groups.values()
+    ]
+    batch_entries.sort(
+        key=lambda item: (
+            not item["batchable"],
+            -item["calls"],
+            item["template_key"],
+            item["geometry_resource_hash"],
+            item["texture_resource_hash"],
+        )
+    )
+    batchable_calls = sum(item["calls"] for item in batch_entries if item["batchable"])
+    compact_semantic_catalog_proved = (
+        prepared_draw_lineage_proved
+        and catalog_counters["semantic_contract_calls"] == prepared_calls
+        and catalog_counters["semantic_template_variations"] == 0
+        and catalog_counters["semantic_resource_variations"] == 0
+        and catalog_counters["semantic_bounded_geometry_calls"] == prepared_calls
+        and catalog_counters["semantic_bounded_texture_calls"] == prepared_calls
+    )
     return {
         "schema": SCHEMA,
         "session": session,
@@ -382,9 +796,12 @@ def build(events: list[dict], static: dict, requested: str | None = None) -> dic
         "status": "complete",
         "associations": associations,
         "submissions": submission_lineage,
+        "templates": template_entries,
+        "batch_groups": batch_entries,
         "totals": {
             "semantic_submissions": live_submissions,
             "semantic_submission_keys": len(submissions),
+            "semantic_instance_keys": len(instances_by_identity),
             "associated_draw_calls": associated_calls,
             "prepared_draw_calls": prepared_calls,
             "unprepared_draw_calls": unprepared_calls,
@@ -397,23 +814,32 @@ def build(events: list[dict], static: dict, requested: str | None = None) -> dic
                 }
             ),
             "association_entries": len(associations),
+            "semantic_template_count": len(template_entries),
+            "semantic_batch_group_count": len(batch_entries),
+            "semantic_batchable_calls": batchable_calls,
             "semantic_render_items_open_at_shutdown": _integer(
                 title_summary, "semantic_render_items_open_at_shutdown"
             ),
             **counters,
+            **catalog_counters,
             **faults,
         },
         "correlation": contract,
-        "qualification": "exact_semantic_submission_to_pm4_and_backend_draw_lineage",
+        "qualification": (
+            "compact_semantic_template_instance_and_conservative_batch_catalog"
+        ),
         "physical_pm4_packet_correlation_proved": (
             physical_pm4_packet_correlation_proved
         ),
         "prepared_draw_lineage_proved": prepared_draw_lineage_proved,
+        "compact_semantic_catalog_proved": compact_semantic_catalog_proved,
+        "native_batching_enabled": False,
         "safety": {
             "bounded_guest_read": True,
             "guest_state_changed": False,
             "native_upload": False,
             "native_draw": False,
+            "native_batching": False,
             "xenos_authority": True,
             "suppression_allowed": False,
         },

--- a/tools/tests/test_native_renderer_dispatch_discovery.py
+++ b/tools/tests/test_native_renderer_dispatch_discovery.py
@@ -1174,6 +1174,15 @@ class NativeRendererDispatchDiscoveryTests(unittest.TestCase):
             "PM4_DRAW_INDX", draw_association["semantic_draw_packet_opcode"]
         )
         self.assertTrue(draw_association["semantic_pm4_packet_construction_proved"])
+        self.assertTrue(
+            draw_association[
+                "semantic_prepared_contract_runtime_join_required"
+            ]
+        )
+        self.assertEqual(
+            "immutable_template_and_dynamic_resource_instance",
+            draw_association["semantic_catalog_classification"],
+        )
         self.assertTrue(draw_association["render_item_invocation_scope_proved"])
         self.assertTrue(draw_association["submission_before_draw_dispatch_proved"])
         self.assertEqual(160, draw_association["graphics_submission_vtable_offset"])

--- a/tools/tests/test_native_renderer_semantic_draws.py
+++ b/tools/tests/test_native_renderer_semantic_draws.py
@@ -42,6 +42,10 @@ def static_inventory():
                 "indirect_packet_constructor_overlap_probe": True,
                 "semantic_pm4_packet_construction_proved": True,
                 "semantic_pm4_backend_join_required": True,
+                "semantic_prepared_contract_runtime_join_required": True,
+                "semantic_catalog_classification": (
+                    "immutable_template_and_dynamic_resource_instance"
+                ),
                 "physical_pm4_packet_correlation_proved": False,
                 "prepared_draw_lineage_proved": False,
                 "classification": "procedural_submission_pm4_packet_boundary",
@@ -75,6 +79,10 @@ def events():
             "graphics_submission_wrapper": "82415CE0",
             "graphics_submission_emitter": "82415F68",
             "semantic_packet_opcode": "PM4_DRAW_INDX_0x22",
+            "semantic_catalog": (
+                "prepared_template_dynamic_resource_instance_and_batch_key"
+            ),
+            "semantic_catalog_capacity": "4096",
             "title_indirect_packet_hooks":
                 "824095B4,82416EFC,8246FC1C,8263BD64,829E8E88,829EC49C",
             "correlation": "exact_render_item_scope_to_emitted_and_backend_pm4_header",
@@ -93,7 +101,15 @@ def events():
             "receiver_address": "40102030",
             "receiver_generation": "7",
             "record_index": "4",
+            "descriptor_kind": "0",
+            "helper_state": "9",
             "graphics_submission_method": "82417BC0",
+            "primary_resource_key": "00001000",
+            "secondary_resource_present": "false",
+            "secondary_resource_key": "00000000",
+            "runtime_submission_object": "40103000",
+            "count_bytes": "48",
+            "source_address": "40104000",
         },
         {
             **common,
@@ -119,9 +135,76 @@ def events():
             "backend_outcome": "prepared_callback",
             "backend_signature": "AABBCCDDEEFF0011",
             "prepared_signature": "AABBCCDDEEFF0011",
+            "semantic_template_key": "1122334455667788",
+            "semantic_prepared_pipeline_hash": "0000000000000001",
+            "semantic_geometry_layout_hash": "0000000000000002",
+            "semantic_texture_layout_hash": "0000000000000003",
+            "semantic_render_state_hash": "0000000000000004",
+            "semantic_geometry_resource_hash": "0000000000000005",
+            "semantic_texture_resource_hash": "0000000000000006",
+            "semantic_vertex_shader": "0000000000000007",
+            "semantic_pixel_shader": "0000000000000008",
+            "semantic_vertex_specialization": "0000000000000009",
+            "semantic_pixel_specialization": "000000000000000A",
+            "semantic_primitive_type": "13",
+            "semantic_source_select": "0",
+            "semantic_indexed": "true",
+            "semantic_minimum_index_count": "12",
+            "semantic_maximum_index_count": "12",
+            "semantic_index_buffer_address": "40105000",
+            "semantic_index_buffer_length": "24",
+            "semantic_index_format": "0",
+            "semantic_index_endianness": "2",
+            "semantic_vertex_binding_count": "1",
+            "semantic_vertex_attribute_count": "3",
+            "semantic_first_vertex_address": "40106000",
+            "semantic_first_vertex_size": "256",
+            "semantic_first_vertex_stride_words": "8",
+            "semantic_first_vertex_endianness": "2",
+            "semantic_texture_fetch_mask": "00000001",
+            "semantic_texture_layout_valid_mask": "00000001",
+            "semantic_texture_state_count": "1",
+            "semantic_geometry_bounded": "true",
+            "semantic_texture_layout_bounded": "true",
+            "semantic_template_variations": "0",
+            "semantic_resource_variations": "0",
+            "semantic_catalog_classification": (
+                "immutable_template_and_dynamic_resource_instance"
+            ),
             "calls": "12",
             "xenos_draw": "preserved",
             "suppression_eligible": "false",
+        },
+        {
+            **common,
+            "event": "native_renderer.discovery.semantic_instance_entry",
+            "key": "0102030405060708",
+            "receiver_address": "40102030",
+            "receiver_generation": "7",
+            "record_index": "4",
+            "descriptor_address": "50001000",
+            "runtime_address": "50002000",
+            "descriptor_hash": "1000000000000001",
+            "runtime_hash": "1000000000000002",
+            "transform_hash": "1000000000000003",
+            "descriptor_variations": "0",
+            "runtime_variations": "11",
+            "transform_variations": "11",
+            "fallback": "xenos_replay",
+            "native_draw": "false",
+            "suppression_allowed": "false",
+        },
+        {
+            **common,
+            "event": "native_renderer.discovery.semantic_instance_summary",
+            "live_observations": "12",
+            "unknown_receivers": "0",
+            "invalid_layouts": "0",
+            "invalid_indices": "0",
+            "replay_fallbacks": "12",
+            "native_admissions": "0",
+            "entries": "1",
+            "overflow": "0",
         },
         {
             **common,
@@ -148,6 +231,15 @@ def events():
             "semantic_draw_unprepared_matches": "0",
             "semantic_draw_pending_packets": "0",
             "semantic_draw_accounting_complete": "true",
+            "semantic_contract_entries": "1",
+            "semantic_contract_calls": "12",
+            "semantic_bounded_geometry_calls": "12",
+            "semantic_bounded_texture_calls": "12",
+            "semantic_stable_template_calls": "12",
+            "semantic_stable_resource_calls": "12",
+            "semantic_template_variations": "0",
+            "semantic_resource_variations": "0",
+            "semantic_catalog_accounting_complete": "true",
         },
     ]
 
@@ -161,6 +253,11 @@ class SemanticDrawTests(unittest.TestCase):
         self.assertEqual(1, document["totals"]["unique_prepared_signatures"])
         self.assertTrue(document["physical_pm4_packet_correlation_proved"])
         self.assertTrue(document["prepared_draw_lineage_proved"])
+        self.assertTrue(document["compact_semantic_catalog_proved"])
+        self.assertEqual(1, document["totals"]["semantic_template_count"])
+        self.assertEqual(1, document["totals"]["semantic_batch_group_count"])
+        self.assertEqual(12, document["totals"]["semantic_batchable_calls"])
+        self.assertFalse(document["native_batching_enabled"])
         self.assertFalse(document["safety"]["native_draw"])
         self.assertFalse(document["safety"]["suppression_allowed"])
 
@@ -175,6 +272,12 @@ class SemanticDrawTests(unittest.TestCase):
         summary["semantic_draw_packet_matches"] = "0"
         summary["semantic_draw_prepared_matches"] = "0"
         summary["semantic_draw_accounting_complete"] = "false"
+        summary["semantic_contract_entries"] = "0"
+        summary["semantic_contract_calls"] = "0"
+        summary["semantic_bounded_geometry_calls"] = "0"
+        summary["semantic_bounded_texture_calls"] = "0"
+        summary["semantic_stable_template_calls"] = "0"
+        summary["semantic_stable_resource_calls"] = "0"
         document = MODULE.build(observed, static_inventory())
         self.assertEqual("complete", document["status"])
         self.assertFalse(document["prepared_draw_lineage_proved"])
@@ -194,6 +297,11 @@ class SemanticDrawTests(unittest.TestCase):
         summary["semantic_draw_packets_recorded"] = "15"
         summary["semantic_draw_packet_matches"] = "15"
         summary["semantic_draw_prepared_matches"] = "15"
+        summary["semantic_contract_calls"] = "15"
+        summary["semantic_bounded_geometry_calls"] = "15"
+        summary["semantic_bounded_texture_calls"] = "15"
+        summary["semantic_stable_template_calls"] = "15"
+        summary["semantic_stable_resource_calls"] = "15"
         document = MODULE.build(observed, static_inventory())
         self.assertEqual(12, document["totals"]["semantic_submissions"])
         self.assertEqual(15, document["totals"]["prepared_draw_calls"])
@@ -203,6 +311,27 @@ class SemanticDrawTests(unittest.TestCase):
         observed = copy.deepcopy(events())
         observed[3]["semantic_record_index"] = "5"
         with self.assertRaisesRegex(ValueError, "identity or safety"):
+            MODULE.build(observed, static_inventory())
+
+    def test_keeps_varying_resources_out_of_conservative_batches(self):
+        observed = copy.deepcopy(events())
+        observed[3]["semantic_resource_variations"] = "1"
+        summary = observed[-1]
+        summary["semantic_stable_resource_calls"] = "0"
+        summary["semantic_resource_variations"] = "1"
+        document = MODULE.build(observed, static_inventory())
+        self.assertFalse(document["compact_semantic_catalog_proved"])
+        self.assertEqual(0, document["totals"]["semantic_batchable_calls"])
+        self.assertFalse(document["batch_groups"][0]["batchable"])
+
+    def test_rejects_submission_without_an_immutable_instance(self):
+        observed = [
+            event
+            for event in copy.deepcopy(events())
+            if event.get("event")
+            != "native_renderer.discovery.semantic_instance_entry"
+        ]
+        with self.assertRaisesRegex(ValueError, "no immutable instance"):
             MODULE.build(observed, static_inventory())
 
     def test_rejects_incomplete_scope_accounting(self):


### PR DESCRIPTION
## Summary

- capture immutable prepared-template contracts separately from dynamic geometry and texture resources
- join prepared draws to exact semantic instances and submissions
- emit fail-closed conservative batch groups while keeping Xenos authoritative
- document the qualified semantic instance catalog and runtime evidence

## Validation

- `python -m unittest discover -s tools/tests -p 'test_*.py'` (322 tests)
- Release build via `tools/build-preview.ps1 -Parallel 16 -JsonEvents`
- AppData qualification session `20260829T210122Z-p37672`
- 403,015 prepared associations, 900 templates, 1,067 conservative batch groups
- 29.672 median FPS and 59.959 Hz presentation cadence
- normal exit; no crash, fatal, assertion, or device-loss log markers

## Safety

- no native upload, native draw, or native batching
- no guest-state mutation or Xenos suppression