### PR TITLE
feat(native-renderer): qualify visibility and lod policy

### DIFF
--- a/config/rexglue/analysis/main-xex.toml
+++ b/config/rexglue/analysis/main-xex.toml
@@ -242,6 +242,36 @@ registers = ["r3"]
 address = 0x82E208CC
 name = "PinyonShiftObserveProceduralModelVisibilityExit"
 
+# Slot 14's record loop exposes title-authoritative visibility and LOD
+# decisions without reconstructing or replacing its camera-space policy. The
+# hooks are observational: record identity is captured after r23/r21 are
+# formed, LOD stores are sampled before the guest write, the selection byte is
+# sampled after the title load, and completion is observed before index advance.
+[[midasm_hook]]
+address = 0x82E20094
+name = "PinyonShiftObserveProceduralModelVisibilityRecordEntry"
+registers = ["r15", "r16", "r20", "r21", "r23"]
+
+[[midasm_hook]]
+address = 0x82E205E4
+name = "PinyonShiftObserveProceduralModelVisibilityLodPrimary"
+registers = ["r6"]
+
+[[midasm_hook]]
+address = 0x82E206DC
+name = "PinyonShiftObserveProceduralModelVisibilityLodSecondary"
+registers = ["r6"]
+
+[[midasm_hook]]
+address = 0x82E206F8
+name = "PinyonShiftObserveProceduralModelVisibilityResult"
+registers = ["r11"]
+
+[[midasm_hook]]
+address = 0x82E2084C
+name = "PinyonShiftObserveProceduralModelVisibilityRecordExit"
+registers = ["r16", "r20"]
+
 [[midasm_hook]]
 address = 0x824170DC
 name = "PinyonShiftObserveProceduralModelRenderStateEntry"

--- a/config/rexglue/analysis/main-xex.toml
+++ b/config/rexglue/analysis/main-xex.toml
@@ -250,7 +250,17 @@ name = "PinyonShiftObserveProceduralModelVisibilityExit"
 [[midasm_hook]]
 address = 0x82E20094
 name = "PinyonShiftObserveProceduralModelVisibilityRecordEntry"
-registers = ["r15", "r16", "r20", "r21", "r23"]
+registers = ["r15", "r16", "r20", "r21", "r23", "f26"]
+
+[[midasm_hook]]
+address = 0x82E20134
+name = "PinyonShiftObserveProceduralModelVisibilityRuntimeThreshold"
+registers = ["f0", "f26"]
+
+[[midasm_hook]]
+address = 0x82E201B0
+name = "PinyonShiftObserveProceduralModelVisibilityDescriptorThreshold"
+registers = ["f0", "f26"]
 
 [[midasm_hook]]
 address = 0x82E205E4

--- a/docs/native-renderer/VISIBILITY_LOD_CONTRACT.md
+++ b/docs/native-renderer/VISIBILITY_LOD_CONTRACT.md
@@ -1,0 +1,94 @@
+# Title-authoritative visibility and LOD contract
+
+NR-05D begins with a passive boundary around the title's existing procedural
+model visibility routine at `0x82E1FD00`. This checkpoint does not attempt to
+name camera fields or reproduce the policy from partial ABI evidence. Instead,
+it records the exact decisions that the title already commits to its runtime
+records, preserving them as the reference contract for later native culling
+and LOD work.
+
+## Proven record loop
+
+The reviewed slot-14 routine iterates descriptor and runtime records in lockstep:
+
+- `r20` is the live `proceduralGeometry::CProceduralModels` receiver;
+- `r16` is the record index;
+- `r15` is the title's category partition;
+- `r23` is `descriptor_base + record_index * 92`;
+- `r21` is `runtime_base + record_index * 68`.
+
+The static discovery contract validates the instructions surrounding four
+observation boundaries:
+
+| Boundary | Address | Meaning |
+| --- | --- | --- |
+| record entry | `0x82E20094` | descriptor/runtime identity is complete |
+| LOD writes | `0x82E205E4`, `0x82E206DC` | title writes the selected index to runtime offset 104 |
+| selection result | `0x82E206F8` | title has loaded the runtime selection byte at offset 18 |
+| record completion | `0x82E2084C` | record result is final, before index/stride advance |
+
+Reaching completion without reaching the result boundary is an early title
+rejection. At the result boundary, the title's own comparison treats any
+nonzero selection byte as accepted and zero as rejected. The census retains a
+256-bin byte-value histogram instead of narrowing that bitfield to a boolean.
+Category 9 is the path that commits a title-selected LOD index.
+
+## Runtime census
+
+The census maintains one thread-local active record and lock-free bounded
+aggregates. It reports:
+
+- total entries, completions, evaluated results, selections, evaluated
+  rejections, and early rejections;
+- per-category versions of the same accounting;
+- LOD-bearing records, repeated title rewrites within those records, and a
+  bounded 32-bin first-selected-index histogram;
+- the complete 256-value title selection-byte histogram;
+- receiver-generation joins, record identity mismatches, hook stack faults,
+  category/LOD overflow, and records left open at shutdown.
+
+The title can legitimately revisit either LOD store more than once for one
+record. Those observations are reported as `lod_rewrites`; they are evidence
+about the title's iterative policy, not lifecycle faults. Qualification fails
+closed if record accounting is unbalanced, any identity or lifecycle join is
+uncertain, a histogram overflows, no selected records or LOD-bearing records
+are observed, or a selected category-9 record lacks its title LOD write.
+
+Generate the static inventory and runtime report with:
+
+```powershell
+python tools/discover-native-renderer-dispatch.py `
+  .local/generated/default `
+  --image .local/generated/default/default.xex `
+  --output .local/qualification/native-renderer-visibility-static.json
+
+python tools/summarize-native-renderer-visibility.py `
+  <diagnostic-jsonl> `
+  --static .local/qualification/native-renderer-visibility-static.json `
+  --output .local/qualification/native-renderer-visibility.json
+```
+
+## Qualification checkpoint
+
+The AppData-backed open-world capture `20260829T223924Z-p43824` completed with
+1,157,645 balanced record entries/completions and no identity, receiver,
+overflow, orphan, or shutdown-open faults. It observed 8,968 title selections,
+40,144 evaluated rejections, 1,108,533 early rejections, 4,484 LOD-bearing
+category-9 records, and 14,553 legitimate in-record LOD rewrites. Selected LOD
+indices were evenly split between 0 and 1 (2,242 records each).
+
+The same 226.49-second capture retained a 30.355 FPS median, 29.745 Hz
+simulation cadence, 59.375 Hz presentation cadence, zero presentation deadline
+misses, and a normal process exit. The first capture encoded repeated LOD
+writes under the old `duplicate_lod` diagnostic name; the v1 reporter records
+that explicit compatibility normalization while the runtime now emits the
+correct `lod_rewrites` name.
+
+## Safety boundary
+
+All hooks are observational. They read only registers already holding title
+decisions; they do not read payload memory, write guest state, alter control
+flow, upload native resources, submit native draws, reorder work, or suppress
+Xenos work. Native culling and native LOD remain disabled. Xenos remains the
+sole rendering and visibility authority until a later policy model is proven
+against this census and independently passes the plan's admission gates.

--- a/docs/native-renderer/VISIBILITY_POLICY_ABI.md
+++ b/docs/native-renderer/VISIBILITY_POLICY_ABI.md
@@ -1,0 +1,39 @@
+# Visibility policy ABI candidates
+
+The first NR-05D runtime census proves the title's visibility and LOD outcomes.
+This checkpoint narrows the inputs that produce those outcomes without naming
+an unproven camera, frustum, or bounds layout.
+
+## Proven structural flow
+
+The slot-14 function preserves its second and third arguments, then partitions
+both by title category:
+
+| Input | Structural use | Evidence |
+| --- | --- | --- |
+| receiver `+4` | shared spatial context | vectors loaded at `+16` and `+32` |
+| argument `r4` | category spatial table | `category * 192`; scalars at `+160`, `+164`, `+168` |
+| argument `r5` | category query table | `category * 32` before helper dispatch |
+| descriptor `+60` | squared-distance comparison scalar | compared against the shared `f26` value |
+| runtime `+44` | earlier squared-distance threshold | compared against the same `f26` value |
+
+The shared context vectors feed a clamp/subtract/vector-sum sequence whose
+result is retained in `f26`. The category query reaches helpers `0x8243F9A0`
+and `0x82441048` before record iteration. These derivations and exact
+instructions are now part of static discovery, so binary or recompilation drift
+fails closed.
+
+## Deliberately unproven semantics
+
+The arithmetic is consistent with point-to-box squared distance and the helper
+pair is consistent with spatial/frustum policy, but those names are not yet an
+ABI contract. We have not proved:
+
+- which shared-context vector is minimum, maximum, eye, or focus position;
+- a camera or frustum-plane layout;
+- whether the category scalars are extents, margins, ranges, or mode data;
+- the descriptor/runtime scalar units or all category-specific branches.
+
+Accordingly this checkpoint enables only a future passive input/outcome
+correlation census. Native policy execution, native culling, native LOD, guest
+state mutation, draw suppression, and Xenos replacement remain disabled.

--- a/docs/native-renderer/VISIBILITY_POLICY_ABI.md
+++ b/docs/native-renderer/VISIBILITY_POLICY_ABI.md
@@ -23,6 +23,14 @@ and `0x82441048` before record iteration. These derivations and exact
 instructions are now part of static discovery, so binary or recompilation drift
 fails closed.
 
+The first helper interpolates between the two vector arguments, forms a
+three-component squared delta, and delegates to `0x8243FD70`. That predicate
+loads a query vector at offset 0 plus scalars at offsets 16, 20, and 24, then
+compares scaled squared distances. The second helper loads six 16-byte vector
+blocks at offsets 0 through 80, combines vector comparisons for both input
+endpoints, and returns only 0, 1, or 2. Static discovery now proves those exact
+structures as well as their callsites.
+
 ## Deliberately unproven semantics
 
 The arithmetic is consistent with point-to-box squared distance and the helper
@@ -34,6 +42,61 @@ ABI contract. We have not proved:
 - whether the category scalars are extents, margins, ranges, or mode data;
 - the descriptor/runtime scalar units or all category-specific branches.
 
+The helper shapes strengthen the segment-distance and six-vector-classifier
+hypotheses, but do not by themselves prove world-space units or that the six
+vectors are camera frustum planes.
+
 Accordingly this checkpoint enables only a future passive input/outcome
 correlation census. Native policy execution, native culling, native LOD, guest
 state mutation, draw suppression, and Xenos replacement remain disabled.
+
+## Passive input/outcome correlation
+
+That census is now implemented at three register-only boundaries:
+
+| Boundary | Address | Captured title value |
+| --- | --- | --- |
+| record entry | `0x82E20094` | shared squared spatial value in `f26` |
+| runtime-scalar comparison | `0x82E20134` | `f26` versus squared runtime `+44` scalar in `f0` |
+| descriptor-scalar comparison | `0x82E201B0` | `f26` versus scaled-and-squared descriptor `+60` scalar in `f0` |
+
+Every completed record joins those observations to its title outcome and
+category. A bounded 256-bin IEEE-754 exponent histogram preserves the spatial
+value distribution separately for early rejection, evaluated rejection, and
+selection without logging raw per-object values. Per-category summaries retain
+threshold reach and comparison counts. Non-finite/negative inputs, duplicate or
+orphan threshold hooks, category drift, histogram drift, or any native-policy
+flag fail qualification closed.
+
+Generate the static contract and the runtime report with:
+
+```powershell
+python tools/discover-native-renderer-dispatch.py `
+  .local/generated/default `
+  --image .local/analysis/default-image.bin `
+  --output .local/qualification/native-renderer-visibility-policy-static.json
+
+python tools/summarize-native-renderer-visibility-policy.py `
+  <diagnostic-jsonl> `
+  --static .local/qualification/native-renderer-visibility-policy-static.json `
+  --output .local/qualification/native-renderer-visibility-policy.json
+```
+
+## Runtime qualification
+
+The consolidated AppData-backed Release capture
+`20260829T230622Z-p39648` completed normally. It correlated 1,768,409 record
+outcomes and the same number of spatial samples, including 1,694,229 early
+rejections, 60,660 evaluated rejections, and 13,520 selections. All threshold
+hooks joined to an open record. Duplicate hooks, orphan hooks, lifecycle and
+identity faults, category and histogram overflow, and invalid spatial or
+threshold values were all zero.
+
+The capture also observed both comparison boundaries in meaningful numbers:
+1,687,112 runtime-threshold observations and 334,276 descriptor-threshold
+observations. Median performance was 30.195 FPS over 8,034 frames, with no
+present-deadline misses and a normal exit.
+
+This qualifies the passive structural input/outcome contract for semantic
+hypothesis testing. It still does not prove camera, frustum, bounds, or unit
+semantics, and it does not enable native policy execution.

--- a/src/native_renderer/graphics_hooks.cpp
+++ b/src/native_renderer/graphics_hooks.cpp
@@ -92,6 +92,8 @@ constexpr size_t kSemanticReceiverStackCapacity = 32;
 constexpr size_t kSemanticVisibilityCategoryCapacity = 32;
 constexpr size_t kSemanticVisibilityLodCapacity = 32;
 constexpr size_t kSemanticVisibilityResultValueCapacity = 256;
+constexpr size_t kSemanticVisibilityPolicyOutcomeCapacity = 3;
+constexpr size_t kSemanticVisibilitySpatialExponentCapacity = 256;
 constexpr size_t kSemanticInstanceCapacity = 4096;
 constexpr size_t kSemanticSubmissionCapacity = 8192;
 constexpr size_t kSemanticRenderItemStackCapacity = 32;
@@ -622,6 +624,21 @@ struct SemanticVisibilityCategoryStats {
   std::atomic<uint64_t> lod_writes{};
 };
 
+enum class SemanticVisibilityPolicyOutcome : size_t {
+  kEarlyRejected,
+  kRejected,
+  kSelected,
+};
+
+struct SemanticVisibilityPolicyStats {
+  std::atomic<uint64_t> records{};
+  std::atomic<uint64_t> spatial_samples{};
+  std::atomic<uint64_t> runtime_threshold_observations{};
+  std::atomic<uint64_t> runtime_distance_less{};
+  std::atomic<uint64_t> descriptor_threshold_observations{};
+  std::atomic<uint64_t> descriptor_distance_exceeded{};
+};
+
 std::atomic<uint64_t> g_semantic_visibility_record_entries{};
 std::atomic<uint64_t> g_semantic_visibility_record_completions{};
 std::atomic<uint64_t> g_semantic_visibility_records_open{};
@@ -651,6 +668,21 @@ std::array<std::atomic<uint64_t>, kSemanticVisibilityLodCapacity>
     g_semantic_visibility_lod_histogram{};
 std::array<std::atomic<uint64_t>, kSemanticVisibilityResultValueCapacity>
     g_semantic_visibility_result_value_histogram{};
+std::array<std::array<SemanticVisibilityPolicyStats,
+                      kSemanticVisibilityPolicyOutcomeCapacity>,
+           kSemanticVisibilityCategoryCapacity>
+    g_semantic_visibility_policy_categories{};
+std::array<std::array<std::atomic<uint64_t>,
+                      kSemanticVisibilitySpatialExponentCapacity>,
+           kSemanticVisibilityPolicyOutcomeCapacity>
+    g_semantic_visibility_spatial_exponents{};
+std::atomic<uint64_t> g_semantic_visibility_policy_invalid_spatial_values{};
+std::atomic<uint64_t> g_semantic_visibility_policy_invalid_threshold_values{};
+std::atomic<uint64_t> g_semantic_visibility_policy_hook_faults{};
+std::atomic<uint64_t> g_semantic_visibility_runtime_threshold_without_record{};
+std::atomic<uint64_t> g_semantic_visibility_duplicate_runtime_threshold{};
+std::atomic<uint64_t> g_semantic_visibility_descriptor_threshold_without_record{};
+std::atomic<uint64_t> g_semantic_visibility_duplicate_descriptor_threshold{};
 
 struct SemanticInstanceEntry {
   uint64_t key = 0;
@@ -938,10 +970,16 @@ struct ActiveSemanticVisibilityRecord {
   uint32_t descriptor_address = 0;
   uint32_t runtime_address = 0;
   uint32_t lod_index = 0;
+  uint8_t spatial_exponent = 0;
   bool joined = false;
   bool result_seen = false;
   bool selected = false;
   bool lod_seen = false;
+  bool spatial_sample_valid = false;
+  bool runtime_threshold_seen = false;
+  bool runtime_distance_less = false;
+  bool descriptor_threshold_seen = false;
+  bool descriptor_distance_exceeded = false;
   bool active = false;
 };
 thread_local ActiveSemanticVisibilityRecord
@@ -1311,6 +1349,38 @@ void ResetTitleDrawProvenance() {
   for (auto &value : g_semantic_visibility_result_value_histogram) {
     value.store(0, std::memory_order_relaxed);
   }
+  for (auto &category : g_semantic_visibility_policy_categories) {
+    for (auto &outcome : category) {
+      outcome.records.store(0, std::memory_order_relaxed);
+      outcome.spatial_samples.store(0, std::memory_order_relaxed);
+      outcome.runtime_threshold_observations.store(
+          0, std::memory_order_relaxed);
+      outcome.runtime_distance_less.store(0, std::memory_order_relaxed);
+      outcome.descriptor_threshold_observations.store(
+          0, std::memory_order_relaxed);
+      outcome.descriptor_distance_exceeded.store(
+          0, std::memory_order_relaxed);
+    }
+  }
+  for (auto &outcome : g_semantic_visibility_spatial_exponents) {
+    for (auto &bucket : outcome) {
+      bucket.store(0, std::memory_order_relaxed);
+    }
+  }
+  g_semantic_visibility_policy_invalid_spatial_values.store(
+      0, std::memory_order_relaxed);
+  g_semantic_visibility_policy_invalid_threshold_values.store(
+      0, std::memory_order_relaxed);
+  g_semantic_visibility_policy_hook_faults.store(
+      0, std::memory_order_relaxed);
+  g_semantic_visibility_runtime_threshold_without_record.store(
+      0, std::memory_order_relaxed);
+  g_semantic_visibility_duplicate_runtime_threshold.store(
+      0, std::memory_order_relaxed);
+  g_semantic_visibility_descriptor_threshold_without_record.store(
+      0, std::memory_order_relaxed);
+  g_semantic_visibility_duplicate_descriptor_threshold.store(
+      0, std::memory_order_relaxed);
   {
     std::scoped_lock lock(g_semantic_instance_mutex);
     std::memset(g_semantic_instances.data(), 0, sizeof(g_semantic_instances));
@@ -2024,11 +2094,21 @@ void EndSemanticReceiverStage(SemanticReceiverStage stage) {
   }
 }
 
+bool SemanticVisibilitySpatialExponent(double value, uint8_t *exponent) {
+  const float narrowed = static_cast<float>(value);
+  if (!std::isfinite(narrowed) || narrowed < 0.0f) {
+    return false;
+  }
+  *exponent = uint8_t((std::bit_cast<uint32_t>(narrowed) >> 23) & 0xFF);
+  return true;
+}
+
 void BeginSemanticVisibilityRecord(uint32_t receiver_address,
                                    uint32_t record_index,
                                    uint32_t category,
                                    uint32_t descriptor_address,
-                                   uint32_t runtime_address) {
+                                   uint32_t runtime_address,
+                                   double spatial_distance_squared) {
   if (!g_command_buffer_lineage_installed.load(std::memory_order_acquire)) {
     return;
   }
@@ -2052,6 +2132,12 @@ void BeginSemanticVisibilityRecord(uint32_t receiver_address,
   record.category = category;
   record.descriptor_address = descriptor_address;
   record.runtime_address = runtime_address;
+  record.spatial_sample_valid = SemanticVisibilitySpatialExponent(
+      spatial_distance_squared, &record.spatial_exponent);
+  if (!record.spatial_sample_valid) {
+    g_semantic_visibility_policy_invalid_spatial_values.fetch_add(
+        1, std::memory_order_relaxed);
+  }
   g_semantic_visibility_records_open.fetch_add(
       1, std::memory_order_relaxed);
   if (g_semantic_visibility_stack_depth) {
@@ -2073,6 +2159,66 @@ void BeginSemanticVisibilityRecord(uint32_t receiver_address,
     g_semantic_visibility_category_overflow.fetch_add(
         1, std::memory_order_relaxed);
   }
+}
+
+void ObserveSemanticVisibilityRuntimeThreshold(
+    double spatial_distance_squared, double threshold_squared) {
+  ActiveSemanticVisibilityRecord &record =
+      g_active_semantic_visibility_record;
+  if (!record.active) {
+    g_semantic_visibility_policy_hook_faults.fetch_add(
+        1, std::memory_order_relaxed);
+    g_semantic_visibility_runtime_threshold_without_record.fetch_add(
+        1, std::memory_order_relaxed);
+    return;
+  }
+  if (record.runtime_threshold_seen) {
+    g_semantic_visibility_policy_hook_faults.fetch_add(
+        1, std::memory_order_relaxed);
+    g_semantic_visibility_duplicate_runtime_threshold.fetch_add(
+        1, std::memory_order_relaxed);
+    return;
+  }
+  record.runtime_threshold_seen = true;
+  if (!std::isfinite(spatial_distance_squared) ||
+      !std::isfinite(threshold_squared) || spatial_distance_squared < 0.0 ||
+      threshold_squared < 0.0) {
+    g_semantic_visibility_policy_invalid_threshold_values.fetch_add(
+        1, std::memory_order_relaxed);
+    return;
+  }
+  record.runtime_distance_less =
+      spatial_distance_squared < threshold_squared;
+}
+
+void ObserveSemanticVisibilityDescriptorThreshold(
+    double spatial_distance_squared, double threshold_squared) {
+  ActiveSemanticVisibilityRecord &record =
+      g_active_semantic_visibility_record;
+  if (!record.active) {
+    g_semantic_visibility_policy_hook_faults.fetch_add(
+        1, std::memory_order_relaxed);
+    g_semantic_visibility_descriptor_threshold_without_record.fetch_add(
+        1, std::memory_order_relaxed);
+    return;
+  }
+  if (record.descriptor_threshold_seen) {
+    g_semantic_visibility_policy_hook_faults.fetch_add(
+        1, std::memory_order_relaxed);
+    g_semantic_visibility_duplicate_descriptor_threshold.fetch_add(
+        1, std::memory_order_relaxed);
+    return;
+  }
+  record.descriptor_threshold_seen = true;
+  if (!std::isfinite(spatial_distance_squared) ||
+      !std::isfinite(threshold_squared) || spatial_distance_squared < 0.0 ||
+      threshold_squared < 0.0) {
+    g_semantic_visibility_policy_invalid_threshold_values.fetch_add(
+        1, std::memory_order_relaxed);
+    return;
+  }
+  record.descriptor_distance_exceeded =
+      spatial_distance_squared > threshold_squared;
 }
 
 void ObserveSemanticVisibilityLod(uint32_t lod_index) {
@@ -2190,6 +2336,42 @@ void EndSemanticVisibilityRecord(uint32_t receiver_address,
     if (category) {
       category->rejected.fetch_add(1, std::memory_order_relaxed);
     }
+  }
+  const SemanticVisibilityPolicyOutcome policy_outcome =
+      !record.result_seen
+          ? SemanticVisibilityPolicyOutcome::kEarlyRejected
+          : (record.selected ? SemanticVisibilityPolicyOutcome::kSelected
+                             : SemanticVisibilityPolicyOutcome::kRejected);
+  const size_t policy_outcome_index = size_t(policy_outcome);
+  if (record.category < kSemanticVisibilityCategoryCapacity) {
+    SemanticVisibilityPolicyStats &policy =
+        g_semantic_visibility_policy_categories[record.category]
+                                              [policy_outcome_index];
+    policy.records.fetch_add(1, std::memory_order_relaxed);
+    if (record.spatial_sample_valid) {
+      policy.spatial_samples.fetch_add(1, std::memory_order_relaxed);
+    }
+    if (record.runtime_threshold_seen) {
+      policy.runtime_threshold_observations.fetch_add(
+          1, std::memory_order_relaxed);
+      if (record.runtime_distance_less) {
+        policy.runtime_distance_less.fetch_add(
+            1, std::memory_order_relaxed);
+      }
+    }
+    if (record.descriptor_threshold_seen) {
+      policy.descriptor_threshold_observations.fetch_add(
+          1, std::memory_order_relaxed);
+      if (record.descriptor_distance_exceeded) {
+        policy.descriptor_distance_exceeded.fetch_add(
+            1, std::memory_order_relaxed);
+      }
+    }
+  }
+  if (record.spatial_sample_valid) {
+    g_semantic_visibility_spatial_exponents[policy_outcome_index]
+                                            [record.spatial_exponent]
+        .fetch_add(1, std::memory_order_relaxed);
   }
   if (record.category == 9 && record.selected) {
     (record.lod_seen ? g_semantic_visibility_selected_with_lod
@@ -9241,6 +9423,18 @@ void EmitSemanticStateCacheSummary() {
   }
 }
 
+const char *SemanticVisibilityPolicyOutcomeName(size_t outcome) {
+  switch (SemanticVisibilityPolicyOutcome(outcome)) {
+  case SemanticVisibilityPolicyOutcome::kEarlyRejected:
+    return "early_rejected";
+  case SemanticVisibilityPolicyOutcome::kRejected:
+    return "rejected";
+  case SemanticVisibilityPolicyOutcome::kSelected:
+    return "selected";
+  }
+  return "unknown";
+}
+
 void EmitSemanticVisibilityCensus() {
   const uint64_t entries = g_semantic_visibility_record_entries.load(
       std::memory_order_relaxed);
@@ -9354,6 +9548,175 @@ void EmitSemanticVisibilityCensus() {
          {"xenos_authority", "true"},
          {"suppression_allowed", "false"}});
   }
+
+  uint64_t policy_records = 0;
+  uint64_t policy_spatial_samples = 0;
+  uint64_t policy_runtime_observations = 0;
+  uint64_t policy_runtime_less = 0;
+  uint64_t policy_descriptor_observations = 0;
+  uint64_t policy_descriptor_exceeded = 0;
+  for (size_t category_index = 0;
+       category_index < kSemanticVisibilityCategoryCapacity;
+       ++category_index) {
+    const SemanticVisibilityCategoryStats &category =
+        g_semantic_visibility_categories[category_index];
+    const std::array<uint64_t, kSemanticVisibilityPolicyOutcomeCapacity>
+        expected_records = {
+            category.early_rejected.load(std::memory_order_relaxed),
+            category.rejected.load(std::memory_order_relaxed),
+            category.selected.load(std::memory_order_relaxed),
+        };
+    for (size_t outcome_index = 0;
+         outcome_index < kSemanticVisibilityPolicyOutcomeCapacity;
+         ++outcome_index) {
+      const SemanticVisibilityPolicyStats &policy =
+          g_semantic_visibility_policy_categories[category_index]
+                                                  [outcome_index];
+      const uint64_t records =
+          policy.records.load(std::memory_order_relaxed);
+      if (!records) {
+        continue;
+      }
+      const uint64_t spatial_samples =
+          policy.spatial_samples.load(std::memory_order_relaxed);
+      const uint64_t runtime_observations =
+          policy.runtime_threshold_observations.load(
+              std::memory_order_relaxed);
+      const uint64_t runtime_less =
+          policy.runtime_distance_less.load(std::memory_order_relaxed);
+      const uint64_t descriptor_observations =
+          policy.descriptor_threshold_observations.load(
+              std::memory_order_relaxed);
+      const uint64_t descriptor_exceeded =
+          policy.descriptor_distance_exceeded.load(
+              std::memory_order_relaxed);
+      const bool policy_complete =
+          records == expected_records[outcome_index] &&
+          spatial_samples == records && runtime_less <= runtime_observations &&
+          runtime_observations <= records &&
+          descriptor_exceeded <= descriptor_observations &&
+          descriptor_observations <= records;
+      policy_records += records;
+      policy_spatial_samples += spatial_samples;
+      policy_runtime_observations += runtime_observations;
+      policy_runtime_less += runtime_less;
+      policy_descriptor_observations += descriptor_observations;
+      policy_descriptor_exceeded += descriptor_exceeded;
+      pinyon_shift::diagnostics::RecordEvent(
+          "native_renderer.discovery.semantic_visibility_policy_category_summary",
+          {{"status", policy_complete ? "complete" : "incomplete"},
+           {"category", std::to_string(category_index)},
+           {"outcome",
+            SemanticVisibilityPolicyOutcomeName(outcome_index)},
+           {"records", std::to_string(records)},
+           {"spatial_samples", std::to_string(spatial_samples)},
+           {"runtime_threshold_observations",
+            std::to_string(runtime_observations)},
+           {"runtime_distance_less", std::to_string(runtime_less)},
+           {"descriptor_threshold_observations",
+            std::to_string(descriptor_observations)},
+           {"descriptor_distance_exceeded",
+            std::to_string(descriptor_exceeded)},
+           {"native_policy_execution", "false"},
+           {"guest_state_changed", "false"},
+           {"xenos_authority", "true"},
+           {"suppression_allowed", "false"}});
+    }
+  }
+
+  uint64_t policy_spatial_histogram_total = 0;
+  for (size_t outcome_index = 0;
+       outcome_index < kSemanticVisibilityPolicyOutcomeCapacity;
+       ++outcome_index) {
+    for (size_t exponent = 0;
+         exponent < kSemanticVisibilitySpatialExponentCapacity;
+         ++exponent) {
+      const uint64_t records =
+          g_semantic_visibility_spatial_exponents[outcome_index][exponent]
+              .load(std::memory_order_relaxed);
+      if (!records) {
+        continue;
+      }
+      policy_spatial_histogram_total += records;
+      pinyon_shift::diagnostics::RecordEvent(
+          "native_renderer.discovery.semantic_visibility_spatial_exponent_summary",
+          {{"status", "complete"},
+           {"outcome",
+            SemanticVisibilityPolicyOutcomeName(outcome_index)},
+           {"float_exponent", std::to_string(exponent)},
+           {"records", std::to_string(records)},
+           {"source", "title_shared_spatial_distance_squared_f26"},
+           {"native_policy_execution", "false"},
+           {"guest_state_changed", "false"},
+           {"xenos_authority", "true"},
+           {"suppression_allowed", "false"}});
+    }
+  }
+
+  const uint64_t policy_invalid_spatial =
+      g_semantic_visibility_policy_invalid_spatial_values.load(
+          std::memory_order_relaxed);
+  const uint64_t policy_invalid_threshold =
+      g_semantic_visibility_policy_invalid_threshold_values.load(
+          std::memory_order_relaxed);
+  const uint64_t policy_hook_faults =
+      g_semantic_visibility_policy_hook_faults.load(
+          std::memory_order_relaxed);
+  const uint64_t runtime_without_record =
+      g_semantic_visibility_runtime_threshold_without_record.load(
+          std::memory_order_relaxed);
+  const uint64_t duplicate_runtime =
+      g_semantic_visibility_duplicate_runtime_threshold.load(
+          std::memory_order_relaxed);
+  const uint64_t descriptor_without_record =
+      g_semantic_visibility_descriptor_threshold_without_record.load(
+          std::memory_order_relaxed);
+  const uint64_t duplicate_descriptor =
+      g_semantic_visibility_duplicate_descriptor_threshold.load(
+          std::memory_order_relaxed);
+  const bool policy_complete =
+      policy_records == completions && policy_spatial_samples == entries &&
+      policy_spatial_histogram_total == policy_spatial_samples &&
+      !policy_invalid_spatial && !policy_invalid_threshold &&
+      !policy_hook_faults &&
+      policy_hook_faults == runtime_without_record + duplicate_runtime +
+                                descriptor_without_record +
+                                duplicate_descriptor;
+  pinyon_shift::diagnostics::RecordEvent(
+      "native_renderer.discovery.semantic_visibility_policy_summary",
+      {{"status", policy_complete ? "complete" : "incomplete"},
+       {"records", std::to_string(policy_records)},
+       {"spatial_samples", std::to_string(policy_spatial_samples)},
+       {"runtime_threshold_observations",
+        std::to_string(policy_runtime_observations)},
+       {"runtime_distance_less", std::to_string(policy_runtime_less)},
+       {"descriptor_threshold_observations",
+        std::to_string(policy_descriptor_observations)},
+       {"descriptor_distance_exceeded",
+        std::to_string(policy_descriptor_exceeded)},
+       {"spatial_histogram_records",
+        std::to_string(policy_spatial_histogram_total)},
+       {"invalid_spatial_values", std::to_string(policy_invalid_spatial)},
+       {"invalid_threshold_values",
+        std::to_string(policy_invalid_threshold)},
+       {"hook_faults", std::to_string(policy_hook_faults)},
+       {"runtime_threshold_without_record",
+        std::to_string(runtime_without_record)},
+       {"duplicate_runtime_threshold", std::to_string(duplicate_runtime)},
+       {"descriptor_threshold_without_record",
+        std::to_string(descriptor_without_record)},
+       {"duplicate_descriptor_threshold",
+        std::to_string(duplicate_descriptor)},
+       {"accounting_complete", policy_complete ? "true" : "false"},
+       {"classification", "title_spatial_policy_input_outcome_correlation"},
+       {"guest_payload_read", "false"},
+       {"guest_state_changed", "false"},
+       {"control_flow_changed", "false"},
+       {"native_policy_execution", "false"},
+       {"native_culling", "false"},
+       {"native_lod", "false"},
+       {"xenos_authority", "true"},
+       {"suppression_allowed", "false"}});
 
   const uint64_t category_overflow =
       g_semantic_visibility_category_overflow.load(
@@ -11797,6 +12160,32 @@ void InstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system,
        {"xenos_authority", "true"},
        {"suppression_allowed", "false"}});
   diagnostics::RecordEvent(
+      "native_renderer.discovery.semantic_visibility_policy_config",
+      {{"status", lineage_armed ? "armed" : "disabled"},
+       {"class", "proceduralGeometry::CProceduralModels"},
+       {"visibility_function", "82E1FD00"},
+       {"record_entry_hook", "82E20094"},
+       {"runtime_threshold_hook", "82E20134"},
+       {"descriptor_threshold_hook", "82E201B0"},
+       {"spatial_distance_source", "f26"},
+       {"threshold_source", "f0"},
+       {"runtime_distance_scalar_offset", "44"},
+       {"descriptor_distance_scalar_offset", "60"},
+       {"spatial_exponent_capacity",
+        std::to_string(kSemanticVisibilitySpatialExponentCapacity)},
+       {"outcomes", "early_rejected,rejected,selected"},
+       {"classification",
+        "title_spatial_policy_input_outcome_correlation"},
+       {"guest_payload_read", "false"},
+       {"guest_state_changed", "false"},
+       {"control_flow_changed", "false"},
+       {"native_policy_execution", "false"},
+       {"native_culling", "false"},
+       {"native_lod", "false"},
+       {"native_draw", "false"},
+       {"xenos_authority", "true"},
+       {"suppression_allowed", "false"}});
+  diagnostics::RecordEvent(
       "native_renderer.discovery.semantic_instance_config",
       {{"status", lineage_armed ? "armed" : "disabled"},
        {"class", "proceduralGeometry::CProceduralModels"},
@@ -12740,9 +13129,19 @@ void PinyonShiftObserveProceduralModelVisibilityExit() {
 
 void PinyonShiftObserveProceduralModelVisibilityRecordEntry(
     PPCRegister &r15, PPCRegister &r16, PPCRegister &r20,
-    PPCRegister &r21, PPCRegister &r23) {
+    PPCRegister &r21, PPCRegister &r23, PPCRegister &f26) {
   BeginSemanticVisibilityRecord(r20.u32, r16.u32, r15.u32, r23.u32,
-                                r21.u32);
+                                r21.u32, f26.f64);
+}
+
+void PinyonShiftObserveProceduralModelVisibilityRuntimeThreshold(
+    PPCRegister &f0, PPCRegister &f26) {
+  ObserveSemanticVisibilityRuntimeThreshold(f26.f64, f0.f64);
+}
+
+void PinyonShiftObserveProceduralModelVisibilityDescriptorThreshold(
+    PPCRegister &f0, PPCRegister &f26) {
+  ObserveSemanticVisibilityDescriptorThreshold(f26.f64, f0.f64);
 }
 
 void PinyonShiftObserveProceduralModelVisibilityLodPrimary(

--- a/src/native_renderer/graphics_hooks.cpp
+++ b/src/native_renderer/graphics_hooks.cpp
@@ -89,6 +89,9 @@ constexpr size_t kIndirectProducerStackCapacity = 32;
 constexpr size_t kIndirectContextStackCapacity = 32;
 constexpr size_t kSemanticReceiverLifecycleCapacity = 1024;
 constexpr size_t kSemanticReceiverStackCapacity = 32;
+constexpr size_t kSemanticVisibilityCategoryCapacity = 32;
+constexpr size_t kSemanticVisibilityLodCapacity = 32;
+constexpr size_t kSemanticVisibilityResultValueCapacity = 256;
 constexpr size_t kSemanticInstanceCapacity = 4096;
 constexpr size_t kSemanticSubmissionCapacity = 8192;
 constexpr size_t kSemanticRenderItemStackCapacity = 32;
@@ -610,6 +613,45 @@ std::atomic<uint64_t> g_semantic_render_state_open{};
 std::atomic<uint64_t> g_semantic_stage_stack_faults{};
 std::atomic<uint64_t> g_semantic_stage_unknown_receivers{};
 
+struct SemanticVisibilityCategoryStats {
+  std::atomic<uint64_t> entries{};
+  std::atomic<uint64_t> completions{};
+  std::atomic<uint64_t> selected{};
+  std::atomic<uint64_t> rejected{};
+  std::atomic<uint64_t> early_rejected{};
+  std::atomic<uint64_t> lod_writes{};
+};
+
+std::atomic<uint64_t> g_semantic_visibility_record_entries{};
+std::atomic<uint64_t> g_semantic_visibility_record_completions{};
+std::atomic<uint64_t> g_semantic_visibility_records_open{};
+std::atomic<uint64_t> g_semantic_visibility_result_observations{};
+std::atomic<uint64_t> g_semantic_visibility_selected_records{};
+std::atomic<uint64_t> g_semantic_visibility_rejected_records{};
+std::atomic<uint64_t> g_semantic_visibility_early_rejected_records{};
+std::atomic<uint64_t> g_semantic_visibility_lod_writes{};
+std::atomic<uint64_t> g_semantic_visibility_selected_with_lod{};
+std::atomic<uint64_t> g_semantic_visibility_selected_without_lod{};
+std::atomic<uint64_t> g_semantic_visibility_record_stack_faults{};
+std::atomic<uint64_t> g_semantic_visibility_entry_overlaps{};
+std::atomic<uint64_t> g_semantic_visibility_lod_without_record{};
+std::atomic<uint64_t> g_semantic_visibility_lod_rewrites{};
+std::atomic<uint64_t> g_semantic_visibility_result_without_record{};
+std::atomic<uint64_t> g_semantic_visibility_duplicate_result{};
+std::atomic<uint64_t> g_semantic_visibility_completion_without_record{};
+std::atomic<uint64_t> g_semantic_visibility_exit_with_record{};
+std::atomic<uint64_t> g_semantic_visibility_record_identity_mismatches{};
+std::atomic<uint64_t> g_semantic_visibility_record_unknown_receivers{};
+std::atomic<uint64_t> g_semantic_visibility_category_overflow{};
+std::atomic<uint64_t> g_semantic_visibility_lod_overflow{};
+std::array<SemanticVisibilityCategoryStats,
+           kSemanticVisibilityCategoryCapacity>
+    g_semantic_visibility_categories{};
+std::array<std::atomic<uint64_t>, kSemanticVisibilityLodCapacity>
+    g_semantic_visibility_lod_histogram{};
+std::array<std::atomic<uint64_t>, kSemanticVisibilityResultValueCapacity>
+    g_semantic_visibility_result_value_histogram{};
+
 struct SemanticInstanceEntry {
   uint64_t key = 0;
   uint64_t calls = 0;
@@ -888,6 +930,22 @@ thread_local std::array<SemanticReceiverStageScope,
     g_semantic_visibility_stack{};
 thread_local size_t g_semantic_visibility_stack_depth = 0;
 thread_local size_t g_semantic_visibility_overflow_depth = 0;
+struct ActiveSemanticVisibilityRecord {
+  uint32_t receiver_address = 0;
+  uint32_t receiver_generation = 0;
+  uint32_t record_index = 0;
+  uint32_t category = 0;
+  uint32_t descriptor_address = 0;
+  uint32_t runtime_address = 0;
+  uint32_t lod_index = 0;
+  bool joined = false;
+  bool result_seen = false;
+  bool selected = false;
+  bool lod_seen = false;
+  bool active = false;
+};
+thread_local ActiveSemanticVisibilityRecord
+    g_active_semantic_visibility_record{};
 thread_local std::array<SemanticReceiverStageScope,
                         kSemanticReceiverStackCapacity>
     g_semantic_render_state_stack{};
@@ -1195,6 +1253,64 @@ void ResetTitleDrawProvenance() {
   g_semantic_stage_stack_faults.store(0, std::memory_order_relaxed);
   g_semantic_stage_unknown_receivers.store(0,
                                             std::memory_order_relaxed);
+  g_semantic_visibility_record_entries.store(0,
+                                               std::memory_order_relaxed);
+  g_semantic_visibility_record_completions.store(
+      0, std::memory_order_relaxed);
+  g_semantic_visibility_records_open.store(0,
+                                            std::memory_order_relaxed);
+  g_semantic_visibility_result_observations.store(
+      0, std::memory_order_relaxed);
+  g_semantic_visibility_selected_records.store(
+      0, std::memory_order_relaxed);
+  g_semantic_visibility_rejected_records.store(
+      0, std::memory_order_relaxed);
+  g_semantic_visibility_early_rejected_records.store(
+      0, std::memory_order_relaxed);
+  g_semantic_visibility_lod_writes.store(0,
+                                         std::memory_order_relaxed);
+  g_semantic_visibility_selected_with_lod.store(
+      0, std::memory_order_relaxed);
+  g_semantic_visibility_selected_without_lod.store(
+      0, std::memory_order_relaxed);
+  g_semantic_visibility_record_stack_faults.store(
+      0, std::memory_order_relaxed);
+  g_semantic_visibility_entry_overlaps.store(0,
+                                              std::memory_order_relaxed);
+  g_semantic_visibility_lod_without_record.store(
+      0, std::memory_order_relaxed);
+  g_semantic_visibility_lod_rewrites.store(0,
+                                            std::memory_order_relaxed);
+  g_semantic_visibility_result_without_record.store(
+      0, std::memory_order_relaxed);
+  g_semantic_visibility_duplicate_result.store(
+      0, std::memory_order_relaxed);
+  g_semantic_visibility_completion_without_record.store(
+      0, std::memory_order_relaxed);
+  g_semantic_visibility_exit_with_record.store(
+      0, std::memory_order_relaxed);
+  g_semantic_visibility_record_identity_mismatches.store(
+      0, std::memory_order_relaxed);
+  g_semantic_visibility_record_unknown_receivers.store(
+      0, std::memory_order_relaxed);
+  g_semantic_visibility_category_overflow.store(
+      0, std::memory_order_relaxed);
+  g_semantic_visibility_lod_overflow.store(0,
+                                            std::memory_order_relaxed);
+  for (auto &category : g_semantic_visibility_categories) {
+    category.entries.store(0, std::memory_order_relaxed);
+    category.completions.store(0, std::memory_order_relaxed);
+    category.selected.store(0, std::memory_order_relaxed);
+    category.rejected.store(0, std::memory_order_relaxed);
+    category.early_rejected.store(0, std::memory_order_relaxed);
+    category.lod_writes.store(0, std::memory_order_relaxed);
+  }
+  for (auto &lod : g_semantic_visibility_lod_histogram) {
+    lod.store(0, std::memory_order_relaxed);
+  }
+  for (auto &value : g_semantic_visibility_result_value_histogram) {
+    value.store(0, std::memory_order_relaxed);
+  }
   {
     std::scoped_lock lock(g_semantic_instance_mutex);
     std::memset(g_semantic_instances.data(), 0, sizeof(g_semantic_instances));
@@ -1307,6 +1423,7 @@ void ResetTitleDrawProvenance() {
   g_semantic_visibility_stack = {};
   g_semantic_visibility_stack_depth = 0;
   g_semantic_visibility_overflow_depth = 0;
+  g_active_semantic_visibility_record = {};
   g_semantic_render_state_stack = {};
   g_semantic_render_state_stack_depth = 0;
   g_semantic_render_state_overflow_depth = 0;
@@ -1904,6 +2021,184 @@ void EndSemanticReceiverStage(SemanticReceiverStage stage) {
     entry->render_state_preparations.fetch_add(1,
                                                 std::memory_order_relaxed);
     entry->render_state_epoch.fetch_add(1, std::memory_order_release);
+  }
+}
+
+void BeginSemanticVisibilityRecord(uint32_t receiver_address,
+                                   uint32_t record_index,
+                                   uint32_t category,
+                                   uint32_t descriptor_address,
+                                   uint32_t runtime_address) {
+  if (!g_command_buffer_lineage_installed.load(std::memory_order_acquire)) {
+    return;
+  }
+  g_semantic_visibility_record_entries.fetch_add(
+      1, std::memory_order_relaxed);
+  if (g_active_semantic_visibility_record.active) {
+    g_semantic_visibility_record_stack_faults.fetch_add(
+        1, std::memory_order_relaxed);
+    g_semantic_visibility_entry_overlaps.fetch_add(
+        1, std::memory_order_relaxed);
+    g_semantic_visibility_records_open.fetch_sub(
+        1, std::memory_order_relaxed);
+    g_active_semantic_visibility_record = {};
+  }
+
+  ActiveSemanticVisibilityRecord &record =
+      g_active_semantic_visibility_record;
+  record.active = true;
+  record.receiver_address = receiver_address;
+  record.record_index = record_index;
+  record.category = category;
+  record.descriptor_address = descriptor_address;
+  record.runtime_address = runtime_address;
+  g_semantic_visibility_records_open.fetch_add(
+      1, std::memory_order_relaxed);
+  if (g_semantic_visibility_stack_depth) {
+    const SemanticReceiverStageScope &scope =
+        g_semantic_visibility_stack[g_semantic_visibility_stack_depth - 1];
+    record.receiver_generation = scope.generation;
+    record.joined = scope.address == receiver_address && scope.generation &&
+                    descriptor_address && runtime_address &&
+                    !(descriptor_address & 3) && !(runtime_address & 3);
+  }
+  if (!record.joined) {
+    g_semantic_visibility_record_unknown_receivers.fetch_add(
+        1, std::memory_order_relaxed);
+  }
+  if (category < kSemanticVisibilityCategoryCapacity) {
+    g_semantic_visibility_categories[category].entries.fetch_add(
+        1, std::memory_order_relaxed);
+  } else {
+    g_semantic_visibility_category_overflow.fetch_add(
+        1, std::memory_order_relaxed);
+  }
+}
+
+void ObserveSemanticVisibilityLod(uint32_t lod_index) {
+  if (!g_command_buffer_lineage_installed.load(std::memory_order_acquire)) {
+    return;
+  }
+  ActiveSemanticVisibilityRecord &record =
+      g_active_semantic_visibility_record;
+  if (!record.active) {
+    g_semantic_visibility_record_stack_faults.fetch_add(
+        1, std::memory_order_relaxed);
+    g_semantic_visibility_lod_without_record.fetch_add(
+        1, std::memory_order_relaxed);
+    return;
+  }
+  if (record.lod_seen) {
+    record.lod_index = lod_index;
+    g_semantic_visibility_lod_rewrites.fetch_add(
+        1, std::memory_order_relaxed);
+    return;
+  }
+  record.lod_seen = true;
+  record.lod_index = lod_index;
+  g_semantic_visibility_lod_writes.fetch_add(1,
+                                              std::memory_order_relaxed);
+  if (record.category < kSemanticVisibilityCategoryCapacity) {
+    g_semantic_visibility_categories[record.category].lod_writes.fetch_add(
+        1, std::memory_order_relaxed);
+  }
+  if (lod_index < kSemanticVisibilityLodCapacity) {
+    g_semantic_visibility_lod_histogram[lod_index].fetch_add(
+        1, std::memory_order_relaxed);
+  } else {
+    g_semantic_visibility_lod_overflow.fetch_add(
+        1, std::memory_order_relaxed);
+  }
+}
+
+void ObserveSemanticVisibilityResult(uint32_t selected) {
+  if (!g_command_buffer_lineage_installed.load(std::memory_order_acquire)) {
+    return;
+  }
+  ActiveSemanticVisibilityRecord &record =
+      g_active_semantic_visibility_record;
+  if (!record.active) {
+    g_semantic_visibility_record_stack_faults.fetch_add(
+        1, std::memory_order_relaxed);
+    g_semantic_visibility_result_without_record.fetch_add(
+        1, std::memory_order_relaxed);
+    return;
+  }
+  if (record.result_seen) {
+    g_semantic_visibility_record_stack_faults.fetch_add(
+        1, std::memory_order_relaxed);
+    g_semantic_visibility_duplicate_result.fetch_add(
+        1, std::memory_order_relaxed);
+    return;
+  }
+  record.result_seen = true;
+  record.selected = selected != 0;
+  g_semantic_visibility_result_value_histogram[selected & 0xFF].fetch_add(
+      1, std::memory_order_relaxed);
+  g_semantic_visibility_result_observations.fetch_add(
+      1, std::memory_order_relaxed);
+}
+
+void EndSemanticVisibilityRecord(uint32_t receiver_address,
+                                 uint32_t record_index) {
+  if (!g_command_buffer_lineage_installed.load(std::memory_order_acquire)) {
+    return;
+  }
+  g_semantic_visibility_record_completions.fetch_add(
+      1, std::memory_order_relaxed);
+  ActiveSemanticVisibilityRecord record =
+      g_active_semantic_visibility_record;
+  g_active_semantic_visibility_record = {};
+  if (!record.active) {
+    g_semantic_visibility_record_stack_faults.fetch_add(
+        1, std::memory_order_relaxed);
+    g_semantic_visibility_completion_without_record.fetch_add(
+        1, std::memory_order_relaxed);
+    return;
+  }
+  g_semantic_visibility_records_open.fetch_sub(
+      1, std::memory_order_relaxed);
+  if (record.receiver_address != receiver_address ||
+      record.record_index != record_index) {
+    g_semantic_visibility_record_identity_mismatches.fetch_add(
+        1, std::memory_order_relaxed);
+  }
+
+  SemanticVisibilityCategoryStats *category =
+      record.category < kSemanticVisibilityCategoryCapacity
+          ? &g_semantic_visibility_categories[record.category]
+          : nullptr;
+  if (category) {
+    category->completions.fetch_add(1, std::memory_order_relaxed);
+  }
+  if (!record.result_seen) {
+    g_semantic_visibility_early_rejected_records.fetch_add(
+        1, std::memory_order_relaxed);
+    if (category) {
+      category->early_rejected.fetch_add(1,
+                                          std::memory_order_relaxed);
+    }
+  } else if (record.selected) {
+    g_semantic_visibility_selected_records.fetch_add(
+        1, std::memory_order_relaxed);
+    if (category) {
+      category->selected.fetch_add(1, std::memory_order_relaxed);
+    }
+  } else {
+    g_semantic_visibility_rejected_records.fetch_add(
+        1, std::memory_order_relaxed);
+    if (category) {
+      category->rejected.fetch_add(1, std::memory_order_relaxed);
+    }
+  }
+  if (record.category == 9 && record.selected) {
+    (record.lod_seen ? g_semantic_visibility_selected_with_lod
+                     : g_semantic_visibility_selected_without_lod)
+        .fetch_add(1, std::memory_order_relaxed);
+  }
+  if (record.lod_seen && record.result_seen && !record.selected) {
+    g_semantic_visibility_record_identity_mismatches.fetch_add(
+        1, std::memory_order_relaxed);
   }
 }
 
@@ -8946,6 +9241,222 @@ void EmitSemanticStateCacheSummary() {
   }
 }
 
+void EmitSemanticVisibilityCensus() {
+  const uint64_t entries = g_semantic_visibility_record_entries.load(
+      std::memory_order_relaxed);
+  const uint64_t completions =
+      g_semantic_visibility_record_completions.load(
+          std::memory_order_relaxed);
+  const uint64_t results =
+      g_semantic_visibility_result_observations.load(
+          std::memory_order_relaxed);
+  const uint64_t selected =
+      g_semantic_visibility_selected_records.load(
+          std::memory_order_relaxed);
+  const uint64_t rejected =
+      g_semantic_visibility_rejected_records.load(
+          std::memory_order_relaxed);
+  const uint64_t early_rejected =
+      g_semantic_visibility_early_rejected_records.load(
+          std::memory_order_relaxed);
+  const uint64_t lod_writes = g_semantic_visibility_lod_writes.load(
+      std::memory_order_relaxed);
+  uint64_t category_entries = 0;
+  uint64_t category_completions = 0;
+  uint64_t category_selected = 0;
+  uint64_t category_rejected = 0;
+  uint64_t category_early_rejected = 0;
+  uint64_t category_lod_writes = 0;
+  for (size_t index = 0; index < kSemanticVisibilityCategoryCapacity;
+       ++index) {
+    const SemanticVisibilityCategoryStats &category =
+        g_semantic_visibility_categories[index];
+    const uint64_t category_entry_count =
+        category.entries.load(std::memory_order_relaxed);
+    if (!category_entry_count) {
+      continue;
+    }
+    const uint64_t category_completion_count =
+        category.completions.load(std::memory_order_relaxed);
+    const uint64_t category_selected_count =
+        category.selected.load(std::memory_order_relaxed);
+    const uint64_t category_rejected_count =
+        category.rejected.load(std::memory_order_relaxed);
+    const uint64_t category_early_rejected_count =
+        category.early_rejected.load(std::memory_order_relaxed);
+    const uint64_t category_lod_count =
+        category.lod_writes.load(std::memory_order_relaxed);
+    const bool category_complete =
+        category_entry_count == category_completion_count &&
+        category_completion_count == category_selected_count +
+                                         category_rejected_count +
+                                         category_early_rejected_count;
+    category_entries += category_entry_count;
+    category_completions += category_completion_count;
+    category_selected += category_selected_count;
+    category_rejected += category_rejected_count;
+    category_early_rejected += category_early_rejected_count;
+    category_lod_writes += category_lod_count;
+    pinyon_shift::diagnostics::RecordEvent(
+        "native_renderer.discovery.semantic_visibility_category_summary",
+        {{"status", category_complete ? "complete" : "incomplete"},
+         {"category", std::to_string(index)},
+         {"entries", std::to_string(category_entry_count)},
+         {"completions", std::to_string(category_completion_count)},
+         {"selected", std::to_string(category_selected_count)},
+         {"rejected", std::to_string(category_rejected_count)},
+         {"early_rejected",
+          std::to_string(category_early_rejected_count)},
+         {"lod_writes", std::to_string(category_lod_count)},
+         {"title_visibility_authority", "true"},
+         {"native_culling", "false"},
+         {"native_lod", "false"},
+         {"xenos_authority", "true"},
+         {"suppression_allowed", "false"}});
+  }
+
+  uint64_t lod_histogram_total = 0;
+  for (size_t index = 0; index < kSemanticVisibilityLodCapacity; ++index) {
+    const uint64_t count = g_semantic_visibility_lod_histogram[index].load(
+        std::memory_order_relaxed);
+    if (!count) {
+      continue;
+    }
+    lod_histogram_total += count;
+    pinyon_shift::diagnostics::RecordEvent(
+        "native_renderer.discovery.semantic_lod_summary",
+        {{"status", "complete"},
+         {"lod_index", std::to_string(index)},
+         {"writes", std::to_string(count)},
+         {"source", "title_selected_runtime_record_plus_104"},
+         {"native_lod", "false"},
+         {"xenos_authority", "true"},
+         {"suppression_allowed", "false"}});
+  }
+
+  uint64_t result_value_histogram_total = 0;
+  for (size_t index = 0;
+       index < kSemanticVisibilityResultValueCapacity; ++index) {
+    const uint64_t count =
+        g_semantic_visibility_result_value_histogram[index].load(
+            std::memory_order_relaxed);
+    if (!count) {
+      continue;
+    }
+    result_value_histogram_total += count;
+    pinyon_shift::diagnostics::RecordEvent(
+        "native_renderer.discovery.semantic_visibility_result_value_summary",
+        {{"status", "complete"},
+         {"selection_value", std::to_string(index)},
+         {"observations", std::to_string(count)},
+         {"interpretation", index ? "selected_nonzero" : "rejected_zero"},
+         {"native_culling", "false"},
+         {"xenos_authority", "true"},
+         {"suppression_allowed", "false"}});
+  }
+
+  const uint64_t category_overflow =
+      g_semantic_visibility_category_overflow.load(
+          std::memory_order_relaxed);
+  const uint64_t lod_overflow = g_semantic_visibility_lod_overflow.load(
+      std::memory_order_relaxed);
+  const uint64_t stack_faults =
+      g_semantic_visibility_record_stack_faults.load(
+          std::memory_order_relaxed);
+  const uint64_t entry_overlaps =
+      g_semantic_visibility_entry_overlaps.load(
+          std::memory_order_relaxed);
+  const uint64_t lod_without_record =
+      g_semantic_visibility_lod_without_record.load(
+          std::memory_order_relaxed);
+  const uint64_t lod_rewrites =
+      g_semantic_visibility_lod_rewrites.load(
+          std::memory_order_relaxed);
+  const uint64_t result_without_record =
+      g_semantic_visibility_result_without_record.load(
+          std::memory_order_relaxed);
+  const uint64_t duplicate_result =
+      g_semantic_visibility_duplicate_result.load(
+          std::memory_order_relaxed);
+  const uint64_t completion_without_record =
+      g_semantic_visibility_completion_without_record.load(
+          std::memory_order_relaxed);
+  const uint64_t exit_with_record =
+      g_semantic_visibility_exit_with_record.load(
+          std::memory_order_relaxed);
+  const uint64_t detailed_protocol_faults =
+      entry_overlaps + lod_without_record + result_without_record +
+      duplicate_result + completion_without_record + exit_with_record;
+  const uint64_t identity_mismatches =
+      g_semantic_visibility_record_identity_mismatches.load(
+          std::memory_order_relaxed);
+  const uint64_t unknown_receivers =
+      g_semantic_visibility_record_unknown_receivers.load(
+          std::memory_order_relaxed);
+  const uint64_t records_open = g_semantic_visibility_records_open.load(
+      std::memory_order_relaxed);
+  const bool accounting_complete =
+      entries && entries == completions &&
+      completions == selected + rejected + early_rejected &&
+      results == selected + rejected && !category_overflow &&
+      category_entries == entries && category_completions == completions &&
+      category_selected == selected && category_rejected == rejected &&
+      category_early_rejected == early_rejected &&
+      category_lod_writes == lod_writes &&
+      lod_histogram_total + lod_overflow == lod_writes && !lod_overflow &&
+      result_value_histogram_total == results &&
+      stack_faults == detailed_protocol_faults && !stack_faults &&
+      !identity_mismatches && !unknown_receivers &&
+      !records_open;
+  pinyon_shift::diagnostics::RecordEvent(
+      "native_renderer.discovery.semantic_visibility_summary",
+      {{"status", accounting_complete ? "complete" : "incomplete"},
+       {"record_entries", std::to_string(entries)},
+       {"record_completions", std::to_string(completions)},
+       {"result_observations", std::to_string(results)},
+       {"selected_records", std::to_string(selected)},
+       {"rejected_records", std::to_string(rejected)},
+       {"early_rejected_records", std::to_string(early_rejected)},
+       {"lod_writes", std::to_string(lod_writes)},
+       {"lod_category_selected_with_lod",
+        std::to_string(g_semantic_visibility_selected_with_lod.load(
+            std::memory_order_relaxed))},
+       {"lod_category_selected_without_lod",
+        std::to_string(g_semantic_visibility_selected_without_lod.load(
+            std::memory_order_relaxed))},
+       {"category_capacity",
+        std::to_string(kSemanticVisibilityCategoryCapacity)},
+       {"lod_capacity", std::to_string(kSemanticVisibilityLodCapacity)},
+       {"category_overflow", std::to_string(category_overflow)},
+       {"lod_overflow", std::to_string(lod_overflow)},
+       {"record_stack_faults", std::to_string(stack_faults)},
+       {"entry_overlaps", std::to_string(entry_overlaps)},
+       {"lod_without_record", std::to_string(lod_without_record)},
+       {"lod_rewrites", std::to_string(lod_rewrites)},
+       {"result_without_record", std::to_string(result_without_record)},
+       {"duplicate_result", std::to_string(duplicate_result)},
+       {"completion_without_record",
+        std::to_string(completion_without_record)},
+       {"visibility_exit_with_record", std::to_string(exit_with_record)},
+       {"record_identity_mismatches",
+        std::to_string(identity_mismatches)},
+       {"record_unknown_receivers", std::to_string(unknown_receivers)},
+       {"record_open_at_shutdown",
+        std::to_string(records_open)},
+       {"accounting_complete",
+        accounting_complete ? "true" : "false"},
+       {"classification",
+        "title_authoritative_visibility_and_lod_observation"},
+       {"guest_payload_read", "false"},
+       {"guest_state_changed", "false"},
+       {"control_flow_changed", "false"},
+       {"native_culling", "false"},
+       {"native_lod", "false"},
+       {"native_draw", "false"},
+       {"xenos_authority", "true"},
+       {"suppression_allowed", "false"}});
+}
+
 void EmitSemanticBatchOpportunitySummary() {
   FinalizeSemanticBatchRun();
   FinalizeSemanticBatchFrame();
@@ -11258,6 +11769,34 @@ void InstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system,
        {"xenos_authority", "true"},
        {"suppression_allowed", "false"}});
   diagnostics::RecordEvent(
+      "native_renderer.discovery.semantic_visibility_config",
+      {{"status", lineage_armed ? "armed" : "disabled"},
+       {"class", "proceduralGeometry::CProceduralModels"},
+       {"visibility_function", "82E1FD00"},
+       {"record_entry_hook", "82E20094"},
+       {"lod_write_hooks", "82E205E4,82E206DC"},
+       {"result_hook", "82E206F8"},
+       {"record_completion_hook", "82E2084C"},
+       {"record_identity",
+        "receiver_generation,record_index,category,descriptor,runtime"},
+       {"visibility_result", "runtime_selection_byte_18"},
+       {"lod_selection", "runtime_record_plus_104"},
+       {"category_capacity",
+        std::to_string(kSemanticVisibilityCategoryCapacity)},
+       {"lod_capacity", std::to_string(kSemanticVisibilityLodCapacity)},
+       {"result_value_capacity",
+        std::to_string(kSemanticVisibilityResultValueCapacity)},
+       {"classification",
+        "title_authoritative_visibility_and_lod_observation"},
+       {"guest_payload_read", "false"},
+       {"guest_state_changed", "false"},
+       {"control_flow_changed", "false"},
+       {"native_culling", "false"},
+       {"native_lod", "false"},
+       {"native_draw", "false"},
+       {"xenos_authority", "true"},
+       {"suppression_allowed", "false"}});
+  diagnostics::RecordEvent(
       "native_renderer.discovery.semantic_instance_config",
       {{"status", lineage_armed ? "armed" : "disabled"},
        {"class", "proceduralGeometry::CProceduralModels"},
@@ -11556,6 +12095,7 @@ void UninstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system) {
     DiscardPendingPassConsumer();
     g_pending_candidate.valid = false;
   }
+  EmitSemanticVisibilityCensus();
   EmitTitleDrawProvenanceSummary();
   EmitSemanticBatchOpportunitySummary();
   EmitCommandBufferLineageSummary();
@@ -12186,7 +12726,42 @@ void PinyonShiftObserveProceduralModelVisibilityEntry(PPCRegister &r3) {
 }
 
 void PinyonShiftObserveProceduralModelVisibilityExit() {
+  if (g_active_semantic_visibility_record.active) {
+    g_semantic_visibility_record_stack_faults.fetch_add(
+        1, std::memory_order_relaxed);
+    g_semantic_visibility_exit_with_record.fetch_add(
+        1, std::memory_order_relaxed);
+    g_semantic_visibility_records_open.fetch_sub(
+        1, std::memory_order_relaxed);
+    g_active_semantic_visibility_record = {};
+  }
   EndSemanticReceiverStage(SemanticReceiverStage::kVisibility);
+}
+
+void PinyonShiftObserveProceduralModelVisibilityRecordEntry(
+    PPCRegister &r15, PPCRegister &r16, PPCRegister &r20,
+    PPCRegister &r21, PPCRegister &r23) {
+  BeginSemanticVisibilityRecord(r20.u32, r16.u32, r15.u32, r23.u32,
+                                r21.u32);
+}
+
+void PinyonShiftObserveProceduralModelVisibilityLodPrimary(
+    PPCRegister &r6) {
+  ObserveSemanticVisibilityLod(r6.u32);
+}
+
+void PinyonShiftObserveProceduralModelVisibilityLodSecondary(
+    PPCRegister &r6) {
+  ObserveSemanticVisibilityLod(r6.u32);
+}
+
+void PinyonShiftObserveProceduralModelVisibilityResult(PPCRegister &r11) {
+  ObserveSemanticVisibilityResult(r11.u32);
+}
+
+void PinyonShiftObserveProceduralModelVisibilityRecordExit(
+    PPCRegister &r16, PPCRegister &r20) {
+  EndSemanticVisibilityRecord(r20.u32, r16.u32);
 }
 
 void PinyonShiftObserveProceduralModelRenderStateEntry(PPCRegister &r3) {

--- a/tools/discover-native-renderer-dispatch.py
+++ b/tools/discover-native-renderer-dispatch.py
@@ -196,6 +196,13 @@ PROCEDURAL_MODEL_RECEIVER = {
     "visibility_vtable_slot": 14,
     "visibility_entry": 0x82E1FD04,
     "visibility_exit": 0x82E208CC,
+    "visibility_record_entry": 0x82E20094,
+    "visibility_lod_hooks": [0x82E205E4, 0x82E206DC],
+    "visibility_result": 0x82E206F8,
+    "visibility_record_exit": 0x82E2084C,
+    "visibility_spatial_prefilter": 0x82E1FEF0,
+    "visibility_spatial_helper": 0x8243F9A0,
+    "visibility_category_helper": 0x82441048,
     "render_state_function": 0x824170D8,
     "render_state_vtable_slot": 40,
     "render_state_entry": 0x824170DC,
@@ -951,7 +958,29 @@ def procedural_model_receiver_lifecycle(
         0x82E1FD4C: "lwz r11,136(r3)",
         0x82E1FE10: "lwz r11,128(r20)",
         0x82E1FEB8: "lwz r9,128(r20)",
+        0x82E1FEF0: "lwz r8,732(r1)",
+        0x82E1FEF4: "mulli r10,r15,192",
+        0x82E1FEF8: "lwz r11,4(r20)",
+        0x82E1FF0C: "add r14,r10,r8",
+        0x82E1FF20: "lfs f12,160(r14)",
+        0x82E1FF24: "lfs f13,164(r14)",
+        0x82E1FF28: "lfs f11,168(r14)",
+        0x82E1FF64: "lwz r11,4(r20)",
+        0x82E1FF80: "lvx128 v63,r11,r9",
+        0x82E1FF88: "lvx128 v62,r11,r8",
+        0x82E1FFA4: "bgt cr6,0x82e20878",
+        0x82E1FFAC: "lwz r4,740(r1)",
+        0x82E1FFDC: "add r3,r11,r4",
+        0x82E20024: "bl 0x8243f9a0",
+        0x82E2003C: "bl 0x82441048",
         0x82E20048: "lwz r11,124(r20)",
+        0x82E20080: "add r23,r11,r18",
+        0x82E20090: "add r21,r11,r17",
+        0x82E205E4: "stw r6,104(r25)",
+        0x82E206DC: "stw r6,104(r25)",
+        0x82E206F4: "lbz r11,18(r24)",
+        0x82E206F8: "cmplwi r11,0",
+        0x82E2084C: "lwz r11,124(r20)",
         0x82E20854: "addi r18,r18,92",
         0x82E20858: "addi r17,r17,68",
         spec["visibility_exit"]: "addi r1,r1,704",
@@ -1243,6 +1272,66 @@ def procedural_model_receiver_lifecycle(
         "visibility_exit_hook_address": "{:08X}".format(
             spec["visibility_exit"]
         ),
+        "visibility_selection": {
+            "record_entry_hook_address": "{:08X}".format(
+                spec["visibility_record_entry"]
+            ),
+            "lod_write_hook_addresses": [
+                "{:08X}".format(address)
+                for address in spec["visibility_lod_hooks"]
+            ],
+            "result_hook_address": "{:08X}".format(
+                spec["visibility_result"]
+            ),
+            "record_exit_hook_address": "{:08X}".format(
+                spec["visibility_record_exit"]
+            ),
+            "receiver_register": "r20",
+            "record_index_register": "r16",
+            "category_register": "r15",
+            "descriptor_register": "r23",
+            "runtime_register": "r21",
+            "selection_byte_offset": 18,
+            "lod_index_offset": 104,
+            "title_visibility_authority": True,
+            "passive_census_required": True,
+            "native_culling_enabled": False,
+            "native_lod_enabled": False,
+            "guest_payload_read": False,
+            "guest_state_changed": False,
+            "control_flow_changed": False,
+            "xenos_authority": True,
+            "suppression_allowed": False,
+        },
+        "visibility_policy_inputs": {
+            "spatial_prefilter_address": "{:08X}".format(
+                spec["visibility_spatial_prefilter"]
+            ),
+            "receiver_spatial_context_pointer_offset": 4,
+            "receiver_spatial_vector_offsets": [16, 32],
+            "category_spatial_argument_register": "r4",
+            "category_spatial_stride": 192,
+            "category_spatial_scalar_offsets": [160, 164, 168],
+            "category_query_argument_register": "r5",
+            "category_query_stride": 32,
+            "spatial_helper_address": "{:08X}".format(
+                spec["visibility_spatial_helper"]
+            ),
+            "category_helper_address": "{:08X}".format(
+                spec["visibility_category_helper"]
+            ),
+            "descriptor_distance_scalar_offset": 60,
+            "runtime_distance_scalar_offset": 44,
+            "squared_distance_register": "f26",
+            "structural_derivation_proved": True,
+            "camera_semantics_proved": False,
+            "frustum_plane_layout_proved": False,
+            "bounds_shape_semantics_proved": False,
+            "native_policy_execution_enabled": False,
+            "guest_state_changed": False,
+            "xenos_authority": True,
+            "suppression_allowed": False,
+        },
         "render_state_function_address": "{:08X}".format(
             spec["render_state_function"]
         ),

--- a/tools/discover-native-renderer-dispatch.py
+++ b/tools/discover-native-renderer-dispatch.py
@@ -203,6 +203,9 @@ PROCEDURAL_MODEL_RECEIVER = {
     "visibility_spatial_prefilter": 0x82E1FEF0,
     "visibility_spatial_helper": 0x8243F9A0,
     "visibility_category_helper": 0x82441048,
+    "visibility_spatial_distance_helper": 0x8243FD70,
+    "visibility_runtime_threshold_hook": 0x82E20134,
+    "visibility_descriptor_threshold_hook": 0x82E201B0,
     "render_state_function": 0x824170D8,
     "render_state_vtable_slot": 40,
     "render_state_entry": 0x824170DC,
@@ -831,6 +834,9 @@ def procedural_model_receiver_lifecycle(
         spec["deleting_destructor_function"],
         spec["array_constructor_function"],
         spec["visibility_function"],
+        spec["visibility_spatial_helper"],
+        spec["visibility_spatial_distance_helper"],
+        spec["visibility_category_helper"],
         spec["render_state_function"],
         spec["render_item_function"],
         spec["resource_binding_function"],
@@ -872,6 +878,24 @@ def procedural_model_receiver_lifecycle(
     visibility = {
         item["address"]: item["text"]
         for item in functions_by_address[spec["visibility_function"]][
+            "instructions"
+        ]
+    }
+    visibility_spatial_helper = {
+        item["address"]: item["text"]
+        for item in functions_by_address[spec["visibility_spatial_helper"]][
+            "instructions"
+        ]
+    }
+    visibility_spatial_distance_helper = {
+        item["address"]: item["text"]
+        for item in functions_by_address[
+            spec["visibility_spatial_distance_helper"]
+        ]["instructions"]
+    }
+    visibility_category_helper = {
+        item["address"]: item["text"]
+        for item in functions_by_address[spec["visibility_category_helper"]][
             "instructions"
         ]
     }
@@ -974,6 +998,12 @@ def procedural_model_receiver_lifecycle(
         0x82E20024: "bl 0x8243f9a0",
         0x82E2003C: "bl 0x82441048",
         0x82E20048: "lwz r11,124(r20)",
+        0x82E2012C: "lfs f0,44(r21)",
+        0x82E20130: "fmuls f0,f0,f0",
+        0x82E20134: "fcmpu cr6,f26,f0",
+        0x82E201A0: "lfs f0,60(r23)",
+        0x82E201AC: "fmuls f0,f0,f0",
+        0x82E201B0: "fcmpu cr6,f26,f0",
         0x82E20080: "add r23,r11,r18",
         0x82E20090: "add r21,r11,r17",
         0x82E205E4: "stw r6,104(r25)",
@@ -990,6 +1020,53 @@ def procedural_model_receiver_lifecycle(
         for address, text in visibility_expected.items()
     ):
         raise ValueError("procedural-model visibility evidence drifted")
+
+    spatial_helper_expected = {
+        0x8243F9A0: "mflr r12",
+        0x8243F9B0: "lfs f13,20(r3)",
+        0x8243F9CC: "lvx128 v63,r0,r4",
+        0x8243F9D0: "lvx128 v62,r0,r5",
+        0x8243F9DC: "vsubfp128 v62,v62,v63",
+        0x8243F9F8: "vmsum3fp128 v62,v62,v62",
+        0x8243FA04: "lfs f1,96(r1)",
+        0x8243FA08: "bl 0x8243fd70",
+    }
+    distance_helper_expected = {
+        0x8243FD74: "lfs f13,20(r3)",
+        0x8243FD8C: "lvx128 v63,r0,r3",
+        0x8243FD94: "lvx128 v62,r0,r4",
+        0x8243FD98: "vsubfp128 v63,v62,v63",
+        0x8243FD9C: "lfs f0,16(r3)",
+        0x8243FDA0: "lfs f13,24(r3)",
+        0x8243FDAC: "vmsum3fp128 v63,v63,v63",
+        0x8243FDB8: "fmuls f0,f0,f12",
+        0x8243FDBC: "fcmpu cr6,f0,f13",
+    }
+    category_helper_expected = {
+        0x8244105C: "addi r11,r3,64",
+        0x8244106C: "addi r10,r3,80",
+        0x82441074: "addi r9,r3,48",
+        0x8244107C: "lvx128 v52,r0,r3",
+        0x82441084: "lvx128 v58,r0,r11",
+        0x82441094: "lvx128 v57,r0,r10",
+        0x824410A0: "addi r10,r3,32",
+        0x824410A4: "lvx128 v54,r0,r9",
+        0x824410B0: "lvx128 v45,r0,r11",
+        0x824410C4: "lvx128 v43,r0,r10",
+        0x824412AC: "li r3,0",
+        0x824412C4: "addi r3,r11,1",
+    }
+    if any(
+        visibility_spatial_helper.get(address) != text
+        for address, text in spatial_helper_expected.items()
+    ) or any(
+        visibility_spatial_distance_helper.get(address) != text
+        for address, text in distance_helper_expected.items()
+    ) or any(
+        visibility_category_helper.get(address) != text
+        for address, text in category_helper_expected.items()
+    ):
+        raise ValueError("procedural-model visibility helper evidence drifted")
 
     render_state_expected = {
         spec["render_state_function"]: "mflr r12",
@@ -1323,6 +1400,33 @@ def procedural_model_receiver_lifecycle(
             "descriptor_distance_scalar_offset": 60,
             "runtime_distance_scalar_offset": 44,
             "squared_distance_register": "f26",
+            "threshold_register": "f0",
+            "runtime_threshold_hook_address": "{:08X}".format(
+                spec["visibility_runtime_threshold_hook"]
+            ),
+            "descriptor_threshold_hook_address": "{:08X}".format(
+                spec["visibility_descriptor_threshold_hook"]
+            ),
+            "passive_input_outcome_correlation_required": True,
+            "spatial_helper_contract": {
+                "distance_helper_address": "{:08X}".format(
+                    spec["visibility_spatial_distance_helper"]
+                ),
+                "query_vector_offset": 0,
+                "query_scalar_offsets": [16, 20, 24],
+                "segment_endpoint_registers": ["v1", "v2"],
+                "squared_delta_operation": "vmsum3fp128",
+                "distance_test_structure_proved": True,
+                "world_space_semantics_proved": False,
+            },
+            "category_helper_contract": {
+                "vector_block_offsets": [0, 16, 32, 48, 64, 80],
+                "vector_block_count": 6,
+                "input_registers": ["v1", "v2"],
+                "return_domain": [0, 1, 2],
+                "six_vector_classifier_structure_proved": True,
+                "frustum_semantics_proved": False,
+            },
             "structural_derivation_proved": True,
             "camera_semantics_proved": False,
             "frustum_plane_layout_proved": False,

--- a/tools/summarize-native-renderer-visibility-policy.py
+++ b/tools/summarize-native-renderer-visibility-policy.py
@@ -1,0 +1,368 @@
+#!/usr/bin/env python3
+"""Qualify passive title visibility-policy input/outcome correlation."""
+
+import argparse
+import json
+import pathlib
+import sys
+
+
+SCHEMA = "pinyon-shift.native-renderer-visibility-policy.v1"
+CONFIG = "native_renderer.discovery.semantic_visibility_policy_config"
+CATEGORY = (
+    "native_renderer.discovery.semantic_visibility_policy_category_summary"
+)
+EXPONENT = (
+    "native_renderer.discovery.semantic_visibility_spatial_exponent_summary"
+)
+SUMMARY = "native_renderer.discovery.semantic_visibility_policy_summary"
+VISIBILITY_CATEGORY = (
+    "native_renderer.discovery.semantic_visibility_category_summary"
+)
+OUTCOMES = ("early_rejected", "rejected", "selected")
+
+
+def read_events(paths):
+    events = []
+    for path in paths:
+        for line in path.read_text(encoding="utf-8").splitlines():
+            if line.strip():
+                events.append(json.loads(line))
+    return events
+
+
+def integer(event, key):
+    try:
+        value = int(event[key])
+    except (KeyError, TypeError, ValueError) as error:
+        raise ValueError(f"invalid {key}") from error
+    if value < 0:
+        raise ValueError(f"negative {key}")
+    return value
+
+
+def exact_event(events, name):
+    matches = [event for event in events if event.get("event") == name]
+    if len(matches) != 1:
+        raise ValueError(f"expected exactly one {name} event")
+    return matches[0]
+
+
+def select_session(events, requested):
+    sessions = {
+        event.get("session") for event in events if event.get("event") == CONFIG
+    }
+    sessions.discard(None)
+    if requested:
+        if requested not in sessions:
+            raise ValueError("requested session has no visibility-policy config")
+        return requested
+    if len(sessions) != 1:
+        raise ValueError("visibility-policy input contains multiple sessions")
+    return next(iter(sessions))
+
+
+def static_contract(document):
+    try:
+        contract = document["procedural_model_receiver_lifecycle"][
+            "visibility_policy_inputs"
+        ]
+    except (KeyError, TypeError) as error:
+        raise ValueError("static visibility-policy contract is missing") from error
+    expected = {
+        "spatial_prefilter_address": "82E1FEF0",
+        "receiver_spatial_context_pointer_offset": 4,
+        "receiver_spatial_vector_offsets": [16, 32],
+        "category_spatial_argument_register": "r4",
+        "category_spatial_stride": 192,
+        "category_spatial_scalar_offsets": [160, 164, 168],
+        "category_query_argument_register": "r5",
+        "category_query_stride": 32,
+        "spatial_helper_address": "8243F9A0",
+        "category_helper_address": "82441048",
+        "descriptor_distance_scalar_offset": 60,
+        "runtime_distance_scalar_offset": 44,
+        "squared_distance_register": "f26",
+        "threshold_register": "f0",
+        "runtime_threshold_hook_address": "82E20134",
+        "descriptor_threshold_hook_address": "82E201B0",
+        "structural_derivation_proved": True,
+        "camera_semantics_proved": False,
+        "frustum_plane_layout_proved": False,
+        "bounds_shape_semantics_proved": False,
+        "native_policy_execution_enabled": False,
+        "guest_state_changed": False,
+        "xenos_authority": True,
+        "suppression_allowed": False,
+    }
+    if any(contract.get(key) != value for key, value in expected.items()):
+        raise ValueError("static visibility-policy contract drifted")
+    if not contract.get("passive_input_outcome_correlation_required"):
+        raise ValueError("static visibility-policy correlation is not required")
+    expected_spatial_helper = {
+        "distance_helper_address": "8243FD70",
+        "query_vector_offset": 0,
+        "query_scalar_offsets": [16, 20, 24],
+        "segment_endpoint_registers": ["v1", "v2"],
+        "squared_delta_operation": "vmsum3fp128",
+        "distance_test_structure_proved": True,
+        "world_space_semantics_proved": False,
+    }
+    expected_category_helper = {
+        "vector_block_offsets": [0, 16, 32, 48, 64, 80],
+        "vector_block_count": 6,
+        "input_registers": ["v1", "v2"],
+        "return_domain": [0, 1, 2],
+        "six_vector_classifier_structure_proved": True,
+        "frustum_semantics_proved": False,
+    }
+    if contract.get("spatial_helper_contract") != expected_spatial_helper or (
+        contract.get("category_helper_contract") != expected_category_helper
+    ):
+        raise ValueError("static visibility-policy helper contract drifted")
+    return contract
+
+
+def build(events, static, requested_session=None):
+    contract = static_contract(static)
+    session = select_session(events, requested_session)
+    selected = [event for event in events if event.get("session") == session]
+    config = exact_event(selected, CONFIG)
+    summary = exact_event(selected, SUMMARY)
+
+    expected_config = {
+        "status": "armed",
+        "class": "proceduralGeometry::CProceduralModels",
+        "visibility_function": "82E1FD00",
+        "record_entry_hook": "82E20094",
+        "runtime_threshold_hook": "82E20134",
+        "descriptor_threshold_hook": "82E201B0",
+        "spatial_distance_source": "f26",
+        "threshold_source": "f0",
+        "runtime_distance_scalar_offset": "44",
+        "descriptor_distance_scalar_offset": "60",
+        "outcomes": "early_rejected,rejected,selected",
+        "classification": "title_spatial_policy_input_outcome_correlation",
+        "guest_payload_read": "false",
+        "guest_state_changed": "false",
+        "control_flow_changed": "false",
+        "native_policy_execution": "false",
+        "native_culling": "false",
+        "native_lod": "false",
+        "native_draw": "false",
+        "xenos_authority": "true",
+        "suppression_allowed": "false",
+    }
+    if any(config.get(key) != value for key, value in expected_config.items()):
+        raise ValueError("visibility-policy runtime configuration drifted")
+    if integer(config, "spatial_exponent_capacity") != 256:
+        raise ValueError("visibility-policy exponent capacity drifted")
+
+    expected_summary = {
+        "status": "complete",
+        "accounting_complete": "true",
+        "classification": "title_spatial_policy_input_outcome_correlation",
+        "guest_payload_read": "false",
+        "guest_state_changed": "false",
+        "control_flow_changed": "false",
+        "native_policy_execution": "false",
+        "native_culling": "false",
+        "native_lod": "false",
+        "xenos_authority": "true",
+        "suppression_allowed": "false",
+    }
+    if any(summary.get(key) != value for key, value in expected_summary.items()):
+        raise ValueError("visibility-policy summary is incomplete or unsafe")
+    total_keys = (
+        "records",
+        "spatial_samples",
+        "runtime_threshold_observations",
+        "runtime_distance_less",
+        "descriptor_threshold_observations",
+        "descriptor_distance_exceeded",
+        "spatial_histogram_records",
+        "invalid_spatial_values",
+        "invalid_threshold_values",
+        "hook_faults",
+        "runtime_threshold_without_record",
+        "duplicate_runtime_threshold",
+        "descriptor_threshold_without_record",
+        "duplicate_descriptor_threshold",
+    )
+    totals = {key: integer(summary, key) for key in total_keys}
+    if (
+        totals["records"] <= 0
+        or totals["spatial_samples"] != totals["records"]
+        or totals["spatial_histogram_records"] != totals["records"]
+        or totals["runtime_distance_less"]
+        > totals["runtime_threshold_observations"]
+        or totals["descriptor_distance_exceeded"]
+        > totals["descriptor_threshold_observations"]
+        or any(
+            totals[key]
+            for key in (
+                "invalid_spatial_values",
+                "invalid_threshold_values",
+                "hook_faults",
+                "runtime_threshold_without_record",
+                "duplicate_runtime_threshold",
+                "descriptor_threshold_without_record",
+                "duplicate_descriptor_threshold",
+            )
+        )
+    ):
+        raise ValueError("visibility-policy aggregate accounting failed")
+
+    visibility = {}
+    for event in selected:
+        if event.get("event") != VISIBILITY_CATEGORY:
+            continue
+        category = integer(event, "category")
+        if category in visibility or event.get("status") != "complete":
+            raise ValueError("visibility category evidence drifted")
+        visibility[category] = {
+            outcome: integer(event, outcome if outcome != "early_rejected" else "early_rejected")
+            for outcome in OUTCOMES
+        }
+
+    categories = {}
+    category_totals = {key: 0 for key in total_keys[:6]}
+    for event in selected:
+        if event.get("event") != CATEGORY:
+            continue
+        category = integer(event, "category")
+        outcome = event.get("outcome")
+        key = (category, outcome)
+        if (
+            key in categories
+            or category not in visibility
+            or outcome not in OUTCOMES
+            or event.get("status") != "complete"
+            or event.get("native_policy_execution") != "false"
+            or event.get("guest_state_changed") != "false"
+            or event.get("xenos_authority") != "true"
+            or event.get("suppression_allowed") != "false"
+        ):
+            raise ValueError("visibility-policy category evidence drifted")
+        item = {key: integer(event, key) for key in total_keys[:6]}
+        if (
+            item["records"] != visibility[category][outcome]
+            or item["spatial_samples"] != item["records"]
+            or item["runtime_distance_less"]
+            > item["runtime_threshold_observations"]
+            or item["descriptor_distance_exceeded"]
+            > item["descriptor_threshold_observations"]
+        ):
+            raise ValueError("visibility-policy category accounting failed")
+        categories[key] = item
+        for field in category_totals:
+            category_totals[field] += item[field]
+    expected_nonzero = {
+        (category, outcome)
+        for category, counts in visibility.items()
+        for outcome, count in counts.items()
+        if count
+    }
+    if set(categories) != expected_nonzero or any(
+        category_totals[key] != totals[key] for key in category_totals
+    ):
+        raise ValueError("visibility-policy category totals drifted")
+
+    histograms = {outcome: {} for outcome in OUTCOMES}
+    for event in selected:
+        if event.get("event") != EXPONENT:
+            continue
+        outcome = event.get("outcome")
+        exponent = integer(event, "float_exponent")
+        if (
+            outcome not in OUTCOMES
+            or exponent >= 256
+            or exponent in histograms[outcome]
+            or event.get("status") != "complete"
+            or event.get("source")
+            != "title_shared_spatial_distance_squared_f26"
+            or event.get("native_policy_execution") != "false"
+            or event.get("guest_state_changed") != "false"
+            or event.get("xenos_authority") != "true"
+            or event.get("suppression_allowed") != "false"
+        ):
+            raise ValueError("visibility-policy exponent evidence drifted")
+        records = integer(event, "records")
+        if not records:
+            raise ValueError("visibility-policy exponent bin is empty")
+        histograms[outcome][exponent] = records
+    histogram_totals = {
+        outcome: sum(histograms[outcome].values()) for outcome in OUTCOMES
+    }
+    for outcome in OUTCOMES:
+        expected = sum(
+            item["spatial_samples"]
+            for (category, item_outcome), item in categories.items()
+            if item_outcome == outcome
+        )
+        if histogram_totals[outcome] != expected:
+            raise ValueError("visibility-policy exponent accounting failed")
+
+    return {
+        "schema": SCHEMA,
+        "status": "complete",
+        "session": session,
+        "static_contract": contract,
+        "totals": totals,
+        "categories": {
+            f"{category}:{outcome}": item
+            for (category, outcome), item in sorted(categories.items())
+        },
+        "spatial_exponent_histograms": {
+            outcome: {
+                str(exponent): count
+                for exponent, count in sorted(histograms[outcome].items())
+            }
+            for outcome in OUTCOMES
+        },
+        "qualification": {
+            "structural_policy_inputs_proved": True,
+            "title_input_outcome_correlation_proved": True,
+            "ready_for_semantic_hypothesis_testing": True,
+            "camera_semantics_proved": False,
+            "frustum_plane_layout_proved": False,
+            "native_policy_execution_enabled": False,
+        },
+        "safety": {
+            "guest_payload_read": False,
+            "guest_state_changed": False,
+            "control_flow_changed": False,
+            "native_culling": False,
+            "native_lod": False,
+            "xenos_authority": True,
+            "suppression_allowed": False,
+        },
+    }
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser()
+    parser.add_argument("events", nargs="+", type=pathlib.Path)
+    parser.add_argument("--static", required=True, type=pathlib.Path)
+    parser.add_argument("--session")
+    parser.add_argument("--output", required=True, type=pathlib.Path)
+    args = parser.parse_args(argv)
+    try:
+        document = build(
+            read_events(args.events),
+            json.loads(args.static.read_text(encoding="utf-8")),
+            args.session,
+        )
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(
+            json.dumps(document, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        return 0
+    except (OSError, ValueError, json.JSONDecodeError) as error:
+        print(f"native renderer visibility policy summary failed: {error}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/summarize-native-renderer-visibility.py
+++ b/tools/summarize-native-renderer-visibility.py
@@ -1,0 +1,401 @@
+"""Validate the passive title-authoritative visibility and LOD census."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import pathlib
+import sys
+
+
+SCHEMA = "pinyon-shift.native-renderer-visibility.v1"
+STATIC_SCHEMA = "pinyon-shift.native-renderer-dispatch-static.v3"
+CONFIG = "native_renderer.discovery.semantic_visibility_config"
+SUMMARY = "native_renderer.discovery.semantic_visibility_summary"
+CATEGORY = "native_renderer.discovery.semantic_visibility_category_summary"
+LOD = "native_renderer.discovery.semantic_lod_summary"
+RESULT_VALUE = (
+    "native_renderer.discovery.semantic_visibility_result_value_summary"
+)
+
+
+def read_events(paths: list[pathlib.Path]) -> list[dict]:
+    wanted = {CONFIG, SUMMARY, CATEGORY, LOD, RESULT_VALUE}
+    events = []
+    for path in paths:
+        for line_number, line in enumerate(
+            path.read_text(encoding="utf-8").splitlines(), 1
+        ):
+            if not line.strip():
+                continue
+            try:
+                event = json.loads(line)
+            except json.JSONDecodeError as error:
+                raise ValueError(
+                    f"{path}:{line_number}: invalid JSON: {error}"
+                ) from error
+            if event.get("event") in wanted:
+                events.append(event)
+    return events
+
+
+def _integer(mapping: dict, key: str) -> int:
+    try:
+        return int(mapping.get(key, ""))
+    except (TypeError, ValueError) as error:
+        raise ValueError(f"invalid integer field: {key}") from error
+
+
+def _select_session(events: list[dict], requested: str | None) -> str:
+    if requested:
+        if not any(event.get("session") == requested for event in events):
+            raise ValueError(f"semantic-visibility session not found: {requested}")
+        return requested
+    sessions = [
+        str(event.get("session", ""))
+        for event in events
+        if event.get("event") == CONFIG and event.get("status") == "armed"
+    ]
+    if not sessions or not sessions[-1]:
+        raise ValueError("no armed semantic-visibility session found")
+    return sessions[-1]
+
+
+def _validate_static(static: dict) -> dict:
+    if static.get("schema") != STATIC_SCHEMA:
+        raise ValueError("unsupported static dispatch inventory schema")
+    contract = static.get("procedural_model_receiver_lifecycle", {}).get(
+        "visibility_selection", {}
+    )
+    expected = {
+        "record_entry_hook_address": "82E20094",
+        "lod_write_hook_addresses": ["82E205E4", "82E206DC"],
+        "result_hook_address": "82E206F8",
+        "record_exit_hook_address": "82E2084C",
+        "receiver_register": "r20",
+        "record_index_register": "r16",
+        "category_register": "r15",
+        "descriptor_register": "r23",
+        "runtime_register": "r21",
+        "selection_byte_offset": 18,
+        "lod_index_offset": 104,
+        "title_visibility_authority": True,
+        "passive_census_required": True,
+        "native_culling_enabled": False,
+        "native_lod_enabled": False,
+        "guest_payload_read": False,
+        "guest_state_changed": False,
+        "control_flow_changed": False,
+        "xenos_authority": True,
+        "suppression_allowed": False,
+    }
+    if any(contract.get(key) != value for key, value in expected.items()):
+        raise ValueError("unsupported static semantic-visibility contract")
+    return contract
+
+
+def build(events: list[dict], static: dict, requested: str | None = None) -> dict:
+    contract = _validate_static(static)
+    session = _select_session(events, requested)
+    selected_events = [
+        event for event in events if event.get("session") == session
+    ]
+    configs = [event for event in selected_events if event.get("event") == CONFIG]
+    summaries = [
+        event for event in selected_events if event.get("event") == SUMMARY
+    ]
+    if len(configs) != 1 or len(summaries) != 1:
+        raise ValueError(
+            "semantic-visibility session needs one config and one summary"
+        )
+    config = configs[0]
+    summary = summaries[0]
+    expected_config = {
+        "status": "armed",
+        "class": "proceduralGeometry::CProceduralModels",
+        "visibility_function": "82E1FD00",
+        "record_entry_hook": "82E20094",
+        "lod_write_hooks": "82E205E4,82E206DC",
+        "result_hook": "82E206F8",
+        "record_completion_hook": "82E2084C",
+        "record_identity": (
+            "receiver_generation,record_index,category,descriptor,runtime"
+        ),
+        "visibility_result": "runtime_selection_byte_18",
+        "lod_selection": "runtime_record_plus_104",
+        "classification": "title_authoritative_visibility_and_lod_observation",
+        "guest_payload_read": "false",
+        "guest_state_changed": "false",
+        "control_flow_changed": "false",
+        "native_culling": "false",
+        "native_lod": "false",
+        "native_draw": "false",
+        "xenos_authority": "true",
+        "suppression_allowed": "false",
+    }
+    if any(config.get(key) != value for key, value in expected_config.items()):
+        raise ValueError("semantic-visibility runtime configuration drifted")
+    if _integer(config, "category_capacity") != 32 or _integer(
+        config, "lod_capacity"
+    ) != 32 or _integer(config, "result_value_capacity") != 256:
+        raise ValueError("semantic-visibility runtime capacity drifted")
+
+    expected_summary = {
+        "classification": "title_authoritative_visibility_and_lod_observation",
+        "guest_payload_read": "false",
+        "guest_state_changed": "false",
+        "control_flow_changed": "false",
+        "native_culling": "false",
+        "native_lod": "false",
+        "native_draw": "false",
+        "xenos_authority": "true",
+        "suppression_allowed": "false",
+    }
+    if any(summary.get(key) != value for key, value in expected_summary.items()):
+        raise ValueError("semantic-visibility summary is incomplete or unsafe")
+    legacy_lod_rewrites = _integer(summary, "duplicate_lod") if (
+        "lod_rewrites" not in summary and "duplicate_lod" in summary
+    ) else 0
+    legacy_lod_rewrite_capture = (
+        legacy_lod_rewrites > 0
+        and summary.get("status") == "incomplete"
+        and summary.get("accounting_complete") == "false"
+        and _integer(summary, "record_stack_faults") == legacy_lod_rewrites
+    )
+    if not legacy_lod_rewrite_capture and (
+        summary.get("status") != "complete"
+        or summary.get("accounting_complete") != "true"
+    ):
+        raise ValueError("semantic-visibility summary is incomplete or unsafe")
+    totals = {
+        key: _integer(summary, key)
+        for key in (
+            "record_entries",
+            "record_completions",
+            "result_observations",
+            "selected_records",
+            "rejected_records",
+            "early_rejected_records",
+            "lod_writes",
+            "lod_category_selected_with_lod",
+            "lod_category_selected_without_lod",
+            "category_overflow",
+            "lod_overflow",
+            "record_stack_faults",
+            "entry_overlaps",
+            "lod_without_record",
+            "result_without_record",
+            "duplicate_result",
+            "completion_without_record",
+            "visibility_exit_with_record",
+            "record_identity_mismatches",
+            "record_unknown_receivers",
+            "record_open_at_shutdown",
+        )
+    }
+    totals["lod_rewrites"] = (
+        legacy_lod_rewrites
+        if legacy_lod_rewrite_capture
+        else _integer(summary, "lod_rewrites")
+    )
+    if legacy_lod_rewrite_capture:
+        totals["record_stack_faults"] -= legacy_lod_rewrites
+    if (
+        totals["record_entries"] <= 0
+        or totals["record_entries"] != totals["record_completions"]
+        or totals["record_completions"]
+        != totals["selected_records"]
+        + totals["rejected_records"]
+        + totals["early_rejected_records"]
+        or totals["result_observations"]
+        != totals["selected_records"] + totals["rejected_records"]
+        or totals["selected_records"] <= 0
+        or totals["lod_writes"] <= 0
+        or totals["lod_category_selected_with_lod"] <= 0
+        or totals["lod_category_selected_without_lod"] != 0
+        or any(
+            totals[key]
+            for key in (
+                "category_overflow",
+                "lod_overflow",
+                "record_stack_faults",
+                "entry_overlaps",
+                "lod_without_record",
+                "result_without_record",
+                "duplicate_result",
+                "completion_without_record",
+                "visibility_exit_with_record",
+                "record_identity_mismatches",
+                "record_unknown_receivers",
+                "record_open_at_shutdown",
+            )
+        )
+    ):
+        raise ValueError("semantic-visibility aggregate accounting failed")
+
+    categories = {}
+    category_totals = {
+        key: 0
+        for key in (
+            "entries",
+            "completions",
+            "selected",
+            "rejected",
+            "early_rejected",
+            "lod_writes",
+        )
+    }
+    for event in selected_events:
+        if event.get("event") != CATEGORY:
+            continue
+        category = _integer(event, "category")
+        if category in categories or not 0 <= category < 32:
+            raise ValueError("duplicate or invalid semantic-visibility category")
+        if (
+            event.get("status") != "complete"
+            or event.get("title_visibility_authority") != "true"
+            or event.get("native_culling") != "false"
+            or event.get("native_lod") != "false"
+            or event.get("xenos_authority") != "true"
+            or event.get("suppression_allowed") != "false"
+        ):
+            raise ValueError("semantic-visibility category is incomplete or unsafe")
+        item = {key: _integer(event, key) for key in category_totals}
+        if (
+            item["entries"] <= 0
+            or item["entries"] != item["completions"]
+            or item["completions"]
+            != item["selected"] + item["rejected"] + item["early_rejected"]
+        ):
+            raise ValueError("semantic-visibility category accounting failed")
+        categories[category] = item
+        for key, value in item.items():
+            category_totals[key] += value
+    if not categories or category_totals != {
+        "entries": totals["record_entries"],
+        "completions": totals["record_completions"],
+        "selected": totals["selected_records"],
+        "rejected": totals["rejected_records"],
+        "early_rejected": totals["early_rejected_records"],
+        "lod_writes": totals["lod_writes"],
+    }:
+        raise ValueError("semantic-visibility category totals drifted")
+
+    lod_histogram = {}
+    for event in selected_events:
+        if event.get("event") != LOD:
+            continue
+        lod_index = _integer(event, "lod_index")
+        if lod_index in lod_histogram or not 0 <= lod_index < 32:
+            raise ValueError("duplicate or invalid semantic LOD index")
+        if (
+            event.get("status") != "complete"
+            or event.get("source") != "title_selected_runtime_record_plus_104"
+            or event.get("native_lod") != "false"
+            or event.get("xenos_authority") != "true"
+            or event.get("suppression_allowed") != "false"
+        ):
+            raise ValueError("semantic LOD summary is incomplete or unsafe")
+        writes = _integer(event, "writes")
+        if writes <= 0:
+            raise ValueError("semantic LOD histogram contains an empty bin")
+        lod_histogram[lod_index] = writes
+    if not lod_histogram or sum(lod_histogram.values()) != totals["lod_writes"]:
+        raise ValueError("semantic LOD histogram accounting failed")
+
+    result_value_histogram = {}
+    for event in selected_events:
+        if event.get("event") != RESULT_VALUE:
+            continue
+        value = _integer(event, "selection_value")
+        if value in result_value_histogram or not 0 <= value < 256:
+            raise ValueError("duplicate or invalid visibility result value")
+        expected_interpretation = (
+            "selected_nonzero" if value else "rejected_zero"
+        )
+        if (
+            event.get("status") != "complete"
+            or event.get("interpretation") != expected_interpretation
+            or event.get("native_culling") != "false"
+            or event.get("xenos_authority") != "true"
+            or event.get("suppression_allowed") != "false"
+        ):
+            raise ValueError("visibility result value is incomplete or unsafe")
+        observations = _integer(event, "observations")
+        if observations <= 0:
+            raise ValueError("visibility result histogram contains an empty bin")
+        result_value_histogram[value] = observations
+    if (
+        not result_value_histogram
+        or sum(result_value_histogram.values())
+        != totals["result_observations"]
+        or result_value_histogram.get(0, 0) != totals["rejected_records"]
+        or sum(
+            count
+            for value, count in result_value_histogram.items()
+            if value
+        )
+        != totals["selected_records"]
+    ):
+        raise ValueError("visibility result histogram accounting failed")
+
+    return {
+        "schema": SCHEMA,
+        "status": "complete",
+        "session": session,
+        "static_contract": contract,
+        "totals": totals,
+        "categories": {str(key): categories[key] for key in sorted(categories)},
+        "lod_histogram": {
+            str(key): lod_histogram[key] for key in sorted(lod_histogram)
+        },
+        "result_value_histogram": {
+            str(key): result_value_histogram[key]
+            for key in sorted(result_value_histogram)
+        },
+        "qualification": {
+            "title_visibility_authority_proved": True,
+            "title_lod_selection_observed": True,
+            "ready_for_native_policy_modeling": True,
+            "capture_model": (
+                "legacy_duplicate_lod_normalized_as_rewrite"
+                if legacy_lod_rewrite_capture
+                else "lod_rewrite_aware"
+            ),
+        },
+        "safety": {
+            "guest_payload_read": False,
+            "guest_state_changed": False,
+            "control_flow_changed": False,
+            "native_culling": False,
+            "native_lod": False,
+            "native_draw": False,
+            "xenos_authority": True,
+            "suppression_allowed": False,
+        },
+    }
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("events", nargs="+", type=pathlib.Path)
+    parser.add_argument("--static", required=True, type=pathlib.Path)
+    parser.add_argument("--session")
+    parser.add_argument("--output", required=True, type=pathlib.Path)
+    args = parser.parse_args(argv)
+    try:
+        static = json.loads(args.static.read_text(encoding="utf-8"))
+        document = build(read_events(args.events), static, args.session)
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(
+            json.dumps(document, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        return 0
+    except (OSError, ValueError, json.JSONDecodeError) as error:
+        print(f"native renderer visibility summary failed: {error}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/tests/test_native_renderer_contract.py
+++ b/tools/tests/test_native_renderer_contract.py
@@ -130,6 +130,12 @@ class NativeRendererContractTests(unittest.TestCase):
             "PinyonShiftObserveProceduralModelVisibilityRecordExit": (
                 "0x82E2084C"
             ),
+            "PinyonShiftObserveProceduralModelVisibilityRuntimeThreshold": (
+                "0x82E20134"
+            ),
+            "PinyonShiftObserveProceduralModelVisibilityDescriptorThreshold": (
+                "0x82E201B0"
+            ),
         }
         for name, address in hooks.items():
             self.assertEqual(analysis.count(f'name = "{name}"'), 1)
@@ -146,6 +152,21 @@ class NativeRendererContractTests(unittest.TestCase):
         self.assertIn('"native_lod": False', summarizer)
         self.assertIn('"xenos_authority": True', summarizer)
         self.assertIn('"suppression_allowed": False', summarizer)
+
+        policy_summarizer = (
+            ROOT / "tools/summarize-native-renderer-visibility-policy.py"
+        ).read_text(encoding="utf-8")
+        self.assertIn(
+            "kSemanticVisibilitySpatialExponentCapacity = 256", source
+        )
+        self.assertIn(
+            "title_spatial_policy_input_outcome_correlation", source
+        )
+        self.assertIn(
+            '"native_policy_execution_enabled": False', policy_summarizer
+        )
+        self.assertIn('"xenos_authority": True', policy_summarizer)
+        self.assertIn('"suppression_allowed": False', policy_summarizer)
 
     def test_exact_pass_consumer_trace_is_bounded_and_fail_closed(self):
         source = (ROOT / "src/native_renderer/graphics_hooks.cpp").read_text(

--- a/tools/tests/test_native_renderer_contract.py
+++ b/tools/tests/test_native_renderer_contract.py
@@ -106,6 +106,47 @@ class NativeRendererContractTests(unittest.TestCase):
         self.assertIn('"bounded_guest_read": True', summarizer)
         self.assertIn('"suppression_allowed": False', summarizer)
 
+    def test_visibility_lod_census_is_exact_bounded_and_passive(self):
+        source = (ROOT / "src/native_renderer/graphics_hooks.cpp").read_text(
+            encoding="utf-8"
+        )
+        analysis = (ROOT / "config/rexglue/analysis/main-xex.toml").read_text(
+            encoding="utf-8"
+        )
+        summarizer = (
+            ROOT / "tools/summarize-native-renderer-visibility.py"
+        ).read_text(encoding="utf-8")
+        hooks = {
+            "PinyonShiftObserveProceduralModelVisibilityRecordEntry": (
+                "0x82E20094"
+            ),
+            "PinyonShiftObserveProceduralModelVisibilityLodPrimary": (
+                "0x82E205E4"
+            ),
+            "PinyonShiftObserveProceduralModelVisibilityLodSecondary": (
+                "0x82E206DC"
+            ),
+            "PinyonShiftObserveProceduralModelVisibilityResult": "0x82E206F8",
+            "PinyonShiftObserveProceduralModelVisibilityRecordExit": (
+                "0x82E2084C"
+            ),
+        }
+        for name, address in hooks.items():
+            self.assertEqual(analysis.count(f'name = "{name}"'), 1)
+            hook = analysis.split(f'name = "{name}"', 1)[0].rsplit(
+                "[[midasm_hook]]", 1
+            )[1]
+            self.assertIn(f"address = {address}", hook)
+            self.assertNotIn("jump_address", hook)
+        self.assertIn("kSemanticVisibilityCategoryCapacity = 32", source)
+        self.assertIn("kSemanticVisibilityLodCapacity = 32", source)
+        self.assertIn("title_authoritative_visibility_and_lod_observation", source)
+        self.assertNotIn("REX_STORE", source)
+        self.assertIn('"native_culling": False', summarizer)
+        self.assertIn('"native_lod": False', summarizer)
+        self.assertIn('"xenos_authority": True', summarizer)
+        self.assertIn('"suppression_allowed": False', summarizer)
+
     def test_exact_pass_consumer_trace_is_bounded_and_fail_closed(self):
         source = (ROOT / "src/native_renderer/graphics_hooks.cpp").read_text(
             encoding="utf-8"

--- a/tools/tests/test_native_renderer_dispatch_discovery.py
+++ b/tools/tests/test_native_renderer_dispatch_discovery.py
@@ -432,7 +432,47 @@ def procedural_model_lifecycle_fixtures():
                 "lwz r11,128(r20)",
                 "loc_82E1FEB8:",
                 "lwz r9,128(r20)",
+                "loc_82E1FEF0:",
+                "lwz r8,732(r1)",
+                "mulli r10,r15,192",
+                "lwz r11,4(r20)",
+                "loc_82E1FF0C:",
+                "add r14,r10,r8",
+                "loc_82E1FF20:",
+                "lfs f12,160(r14)",
+                "lfs f13,164(r14)",
+                "lfs f11,168(r14)",
+                "loc_82E1FF64:",
+                "lwz r11,4(r20)",
+                "loc_82E1FF80:",
+                "lvx128 v63,r11,r9",
+                "loc_82E1FF88:",
+                "lvx128 v62,r11,r8",
+                "loc_82E1FFA4:",
+                "bgt cr6,0x82e20878",
+                "loc_82E1FFAC:",
+                "lwz r4,740(r1)",
+                "loc_82E1FFDC:",
+                "add r3,r11,r4",
+                "loc_82E20024:",
+                "bl 0x8243f9a0",
+                "loc_82E2003C:",
+                "bl 0x82441048",
                 "loc_82E20048:",
+                "lwz r11,124(r20)",
+                "loc_82E20080:",
+                "add r23,r11,r18",
+                "loc_82E20090:",
+                "add r21,r11,r17",
+                "loc_82E205E4:",
+                "stw r6,104(r25)",
+                "loc_82E206DC:",
+                "stw r6,104(r25)",
+                "loc_82E206F4:",
+                "lbz r11,18(r24)",
+                "loc_82E206F8:",
+                "cmplwi r11,0",
+                "loc_82E2084C:",
                 "lwz r11,124(r20)",
                 "loc_82E20854:",
                 "addi r18,r18,92",
@@ -1106,6 +1146,36 @@ class NativeRendererDispatchDiscoveryTests(unittest.TestCase):
         self.assertEqual(512, lifecycle["object_size"])
         self.assertTrue(lifecycle["visibility_preparation_boundary_proved"])
         self.assertTrue(lifecycle["render_state_boundary_proved"])
+        visibility = lifecycle["visibility_selection"]
+        self.assertEqual("82E20094", visibility["record_entry_hook_address"])
+        self.assertEqual(
+            ["82E205E4", "82E206DC"],
+            visibility["lod_write_hook_addresses"],
+        )
+        self.assertEqual("82E206F8", visibility["result_hook_address"])
+        self.assertEqual("82E2084C", visibility["record_exit_hook_address"])
+        self.assertEqual(18, visibility["selection_byte_offset"])
+        self.assertEqual(104, visibility["lod_index_offset"])
+        self.assertTrue(visibility["title_visibility_authority"])
+        self.assertTrue(visibility["passive_census_required"])
+        self.assertFalse(visibility["native_culling_enabled"])
+        self.assertFalse(visibility["native_lod_enabled"])
+        self.assertTrue(visibility["xenos_authority"])
+        self.assertFalse(visibility["suppression_allowed"])
+        policy = lifecycle["visibility_policy_inputs"]
+        self.assertEqual("82E1FEF0", policy["spatial_prefilter_address"])
+        self.assertEqual(4, policy["receiver_spatial_context_pointer_offset"])
+        self.assertEqual([16, 32], policy["receiver_spatial_vector_offsets"])
+        self.assertEqual(192, policy["category_spatial_stride"])
+        self.assertEqual([160, 164, 168], policy["category_spatial_scalar_offsets"])
+        self.assertEqual(32, policy["category_query_stride"])
+        self.assertEqual("8243F9A0", policy["spatial_helper_address"])
+        self.assertEqual("82441048", policy["category_helper_address"])
+        self.assertEqual(60, policy["descriptor_distance_scalar_offset"])
+        self.assertEqual(44, policy["runtime_distance_scalar_offset"])
+        self.assertTrue(policy["structural_derivation_proved"])
+        self.assertFalse(policy["camera_semantics_proved"])
+        self.assertFalse(policy["native_policy_execution_enabled"])
         self.assertEqual(
             92, lifecycle["field_layout"]["descriptor_record_stride"]
         )

--- a/tools/tests/test_native_renderer_dispatch_discovery.py
+++ b/tools/tests/test_native_renderer_dispatch_discovery.py
@@ -460,6 +460,15 @@ def procedural_model_lifecycle_fixtures():
                 "bl 0x82441048",
                 "loc_82E20048:",
                 "lwz r11,124(r20)",
+                "loc_82E2012C:",
+                "lfs f0,44(r21)",
+                "fmuls f0,f0,f0",
+                "fcmpu cr6,f26,f0",
+                "loc_82E201A0:",
+                "lfs f0,60(r23)",
+                "loc_82E201AC:",
+                "fmuls f0,f0,f0",
+                "fcmpu cr6,f26,f0",
                 "loc_82E20080:",
                 "add r23,r11,r18",
                 "loc_82E20090:",
@@ -480,6 +489,75 @@ def procedural_model_lifecycle_fixtures():
                 "addi r17,r17,68",
                 "loc_82E208CC:",
                 "addi r1,r1,704",
+                "blr",
+            ],
+        ),
+        fixture(
+            0x8243F9A0,
+            [
+                "mflr r12",
+                "loc_8243F9B0:",
+                "lfs f13,20(r3)",
+                "loc_8243F9CC:",
+                "lvx128 v63,r0,r4",
+                "lvx128 v62,r0,r5",
+                "loc_8243F9DC:",
+                "vsubfp128 v62,v62,v63",
+                "loc_8243F9F8:",
+                "vmsum3fp128 v62,v62,v62",
+                "loc_8243FA04:",
+                "lfs f1,96(r1)",
+                "bl 0x8243fd70",
+                "blr",
+            ],
+        ),
+        fixture(
+            0x8243FD70,
+            [
+                "lis r11,-32256",
+                "lfs f13,20(r3)",
+                "loc_8243FD8C:",
+                "lvx128 v63,r0,r3",
+                "loc_8243FD94:",
+                "lvx128 v62,r0,r4",
+                "vsubfp128 v63,v62,v63",
+                "lfs f0,16(r3)",
+                "lfs f13,24(r3)",
+                "loc_8243FDAC:",
+                "vmsum3fp128 v63,v63,v63",
+                "loc_8243FDB8:",
+                "fmuls f0,f0,f12",
+                "fcmpu cr6,f0,f13",
+                "blr",
+            ],
+        ),
+        fixture(
+            0x82441048,
+            [
+                "vor128 v62,v1,v1",
+                "loc_8244105C:",
+                "addi r11,r3,64",
+                "loc_8244106C:",
+                "addi r10,r3,80",
+                "loc_82441074:",
+                "addi r9,r3,48",
+                "loc_8244107C:",
+                "lvx128 v52,r0,r3",
+                "loc_82441084:",
+                "lvx128 v58,r0,r11",
+                "loc_82441094:",
+                "lvx128 v57,r0,r10",
+                "loc_824410A0:",
+                "addi r10,r3,32",
+                "lvx128 v54,r0,r9",
+                "loc_824410B0:",
+                "lvx128 v45,r0,r11",
+                "loc_824410C4:",
+                "lvx128 v43,r0,r10",
+                "loc_824412AC:",
+                "li r3,0",
+                "loc_824412C4:",
+                "addi r3,r11,1",
                 "blr",
             ],
         ),
@@ -1173,6 +1251,26 @@ class NativeRendererDispatchDiscoveryTests(unittest.TestCase):
         self.assertEqual("82441048", policy["category_helper_address"])
         self.assertEqual(60, policy["descriptor_distance_scalar_offset"])
         self.assertEqual(44, policy["runtime_distance_scalar_offset"])
+        self.assertEqual("82E20134", policy["runtime_threshold_hook_address"])
+        self.assertEqual(
+            "82E201B0", policy["descriptor_threshold_hook_address"]
+        )
+        self.assertTrue(policy["passive_input_outcome_correlation_required"])
+        spatial_helper = policy["spatial_helper_contract"]
+        self.assertEqual("8243FD70", spatial_helper["distance_helper_address"])
+        self.assertEqual([16, 20, 24], spatial_helper["query_scalar_offsets"])
+        self.assertTrue(spatial_helper["distance_test_structure_proved"])
+        self.assertFalse(spatial_helper["world_space_semantics_proved"])
+        category_helper = policy["category_helper_contract"]
+        self.assertEqual(
+            [0, 16, 32, 48, 64, 80],
+            category_helper["vector_block_offsets"],
+        )
+        self.assertEqual([0, 1, 2], category_helper["return_domain"])
+        self.assertTrue(
+            category_helper["six_vector_classifier_structure_proved"]
+        )
+        self.assertFalse(category_helper["frustum_semantics_proved"])
         self.assertTrue(policy["structural_derivation_proved"])
         self.assertFalse(policy["camera_semantics_proved"])
         self.assertFalse(policy["native_policy_execution_enabled"])

--- a/tools/tests/test_native_renderer_visibility.py
+++ b/tools/tests/test_native_renderer_visibility.py
@@ -1,0 +1,239 @@
+import importlib.util
+from pathlib import Path
+import unittest
+
+
+SCRIPT = Path(__file__).parents[1] / "summarize-native-renderer-visibility.py"
+SPEC = importlib.util.spec_from_file_location("native_renderer_visibility", SCRIPT)
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+def static_contract():
+    return {
+        "schema": "pinyon-shift.native-renderer-dispatch-static.v3",
+        "procedural_model_receiver_lifecycle": {
+            "visibility_selection": {
+                "record_entry_hook_address": "82E20094",
+                "lod_write_hook_addresses": ["82E205E4", "82E206DC"],
+                "result_hook_address": "82E206F8",
+                "record_exit_hook_address": "82E2084C",
+                "receiver_register": "r20",
+                "record_index_register": "r16",
+                "category_register": "r15",
+                "descriptor_register": "r23",
+                "runtime_register": "r21",
+                "selection_byte_offset": 18,
+                "lod_index_offset": 104,
+                "title_visibility_authority": True,
+                "passive_census_required": True,
+                "native_culling_enabled": False,
+                "native_lod_enabled": False,
+                "guest_payload_read": False,
+                "guest_state_changed": False,
+                "control_flow_changed": False,
+                "xenos_authority": True,
+                "suppression_allowed": False,
+            }
+        },
+    }
+
+
+def events():
+    common = {"session": "test-session"}
+    return [
+        {
+            **common,
+            "event": MODULE.CONFIG,
+            "status": "armed",
+            "class": "proceduralGeometry::CProceduralModels",
+            "visibility_function": "82E1FD00",
+            "record_entry_hook": "82E20094",
+            "lod_write_hooks": "82E205E4,82E206DC",
+            "result_hook": "82E206F8",
+            "record_completion_hook": "82E2084C",
+            "record_identity": (
+                "receiver_generation,record_index,category,descriptor,runtime"
+            ),
+            "visibility_result": "runtime_selection_byte_18",
+            "lod_selection": "runtime_record_plus_104",
+            "category_capacity": "32",
+            "lod_capacity": "32",
+            "result_value_capacity": "256",
+            "classification": (
+                "title_authoritative_visibility_and_lod_observation"
+            ),
+            "guest_payload_read": "false",
+            "guest_state_changed": "false",
+            "control_flow_changed": "false",
+            "native_culling": "false",
+            "native_lod": "false",
+            "native_draw": "false",
+            "xenos_authority": "true",
+            "suppression_allowed": "false",
+        },
+        {
+            **common,
+            "event": MODULE.CATEGORY,
+            "status": "complete",
+            "category": "2",
+            "entries": "5",
+            "completions": "5",
+            "selected": "1",
+            "rejected": "1",
+            "early_rejected": "3",
+            "lod_writes": "0",
+            "title_visibility_authority": "true",
+            "native_culling": "false",
+            "native_lod": "false",
+            "xenos_authority": "true",
+            "suppression_allowed": "false",
+        },
+        {
+            **common,
+            "event": MODULE.CATEGORY,
+            "status": "complete",
+            "category": "9",
+            "entries": "5",
+            "completions": "5",
+            "selected": "3",
+            "rejected": "1",
+            "early_rejected": "1",
+            "lod_writes": "3",
+            "title_visibility_authority": "true",
+            "native_culling": "false",
+            "native_lod": "false",
+            "xenos_authority": "true",
+            "suppression_allowed": "false",
+        },
+        {
+            **common,
+            "event": MODULE.LOD,
+            "status": "complete",
+            "lod_index": "2",
+            "writes": "3",
+            "source": "title_selected_runtime_record_plus_104",
+            "native_lod": "false",
+            "xenos_authority": "true",
+            "suppression_allowed": "false",
+        },
+        {
+            **common,
+            "event": MODULE.RESULT_VALUE,
+            "status": "complete",
+            "selection_value": "0",
+            "observations": "2",
+            "interpretation": "rejected_zero",
+            "native_culling": "false",
+            "xenos_authority": "true",
+            "suppression_allowed": "false",
+        },
+        {
+            **common,
+            "event": MODULE.RESULT_VALUE,
+            "status": "complete",
+            "selection_value": "7",
+            "observations": "4",
+            "interpretation": "selected_nonzero",
+            "native_culling": "false",
+            "xenos_authority": "true",
+            "suppression_allowed": "false",
+        },
+        {
+            **common,
+            "event": MODULE.SUMMARY,
+            "status": "complete",
+            "record_entries": "10",
+            "record_completions": "10",
+            "result_observations": "6",
+            "selected_records": "4",
+            "rejected_records": "2",
+            "early_rejected_records": "4",
+            "lod_writes": "3",
+            "lod_category_selected_with_lod": "3",
+            "lod_category_selected_without_lod": "0",
+            "category_overflow": "0",
+            "lod_overflow": "0",
+            "record_stack_faults": "0",
+            "entry_overlaps": "0",
+            "lod_without_record": "0",
+            "lod_rewrites": "2",
+            "result_without_record": "0",
+            "duplicate_result": "0",
+            "completion_without_record": "0",
+            "visibility_exit_with_record": "0",
+            "record_identity_mismatches": "0",
+            "record_unknown_receivers": "0",
+            "record_open_at_shutdown": "0",
+            "accounting_complete": "true",
+            "classification": (
+                "title_authoritative_visibility_and_lod_observation"
+            ),
+            "guest_payload_read": "false",
+            "guest_state_changed": "false",
+            "control_flow_changed": "false",
+            "native_culling": "false",
+            "native_lod": "false",
+            "native_draw": "false",
+            "xenos_authority": "true",
+            "suppression_allowed": "false",
+        },
+    ]
+
+
+class NativeRendererVisibilityTests(unittest.TestCase):
+    def test_accepts_complete_passive_census(self):
+        document = MODULE.build(events(), static_contract())
+        self.assertEqual(MODULE.SCHEMA, document["schema"])
+        self.assertEqual("complete", document["status"])
+        self.assertEqual(4, document["totals"]["selected_records"])
+        self.assertEqual(2, document["totals"]["lod_rewrites"])
+        self.assertEqual({"2": 3}, document["lod_histogram"])
+        self.assertEqual(
+            {"0": 2, "7": 4}, document["result_value_histogram"]
+        )
+        self.assertTrue(
+            document["qualification"]["ready_for_native_policy_modeling"]
+        )
+        self.assertTrue(document["safety"]["xenos_authority"])
+        self.assertFalse(document["safety"]["native_culling"])
+
+    def test_rejects_runtime_faults(self):
+        broken = events()
+        broken[-1]["record_stack_faults"] = "1"
+        broken[-1]["duplicate_result"] = "1"
+        with self.assertRaisesRegex(ValueError, "aggregate accounting"):
+            MODULE.build(broken, static_contract())
+
+    def test_normalizes_legacy_lod_rewrites(self):
+        legacy = events()
+        legacy[-1].pop("lod_rewrites")
+        legacy[-1]["duplicate_lod"] = "2"
+        legacy[-1]["record_stack_faults"] = "2"
+        legacy[-1]["status"] = "incomplete"
+        legacy[-1]["accounting_complete"] = "false"
+        document = MODULE.build(legacy, static_contract())
+        self.assertEqual(2, document["totals"]["lod_rewrites"])
+        self.assertEqual(0, document["totals"]["record_stack_faults"])
+        self.assertEqual(
+            "legacy_duplicate_lod_normalized_as_rewrite",
+            document["qualification"]["capture_model"],
+        )
+
+    def test_rejects_native_execution(self):
+        broken = events()
+        broken[0]["native_lod"] = "true"
+        with self.assertRaisesRegex(ValueError, "configuration drifted"):
+            MODULE.build(broken, static_contract())
+
+    def test_rejects_static_suppression(self):
+        broken = static_contract()
+        broken["procedural_model_receiver_lifecycle"]["visibility_selection"][
+            "suppression_allowed"
+        ] = True
+        with self.assertRaisesRegex(ValueError, "static semantic-visibility"):
+            MODULE.build(events(), broken)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/tests/test_native_renderer_visibility_policy.py
+++ b/tools/tests/test_native_renderer_visibility_policy.py
@@ -1,0 +1,216 @@
+import importlib.util
+import pathlib
+import unittest
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+TOOL = ROOT / "tools/summarize-native-renderer-visibility-policy.py"
+SPEC = importlib.util.spec_from_file_location("visibility_policy", TOOL)
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+def static_contract():
+    return {
+        "procedural_model_receiver_lifecycle": {
+            "visibility_policy_inputs": {
+                "spatial_prefilter_address": "82E1FEF0",
+                "receiver_spatial_context_pointer_offset": 4,
+                "receiver_spatial_vector_offsets": [16, 32],
+                "category_spatial_argument_register": "r4",
+                "category_spatial_stride": 192,
+                "category_spatial_scalar_offsets": [160, 164, 168],
+                "category_query_argument_register": "r5",
+                "category_query_stride": 32,
+                "spatial_helper_address": "8243F9A0",
+                "category_helper_address": "82441048",
+                "descriptor_distance_scalar_offset": 60,
+                "runtime_distance_scalar_offset": 44,
+                "squared_distance_register": "f26",
+                "threshold_register": "f0",
+                "runtime_threshold_hook_address": "82E20134",
+                "descriptor_threshold_hook_address": "82E201B0",
+                "passive_input_outcome_correlation_required": True,
+                "spatial_helper_contract": {
+                    "distance_helper_address": "8243FD70",
+                    "query_vector_offset": 0,
+                    "query_scalar_offsets": [16, 20, 24],
+                    "segment_endpoint_registers": ["v1", "v2"],
+                    "squared_delta_operation": "vmsum3fp128",
+                    "distance_test_structure_proved": True,
+                    "world_space_semantics_proved": False,
+                },
+                "category_helper_contract": {
+                    "vector_block_offsets": [0, 16, 32, 48, 64, 80],
+                    "vector_block_count": 6,
+                    "input_registers": ["v1", "v2"],
+                    "return_domain": [0, 1, 2],
+                    "six_vector_classifier_structure_proved": True,
+                    "frustum_semantics_proved": False,
+                },
+                "structural_derivation_proved": True,
+                "camera_semantics_proved": False,
+                "frustum_plane_layout_proved": False,
+                "bounds_shape_semantics_proved": False,
+                "native_policy_execution_enabled": False,
+                "guest_state_changed": False,
+                "xenos_authority": True,
+                "suppression_allowed": False,
+            }
+        }
+    }
+
+
+def events():
+    common = {"session": "policy-session"}
+    safe = {
+        "native_policy_execution": "false",
+        "guest_state_changed": "false",
+        "xenos_authority": "true",
+        "suppression_allowed": "false",
+    }
+    result = [
+        {
+            **common,
+            "event": MODULE.CONFIG,
+            "status": "armed",
+            "class": "proceduralGeometry::CProceduralModels",
+            "visibility_function": "82E1FD00",
+            "record_entry_hook": "82E20094",
+            "runtime_threshold_hook": "82E20134",
+            "descriptor_threshold_hook": "82E201B0",
+            "spatial_distance_source": "f26",
+            "threshold_source": "f0",
+            "runtime_distance_scalar_offset": "44",
+            "descriptor_distance_scalar_offset": "60",
+            "spatial_exponent_capacity": "256",
+            "outcomes": "early_rejected,rejected,selected",
+            "classification": "title_spatial_policy_input_outcome_correlation",
+            "guest_payload_read": "false",
+            "guest_state_changed": "false",
+            "control_flow_changed": "false",
+            "native_policy_execution": "false",
+            "native_culling": "false",
+            "native_lod": "false",
+            "native_draw": "false",
+            "xenos_authority": "true",
+            "suppression_allowed": "false",
+        },
+        {
+            **common,
+            "event": MODULE.VISIBILITY_CATEGORY,
+            "status": "complete",
+            "category": "9",
+            "entries": "5",
+            "completions": "5",
+            "selected": "2",
+            "rejected": "1",
+            "early_rejected": "2",
+            "lod_writes": "2",
+        },
+    ]
+    counts = {
+        "early_rejected": (2, 1, 1, 2, 1),
+        "rejected": (1, 1, 0, 1, 0),
+        "selected": (2, 2, 1, 2, 0),
+    }
+    for outcome, (records, runtime, less, descriptor, exceeded) in counts.items():
+        result.append(
+            {
+                **common,
+                **safe,
+                "event": MODULE.CATEGORY,
+                "status": "complete",
+                "category": "9",
+                "outcome": outcome,
+                "records": str(records),
+                "spatial_samples": str(records),
+                "runtime_threshold_observations": str(runtime),
+                "runtime_distance_less": str(less),
+                "descriptor_threshold_observations": str(descriptor),
+                "descriptor_distance_exceeded": str(exceeded),
+            }
+        )
+        result.append(
+            {
+                **common,
+                **safe,
+                "event": MODULE.EXPONENT,
+                "status": "complete",
+                "outcome": outcome,
+                "float_exponent": "127",
+                "records": str(records),
+                "source": "title_shared_spatial_distance_squared_f26",
+            }
+        )
+    result.append(
+        {
+            **common,
+            "event": MODULE.SUMMARY,
+            "status": "complete",
+            "records": "5",
+            "spatial_samples": "5",
+            "runtime_threshold_observations": "4",
+            "runtime_distance_less": "2",
+            "descriptor_threshold_observations": "5",
+            "descriptor_distance_exceeded": "1",
+            "spatial_histogram_records": "5",
+            "invalid_spatial_values": "0",
+            "invalid_threshold_values": "0",
+            "hook_faults": "0",
+            "runtime_threshold_without_record": "0",
+            "duplicate_runtime_threshold": "0",
+            "descriptor_threshold_without_record": "0",
+            "duplicate_descriptor_threshold": "0",
+            "accounting_complete": "true",
+            "classification": "title_spatial_policy_input_outcome_correlation",
+            "guest_payload_read": "false",
+            "guest_state_changed": "false",
+            "control_flow_changed": "false",
+            "native_policy_execution": "false",
+            "native_culling": "false",
+            "native_lod": "false",
+            "xenos_authority": "true",
+            "suppression_allowed": "false",
+        }
+    )
+    return result
+
+
+class VisibilityPolicyTests(unittest.TestCase):
+    def test_accepts_complete_passive_correlation(self):
+        document = MODULE.build(events(), static_contract())
+        self.assertEqual(MODULE.SCHEMA, document["schema"])
+        self.assertEqual(5, document["totals"]["records"])
+        self.assertEqual(2, document["totals"]["runtime_distance_less"])
+        self.assertTrue(
+            document["qualification"]["title_input_outcome_correlation_proved"]
+        )
+        self.assertFalse(
+            document["qualification"]["native_policy_execution_enabled"]
+        )
+
+    def test_rejects_hook_fault(self):
+        broken = events()
+        broken[-1]["hook_faults"] = "1"
+        broken[-1]["duplicate_runtime_threshold"] = "1"
+        with self.assertRaisesRegex(ValueError, "aggregate accounting"):
+            MODULE.build(broken, static_contract())
+
+    def test_rejects_category_drift(self):
+        broken = events()
+        broken[1]["selected"] = "3"
+        with self.assertRaisesRegex(ValueError, "category accounting"):
+            MODULE.build(broken, static_contract())
+
+    def test_rejects_static_native_execution(self):
+        broken = static_contract()
+        broken["procedural_model_receiver_lifecycle"][
+            "visibility_policy_inputs"
+        ]["native_policy_execution_enabled"] = True
+        with self.assertRaisesRegex(ValueError, "static visibility-policy"):
+            MODULE.build(events(), broken)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- census the title-authoritative visibility outcomes and iterative LOD rewrites
- prove structural spatial/category/threshold ABI inputs without assigning unproven camera or frustum semantics
- correlate passive register-only policy inputs to title outcomes with bounded diagnostics and fail-closed reports
- preserve Xenos authority, control flow, guest state, and draw submission

## Validation
- 58 focused native-renderer unit tests pass
- consolidated Windows Release build passes
- AppData-backed session \20260829T230622Z-p39648\ exits normally
- 1,768,409 records correlate with zero hook, lifecycle, identity, overflow, or invalid-value faults
- median 30.195 FPS over 8,034 frames; zero present-deadline misses

## Safety
- native culling, native LOD, native draws, and suppression remain disabled
- this qualifies semantic hypothesis testing only; camera/frustum/bounds semantics remain unproven