### PR TITLE
perf(native-renderer): model bounded state caches

### DIFF
--- a/docs/native-renderer/SEMANTIC_BATCH_ADMISSION.md
+++ b/docs/native-renderer/SEMANTIC_BATCH_ADMISSION.md
@@ -127,3 +127,7 @@ It separates a resource-free pipeline identity from draw arguments, geometry,
 textures, render targets, and shader-used constant values, then measures
 mesh/material instancing, material reuse, and pipeline reuse independently.
 See `SEMANTIC_BATCH_EQUIVALENCE.md`.
+
+The measured material and pipeline opportunities feed a bounded shadow cache
+without enabling native state objects or execution. See
+`SEMANTIC_STATE_CACHE.md`.

--- a/docs/native-renderer/SEMANTIC_BATCH_EQUIVALENCE.md
+++ b/docs/native-renderer/SEMANTIC_BATCH_EQUIVALENCE.md
@@ -71,7 +71,7 @@ enter any equivalence level.
 ## Fail-closed report
 
 `tools/summarize-native-renderer-semantic-batches.py` emits schema
-`pinyon-shift.native-renderer-semantic-batch-admission.v2`. It requires one
+`pinyon-shift.native-renderer-semantic-batch-admission.v3`. It requires one
 complete summary for every equivalence level and reconciles every retained
 entry to the exact eligible-draw total. Continuation accounting must match
 both semantic-instance and parameter transitions, with zero table overflow.
@@ -104,3 +104,6 @@ The largest compact shader-parameter payload was 700 bytes, below the
 prepared-pipeline caches as the next implementation batch, but those reuse
 paths must not be reported as draw-count reduction. Native execution,
 reordering, admission, upload, draw, and suppression remain disabled.
+
+The follow-up bounded shadow-cache contract is documented in
+`docs/native-renderer/SEMANTIC_STATE_CACHE.md`.

--- a/docs/native-renderer/SEMANTIC_STATE_CACHE.md
+++ b/docs/native-renderer/SEMANTIC_STATE_CACHE.md
@@ -1,0 +1,118 @@
+# Semantic state-cache admission
+
+This NR-05C checkpoint turns the measured material and pipeline reuse into a
+bounded cache contract. It is still a shadow implementation: it records the
+work a future native renderer could avoid, but does not create native state
+objects, bind native resources, issue native draws, reorder work, or suppress
+Xenos output.
+
+## Cache identities
+
+The cache consumes the resource-free pipeline identity established by the
+semantic batch-equivalence ladder:
+
+- `pipeline_state` keys the immutable prepared pipeline, shader and
+  specialization state, resource-free vertex/texture layouts, and normalized
+  render state;
+- `material_state` adds texture-resource and render-target-resource identities
+  to the pipeline key.
+
+Geometry resources, draw arguments, and shader-parameter values are not part
+of either cached state object. They remain per-draw inputs. Texture and target
+content invalidation is deliberately outside this descriptor/state cache and
+continues to require the resource-generation and deferred-destruction work in
+NR-04D and PR 9.
+
+## Bounded replacement policy
+
+Each level is measured simultaneously at three four-way set-associative
+profiles: compact (64 entries), balanced (256), and headroom (1,024). Lookups
+inspect only four entries in each profile. A miss fills an empty way or evicts
+the least-recently-used way in that bucket, giving deterministic bounded
+memory and constant lookup cost without heap allocation. Measuring all three
+profiles in one gameplay session avoids a separate build and run merely to
+select capacity.
+
+The cache lifetime is one census session. Reset and uninstall discard all
+shadow entries; no native object survives the session boundary.
+
+## Reuse classes
+
+Every fail-closed eligible semantic draw performs one lookup in both cache
+levels. Hits are partitioned exactly once into:
+
+- `consecutive_hits`: the immediately preceding eligible draw in the same
+  frame used the same key, so a later executor could elide a redundant bind;
+- `nonconsecutive_same_frame_hits`: the object was already resident in this
+  frame, but another state intervened, so construction is avoided while a bind
+  remains required;
+- `cross_frame_hits`: the resident object was last used in an earlier frame.
+
+A rejected draw breaks bind continuity because it may change authoritative
+guest state. Frame boundaries also prevent bind elision. Cache residency may
+continue across both boundaries because object identity remains explicit.
+
+Misses model object construction. Hits model construction avoided. Only
+consecutive hits count as binding elisions; all other lookups count as required
+bindings. This prevents the broader cache-hit metric from being mislabeled as
+command reduction.
+
+## Fail-closed report
+
+`tools/summarize-native-renderer-semantic-batches.py` emits schema
+`pinyon-shift.native-renderer-semantic-batch-admission.v3`. It requires one
+complete summary for every cache level and capacity profile and verifies:
+
+- one lookup per eligible draw at both levels;
+- hits plus misses equal lookups;
+- the three hit classes partition all hits;
+- construction and binding accounting reconcile;
+- resident and maximum-resident counts stay within capacity;
+- eviction, bucket, way, capacity, policy, and percentage fields agree; and
+- native objects, bindings, draws, reordering, and suppression all remain off
+  while Xenos stays authoritative.
+
+The report exposes `state_object_cache_reuse_proved` and
+`state_binding_elision_proved` as evidence flags. Neither flag admits native
+execution. It also selects the smallest zero-eviction profile independently
+for material and pipeline state when the capture proves one.
+
+## Qualification result
+
+Release/AppData session `20260829T220629Z-p41464` observed 699,166 prepared
+draws over 2,116 frames and admitted 473,474. All six cache summaries
+reconciled one lookup per eligible draw. The installed profile loaded into
+live festival gameplay, Xenos remained authoritative, no native state object
+or binding was created, no suppression gate changed, and shutdown was clean.
+
+Material-state results were:
+
+- compact: 473,038 hits, 436 misses, 99.908% hit rate, and 388 evictions;
+- balanced: 473,406 hits, 68 misses, 99.986% hit rate, and one eviction;
+- headroom: 473,406 hits, 68 misses, 99.986% hit rate, zero evictions, and 68
+  resident entries.
+
+All material profiles found 55,368 consecutive binding elisions (11.694%).
+The zero-eviction selection is therefore `headroom`; the balanced profile is
+nearly sufficient but does not meet the strict gate in this capture.
+
+Pipeline-state results were identical at every capacity: 473,440 hits, 34
+misses, 99.993% hit rate, zero evictions, and 34 resident entries. They found
+217,928 consecutive binding elisions (46.027%). The smallest zero-eviction
+selection is `compact`.
+
+The 1,024-entry material cache also measured 384,003 non-consecutive
+same-frame hits and 34,035 cross-frame hits. The 64-entry pipeline cache
+measured 234,310 and 21,202 respectively. These prove that an object cache is
+valuable independently of consecutive bind elision.
+
+The session measured 30.082 median FPS, 15.109 FPS one-percent low, 59.019 Hz
+presentation, and zero present-deadline misses. No fatal, panic, assertion,
+device-loss, unhandled-exception, or access-violation signature appeared. The
+state-cache report SHA-256 is
+`46C1C045A52FAF32F06AFE56AA82F5B6FF87495DA83DA6D2069F5F55E7805D9D`.
+
+The next implementation may use the selected capacities for native immutable
+state objects, but resource lifetime and fence-gated destruction must be in
+place before any cached native resource view can outlive its observed guest
+generation. Native execution and suppression remain inadmissible.

--- a/src/native_renderer/graphics_hooks.cpp
+++ b/src/native_renderer/graphics_hooks.cpp
@@ -96,6 +96,12 @@ constexpr size_t kSemanticPreparedTemplateCapacity =
     kTitleDrawProvenanceCapacity;
 constexpr size_t kSemanticBatchOpportunityCapacity =
     kTitleDrawProvenanceCapacity;
+constexpr size_t kSemanticStateCacheWays = 4;
+constexpr size_t kSemanticStateCacheCompactBucketCount = 16;
+constexpr size_t kSemanticStateCacheBalancedBucketCount = 64;
+constexpr size_t kSemanticStateCacheHeadroomBucketCount = 256;
+constexpr size_t kSemanticStateCacheMaximumCapacity =
+    kSemanticStateCacheHeadroomBucketCount * kSemanticStateCacheWays;
 constexpr uint64_t kSemanticBatchMaximumParameterPayloadBytes =
     2 * rex::system::kGraphicsFloatConstantObservationLimit *
         5 * sizeof(uint32_t) +
@@ -307,6 +313,42 @@ struct SemanticBatchEquivalenceRun {
   bool valid = false;
 };
 
+enum class SemanticStateCacheLevel : uint32_t {
+  kMaterial = 0,
+  kPipeline = 1,
+  kCount = 2,
+};
+
+enum class SemanticStateCacheProfile : uint32_t {
+  kCompact = 0,
+  kBalanced = 1,
+  kHeadroom = 2,
+  kCount = 3,
+};
+
+struct SemanticStateCacheEntry {
+  uint64_t key = 0;
+  uint64_t last_use_sequence = 0;
+  uint64_t last_frame = 0;
+};
+
+struct SemanticStateCacheStats {
+  uint64_t lookups = 0;
+  uint64_t hits = 0;
+  uint64_t misses = 0;
+  uint64_t evictions = 0;
+  uint64_t full_bucket_misses = 0;
+  uint64_t consecutive_hits = 0;
+  uint64_t nonconsecutive_same_frame_hits = 0;
+  uint64_t cross_frame_hits = 0;
+  uint64_t resident_entries = 0;
+  uint64_t maximum_resident_entries = 0;
+  uint64_t use_sequence = 0;
+  uint64_t previous_key = 0;
+  uint64_t previous_frame = 0;
+  bool previous_valid = false;
+};
+
 struct TitleDrawProvenanceEntry {
   uint64_t backend_signature = 0;
   uint32_t backend_outcome = 0;
@@ -407,6 +449,15 @@ std::array<std::array<SemanticBatchEquivalenceEntry,
                       kSemanticBatchOpportunityCapacity>,
            size_t(SemanticBatchEquivalence::kCount)>
     g_semantic_batch_equivalence_opportunities{};
+std::array<std::array<std::array<SemanticStateCacheEntry,
+                                 kSemanticStateCacheMaximumCapacity>,
+                      size_t(SemanticStateCacheProfile::kCount)>,
+           size_t(SemanticStateCacheLevel::kCount)>
+    g_semantic_state_caches{};
+std::array<std::array<SemanticStateCacheStats,
+                      size_t(SemanticStateCacheProfile::kCount)>,
+           size_t(SemanticStateCacheLevel::kCount)>
+    g_semantic_state_cache_stats{};
 std::array<TitleIndirectPacketEntry, kTitleIndirectPacketCapacity>
     g_title_indirect_packets{};
 std::mutex g_title_packet_provenance_mutex;
@@ -981,6 +1032,13 @@ void ResetTitleDrawProvenance() {
       entry = {};
     }
   }
+  for (auto &level : g_semantic_state_caches) {
+    for (auto &cache : level) {
+      for (SemanticStateCacheEntry &entry : cache) {
+        entry = {};
+      }
+    }
+  }
   for (TitleIndirectPacketEntry &entry : g_title_indirect_packets) {
     entry = {};
   }
@@ -1033,6 +1091,7 @@ void ResetTitleDrawProvenance() {
   g_semantic_batch_equivalence_counts = {};
   g_semantic_batch_equivalence_overflows = {};
   g_semantic_batch_equivalence_runs = {};
+  g_semantic_state_cache_stats = {};
   g_title_packet_submission_sequence = 0;
   g_title_indirect_packets_recorded = 0;
   g_title_indirect_packet_address_failures = 0;
@@ -1307,6 +1366,16 @@ void ConfigureTitleDrawProvenance(bool census_requested,
         "shader_constants_and_semantic_instance"},
        {"semantic_batch_maximum_parameter_payload_bytes",
         std::to_string(kSemanticBatchMaximumParameterPayloadBytes)},
+       {"semantic_state_cache_levels", "material,pipeline"},
+       {"semantic_state_cache_profiles",
+        "compact:64,balanced:256,headroom:1024"},
+       {"semantic_state_cache_ways",
+        std::to_string(kSemanticStateCacheWays)},
+       {"semantic_state_cache_maximum_capacity",
+        std::to_string(kSemanticStateCacheMaximumCapacity)},
+       {"semantic_state_cache_policy", "set_associative_lru"},
+       {"semantic_state_cache_lifetime", "census_session"},
+       {"semantic_state_cache_execution", "shadow_measurement_only"},
        {"semantic_batch_execution", "disabled_measurement_only"},
        {"guest_payload_read", "false"},
        {"guest_state_changed", "false"},
@@ -8235,6 +8304,154 @@ const char *SemanticBatchEquivalenceName(
   return "unknown";
 }
 
+const char *SemanticStateCacheLevelName(SemanticStateCacheLevel level) {
+  switch (level) {
+  case SemanticStateCacheLevel::kMaterial:
+    return "material_state";
+  case SemanticStateCacheLevel::kPipeline:
+    return "pipeline_state";
+  case SemanticStateCacheLevel::kCount:
+    break;
+  }
+  return "unknown";
+}
+
+const char *SemanticStateCacheProfileName(
+    SemanticStateCacheProfile profile) {
+  switch (profile) {
+  case SemanticStateCacheProfile::kCompact:
+    return "compact";
+  case SemanticStateCacheProfile::kBalanced:
+    return "balanced";
+  case SemanticStateCacheProfile::kHeadroom:
+    return "headroom";
+  case SemanticStateCacheProfile::kCount:
+    break;
+  }
+  return "unknown";
+}
+
+size_t SemanticStateCacheBucketCount(
+    SemanticStateCacheProfile profile) {
+  switch (profile) {
+  case SemanticStateCacheProfile::kCompact:
+    return kSemanticStateCacheCompactBucketCount;
+  case SemanticStateCacheProfile::kBalanced:
+    return kSemanticStateCacheBalancedBucketCount;
+  case SemanticStateCacheProfile::kHeadroom:
+    return kSemanticStateCacheHeadroomBucketCount;
+  case SemanticStateCacheProfile::kCount:
+    break;
+  }
+  return 0;
+}
+
+uint64_t SemanticStateCacheKey(
+    SemanticStateCacheLevel level,
+    const SemanticPreparedDrawContract &contract) {
+  uint64_t key = UINT64_C(0xCBF29CE484222325);
+  key = HashCombine(key, contract.batch_pipeline_key);
+  if (level == SemanticStateCacheLevel::kMaterial) {
+    key = HashCombine(key, contract.texture_resource_hash);
+    key = HashCombine(key, contract.render_target_resource_hash);
+  }
+  return key ? key : 1;
+}
+
+void BreakSemanticStateCacheContinuity() {
+  for (auto &level : g_semantic_state_cache_stats) {
+    for (SemanticStateCacheStats &stats : level) {
+      stats.previous_valid = false;
+    }
+  }
+}
+
+void RecordSemanticStateCacheLookup(
+    SemanticStateCacheLevel level, SemanticStateCacheProfile profile,
+    uint64_t frame,
+    const SemanticPreparedDrawContract &contract) {
+  const size_t level_index = size_t(level);
+  const size_t profile_index = size_t(profile);
+  SemanticStateCacheStats &stats =
+      g_semantic_state_cache_stats[level_index][profile_index];
+  auto &cache = g_semantic_state_caches[level_index][profile_index];
+  const uint64_t key = SemanticStateCacheKey(level, contract);
+  const size_t bucket_count = SemanticStateCacheBucketCount(profile);
+  const size_t bucket = size_t(key % bucket_count);
+  const size_t first_way = bucket * kSemanticStateCacheWays;
+  size_t hit_index = kSemanticStateCacheMaximumCapacity;
+  size_t empty_index = kSemanticStateCacheMaximumCapacity;
+  size_t least_recent_index = first_way;
+  uint64_t least_recent_sequence = UINT64_MAX;
+  for (size_t way = 0; way < kSemanticStateCacheWays; ++way) {
+    const size_t index = first_way + way;
+    const SemanticStateCacheEntry &entry = cache[index];
+    if (entry.key == key) {
+      hit_index = index;
+      break;
+    }
+    if (!entry.key &&
+        empty_index == kSemanticStateCacheMaximumCapacity) {
+      empty_index = index;
+    }
+    if (entry.key && entry.last_use_sequence < least_recent_sequence) {
+      least_recent_sequence = entry.last_use_sequence;
+      least_recent_index = index;
+    }
+  }
+
+  ++stats.lookups;
+  ++stats.use_sequence;
+  if (hit_index != kSemanticStateCacheMaximumCapacity) {
+    ++stats.hits;
+    SemanticStateCacheEntry &entry = cache[hit_index];
+    if (stats.previous_valid && stats.previous_frame == frame &&
+        stats.previous_key == key) {
+      ++stats.consecutive_hits;
+    } else if (entry.last_frame == frame) {
+      ++stats.nonconsecutive_same_frame_hits;
+    } else {
+      ++stats.cross_frame_hits;
+    }
+    entry.last_use_sequence = stats.use_sequence;
+    entry.last_frame = frame;
+  } else {
+    ++stats.misses;
+    size_t insert_index = empty_index;
+    if (insert_index == kSemanticStateCacheMaximumCapacity) {
+      insert_index = least_recent_index;
+      ++stats.full_bucket_misses;
+      ++stats.evictions;
+    } else {
+      ++stats.resident_entries;
+      stats.maximum_resident_entries =
+          std::max(stats.maximum_resident_entries,
+                   stats.resident_entries);
+    }
+    cache[insert_index] = {
+        .key = key,
+        .last_use_sequence = stats.use_sequence,
+        .last_frame = frame,
+    };
+  }
+  stats.previous_key = key;
+  stats.previous_frame = frame;
+  stats.previous_valid = true;
+}
+
+void RecordSemanticStateCacheLookups(
+    uint64_t frame, const SemanticPreparedDrawContract &contract) {
+  for (size_t level = 0;
+       level < size_t(SemanticStateCacheLevel::kCount); ++level) {
+    for (size_t profile = 0;
+         profile < size_t(SemanticStateCacheProfile::kCount); ++profile) {
+      RecordSemanticStateCacheLookup(
+          SemanticStateCacheLevel(level),
+          SemanticStateCacheProfile(profile), frame, contract);
+    }
+  }
+}
+
 void FinalizeSemanticBatchEquivalenceRun(
     SemanticBatchEquivalence equivalence) {
   const size_t level = size_t(equivalence);
@@ -8421,6 +8638,7 @@ void RecordSemanticBatchOpportunity(
   if (opportunity_index == kSemanticBatchOpportunityCapacity) {
     FinalizeSemanticBatchRun();
     FinalizeSemanticBatchEquivalenceRuns();
+    BreakSemanticStateCacheContinuity();
     g_semantic_batch_previous_eligible = false;
     return;
   }
@@ -8440,6 +8658,7 @@ void RecordSemanticBatchOpportunity(
     ++g_semantic_batch_rejections[size_t(rejection)];
     FinalizeSemanticBatchRun();
     FinalizeSemanticBatchEquivalenceRuns();
+    BreakSemanticStateCacheContinuity();
     g_semantic_batch_previous_eligible = false;
     return;
   }
@@ -8452,6 +8671,7 @@ void RecordSemanticBatchOpportunity(
   g_semantic_batch_maximum_parameter_payload_bytes =
       std::max(g_semantic_batch_maximum_parameter_payload_bytes,
                parameter_payload_bytes);
+  RecordSemanticStateCacheLookups(observation.frame_sequence, contract);
   for (size_t level = 0;
        level < size_t(SemanticBatchEquivalence::kCount); ++level) {
     RecordSemanticBatchEquivalenceOpportunity(
@@ -8644,10 +8864,93 @@ void EmitSemanticBatchEquivalenceSummary() {
   }
 }
 
+void EmitSemanticStateCacheSummary() {
+  for (size_t level = 0;
+       level < size_t(SemanticStateCacheLevel::kCount); ++level) {
+    const SemanticStateCacheLevel cache_level =
+        SemanticStateCacheLevel(level);
+    for (size_t profile = 0;
+         profile < size_t(SemanticStateCacheProfile::kCount); ++profile) {
+      const SemanticStateCacheProfile cache_profile =
+          SemanticStateCacheProfile(profile);
+      const SemanticStateCacheStats &stats =
+          g_semantic_state_cache_stats[level][profile];
+      const size_t bucket_count =
+          SemanticStateCacheBucketCount(cache_profile);
+      const size_t capacity = bucket_count * kSemanticStateCacheWays;
+      const bool accounting_complete =
+          stats.lookups == g_semantic_batch_eligible_draws &&
+          stats.hits + stats.misses == stats.lookups &&
+          stats.consecutive_hits +
+                  stats.nonconsecutive_same_frame_hits +
+                  stats.cross_frame_hits ==
+              stats.hits &&
+          stats.evictions <= stats.misses &&
+          stats.resident_entries <= capacity &&
+          stats.maximum_resident_entries <= capacity;
+      const uint64_t required_bindings =
+          stats.lookups >= stats.consecutive_hits
+              ? stats.lookups - stats.consecutive_hits
+              : 0;
+      const double hit_percent =
+          stats.lookups ? 100.0 * stats.hits / stats.lookups : 0.0;
+      const double bind_elision_percent =
+          stats.lookups
+              ? 100.0 * stats.consecutive_hits / stats.lookups
+              : 0.0;
+      pinyon_shift::diagnostics::RecordEvent(
+          "native_renderer.discovery.semantic_state_cache_summary",
+          {{"status", accounting_complete ? "complete" : "incomplete"},
+           {"cache_level", SemanticStateCacheLevelName(cache_level)},
+           {"cache_profile",
+            SemanticStateCacheProfileName(cache_profile)},
+           {"eligible_draws",
+            std::to_string(g_semantic_batch_eligible_draws)},
+           {"lookups", std::to_string(stats.lookups)},
+           {"hits", std::to_string(stats.hits)},
+           {"misses", std::to_string(stats.misses)},
+           {"hit_percent", fmt::format("{:.3f}", hit_percent)},
+           {"evictions", std::to_string(stats.evictions)},
+           {"full_bucket_misses",
+            std::to_string(stats.full_bucket_misses)},
+           {"resident_entries", std::to_string(stats.resident_entries)},
+           {"maximum_resident_entries",
+            std::to_string(stats.maximum_resident_entries)},
+           {"consecutive_hits",
+            std::to_string(stats.consecutive_hits)},
+           {"nonconsecutive_same_frame_hits",
+            std::to_string(stats.nonconsecutive_same_frame_hits)},
+           {"cross_frame_hits", std::to_string(stats.cross_frame_hits)},
+           {"object_constructions", std::to_string(stats.misses)},
+           {"object_constructions_avoided",
+            std::to_string(stats.hits)},
+           {"required_bindings", std::to_string(required_bindings)},
+           {"binding_elisions",
+            std::to_string(stats.consecutive_hits)},
+           {"binding_elision_percent",
+            fmt::format("{:.3f}", bind_elision_percent)},
+           {"bucket_count", std::to_string(bucket_count)},
+           {"ways", std::to_string(kSemanticStateCacheWays)},
+           {"capacity", std::to_string(capacity)},
+           {"policy", "set_associative_lru"},
+           {"lifetime", "census_session"},
+           {"accounting_complete",
+            accounting_complete ? "true" : "false"},
+           {"native_state_objects", "false"},
+           {"native_bindings", "false"},
+           {"native_draw", "false"},
+           {"reordering", "false"},
+           {"xenos_authority", "true"},
+           {"suppression_allowed", "false"}});
+    }
+  }
+}
+
 void EmitSemanticBatchOpportunitySummary() {
   FinalizeSemanticBatchRun();
   FinalizeSemanticBatchFrame();
   EmitSemanticBatchEquivalenceSummary();
+  EmitSemanticStateCacheSummary();
   uint64_t entry_draws = 0;
   uint64_t entry_eligible_draws = 0;
   uint64_t entry_rejected_draws = 0;

--- a/tools/discover-native-renderer-dispatch.py
+++ b/tools/discover-native-renderer-dispatch.py
@@ -1474,6 +1474,12 @@ def procedural_model_receiver_lifecycle(
                 "resource_free_layout_and_prepared_state"
             ),
             "semantic_batch_execution_enabled": False,
+            "semantic_state_cache_required": True,
+            "semantic_state_cache_policy": "set_associative_lru",
+            "semantic_state_cache_profiles": (
+                "compact:64,balanced:256,headroom:1024"
+            ),
+            "semantic_state_cache_execution_enabled": False,
             "physical_pm4_packet_correlation_proved": False,
             "prepared_draw_lineage_proved": False,
             "classification": "procedural_submission_pm4_packet_boundary",

--- a/tools/summarize-native-renderer-semantic-batches.py
+++ b/tools/summarize-native-renderer-semantic-batches.py
@@ -8,7 +8,7 @@ import pathlib
 import sys
 
 
-SCHEMA = "pinyon-shift.native-renderer-semantic-batch-admission.v2"
+SCHEMA = "pinyon-shift.native-renderer-semantic-batch-admission.v3"
 STATIC_SCHEMA = "pinyon-shift.native-renderer-dispatch-static.v3"
 TITLE_CONFIG = "native_renderer.discovery.title_provenance_config"
 TITLE_SUMMARY = "native_renderer.discovery.title_provenance_summary"
@@ -20,12 +20,21 @@ EQUIVALENCE_ENTRY = (
 EQUIVALENCE_SUMMARY = (
     "native_renderer.discovery.semantic_batch_equivalence_summary"
 )
+STATE_CACHE_SUMMARY = (
+    "native_renderer.discovery.semantic_state_cache_summary"
+)
 EXPECTED_ORDERING = "exact_consecutive_prepared_draw_order"
 EXPECTED_EQUIVALENCES = (
     "mesh_material_instance",
     "material_state_reuse",
     "pipeline_state_reuse",
 )
+EXPECTED_STATE_CACHE_LEVELS = ("material_state", "pipeline_state")
+EXPECTED_STATE_CACHE_PROFILES = {
+    "compact": 64,
+    "balanced": 256,
+    "headroom": 1024,
+}
 REJECTION_FIELDS = {
     "missing_title_resource": "reject_missing_title_resource",
     "non_opaque": "reject_non_opaque",
@@ -51,6 +60,7 @@ def read_events(paths: list[pathlib.Path]) -> list[dict]:
         BATCH_SUMMARY,
         EQUIVALENCE_ENTRY,
         EQUIVALENCE_SUMMARY,
+        STATE_CACHE_SUMMARY,
     }
     for path in paths:
         for line_number, line in enumerate(
@@ -142,6 +152,12 @@ def _validate_static(static: dict) -> dict:
             "resource_free_layout_and_prepared_state"
         ),
         "semantic_batch_execution_enabled": False,
+        "semantic_state_cache_required": True,
+        "semantic_state_cache_policy": "set_associative_lru",
+        "semantic_state_cache_profiles": (
+            "compact:64,balanced:256,headroom:1024"
+        ),
+        "semantic_state_cache_execution_enabled": False,
         "native_rendering_enabled": False,
         "suppression_eligible": False,
     }
@@ -377,6 +393,141 @@ def _build_equivalence_levels(
     return result
 
 
+def _build_state_caches(
+    selected: list[dict], eligible_draws: int
+) -> dict[str, dict]:
+    result = {}
+    for cache_level in EXPECTED_STATE_CACHE_LEVELS:
+        profiles = {}
+        for cache_profile, expected_capacity in (
+            EXPECTED_STATE_CACHE_PROFILES.items()
+        ):
+            summaries = [
+                event
+                for event in selected
+                if event.get("event") == STATE_CACHE_SUMMARY
+                and event.get("cache_level") == cache_level
+                and event.get("cache_profile") == cache_profile
+            ]
+            if len(summaries) != 1:
+                raise ValueError(
+                    "semantic state cache needs one summary: "
+                    f"{cache_level}/{cache_profile}"
+                )
+            summary = summaries[0]
+            if (
+                summary.get("status") != "complete"
+                or summary.get("accounting_complete") != "true"
+                or summary.get("policy") != "set_associative_lru"
+                or summary.get("lifetime") != "census_session"
+                or summary.get("native_state_objects") != "false"
+                or summary.get("native_bindings") != "false"
+                or summary.get("native_draw") != "false"
+                or summary.get("reordering") != "false"
+                or summary.get("xenos_authority") != "true"
+                or summary.get("suppression_allowed") != "false"
+            ):
+                raise ValueError(
+                    "semantic state cache is incomplete or unsafe: "
+                    f"{cache_level}/{cache_profile}"
+                )
+            totals = {
+                name: _integer(summary, name)
+                for name in (
+                    "eligible_draws",
+                    "lookups",
+                    "hits",
+                    "misses",
+                    "evictions",
+                    "full_bucket_misses",
+                    "resident_entries",
+                    "maximum_resident_entries",
+                    "consecutive_hits",
+                    "nonconsecutive_same_frame_hits",
+                    "cross_frame_hits",
+                    "object_constructions",
+                    "object_constructions_avoided",
+                    "required_bindings",
+                    "binding_elisions",
+                    "bucket_count",
+                    "ways",
+                    "capacity",
+                )
+            }
+            totals["hit_percent"] = _number(summary, "hit_percent")
+            totals["binding_elision_percent"] = _number(
+                summary, "binding_elision_percent"
+            )
+            expected_hit_percent = (
+                100.0 * totals["hits"] / totals["lookups"]
+                if totals["lookups"]
+                else 0.0
+            )
+            expected_elision_percent = (
+                100.0 * totals["binding_elisions"] / totals["lookups"]
+                if totals["lookups"]
+                else 0.0
+            )
+            if (
+                totals["eligible_draws"] != eligible_draws
+                or totals["lookups"] != eligible_draws
+                or totals["hits"] + totals["misses"]
+                != totals["lookups"]
+                or totals["consecutive_hits"]
+                + totals["nonconsecutive_same_frame_hits"]
+                + totals["cross_frame_hits"]
+                != totals["hits"]
+                or totals["object_constructions"] != totals["misses"]
+                or totals["object_constructions_avoided"]
+                != totals["hits"]
+                or totals["required_bindings"]
+                + totals["binding_elisions"]
+                != totals["lookups"]
+                or totals["binding_elisions"]
+                != totals["consecutive_hits"]
+                or totals["full_bucket_misses"] != totals["evictions"]
+                or totals["evictions"] > totals["misses"]
+                or totals["resident_entries"] > totals["capacity"]
+                or totals["maximum_resident_entries"]
+                > totals["capacity"]
+                or totals["capacity"] != expected_capacity
+                or totals["capacity"]
+                != totals["bucket_count"] * totals["ways"]
+                or totals["bucket_count"] <= 0
+                or totals["ways"] <= 0
+            ):
+                raise ValueError(
+                    "semantic state cache accounting failed: "
+                    f"{cache_level}/{cache_profile}"
+                )
+            if (
+                abs(totals["hit_percent"] - expected_hit_percent) > 0.001
+                or abs(
+                    totals["binding_elision_percent"]
+                    - expected_elision_percent
+                )
+                > 0.001
+            ):
+                raise ValueError(
+                    "semantic state cache percentage drifted: "
+                    f"{cache_level}/{cache_profile}"
+                )
+            profiles[cache_profile] = totals
+        zero_eviction_profile = next(
+            (
+                profile
+                for profile in EXPECTED_STATE_CACHE_PROFILES
+                if profiles[profile]["evictions"] == 0
+            ),
+            None,
+        )
+        result[cache_level] = {
+            "profiles": profiles,
+            "minimum_zero_eviction_profile": zero_eviction_profile,
+        }
+    return result
+
+
 def build(events: list[dict], static: dict, requested: str | None = None) -> dict:
     contract = _validate_static(static)
     session = _select_session(events, requested)
@@ -409,6 +560,18 @@ def build(events: list[dict], static: dict, requested: str | None = None) -> dic
             config, "semantic_batch_maximum_parameter_payload_bytes"
         )
         <= 0
+        or config.get("semantic_state_cache_levels")
+        != "material,pipeline"
+        or config.get("semantic_state_cache_profiles")
+        != "compact:64,balanced:256,headroom:1024"
+        or _integer(config, "semantic_state_cache_ways") <= 0
+        or _integer(config, "semantic_state_cache_maximum_capacity")
+        != 1024
+        or config.get("semantic_state_cache_policy")
+        != "set_associative_lru"
+        or config.get("semantic_state_cache_lifetime") != "census_session"
+        or config.get("semantic_state_cache_execution")
+        != "shadow_measurement_only"
         or config.get("xenos_authority") != "true"
         or config.get("suppression_allowed") != "false"
     ):
@@ -623,6 +786,9 @@ def build(events: list[dict], static: dict, requested: str | None = None) -> dic
     equivalence_levels = _build_equivalence_levels(
         selected, totals["eligible_draws"]
     )
+    state_caches = _build_state_caches(
+        selected, totals["eligible_draws"]
+    )
 
     entries.sort(
         key=lambda item: (
@@ -657,12 +823,21 @@ def build(events: list[dict], static: dict, requested: str | None = None) -> dic
         "totals": totals,
         "rejections": reported_rejections,
         "equivalence_levels": equivalence_levels,
+        "state_caches": state_caches,
         "conservative_batch_plan_proved": conservative_batch_plan_proved,
         "mesh_material_instancing_opportunity_proved": (
             mesh_material_instancing_opportunity_proved
         ),
         "instancing_parameter_path_required": (
             instancing_parameter_path_required
+        ),
+        "state_object_cache_reuse_proved": all(
+            cache["profiles"]["headroom"]["hits"] > 0
+            for cache in state_caches.values()
+        ),
+        "state_binding_elision_proved": any(
+            cache["profiles"]["headroom"]["binding_elisions"] > 0
+            for cache in state_caches.values()
         ),
         "execution_admitted": False,
         "contract": contract,

--- a/tools/tests/test_native_renderer_dispatch_discovery.py
+++ b/tools/tests/test_native_renderer_dispatch_discovery.py
@@ -1202,6 +1202,20 @@ class NativeRendererDispatchDiscoveryTests(unittest.TestCase):
         self.assertFalse(
             draw_association["semantic_batch_execution_enabled"]
         )
+        self.assertTrue(
+            draw_association["semantic_state_cache_required"]
+        )
+        self.assertEqual(
+            "set_associative_lru",
+            draw_association["semantic_state_cache_policy"],
+        )
+        self.assertEqual(
+            "compact:64,balanced:256,headroom:1024",
+            draw_association["semantic_state_cache_profiles"],
+        )
+        self.assertFalse(
+            draw_association["semantic_state_cache_execution_enabled"]
+        )
         self.assertTrue(draw_association["render_item_invocation_scope_proved"])
         self.assertTrue(draw_association["submission_before_draw_dispatch_proved"])
         self.assertEqual(160, draw_association["graphics_submission_vtable_offset"])

--- a/tools/tests/test_native_renderer_semantic_batches.py
+++ b/tools/tests/test_native_renderer_semantic_batches.py
@@ -32,6 +32,12 @@ def static_inventory():
                     "resource_free_layout_and_prepared_state"
                 ),
                 "semantic_batch_execution_enabled": False,
+                "semantic_state_cache_required": True,
+                "semantic_state_cache_policy": "set_associative_lru",
+                "semantic_state_cache_profiles": (
+                    "compact:64,balanced:256,headroom:1024"
+                ),
+                "semantic_state_cache_execution_enabled": False,
                 "native_rendering_enabled": False,
                 "suppression_eligible": False,
             }
@@ -163,6 +169,75 @@ def events():
                 },
             ]
         )
+    cache_events = []
+    cache_metrics = {
+        "material_state": {
+            "hits": 8,
+            "misses": 2,
+            "consecutive_hits": 6,
+            "nonconsecutive_same_frame_hits": 1,
+            "cross_frame_hits": 1,
+            "resident_entries": 2,
+        },
+        "pipeline_state": {
+            "hits": 9,
+            "misses": 1,
+            "consecutive_hits": 6,
+            "nonconsecutive_same_frame_hits": 2,
+            "cross_frame_hits": 1,
+            "resident_entries": 1,
+        },
+    }
+    for cache_level, metrics in cache_metrics.items():
+        for cache_profile, capacity in (
+            MODULE.EXPECTED_STATE_CACHE_PROFILES.items()
+        ):
+            cache_events.append(
+                {
+                    **common,
+                    "event": MODULE.STATE_CACHE_SUMMARY,
+                    "status": "complete",
+                    "cache_level": cache_level,
+                    "cache_profile": cache_profile,
+                    "eligible_draws": "10",
+                    "lookups": "10",
+                    "hits": str(metrics["hits"]),
+                    "misses": str(metrics["misses"]),
+                    "hit_percent": f'{metrics["hits"] * 10:.3f}',
+                    "evictions": "0",
+                    "full_bucket_misses": "0",
+                    "resident_entries": str(metrics["resident_entries"]),
+                    "maximum_resident_entries": str(
+                        metrics["resident_entries"]
+                    ),
+                    "consecutive_hits": str(metrics["consecutive_hits"]),
+                    "nonconsecutive_same_frame_hits": str(
+                        metrics["nonconsecutive_same_frame_hits"]
+                    ),
+                    "cross_frame_hits": str(metrics["cross_frame_hits"]),
+                    "object_constructions": str(metrics["misses"]),
+                    "object_constructions_avoided": str(metrics["hits"]),
+                    "required_bindings": str(
+                        10 - metrics["consecutive_hits"]
+                    ),
+                    "binding_elisions": str(metrics["consecutive_hits"]),
+                    "binding_elision_percent": (
+                        f'{metrics["consecutive_hits"] * 10:.3f}'
+                    ),
+                    "bucket_count": str(capacity // 4),
+                    "ways": "4",
+                    "capacity": str(capacity),
+                    "policy": "set_associative_lru",
+                    "lifetime": "census_session",
+                    "accounting_complete": "true",
+                    "native_state_objects": "false",
+                    "native_bindings": "false",
+                    "native_draw": "false",
+                    "reordering": "false",
+                    "xenos_authority": "true",
+                    "suppression_allowed": "false",
+                }
+            )
     return [
         {
             **common,
@@ -182,6 +257,15 @@ def events():
                 "shader_constants_and_semantic_instance"
             ),
             "semantic_batch_maximum_parameter_payload_bytes": "2756",
+            "semantic_state_cache_levels": "material,pipeline",
+            "semantic_state_cache_profiles": (
+                "compact:64,balanced:256,headroom:1024"
+            ),
+            "semantic_state_cache_ways": "4",
+            "semantic_state_cache_maximum_capacity": "1024",
+            "semantic_state_cache_policy": "set_associative_lru",
+            "semantic_state_cache_lifetime": "census_session",
+            "semantic_state_cache_execution": "shadow_measurement_only",
             "semantic_batch_execution": "disabled_measurement_only",
             "xenos_authority": "true",
             "suppression_allowed": "false",
@@ -248,6 +332,7 @@ def events():
             "semantic_draw_prepared_matches": "12",
             "semantic_draw_unprepared_matches": "0",
         },
+        *cache_events,
         summary,
     ]
 
@@ -265,6 +350,20 @@ class SemanticBatchTests(unittest.TestCase):
             document["mesh_material_instancing_opportunity_proved"]
         )
         self.assertTrue(document["instancing_parameter_path_required"])
+        self.assertTrue(document["state_object_cache_reuse_proved"])
+        self.assertTrue(document["state_binding_elision_proved"])
+        self.assertEqual(
+            8,
+            document["state_caches"]["material_state"]["profiles"][
+                "headroom"
+            ]["hits"],
+        )
+        self.assertEqual(
+            "compact",
+            document["state_caches"]["material_state"][
+                "minimum_zero_eviction_profile"
+            ],
+        )
         self.assertEqual(
             6,
             document["equivalence_levels"]["mesh_material_instance"][
@@ -321,6 +420,29 @@ class SemanticBatchTests(unittest.TestCase):
             if event.get("event") == MODULE.EQUIVALENCE_SUMMARY
         )
         equivalence_summary["native_batch_execution"] = "true"
+        with self.assertRaisesRegex(ValueError, "incomplete or unsafe"):
+            MODULE.build(observed, static_inventory())
+
+    def test_rejects_state_cache_accounting_drift(self):
+        observed = events()
+        cache_summary = next(
+            event
+            for event in observed
+            if event.get("event") == MODULE.STATE_CACHE_SUMMARY
+            and event.get("cache_level") == "material_state"
+        )
+        cache_summary["cross_frame_hits"] = "2"
+        with self.assertRaisesRegex(ValueError, "cache accounting"):
+            MODULE.build(observed, static_inventory())
+
+    def test_rejects_unsafe_state_cache_summary(self):
+        observed = events()
+        cache_summary = next(
+            event
+            for event in observed
+            if event.get("event") == MODULE.STATE_CACHE_SUMMARY
+        )
+        cache_summary["native_state_objects"] = "true"
         with self.assertRaisesRegex(ValueError, "incomplete or unsafe"):
             MODULE.build(observed, static_inventory())
 


### PR DESCRIPTION
## Summary
- model material and pipeline state reuse with bounded four-way LRU shadow caches
- evaluate 64, 256, and 1,024-entry profiles in one gameplay capture
- classify consecutive, non-consecutive same-frame, and cross-frame hits
- extend the fail-closed semantic report to schema v3
- keep native objects, bindings, draws, reordering, and suppression disabled

## Qualification
- 331 Python tests passed
- Release build passed
- AppData session 20260829T220629Z-p41464 loaded live gameplay and exited normally
- material selection: headroom, 99.986% hits, zero evictions
- pipeline selection: compact, 99.993% hits, zero evictions
- 30.082 median FPS, 15.109 FPS 1% low, zero present-deadline misses
- no fatal/error signatures