### PR TITLE
feat(native-renderer): measure semantic batch admission

### DIFF
--- a/docs/native-renderer/SEMANTIC_BATCH_ADMISSION.md
+++ b/docs/native-renderer/SEMANTIC_BATCH_ADMISSION.md
@@ -1,0 +1,123 @@
+# Semantic batch-admission census
+
+This NR-05C measurement checkpoint turns the global semantic catalog into an
+execution-order plan. It records only exact consecutive prepared draws and
+never assumes that globally compatible groups may be reordered. The census is
+passive: Xenos still executes every draw, and native upload, drawing, batching,
+admission, and suppression remain disabled.
+
+## Exact batch identity
+
+One opportunity key combines:
+
+- the immutable prepared-template key;
+- decoded geometry- and texture-resource hashes;
+- the title's primary and optional secondary resource keys;
+- the fail-closed eligibility result.
+
+The title resource keys travel with the already-proved semantic submission
+identity into the physical `PM4_DRAW_INDX` join. They are not looked up again
+from mutable guest state at backend time.
+
+An executable run exists only while eligible draws with the same exact key are
+adjacent in one frame. A frame boundary, rejected draw, or key transition
+closes the run. The census performs no front-to-back or material reordering.
+
+## Admission boundary
+
+The first measured admission class is intentionally narrow. A draw must have:
+
+- a nonzero title primary-resource key;
+- opaque color writes with blending disabled;
+- no resolved render-target input;
+- no query/conditional behavior or memexport;
+- bounded geometry with one supported vertex binding and a supported indexed
+  or auto-index source;
+- bounded texture layout with one to four fetches;
+- no constant-observation overflow;
+- a complete prepared vertex/pixel pipeline and the expected color/depth
+  target coverage.
+
+Every first failing predicate is counted by name. Rejected entries retain
+their exact template/resource identity and remain on Xenos. Eligibility is a
+measurement classification, not permission to upload, issue, or suppress a
+draw.
+
+## Measurements
+
+For each exact opportunity the runtime records draw and frame coverage,
+consecutive runs, multi-draw runs and their draw coverage, maximum run length,
+and whether consecutive draws switch semantic instances or repeat the same
+instance. The summary additionally records per-frame density and template,
+geometry, texture, and title-resource transitions.
+
+Projected command count is conservative:
+
+```text
+eligible consecutive runs + rejected Xenos draws
+```
+
+Potential reduction is the eligible draw count minus eligible consecutive
+runs. It is not a performance claim; it is the upper bound for a future
+order-preserving implementation with the current admission rules.
+
+## Fail-closed report
+
+Generate the report from the same diagnostic session and static dispatch
+inventory used by the semantic catalog:
+
+```powershell
+python tools/summarize-native-renderer-semantic-batches.py `
+  <diagnostic-jsonl> `
+  --static <native-renderer-dispatch-static.json> `
+  --session <session> `
+  --output <semantic-batch-admission.json>
+```
+
+Schema `pinyon-shift.native-renderer-semantic-batch-admission.v1` requires:
+
+- one armed provenance configuration and one batch summary;
+- exact equality with the prepared semantic-contract call count;
+- zero matched unprepared draws and zero opportunity-table overflow;
+- entry, run, rejection, projected-command, and reduction accounting to
+  reconcile exactly;
+- explicit Xenos authority with native execution and suppression disabled.
+
+`conservative_batch_plan_proved` also requires at least one eligible draw, one
+multi-draw run, and a nonzero order-preserving command reduction. Failure keeps
+the plan unproved and does not change runtime rendering.
+
+## Qualification result
+
+Release/AppData session `20260829T211909Z-p31988` exercised 2,839 frames of
+live festival gameplay and classified 938,575 exact prepared semantic draws.
+Of those, 635,197 passed the narrow admission predicates. The remaining
+303,378 were rejected fail-closed: 166,953 for non-opaque state and 136,425
+for resolved-render-target input. No opportunity-table overflow or accounting
+fault occurred.
+
+The exact executable-order result is decisive: all 635,197 eligible draws
+formed single-draw runs. Maximum run length was one, multi-draw run coverage
+was zero, and the projected command reduction was therefore zero. The report
+correctly leaves `conservative_batch_plan_proved` false. This is not a runtime
+failure; it proves that the full template/geometry/texture/title-resource key
+is too specific to justify an executor in the observed scene.
+
+The same session exited normally with Xenos authoritative and native upload,
+draw, batch execution, reordering, admission, and suppression disabled. It
+measured 29.725 median FPS, 15.151 FPS one-percent low, 59.986 Hz presentation,
+and zero present-deadline misses. The rendered festival scene remained
+visually intact. The admission report SHA-256 is
+`D694D7683ABBD05B0D678BDB40A99EDA75FFE1F51AA9958A1428C39B411ABF3F`.
+The saved progress image is
+`.local/qualification/native-renderer-semantic-batch-progress.jpg`, SHA-256
+`BAE6948F17E50F07B288B316C4E557AD2FE0858485F7658517FDC25C5C4E3971`.
+
+## Next gate
+
+Do not implement an executor for this exact grouping. First measure a safe
+coarser equivalence boundary that separates immutable mesh/material state from
+per-instance resource identity, or evaluate an order-preserving instancing
+path that can carry per-draw parameters explicitly. Any later executor must
+still retain per-item Xenos fallback and remain incapable of suppression until
+paired visual and side-effect qualification passes.

--- a/docs/native-renderer/SEMANTIC_INSTANCE_CATALOG.md
+++ b/docs/native-renderer/SEMANTIC_INSTANCE_CATALOG.md
@@ -125,3 +125,13 @@ The live 3072x1728 screenshot is
 `.local/qualification/native-renderer-semantic-instance-catalog-progress.png`,
 SHA-256
 `F792181CBF2A11251259D1F54A79F0F22CE0161098FAEE6643BC0E5007AF1941`.
+
+The next NR-05C checkpoint converts these global groups into a conservative
+execution-order census. It admits only exact consecutive opaque prepared draws
+within one frame, records every rejection reason, and measures projected
+command reduction without issuing native work. See
+`SEMANTIC_BATCH_ADMISSION.md`.
+
+Session `20260829T211909Z-p31988` completed that census and found no adjacent
+multi-draw runs under the exact full-resource identity. An executor remains
+deferred pending a safely coarser equivalence boundary.

--- a/src/native_renderer/graphics_hooks.cpp
+++ b/src/native_renderer/graphics_hooks.cpp
@@ -94,6 +94,8 @@ constexpr size_t kSemanticSubmissionCapacity = 8192;
 constexpr size_t kSemanticRenderItemStackCapacity = 32;
 constexpr size_t kSemanticPreparedTemplateCapacity =
     kTitleDrawProvenanceCapacity;
+constexpr size_t kSemanticBatchOpportunityCapacity =
+    kTitleDrawProvenanceCapacity;
 constexpr size_t kSemanticDescriptorWordCount = 92 / sizeof(uint32_t);
 constexpr size_t kSemanticRuntimeWordCount = 68 / sizeof(uint32_t);
 constexpr size_t kSemanticTransformWordCount = 192 / sizeof(uint32_t);
@@ -143,8 +145,13 @@ struct SemanticDrawIdentity {
   uint32_t record_index = 0;
   uint32_t descriptor_address = 0;
   uint32_t runtime_address = 0;
+  uint32_t descriptor_kind = 0;
+  uint32_t helper_state = 0;
+  uint32_t primary_resource_key = 0;
+  uint32_t secondary_resource_key = 0;
   uint32_t direct_title_origins = 0;
   uint32_t indirect_packet_origins = 0;
+  bool secondary_resource_present = false;
   bool valid = false;
 };
 
@@ -198,6 +205,55 @@ struct SemanticPreparedDrawContract {
   bool indexed = false;
   bool geometry_bounded = false;
   bool texture_layout_bounded = false;
+  bool valid = false;
+};
+
+enum class SemanticBatchRejection : uint32_t {
+  kNone = 0,
+  kMissingTitleResource = 1,
+  kNonOpaque = 2,
+  kResolvedInput = 3,
+  kQueryOrConditional = 4,
+  kMemexport = 5,
+  kUnboundedGeometry = 6,
+  kUnsupportedGeometry = 7,
+  kConstantOverflow = 8,
+  kUnboundedTextureLayout = 9,
+  kTextureCount = 10,
+  kIncompletePreparedPipeline = 11,
+  kRenderTargetCoverage = 12,
+  kCount = 13,
+};
+
+struct SemanticBatchOpportunityEntry {
+  uint64_t key = 0;
+  uint64_t template_key = 0;
+  uint64_t geometry_resource_hash = 0;
+  uint64_t texture_resource_hash = 0;
+  uint64_t draws = 0;
+  uint64_t frames = 0;
+  uint64_t first_frame = 0;
+  uint64_t last_frame = 0;
+  uint64_t consecutive_runs = 0;
+  uint64_t multi_draw_runs = 0;
+  uint64_t multi_draw_draws = 0;
+  uint64_t maximum_run_length = 0;
+  uint64_t instance_switches = 0;
+  uint64_t same_instance_continuations = 0;
+  uint32_t primary_resource_key = 0;
+  uint32_t secondary_resource_key = 0;
+  SemanticBatchRejection rejection = SemanticBatchRejection::kNone;
+  bool secondary_resource_present = false;
+};
+
+struct SemanticBatchRun {
+  uint64_t key = 0;
+  uint64_t frame = 0;
+  uint64_t length = 0;
+  size_t opportunity_index = 0;
+  uint32_t receiver_address = 0;
+  uint32_t receiver_generation = 0;
+  uint32_t record_index = 0;
   bool valid = false;
 };
 
@@ -294,6 +350,9 @@ std::array<TitlePacketProvenanceEntry, kTitlePacketProvenanceCapacity>
     g_title_packet_provenance{};
 std::array<TitleDrawProvenanceEntry, kTitleDrawProvenanceCapacity>
     g_title_draw_provenance{};
+std::array<SemanticBatchOpportunityEntry,
+           kSemanticBatchOpportunityCapacity>
+    g_semantic_batch_opportunities{};
 std::array<TitleIndirectPacketEntry, kTitleIndirectPacketCapacity>
     g_title_indirect_packets{};
 std::mutex g_title_packet_provenance_mutex;
@@ -320,6 +379,32 @@ std::atomic<uint64_t> g_title_origin_stack_overflow{};
 std::atomic<uint64_t> g_title_packets_without_origin{};
 uint64_t g_title_draw_provenance_count = 0;
 uint64_t g_title_draw_provenance_overflow = 0;
+uint64_t g_semantic_batch_observations = 0;
+uint64_t g_semantic_batch_eligible_draws = 0;
+uint64_t g_semantic_batch_rejected_draws = 0;
+uint64_t g_semantic_batch_opportunity_count = 0;
+uint64_t g_semantic_batch_opportunity_overflow = 0;
+uint64_t g_semantic_batch_consecutive_runs = 0;
+uint64_t g_semantic_batch_multi_draw_runs = 0;
+uint64_t g_semantic_batch_multi_draw_draws = 0;
+uint64_t g_semantic_batch_maximum_run_length = 0;
+uint64_t g_semantic_batch_instance_switches = 0;
+uint64_t g_semantic_batch_same_instance_continuations = 0;
+uint64_t g_semantic_batch_frame_count = 0;
+uint64_t g_semantic_batch_current_frame = 0;
+uint64_t g_semantic_batch_current_frame_draws = 0;
+uint64_t g_semantic_batch_maximum_draws_per_frame = 0;
+uint64_t g_semantic_batch_template_transitions = 0;
+uint64_t g_semantic_batch_geometry_transitions = 0;
+uint64_t g_semantic_batch_texture_transitions = 0;
+uint64_t g_semantic_batch_title_resource_transitions = 0;
+std::array<uint64_t, size_t(SemanticBatchRejection::kCount)>
+    g_semantic_batch_rejections{};
+SemanticBatchRun g_semantic_batch_run{};
+SemanticPreparedDrawContract g_semantic_batch_previous_contract{};
+SemanticDrawIdentity g_semantic_batch_previous_identity{};
+uint64_t g_semantic_batch_previous_frame = 0;
+bool g_semantic_batch_previous_eligible = false;
 uint64_t g_title_packet_submission_sequence = 0;
 uint64_t g_title_indirect_packets_recorded = 0;
 uint64_t g_title_indirect_packet_address_failures = 0;
@@ -824,6 +909,10 @@ void ResetTitleDrawProvenance() {
   for (TitleDrawProvenanceEntry &entry : g_title_draw_provenance) {
     entry = {};
   }
+  for (SemanticBatchOpportunityEntry &entry :
+       g_semantic_batch_opportunities) {
+    entry = {};
+  }
   for (TitleIndirectPacketEntry &entry : g_title_indirect_packets) {
     entry = {};
   }
@@ -846,6 +935,31 @@ void ResetTitleDrawProvenance() {
   g_title_packets_without_origin.store(0, std::memory_order_relaxed);
   g_title_draw_provenance_count = 0;
   g_title_draw_provenance_overflow = 0;
+  g_semantic_batch_observations = 0;
+  g_semantic_batch_eligible_draws = 0;
+  g_semantic_batch_rejected_draws = 0;
+  g_semantic_batch_opportunity_count = 0;
+  g_semantic_batch_opportunity_overflow = 0;
+  g_semantic_batch_consecutive_runs = 0;
+  g_semantic_batch_multi_draw_runs = 0;
+  g_semantic_batch_multi_draw_draws = 0;
+  g_semantic_batch_maximum_run_length = 0;
+  g_semantic_batch_instance_switches = 0;
+  g_semantic_batch_same_instance_continuations = 0;
+  g_semantic_batch_frame_count = 0;
+  g_semantic_batch_current_frame = 0;
+  g_semantic_batch_current_frame_draws = 0;
+  g_semantic_batch_maximum_draws_per_frame = 0;
+  g_semantic_batch_template_transitions = 0;
+  g_semantic_batch_geometry_transitions = 0;
+  g_semantic_batch_texture_transitions = 0;
+  g_semantic_batch_title_resource_transitions = 0;
+  g_semantic_batch_rejections = {};
+  g_semantic_batch_run = {};
+  g_semantic_batch_previous_contract = {};
+  g_semantic_batch_previous_identity = {};
+  g_semantic_batch_previous_frame = 0;
+  g_semantic_batch_previous_eligible = false;
   g_title_packet_submission_sequence = 0;
   g_title_indirect_packets_recorded = 0;
   g_title_indirect_packet_address_failures = 0;
@@ -1086,6 +1200,8 @@ void ConfigureTitleDrawProvenance(bool census_requested,
        {"packet_key", "physical_pm4_header_address"},
        {"packet_capacity", std::to_string(kTitlePacketProvenanceCapacity)},
        {"aggregate_capacity", std::to_string(kTitleDrawProvenanceCapacity)},
+       {"semantic_batch_opportunity_capacity",
+        std::to_string(kSemanticBatchOpportunityCapacity)},
        {"origin_stack_capacity", std::to_string(kTitleOriginStackCapacity)},
        {"semantic_render_item_stack_capacity",
         std::to_string(kSemanticRenderItemStackCapacity)},
@@ -1106,7 +1222,11 @@ void ConfigureTitleDrawProvenance(bool census_requested,
        {"metadata",
         "origin_wrapper,entry_lr,r3-r10,outcome,backend_outcome,"
         "backend_signature,semantic_submission_key,semantic_receiver,"
-        "semantic_record_index"},
+        "semantic_record_index,semantic_template_key,geometry_resource,"
+        "texture_resource,title_resource_keys"},
+       {"semantic_batch_planner",
+        "exact_consecutive_opaque_prepared_draw_order"},
+       {"semantic_batch_execution", "disabled_measurement_only"},
        {"guest_payload_read", "false"},
        {"guest_state_changed", "false"},
        {"control_flow_changed", "false"},
@@ -4310,7 +4430,12 @@ void JoinProceduralModelSemanticDraw(uint64_t submission_key,
                                      uint32_t receiver_generation,
                                      uint32_t record_index,
                                      uint32_t descriptor_address,
-                                     uint32_t runtime_address) {
+                                     uint32_t runtime_address,
+                                     uint32_t descriptor_kind,
+                                     uint32_t helper_state,
+                                     uint32_t primary_resource_key,
+                                     uint32_t secondary_resource_key,
+                                     bool secondary_resource_present) {
   if (!g_semantic_render_item_stack_depth) {
     g_semantic_draw_scope_mismatches.fetch_add(1,
                                                 std::memory_order_relaxed);
@@ -4329,6 +4454,11 @@ void JoinProceduralModelSemanticDraw(uint64_t submission_key,
     return;
   }
   semantic_draw.submission_key = submission_key;
+  semantic_draw.descriptor_kind = descriptor_kind;
+  semantic_draw.helper_state = helper_state;
+  semantic_draw.primary_resource_key = primary_resource_key;
+  semantic_draw.secondary_resource_key = secondary_resource_key;
+  semantic_draw.secondary_resource_present = secondary_resource_present;
   semantic_draw.valid = true;
   g_semantic_draw_scope_joins.fetch_add(1, std::memory_order_relaxed);
 }
@@ -4550,7 +4680,9 @@ void RecordProceduralModelGeometrySubmission(
   key = key ? key : 1;
   JoinProceduralModelSemanticDraw(
       key, receiver_address, receiver_generation, record_index,
-      descriptor_address, runtime_address);
+      descriptor_address, runtime_address, descriptor_kind, helper_state,
+      primary_resource_key, secondary_resource_key,
+      secondary_resource_present);
 
   size_t index = size_t(key % kSemanticSubmissionCapacity);
   for (size_t probe = 0; probe < kSemanticSubmissionCapacity; ++probe) {
@@ -7601,6 +7733,455 @@ bool IsIsolatedDrawEligible(
          (prepared.flags & 3) == 3 && prepared.bound_render_target_bits == 3;
 }
 
+const char *SemanticBatchRejectionName(SemanticBatchRejection rejection) {
+  switch (rejection) {
+  case SemanticBatchRejection::kNone:
+    return "none";
+  case SemanticBatchRejection::kMissingTitleResource:
+    return "missing_title_resource";
+  case SemanticBatchRejection::kNonOpaque:
+    return "non_opaque";
+  case SemanticBatchRejection::kResolvedInput:
+    return "resolved_input";
+  case SemanticBatchRejection::kQueryOrConditional:
+    return "query_or_conditional";
+  case SemanticBatchRejection::kMemexport:
+    return "memexport";
+  case SemanticBatchRejection::kUnboundedGeometry:
+    return "unbounded_geometry";
+  case SemanticBatchRejection::kUnsupportedGeometry:
+    return "unsupported_geometry";
+  case SemanticBatchRejection::kConstantOverflow:
+    return "constant_overflow";
+  case SemanticBatchRejection::kUnboundedTextureLayout:
+    return "unbounded_texture_layout";
+  case SemanticBatchRejection::kTextureCount:
+    return "texture_count";
+  case SemanticBatchRejection::kIncompletePreparedPipeline:
+    return "incomplete_prepared_pipeline";
+  case SemanticBatchRejection::kRenderTargetCoverage:
+    return "render_target_coverage";
+  case SemanticBatchRejection::kCount:
+    break;
+  }
+  return "unknown";
+}
+
+SemanticBatchRejection ClassifySemanticBatchRejection(
+    const rex::system::GraphicsDrawObservation &observation,
+    bool samples_resolved_target,
+    const rex::system::GraphicsPreparedDrawObservation &prepared,
+    const SemanticDrawIdentity &identity,
+    const SemanticPreparedDrawContract &contract) {
+  if (!identity.primary_resource_key) {
+    return SemanticBatchRejection::kMissingTitleResource;
+  }
+  if (!IsOpaqueColorState(observation)) {
+    return SemanticBatchRejection::kNonOpaque;
+  }
+  if (samples_resolved_target) {
+    return SemanticBatchRejection::kResolvedInput;
+  }
+  if (observation.viz_query_condition || (observation.pa_sc_viz_query & 1)) {
+    return SemanticBatchRejection::kQueryOrConditional;
+  }
+  if (observation.vertex_memexport) {
+    return SemanticBatchRejection::kMemexport;
+  }
+  if (!contract.geometry_bounded || observation.vertex_binding_count != 1) {
+    return SemanticBatchRejection::kUnboundedGeometry;
+  }
+  const bool supported_geometry =
+      (observation.indexed &&
+       observation.source_select ==
+           uint32_t(rex::graphics::xenos::SourceSelect::kDMA) &&
+       observation.index_format <= 1 && observation.index_endianness <= 3 &&
+       prepared.index_buffer_type == 1) ||
+      (!observation.indexed &&
+       observation.source_select ==
+           uint32_t(rex::graphics::xenos::SourceSelect::kAutoIndex) &&
+       prepared.index_buffer_type == 0);
+  if (!supported_geometry) {
+    return SemanticBatchRejection::kUnsupportedGeometry;
+  }
+  if (observation.vertex_float_constant_overflow ||
+      observation.pixel_float_constant_overflow) {
+    return SemanticBatchRejection::kConstantOverflow;
+  }
+  if (!contract.texture_layout_bounded) {
+    return SemanticBatchRejection::kUnboundedTextureLayout;
+  }
+  const uint32_t texture_count = std::popcount(observation.texture_fetch_mask);
+  if (texture_count < 1 || texture_count > 4) {
+    return SemanticBatchRejection::kTextureCount;
+  }
+  if ((prepared.flags & 3) != 3) {
+    return SemanticBatchRejection::kIncompletePreparedPipeline;
+  }
+  if (prepared.bound_render_target_bits != 3) {
+    return SemanticBatchRejection::kRenderTargetCoverage;
+  }
+  return SemanticBatchRejection::kNone;
+}
+
+void FinalizeSemanticBatchFrame() {
+  if (!g_semantic_batch_current_frame) {
+    return;
+  }
+  ++g_semantic_batch_frame_count;
+  g_semantic_batch_maximum_draws_per_frame =
+      std::max(g_semantic_batch_maximum_draws_per_frame,
+               g_semantic_batch_current_frame_draws);
+  g_semantic_batch_current_frame = 0;
+  g_semantic_batch_current_frame_draws = 0;
+}
+
+void FinalizeSemanticBatchRun() {
+  if (!g_semantic_batch_run.valid) {
+    return;
+  }
+  SemanticBatchOpportunityEntry &entry =
+      g_semantic_batch_opportunities[g_semantic_batch_run.opportunity_index];
+  ++entry.consecutive_runs;
+  entry.maximum_run_length =
+      std::max(entry.maximum_run_length, g_semantic_batch_run.length);
+  ++g_semantic_batch_consecutive_runs;
+  g_semantic_batch_maximum_run_length =
+      std::max(g_semantic_batch_maximum_run_length,
+               g_semantic_batch_run.length);
+  if (g_semantic_batch_run.length > 1) {
+    ++entry.multi_draw_runs;
+    entry.multi_draw_draws += g_semantic_batch_run.length;
+    ++g_semantic_batch_multi_draw_runs;
+    g_semantic_batch_multi_draw_draws += g_semantic_batch_run.length;
+  }
+  g_semantic_batch_run = {};
+}
+
+size_t FindOrCreateSemanticBatchOpportunity(
+    uint64_t key, const SemanticPreparedDrawContract &contract,
+    const SemanticDrawIdentity &identity, SemanticBatchRejection rejection) {
+  size_t index = size_t(key % kSemanticBatchOpportunityCapacity);
+  for (size_t probe = 0; probe < kSemanticBatchOpportunityCapacity; ++probe) {
+    SemanticBatchOpportunityEntry &entry =
+        g_semantic_batch_opportunities[index];
+    if (!entry.key) {
+      entry.key = key;
+      entry.template_key = contract.template_key;
+      entry.geometry_resource_hash = contract.geometry_resource_hash;
+      entry.texture_resource_hash = contract.texture_resource_hash;
+      entry.primary_resource_key = identity.primary_resource_key;
+      entry.secondary_resource_key = identity.secondary_resource_key;
+      entry.secondary_resource_present = identity.secondary_resource_present;
+      entry.rejection = rejection;
+      ++g_semantic_batch_opportunity_count;
+      return index;
+    }
+    if (entry.key == key && entry.template_key == contract.template_key &&
+        entry.geometry_resource_hash == contract.geometry_resource_hash &&
+        entry.texture_resource_hash == contract.texture_resource_hash &&
+        entry.primary_resource_key == identity.primary_resource_key &&
+        entry.secondary_resource_key == identity.secondary_resource_key &&
+        entry.secondary_resource_present ==
+            identity.secondary_resource_present &&
+        entry.rejection == rejection) {
+      return index;
+    }
+    index = (index + 1) % kSemanticBatchOpportunityCapacity;
+  }
+  ++g_semantic_batch_opportunity_overflow;
+  return kSemanticBatchOpportunityCapacity;
+}
+
+void RecordSemanticBatchOpportunity(
+    const rex::system::GraphicsDrawObservation &observation,
+    bool samples_resolved_target,
+    const rex::system::GraphicsPreparedDrawObservation &prepared,
+    const TitleDrawOrigin &origin) {
+  if (!origin.semantic_draw.valid) {
+    return;
+  }
+  const SemanticDrawIdentity &identity = origin.semantic_draw;
+  const SemanticPreparedDrawContract contract =
+      BuildSemanticPreparedDrawContract(observation, prepared);
+  const SemanticBatchRejection rejection =
+      ClassifySemanticBatchRejection(observation, samples_resolved_target,
+                                     prepared, identity, contract);
+  const bool eligible = rejection == SemanticBatchRejection::kNone;
+  ++g_semantic_batch_observations;
+  if (g_semantic_batch_current_frame != observation.frame_sequence) {
+    FinalizeSemanticBatchFrame();
+    g_semantic_batch_current_frame = observation.frame_sequence;
+  }
+  ++g_semantic_batch_current_frame_draws;
+
+  uint64_t key = UINT64_C(0xCBF29CE484222325);
+  for (uint64_t value :
+       {contract.template_key, contract.geometry_resource_hash,
+        contract.texture_resource_hash, uint64_t(identity.primary_resource_key),
+        uint64_t(identity.secondary_resource_present),
+        uint64_t(identity.secondary_resource_key), uint64_t(rejection)}) {
+    key = HashCombine(key, value);
+  }
+  key = key ? key : 1;
+  const size_t opportunity_index = FindOrCreateSemanticBatchOpportunity(
+      key, contract, identity, rejection);
+  if (opportunity_index == kSemanticBatchOpportunityCapacity) {
+    FinalizeSemanticBatchRun();
+    g_semantic_batch_previous_eligible = false;
+    return;
+  }
+  SemanticBatchOpportunityEntry &entry =
+      g_semantic_batch_opportunities[opportunity_index];
+  ++entry.draws;
+  if (!entry.first_frame) {
+    entry.first_frame = observation.frame_sequence;
+  }
+  if (entry.last_frame != observation.frame_sequence) {
+    ++entry.frames;
+  }
+  entry.last_frame = observation.frame_sequence;
+
+  if (!eligible) {
+    ++g_semantic_batch_rejected_draws;
+    ++g_semantic_batch_rejections[size_t(rejection)];
+    FinalizeSemanticBatchRun();
+    g_semantic_batch_previous_eligible = false;
+    return;
+  }
+  ++g_semantic_batch_eligible_draws;
+  if (g_semantic_batch_previous_eligible &&
+      g_semantic_batch_previous_frame == observation.frame_sequence) {
+    g_semantic_batch_template_transitions +=
+        g_semantic_batch_previous_contract.template_key !=
+        contract.template_key;
+    g_semantic_batch_geometry_transitions +=
+        g_semantic_batch_previous_contract.geometry_resource_hash !=
+        contract.geometry_resource_hash;
+    g_semantic_batch_texture_transitions +=
+        g_semantic_batch_previous_contract.texture_resource_hash !=
+        contract.texture_resource_hash;
+    g_semantic_batch_title_resource_transitions +=
+        g_semantic_batch_previous_identity.primary_resource_key !=
+            identity.primary_resource_key ||
+        g_semantic_batch_previous_identity.secondary_resource_present !=
+            identity.secondary_resource_present ||
+        g_semantic_batch_previous_identity.secondary_resource_key !=
+            identity.secondary_resource_key;
+  }
+  g_semantic_batch_previous_contract = contract;
+  g_semantic_batch_previous_identity = identity;
+  g_semantic_batch_previous_frame = observation.frame_sequence;
+  g_semantic_batch_previous_eligible = true;
+
+  if (g_semantic_batch_run.valid &&
+      g_semantic_batch_run.frame == observation.frame_sequence &&
+      g_semantic_batch_run.key == key) {
+    const bool same_instance =
+        g_semantic_batch_run.receiver_address == identity.receiver_address &&
+        g_semantic_batch_run.receiver_generation ==
+            identity.receiver_generation &&
+        g_semantic_batch_run.record_index == identity.record_index;
+    if (same_instance) {
+      ++entry.same_instance_continuations;
+      ++g_semantic_batch_same_instance_continuations;
+    } else {
+      ++entry.instance_switches;
+      ++g_semantic_batch_instance_switches;
+    }
+    ++g_semantic_batch_run.length;
+    g_semantic_batch_run.receiver_address = identity.receiver_address;
+    g_semantic_batch_run.receiver_generation = identity.receiver_generation;
+    g_semantic_batch_run.record_index = identity.record_index;
+    return;
+  }
+  FinalizeSemanticBatchRun();
+  g_semantic_batch_run = {
+      .key = key,
+      .frame = observation.frame_sequence,
+      .length = 1,
+      .opportunity_index = opportunity_index,
+      .receiver_address = identity.receiver_address,
+      .receiver_generation = identity.receiver_generation,
+      .record_index = identity.record_index,
+      .valid = true,
+  };
+}
+
+void EmitSemanticBatchOpportunitySummary() {
+  FinalizeSemanticBatchRun();
+  FinalizeSemanticBatchFrame();
+  uint64_t entry_draws = 0;
+  uint64_t entry_eligible_draws = 0;
+  uint64_t entry_rejected_draws = 0;
+  uint64_t entry_runs = 0;
+  uint64_t entry_multi_draw_runs = 0;
+  uint64_t entry_multi_draw_draws = 0;
+  uint64_t rejection_total = 0;
+  for (uint64_t count : g_semantic_batch_rejections) {
+    rejection_total += count;
+  }
+  for (const SemanticBatchOpportunityEntry &entry :
+       g_semantic_batch_opportunities) {
+    if (!entry.key) {
+      continue;
+    }
+    entry_draws += entry.draws;
+    if (entry.rejection == SemanticBatchRejection::kNone) {
+      entry_eligible_draws += entry.draws;
+    } else {
+      entry_rejected_draws += entry.draws;
+    }
+    entry_runs += entry.consecutive_runs;
+    entry_multi_draw_runs += entry.multi_draw_runs;
+    entry_multi_draw_draws += entry.multi_draw_draws;
+    pinyon_shift::diagnostics::RecordEvent(
+        "native_renderer.discovery.semantic_batch_entry",
+        {{"opportunity_key", fmt::format("{:016X}", entry.key)},
+         {"template_key", fmt::format("{:016X}", entry.template_key)},
+         {"geometry_resource_hash",
+          fmt::format("{:016X}", entry.geometry_resource_hash)},
+         {"texture_resource_hash",
+          fmt::format("{:016X}", entry.texture_resource_hash)},
+         {"primary_resource_key",
+          fmt::format("{:08X}", entry.primary_resource_key)},
+         {"secondary_resource_present",
+          entry.secondary_resource_present ? "true" : "false"},
+         {"secondary_resource_key",
+          fmt::format("{:08X}", entry.secondary_resource_key)},
+         {"draws", std::to_string(entry.draws)},
+         {"frames", std::to_string(entry.frames)},
+         {"first_frame", std::to_string(entry.first_frame)},
+         {"last_frame", std::to_string(entry.last_frame)},
+         {"consecutive_runs", std::to_string(entry.consecutive_runs)},
+         {"multi_draw_runs", std::to_string(entry.multi_draw_runs)},
+         {"multi_draw_draws", std::to_string(entry.multi_draw_draws)},
+         {"maximum_run_length",
+          std::to_string(entry.maximum_run_length)},
+         {"instance_switches", std::to_string(entry.instance_switches)},
+         {"same_instance_continuations",
+          std::to_string(entry.same_instance_continuations)},
+         {"eligible",
+          entry.rejection == SemanticBatchRejection::kNone ? "true"
+                                                           : "false"},
+         {"rejection", SemanticBatchRejectionName(entry.rejection)},
+         {"classification",
+          entry.rejection == SemanticBatchRejection::kNone
+              ? "conservative_consecutive_batch_candidate"
+              : "xenos_replay_rejected"},
+         {"native_batch", "false"},
+         {"xenos_draw", "preserved"},
+         {"suppression_allowed", "false"}});
+  }
+  const bool accounting_complete =
+      !g_semantic_batch_opportunity_overflow &&
+      g_semantic_batch_observations ==
+          g_semantic_batch_eligible_draws + g_semantic_batch_rejected_draws &&
+      g_semantic_batch_observations == entry_draws &&
+      g_semantic_batch_eligible_draws == entry_eligible_draws &&
+      g_semantic_batch_rejected_draws == entry_rejected_draws &&
+      g_semantic_batch_rejected_draws == rejection_total &&
+      g_semantic_batch_consecutive_runs == entry_runs &&
+      g_semantic_batch_multi_draw_runs == entry_multi_draw_runs &&
+      g_semantic_batch_multi_draw_draws == entry_multi_draw_draws;
+  const uint64_t projected_commands =
+      g_semantic_batch_consecutive_runs + g_semantic_batch_rejected_draws;
+  const uint64_t potential_command_reduction =
+      g_semantic_batch_eligible_draws >= g_semantic_batch_consecutive_runs
+          ? g_semantic_batch_eligible_draws -
+                g_semantic_batch_consecutive_runs
+          : 0;
+  const double reduction_percent = g_semantic_batch_observations
+                                       ? 100.0 * potential_command_reduction /
+                                             g_semantic_batch_observations
+                                       : 0.0;
+  pinyon_shift::diagnostics::RecordEvent(
+      "native_renderer.discovery.semantic_batch_summary",
+      {{"status", !g_semantic_batch_observations
+                       ? "not_observed"
+                       : (accounting_complete ? "complete"
+                                              : "incomplete")},
+       {"observations", std::to_string(g_semantic_batch_observations)},
+       {"eligible_draws", std::to_string(g_semantic_batch_eligible_draws)},
+       {"rejected_draws", std::to_string(g_semantic_batch_rejected_draws)},
+       {"opportunity_entries",
+        std::to_string(g_semantic_batch_opportunity_count)},
+       {"opportunity_overflow",
+        std::to_string(g_semantic_batch_opportunity_overflow)},
+       {"consecutive_runs",
+        std::to_string(g_semantic_batch_consecutive_runs)},
+       {"multi_draw_runs",
+        std::to_string(g_semantic_batch_multi_draw_runs)},
+       {"multi_draw_draws",
+        std::to_string(g_semantic_batch_multi_draw_draws)},
+       {"maximum_run_length",
+        std::to_string(g_semantic_batch_maximum_run_length)},
+       {"instance_switches",
+        std::to_string(g_semantic_batch_instance_switches)},
+       {"same_instance_continuations",
+        std::to_string(g_semantic_batch_same_instance_continuations)},
+       {"frames", std::to_string(g_semantic_batch_frame_count)},
+       {"maximum_draws_per_frame",
+        std::to_string(g_semantic_batch_maximum_draws_per_frame)},
+       {"template_transitions",
+        std::to_string(g_semantic_batch_template_transitions)},
+       {"geometry_transitions",
+        std::to_string(g_semantic_batch_geometry_transitions)},
+       {"texture_transitions",
+        std::to_string(g_semantic_batch_texture_transitions)},
+       {"title_resource_transitions",
+        std::to_string(g_semantic_batch_title_resource_transitions)},
+       {"projected_commands", std::to_string(projected_commands)},
+       {"potential_command_reduction",
+        std::to_string(potential_command_reduction)},
+       {"potential_command_reduction_percent",
+        fmt::format("{:.3f}", reduction_percent)},
+       {"reject_missing_title_resource",
+        std::to_string(g_semantic_batch_rejections[size_t(
+            SemanticBatchRejection::kMissingTitleResource)])},
+       {"reject_non_opaque",
+        std::to_string(g_semantic_batch_rejections[
+            size_t(SemanticBatchRejection::kNonOpaque)])},
+       {"reject_resolved_input",
+        std::to_string(g_semantic_batch_rejections[
+            size_t(SemanticBatchRejection::kResolvedInput)])},
+       {"reject_query_or_conditional",
+        std::to_string(g_semantic_batch_rejections[size_t(
+            SemanticBatchRejection::kQueryOrConditional)])},
+       {"reject_memexport",
+        std::to_string(g_semantic_batch_rejections[
+            size_t(SemanticBatchRejection::kMemexport)])},
+       {"reject_unbounded_geometry",
+        std::to_string(g_semantic_batch_rejections[size_t(
+            SemanticBatchRejection::kUnboundedGeometry)])},
+       {"reject_unsupported_geometry",
+        std::to_string(g_semantic_batch_rejections[size_t(
+            SemanticBatchRejection::kUnsupportedGeometry)])},
+       {"reject_constant_overflow",
+        std::to_string(g_semantic_batch_rejections[
+            size_t(SemanticBatchRejection::kConstantOverflow)])},
+       {"reject_unbounded_texture_layout",
+        std::to_string(g_semantic_batch_rejections[size_t(
+            SemanticBatchRejection::kUnboundedTextureLayout)])},
+       {"reject_texture_count",
+        std::to_string(g_semantic_batch_rejections[
+            size_t(SemanticBatchRejection::kTextureCount)])},
+       {"reject_incomplete_prepared_pipeline",
+        std::to_string(g_semantic_batch_rejections[size_t(
+            SemanticBatchRejection::kIncompletePreparedPipeline)])},
+       {"reject_render_target_coverage",
+        std::to_string(g_semantic_batch_rejections[size_t(
+            SemanticBatchRejection::kRenderTargetCoverage)])},
+       {"accounting_complete", accounting_complete ? "true" : "false"},
+       {"ordering", "exact_consecutive_prepared_draw_order"},
+       {"reordering", "false"},
+       {"native_batch_execution", "false"},
+       {"native_upload", "false"},
+       {"native_draw", "false"},
+       {"xenos_authority", "true"},
+       {"suppression_allowed", "false"}});
+}
+
 void RecordCandidate(
     const rex::system::GraphicsDrawObservation &observation,
     bool samples_resolved_target,
@@ -7627,6 +8208,9 @@ void ObservePreparedDraw(
     RecordTitleDrawProvenance(prepared_signature, true, 0, sample,
                               g_pending_candidate.title_origin,
                               &observation);
+    RecordSemanticBatchOpportunity(
+        sample, g_pending_candidate.samples_resolved_target, observation,
+        g_pending_candidate.title_origin);
     g_isolated_draw.prepared_signature = prepared_signature;
     g_isolated_draw.frame = sample.frame_sequence;
     g_isolated_draw.draw = sample.draw_sequence;
@@ -10027,6 +10611,7 @@ void UninstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system) {
     g_pending_candidate.valid = false;
   }
   EmitTitleDrawProvenanceSummary();
+  EmitSemanticBatchOpportunitySummary();
   EmitCommandBufferLineageSummary();
   if (g_pass_consumer_trace.pending) {
     ++g_pass_consumer_trace.superseded_without_resolve;

--- a/tools/discover-native-renderer-dispatch.py
+++ b/tools/discover-native-renderer-dispatch.py
@@ -1465,6 +1465,11 @@ def procedural_model_receiver_lifecycle(
             "semantic_catalog_classification": (
                 "immutable_template_and_dynamic_resource_instance"
             ),
+            "semantic_batch_admission_census_required": True,
+            "semantic_batch_ordering": (
+                "exact_consecutive_prepared_draw_order"
+            ),
+            "semantic_batch_execution_enabled": False,
             "physical_pm4_packet_correlation_proved": False,
             "prepared_draw_lineage_proved": False,
             "classification": "procedural_submission_pm4_packet_boundary",

--- a/tools/summarize-native-renderer-semantic-batches.py
+++ b/tools/summarize-native-renderer-semantic-batches.py
@@ -1,0 +1,405 @@
+"""Validate the in-order semantic batch-admission census."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import pathlib
+import sys
+
+
+SCHEMA = "pinyon-shift.native-renderer-semantic-batch-admission.v1"
+STATIC_SCHEMA = "pinyon-shift.native-renderer-dispatch-static.v3"
+TITLE_CONFIG = "native_renderer.discovery.title_provenance_config"
+TITLE_SUMMARY = "native_renderer.discovery.title_provenance_summary"
+BATCH_ENTRY = "native_renderer.discovery.semantic_batch_entry"
+BATCH_SUMMARY = "native_renderer.discovery.semantic_batch_summary"
+EXPECTED_ORDERING = "exact_consecutive_prepared_draw_order"
+REJECTION_FIELDS = {
+    "missing_title_resource": "reject_missing_title_resource",
+    "non_opaque": "reject_non_opaque",
+    "resolved_input": "reject_resolved_input",
+    "query_or_conditional": "reject_query_or_conditional",
+    "memexport": "reject_memexport",
+    "unbounded_geometry": "reject_unbounded_geometry",
+    "unsupported_geometry": "reject_unsupported_geometry",
+    "constant_overflow": "reject_constant_overflow",
+    "unbounded_texture_layout": "reject_unbounded_texture_layout",
+    "texture_count": "reject_texture_count",
+    "incomplete_prepared_pipeline": "reject_incomplete_prepared_pipeline",
+    "render_target_coverage": "reject_render_target_coverage",
+}
+
+
+def read_events(paths: list[pathlib.Path]) -> list[dict]:
+    events = []
+    wanted = {TITLE_CONFIG, TITLE_SUMMARY, BATCH_ENTRY, BATCH_SUMMARY}
+    for path in paths:
+        for line_number, line in enumerate(
+            path.read_text(encoding="utf-8").splitlines(), 1
+        ):
+            if not line.strip():
+                continue
+            try:
+                event = json.loads(line)
+            except json.JSONDecodeError as error:
+                raise ValueError(
+                    f"{path}:{line_number}: invalid JSON: {error}"
+                ) from error
+            if event.get("event") in wanted:
+                events.append(event)
+    return events
+
+
+def _integer(mapping: dict, key: str) -> int:
+    try:
+        return int(mapping.get(key, ""))
+    except (TypeError, ValueError) as error:
+        raise ValueError(f"invalid integer field: {key}") from error
+
+
+def _number(mapping: dict, key: str) -> float:
+    try:
+        return float(mapping.get(key, ""))
+    except (TypeError, ValueError) as error:
+        raise ValueError(f"invalid number field: {key}") from error
+
+
+def _hex(mapping: dict, key: str, width: int) -> str:
+    value = str(mapping.get(key, "")).upper()
+    if len(value) != width:
+        raise ValueError(f"invalid hexadecimal field: {key}")
+    try:
+        int(value, 16)
+    except ValueError as error:
+        raise ValueError(f"invalid hexadecimal field: {key}") from error
+    return value
+
+
+def _boolean(mapping: dict, key: str) -> bool:
+    value = str(mapping.get(key, "")).lower()
+    if value not in {"true", "false"}:
+        raise ValueError(f"invalid boolean field: {key}")
+    return value == "true"
+
+
+def _select_session(events: list[dict], requested: str | None) -> str:
+    if requested:
+        if not any(event.get("session") == requested for event in events):
+            raise ValueError(f"semantic-batch session not found: {requested}")
+        return requested
+    sessions = [
+        str(event.get("session", ""))
+        for event in events
+        if event.get("event") == TITLE_CONFIG
+        and event.get("status") == "armed"
+    ]
+    if not sessions or not sessions[-1]:
+        raise ValueError("no armed semantic-batch session found")
+    return sessions[-1]
+
+
+def _validate_static(static: dict) -> dict:
+    if static.get("schema") != STATIC_SCHEMA:
+        raise ValueError("unsupported static dispatch inventory schema")
+    lifecycle = static.get("procedural_model_receiver_lifecycle", {})
+    contract = lifecycle.get("semantic_draw_association", {})
+    expected = {
+        "semantic_pm4_packet_construction_proved": True,
+        "semantic_pm4_backend_join_required": True,
+        "semantic_prepared_contract_runtime_join_required": True,
+        "semantic_catalog_classification": (
+            "immutable_template_and_dynamic_resource_instance"
+        ),
+        "semantic_batch_admission_census_required": True,
+        "semantic_batch_ordering": EXPECTED_ORDERING,
+        "semantic_batch_execution_enabled": False,
+        "native_rendering_enabled": False,
+        "suppression_eligible": False,
+    }
+    if any(contract.get(key) != value for key, value in expected.items()):
+        raise ValueError("unsupported semantic-batch static contract")
+    return contract
+
+
+def build(events: list[dict], static: dict, requested: str | None = None) -> dict:
+    contract = _validate_static(static)
+    session = _select_session(events, requested)
+    selected = [event for event in events if event.get("session") == session]
+    configs = [event for event in selected if event.get("event") == TITLE_CONFIG]
+    title_summaries = [
+        event for event in selected if event.get("event") == TITLE_SUMMARY
+    ]
+    summaries = [event for event in selected if event.get("event") == BATCH_SUMMARY]
+    if len(configs) != 1 or len(title_summaries) != 1 or len(summaries) != 1:
+        raise ValueError(
+            "semantic-batch session needs one config, title summary, and batch summary"
+        )
+    config = configs[0]
+    title_summary = title_summaries[0]
+    summary = summaries[0]
+    if (
+        config.get("status") != "armed"
+        or config.get("semantic_batch_planner")
+        != "exact_consecutive_opaque_prepared_draw_order"
+        or config.get("semantic_batch_execution")
+        != "disabled_measurement_only"
+        or config.get("xenos_authority") != "true"
+        or config.get("suppression_allowed") != "false"
+    ):
+        raise ValueError("semantic-batch runtime configuration drifted")
+    if (
+        summary.get("status") != "complete"
+        or summary.get("ordering") != EXPECTED_ORDERING
+        or summary.get("reordering") != "false"
+        or summary.get("native_batch_execution") != "false"
+        or summary.get("native_upload") != "false"
+        or summary.get("native_draw") != "false"
+        or summary.get("xenos_authority") != "true"
+        or summary.get("suppression_allowed") != "false"
+        or summary.get("accounting_complete") != "true"
+    ):
+        raise ValueError("semantic-batch summary is incomplete or unsafe")
+
+    entries = []
+    seen_keys = set()
+    entry_draws = 0
+    eligible_draws = 0
+    rejected_draws = 0
+    consecutive_runs = 0
+    multi_draw_runs = 0
+    multi_draw_draws = 0
+    instance_switches = 0
+    same_instance_continuations = 0
+    rejections = {name: 0 for name in REJECTION_FIELDS}
+    for event in selected:
+        if event.get("event") != BATCH_ENTRY:
+            continue
+        opportunity_key = _hex(event, "opportunity_key", 16)
+        if opportunity_key in seen_keys or int(opportunity_key, 16) == 0:
+            raise ValueError("duplicate or zero semantic-batch opportunity key")
+        seen_keys.add(opportunity_key)
+        eligible = _boolean(event, "eligible")
+        rejection = str(event.get("rejection", ""))
+        classification = str(event.get("classification", ""))
+        if eligible:
+            if (
+                rejection != "none"
+                or classification != "conservative_consecutive_batch_candidate"
+            ):
+                raise ValueError("eligible semantic-batch entry is inconsistent")
+        elif (
+            rejection not in REJECTION_FIELDS
+            or classification != "xenos_replay_rejected"
+        ):
+            raise ValueError("rejected semantic-batch entry is inconsistent")
+        if (
+            event.get("native_batch") != "false"
+            or event.get("xenos_draw") != "preserved"
+            or event.get("suppression_allowed") != "false"
+        ):
+            raise ValueError("semantic-batch entry crossed the safety boundary")
+        item = {
+            "opportunity_key": opportunity_key,
+            "template_key": _hex(event, "template_key", 16),
+            "geometry_resource_hash": _hex(
+                event, "geometry_resource_hash", 16
+            ),
+            "texture_resource_hash": _hex(event, "texture_resource_hash", 16),
+            "primary_resource_key": _hex(event, "primary_resource_key", 8),
+            "secondary_resource_present": _boolean(
+                event, "secondary_resource_present"
+            ),
+            "secondary_resource_key": _hex(
+                event, "secondary_resource_key", 8
+            ),
+            "draws": _integer(event, "draws"),
+            "frames": _integer(event, "frames"),
+            "first_frame": _integer(event, "first_frame"),
+            "last_frame": _integer(event, "last_frame"),
+            "consecutive_runs": _integer(event, "consecutive_runs"),
+            "multi_draw_runs": _integer(event, "multi_draw_runs"),
+            "multi_draw_draws": _integer(event, "multi_draw_draws"),
+            "maximum_run_length": _integer(event, "maximum_run_length"),
+            "instance_switches": _integer(event, "instance_switches"),
+            "same_instance_continuations": _integer(
+                event, "same_instance_continuations"
+            ),
+            "eligible": eligible,
+            "rejection": rejection,
+            "classification": classification,
+        }
+        if (
+            item["draws"] <= 0
+            or item["frames"] <= 0
+            or item["last_frame"] < item["first_frame"]
+            or any(
+                item[key] < 0
+                for key in (
+                    "consecutive_runs",
+                    "multi_draw_runs",
+                    "multi_draw_draws",
+                    "maximum_run_length",
+                    "instance_switches",
+                    "same_instance_continuations",
+                )
+            )
+        ):
+            raise ValueError("semantic-batch entry has invalid counters")
+        if eligible:
+            if (
+                item["consecutive_runs"] <= 0
+                or item["maximum_run_length"] <= 0
+                or item["multi_draw_draws"] > item["draws"]
+            ):
+                raise ValueError("eligible semantic-batch run accounting failed")
+            eligible_draws += item["draws"]
+        else:
+            if any(
+                item[key]
+                for key in (
+                    "consecutive_runs",
+                    "multi_draw_runs",
+                    "multi_draw_draws",
+                    "maximum_run_length",
+                    "instance_switches",
+                    "same_instance_continuations",
+                )
+            ):
+                raise ValueError("rejected semantic-batch entry owns a run")
+            rejected_draws += item["draws"]
+            rejections[rejection] += item["draws"]
+        entry_draws += item["draws"]
+        consecutive_runs += item["consecutive_runs"]
+        multi_draw_runs += item["multi_draw_runs"]
+        multi_draw_draws += item["multi_draw_draws"]
+        instance_switches += item["instance_switches"]
+        same_instance_continuations += item["same_instance_continuations"]
+        entries.append(item)
+
+    totals = {
+        key: _integer(summary, key)
+        for key in (
+            "observations",
+            "eligible_draws",
+            "rejected_draws",
+            "opportunity_entries",
+            "opportunity_overflow",
+            "consecutive_runs",
+            "multi_draw_runs",
+            "multi_draw_draws",
+            "maximum_run_length",
+            "instance_switches",
+            "same_instance_continuations",
+            "frames",
+            "maximum_draws_per_frame",
+            "template_transitions",
+            "geometry_transitions",
+            "texture_transitions",
+            "title_resource_transitions",
+            "projected_commands",
+            "potential_command_reduction",
+        )
+    }
+    totals["potential_command_reduction_percent"] = _number(
+        summary, "potential_command_reduction_percent"
+    )
+    reported_rejections = {
+        name: _integer(summary, field)
+        for name, field in REJECTION_FIELDS.items()
+    }
+    if (
+        totals["observations"] <= 0
+        or totals["opportunity_overflow"] != 0
+        or totals["opportunity_entries"] != len(entries)
+        or totals["observations"] != entry_draws
+        or totals["eligible_draws"] != eligible_draws
+        or totals["rejected_draws"] != rejected_draws
+        or totals["eligible_draws"] + totals["rejected_draws"]
+        != totals["observations"]
+        or totals["consecutive_runs"] != consecutive_runs
+        or totals["multi_draw_runs"] != multi_draw_runs
+        or totals["multi_draw_draws"] != multi_draw_draws
+        or totals["instance_switches"] != instance_switches
+        or totals["same_instance_continuations"]
+        != same_instance_continuations
+        or totals["projected_commands"]
+        != totals["consecutive_runs"] + totals["rejected_draws"]
+        or totals["potential_command_reduction"]
+        != totals["eligible_draws"] - totals["consecutive_runs"]
+        or reported_rejections != rejections
+        or sum(reported_rejections.values()) != totals["rejected_draws"]
+        or totals["observations"]
+        != _integer(title_summary, "semantic_contract_calls")
+        or totals["observations"]
+        != _integer(title_summary, "semantic_draw_prepared_matches")
+        or _integer(title_summary, "semantic_draw_unprepared_matches") != 0
+    ):
+        raise ValueError("semantic-batch aggregate accounting failed")
+    expected_percent = (
+        100.0 * totals["potential_command_reduction"] / totals["observations"]
+    )
+    if abs(totals["potential_command_reduction_percent"] - expected_percent) > 0.001:
+        raise ValueError("semantic-batch reduction percentage drifted")
+
+    entries.sort(
+        key=lambda item: (
+            not item["eligible"],
+            -item["multi_draw_draws"],
+            -item["draws"],
+            item["opportunity_key"],
+        )
+    )
+    conservative_batch_plan_proved = (
+        totals["eligible_draws"] > 0
+        and totals["multi_draw_runs"] > 0
+        and totals["potential_command_reduction"] > 0
+    )
+    return {
+        "schema": SCHEMA,
+        "session": session,
+        "scene": str(config.get("scene", "unmarked")),
+        "status": "complete",
+        "groups": entries,
+        "totals": totals,
+        "rejections": reported_rejections,
+        "conservative_batch_plan_proved": conservative_batch_plan_proved,
+        "execution_admitted": False,
+        "contract": contract,
+        "safety": {
+            "exact_consecutive_order": True,
+            "reordering": False,
+            "guest_state_changed": False,
+            "native_upload": False,
+            "native_draw": False,
+            "native_batch_execution": False,
+            "xenos_authority": True,
+            "suppression_allowed": False,
+        },
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("logs", nargs="+", type=pathlib.Path)
+    parser.add_argument("--static", required=True, type=pathlib.Path)
+    parser.add_argument("--session")
+    parser.add_argument("--output", required=True, type=pathlib.Path)
+    args = parser.parse_args(argv)
+    try:
+        events = read_events(args.logs)
+        static = json.loads(args.static.read_text(encoding="utf-8"))
+        document = build(events, static, args.session)
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(
+            json.dumps(document, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+    except (OSError, ValueError, json.JSONDecodeError) as error:
+        print(f"native renderer semantic batch summary failed: {error}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/tests/test_native_renderer_dispatch_discovery.py
+++ b/tools/tests/test_native_renderer_dispatch_discovery.py
@@ -1183,6 +1183,16 @@ class NativeRendererDispatchDiscoveryTests(unittest.TestCase):
             "immutable_template_and_dynamic_resource_instance",
             draw_association["semantic_catalog_classification"],
         )
+        self.assertTrue(
+            draw_association["semantic_batch_admission_census_required"]
+        )
+        self.assertEqual(
+            "exact_consecutive_prepared_draw_order",
+            draw_association["semantic_batch_ordering"],
+        )
+        self.assertFalse(
+            draw_association["semantic_batch_execution_enabled"]
+        )
         self.assertTrue(draw_association["render_item_invocation_scope_proved"])
         self.assertTrue(draw_association["submission_before_draw_dispatch_proved"])
         self.assertEqual(160, draw_association["graphics_submission_vtable_offset"])

--- a/tools/tests/test_native_renderer_semantic_batches.py
+++ b/tools/tests/test_native_renderer_semantic_batches.py
@@ -1,0 +1,195 @@
+import copy
+import importlib.util
+import sys
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+TOOL = ROOT / "tools" / "summarize-native-renderer-semantic-batches.py"
+SPEC = importlib.util.spec_from_file_location("semantic_batches", TOOL)
+assert SPEC and SPEC.loader
+MODULE = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = MODULE
+SPEC.loader.exec_module(MODULE)
+
+
+def static_inventory():
+    return {
+        "schema": MODULE.STATIC_SCHEMA,
+        "procedural_model_receiver_lifecycle": {
+            "semantic_draw_association": {
+                "semantic_pm4_packet_construction_proved": True,
+                "semantic_pm4_backend_join_required": True,
+                "semantic_prepared_contract_runtime_join_required": True,
+                "semantic_catalog_classification": (
+                    "immutable_template_and_dynamic_resource_instance"
+                ),
+                "semantic_batch_admission_census_required": True,
+                "semantic_batch_ordering": MODULE.EXPECTED_ORDERING,
+                "semantic_batch_execution_enabled": False,
+                "native_rendering_enabled": False,
+                "suppression_eligible": False,
+            }
+        },
+    }
+
+
+def events():
+    common = {"schema": 1, "session": "batch-session"}
+    summary = {
+        **common,
+        "event": MODULE.BATCH_SUMMARY,
+        "status": "complete",
+        "observations": "12",
+        "eligible_draws": "10",
+        "rejected_draws": "2",
+        "opportunity_entries": "2",
+        "opportunity_overflow": "0",
+        "consecutive_runs": "4",
+        "multi_draw_runs": "2",
+        "multi_draw_draws": "8",
+        "maximum_run_length": "5",
+        "instance_switches": "3",
+        "same_instance_continuations": "3",
+        "frames": "2",
+        "maximum_draws_per_frame": "7",
+        "template_transitions": "4",
+        "geometry_transitions": "3",
+        "texture_transitions": "2",
+        "title_resource_transitions": "1",
+        "projected_commands": "6",
+        "potential_command_reduction": "6",
+        "potential_command_reduction_percent": "50.000",
+        "accounting_complete": "true",
+        "ordering": MODULE.EXPECTED_ORDERING,
+        "reordering": "false",
+        "native_batch_execution": "false",
+        "native_upload": "false",
+        "native_draw": "false",
+        "xenos_authority": "true",
+        "suppression_allowed": "false",
+    }
+    for field in MODULE.REJECTION_FIELDS.values():
+        summary[field] = "0"
+    summary["reject_non_opaque"] = "2"
+    return [
+        {
+            **common,
+            "event": MODULE.TITLE_CONFIG,
+            "status": "armed",
+            "scene": "open_world",
+            "semantic_batch_planner": (
+                "exact_consecutive_opaque_prepared_draw_order"
+            ),
+            "semantic_batch_execution": "disabled_measurement_only",
+            "xenos_authority": "true",
+            "suppression_allowed": "false",
+        },
+        {
+            **common,
+            "event": MODULE.BATCH_ENTRY,
+            "opportunity_key": "1000000000000001",
+            "template_key": "2000000000000001",
+            "geometry_resource_hash": "3000000000000001",
+            "texture_resource_hash": "4000000000000001",
+            "primary_resource_key": "50000001",
+            "secondary_resource_present": "false",
+            "secondary_resource_key": "00000000",
+            "draws": "10",
+            "frames": "2",
+            "first_frame": "20",
+            "last_frame": "21",
+            "consecutive_runs": "4",
+            "multi_draw_runs": "2",
+            "multi_draw_draws": "8",
+            "maximum_run_length": "5",
+            "instance_switches": "3",
+            "same_instance_continuations": "3",
+            "eligible": "true",
+            "rejection": "none",
+            "classification": "conservative_consecutive_batch_candidate",
+            "native_batch": "false",
+            "xenos_draw": "preserved",
+            "suppression_allowed": "false",
+        },
+        {
+            **common,
+            "event": MODULE.BATCH_ENTRY,
+            "opportunity_key": "1000000000000002",
+            "template_key": "2000000000000002",
+            "geometry_resource_hash": "3000000000000002",
+            "texture_resource_hash": "4000000000000002",
+            "primary_resource_key": "50000002",
+            "secondary_resource_present": "true",
+            "secondary_resource_key": "60000002",
+            "draws": "2",
+            "frames": "1",
+            "first_frame": "21",
+            "last_frame": "21",
+            "consecutive_runs": "0",
+            "multi_draw_runs": "0",
+            "multi_draw_draws": "0",
+            "maximum_run_length": "0",
+            "instance_switches": "0",
+            "same_instance_continuations": "0",
+            "eligible": "false",
+            "rejection": "non_opaque",
+            "classification": "xenos_replay_rejected",
+            "native_batch": "false",
+            "xenos_draw": "preserved",
+            "suppression_allowed": "false",
+        },
+        {
+            **common,
+            "event": MODULE.TITLE_SUMMARY,
+            "semantic_contract_calls": "12",
+            "semantic_draw_prepared_matches": "12",
+            "semantic_draw_unprepared_matches": "0",
+        },
+        summary,
+    ]
+
+
+class SemanticBatchTests(unittest.TestCase):
+    def test_builds_fail_closed_in_order_batch_plan(self):
+        document = MODULE.build(events(), static_inventory())
+        self.assertEqual("complete", document["status"])
+        self.assertTrue(document["conservative_batch_plan_proved"])
+        self.assertFalse(document["execution_admitted"])
+        self.assertEqual(10, document["totals"]["eligible_draws"])
+        self.assertEqual(6, document["totals"]["potential_command_reduction"])
+        self.assertEqual(2, document["rejections"]["non_opaque"])
+        self.assertFalse(document["safety"]["native_batch_execution"])
+        self.assertTrue(document["safety"]["xenos_authority"])
+
+    def test_rejects_duplicate_opportunity_key(self):
+        observed = events()
+        observed.insert(3, copy.deepcopy(observed[1]))
+        observed[-1]["opportunity_entries"] = "3"
+        with self.assertRaisesRegex(ValueError, "duplicate or zero"):
+            MODULE.build(observed, static_inventory())
+
+    def test_rejects_unsafe_runtime_summary(self):
+        observed = events()
+        observed[-1]["native_batch_execution"] = "true"
+        with self.assertRaisesRegex(ValueError, "incomplete or unsafe"):
+            MODULE.build(observed, static_inventory())
+
+    def test_rejects_aggregate_drift(self):
+        observed = events()
+        observed[-1]["potential_command_reduction"] = "5"
+        with self.assertRaisesRegex(ValueError, "aggregate accounting"):
+            MODULE.build(observed, static_inventory())
+
+    def test_requires_static_admission_contract(self):
+        static = static_inventory()
+        static["procedural_model_receiver_lifecycle"][
+            "semantic_draw_association"
+        ]["semantic_batch_execution_enabled"] = True
+        with self.assertRaisesRegex(ValueError, "static contract"):
+            MODULE.build(events(), static)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- carry exact title resource identity through the proved semantic-to-PM4 join
- measure fail-closed, exact-consecutive opaque batch opportunities without native execution
- add a reconciled admission report, static contract, tests, and qualification documentation

## Qualification

- Release/AppData session `20260829T211909Z-p31988` exited normally
- 938,575 prepared draws across 2,839 frames
- 635,197 eligible draws; 303,378 fail-closed rejections
- maximum consecutive run length 1; zero multi-draw runs and zero projected command reduction
- 29.725 median FPS, 15.151 FPS one-percent low, 59.986 Hz presentation, zero deadline misses
- Xenos remained authoritative; native upload, draw, batching, reordering, and suppression stayed disabled

## Tests

- `python -m unittest discover -s tools\\tests -p 'test_*.py'` (327 passed)
- `python -m py_compile ...` for changed Python files
- `.\\tools\\build-preview.ps1 -Parallel 16 -JsonEvents`
- consolidated AppData gameplay qualification and full report bundle