### PR TITLE
feat(native-renderer): qualify shadow visibility models

### DIFF
--- a/config/rexglue/analysis/main-xex.toml
+++ b/config/rexglue/analysis/main-xex.toml
@@ -276,6 +276,11 @@ name = "PinyonShiftObserveProceduralModelVisibilityLocalDistance"
 registers = ["f0", "f31"]
 
 [[midasm_hook]]
+address = 0x82E2034C
+name = "PinyonShiftObserveProceduralModelVisibilitySpatialHelperInput"
+registers = ["r3", "r4", "r5"]
+
+[[midasm_hook]]
 address = 0x82E20350
 name = "PinyonShiftObserveProceduralModelVisibilitySpatialHelperResult"
 registers = ["r3"]

--- a/docs/native-renderer/VISIBILITY_POLICY_ABI.md
+++ b/docs/native-renderer/VISIBILITY_POLICY_ABI.md
@@ -150,3 +150,26 @@ specified above. The authoritative census had zero lifecycle, identity,
 overflow, or shutdown-open faults. Median performance was 30.224 FPS over 6,413
 frames, there were no present-deadline misses, no fatal log signatures, and
 Xenos remained the sole rendering authority.
+
+## Title-result shadow selection
+
+The first executable shadow policy turns the proved helper-result domain into a
+per-record native decision without changing the title's decision. Within an
+active title record, the model predicts selection when at least one six-vector
+helper call returns 1 or 2; a modelled record with only zero results predicts
+rejection. Records that never reach the helper remain explicitly unmodelled
+rather than being guessed as invisible.
+
+At record completion the shadow result is compared with the authoritative title
+selection byte. Bounded category/outcome telemetry records model coverage,
+predicted selections and rejections, exact title matches, false positives,
+false negatives, records that observed each nonzero helper result, and records
+that observed both. Qualification requires complete reconciliation with the
+visibility census and zero false positives or false negatives.
+
+This is an observational native state-machine model, not an independent camera
+or frustum implementation. It reads only the already captured register result
+domain, changes no guest state or control flow, performs no native draw, and
+cannot suppress Xenos work. Its purpose is to prove the selection mapping before
+the next batch mirrors the spatial helper inputs independently. Release and
+AppData qualification are intentionally deferred to that consolidated batch.

--- a/docs/native-renderer/VISIBILITY_POLICY_ABI.md
+++ b/docs/native-renderer/VISIBILITY_POLICY_ABI.md
@@ -171,8 +171,7 @@ This is an observational native state-machine model, not an independent camera
 or frustum implementation. It reads only the already captured register result
 domain, changes no guest state or control flow, performs no native draw, and
 cannot suppress Xenos work. Its purpose is to prove the selection mapping before
-the next batch mirrors the spatial helper inputs independently. Release and
-AppData qualification are intentionally deferred to that consolidated batch.
+the next batch mirrors the spatial helper inputs independently.
 
 ## Independent spatial-helper shadow
 
@@ -196,3 +195,20 @@ are counted and excluded. The mirror writes no guest memory, changes no control
 flow, and still cannot cull, select LOD, draw, or suppress Xenos. Its runtime
 qualification is batched with the title-result shadow model in one Release and
 AppData session.
+
+## Consolidated shadow-model qualification
+
+Release/AppData session `20260830T000441Z-p37468` completed normally with no
+fatal signatures and kept Xenos as the sole rendering authority. The
+authoritative census reconciled 1,631,224 records with zero lifecycle, identity,
+overflow, or shutdown-open faults. The title-result model matched all 28,092
+modelled records with zero false positives or false negatives. The independent
+spatial mirror matched all 232,692 in-scope helper results with zero invalid
+inputs, missing pairs, false positives, or false negatives.
+
+The optimized telemetry derives empty-record totals from the authoritative
+census and performs no atomic updates for records that never reach either shadow
+model. Median performance recovered to 30.153 FPS over 8,234 frames, with a
+19.225 FPS one-percent low and zero present-deadline misses. This qualifies the
+independent spatial helper and the title-result selection mapping for the next
+category-classifier shadow milestone; native policy execution remains disabled.

--- a/docs/native-renderer/VISIBILITY_POLICY_ABI.md
+++ b/docs/native-renderer/VISIBILITY_POLICY_ABI.md
@@ -173,3 +173,26 @@ domain, changes no guest state or control flow, performs no native draw, and
 cannot suppress Xenos work. Its purpose is to prove the selection mapping before
 the next batch mirrors the spatial helper inputs independently. Release and
 AppData qualification are intentionally deferred to that consolidated batch.
+
+## Independent spatial-helper shadow
+
+The second model mirrors `0x8243F9A0` independently at its exact callsite. A
+pre-call hook at `0x82E2034C` reads only the helper's bounded arguments: six
+query floats at offsets 0, 4, 8, 16, 20, and 24 plus two three-float segment
+endpoints. The 52-byte payload contract is static, aligned, and record-scoped.
+
+The host mirror preserves the title's two-stage scalar policy. A negative query
+scalar at offset 20 accepts immediately. Otherwise it constructs the segment
+midpoint with the title's 0.5 factor, computes the squared half-segment and
+query distances, and accepts when query scalar 16 times the query distance is
+less than or equal to query scalar 24 times the squared half-segment. Every
+finite host prediction is compared with the low-byte title result at
+`0x82E20350`.
+
+Category/outcome telemetry reconciles one input and comparison with every
+in-scope oracle helper observation. Invalid inputs, missing input/result pairs,
+false positives, and false negatives fail closed. Unscoped continuation resumes
+are counted and excluded. The mirror writes no guest memory, changes no control
+flow, and still cannot cull, select LOD, draw, or suppress Xenos. Its runtime
+qualification is batched with the title-result shadow model in one Release and
+AppData session.

--- a/src/native_renderer/graphics_hooks.cpp
+++ b/src/native_renderer/graphics_hooks.cpp
@@ -652,7 +652,6 @@ struct SemanticVisibilityOracleStats {
 };
 
 struct SemanticVisibilityShadowStats {
-  std::atomic<uint64_t> records{};
   std::atomic<uint64_t> modelled_records{};
   std::atomic<uint64_t> predicted_selected{};
   std::atomic<uint64_t> predicted_rejected{};
@@ -665,7 +664,6 @@ struct SemanticVisibilityShadowStats {
 };
 
 struct SemanticVisibilitySpatialShadowStats {
-  std::atomic<uint64_t> records{};
   std::atomic<uint64_t> input_observations{};
   std::atomic<uint64_t> comparisons{};
   std::atomic<uint64_t> matches{};
@@ -2680,7 +2678,6 @@ void EndSemanticVisibilityRecord(uint32_t receiver_address,
     SemanticVisibilityShadowStats &shadow =
         g_semantic_visibility_shadow_categories[record.category]
                                                [policy_outcome_index];
-    shadow.records.fetch_add(1, std::memory_order_relaxed);
     if (record.category_helper_observations) {
       shadow.modelled_records.fetch_add(1, std::memory_order_relaxed);
       const bool result_1_seen = record.category_helper_results[1] != 0;
@@ -2711,20 +2708,22 @@ void EndSemanticVisibilityRecord(uint32_t receiver_address,
     SemanticVisibilitySpatialShadowStats &spatial_shadow =
         g_semantic_visibility_spatial_shadow_categories[record.category]
                                                        [policy_outcome_index];
-    spatial_shadow.records.fetch_add(1, std::memory_order_relaxed);
-    spatial_shadow.input_observations.fetch_add(
-        record.spatial_shadow_input_observations,
-        std::memory_order_relaxed);
-    spatial_shadow.comparisons.fetch_add(
-        record.spatial_shadow_comparisons, std::memory_order_relaxed);
-    spatial_shadow.matches.fetch_add(record.spatial_shadow_matches,
-                                     std::memory_order_relaxed);
-    spatial_shadow.false_positive.fetch_add(
-        record.spatial_shadow_false_positive, std::memory_order_relaxed);
-    spatial_shadow.false_negative.fetch_add(
-        record.spatial_shadow_false_negative, std::memory_order_relaxed);
-    spatial_shadow.invalid_inputs.fetch_add(
-        record.spatial_shadow_invalid_inputs, std::memory_order_relaxed);
+    if (record.spatial_shadow_input_observations ||
+        record.spatial_shadow_invalid_inputs) {
+      spatial_shadow.input_observations.fetch_add(
+          record.spatial_shadow_input_observations,
+          std::memory_order_relaxed);
+      spatial_shadow.comparisons.fetch_add(
+          record.spatial_shadow_comparisons, std::memory_order_relaxed);
+      spatial_shadow.matches.fetch_add(record.spatial_shadow_matches,
+                                       std::memory_order_relaxed);
+      spatial_shadow.false_positive.fetch_add(
+          record.spatial_shadow_false_positive, std::memory_order_relaxed);
+      spatial_shadow.false_negative.fetch_add(
+          record.spatial_shadow_false_negative, std::memory_order_relaxed);
+      spatial_shadow.invalid_inputs.fetch_add(
+          record.spatial_shadow_invalid_inputs, std::memory_order_relaxed);
+    }
   }
   if (record.spatial_sample_valid) {
     g_semantic_visibility_spatial_exponents[policy_outcome_index]
@@ -10291,7 +10290,9 @@ void EmitSemanticVisibilityCensus() {
           g_semantic_visibility_shadow_categories[category_index]
                                                  [outcome_index];
       const uint64_t records =
-          shadow.records.load(std::memory_order_relaxed);
+          g_semantic_visibility_oracle_categories[category_index]
+                                                 [outcome_index]
+              .records.load(std::memory_order_relaxed);
       if (!records) {
         continue;
       }
@@ -10313,12 +10314,8 @@ void EmitSemanticVisibilityCensus() {
           shadow.result_2_records.load(std::memory_order_relaxed);
       const uint64_t mixed_nonzero_records =
           shadow.mixed_nonzero_records.load(std::memory_order_relaxed);
-      const uint64_t expected_records =
-          g_semantic_visibility_oracle_categories[category_index]
-                                                 [outcome_index]
-              .records.load(std::memory_order_relaxed);
       const bool category_complete =
-          records == expected_records && modelled_records <= records &&
+          modelled_records <= records &&
           predicted_selected + predicted_rejected == modelled_records &&
           title_matches + false_positive + false_negative == modelled_records &&
           result_1_records <= modelled_records &&
@@ -10417,8 +10414,11 @@ void EmitSemanticVisibilityCensus() {
       const SemanticVisibilitySpatialShadowStats &spatial_shadow =
           g_semantic_visibility_spatial_shadow_categories[category_index]
                                                          [outcome_index];
+      const SemanticVisibilityOracleStats &oracle =
+          g_semantic_visibility_oracle_categories[category_index]
+                                                 [outcome_index];
       const uint64_t records =
-          spatial_shadow.records.load(std::memory_order_relaxed);
+          oracle.records.load(std::memory_order_relaxed);
       if (!records) {
         continue;
       }
@@ -10434,15 +10434,10 @@ void EmitSemanticVisibilityCensus() {
           spatial_shadow.false_negative.load(std::memory_order_relaxed);
       const uint64_t invalid_inputs =
           spatial_shadow.invalid_inputs.load(std::memory_order_relaxed);
-      const SemanticVisibilityOracleStats &oracle =
-          g_semantic_visibility_oracle_categories[category_index]
-                                                 [outcome_index];
-      const uint64_t expected_records =
-          oracle.records.load(std::memory_order_relaxed);
       const uint64_t expected_inputs =
           oracle.spatial_helper_observations.load(std::memory_order_relaxed);
       const bool category_complete =
-          records == expected_records && inputs == expected_inputs &&
+          inputs == expected_inputs &&
           comparisons == inputs &&
           matches + false_positive + false_negative == comparisons &&
           !invalid_inputs;

--- a/src/native_renderer/graphics_hooks.cpp
+++ b/src/native_renderer/graphics_hooks.cpp
@@ -651,6 +651,19 @@ struct SemanticVisibilityOracleStats {
   std::array<std::atomic<uint64_t>, 3> category_results{};
 };
 
+struct SemanticVisibilityShadowStats {
+  std::atomic<uint64_t> records{};
+  std::atomic<uint64_t> modelled_records{};
+  std::atomic<uint64_t> predicted_selected{};
+  std::atomic<uint64_t> predicted_rejected{};
+  std::atomic<uint64_t> title_matches{};
+  std::atomic<uint64_t> false_positive{};
+  std::atomic<uint64_t> false_negative{};
+  std::atomic<uint64_t> result_1_records{};
+  std::atomic<uint64_t> result_2_records{};
+  std::atomic<uint64_t> mixed_nonzero_records{};
+};
+
 std::atomic<uint64_t> g_semantic_visibility_record_entries{};
 std::atomic<uint64_t> g_semantic_visibility_record_completions{};
 std::atomic<uint64_t> g_semantic_visibility_records_open{};
@@ -708,6 +721,10 @@ std::atomic<uint64_t> g_semantic_visibility_spatial_helper_without_local_pass{};
 std::atomic<uint64_t> g_semantic_visibility_category_helper_without_record{};
 std::atomic<uint64_t> g_semantic_visibility_category_helper_without_spatial_pass{};
 std::atomic<uint64_t> g_semantic_visibility_category_helper_invalid_result{};
+std::array<std::array<SemanticVisibilityShadowStats,
+                      kSemanticVisibilityPolicyOutcomeCapacity>,
+           kSemanticVisibilityCategoryCapacity>
+    g_semantic_visibility_shadow_categories{};
 
 struct SemanticInstanceEntry {
   uint64_t key = 0;
@@ -2515,6 +2532,37 @@ void EndSemanticVisibilityRecord(uint32_t receiver_address,
       oracle.category_results[result].fetch_add(
           record.category_helper_results[result],
           std::memory_order_relaxed);
+    }
+    SemanticVisibilityShadowStats &shadow =
+        g_semantic_visibility_shadow_categories[record.category]
+                                               [policy_outcome_index];
+    shadow.records.fetch_add(1, std::memory_order_relaxed);
+    if (record.category_helper_observations) {
+      shadow.modelled_records.fetch_add(1, std::memory_order_relaxed);
+      const bool result_1_seen = record.category_helper_results[1] != 0;
+      const bool result_2_seen = record.category_helper_results[2] != 0;
+      const bool predicted_selected = result_1_seen || result_2_seen;
+      const bool title_selected = record.result_seen && record.selected;
+      (predicted_selected ? shadow.predicted_selected
+                          : shadow.predicted_rejected)
+          .fetch_add(1, std::memory_order_relaxed);
+      if (predicted_selected == title_selected) {
+        shadow.title_matches.fetch_add(1, std::memory_order_relaxed);
+      } else if (predicted_selected) {
+        shadow.false_positive.fetch_add(1, std::memory_order_relaxed);
+      } else {
+        shadow.false_negative.fetch_add(1, std::memory_order_relaxed);
+      }
+      if (result_1_seen) {
+        shadow.result_1_records.fetch_add(1, std::memory_order_relaxed);
+      }
+      if (result_2_seen) {
+        shadow.result_2_records.fetch_add(1, std::memory_order_relaxed);
+      }
+      if (result_1_seen && result_2_seen) {
+        shadow.mixed_nonzero_records.fetch_add(1,
+                                               std::memory_order_relaxed);
+      }
     }
   }
   if (record.spatial_sample_valid) {
@@ -10058,6 +10106,136 @@ void EmitSemanticVisibilityCensus() {
        {"native_policy_execution", "false"},
        {"native_culling", "false"},
        {"native_lod", "false"},
+        {"xenos_authority", "true"},
+        {"suppression_allowed", "false"}});
+
+  uint64_t shadow_records = 0;
+  uint64_t shadow_modelled_records = 0;
+  uint64_t shadow_predicted_selected = 0;
+  uint64_t shadow_predicted_rejected = 0;
+  uint64_t shadow_title_matches = 0;
+  uint64_t shadow_false_positive = 0;
+  uint64_t shadow_false_negative = 0;
+  uint64_t shadow_result_1_records = 0;
+  uint64_t shadow_result_2_records = 0;
+  uint64_t shadow_mixed_nonzero_records = 0;
+  bool shadow_category_accounting_complete = true;
+  for (size_t category_index = 0;
+       category_index < kSemanticVisibilityCategoryCapacity;
+       ++category_index) {
+    for (size_t outcome_index = 0;
+         outcome_index < kSemanticVisibilityPolicyOutcomeCapacity;
+         ++outcome_index) {
+      const SemanticVisibilityShadowStats &shadow =
+          g_semantic_visibility_shadow_categories[category_index]
+                                                 [outcome_index];
+      const uint64_t records =
+          shadow.records.load(std::memory_order_relaxed);
+      if (!records) {
+        continue;
+      }
+      const uint64_t modelled_records =
+          shadow.modelled_records.load(std::memory_order_relaxed);
+      const uint64_t predicted_selected =
+          shadow.predicted_selected.load(std::memory_order_relaxed);
+      const uint64_t predicted_rejected =
+          shadow.predicted_rejected.load(std::memory_order_relaxed);
+      const uint64_t title_matches =
+          shadow.title_matches.load(std::memory_order_relaxed);
+      const uint64_t false_positive =
+          shadow.false_positive.load(std::memory_order_relaxed);
+      const uint64_t false_negative =
+          shadow.false_negative.load(std::memory_order_relaxed);
+      const uint64_t result_1_records =
+          shadow.result_1_records.load(std::memory_order_relaxed);
+      const uint64_t result_2_records =
+          shadow.result_2_records.load(std::memory_order_relaxed);
+      const uint64_t mixed_nonzero_records =
+          shadow.mixed_nonzero_records.load(std::memory_order_relaxed);
+      const uint64_t expected_records =
+          g_semantic_visibility_oracle_categories[category_index]
+                                                 [outcome_index]
+              .records.load(std::memory_order_relaxed);
+      const bool category_complete =
+          records == expected_records && modelled_records <= records &&
+          predicted_selected + predicted_rejected == modelled_records &&
+          title_matches + false_positive + false_negative == modelled_records &&
+          result_1_records <= modelled_records &&
+          result_2_records <= modelled_records &&
+          mixed_nonzero_records <= result_1_records &&
+          mixed_nonzero_records <= result_2_records;
+      shadow_category_accounting_complete &= category_complete;
+      shadow_records += records;
+      shadow_modelled_records += modelled_records;
+      shadow_predicted_selected += predicted_selected;
+      shadow_predicted_rejected += predicted_rejected;
+      shadow_title_matches += title_matches;
+      shadow_false_positive += false_positive;
+      shadow_false_negative += false_negative;
+      shadow_result_1_records += result_1_records;
+      shadow_result_2_records += result_2_records;
+      shadow_mixed_nonzero_records += mixed_nonzero_records;
+      pinyon_shift::diagnostics::RecordEvent(
+          "native_renderer.discovery.semantic_visibility_shadow_category_summary",
+          {{"status", category_complete ? "complete" : "incomplete"},
+           {"category", std::to_string(category_index)},
+           {"outcome", SemanticVisibilityPolicyOutcomeName(outcome_index)},
+           {"records", std::to_string(records)},
+           {"modelled_records", std::to_string(modelled_records)},
+           {"predicted_selected", std::to_string(predicted_selected)},
+           {"predicted_rejected", std::to_string(predicted_rejected)},
+           {"title_matches", std::to_string(title_matches)},
+           {"false_positive", std::to_string(false_positive)},
+           {"false_negative", std::to_string(false_negative)},
+           {"result_1_records", std::to_string(result_1_records)},
+           {"result_2_records", std::to_string(result_2_records)},
+           {"mixed_nonzero_records",
+            std::to_string(mixed_nonzero_records)},
+           {"native_policy_execution", "shadow_only"},
+           {"guest_state_changed", "false"},
+           {"xenos_authority", "true"},
+           {"suppression_allowed", "false"}});
+    }
+  }
+  const bool shadow_complete =
+      shadow_category_accounting_complete &&
+      shadow_records == oracle_records &&
+      shadow_modelled_records <= shadow_records &&
+      shadow_predicted_selected + shadow_predicted_rejected ==
+          shadow_modelled_records &&
+      shadow_title_matches + shadow_false_positive + shadow_false_negative ==
+          shadow_modelled_records &&
+      shadow_result_1_records <= shadow_modelled_records &&
+      shadow_result_2_records <= shadow_modelled_records &&
+      shadow_mixed_nonzero_records <= shadow_result_1_records &&
+      shadow_mixed_nonzero_records <= shadow_result_2_records &&
+      !shadow_false_positive && !shadow_false_negative;
+  pinyon_shift::diagnostics::RecordEvent(
+      "native_renderer.discovery.semantic_visibility_shadow_summary",
+      {{"status", shadow_complete ? "complete" : "incomplete"},
+       {"records", std::to_string(shadow_records)},
+       {"modelled_records", std::to_string(shadow_modelled_records)},
+       {"unmodelled_records",
+        std::to_string(shadow_records - shadow_modelled_records)},
+       {"predicted_selected", std::to_string(shadow_predicted_selected)},
+       {"predicted_rejected", std::to_string(shadow_predicted_rejected)},
+       {"title_matches", std::to_string(shadow_title_matches)},
+       {"false_positive", std::to_string(shadow_false_positive)},
+       {"false_negative", std::to_string(shadow_false_negative)},
+       {"result_1_records", std::to_string(shadow_result_1_records)},
+       {"result_2_records", std::to_string(shadow_result_2_records)},
+       {"mixed_nonzero_records",
+        std::to_string(shadow_mixed_nonzero_records)},
+       {"accounting_complete", shadow_complete ? "true" : "false"},
+       {"model", "any_nonzero_category_result_selects"},
+       {"scope", "active_title_record_only"},
+       {"classification", "title_result_domain_shadow_selection"},
+       {"guest_payload_read", "false"},
+       {"guest_state_changed", "false"},
+       {"control_flow_changed", "false"},
+       {"native_policy_execution", "shadow_only"},
+       {"native_culling", "false"},
+       {"native_lod", "false"},
        {"xenos_authority", "true"},
        {"suppression_allowed", "false"}});
 
@@ -12551,6 +12729,29 @@ void InstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system,
        {"guest_state_changed", "false"},
        {"control_flow_changed", "false"},
        {"native_policy_execution", "false"},
+       {"native_culling", "false"},
+       {"native_lod", "false"},
+       {"native_draw", "false"},
+       {"xenos_authority", "true"},
+       {"suppression_allowed", "false"}});
+  diagnostics::RecordEvent(
+      "native_renderer.discovery.semantic_visibility_shadow_config",
+      {{"status", lineage_armed ? "armed" : "disabled"},
+       {"class", "proceduralGeometry::CProceduralModels"},
+       {"visibility_function", "82E1FD00"},
+       {"record_entry_hook", "82E20094"},
+       {"category_helper_result_hook", "82E20368"},
+       {"title_result_hook", "82E206F8"},
+       {"record_completion_hook", "82E2084C"},
+       {"model", "any_nonzero_category_result_selects"},
+       {"category_result_domain", "0,1,2"},
+       {"outcomes", "early_rejected,rejected,selected"},
+       {"scope", "active_title_record_only"},
+       {"classification", "title_result_domain_shadow_selection"},
+       {"guest_payload_read", "false"},
+       {"guest_state_changed", "false"},
+       {"control_flow_changed", "false"},
+       {"native_policy_execution", "shadow_only"},
        {"native_culling", "false"},
        {"native_lod", "false"},
        {"native_draw", "false"},

--- a/src/native_renderer/graphics_hooks.cpp
+++ b/src/native_renderer/graphics_hooks.cpp
@@ -664,6 +664,16 @@ struct SemanticVisibilityShadowStats {
   std::atomic<uint64_t> mixed_nonzero_records{};
 };
 
+struct SemanticVisibilitySpatialShadowStats {
+  std::atomic<uint64_t> records{};
+  std::atomic<uint64_t> input_observations{};
+  std::atomic<uint64_t> comparisons{};
+  std::atomic<uint64_t> matches{};
+  std::atomic<uint64_t> false_positive{};
+  std::atomic<uint64_t> false_negative{};
+  std::atomic<uint64_t> invalid_inputs{};
+};
+
 std::atomic<uint64_t> g_semantic_visibility_record_entries{};
 std::atomic<uint64_t> g_semantic_visibility_record_completions{};
 std::atomic<uint64_t> g_semantic_visibility_records_open{};
@@ -725,6 +735,12 @@ std::array<std::array<SemanticVisibilityShadowStats,
                       kSemanticVisibilityPolicyOutcomeCapacity>,
            kSemanticVisibilityCategoryCapacity>
     g_semantic_visibility_shadow_categories{};
+std::array<std::array<SemanticVisibilitySpatialShadowStats,
+                      kSemanticVisibilityPolicyOutcomeCapacity>,
+           kSemanticVisibilityCategoryCapacity>
+    g_semantic_visibility_spatial_shadow_categories{};
+std::atomic<uint64_t> g_semantic_visibility_spatial_shadow_input_without_record{};
+std::atomic<uint64_t> g_semantic_visibility_spatial_shadow_result_without_input{};
 
 struct SemanticInstanceEntry {
   uint64_t key = 0;
@@ -1028,8 +1044,17 @@ struct ActiveSemanticVisibilityRecord {
   uint32_t local_distance_passes = 0;
   uint32_t spatial_helper_observations = 0;
   uint32_t spatial_helper_passes = 0;
+  uint32_t spatial_shadow_input_observations = 0;
+  uint32_t spatial_shadow_comparisons = 0;
+  uint32_t spatial_shadow_matches = 0;
+  uint32_t spatial_shadow_false_positive = 0;
+  uint32_t spatial_shadow_false_negative = 0;
+  uint32_t spatial_shadow_invalid_inputs = 0;
   uint32_t category_helper_observations = 0;
   std::array<uint32_t, 3> category_helper_results{};
+  bool spatial_shadow_pending = false;
+  bool spatial_shadow_valid = false;
+  bool spatial_shadow_prediction = false;
   bool active = false;
 };
 thread_local ActiveSemanticVisibilityRecord
@@ -2153,6 +2178,102 @@ bool SemanticVisibilitySpatialExponent(double value, uint8_t *exponent) {
   return true;
 }
 
+float LoadSemanticVisibilityGuestFloat(rex::memory::Memory *memory,
+                                       uint32_t address) {
+  const uint32_t bits = static_cast<uint32_t>(
+      *rex::memory::GuestPtr<rex::be_u32 *>(memory->virtual_membase(),
+                                            address));
+  return std::bit_cast<float>(bits);
+}
+
+float SemanticVisibilitySumSquares3(float x, float y, float z) {
+  const float xy = float(float(x * x) + float(y * y));
+  return float(xy + float(z * z));
+}
+
+void ObserveSemanticVisibilitySpatialHelperInput(uint32_t query_address,
+                                                 uint32_t endpoint_a_address,
+                                                 uint32_t endpoint_b_address) {
+  ActiveSemanticVisibilityRecord &record =
+      g_active_semantic_visibility_record;
+  if (!record.active) {
+    g_semantic_visibility_spatial_shadow_input_without_record.fetch_add(
+        1, std::memory_order_relaxed);
+    return;
+  }
+  ++record.spatial_shadow_input_observations;
+  if (record.spatial_shadow_pending ||
+      record.spatial_shadow_input_observations >
+          record.local_distance_passes) {
+    g_semantic_visibility_policy_hook_faults.fetch_add(
+        1, std::memory_order_relaxed);
+    ++record.spatial_shadow_invalid_inputs;
+  }
+  record.spatial_shadow_pending = true;
+  record.spatial_shadow_valid = false;
+  if (!query_address || !endpoint_a_address || !endpoint_b_address ||
+      (query_address & 3) || (endpoint_a_address & 3) ||
+      (endpoint_b_address & 3)) {
+    ++record.spatial_shadow_invalid_inputs;
+    return;
+  }
+  rex::memory::Memory *memory =
+      g_command_buffer_lineage_memory.load(std::memory_order_acquire);
+  if (!memory) {
+    ++record.spatial_shadow_invalid_inputs;
+    return;
+  }
+  std::array<float, 10> values = {
+      LoadSemanticVisibilityGuestFloat(memory, query_address + 0),
+      LoadSemanticVisibilityGuestFloat(memory, query_address + 4),
+      LoadSemanticVisibilityGuestFloat(memory, query_address + 8),
+      LoadSemanticVisibilityGuestFloat(memory, query_address + 16),
+      LoadSemanticVisibilityGuestFloat(memory, query_address + 20),
+      LoadSemanticVisibilityGuestFloat(memory, query_address + 24),
+      LoadSemanticVisibilityGuestFloat(memory, endpoint_a_address + 0),
+      LoadSemanticVisibilityGuestFloat(memory, endpoint_a_address + 4),
+      LoadSemanticVisibilityGuestFloat(memory, endpoint_a_address + 8),
+      LoadSemanticVisibilityGuestFloat(memory, endpoint_b_address + 0),
+  };
+  const float endpoint_b_y =
+      LoadSemanticVisibilityGuestFloat(memory, endpoint_b_address + 4);
+  const float endpoint_b_z =
+      LoadSemanticVisibilityGuestFloat(memory, endpoint_b_address + 8);
+  if (!std::all_of(values.begin(), values.end(), [](float value) {
+        return std::isfinite(value);
+      }) ||
+      !std::isfinite(endpoint_b_y) || !std::isfinite(endpoint_b_z)) {
+    ++record.spatial_shadow_invalid_inputs;
+    return;
+  }
+  if (values[4] < 0.0f) {
+    record.spatial_shadow_prediction = true;
+    record.spatial_shadow_valid = true;
+    return;
+  }
+  const float half_x = float(float(values[9] - values[6]) * 0.5f);
+  const float half_y = float(float(endpoint_b_y - values[7]) * 0.5f);
+  const float half_z = float(float(endpoint_b_z - values[8]) * 0.5f);
+  const float midpoint_x = float(values[6] + half_x);
+  const float midpoint_y = float(values[7] + half_y);
+  const float midpoint_z = float(values[8] + half_z);
+  const float segment_distance_squared =
+      SemanticVisibilitySumSquares3(half_x, half_y, half_z);
+  const float query_x = float(midpoint_x - values[0]);
+  const float query_y = float(midpoint_y - values[1]);
+  const float query_z = float(midpoint_z - values[2]);
+  const float query_distance_squared =
+      SemanticVisibilitySumSquares3(query_x, query_y, query_z);
+  const float lhs = float(values[3] * query_distance_squared);
+  const float rhs = float(values[5] * segment_distance_squared);
+  if (!std::isfinite(lhs) || !std::isfinite(rhs)) {
+    ++record.spatial_shadow_invalid_inputs;
+    return;
+  }
+  record.spatial_shadow_prediction = lhs <= rhs;
+  record.spatial_shadow_valid = true;
+}
+
 void BeginSemanticVisibilityRecord(uint32_t receiver_address,
                                    uint32_t record_index,
                                    uint32_t category,
@@ -2324,6 +2445,24 @@ void ObserveSemanticVisibilitySpatialHelperResult(uint32_t result) {
         1, std::memory_order_relaxed);
     return;
   }
+  if (!record.spatial_shadow_pending) {
+    g_semantic_visibility_spatial_shadow_result_without_input.fetch_add(
+        1, std::memory_order_relaxed);
+  } else {
+    if (record.spatial_shadow_valid) {
+      ++record.spatial_shadow_comparisons;
+      const bool title_result = (result & 0xFF) != 0;
+      if (record.spatial_shadow_prediction == title_result) {
+        ++record.spatial_shadow_matches;
+      } else if (record.spatial_shadow_prediction) {
+        ++record.spatial_shadow_false_positive;
+      } else {
+        ++record.spatial_shadow_false_negative;
+      }
+    }
+    record.spatial_shadow_pending = false;
+    record.spatial_shadow_valid = false;
+  }
   if (record.spatial_helper_observations >= record.local_distance_passes) {
     g_semantic_visibility_policy_hook_faults.fetch_add(
         1, std::memory_order_relaxed);
@@ -2484,6 +2623,11 @@ void EndSemanticVisibilityRecord(uint32_t receiver_address,
           : (record.selected ? SemanticVisibilityPolicyOutcome::kSelected
                              : SemanticVisibilityPolicyOutcome::kRejected);
   const size_t policy_outcome_index = size_t(policy_outcome);
+  if (record.spatial_shadow_pending) {
+    ++record.spatial_shadow_invalid_inputs;
+    g_semantic_visibility_policy_hook_faults.fetch_add(
+        1, std::memory_order_relaxed);
+  }
   if (record.category < kSemanticVisibilityCategoryCapacity) {
     SemanticVisibilityPolicyStats &policy =
         g_semantic_visibility_policy_categories[record.category]
@@ -2564,6 +2708,23 @@ void EndSemanticVisibilityRecord(uint32_t receiver_address,
                                                std::memory_order_relaxed);
       }
     }
+    SemanticVisibilitySpatialShadowStats &spatial_shadow =
+        g_semantic_visibility_spatial_shadow_categories[record.category]
+                                                       [policy_outcome_index];
+    spatial_shadow.records.fetch_add(1, std::memory_order_relaxed);
+    spatial_shadow.input_observations.fetch_add(
+        record.spatial_shadow_input_observations,
+        std::memory_order_relaxed);
+    spatial_shadow.comparisons.fetch_add(
+        record.spatial_shadow_comparisons, std::memory_order_relaxed);
+    spatial_shadow.matches.fetch_add(record.spatial_shadow_matches,
+                                     std::memory_order_relaxed);
+    spatial_shadow.false_positive.fetch_add(
+        record.spatial_shadow_false_positive, std::memory_order_relaxed);
+    spatial_shadow.false_negative.fetch_add(
+        record.spatial_shadow_false_negative, std::memory_order_relaxed);
+    spatial_shadow.invalid_inputs.fetch_add(
+        record.spatial_shadow_invalid_inputs, std::memory_order_relaxed);
   }
   if (record.spatial_sample_valid) {
     g_semantic_visibility_spatial_exponents[policy_outcome_index]
@@ -10239,6 +10400,123 @@ void EmitSemanticVisibilityCensus() {
        {"xenos_authority", "true"},
        {"suppression_allowed", "false"}});
 
+  uint64_t spatial_shadow_records = 0;
+  uint64_t spatial_shadow_inputs = 0;
+  uint64_t spatial_shadow_comparisons = 0;
+  uint64_t spatial_shadow_matches = 0;
+  uint64_t spatial_shadow_false_positive = 0;
+  uint64_t spatial_shadow_false_negative = 0;
+  uint64_t spatial_shadow_invalid_inputs = 0;
+  bool spatial_shadow_category_accounting_complete = true;
+  for (size_t category_index = 0;
+       category_index < kSemanticVisibilityCategoryCapacity;
+       ++category_index) {
+    for (size_t outcome_index = 0;
+         outcome_index < kSemanticVisibilityPolicyOutcomeCapacity;
+         ++outcome_index) {
+      const SemanticVisibilitySpatialShadowStats &spatial_shadow =
+          g_semantic_visibility_spatial_shadow_categories[category_index]
+                                                         [outcome_index];
+      const uint64_t records =
+          spatial_shadow.records.load(std::memory_order_relaxed);
+      if (!records) {
+        continue;
+      }
+      const uint64_t inputs =
+          spatial_shadow.input_observations.load(std::memory_order_relaxed);
+      const uint64_t comparisons =
+          spatial_shadow.comparisons.load(std::memory_order_relaxed);
+      const uint64_t matches =
+          spatial_shadow.matches.load(std::memory_order_relaxed);
+      const uint64_t false_positive =
+          spatial_shadow.false_positive.load(std::memory_order_relaxed);
+      const uint64_t false_negative =
+          spatial_shadow.false_negative.load(std::memory_order_relaxed);
+      const uint64_t invalid_inputs =
+          spatial_shadow.invalid_inputs.load(std::memory_order_relaxed);
+      const SemanticVisibilityOracleStats &oracle =
+          g_semantic_visibility_oracle_categories[category_index]
+                                                 [outcome_index];
+      const uint64_t expected_records =
+          oracle.records.load(std::memory_order_relaxed);
+      const uint64_t expected_inputs =
+          oracle.spatial_helper_observations.load(std::memory_order_relaxed);
+      const bool category_complete =
+          records == expected_records && inputs == expected_inputs &&
+          comparisons == inputs &&
+          matches + false_positive + false_negative == comparisons &&
+          !invalid_inputs;
+      spatial_shadow_category_accounting_complete &= category_complete;
+      spatial_shadow_records += records;
+      spatial_shadow_inputs += inputs;
+      spatial_shadow_comparisons += comparisons;
+      spatial_shadow_matches += matches;
+      spatial_shadow_false_positive += false_positive;
+      spatial_shadow_false_negative += false_negative;
+      spatial_shadow_invalid_inputs += invalid_inputs;
+      pinyon_shift::diagnostics::RecordEvent(
+          "native_renderer.discovery.semantic_visibility_spatial_shadow_category_summary",
+          {{"status", category_complete ? "complete" : "incomplete"},
+           {"category", std::to_string(category_index)},
+           {"outcome", SemanticVisibilityPolicyOutcomeName(outcome_index)},
+           {"records", std::to_string(records)},
+           {"input_observations", std::to_string(inputs)},
+           {"comparisons", std::to_string(comparisons)},
+           {"matches", std::to_string(matches)},
+           {"false_positive", std::to_string(false_positive)},
+           {"false_negative", std::to_string(false_negative)},
+           {"invalid_inputs", std::to_string(invalid_inputs)},
+           {"native_policy_execution", "shadow_only"},
+           {"guest_payload_read", "bounded_spatial_helper_inputs"},
+           {"guest_state_changed", "false"},
+           {"xenos_authority", "true"},
+           {"suppression_allowed", "false"}});
+    }
+  }
+  const uint64_t spatial_shadow_input_without_record =
+      g_semantic_visibility_spatial_shadow_input_without_record.load(
+          std::memory_order_relaxed);
+  const uint64_t spatial_shadow_result_without_input =
+      g_semantic_visibility_spatial_shadow_result_without_input.load(
+          std::memory_order_relaxed);
+  const bool spatial_shadow_complete =
+      spatial_shadow_category_accounting_complete &&
+      spatial_shadow_records == oracle_records &&
+      spatial_shadow_inputs == oracle_spatial_observations &&
+      spatial_shadow_comparisons == spatial_shadow_inputs &&
+      spatial_shadow_matches + spatial_shadow_false_positive +
+              spatial_shadow_false_negative ==
+          spatial_shadow_comparisons &&
+      !spatial_shadow_false_positive && !spatial_shadow_false_negative &&
+      !spatial_shadow_invalid_inputs;
+  pinyon_shift::diagnostics::RecordEvent(
+      "native_renderer.discovery.semantic_visibility_spatial_shadow_summary",
+      {{"status", spatial_shadow_complete ? "complete" : "incomplete"},
+       {"records", std::to_string(spatial_shadow_records)},
+       {"input_observations", std::to_string(spatial_shadow_inputs)},
+       {"comparisons", std::to_string(spatial_shadow_comparisons)},
+       {"matches", std::to_string(spatial_shadow_matches)},
+       {"false_positive", std::to_string(spatial_shadow_false_positive)},
+       {"false_negative", std::to_string(spatial_shadow_false_negative)},
+       {"invalid_inputs", std::to_string(spatial_shadow_invalid_inputs)},
+       {"input_without_record",
+        std::to_string(spatial_shadow_input_without_record)},
+       {"result_without_input",
+        std::to_string(spatial_shadow_result_without_input)},
+       {"accounting_complete", spatial_shadow_complete ? "true" : "false"},
+       {"model", "bounded_title_spatial_helper_scalar_mirror"},
+       {"scope", "active_title_record_only"},
+       {"unscoped_continuations_excluded", "true"},
+       {"classification", "independent_spatial_helper_shadow"},
+       {"guest_payload_read", "bounded_spatial_helper_inputs"},
+       {"guest_state_changed", "false"},
+       {"control_flow_changed", "false"},
+       {"native_policy_execution", "shadow_only"},
+       {"native_culling", "false"},
+       {"native_lod", "false"},
+       {"xenos_authority", "true"},
+       {"suppression_allowed", "false"}});
+
   const uint64_t category_overflow =
       g_semantic_visibility_category_overflow.load(
           std::memory_order_relaxed);
@@ -12758,6 +13036,34 @@ void InstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system,
        {"xenos_authority", "true"},
        {"suppression_allowed", "false"}});
   diagnostics::RecordEvent(
+      "native_renderer.discovery.semantic_visibility_spatial_shadow_config",
+      {{"status", lineage_armed ? "armed" : "disabled"},
+       {"class", "proceduralGeometry::CProceduralModels"},
+       {"visibility_function", "82E1FD00"},
+       {"input_hook", "82E2034C"},
+       {"result_hook", "82E20350"},
+       {"helper", "8243F9A0"},
+       {"distance_helper", "8243FD70"},
+       {"query_vector_offsets", "0,4,8"},
+       {"query_scalar_offsets", "16,20,24"},
+       {"endpoint_vector_offsets", "0,4,8"},
+       {"interpolation_factor", "0.5"},
+       {"shortcut", "query_scalar_20_less_than_zero_selects"},
+       {"comparison",
+        "query_scalar_16_times_distance_squared_le_query_scalar_24_times_half_segment_squared"},
+       {"bounded_guest_payload_bytes", "52"},
+       {"scope", "active_title_record_only"},
+       {"classification", "independent_spatial_helper_shadow"},
+       {"guest_payload_read", "bounded_spatial_helper_inputs"},
+       {"guest_state_changed", "false"},
+       {"control_flow_changed", "false"},
+       {"native_policy_execution", "shadow_only"},
+       {"native_culling", "false"},
+       {"native_lod", "false"},
+       {"native_draw", "false"},
+       {"xenos_authority", "true"},
+       {"suppression_allowed", "false"}});
+  diagnostics::RecordEvent(
       "native_renderer.discovery.semantic_instance_config",
       {{"status", lineage_armed ? "armed" : "disabled"},
        {"class", "proceduralGeometry::CProceduralModels"},
@@ -13724,6 +14030,11 @@ void PinyonShiftObserveProceduralModelVisibilityCandidateThreshold(
 void PinyonShiftObserveProceduralModelVisibilityLocalDistance(
     PPCRegister &f0, PPCRegister &f31) {
   ObserveSemanticVisibilityLocalDistance(f31.f64, f0.f64);
+}
+
+void PinyonShiftObserveProceduralModelVisibilitySpatialHelperInput(
+    PPCRegister &r3, PPCRegister &r4, PPCRegister &r5) {
+  ObserveSemanticVisibilitySpatialHelperInput(r3.u32, r4.u32, r5.u32);
 }
 
 void PinyonShiftObserveProceduralModelVisibilitySpatialHelperResult(

--- a/tools/discover-native-renderer-dispatch.py
+++ b/tools/discover-native-renderer-dispatch.py
@@ -1459,6 +1459,32 @@ def procedural_model_receiver_lifecycle(
             "xenos_authority": True,
             "suppression_allowed": False,
         },
+        "visibility_shadow_policy": {
+            "record_entry_hook_address": "{:08X}".format(
+                spec["visibility_record_entry"]
+            ),
+            "category_helper_result_hook_address": "{:08X}".format(
+                spec["visibility_category_helper_result_hook"]
+            ),
+            "title_result_hook_address": "{:08X}".format(
+                spec["visibility_result"]
+            ),
+            "record_exit_hook_address": "{:08X}".format(
+                spec["visibility_record_exit"]
+            ),
+            "model": "any_nonzero_category_result_selects",
+            "category_result_domain": [0, 1, 2],
+            "scope": "active_title_record_only",
+            "title_outcome_comparison_required": True,
+            "guest_payload_read": False,
+            "guest_state_changed": False,
+            "control_flow_changed": False,
+            "native_policy_execution": "shadow_only",
+            "native_culling_enabled": False,
+            "native_lod_enabled": False,
+            "xenos_authority": True,
+            "suppression_allowed": False,
+        },
         "render_state_function_address": "{:08X}".format(
             spec["render_state_function"]
         ),

--- a/tools/discover-native-renderer-dispatch.py
+++ b/tools/discover-native-renderer-dispatch.py
@@ -208,6 +208,7 @@ PROCEDURAL_MODEL_RECEIVER = {
     "visibility_descriptor_threshold_hook": 0x82E201B0,
     "visibility_candidate_threshold_hook": 0x82E20258,
     "visibility_local_distance_hook": 0x82E202D8,
+    "visibility_spatial_helper_input_hook": 0x82E2034C,
     "visibility_spatial_helper_result_hook": 0x82E20350,
     "visibility_category_helper_result_hook": 0x82E20368,
     "render_state_function": 0x824170D8,
@@ -1426,6 +1427,9 @@ def procedural_model_receiver_lifecycle(
             "spatial_helper_result_hook_address": "{:08X}".format(
                 spec["visibility_spatial_helper_result_hook"]
             ),
+            "spatial_helper_input_hook_address": "{:08X}".format(
+                spec["visibility_spatial_helper_input_hook"]
+            ),
             "category_helper_result_hook_address": "{:08X}".format(
                 spec["visibility_category_helper_result_hook"]
             ),
@@ -1477,6 +1481,38 @@ def procedural_model_receiver_lifecycle(
             "scope": "active_title_record_only",
             "title_outcome_comparison_required": True,
             "guest_payload_read": False,
+            "guest_state_changed": False,
+            "control_flow_changed": False,
+            "native_policy_execution": "shadow_only",
+            "native_culling_enabled": False,
+            "native_lod_enabled": False,
+            "xenos_authority": True,
+            "suppression_allowed": False,
+        },
+        "visibility_spatial_shadow": {
+            "input_hook_address": "{:08X}".format(
+                spec["visibility_spatial_helper_input_hook"]
+            ),
+            "result_hook_address": "{:08X}".format(
+                spec["visibility_spatial_helper_result_hook"]
+            ),
+            "helper_address": "{:08X}".format(
+                spec["visibility_spatial_helper"]
+            ),
+            "distance_helper_address": "{:08X}".format(
+                spec["visibility_spatial_distance_helper"]
+            ),
+            "query_vector_offsets": [0, 4, 8],
+            "query_scalar_offsets": [16, 20, 24],
+            "endpoint_vector_offsets": [0, 4, 8],
+            "interpolation_factor": 0.5,
+            "shortcut": "query_scalar_20_less_than_zero_selects",
+            "comparison": "query_scalar_16_times_distance_squared_le_"
+            "query_scalar_24_times_half_segment_squared",
+            "bounded_guest_payload_bytes": 52,
+            "scope": "active_title_record_only",
+            "title_result_comparison_required": True,
+            "guest_payload_read": "bounded_spatial_helper_inputs",
             "guest_state_changed": False,
             "control_flow_changed": False,
             "native_policy_execution": "shadow_only",

--- a/tools/summarize-native-renderer-visibility-shadow.py
+++ b/tools/summarize-native-renderer-visibility-shadow.py
@@ -1,0 +1,291 @@
+#!/usr/bin/env python3
+"""Qualify the passive title-result visibility shadow model."""
+
+import argparse
+import json
+import pathlib
+import sys
+
+
+SCHEMA = "pinyon-shift.native-renderer-visibility-shadow.v1"
+CONFIG = "native_renderer.discovery.semantic_visibility_shadow_config"
+CATEGORY = (
+    "native_renderer.discovery.semantic_visibility_shadow_category_summary"
+)
+SUMMARY = "native_renderer.discovery.semantic_visibility_shadow_summary"
+VISIBILITY_CATEGORY = (
+    "native_renderer.discovery.semantic_visibility_category_summary"
+)
+OUTCOMES = ("early_rejected", "rejected", "selected")
+COUNT_KEYS = (
+    "records",
+    "modelled_records",
+    "predicted_selected",
+    "predicted_rejected",
+    "title_matches",
+    "false_positive",
+    "false_negative",
+    "result_1_records",
+    "result_2_records",
+    "mixed_nonzero_records",
+)
+
+
+def read_events(paths):
+    events = []
+    for path in paths:
+        for line in path.read_text(encoding="utf-8").splitlines():
+            if line.strip():
+                events.append(json.loads(line))
+    return events
+
+
+def integer(event, key):
+    try:
+        value = int(event[key])
+    except (KeyError, TypeError, ValueError) as error:
+        raise ValueError(f"invalid {key}") from error
+    if value < 0:
+        raise ValueError(f"negative {key}")
+    return value
+
+
+def exact_event(events, name):
+    matches = [event for event in events if event.get("event") == name]
+    if len(matches) != 1:
+        raise ValueError(f"expected exactly one {name} event")
+    return matches[0]
+
+
+def select_session(events, requested):
+    sessions = {
+        event.get("session") for event in events if event.get("event") == CONFIG
+    }
+    sessions.discard(None)
+    if requested:
+        if requested not in sessions:
+            raise ValueError("requested session has no visibility-shadow config")
+        return requested
+    if len(sessions) != 1:
+        raise ValueError("visibility-shadow input contains multiple sessions")
+    return next(iter(sessions))
+
+
+def static_contract(document):
+    try:
+        contract = document["procedural_model_receiver_lifecycle"][
+            "visibility_shadow_policy"
+        ]
+    except (KeyError, TypeError) as error:
+        raise ValueError("static visibility-shadow contract is missing") from error
+    expected = {
+        "record_entry_hook_address": "82E20094",
+        "category_helper_result_hook_address": "82E20368",
+        "title_result_hook_address": "82E206F8",
+        "record_exit_hook_address": "82E2084C",
+        "model": "any_nonzero_category_result_selects",
+        "category_result_domain": [0, 1, 2],
+        "scope": "active_title_record_only",
+        "title_outcome_comparison_required": True,
+        "guest_payload_read": False,
+        "guest_state_changed": False,
+        "control_flow_changed": False,
+        "native_policy_execution": "shadow_only",
+        "native_culling_enabled": False,
+        "native_lod_enabled": False,
+        "xenos_authority": True,
+        "suppression_allowed": False,
+    }
+    if any(contract.get(key) != value for key, value in expected.items()):
+        raise ValueError("static visibility-shadow contract drifted")
+    return contract
+
+
+def validate_counts(item):
+    if (
+        item["modelled_records"] > item["records"]
+        or item["predicted_selected"] + item["predicted_rejected"]
+        != item["modelled_records"]
+        or item["title_matches"]
+        + item["false_positive"]
+        + item["false_negative"]
+        != item["modelled_records"]
+        or item["result_1_records"] > item["modelled_records"]
+        or item["result_2_records"] > item["modelled_records"]
+        or item["mixed_nonzero_records"] > item["result_1_records"]
+        or item["mixed_nonzero_records"] > item["result_2_records"]
+    ):
+        raise ValueError("visibility-shadow accounting failed")
+
+
+def build(events, static, requested_session=None):
+    contract = static_contract(static)
+    session = select_session(events, requested_session)
+    selected = [event for event in events if event.get("session") == session]
+    config = exact_event(selected, CONFIG)
+    summary = exact_event(selected, SUMMARY)
+    expected_config = {
+        "status": "armed",
+        "class": "proceduralGeometry::CProceduralModels",
+        "visibility_function": "82E1FD00",
+        "record_entry_hook": "82E20094",
+        "category_helper_result_hook": "82E20368",
+        "title_result_hook": "82E206F8",
+        "record_completion_hook": "82E2084C",
+        "model": "any_nonzero_category_result_selects",
+        "category_result_domain": "0,1,2",
+        "outcomes": "early_rejected,rejected,selected",
+        "scope": "active_title_record_only",
+        "classification": "title_result_domain_shadow_selection",
+        "guest_payload_read": "false",
+        "guest_state_changed": "false",
+        "control_flow_changed": "false",
+        "native_policy_execution": "shadow_only",
+        "native_culling": "false",
+        "native_lod": "false",
+        "native_draw": "false",
+        "xenos_authority": "true",
+        "suppression_allowed": "false",
+    }
+    if any(config.get(key) != value for key, value in expected_config.items()):
+        raise ValueError("visibility-shadow runtime configuration drifted")
+    expected_summary = {
+        "status": "complete",
+        "accounting_complete": "true",
+        "model": "any_nonzero_category_result_selects",
+        "scope": "active_title_record_only",
+        "classification": "title_result_domain_shadow_selection",
+        "guest_payload_read": "false",
+        "guest_state_changed": "false",
+        "control_flow_changed": "false",
+        "native_policy_execution": "shadow_only",
+        "native_culling": "false",
+        "native_lod": "false",
+        "xenos_authority": "true",
+        "suppression_allowed": "false",
+    }
+    if any(summary.get(key) != value for key, value in expected_summary.items()):
+        raise ValueError("visibility-shadow summary is incomplete or unsafe")
+    totals = {key: integer(summary, key) for key in COUNT_KEYS}
+    unmodelled_records = integer(summary, "unmodelled_records")
+    validate_counts(totals)
+    if (
+        totals["records"] <= 0
+        or totals["modelled_records"] <= 0
+        or unmodelled_records
+        != totals["records"] - totals["modelled_records"]
+        or totals["false_positive"]
+        or totals["false_negative"]
+    ):
+        raise ValueError("visibility-shadow aggregate qualification failed")
+
+    visibility = {}
+    for event in selected:
+        if event.get("event") != VISIBILITY_CATEGORY:
+            continue
+        category = integer(event, "category")
+        if category in visibility or event.get("status") != "complete":
+            raise ValueError("visibility category evidence drifted")
+        visibility[category] = {
+            outcome: integer(event, outcome) for outcome in OUTCOMES
+        }
+
+    categories = {}
+    sums = {key: 0 for key in COUNT_KEYS}
+    for event in selected:
+        if event.get("event") != CATEGORY:
+            continue
+        category = integer(event, "category")
+        outcome = event.get("outcome")
+        key = (category, outcome)
+        if (
+            key in categories
+            or category not in visibility
+            or outcome not in OUTCOMES
+            or event.get("status") != "complete"
+            or event.get("native_policy_execution") != "shadow_only"
+            or event.get("guest_state_changed") != "false"
+            or event.get("xenos_authority") != "true"
+            or event.get("suppression_allowed") != "false"
+        ):
+            raise ValueError("visibility-shadow category evidence drifted")
+        item = {field: integer(event, field) for field in COUNT_KEYS}
+        validate_counts(item)
+        if (
+            item["records"] != visibility[category][outcome]
+            or item["false_positive"]
+            or item["false_negative"]
+        ):
+            raise ValueError("visibility-shadow title comparison failed")
+        categories[key] = item
+        for field in COUNT_KEYS:
+            sums[field] += item[field]
+    expected_nonzero = {
+        (category, outcome)
+        for category, counts in visibility.items()
+        for outcome, count in counts.items()
+        if count
+    }
+    if set(categories) != expected_nonzero or any(
+        sums[key] != totals[key] for key in COUNT_KEYS
+    ):
+        raise ValueError("visibility-shadow category totals drifted")
+
+    return {
+        "schema": SCHEMA,
+        "status": "complete",
+        "session": session,
+        "static_contract": contract,
+        "totals": {**totals, "unmodelled_records": unmodelled_records},
+        "categories": {
+            f"{category}:{outcome}": item
+            for (category, outcome), item in sorted(categories.items())
+        },
+        "qualification": {
+            "title_result_shadow_model_proved": True,
+            "zero_title_mismatches": True,
+            "modelled_records": totals["modelled_records"],
+            "ready_for_independent_spatial_shadow_model": True,
+            "native_policy_execution_enabled": False,
+        },
+        "safety": {
+            "guest_payload_read": False,
+            "guest_state_changed": False,
+            "control_flow_changed": False,
+            "native_culling": False,
+            "native_lod": False,
+            "xenos_authority": True,
+            "suppression_allowed": False,
+        },
+    }
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser()
+    parser.add_argument("events", nargs="+", type=pathlib.Path)
+    parser.add_argument("--static", required=True, type=pathlib.Path)
+    parser.add_argument("--session")
+    parser.add_argument("--output", required=True, type=pathlib.Path)
+    args = parser.parse_args(argv)
+    try:
+        document = build(
+            read_events(args.events),
+            json.loads(args.static.read_text(encoding="utf-8")),
+            args.session,
+        )
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(
+            json.dumps(document, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        return 0
+    except (OSError, ValueError, json.JSONDecodeError) as error:
+        print(
+            f"native renderer visibility shadow summary failed: {error}",
+            file=sys.stderr,
+        )
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/summarize-native-renderer-visibility-spatial-shadow.py
+++ b/tools/summarize-native-renderer-visibility-spatial-shadow.py
@@ -1,0 +1,300 @@
+#!/usr/bin/env python3
+"""Qualify the independent scalar mirror of the title spatial helper."""
+
+import argparse
+import json
+import pathlib
+import sys
+
+
+SCHEMA = "pinyon-shift.native-renderer-visibility-spatial-shadow.v1"
+CONFIG = "native_renderer.discovery.semantic_visibility_spatial_shadow_config"
+CATEGORY = (
+    "native_renderer.discovery."
+    "semantic_visibility_spatial_shadow_category_summary"
+)
+SUMMARY = (
+    "native_renderer.discovery.semantic_visibility_spatial_shadow_summary"
+)
+ORACLE_CATEGORY = (
+    "native_renderer.discovery.semantic_visibility_oracle_category_summary"
+)
+OUTCOMES = ("early_rejected", "rejected", "selected")
+COUNT_KEYS = (
+    "records",
+    "input_observations",
+    "comparisons",
+    "matches",
+    "false_positive",
+    "false_negative",
+    "invalid_inputs",
+)
+
+
+def read_events(paths):
+    events = []
+    for path in paths:
+        for line in path.read_text(encoding="utf-8").splitlines():
+            if line.strip():
+                events.append(json.loads(line))
+    return events
+
+
+def integer(event, key):
+    try:
+        value = int(event[key])
+    except (KeyError, TypeError, ValueError) as error:
+        raise ValueError(f"invalid {key}") from error
+    if value < 0:
+        raise ValueError(f"negative {key}")
+    return value
+
+
+def exact_event(events, name):
+    matches = [event for event in events if event.get("event") == name]
+    if len(matches) != 1:
+        raise ValueError(f"expected exactly one {name} event")
+    return matches[0]
+
+
+def select_session(events, requested):
+    sessions = {
+        event.get("session") for event in events if event.get("event") == CONFIG
+    }
+    sessions.discard(None)
+    if requested:
+        if requested not in sessions:
+            raise ValueError("requested session has no spatial-shadow config")
+        return requested
+    if len(sessions) != 1:
+        raise ValueError("spatial-shadow input contains multiple sessions")
+    return next(iter(sessions))
+
+
+def static_contract(document):
+    try:
+        contract = document["procedural_model_receiver_lifecycle"][
+            "visibility_spatial_shadow"
+        ]
+    except (KeyError, TypeError) as error:
+        raise ValueError("static spatial-shadow contract is missing") from error
+    expected = {
+        "input_hook_address": "82E2034C",
+        "result_hook_address": "82E20350",
+        "helper_address": "8243F9A0",
+        "distance_helper_address": "8243FD70",
+        "query_vector_offsets": [0, 4, 8],
+        "query_scalar_offsets": [16, 20, 24],
+        "endpoint_vector_offsets": [0, 4, 8],
+        "interpolation_factor": 0.5,
+        "shortcut": "query_scalar_20_less_than_zero_selects",
+        "comparison": "query_scalar_16_times_distance_squared_le_"
+        "query_scalar_24_times_half_segment_squared",
+        "bounded_guest_payload_bytes": 52,
+        "scope": "active_title_record_only",
+        "title_result_comparison_required": True,
+        "guest_payload_read": "bounded_spatial_helper_inputs",
+        "guest_state_changed": False,
+        "control_flow_changed": False,
+        "native_policy_execution": "shadow_only",
+        "native_culling_enabled": False,
+        "native_lod_enabled": False,
+        "xenos_authority": True,
+        "suppression_allowed": False,
+    }
+    if any(contract.get(key) != value for key, value in expected.items()):
+        raise ValueError("static spatial-shadow contract drifted")
+    return contract
+
+
+def validate_counts(item):
+    if (
+        item["comparisons"] != item["input_observations"]
+        or item["matches"]
+        + item["false_positive"]
+        + item["false_negative"]
+        != item["comparisons"]
+        or item["false_positive"]
+        or item["false_negative"]
+        or item["invalid_inputs"]
+    ):
+        raise ValueError("spatial-shadow comparison failed")
+
+
+def build(events, static, requested_session=None):
+    contract = static_contract(static)
+    session = select_session(events, requested_session)
+    selected = [event for event in events if event.get("session") == session]
+    config = exact_event(selected, CONFIG)
+    summary = exact_event(selected, SUMMARY)
+    expected_config = {
+        "status": "armed",
+        "class": "proceduralGeometry::CProceduralModels",
+        "visibility_function": "82E1FD00",
+        "input_hook": "82E2034C",
+        "result_hook": "82E20350",
+        "helper": "8243F9A0",
+        "distance_helper": "8243FD70",
+        "query_vector_offsets": "0,4,8",
+        "query_scalar_offsets": "16,20,24",
+        "endpoint_vector_offsets": "0,4,8",
+        "interpolation_factor": "0.5",
+        "shortcut": "query_scalar_20_less_than_zero_selects",
+        "comparison": "query_scalar_16_times_distance_squared_le_"
+        "query_scalar_24_times_half_segment_squared",
+        "bounded_guest_payload_bytes": "52",
+        "scope": "active_title_record_only",
+        "classification": "independent_spatial_helper_shadow",
+        "guest_payload_read": "bounded_spatial_helper_inputs",
+        "guest_state_changed": "false",
+        "control_flow_changed": "false",
+        "native_policy_execution": "shadow_only",
+        "native_culling": "false",
+        "native_lod": "false",
+        "native_draw": "false",
+        "xenos_authority": "true",
+        "suppression_allowed": "false",
+    }
+    if any(config.get(key) != value for key, value in expected_config.items()):
+        raise ValueError("spatial-shadow runtime configuration drifted")
+    expected_summary = {
+        "status": "complete",
+        "accounting_complete": "true",
+        "model": "bounded_title_spatial_helper_scalar_mirror",
+        "scope": "active_title_record_only",
+        "unscoped_continuations_excluded": "true",
+        "classification": "independent_spatial_helper_shadow",
+        "guest_payload_read": "bounded_spatial_helper_inputs",
+        "guest_state_changed": "false",
+        "control_flow_changed": "false",
+        "native_policy_execution": "shadow_only",
+        "native_culling": "false",
+        "native_lod": "false",
+        "xenos_authority": "true",
+        "suppression_allowed": "false",
+    }
+    if any(summary.get(key) != value for key, value in expected_summary.items()):
+        raise ValueError("spatial-shadow summary is incomplete or unsafe")
+    totals = {key: integer(summary, key) for key in COUNT_KEYS}
+    diagnostics = {
+        "input_without_record": integer(summary, "input_without_record"),
+        "result_without_input": integer(summary, "result_without_input"),
+    }
+    validate_counts(totals)
+    if totals["records"] <= 0 or totals["comparisons"] <= 0:
+        raise ValueError("spatial-shadow has no qualifying comparisons")
+
+    oracle = {}
+    for event in selected:
+        if event.get("event") != ORACLE_CATEGORY:
+            continue
+        category = integer(event, "category")
+        outcome = event.get("outcome")
+        key = (category, outcome)
+        if (
+            key in oracle
+            or outcome not in OUTCOMES
+            or event.get("status") != "complete"
+        ):
+            raise ValueError("visibility-oracle category evidence drifted")
+        oracle[key] = {
+            "records": integer(event, "records"),
+            "input_observations": integer(
+                event, "spatial_helper_observations"
+            ),
+        }
+
+    categories = {}
+    sums = {key: 0 for key in COUNT_KEYS}
+    for event in selected:
+        if event.get("event") != CATEGORY:
+            continue
+        category = integer(event, "category")
+        outcome = event.get("outcome")
+        key = (category, outcome)
+        if (
+            key in categories
+            or key not in oracle
+            or event.get("status") != "complete"
+            or event.get("native_policy_execution") != "shadow_only"
+            or event.get("guest_payload_read")
+            != "bounded_spatial_helper_inputs"
+            or event.get("guest_state_changed") != "false"
+            or event.get("xenos_authority") != "true"
+            or event.get("suppression_allowed") != "false"
+        ):
+            raise ValueError("spatial-shadow category evidence drifted")
+        item = {field: integer(event, field) for field in COUNT_KEYS}
+        validate_counts(item)
+        if (
+            item["records"] != oracle[key]["records"]
+            or item["input_observations"]
+            != oracle[key]["input_observations"]
+        ):
+            raise ValueError("spatial-shadow oracle reconciliation failed")
+        categories[key] = item
+        for field in COUNT_KEYS:
+            sums[field] += item[field]
+    if set(categories) != set(oracle) or any(
+        sums[key] != totals[key] for key in COUNT_KEYS
+    ):
+        raise ValueError("spatial-shadow category totals drifted")
+
+    return {
+        "schema": SCHEMA,
+        "status": "complete",
+        "session": session,
+        "static_contract": contract,
+        "totals": {**totals, **diagnostics},
+        "categories": {
+            f"{category}:{outcome}": item
+            for (category, outcome), item in sorted(categories.items())
+        },
+        "qualification": {
+            "independent_spatial_helper_shadow_proved": True,
+            "zero_title_mismatches": True,
+            "bounded_input_reads_proved": True,
+            "ready_for_category_classifier_shadow": True,
+            "native_policy_execution_enabled": False,
+        },
+        "safety": {
+            "guest_payload_read": "bounded_spatial_helper_inputs",
+            "guest_state_changed": False,
+            "control_flow_changed": False,
+            "native_culling": False,
+            "native_lod": False,
+            "xenos_authority": True,
+            "suppression_allowed": False,
+        },
+    }
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser()
+    parser.add_argument("events", nargs="+", type=pathlib.Path)
+    parser.add_argument("--static", required=True, type=pathlib.Path)
+    parser.add_argument("--session")
+    parser.add_argument("--output", required=True, type=pathlib.Path)
+    args = parser.parse_args(argv)
+    try:
+        document = build(
+            read_events(args.events),
+            json.loads(args.static.read_text(encoding="utf-8")),
+            args.session,
+        )
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(
+            json.dumps(document, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        return 0
+    except (OSError, ValueError, json.JSONDecodeError) as error:
+        print(
+            f"native renderer spatial shadow summary failed: {error}",
+            file=sys.stderr,
+        )
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/tests/test_native_renderer_contract.py
+++ b/tools/tests/test_native_renderer_contract.py
@@ -189,6 +189,15 @@ class NativeRendererContractTests(unittest.TestCase):
         self.assertIn('"xenos_authority": True', oracle_summarizer)
         self.assertIn('"suppression_allowed": False', oracle_summarizer)
 
+        shadow_summarizer = (
+            ROOT / "tools/summarize-native-renderer-visibility-shadow.py"
+        ).read_text(encoding="utf-8")
+        self.assertIn("title_result_domain_shadow_selection", source)
+        self.assertIn('"native_policy_execution": "shadow_only"', shadow_summarizer)
+        self.assertIn('"guest_state_changed": False', shadow_summarizer)
+        self.assertIn('"xenos_authority": True', shadow_summarizer)
+        self.assertIn('"suppression_allowed": False', shadow_summarizer)
+
     def test_exact_pass_consumer_trace_is_bounded_and_fail_closed(self):
         source = (ROOT / "src/native_renderer/graphics_hooks.cpp").read_text(
             encoding="utf-8"

--- a/tools/tests/test_native_renderer_contract.py
+++ b/tools/tests/test_native_renderer_contract.py
@@ -142,6 +142,9 @@ class NativeRendererContractTests(unittest.TestCase):
             "PinyonShiftObserveProceduralModelVisibilityLocalDistance": (
                 "0x82E202D8"
             ),
+            "PinyonShiftObserveProceduralModelVisibilitySpatialHelperInput": (
+                "0x82E2034C"
+            ),
             "PinyonShiftObserveProceduralModelVisibilitySpatialHelperResult": (
                 "0x82E20350"
             ),
@@ -197,6 +200,18 @@ class NativeRendererContractTests(unittest.TestCase):
         self.assertIn('"guest_state_changed": False', shadow_summarizer)
         self.assertIn('"xenos_authority": True', shadow_summarizer)
         self.assertIn('"suppression_allowed": False', shadow_summarizer)
+
+        spatial_shadow_summarizer = (
+            ROOT / "tools/summarize-native-renderer-visibility-spatial-shadow.py"
+        ).read_text(encoding="utf-8")
+        self.assertIn("independent_spatial_helper_shadow", source)
+        self.assertIn(
+            '"guest_payload_read": "bounded_spatial_helper_inputs"',
+            spatial_shadow_summarizer,
+        )
+        self.assertIn('"guest_state_changed": False', spatial_shadow_summarizer)
+        self.assertIn('"xenos_authority": True', spatial_shadow_summarizer)
+        self.assertIn('"suppression_allowed": False', spatial_shadow_summarizer)
 
     def test_exact_pass_consumer_trace_is_bounded_and_fail_closed(self):
         source = (ROOT / "src/native_renderer/graphics_hooks.cpp").read_text(

--- a/tools/tests/test_native_renderer_dispatch_discovery.py
+++ b/tools/tests/test_native_renderer_dispatch_discovery.py
@@ -1299,6 +1299,21 @@ class NativeRendererDispatchDiscoveryTests(unittest.TestCase):
         self.assertTrue(policy["structural_derivation_proved"])
         self.assertFalse(policy["camera_semantics_proved"])
         self.assertFalse(policy["native_policy_execution_enabled"])
+        shadow = lifecycle["visibility_shadow_policy"]
+        self.assertEqual("82E20094", shadow["record_entry_hook_address"])
+        self.assertEqual(
+            "82E20368", shadow["category_helper_result_hook_address"]
+        )
+        self.assertEqual("82E206F8", shadow["title_result_hook_address"])
+        self.assertEqual("82E2084C", shadow["record_exit_hook_address"])
+        self.assertEqual(
+            "any_nonzero_category_result_selects", shadow["model"]
+        )
+        self.assertEqual([0, 1, 2], shadow["category_result_domain"])
+        self.assertEqual("shadow_only", shadow["native_policy_execution"])
+        self.assertFalse(shadow["guest_state_changed"])
+        self.assertTrue(shadow["xenos_authority"])
+        self.assertFalse(shadow["suppression_allowed"])
         self.assertEqual(
             92, lifecycle["field_layout"]["descriptor_record_stride"]
         )

--- a/tools/tests/test_native_renderer_dispatch_discovery.py
+++ b/tools/tests/test_native_renderer_dispatch_discovery.py
@@ -1314,6 +1314,21 @@ class NativeRendererDispatchDiscoveryTests(unittest.TestCase):
         self.assertFalse(shadow["guest_state_changed"])
         self.assertTrue(shadow["xenos_authority"])
         self.assertFalse(shadow["suppression_allowed"])
+        spatial_shadow = lifecycle["visibility_spatial_shadow"]
+        self.assertEqual("82E2034C", spatial_shadow["input_hook_address"])
+        self.assertEqual("82E20350", spatial_shadow["result_hook_address"])
+        self.assertEqual("8243F9A0", spatial_shadow["helper_address"])
+        self.assertEqual(
+            "8243FD70", spatial_shadow["distance_helper_address"]
+        )
+        self.assertEqual(52, spatial_shadow["bounded_guest_payload_bytes"])
+        self.assertEqual(
+            "bounded_spatial_helper_inputs",
+            spatial_shadow["guest_payload_read"],
+        )
+        self.assertFalse(spatial_shadow["guest_state_changed"])
+        self.assertTrue(spatial_shadow["xenos_authority"])
+        self.assertFalse(spatial_shadow["suppression_allowed"])
         self.assertEqual(
             92, lifecycle["field_layout"]["descriptor_record_stride"]
         )

--- a/tools/tests/test_native_renderer_visibility_shadow.py
+++ b/tools/tests/test_native_renderer_visibility_shadow.py
@@ -1,0 +1,163 @@
+import copy
+import importlib.util
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).parents[2]
+TOOL = ROOT / "tools" / "summarize-native-renderer-visibility-shadow.py"
+SPEC = importlib.util.spec_from_file_location("visibility_shadow", TOOL)
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+class VisibilityShadowReportTests(unittest.TestCase):
+    def static(self):
+        return {
+            "procedural_model_receiver_lifecycle": {
+                "visibility_shadow_policy": {
+                    "record_entry_hook_address": "82E20094",
+                    "category_helper_result_hook_address": "82E20368",
+                    "title_result_hook_address": "82E206F8",
+                    "record_exit_hook_address": "82E2084C",
+                    "model": "any_nonzero_category_result_selects",
+                    "category_result_domain": [0, 1, 2],
+                    "scope": "active_title_record_only",
+                    "title_outcome_comparison_required": True,
+                    "guest_payload_read": False,
+                    "guest_state_changed": False,
+                    "control_flow_changed": False,
+                    "native_policy_execution": "shadow_only",
+                    "native_culling_enabled": False,
+                    "native_lod_enabled": False,
+                    "xenos_authority": True,
+                    "suppression_allowed": False,
+                }
+            }
+        }
+
+    def config(self):
+        return {
+            "event": MODULE.CONFIG,
+            "session": "test",
+            "status": "armed",
+            "class": "proceduralGeometry::CProceduralModels",
+            "visibility_function": "82E1FD00",
+            "record_entry_hook": "82E20094",
+            "category_helper_result_hook": "82E20368",
+            "title_result_hook": "82E206F8",
+            "record_completion_hook": "82E2084C",
+            "model": "any_nonzero_category_result_selects",
+            "category_result_domain": "0,1,2",
+            "outcomes": "early_rejected,rejected,selected",
+            "scope": "active_title_record_only",
+            "classification": "title_result_domain_shadow_selection",
+            "guest_payload_read": "false",
+            "guest_state_changed": "false",
+            "control_flow_changed": "false",
+            "native_policy_execution": "shadow_only",
+            "native_culling": "false",
+            "native_lod": "false",
+            "native_draw": "false",
+            "xenos_authority": "true",
+            "suppression_allowed": "false",
+        }
+
+    def category(self, outcome, records, modelled, selected=0, rejected=0):
+        result_1 = selected
+        return {
+            "event": MODULE.CATEGORY,
+            "session": "test",
+            "status": "complete",
+            "category": "9",
+            "outcome": outcome,
+            "records": str(records),
+            "modelled_records": str(modelled),
+            "predicted_selected": str(selected),
+            "predicted_rejected": str(rejected),
+            "title_matches": str(modelled),
+            "false_positive": "0",
+            "false_negative": "0",
+            "result_1_records": str(result_1),
+            "result_2_records": "0",
+            "mixed_nonzero_records": "0",
+            "native_policy_execution": "shadow_only",
+            "guest_state_changed": "false",
+            "xenos_authority": "true",
+            "suppression_allowed": "false",
+        }
+
+    def events(self):
+        categories = [
+            self.category("early_rejected", 4, 0),
+            self.category("rejected", 2, 2, rejected=2),
+            self.category("selected", 1, 1, selected=1),
+        ]
+        summary = {
+            "event": MODULE.SUMMARY,
+            "session": "test",
+            "status": "complete",
+            "records": "7",
+            "modelled_records": "3",
+            "unmodelled_records": "4",
+            "predicted_selected": "1",
+            "predicted_rejected": "2",
+            "title_matches": "3",
+            "false_positive": "0",
+            "false_negative": "0",
+            "result_1_records": "1",
+            "result_2_records": "0",
+            "mixed_nonzero_records": "0",
+            "accounting_complete": "true",
+            "model": "any_nonzero_category_result_selects",
+            "scope": "active_title_record_only",
+            "classification": "title_result_domain_shadow_selection",
+            "guest_payload_read": "false",
+            "guest_state_changed": "false",
+            "control_flow_changed": "false",
+            "native_policy_execution": "shadow_only",
+            "native_culling": "false",
+            "native_lod": "false",
+            "xenos_authority": "true",
+            "suppression_allowed": "false",
+        }
+        visibility = {
+            "event": MODULE.VISIBILITY_CATEGORY,
+            "session": "test",
+            "status": "complete",
+            "category": "9",
+            "early_rejected": "4",
+            "rejected": "2",
+            "selected": "1",
+        }
+        return [self.config(), visibility, *categories, summary]
+
+    def test_build_qualifies_zero_mismatch_shadow_model(self):
+        document = MODULE.build(self.events(), self.static())
+        self.assertEqual("complete", document["status"])
+        self.assertTrue(
+            document["qualification"]["title_result_shadow_model_proved"]
+        )
+        self.assertEqual(3, document["totals"]["modelled_records"])
+        self.assertTrue(document["safety"]["xenos_authority"])
+        self.assertFalse(document["safety"]["suppression_allowed"])
+
+    def test_build_rejects_runtime_mismatch(self):
+        events = copy.deepcopy(self.events())
+        summary = next(event for event in events if event["event"] == MODULE.SUMMARY)
+        summary["status"] = "incomplete"
+        summary["accounting_complete"] = "false"
+        with self.assertRaisesRegex(ValueError, "incomplete or unsafe"):
+            MODULE.build(events, self.static())
+
+    def test_build_rejects_static_suppression_drift(self):
+        static = self.static()
+        static["procedural_model_receiver_lifecycle"][
+            "visibility_shadow_policy"
+        ]["suppression_allowed"] = True
+        with self.assertRaisesRegex(ValueError, "contract drifted"):
+            MODULE.build(self.events(), static)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/tests/test_native_renderer_visibility_spatial_shadow.py
+++ b/tools/tests/test_native_renderer_visibility_spatial_shadow.py
@@ -1,0 +1,176 @@
+import copy
+import importlib.util
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).parents[2]
+TOOL = (
+    ROOT / "tools" / "summarize-native-renderer-visibility-spatial-shadow.py"
+)
+SPEC = importlib.util.spec_from_file_location("visibility_spatial_shadow", TOOL)
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+class VisibilitySpatialShadowReportTests(unittest.TestCase):
+    def static(self):
+        return {
+            "procedural_model_receiver_lifecycle": {
+                "visibility_spatial_shadow": {
+                    "input_hook_address": "82E2034C",
+                    "result_hook_address": "82E20350",
+                    "helper_address": "8243F9A0",
+                    "distance_helper_address": "8243FD70",
+                    "query_vector_offsets": [0, 4, 8],
+                    "query_scalar_offsets": [16, 20, 24],
+                    "endpoint_vector_offsets": [0, 4, 8],
+                    "interpolation_factor": 0.5,
+                    "shortcut": "query_scalar_20_less_than_zero_selects",
+                    "comparison": "query_scalar_16_times_distance_squared_le_"
+                    "query_scalar_24_times_half_segment_squared",
+                    "bounded_guest_payload_bytes": 52,
+                    "scope": "active_title_record_only",
+                    "title_result_comparison_required": True,
+                    "guest_payload_read": "bounded_spatial_helper_inputs",
+                    "guest_state_changed": False,
+                    "control_flow_changed": False,
+                    "native_policy_execution": "shadow_only",
+                    "native_culling_enabled": False,
+                    "native_lod_enabled": False,
+                    "xenos_authority": True,
+                    "suppression_allowed": False,
+                }
+            }
+        }
+
+    def config(self):
+        return {
+            "event": MODULE.CONFIG,
+            "session": "test",
+            "status": "armed",
+            "class": "proceduralGeometry::CProceduralModels",
+            "visibility_function": "82E1FD00",
+            "input_hook": "82E2034C",
+            "result_hook": "82E20350",
+            "helper": "8243F9A0",
+            "distance_helper": "8243FD70",
+            "query_vector_offsets": "0,4,8",
+            "query_scalar_offsets": "16,20,24",
+            "endpoint_vector_offsets": "0,4,8",
+            "interpolation_factor": "0.5",
+            "shortcut": "query_scalar_20_less_than_zero_selects",
+            "comparison": "query_scalar_16_times_distance_squared_le_"
+            "query_scalar_24_times_half_segment_squared",
+            "bounded_guest_payload_bytes": "52",
+            "scope": "active_title_record_only",
+            "classification": "independent_spatial_helper_shadow",
+            "guest_payload_read": "bounded_spatial_helper_inputs",
+            "guest_state_changed": "false",
+            "control_flow_changed": "false",
+            "native_policy_execution": "shadow_only",
+            "native_culling": "false",
+            "native_lod": "false",
+            "native_draw": "false",
+            "xenos_authority": "true",
+            "suppression_allowed": "false",
+        }
+
+    def oracle(self, outcome, records, inputs):
+        return {
+            "event": MODULE.ORACLE_CATEGORY,
+            "session": "test",
+            "status": "complete",
+            "category": "9",
+            "outcome": outcome,
+            "records": str(records),
+            "spatial_helper_observations": str(inputs),
+        }
+
+    def category(self, outcome, records, inputs):
+        return {
+            "event": MODULE.CATEGORY,
+            "session": "test",
+            "status": "complete",
+            "category": "9",
+            "outcome": outcome,
+            "records": str(records),
+            "input_observations": str(inputs),
+            "comparisons": str(inputs),
+            "matches": str(inputs),
+            "false_positive": "0",
+            "false_negative": "0",
+            "invalid_inputs": "0",
+            "native_policy_execution": "shadow_only",
+            "guest_payload_read": "bounded_spatial_helper_inputs",
+            "guest_state_changed": "false",
+            "xenos_authority": "true",
+            "suppression_allowed": "false",
+        }
+
+    def events(self):
+        rows = [("early_rejected", 4, 0), ("rejected", 2, 4), ("selected", 1, 3)]
+        summary = {
+            "event": MODULE.SUMMARY,
+            "session": "test",
+            "status": "complete",
+            "records": "7",
+            "input_observations": "7",
+            "comparisons": "7",
+            "matches": "7",
+            "false_positive": "0",
+            "false_negative": "0",
+            "invalid_inputs": "0",
+            "input_without_record": "2",
+            "result_without_input": "0",
+            "accounting_complete": "true",
+            "model": "bounded_title_spatial_helper_scalar_mirror",
+            "scope": "active_title_record_only",
+            "unscoped_continuations_excluded": "true",
+            "classification": "independent_spatial_helper_shadow",
+            "guest_payload_read": "bounded_spatial_helper_inputs",
+            "guest_state_changed": "false",
+            "control_flow_changed": "false",
+            "native_policy_execution": "shadow_only",
+            "native_culling": "false",
+            "native_lod": "false",
+            "xenos_authority": "true",
+            "suppression_allowed": "false",
+        }
+        return [
+            self.config(),
+            *(self.oracle(*row) for row in rows),
+            *(self.category(*row) for row in rows),
+            summary,
+        ]
+
+    def test_build_qualifies_exact_spatial_mirror(self):
+        document = MODULE.build(self.events(), self.static())
+        self.assertEqual("complete", document["status"])
+        self.assertEqual(7, document["totals"]["matches"])
+        self.assertTrue(
+            document["qualification"][
+                "independent_spatial_helper_shadow_proved"
+            ]
+        )
+        self.assertFalse(document["safety"]["guest_state_changed"])
+        self.assertTrue(document["safety"]["xenos_authority"])
+
+    def test_build_rejects_incomplete_runtime_summary(self):
+        events = copy.deepcopy(self.events())
+        summary = next(event for event in events if event["event"] == MODULE.SUMMARY)
+        summary["status"] = "incomplete"
+        with self.assertRaisesRegex(ValueError, "incomplete or unsafe"):
+            MODULE.build(events, self.static())
+
+    def test_build_rejects_static_guest_write_drift(self):
+        static = self.static()
+        static["procedural_model_receiver_lifecycle"][
+            "visibility_spatial_shadow"
+        ]["guest_state_changed"] = True
+        with self.assertRaisesRegex(ValueError, "contract drifted"):
+            MODULE.build(self.events(), static)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a passive title-result shadow selection model
- mirror the title spatial-helper scalar policy from bounded guest inputs
- add static contracts, fail-closed reports, and focused regression tests
- avoid hot-path telemetry work for records that never reach a shadow model

## Safety
- Xenos remains the sole rendering authority
- no guest state or control-flow changes
- no native culling, LOD, draw, or suppression

## Qualification
- Release/AppData session: \20260830T000441Z-p37468\`n- title shadow: 28,092/28,092 exact, zero mismatches
- spatial shadow: 232,692/232,692 exact, zero invalid inputs or mismatches
- visibility census: 1,631,224 records, zero lifecycle/identity faults
- median: 30.153 FPS over 8,234 frames; 1% low: 19.225 FPS
- zero present-deadline misses; normal exit; zero fatal signatures

## Tests
\python -m unittest tools.tests.test_native_renderer_visibility_spatial_shadow tools.tests.test_native_renderer_visibility_shadow tools.tests.test_native_renderer_visibility_oracle tools.tests.test_native_renderer_visibility_policy tools.tests.test_native_renderer_visibility tools.tests.test_native_renderer_contract tools.tests.test_native_renderer_dispatch_discovery\`n
67 tests passed.