### PR TITLE
feat(native-renderer): classify instance equivalence

### DIFF
--- a/docs/native-renderer/SEMANTIC_BATCH_ADMISSION.md
+++ b/docs/native-renderer/SEMANTIC_BATCH_ADMISSION.md
@@ -121,3 +121,9 @@ per-instance resource identity, or evaluate an order-preserving instancing
 path that can carry per-draw parameters explicitly. Any later executor must
 still retain per-item Xenos fallback and remain incapable of suppression until
 paired visual and side-effect qualification passes.
+
+The follow-up equivalence ladder now implements that measurement boundary.
+It separates a resource-free pipeline identity from draw arguments, geometry,
+textures, render targets, and shader-used constant values, then measures
+mesh/material instancing, material reuse, and pipeline reuse independently.
+See `SEMANTIC_BATCH_EQUIVALENCE.md`.

--- a/docs/native-renderer/SEMANTIC_BATCH_EQUIVALENCE.md
+++ b/docs/native-renderer/SEMANTIC_BATCH_EQUIVALENCE.md
@@ -1,0 +1,106 @@
+# Semantic batch-equivalence ladder
+
+This NR-05C checkpoint separates native instancing compatibility from broader
+state reuse. It is a passive measurement layer: every draw still executes on
+Xenos, and native upload, draw, batching, reordering, admission, and
+suppression remain disabled.
+
+## Why a second identity is required
+
+The first exact-order census used the complete prepared-template and resource
+identity. Session `20260829T211909Z-p31988` found 635,197 eligible draws but no
+multi-draw run. That identity is useful as a fail-closed replay key, but it is
+too specific for measuring native instancing.
+
+The exact prepared-template hash intentionally retains the raw observed state
+needed to audit replay. Some of that state is resource-bearing: vertex-buffer
+sizes, draw ranges, texture fetch words containing base and mip addresses, and
+EDRAM target bases. The equivalence ladder therefore adds a separate
+`batch_pipeline_key`; it does not silently weaken the exact replay identity.
+
+## Resource-free pipeline identity
+
+The batch pipeline key retains:
+
+- prepared host primitive, shader type, index mode, render-target formats,
+  depth/color state, and prepared-stage completeness;
+- vertex declaration, binding stride/endianness, and shader fetch mapping;
+- texture instruction and sampler layout;
+- shaders and specialization masks;
+- opaque render state and shader constant usage layout.
+
+It excludes and records separately:
+
+- index and vertex-buffer addresses and byte sizes;
+- index count and vertex range arguments;
+- texture base and mip addresses;
+- EDRAM color and depth target bases;
+- shader-used constant values.
+
+Texture fetch dwords 1 and 5 are normalized by masking their 20-bit base and
+mip page fields. Color and depth target state masks the 12-bit EDRAM base while
+retaining format state. The original raw hashes remain available for audit.
+
+## Three consecutive equivalence levels
+
+All levels preserve exact draw order and stop at frame boundaries or rejected
+draws:
+
+1. `mesh_material_instance` combines the resource-free pipeline, exact draw
+   arguments, geometry resources, texture resources, and render target. A
+   multi-draw run is the narrow candidate for explicit native instancing.
+2. `material_state_reuse` combines pipeline, texture resources, and render
+   target while allowing geometry and draw arguments to differ. It measures
+   material/state binding reuse, not draw-count reduction.
+3. `pipeline_state_reuse` uses only the resource-free pipeline key. It measures
+   prepared-pipeline reuse and does not imply compatible resources or targets.
+
+Each level records consecutive runs, multi-draw coverage, maximum run length,
+semantic-instance switches, and shader-parameter switches. The parameter hash
+contains only shader-used vertex/pixel float constants plus masked used
+boolean and loop constants. A mesh/material run with instance and parameter
+switches proves that a later executor needs an explicit per-instance parameter
+buffer; it does not authorize one.
+
+The runtime also records total and maximum compact parameter payload bytes.
+The fail-closed observation limit is 2,756 bytes per draw: up to 64 indexed
+float constants per shader stage, eight used boolean blocks, and 32 used loop
+constants. Overflowed float-constant observations are rejected before they can
+enter any equivalence level.
+
+## Fail-closed report
+
+`tools/summarize-native-renderer-semantic-batches.py` emits schema
+`pinyon-shift.native-renderer-semantic-batch-admission.v2`. It requires one
+complete summary for every equivalence level and reconciles every retained
+entry to the exact eligible-draw total. Continuation accounting must match
+both semantic-instance and parameter transitions, with zero table overflow.
+
+`mesh_material_instancing_opportunity_proved` requires a multi-draw
+mesh/material run, nonzero potential reduction, and at least one semantic
+instance switch. `instancing_parameter_path_required` additionally requires a
+shader-parameter switch. Neither result enables execution.
+
+## Qualification result
+
+Release/AppData session `20260829T214335Z-p7092` observed 1,180,157 prepared
+draws over 3,562 frames. The fail-closed predicates admitted 798,633 draws and
+rejected 381,524. The session loaded the installed AppData profile into live
+gameplay, retained Xenos authority, found no overflow, and shut down normally.
+
+The exact replay identity and `mesh_material_instance` identity both produced
+only single-draw runs. Consequently, this scene does not justify a native
+instancing executor or an instance-parameter upload path yet.
+
+The broader reuse levels did find material opportunities:
+
+- `material_state_reuse` found 76,302 multi-draw runs covering 169,902 draws,
+  with maximum run length 5 and 93,600 reusable continuations (11.72%).
+- `pipeline_state_reuse` found 144,898 multi-draw runs covering 512,218 draws,
+  with maximum run length 36 and 367,320 reusable continuations (45.994%).
+
+The largest compact shader-parameter payload was 700 bytes, below the
+2,756-byte fail-closed bound. These results support pursuing state-binding and
+prepared-pipeline caches as the next implementation batch, but those reuse
+paths must not be reported as draw-count reduction. Native execution,
+reordering, admission, upload, draw, and suppression remain disabled.

--- a/src/native_renderer/graphics_hooks.cpp
+++ b/src/native_renderer/graphics_hooks.cpp
@@ -96,6 +96,11 @@ constexpr size_t kSemanticPreparedTemplateCapacity =
     kTitleDrawProvenanceCapacity;
 constexpr size_t kSemanticBatchOpportunityCapacity =
     kTitleDrawProvenanceCapacity;
+constexpr uint64_t kSemanticBatchMaximumParameterPayloadBytes =
+    2 * rex::system::kGraphicsFloatConstantObservationLimit *
+        5 * sizeof(uint32_t) +
+    8 * 2 * sizeof(uint32_t) + sizeof(uint32_t) +
+    32 * sizeof(uint32_t);
 constexpr size_t kSemanticDescriptorWordCount = 92 / sizeof(uint32_t);
 constexpr size_t kSemanticRuntimeWordCount = 68 / sizeof(uint32_t);
 constexpr size_t kSemanticTransformWordCount = 192 / sizeof(uint32_t);
@@ -173,12 +178,17 @@ struct TitlePacketProvenanceEntry {
 
 struct SemanticPreparedDrawContract {
   uint64_t template_key = 0;
+  uint64_t batch_pipeline_key = 0;
+  uint64_t draw_argument_hash = 0;
   uint64_t prepared_pipeline_hash = 0;
   uint64_t geometry_layout_hash = 0;
   uint64_t texture_layout_hash = 0;
+  uint64_t batch_geometry_layout_hash = 0;
+  uint64_t batch_texture_layout_hash = 0;
   uint64_t render_state_hash = 0;
   uint64_t geometry_resource_hash = 0;
   uint64_t texture_resource_hash = 0;
+  uint64_t render_target_resource_hash = 0;
   uint64_t vertex_shader_hash = 0;
   uint64_t pixel_shader_hash = 0;
   uint64_t vertex_specialization_mask = 0;
@@ -250,6 +260,46 @@ struct SemanticBatchRun {
   uint64_t key = 0;
   uint64_t frame = 0;
   uint64_t length = 0;
+  size_t opportunity_index = 0;
+  uint32_t receiver_address = 0;
+  uint32_t receiver_generation = 0;
+  uint32_t record_index = 0;
+  bool valid = false;
+};
+
+enum class SemanticBatchEquivalence : uint32_t {
+  kMeshMaterial = 0,
+  kMaterial = 1,
+  kPipeline = 2,
+  kCount = 3,
+};
+
+struct SemanticBatchEquivalenceEntry {
+  uint64_t key = 0;
+  uint64_t pipeline_key = 0;
+  uint64_t draw_argument_hash = 0;
+  uint64_t geometry_resource_hash = 0;
+  uint64_t texture_resource_hash = 0;
+  uint64_t render_target_resource_hash = 0;
+  uint64_t draws = 0;
+  uint64_t frames = 0;
+  uint64_t first_frame = 0;
+  uint64_t last_frame = 0;
+  uint64_t consecutive_runs = 0;
+  uint64_t multi_draw_runs = 0;
+  uint64_t multi_draw_draws = 0;
+  uint64_t maximum_run_length = 0;
+  uint64_t instance_switches = 0;
+  uint64_t same_instance_continuations = 0;
+  uint64_t parameter_switches = 0;
+  uint64_t same_parameter_continuations = 0;
+};
+
+struct SemanticBatchEquivalenceRun {
+  uint64_t key = 0;
+  uint64_t frame = 0;
+  uint64_t length = 0;
+  uint64_t parameter_hash = 0;
   size_t opportunity_index = 0;
   uint32_t receiver_address = 0;
   uint32_t receiver_generation = 0;
@@ -353,6 +403,10 @@ std::array<TitleDrawProvenanceEntry, kTitleDrawProvenanceCapacity>
 std::array<SemanticBatchOpportunityEntry,
            kSemanticBatchOpportunityCapacity>
     g_semantic_batch_opportunities{};
+std::array<std::array<SemanticBatchEquivalenceEntry,
+                      kSemanticBatchOpportunityCapacity>,
+           size_t(SemanticBatchEquivalence::kCount)>
+    g_semantic_batch_equivalence_opportunities{};
 std::array<TitleIndirectPacketEntry, kTitleIndirectPacketCapacity>
     g_title_indirect_packets{};
 std::mutex g_title_packet_provenance_mutex;
@@ -405,6 +459,15 @@ SemanticPreparedDrawContract g_semantic_batch_previous_contract{};
 SemanticDrawIdentity g_semantic_batch_previous_identity{};
 uint64_t g_semantic_batch_previous_frame = 0;
 bool g_semantic_batch_previous_eligible = false;
+uint64_t g_semantic_batch_parameter_payload_bytes = 0;
+uint64_t g_semantic_batch_maximum_parameter_payload_bytes = 0;
+std::array<uint64_t, size_t(SemanticBatchEquivalence::kCount)>
+    g_semantic_batch_equivalence_counts{};
+std::array<uint64_t, size_t(SemanticBatchEquivalence::kCount)>
+    g_semantic_batch_equivalence_overflows{};
+std::array<SemanticBatchEquivalenceRun,
+           size_t(SemanticBatchEquivalence::kCount)>
+    g_semantic_batch_equivalence_runs{};
 uint64_t g_title_packet_submission_sequence = 0;
 uint64_t g_title_indirect_packets_recorded = 0;
 uint64_t g_title_indirect_packet_address_failures = 0;
@@ -913,6 +976,11 @@ void ResetTitleDrawProvenance() {
        g_semantic_batch_opportunities) {
     entry = {};
   }
+  for (auto &level : g_semantic_batch_equivalence_opportunities) {
+    for (SemanticBatchEquivalenceEntry &entry : level) {
+      entry = {};
+    }
+  }
   for (TitleIndirectPacketEntry &entry : g_title_indirect_packets) {
     entry = {};
   }
@@ -960,6 +1028,11 @@ void ResetTitleDrawProvenance() {
   g_semantic_batch_previous_identity = {};
   g_semantic_batch_previous_frame = 0;
   g_semantic_batch_previous_eligible = false;
+  g_semantic_batch_parameter_payload_bytes = 0;
+  g_semantic_batch_maximum_parameter_payload_bytes = 0;
+  g_semantic_batch_equivalence_counts = {};
+  g_semantic_batch_equivalence_overflows = {};
+  g_semantic_batch_equivalence_runs = {};
   g_title_packet_submission_sequence = 0;
   g_title_indirect_packets_recorded = 0;
   g_title_indirect_packet_address_failures = 0;
@@ -1226,6 +1299,14 @@ void ConfigureTitleDrawProvenance(bool census_requested,
         "texture_resource,title_resource_keys"},
        {"semantic_batch_planner",
         "exact_consecutive_opaque_prepared_draw_order"},
+       {"semantic_batch_equivalence_ladder",
+        "mesh_material,material,pipeline"},
+       {"semantic_batch_pipeline_identity",
+        "resource_free_layout_and_prepared_state"},
+       {"semantic_batch_instance_parameters",
+        "shader_constants_and_semantic_instance"},
+       {"semantic_batch_maximum_parameter_payload_bytes",
+        std::to_string(kSemanticBatchMaximumParameterPayloadBytes)},
        {"semantic_batch_execution", "disabled_measurement_only"},
        {"guest_payload_read", "false"},
        {"guest_state_changed", "false"},
@@ -6907,6 +6988,198 @@ uint64_t SemanticTextureLayoutHash(
   return hash ? hash : 1;
 }
 
+uint64_t SemanticBatchGeometryLayoutHash(
+    const rex::system::GraphicsDrawObservation &observation) {
+  uint64_t hash = UINT64_C(0xCBF29CE484222325);
+  for (uint64_t value :
+       {uint64_t(observation.primitive_type),
+        uint64_t(observation.source_select), uint64_t(observation.indexed),
+        uint64_t(observation.index_format),
+        uint64_t(observation.index_endianness),
+        uint64_t(observation.index_reset_enabled),
+        uint64_t(observation.vertex_binding_count),
+        uint64_t(observation.vertex_binding_overflow),
+        uint64_t(observation.vertex_attribute_count),
+        uint64_t(observation.vertex_attribute_overflow)}) {
+    hash = HashCombine(hash, value);
+  }
+  const uint32_t binding_count = std::min(
+      observation.vertex_binding_count,
+      rex::system::kGraphicsVertexBindingObservationLimit);
+  for (uint32_t i = 0; i < binding_count; ++i) {
+    const auto &binding = observation.vertex_bindings[i];
+    for (uint32_t value : {binding.fetch_constant, binding.stride_words,
+                           binding.endianness}) {
+      hash = HashCombine(hash, value);
+    }
+  }
+  const uint32_t attribute_count = std::min(
+      observation.vertex_attribute_count,
+      rex::system::kGraphicsVertexAttributeObservationLimit);
+  for (uint32_t i = 0; i < attribute_count; ++i) {
+    const auto &attribute = observation.vertex_attributes[i];
+    for (uint64_t value :
+         {uint64_t(attribute.binding_index),
+          uint64_t(attribute.fetch_constant),
+          uint64_t(uint32_t(attribute.offset_words)),
+          uint64_t(attribute.stride_words), uint64_t(attribute.data_format),
+          uint64_t(attribute.fetch_word_mask),
+          uint64_t(uint32_t(attribute.exp_adjust)),
+          uint64_t(attribute.signed_rf_mode),
+          uint64_t(attribute.result_storage_target),
+          uint64_t(attribute.result_storage_index),
+          uint64_t(attribute.result_write_mask),
+          uint64_t(attribute.result_components), uint64_t(attribute.flags)}) {
+      hash = HashCombine(hash, value);
+    }
+  }
+  return hash ? hash : 1;
+}
+
+uint64_t SemanticBatchTextureLayoutHash(
+    const rex::system::GraphicsDrawObservation &observation) {
+  uint64_t hash = UINT64_C(0xCBF29CE484222325);
+  hash = HashCombine(hash, observation.texture_fetch_mask);
+  hash = HashCombine(hash, observation.texture_fetch_layout_valid_mask);
+  hash = HashCombine(hash, observation.texture_state_count);
+  hash = HashCombine(hash, observation.texture_state_overflow);
+  const uint32_t texture_count = std::min(
+      observation.texture_state_count,
+      rex::system::kGraphicsTextureFetchObservationLimit);
+  for (uint32_t i = 0; i < texture_count; ++i) {
+    const auto &state = observation.texture_states[i];
+    for (uint32_t value :
+         {state.stage, state.fetch_constant, state.opcode, state.dimension,
+          state.filters, state.flags, state.lod_bias, state.offsets,
+          state.result_storage_target, state.result_storage_index,
+          state.result_write_mask, state.result_components}) {
+      hash = HashCombine(hash, value);
+    }
+    for (uint32_t dword = 0; dword < std::size(state.dwords); ++dword) {
+      uint32_t value = state.dwords[dword];
+      if (dword == 1 || dword == 5) {
+        value &= UINT32_C(0x00000FFF);
+      }
+      hash = HashCombine(hash, value);
+    }
+  }
+  return hash ? hash : 1;
+}
+
+uint64_t SemanticBatchRenderStateHash(
+    const rex::system::GraphicsDrawObservation &observation) {
+  uint64_t hash = UINT64_C(0xCBF29CE484222325);
+  for (uint64_t value :
+       {observation.vertex_shader_hash, observation.pixel_shader_hash,
+        uint64_t(observation.surface_info),
+        uint64_t(observation.color_info[0] & UINT32_C(0xFFFF0000)),
+        uint64_t(observation.color_info[1] & UINT32_C(0xFFFF0000)),
+        uint64_t(observation.color_info[2] & UINT32_C(0xFFFF0000)),
+        uint64_t(observation.color_info[3] & UINT32_C(0xFFFF0000)),
+        uint64_t(observation.depth_info & UINT32_C(0xFFFF0000)),
+        uint64_t(observation.rb_modecontrol),
+        uint64_t(observation.rb_color_mask),
+        uint64_t(observation.rb_blendcontrol[0]),
+        uint64_t(observation.rb_blendcontrol[1]),
+        uint64_t(observation.rb_blendcontrol[2]),
+        uint64_t(observation.rb_blendcontrol[3]),
+        uint64_t(observation.rb_depthcontrol),
+        uint64_t(observation.pa_su_sc_mode_cntl),
+        uint64_t(observation.pa_su_vtx_cntl),
+        uint64_t(observation.vertex_float_constant_count),
+        uint64_t(observation.vertex_float_constant_overflow),
+        uint64_t(observation.pixel_float_constant_count),
+        uint64_t(observation.pixel_float_constant_overflow),
+        uint64_t(observation.loop_constant_bitmap)}) {
+    hash = HashCombine(hash, value);
+  }
+  for (uint32_t value : observation.bool_constant_bitmap) {
+    hash = HashCombine(hash, value);
+  }
+  return hash ? hash : 1;
+}
+
+uint64_t SemanticDrawArgumentHash(
+    const rex::system::GraphicsDrawObservation &observation) {
+  uint64_t hash = UINT64_C(0xCBF29CE484222325);
+  for (uint64_t value :
+       {uint64_t(observation.index_count),
+        uint64_t(observation.vertex_index_offset),
+        uint64_t(observation.vertex_index_min),
+        uint64_t(observation.vertex_index_max),
+        uint64_t(observation.index_reset)}) {
+    hash = HashCombine(hash, value);
+  }
+  return hash ? hash : 1;
+}
+
+uint64_t SemanticRenderTargetResourceHash(
+    const rex::system::GraphicsDrawObservation &observation) {
+  uint64_t hash = UINT64_C(0xCBF29CE484222325);
+  for (uint32_t color_info : observation.color_info) {
+    hash = HashCombine(hash, color_info & UINT32_C(0x00000FFF));
+  }
+  hash = HashCombine(hash,
+                     observation.depth_info & UINT32_C(0x00000FFF));
+  return hash ? hash : 1;
+}
+
+uint64_t SemanticInstanceParameterHash(
+    const rex::system::GraphicsDrawObservation &observation) {
+  uint64_t hash = UINT64_C(0xCBF29CE484222325);
+  const uint32_t vertex_count = std::min(
+      observation.vertex_float_constant_count,
+      rex::system::kGraphicsFloatConstantObservationLimit);
+  for (uint32_t i = 0; i < vertex_count; ++i) {
+    const auto &constant = observation.vertex_float_constants[i];
+    hash = HashCombine(hash, constant.index);
+    for (uint32_t value : constant.values) {
+      hash = HashCombine(hash, value);
+    }
+  }
+  const uint32_t pixel_count = std::min(
+      observation.pixel_float_constant_count,
+      rex::system::kGraphicsFloatConstantObservationLimit);
+  for (uint32_t i = 0; i < pixel_count; ++i) {
+    const auto &constant = observation.pixel_float_constants[i];
+    hash = HashCombine(hash, constant.index);
+    for (uint32_t value : constant.values) {
+      hash = HashCombine(hash, value);
+    }
+  }
+  for (uint32_t i = 0; i < std::size(observation.bool_constant_bitmap); ++i) {
+    hash = HashCombine(hash, observation.bool_constant_bitmap[i]);
+    hash = HashCombine(hash, observation.bool_constant_values[i] &
+                                 observation.bool_constant_bitmap[i]);
+  }
+  hash = HashCombine(hash, observation.loop_constant_bitmap);
+  for (uint32_t i = 0; i < std::size(observation.loop_constant_values); ++i) {
+    if (observation.loop_constant_bitmap & (uint32_t(1) << i)) {
+      hash = HashCombine(hash, observation.loop_constant_values[i]);
+    }
+  }
+  return hash ? hash : 1;
+}
+
+uint64_t SemanticInstanceParameterPayloadBytes(
+    const rex::system::GraphicsDrawObservation &observation) {
+  const uint64_t vertex_count = std::min(
+      observation.vertex_float_constant_count,
+      rex::system::kGraphicsFloatConstantObservationLimit);
+  const uint64_t pixel_count = std::min(
+      observation.pixel_float_constant_count,
+      rex::system::kGraphicsFloatConstantObservationLimit);
+  uint64_t bytes =
+      (vertex_count + pixel_count) * 5 * sizeof(uint32_t);
+  for (uint32_t bitmap : observation.bool_constant_bitmap) {
+    bytes += bitmap ? 2 * sizeof(uint32_t) : 0;
+  }
+  bytes += observation.loop_constant_bitmap ? sizeof(uint32_t) : 0;
+  bytes += std::popcount(observation.loop_constant_bitmap) *
+           sizeof(uint32_t);
+  return bytes;
+}
+
 uint64_t SemanticRenderStateHash(
     const rex::system::GraphicsDrawObservation &observation) {
   uint64_t hash = UINT64_C(0xCBF29CE484222325);
@@ -6989,12 +7262,19 @@ SemanticPreparedDrawContract BuildSemanticPreparedDrawContract(
       (observation.texture_fetch_layout_valid_mask &
        observation.texture_fetch_mask) == observation.texture_fetch_mask;
   SemanticPreparedDrawContract contract{
+      .draw_argument_hash = SemanticDrawArgumentHash(observation),
       .prepared_pipeline_hash = PreparedPipelineHash(prepared),
       .geometry_layout_hash = SemanticGeometryLayoutHash(observation),
       .texture_layout_hash = SemanticTextureLayoutHash(observation),
+      .batch_geometry_layout_hash =
+          SemanticBatchGeometryLayoutHash(observation),
+      .batch_texture_layout_hash =
+          SemanticBatchTextureLayoutHash(observation),
       .render_state_hash = SemanticRenderStateHash(observation),
       .geometry_resource_hash = SemanticGeometryResourceHash(observation),
       .texture_resource_hash = SemanticTextureResourceHash(observation),
+      .render_target_resource_hash =
+          SemanticRenderTargetResourceHash(observation),
       .vertex_shader_hash = prepared.vertex_shader_hash,
       .pixel_shader_hash = prepared.pixel_shader_hash,
       .vertex_specialization_mask = prepared.vertex_specialization_mask,
@@ -7048,6 +7328,24 @@ SemanticPreparedDrawContract BuildSemanticPreparedDrawContract(
   template_key = HashCombine(template_key, contract.texture_layout_valid_mask);
   template_key = HashCombine(template_key, contract.texture_state_count);
   contract.template_key = template_key ? template_key : 1;
+  uint64_t batch_pipeline_key = UINT64_C(0xCBF29CE484222325);
+  batch_pipeline_key =
+      HashCombine(batch_pipeline_key, contract.prepared_pipeline_hash);
+  batch_pipeline_key =
+      HashCombine(batch_pipeline_key, contract.batch_geometry_layout_hash);
+  batch_pipeline_key =
+      HashCombine(batch_pipeline_key, contract.batch_texture_layout_hash);
+  batch_pipeline_key = HashCombine(
+      batch_pipeline_key, SemanticBatchRenderStateHash(observation));
+  batch_pipeline_key =
+      HashCombine(batch_pipeline_key, contract.vertex_shader_hash);
+  batch_pipeline_key =
+      HashCombine(batch_pipeline_key, contract.pixel_shader_hash);
+  batch_pipeline_key =
+      HashCombine(batch_pipeline_key, contract.vertex_specialization_mask);
+  batch_pipeline_key =
+      HashCombine(batch_pipeline_key, contract.pixel_specialization_mask);
+  contract.batch_pipeline_key = batch_pipeline_key ? batch_pipeline_key : 1;
   return contract;
 }
 
@@ -7075,7 +7373,9 @@ void UpdateSemanticPreparedDrawContract(
     ++contract.template_variations;
   }
   if (contract.geometry_resource_hash != current.geometry_resource_hash ||
-      contract.texture_resource_hash != current.texture_resource_hash) {
+      contract.texture_resource_hash != current.texture_resource_hash ||
+      contract.render_target_resource_hash !=
+          current.render_target_resource_hash) {
     ++contract.resource_variations;
   }
   contract.minimum_index_count =
@@ -7237,6 +7537,16 @@ void EmitTitleDrawProvenanceSummary() {
           semantic_contract.valid
               ? fmt::format("{:016X}", semantic_contract.template_key)
               : ""},
+         {"semantic_batch_pipeline_key",
+          semantic_contract.valid
+              ? fmt::format("{:016X}",
+                            semantic_contract.batch_pipeline_key)
+              : ""},
+         {"semantic_draw_argument_hash",
+          semantic_contract.valid
+              ? fmt::format("{:016X}",
+                            semantic_contract.draw_argument_hash)
+              : ""},
          {"semantic_prepared_pipeline_hash",
           semantic_contract.valid
               ? fmt::format("{:016X}",
@@ -7249,6 +7559,17 @@ void EmitTitleDrawProvenanceSummary() {
          {"semantic_texture_layout_hash",
           semantic_contract.valid
               ? fmt::format("{:016X}", semantic_contract.texture_layout_hash)
+              : ""},
+         {"semantic_batch_geometry_layout_hash",
+          semantic_contract.valid
+              ? fmt::format(
+                    "{:016X}",
+                    semantic_contract.batch_geometry_layout_hash)
+              : ""},
+         {"semantic_batch_texture_layout_hash",
+          semantic_contract.valid
+              ? fmt::format("{:016X}",
+                            semantic_contract.batch_texture_layout_hash)
               : ""},
          {"semantic_render_state_hash",
           semantic_contract.valid
@@ -7263,6 +7584,12 @@ void EmitTitleDrawProvenanceSummary() {
           semantic_contract.valid
               ? fmt::format("{:016X}",
                             semantic_contract.texture_resource_hash)
+              : ""},
+         {"semantic_render_target_resource_hash",
+          semantic_contract.valid
+              ? fmt::format(
+                    "{:016X}",
+                    semantic_contract.render_target_resource_hash)
               : ""},
          {"semantic_vertex_shader",
           semantic_contract.valid
@@ -7893,6 +8220,171 @@ size_t FindOrCreateSemanticBatchOpportunity(
   return kSemanticBatchOpportunityCapacity;
 }
 
+const char *SemanticBatchEquivalenceName(
+    SemanticBatchEquivalence equivalence) {
+  switch (equivalence) {
+  case SemanticBatchEquivalence::kMeshMaterial:
+    return "mesh_material_instance";
+  case SemanticBatchEquivalence::kMaterial:
+    return "material_state_reuse";
+  case SemanticBatchEquivalence::kPipeline:
+    return "pipeline_state_reuse";
+  case SemanticBatchEquivalence::kCount:
+    break;
+  }
+  return "unknown";
+}
+
+void FinalizeSemanticBatchEquivalenceRun(
+    SemanticBatchEquivalence equivalence) {
+  const size_t level = size_t(equivalence);
+  SemanticBatchEquivalenceRun &run =
+      g_semantic_batch_equivalence_runs[level];
+  if (!run.valid) {
+    return;
+  }
+  SemanticBatchEquivalenceEntry &entry =
+      g_semantic_batch_equivalence_opportunities[level]
+                                                [run.opportunity_index];
+  ++entry.consecutive_runs;
+  entry.maximum_run_length = std::max(entry.maximum_run_length, run.length);
+  if (run.length > 1) {
+    ++entry.multi_draw_runs;
+    entry.multi_draw_draws += run.length;
+  }
+  run = {};
+}
+
+void FinalizeSemanticBatchEquivalenceRuns() {
+  for (size_t level = 0;
+       level < size_t(SemanticBatchEquivalence::kCount); ++level) {
+    FinalizeSemanticBatchEquivalenceRun(
+        SemanticBatchEquivalence(level));
+  }
+}
+
+size_t FindOrCreateSemanticBatchEquivalenceOpportunity(
+    SemanticBatchEquivalence equivalence, uint64_t key,
+    const SemanticPreparedDrawContract &contract) {
+  const size_t level = size_t(equivalence);
+  const uint64_t draw_argument_hash =
+      equivalence == SemanticBatchEquivalence::kMeshMaterial
+          ? contract.draw_argument_hash
+          : 0;
+  const uint64_t geometry_resource_hash =
+      equivalence == SemanticBatchEquivalence::kMeshMaterial
+          ? contract.geometry_resource_hash
+          : 0;
+  const uint64_t texture_resource_hash =
+      equivalence != SemanticBatchEquivalence::kPipeline
+          ? contract.texture_resource_hash
+          : 0;
+  const uint64_t render_target_resource_hash =
+      equivalence != SemanticBatchEquivalence::kPipeline
+          ? contract.render_target_resource_hash
+          : 0;
+  size_t index = size_t(key % kSemanticBatchOpportunityCapacity);
+  for (size_t probe = 0; probe < kSemanticBatchOpportunityCapacity; ++probe) {
+    SemanticBatchEquivalenceEntry &entry =
+        g_semantic_batch_equivalence_opportunities[level][index];
+    if (!entry.key) {
+      entry.key = key;
+      entry.pipeline_key = contract.batch_pipeline_key;
+      entry.draw_argument_hash = draw_argument_hash;
+      entry.geometry_resource_hash = geometry_resource_hash;
+      entry.texture_resource_hash = texture_resource_hash;
+      entry.render_target_resource_hash = render_target_resource_hash;
+      ++g_semantic_batch_equivalence_counts[level];
+      return index;
+    }
+    if (entry.key == key &&
+        entry.pipeline_key == contract.batch_pipeline_key &&
+        entry.draw_argument_hash == draw_argument_hash &&
+        entry.geometry_resource_hash == geometry_resource_hash &&
+        entry.texture_resource_hash == texture_resource_hash &&
+        entry.render_target_resource_hash == render_target_resource_hash) {
+      return index;
+    }
+    index = (index + 1) % kSemanticBatchOpportunityCapacity;
+  }
+  ++g_semantic_batch_equivalence_overflows[level];
+  return kSemanticBatchOpportunityCapacity;
+}
+
+void RecordSemanticBatchEquivalenceOpportunity(
+    SemanticBatchEquivalence equivalence,
+    const rex::system::GraphicsDrawObservation &observation,
+    const SemanticPreparedDrawContract &contract,
+    const SemanticDrawIdentity &identity, uint64_t parameter_hash) {
+  uint64_t key = UINT64_C(0xCBF29CE484222325);
+  key = HashCombine(key, contract.batch_pipeline_key);
+  if (equivalence == SemanticBatchEquivalence::kMeshMaterial) {
+    key = HashCombine(key, contract.draw_argument_hash);
+    key = HashCombine(key, contract.geometry_resource_hash);
+  }
+  if (equivalence != SemanticBatchEquivalence::kPipeline) {
+    key = HashCombine(key, contract.texture_resource_hash);
+    key = HashCombine(key, contract.render_target_resource_hash);
+  }
+  key = key ? key : 1;
+  const size_t opportunity_index =
+      FindOrCreateSemanticBatchEquivalenceOpportunity(equivalence, key,
+                                                      contract);
+  const size_t level = size_t(equivalence);
+  if (opportunity_index == kSemanticBatchOpportunityCapacity) {
+    FinalizeSemanticBatchEquivalenceRun(equivalence);
+    return;
+  }
+  SemanticBatchEquivalenceEntry &entry =
+      g_semantic_batch_equivalence_opportunities[level][opportunity_index];
+  ++entry.draws;
+  if (!entry.first_frame) {
+    entry.first_frame = observation.frame_sequence;
+  }
+  if (entry.last_frame != observation.frame_sequence) {
+    ++entry.frames;
+  }
+  entry.last_frame = observation.frame_sequence;
+
+  SemanticBatchEquivalenceRun &run =
+      g_semantic_batch_equivalence_runs[level];
+  if (run.valid && run.frame == observation.frame_sequence &&
+      run.key == key) {
+    const bool same_instance =
+        run.receiver_address == identity.receiver_address &&
+        run.receiver_generation == identity.receiver_generation &&
+        run.record_index == identity.record_index;
+    if (same_instance) {
+      ++entry.same_instance_continuations;
+    } else {
+      ++entry.instance_switches;
+    }
+    if (run.parameter_hash == parameter_hash) {
+      ++entry.same_parameter_continuations;
+    } else {
+      ++entry.parameter_switches;
+    }
+    ++run.length;
+    run.parameter_hash = parameter_hash;
+    run.receiver_address = identity.receiver_address;
+    run.receiver_generation = identity.receiver_generation;
+    run.record_index = identity.record_index;
+    return;
+  }
+  FinalizeSemanticBatchEquivalenceRun(equivalence);
+  run = {
+      .key = key,
+      .frame = observation.frame_sequence,
+      .length = 1,
+      .parameter_hash = parameter_hash,
+      .opportunity_index = opportunity_index,
+      .receiver_address = identity.receiver_address,
+      .receiver_generation = identity.receiver_generation,
+      .record_index = identity.record_index,
+      .valid = true,
+  };
+}
+
 void RecordSemanticBatchOpportunity(
     const rex::system::GraphicsDrawObservation &observation,
     bool samples_resolved_target,
@@ -7928,6 +8420,7 @@ void RecordSemanticBatchOpportunity(
       key, contract, identity, rejection);
   if (opportunity_index == kSemanticBatchOpportunityCapacity) {
     FinalizeSemanticBatchRun();
+    FinalizeSemanticBatchEquivalenceRuns();
     g_semantic_batch_previous_eligible = false;
     return;
   }
@@ -7946,10 +8439,25 @@ void RecordSemanticBatchOpportunity(
     ++g_semantic_batch_rejected_draws;
     ++g_semantic_batch_rejections[size_t(rejection)];
     FinalizeSemanticBatchRun();
+    FinalizeSemanticBatchEquivalenceRuns();
     g_semantic_batch_previous_eligible = false;
     return;
   }
   ++g_semantic_batch_eligible_draws;
+  const uint64_t parameter_hash =
+      SemanticInstanceParameterHash(observation);
+  const uint64_t parameter_payload_bytes =
+      SemanticInstanceParameterPayloadBytes(observation);
+  g_semantic_batch_parameter_payload_bytes += parameter_payload_bytes;
+  g_semantic_batch_maximum_parameter_payload_bytes =
+      std::max(g_semantic_batch_maximum_parameter_payload_bytes,
+               parameter_payload_bytes);
+  for (size_t level = 0;
+       level < size_t(SemanticBatchEquivalence::kCount); ++level) {
+    RecordSemanticBatchEquivalenceOpportunity(
+        SemanticBatchEquivalence(level), observation, contract, identity,
+        parameter_hash);
+  }
   if (g_semantic_batch_previous_eligible &&
       g_semantic_batch_previous_frame == observation.frame_sequence) {
     g_semantic_batch_template_transitions +=
@@ -8008,9 +8516,138 @@ void RecordSemanticBatchOpportunity(
   };
 }
 
+void EmitSemanticBatchEquivalenceSummary() {
+  FinalizeSemanticBatchEquivalenceRuns();
+  for (size_t level = 0;
+       level < size_t(SemanticBatchEquivalence::kCount); ++level) {
+    const SemanticBatchEquivalence equivalence =
+        SemanticBatchEquivalence(level);
+    uint64_t entry_draws = 0;
+    uint64_t consecutive_runs = 0;
+    uint64_t multi_draw_runs = 0;
+    uint64_t multi_draw_draws = 0;
+    uint64_t maximum_run_length = 0;
+    uint64_t instance_switches = 0;
+    uint64_t same_instance_continuations = 0;
+    uint64_t parameter_switches = 0;
+    uint64_t same_parameter_continuations = 0;
+    for (const SemanticBatchEquivalenceEntry &entry :
+         g_semantic_batch_equivalence_opportunities[level]) {
+      if (!entry.key) {
+        continue;
+      }
+      entry_draws += entry.draws;
+      consecutive_runs += entry.consecutive_runs;
+      multi_draw_runs += entry.multi_draw_runs;
+      multi_draw_draws += entry.multi_draw_draws;
+      maximum_run_length =
+          std::max(maximum_run_length, entry.maximum_run_length);
+      instance_switches += entry.instance_switches;
+      same_instance_continuations += entry.same_instance_continuations;
+      parameter_switches += entry.parameter_switches;
+      same_parameter_continuations +=
+          entry.same_parameter_continuations;
+      pinyon_shift::diagnostics::RecordEvent(
+          "native_renderer.discovery.semantic_batch_equivalence_entry",
+          {{"equivalence", SemanticBatchEquivalenceName(equivalence)},
+           {"opportunity_key", fmt::format("{:016X}", entry.key)},
+           {"pipeline_key", fmt::format("{:016X}", entry.pipeline_key)},
+           {"draw_argument_hash",
+            entry.draw_argument_hash
+                ? fmt::format("{:016X}", entry.draw_argument_hash)
+                : ""},
+           {"geometry_resource_hash",
+            entry.geometry_resource_hash
+                ? fmt::format("{:016X}", entry.geometry_resource_hash)
+                : ""},
+           {"texture_resource_hash",
+            entry.texture_resource_hash
+                ? fmt::format("{:016X}", entry.texture_resource_hash)
+                : ""},
+           {"render_target_resource_hash",
+            entry.render_target_resource_hash
+                ? fmt::format("{:016X}",
+                              entry.render_target_resource_hash)
+                : ""},
+           {"draws", std::to_string(entry.draws)},
+           {"frames", std::to_string(entry.frames)},
+           {"first_frame", std::to_string(entry.first_frame)},
+           {"last_frame", std::to_string(entry.last_frame)},
+           {"consecutive_runs", std::to_string(entry.consecutive_runs)},
+           {"multi_draw_runs", std::to_string(entry.multi_draw_runs)},
+           {"multi_draw_draws", std::to_string(entry.multi_draw_draws)},
+           {"maximum_run_length",
+            std::to_string(entry.maximum_run_length)},
+           {"instance_switches", std::to_string(entry.instance_switches)},
+           {"same_instance_continuations",
+            std::to_string(entry.same_instance_continuations)},
+           {"parameter_switches", std::to_string(entry.parameter_switches)},
+           {"same_parameter_continuations",
+            std::to_string(entry.same_parameter_continuations)},
+           {"ordering", "exact_consecutive_prepared_draw_order"},
+           {"xenos_draw", "preserved"},
+           {"native_batch", "false"},
+           {"suppression_allowed", "false"}});
+    }
+    const bool accounting_complete =
+        !g_semantic_batch_equivalence_overflows[level] &&
+        entry_draws == g_semantic_batch_eligible_draws &&
+        instance_switches + same_instance_continuations ==
+            multi_draw_draws - multi_draw_runs &&
+        parameter_switches + same_parameter_continuations ==
+            multi_draw_draws - multi_draw_runs;
+    const uint64_t potential_reduction =
+        g_semantic_batch_eligible_draws >= consecutive_runs
+            ? g_semantic_batch_eligible_draws - consecutive_runs
+            : 0;
+    const double reduction_percent = g_semantic_batch_eligible_draws
+                                         ? 100.0 * potential_reduction /
+                                               g_semantic_batch_eligible_draws
+                                         : 0.0;
+    pinyon_shift::diagnostics::RecordEvent(
+        "native_renderer.discovery.semantic_batch_equivalence_summary",
+        {{"status", accounting_complete ? "complete" : "incomplete"},
+         {"equivalence", SemanticBatchEquivalenceName(equivalence)},
+         {"eligible_draws", std::to_string(g_semantic_batch_eligible_draws)},
+         {"opportunity_entries",
+          std::to_string(g_semantic_batch_equivalence_counts[level])},
+         {"opportunity_overflow",
+          std::to_string(g_semantic_batch_equivalence_overflows[level])},
+         {"consecutive_runs", std::to_string(consecutive_runs)},
+         {"multi_draw_runs", std::to_string(multi_draw_runs)},
+         {"multi_draw_draws", std::to_string(multi_draw_draws)},
+         {"maximum_run_length", std::to_string(maximum_run_length)},
+         {"instance_switches", std::to_string(instance_switches)},
+         {"same_instance_continuations",
+          std::to_string(same_instance_continuations)},
+         {"parameter_switches", std::to_string(parameter_switches)},
+         {"same_parameter_continuations",
+          std::to_string(same_parameter_continuations)},
+         {"potential_reduction", std::to_string(potential_reduction)},
+         {"potential_reduction_percent",
+          fmt::format("{:.3f}", reduction_percent)},
+         {"accounting_complete", accounting_complete ? "true" : "false"},
+         {"identity",
+          equivalence == SemanticBatchEquivalence::kMeshMaterial
+              ? "pipeline,draw_arguments,geometry,texture,render_target"
+              : (equivalence == SemanticBatchEquivalence::kMaterial
+                     ? "pipeline,texture,render_target"
+                     : "pipeline")},
+         {"parameterization", "observed_not_executed"},
+         {"ordering", "exact_consecutive_prepared_draw_order"},
+         {"reordering", "false"},
+         {"native_batch_execution", "false"},
+         {"native_upload", "false"},
+         {"native_draw", "false"},
+         {"xenos_authority", "true"},
+         {"suppression_allowed", "false"}});
+  }
+}
+
 void EmitSemanticBatchOpportunitySummary() {
   FinalizeSemanticBatchRun();
   FinalizeSemanticBatchFrame();
+  EmitSemanticBatchEquivalenceSummary();
   uint64_t entry_draws = 0;
   uint64_t entry_eligible_draws = 0;
   uint64_t entry_rejected_draws = 0;
@@ -8131,6 +8768,12 @@ void EmitSemanticBatchOpportunitySummary() {
         std::to_string(g_semantic_batch_texture_transitions)},
        {"title_resource_transitions",
         std::to_string(g_semantic_batch_title_resource_transitions)},
+       {"parameter_payload_bytes",
+        std::to_string(g_semantic_batch_parameter_payload_bytes)},
+       {"maximum_parameter_payload_bytes",
+        std::to_string(g_semantic_batch_maximum_parameter_payload_bytes)},
+       {"parameter_payload_limit_bytes",
+        std::to_string(kSemanticBatchMaximumParameterPayloadBytes)},
        {"projected_commands", std::to_string(projected_commands)},
        {"potential_command_reduction",
         std::to_string(potential_command_reduction)},

--- a/tools/discover-native-renderer-dispatch.py
+++ b/tools/discover-native-renderer-dispatch.py
@@ -1469,6 +1469,10 @@ def procedural_model_receiver_lifecycle(
             "semantic_batch_ordering": (
                 "exact_consecutive_prepared_draw_order"
             ),
+            "semantic_batch_equivalence_ladder_required": True,
+            "semantic_batch_pipeline_identity": (
+                "resource_free_layout_and_prepared_state"
+            ),
             "semantic_batch_execution_enabled": False,
             "physical_pm4_packet_correlation_proved": False,
             "prepared_draw_lineage_proved": False,

--- a/tools/summarize-native-renderer-semantic-batches.py
+++ b/tools/summarize-native-renderer-semantic-batches.py
@@ -8,13 +8,24 @@ import pathlib
 import sys
 
 
-SCHEMA = "pinyon-shift.native-renderer-semantic-batch-admission.v1"
+SCHEMA = "pinyon-shift.native-renderer-semantic-batch-admission.v2"
 STATIC_SCHEMA = "pinyon-shift.native-renderer-dispatch-static.v3"
 TITLE_CONFIG = "native_renderer.discovery.title_provenance_config"
 TITLE_SUMMARY = "native_renderer.discovery.title_provenance_summary"
 BATCH_ENTRY = "native_renderer.discovery.semantic_batch_entry"
 BATCH_SUMMARY = "native_renderer.discovery.semantic_batch_summary"
+EQUIVALENCE_ENTRY = (
+    "native_renderer.discovery.semantic_batch_equivalence_entry"
+)
+EQUIVALENCE_SUMMARY = (
+    "native_renderer.discovery.semantic_batch_equivalence_summary"
+)
 EXPECTED_ORDERING = "exact_consecutive_prepared_draw_order"
+EXPECTED_EQUIVALENCES = (
+    "mesh_material_instance",
+    "material_state_reuse",
+    "pipeline_state_reuse",
+)
 REJECTION_FIELDS = {
     "missing_title_resource": "reject_missing_title_resource",
     "non_opaque": "reject_non_opaque",
@@ -33,7 +44,14 @@ REJECTION_FIELDS = {
 
 def read_events(paths: list[pathlib.Path]) -> list[dict]:
     events = []
-    wanted = {TITLE_CONFIG, TITLE_SUMMARY, BATCH_ENTRY, BATCH_SUMMARY}
+    wanted = {
+        TITLE_CONFIG,
+        TITLE_SUMMARY,
+        BATCH_ENTRY,
+        BATCH_SUMMARY,
+        EQUIVALENCE_ENTRY,
+        EQUIVALENCE_SUMMARY,
+    }
     for path in paths:
         for line_number, line in enumerate(
             path.read_text(encoding="utf-8").splitlines(), 1
@@ -76,6 +94,12 @@ def _hex(mapping: dict, key: str, width: int) -> str:
     return value
 
 
+def _optional_hex(mapping: dict, key: str, width: int) -> str | None:
+    if mapping.get(key, "") == "":
+        return None
+    return _hex(mapping, key, width)
+
+
 def _boolean(mapping: dict, key: str) -> bool:
     value = str(mapping.get(key, "")).lower()
     if value not in {"true", "false"}:
@@ -113,6 +137,10 @@ def _validate_static(static: dict) -> dict:
         ),
         "semantic_batch_admission_census_required": True,
         "semantic_batch_ordering": EXPECTED_ORDERING,
+        "semantic_batch_equivalence_ladder_required": True,
+        "semantic_batch_pipeline_identity": (
+            "resource_free_layout_and_prepared_state"
+        ),
         "semantic_batch_execution_enabled": False,
         "native_rendering_enabled": False,
         "suppression_eligible": False,
@@ -120,6 +148,233 @@ def _validate_static(static: dict) -> dict:
     if any(contract.get(key) != value for key, value in expected.items()):
         raise ValueError("unsupported semantic-batch static contract")
     return contract
+
+
+def _build_equivalence_levels(
+    selected: list[dict], eligible_draws: int
+) -> dict[str, dict]:
+    result = {}
+    for equivalence in EXPECTED_EQUIVALENCES:
+        summaries = [
+            event
+            for event in selected
+            if event.get("event") == EQUIVALENCE_SUMMARY
+            and event.get("equivalence") == equivalence
+        ]
+        if len(summaries) != 1:
+            raise ValueError(
+                f"semantic-batch equivalence needs one summary: {equivalence}"
+            )
+        summary = summaries[0]
+        if (
+            summary.get("status") != "complete"
+            or summary.get("accounting_complete") != "true"
+            or summary.get("ordering") != EXPECTED_ORDERING
+            or summary.get("reordering") != "false"
+            or summary.get("parameterization") != "observed_not_executed"
+            or summary.get("native_batch_execution") != "false"
+            or summary.get("native_upload") != "false"
+            or summary.get("native_draw") != "false"
+            or summary.get("xenos_authority") != "true"
+            or summary.get("suppression_allowed") != "false"
+        ):
+            raise ValueError(
+                f"semantic-batch equivalence is incomplete or unsafe: {equivalence}"
+            )
+        expected_identity = {
+            "mesh_material_instance": (
+                "pipeline,draw_arguments,geometry,texture,render_target"
+            ),
+            "material_state_reuse": "pipeline,texture,render_target",
+            "pipeline_state_reuse": "pipeline",
+        }[equivalence]
+        if summary.get("identity") != expected_identity:
+            raise ValueError(
+                f"semantic-batch equivalence identity drifted: {equivalence}"
+            )
+
+        entries = []
+        seen_keys = set()
+        aggregates = {
+            "draws": 0,
+            "consecutive_runs": 0,
+            "multi_draw_runs": 0,
+            "multi_draw_draws": 0,
+            "maximum_run_length": 0,
+            "instance_switches": 0,
+            "same_instance_continuations": 0,
+            "parameter_switches": 0,
+            "same_parameter_continuations": 0,
+        }
+        for event in selected:
+            if (
+                event.get("event") != EQUIVALENCE_ENTRY
+                or event.get("equivalence") != equivalence
+            ):
+                continue
+            key = _hex(event, "opportunity_key", 16)
+            if key in seen_keys or int(key, 16) == 0:
+                raise ValueError(
+                    f"duplicate or zero equivalence key: {equivalence}"
+                )
+            seen_keys.add(key)
+            if (
+                event.get("ordering") != EXPECTED_ORDERING
+                or event.get("xenos_draw") != "preserved"
+                or event.get("native_batch") != "false"
+                or event.get("suppression_allowed") != "false"
+            ):
+                raise ValueError(
+                    f"semantic-batch equivalence crossed safety: {equivalence}"
+                )
+            item = {
+                "opportunity_key": key,
+                "pipeline_key": _hex(event, "pipeline_key", 16),
+                "draw_argument_hash": _optional_hex(
+                    event, "draw_argument_hash", 16
+                ),
+                "geometry_resource_hash": _optional_hex(
+                    event, "geometry_resource_hash", 16
+                ),
+                "texture_resource_hash": _optional_hex(
+                    event, "texture_resource_hash", 16
+                ),
+                "render_target_resource_hash": _optional_hex(
+                    event, "render_target_resource_hash", 16
+                ),
+                **{
+                    name: _integer(event, name)
+                    for name in (
+                        "draws",
+                        "frames",
+                        "first_frame",
+                        "last_frame",
+                        "consecutive_runs",
+                        "multi_draw_runs",
+                        "multi_draw_draws",
+                        "maximum_run_length",
+                        "instance_switches",
+                        "same_instance_continuations",
+                        "parameter_switches",
+                        "same_parameter_continuations",
+                    )
+                },
+            }
+            if (
+                item["draws"] <= 0
+                or item["frames"] <= 0
+                or item["last_frame"] < item["first_frame"]
+                or item["consecutive_runs"] <= 0
+                or item["maximum_run_length"] <= 0
+                or item["multi_draw_draws"] > item["draws"]
+            ):
+                raise ValueError(
+                    f"invalid semantic-batch equivalence entry: {equivalence}"
+                )
+            if equivalence == "mesh_material_instance":
+                if not all(
+                    item[name]
+                    for name in (
+                        "draw_argument_hash",
+                        "geometry_resource_hash",
+                        "texture_resource_hash",
+                        "render_target_resource_hash",
+                    )
+                ):
+                    raise ValueError("mesh-material identity is incomplete")
+            elif equivalence == "material_state_reuse":
+                if (
+                    item["draw_argument_hash"]
+                    or item["geometry_resource_hash"]
+                    or not item["texture_resource_hash"]
+                    or not item["render_target_resource_hash"]
+                ):
+                    raise ValueError("material identity is inconsistent")
+            elif any(
+                item[name]
+                for name in (
+                    "draw_argument_hash",
+                    "geometry_resource_hash",
+                    "texture_resource_hash",
+                    "render_target_resource_hash",
+                )
+            ):
+                raise ValueError("pipeline identity is inconsistent")
+            for name in aggregates:
+                if name == "maximum_run_length":
+                    aggregates[name] = max(aggregates[name], item[name])
+                else:
+                    aggregates[name] += item[name]
+            entries.append(item)
+
+        totals = {
+            name: _integer(summary, name)
+            for name in (
+                "eligible_draws",
+                "opportunity_entries",
+                "opportunity_overflow",
+                "consecutive_runs",
+                "multi_draw_runs",
+                "multi_draw_draws",
+                "maximum_run_length",
+                "instance_switches",
+                "same_instance_continuations",
+                "parameter_switches",
+                "same_parameter_continuations",
+                "potential_reduction",
+            )
+        }
+        totals["potential_reduction_percent"] = _number(
+            summary, "potential_reduction_percent"
+        )
+        continuation_count = (
+            totals["multi_draw_draws"] - totals["multi_draw_runs"]
+        )
+        if (
+            totals["eligible_draws"] != eligible_draws
+            or totals["opportunity_overflow"] != 0
+            or totals["opportunity_entries"] != len(entries)
+            or aggregates["draws"] != eligible_draws
+            or any(
+                totals[name] != aggregates[name]
+                for name in aggregates
+                if name != "draws"
+            )
+            or totals["instance_switches"]
+            + totals["same_instance_continuations"]
+            != continuation_count
+            or totals["parameter_switches"]
+            + totals["same_parameter_continuations"]
+            != continuation_count
+            or totals["potential_reduction"]
+            != eligible_draws - totals["consecutive_runs"]
+        ):
+            raise ValueError(
+                f"semantic-batch equivalence accounting failed: {equivalence}"
+            )
+        expected_percent = (
+            100.0 * totals["potential_reduction"] / eligible_draws
+            if eligible_draws
+            else 0.0
+        )
+        if (
+            abs(
+                totals["potential_reduction_percent"] - expected_percent
+            )
+            > 0.001
+        ):
+            raise ValueError(
+                f"semantic-batch equivalence percentage drifted: {equivalence}"
+            )
+        entries.sort(
+            key=lambda item: (
+                -item["multi_draw_draws"],
+                -item["draws"],
+                item["opportunity_key"],
+            )
+        )
+        result[equivalence] = {"groups": entries, "totals": totals}
+    return result
 
 
 def build(events: list[dict], static: dict, requested: str | None = None) -> dict:
@@ -144,6 +399,16 @@ def build(events: list[dict], static: dict, requested: str | None = None) -> dic
         != "exact_consecutive_opaque_prepared_draw_order"
         or config.get("semantic_batch_execution")
         != "disabled_measurement_only"
+        or config.get("semantic_batch_equivalence_ladder")
+        != "mesh_material,material,pipeline"
+        or config.get("semantic_batch_pipeline_identity")
+        != "resource_free_layout_and_prepared_state"
+        or config.get("semantic_batch_instance_parameters")
+        != "shader_constants_and_semantic_instance"
+        or _integer(
+            config, "semantic_batch_maximum_parameter_payload_bytes"
+        )
+        <= 0
         or config.get("xenos_authority") != "true"
         or config.get("suppression_allowed") != "false"
     ):
@@ -297,6 +562,9 @@ def build(events: list[dict], static: dict, requested: str | None = None) -> dic
             "geometry_transitions",
             "texture_transitions",
             "title_resource_transitions",
+            "parameter_payload_bytes",
+            "maximum_parameter_payload_bytes",
+            "parameter_payload_limit_bytes",
             "projected_commands",
             "potential_command_reduction",
         )
@@ -334,6 +602,16 @@ def build(events: list[dict], static: dict, requested: str | None = None) -> dic
         or totals["observations"]
         != _integer(title_summary, "semantic_draw_prepared_matches")
         or _integer(title_summary, "semantic_draw_unprepared_matches") != 0
+        or totals["parameter_payload_bytes"] <= 0
+        or totals["maximum_parameter_payload_bytes"] <= 0
+        or totals["maximum_parameter_payload_bytes"]
+        > totals["parameter_payload_limit_bytes"]
+        or totals["parameter_payload_bytes"]
+        > totals["eligible_draws"] * totals["parameter_payload_limit_bytes"]
+        or totals["parameter_payload_limit_bytes"]
+        != _integer(
+            config, "semantic_batch_maximum_parameter_payload_bytes"
+        )
     ):
         raise ValueError("semantic-batch aggregate accounting failed")
     expected_percent = (
@@ -341,6 +619,10 @@ def build(events: list[dict], static: dict, requested: str | None = None) -> dic
     )
     if abs(totals["potential_command_reduction_percent"] - expected_percent) > 0.001:
         raise ValueError("semantic-batch reduction percentage drifted")
+
+    equivalence_levels = _build_equivalence_levels(
+        selected, totals["eligible_draws"]
+    )
 
     entries.sort(
         key=lambda item: (
@@ -355,6 +637,17 @@ def build(events: list[dict], static: dict, requested: str | None = None) -> dic
         and totals["multi_draw_runs"] > 0
         and totals["potential_command_reduction"] > 0
     )
+    mesh_material = equivalence_levels["mesh_material_instance"]["totals"]
+    instancing_parameter_path_required = (
+        mesh_material["multi_draw_runs"] > 0
+        and mesh_material["instance_switches"] > 0
+        and mesh_material["parameter_switches"] > 0
+    )
+    mesh_material_instancing_opportunity_proved = (
+        mesh_material["multi_draw_runs"] > 0
+        and mesh_material["potential_reduction"] > 0
+        and mesh_material["instance_switches"] > 0
+    )
     return {
         "schema": SCHEMA,
         "session": session,
@@ -363,7 +656,14 @@ def build(events: list[dict], static: dict, requested: str | None = None) -> dic
         "groups": entries,
         "totals": totals,
         "rejections": reported_rejections,
+        "equivalence_levels": equivalence_levels,
         "conservative_batch_plan_proved": conservative_batch_plan_proved,
+        "mesh_material_instancing_opportunity_proved": (
+            mesh_material_instancing_opportunity_proved
+        ),
+        "instancing_parameter_path_required": (
+            instancing_parameter_path_required
+        ),
         "execution_admitted": False,
         "contract": contract,
         "safety": {

--- a/tools/tests/test_native_renderer_dispatch_discovery.py
+++ b/tools/tests/test_native_renderer_dispatch_discovery.py
@@ -1190,6 +1190,15 @@ class NativeRendererDispatchDiscoveryTests(unittest.TestCase):
             "exact_consecutive_prepared_draw_order",
             draw_association["semantic_batch_ordering"],
         )
+        self.assertTrue(
+            draw_association[
+                "semantic_batch_equivalence_ladder_required"
+            ]
+        )
+        self.assertEqual(
+            "resource_free_layout_and_prepared_state",
+            draw_association["semantic_batch_pipeline_identity"],
+        )
         self.assertFalse(
             draw_association["semantic_batch_execution_enabled"]
         )

--- a/tools/tests/test_native_renderer_semantic_batches.py
+++ b/tools/tests/test_native_renderer_semantic_batches.py
@@ -27,6 +27,10 @@ def static_inventory():
                 ),
                 "semantic_batch_admission_census_required": True,
                 "semantic_batch_ordering": MODULE.EXPECTED_ORDERING,
+                "semantic_batch_equivalence_ladder_required": True,
+                "semantic_batch_pipeline_identity": (
+                    "resource_free_layout_and_prepared_state"
+                ),
                 "semantic_batch_execution_enabled": False,
                 "native_rendering_enabled": False,
                 "suppression_eligible": False,
@@ -58,6 +62,9 @@ def events():
         "geometry_transitions": "3",
         "texture_transitions": "2",
         "title_resource_transitions": "1",
+        "parameter_payload_bytes": "2400",
+        "maximum_parameter_payload_bytes": "240",
+        "parameter_payload_limit_bytes": "2756",
         "projected_commands": "6",
         "potential_command_reduction": "6",
         "potential_command_reduction_percent": "50.000",
@@ -73,6 +80,89 @@ def events():
     for field in MODULE.REJECTION_FIELDS.values():
         summary[field] = "0"
     summary["reject_non_opaque"] = "2"
+    identities = {
+        "mesh_material_instance": (
+            "pipeline,draw_arguments,geometry,texture,render_target"
+        ),
+        "material_state_reuse": "pipeline,texture,render_target",
+        "pipeline_state_reuse": "pipeline",
+    }
+    equivalence_events = []
+    for index, equivalence in enumerate(MODULE.EXPECTED_EQUIVALENCES, 1):
+        mesh = equivalence == "mesh_material_instance"
+        material = equivalence == "material_state_reuse"
+        equivalence_events.extend(
+            [
+                {
+                    **common,
+                    "event": MODULE.EQUIVALENCE_ENTRY,
+                    "equivalence": equivalence,
+                    "opportunity_key": f"700000000000000{index}",
+                    "pipeline_key": f"710000000000000{index}",
+                    "draw_argument_hash": (
+                        f"720000000000000{index}" if mesh else ""
+                    ),
+                    "geometry_resource_hash": (
+                        f"730000000000000{index}" if mesh else ""
+                    ),
+                    "texture_resource_hash": (
+                        f"740000000000000{index}"
+                        if mesh or material
+                        else ""
+                    ),
+                    "render_target_resource_hash": (
+                        f"750000000000000{index}"
+                        if mesh or material
+                        else ""
+                    ),
+                    "draws": "10",
+                    "frames": "2",
+                    "first_frame": "20",
+                    "last_frame": "21",
+                    "consecutive_runs": "4",
+                    "multi_draw_runs": "2",
+                    "multi_draw_draws": "8",
+                    "maximum_run_length": "5",
+                    "instance_switches": "3",
+                    "same_instance_continuations": "3",
+                    "parameter_switches": "4",
+                    "same_parameter_continuations": "2",
+                    "ordering": MODULE.EXPECTED_ORDERING,
+                    "xenos_draw": "preserved",
+                    "native_batch": "false",
+                    "suppression_allowed": "false",
+                },
+                {
+                    **common,
+                    "event": MODULE.EQUIVALENCE_SUMMARY,
+                    "status": "complete",
+                    "equivalence": equivalence,
+                    "eligible_draws": "10",
+                    "opportunity_entries": "1",
+                    "opportunity_overflow": "0",
+                    "consecutive_runs": "4",
+                    "multi_draw_runs": "2",
+                    "multi_draw_draws": "8",
+                    "maximum_run_length": "5",
+                    "instance_switches": "3",
+                    "same_instance_continuations": "3",
+                    "parameter_switches": "4",
+                    "same_parameter_continuations": "2",
+                    "potential_reduction": "6",
+                    "potential_reduction_percent": "60.000",
+                    "accounting_complete": "true",
+                    "identity": identities[equivalence],
+                    "parameterization": "observed_not_executed",
+                    "ordering": MODULE.EXPECTED_ORDERING,
+                    "reordering": "false",
+                    "native_batch_execution": "false",
+                    "native_upload": "false",
+                    "native_draw": "false",
+                    "xenos_authority": "true",
+                    "suppression_allowed": "false",
+                },
+            ]
+        )
     return [
         {
             **common,
@@ -82,6 +172,16 @@ def events():
             "semantic_batch_planner": (
                 "exact_consecutive_opaque_prepared_draw_order"
             ),
+            "semantic_batch_equivalence_ladder": (
+                "mesh_material,material,pipeline"
+            ),
+            "semantic_batch_pipeline_identity": (
+                "resource_free_layout_and_prepared_state"
+            ),
+            "semantic_batch_instance_parameters": (
+                "shader_constants_and_semantic_instance"
+            ),
+            "semantic_batch_maximum_parameter_payload_bytes": "2756",
             "semantic_batch_execution": "disabled_measurement_only",
             "xenos_authority": "true",
             "suppression_allowed": "false",
@@ -113,6 +213,7 @@ def events():
             "xenos_draw": "preserved",
             "suppression_allowed": "false",
         },
+        *equivalence_events,
         {
             **common,
             "event": MODULE.BATCH_ENTRY,
@@ -160,6 +261,16 @@ class SemanticBatchTests(unittest.TestCase):
         self.assertEqual(10, document["totals"]["eligible_draws"])
         self.assertEqual(6, document["totals"]["potential_command_reduction"])
         self.assertEqual(2, document["rejections"]["non_opaque"])
+        self.assertTrue(
+            document["mesh_material_instancing_opportunity_proved"]
+        )
+        self.assertTrue(document["instancing_parameter_path_required"])
+        self.assertEqual(
+            6,
+            document["equivalence_levels"]["mesh_material_instance"][
+                "totals"
+            ]["potential_reduction"],
+        )
         self.assertFalse(document["safety"]["native_batch_execution"])
         self.assertTrue(document["safety"]["xenos_authority"])
 
@@ -189,6 +300,29 @@ class SemanticBatchTests(unittest.TestCase):
         ]["semantic_batch_execution_enabled"] = True
         with self.assertRaisesRegex(ValueError, "static contract"):
             MODULE.build(events(), static)
+
+    def test_rejects_equivalence_aggregate_drift(self):
+        observed = events()
+        equivalence_summary = next(
+            event
+            for event in observed
+            if event.get("event") == MODULE.EQUIVALENCE_SUMMARY
+            and event.get("equivalence") == "mesh_material_instance"
+        )
+        equivalence_summary["parameter_switches"] = "3"
+        with self.assertRaisesRegex(ValueError, "equivalence accounting"):
+            MODULE.build(observed, static_inventory())
+
+    def test_rejects_unsafe_equivalence_summary(self):
+        observed = events()
+        equivalence_summary = next(
+            event
+            for event in observed
+            if event.get("event") == MODULE.EQUIVALENCE_SUMMARY
+        )
+        equivalence_summary["native_batch_execution"] = "true"
+        with self.assertRaisesRegex(ValueError, "incomplete or unsafe"):
+            MODULE.build(observed, static_inventory())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- preserve the exact replay identity while adding a resource-free pipeline key
- measure mesh/material, material-state, and pipeline-state reuse in exact order
- validate bounded shader-parameter payloads and fail-closed accounting
- document the consolidated Release/AppData qualification result

## Results
- mesh/material instancing: no multi-draw runs
- material-state reuse: 11.72% reusable continuations, max run 5
- pipeline-state reuse: 45.994% reusable continuations, max run 36
- Xenos remains authoritative; native execution and suppression stay disabled

## Validation
- 20 targeted Python tests passed
- Python compilation and diff checks passed
- Release build passed
- AppData session 20260829T214335Z-p7092 loaded gameplay and exited normally
- no fatal/error signatures or telemetry overflow