### PR TITLE
feat(native-renderer): mirror category visibility classifier

### DIFF
--- a/config/rexglue/analysis/main-xex.toml
+++ b/config/rexglue/analysis/main-xex.toml
@@ -286,6 +286,11 @@ name = "PinyonShiftObserveProceduralModelVisibilitySpatialHelperResult"
 registers = ["r3"]
 
 [[midasm_hook]]
+address = 0x82E20364
+name = "PinyonShiftObserveProceduralModelVisibilityCategoryHelperInput"
+registers = ["r3", "v1", "v2"]
+
+[[midasm_hook]]
 address = 0x82E20368
 name = "PinyonShiftObserveProceduralModelVisibilityCategoryHelperResult"
 registers = ["r3"]

--- a/docs/native-renderer/VISIBILITY_POLICY_ABI.md
+++ b/docs/native-renderer/VISIBILITY_POLICY_ABI.md
@@ -212,3 +212,31 @@ model. Median performance recovered to 30.153 FPS over 8,234 frames, with a
 19.225 FPS one-percent low and zero present-deadline misses. This qualifies the
 independent spatial helper and the title-result selection mapping for the next
 category-classifier shadow milestone; native policy execution remains disabled.
+
+## Independent category-classifier shadow
+
+The third executable model mirrors the six-vector helper at `0x82441048`. A
+pre-call hook at `0x82E20364` receives the two endpoint vectors from `v1` and
+`v2` and bounded-reads the six 16-byte plane vectors at offsets 0 through 80.
+The generated helper's `{+1,+1,-1,0}` vector constant transforms each plane's
+three spatial axes before support selection and dot products. The transformed
+sign of each axis selects the positive and negative support points. A
+positive-support dot product greater than or equal to zero sets the intersection
+bit; a negative-support dot product greater than zero sets the outside bits. The
+combined bits map to the title's proved 0/1/2 result domain.
+
+Every finite prediction is compared at `0x82E20368`. Category/outcome telemetry
+reconciles one input and comparison with every in-scope oracle classifier call,
+and fails closed on invalid inputs, missing pairs, or any result mismatch. The
+payload contract is limited to 96 guest bytes per call. The model writes no guest
+memory, changes no control flow, cannot cull or draw, and cannot suppress Xenos.
+Release/AppData qualification was held until this complete checkpoint passed
+its static, report, and compile gates. Consolidated Release/AppData
+session `20260830T005146Z-p2496` then matched all 212,464 in-scope category
+classifier calls, all 212,464 spatial-helper calls, and all 25,650 modelled
+title results, with zero invalid inputs, missing pairs, or mismatches. The
+process exited normally with no fatal signatures. Median performance was 30.570
+FPS over 4,963 frames, with a 15.451 FPS one-percent low and zero
+present-deadline misses. This qualifies the independent category classifier for
+native visibility-policy assembly while native policy execution remains
+disabled and Xenos remains authoritative.

--- a/src/native_renderer/graphics_hooks.cpp
+++ b/src/native_renderer/graphics_hooks.cpp
@@ -672,6 +672,14 @@ struct SemanticVisibilitySpatialShadowStats {
   std::atomic<uint64_t> invalid_inputs{};
 };
 
+struct SemanticVisibilityCategoryShadowStats {
+  std::atomic<uint64_t> input_observations{};
+  std::atomic<uint64_t> comparisons{};
+  std::atomic<uint64_t> matches{};
+  std::atomic<uint64_t> false_result{};
+  std::atomic<uint64_t> invalid_inputs{};
+};
+
 std::atomic<uint64_t> g_semantic_visibility_record_entries{};
 std::atomic<uint64_t> g_semantic_visibility_record_completions{};
 std::atomic<uint64_t> g_semantic_visibility_records_open{};
@@ -739,6 +747,12 @@ std::array<std::array<SemanticVisibilitySpatialShadowStats,
     g_semantic_visibility_spatial_shadow_categories{};
 std::atomic<uint64_t> g_semantic_visibility_spatial_shadow_input_without_record{};
 std::atomic<uint64_t> g_semantic_visibility_spatial_shadow_result_without_input{};
+std::array<std::array<SemanticVisibilityCategoryShadowStats,
+                      kSemanticVisibilityPolicyOutcomeCapacity>,
+           kSemanticVisibilityCategoryCapacity>
+    g_semantic_visibility_category_shadow_categories{};
+std::atomic<uint64_t> g_semantic_visibility_category_shadow_input_without_record{};
+std::atomic<uint64_t> g_semantic_visibility_category_shadow_result_without_input{};
 
 struct SemanticInstanceEntry {
   uint64_t key = 0;
@@ -1050,9 +1064,17 @@ struct ActiveSemanticVisibilityRecord {
   uint32_t spatial_shadow_invalid_inputs = 0;
   uint32_t category_helper_observations = 0;
   std::array<uint32_t, 3> category_helper_results{};
+  uint32_t category_shadow_input_observations = 0;
+  uint32_t category_shadow_comparisons = 0;
+  uint32_t category_shadow_matches = 0;
+  uint32_t category_shadow_false_result = 0;
+  uint32_t category_shadow_invalid_inputs = 0;
   bool spatial_shadow_pending = false;
   bool spatial_shadow_valid = false;
   bool spatial_shadow_prediction = false;
+  bool category_shadow_pending = false;
+  bool category_shadow_valid = false;
+  uint32_t category_shadow_prediction = 0;
   bool active = false;
 };
 thread_local ActiveSemanticVisibilityRecord
@@ -2272,6 +2294,111 @@ void ObserveSemanticVisibilitySpatialHelperInput(uint32_t query_address,
   record.spatial_shadow_valid = true;
 }
 
+float SemanticVisibilityDot4(float ax, float ay, float az, float aw,
+                             float bx, float by, float bz, float bw) {
+  const simde__m128 a = simde_mm_set_ps(ax, ay, az, aw);
+  const simde__m128 b = simde_mm_set_ps(bx, by, bz, bw);
+  return simde_mm_cvtss_f32(simde_mm_dp_ps(a, b, 0xFF));
+}
+
+uint32_t ClassifySemanticVisibilityCategory(
+    const std::array<std::array<float, 4>, 6> &planes,
+    const std::array<float, 3> &endpoint_a,
+    const std::array<float, 3> &endpoint_b) {
+  constexpr std::array<float, 3> kAxisSigns = {1.0f, 1.0f, -1.0f};
+  uint32_t classification_bits = 0;
+  for (const std::array<float, 4> &plane : planes) {
+    const std::array<float, 3> axis = {
+        plane[0] * kAxisSigns[0], plane[1] * kAxisSigns[1],
+        plane[2] * kAxisSigns[2]};
+    std::array<float, 3> positive{};
+    std::array<float, 3> negative{};
+    for (size_t axis_index = 0; axis_index < 3; ++axis_index) {
+      const bool nonnegative = axis[axis_index] >= 0.0f;
+      positive[axis_index] =
+          nonnegative ? endpoint_b[axis_index] : endpoint_a[axis_index];
+      negative[axis_index] =
+          nonnegative ? endpoint_a[axis_index] : endpoint_b[axis_index];
+    }
+    const float positive_dot = SemanticVisibilityDot4(
+        axis[0], axis[1], axis[2], plane[3], positive[0], positive[1],
+        positive[2], 1.0f);
+    const float negative_dot = SemanticVisibilityDot4(
+        axis[0], axis[1], axis[2], plane[3], negative[0], negative[1],
+        negative[2], 1.0f);
+    if (positive_dot >= 0.0f) {
+      classification_bits |= 1;
+    }
+    if (negative_dot > 0.0f) {
+      classification_bits |= 3;
+    }
+  }
+  return classification_bits == 3 ? 0 : (classification_bits == 1 ? 1 : 2);
+}
+
+void ObserveSemanticVisibilityCategoryHelperInput(
+    uint32_t plane_address, const PPCVRegister &endpoint_a,
+    const PPCVRegister &endpoint_b) {
+  ActiveSemanticVisibilityRecord &record =
+      g_active_semantic_visibility_record;
+  if (!record.active) {
+    g_semantic_visibility_category_shadow_input_without_record.fetch_add(
+        1, std::memory_order_relaxed);
+    return;
+  }
+  ++record.category_shadow_input_observations;
+  if (record.category_shadow_pending ||
+      record.category_shadow_input_observations >
+          record.spatial_helper_passes) {
+    g_semantic_visibility_policy_hook_faults.fetch_add(
+        1, std::memory_order_relaxed);
+    ++record.category_shadow_invalid_inputs;
+  }
+  record.category_shadow_pending = true;
+  record.category_shadow_valid = false;
+  if (!plane_address || (plane_address & 15)) {
+    ++record.category_shadow_invalid_inputs;
+    return;
+  }
+  rex::memory::Memory *memory =
+      g_command_buffer_lineage_memory.load(std::memory_order_acquire);
+  if (!memory) {
+    ++record.category_shadow_invalid_inputs;
+    return;
+  }
+
+  const std::array<float, 3> a = {endpoint_a.f32[3], endpoint_a.f32[2],
+                                  endpoint_a.f32[1]};
+  const std::array<float, 3> b = {endpoint_b.f32[3], endpoint_b.f32[2],
+                                  endpoint_b.f32[1]};
+  if (!std::all_of(a.begin(), a.end(),
+                   [](float value) { return std::isfinite(value); }) ||
+      !std::all_of(b.begin(), b.end(),
+                   [](float value) { return std::isfinite(value); })) {
+    ++record.category_shadow_invalid_inputs;
+    return;
+  }
+
+  std::array<std::array<float, 4>, 6> planes{};
+  for (uint32_t plane_index = 0; plane_index < 6; ++plane_index) {
+    const uint32_t offset = plane_address + plane_index * 16;
+    planes[plane_index] = {
+        LoadSemanticVisibilityGuestFloat(memory, offset + 0),
+        LoadSemanticVisibilityGuestFloat(memory, offset + 4),
+        LoadSemanticVisibilityGuestFloat(memory, offset + 8),
+        LoadSemanticVisibilityGuestFloat(memory, offset + 12)};
+    const std::array<float, 4> &plane = planes[plane_index];
+    if (!std::all_of(plane.begin(), plane.end(),
+                     [](float value) { return std::isfinite(value); })) {
+      ++record.category_shadow_invalid_inputs;
+      return;
+    }
+  }
+  record.category_shadow_prediction =
+      ClassifySemanticVisibilityCategory(planes, a, b);
+  record.category_shadow_valid = true;
+}
+
 void BeginSemanticVisibilityRecord(uint32_t receiver_address,
                                    uint32_t record_index,
                                    uint32_t category,
@@ -2481,6 +2608,21 @@ void ObserveSemanticVisibilityCategoryHelperResult(uint32_t result) {
         1, std::memory_order_relaxed);
     return;
   }
+  if (!record.category_shadow_pending) {
+    g_semantic_visibility_category_shadow_result_without_input.fetch_add(
+        1, std::memory_order_relaxed);
+  } else {
+    if (record.category_shadow_valid) {
+      ++record.category_shadow_comparisons;
+      if (record.category_shadow_prediction == result) {
+        ++record.category_shadow_matches;
+      } else {
+        ++record.category_shadow_false_result;
+      }
+    }
+    record.category_shadow_pending = false;
+    record.category_shadow_valid = false;
+  }
   if (record.category_helper_observations >=
       record.spatial_helper_passes) {
     g_semantic_visibility_policy_hook_faults.fetch_add(
@@ -2626,6 +2768,11 @@ void EndSemanticVisibilityRecord(uint32_t receiver_address,
     g_semantic_visibility_policy_hook_faults.fetch_add(
         1, std::memory_order_relaxed);
   }
+  if (record.category_shadow_pending) {
+    ++record.category_shadow_invalid_inputs;
+    g_semantic_visibility_policy_hook_faults.fetch_add(
+        1, std::memory_order_relaxed);
+  }
   if (record.category < kSemanticVisibilityCategoryCapacity) {
     SemanticVisibilityPolicyStats &policy =
         g_semantic_visibility_policy_categories[record.category]
@@ -2723,6 +2870,23 @@ void EndSemanticVisibilityRecord(uint32_t receiver_address,
           record.spatial_shadow_false_negative, std::memory_order_relaxed);
       spatial_shadow.invalid_inputs.fetch_add(
           record.spatial_shadow_invalid_inputs, std::memory_order_relaxed);
+    }
+    SemanticVisibilityCategoryShadowStats &category_shadow =
+        g_semantic_visibility_category_shadow_categories[record.category]
+                                                         [policy_outcome_index];
+    if (record.category_shadow_input_observations ||
+        record.category_shadow_invalid_inputs) {
+      category_shadow.input_observations.fetch_add(
+          record.category_shadow_input_observations,
+          std::memory_order_relaxed);
+      category_shadow.comparisons.fetch_add(
+          record.category_shadow_comparisons, std::memory_order_relaxed);
+      category_shadow.matches.fetch_add(record.category_shadow_matches,
+                                        std::memory_order_relaxed);
+      category_shadow.false_result.fetch_add(
+          record.category_shadow_false_result, std::memory_order_relaxed);
+      category_shadow.invalid_inputs.fetch_add(
+          record.category_shadow_invalid_inputs, std::memory_order_relaxed);
     }
   }
   if (record.spatial_sample_valid) {
@@ -10510,6 +10674,111 @@ void EmitSemanticVisibilityCensus() {
        {"native_culling", "false"},
        {"native_lod", "false"},
        {"xenos_authority", "true"},
+        {"suppression_allowed", "false"}});
+
+  uint64_t category_shadow_records = 0;
+  uint64_t category_shadow_inputs = 0;
+  uint64_t category_shadow_comparisons = 0;
+  uint64_t category_shadow_matches = 0;
+  uint64_t category_shadow_false_result = 0;
+  uint64_t category_shadow_invalid_inputs = 0;
+  bool category_shadow_category_accounting_complete = true;
+  for (size_t category_index = 0;
+       category_index < kSemanticVisibilityCategoryCapacity;
+       ++category_index) {
+    for (size_t outcome_index = 0;
+         outcome_index < kSemanticVisibilityPolicyOutcomeCapacity;
+         ++outcome_index) {
+      const SemanticVisibilityCategoryShadowStats &category_shadow =
+          g_semantic_visibility_category_shadow_categories[category_index]
+                                                           [outcome_index];
+      const SemanticVisibilityOracleStats &oracle =
+          g_semantic_visibility_oracle_categories[category_index]
+                                                 [outcome_index];
+      const uint64_t records =
+          oracle.records.load(std::memory_order_relaxed);
+      if (!records) {
+        continue;
+      }
+      const uint64_t inputs =
+          category_shadow.input_observations.load(std::memory_order_relaxed);
+      const uint64_t comparisons =
+          category_shadow.comparisons.load(std::memory_order_relaxed);
+      const uint64_t matches =
+          category_shadow.matches.load(std::memory_order_relaxed);
+      const uint64_t false_result =
+          category_shadow.false_result.load(std::memory_order_relaxed);
+      const uint64_t invalid_inputs =
+          category_shadow.invalid_inputs.load(std::memory_order_relaxed);
+      const uint64_t expected_inputs =
+          oracle.category_helper_observations.load(std::memory_order_relaxed);
+      const bool category_complete =
+          inputs == expected_inputs && comparisons == inputs &&
+          matches + false_result == comparisons && !invalid_inputs;
+      category_shadow_category_accounting_complete &= category_complete;
+      category_shadow_records += records;
+      category_shadow_inputs += inputs;
+      category_shadow_comparisons += comparisons;
+      category_shadow_matches += matches;
+      category_shadow_false_result += false_result;
+      category_shadow_invalid_inputs += invalid_inputs;
+      pinyon_shift::diagnostics::RecordEvent(
+          "native_renderer.discovery.semantic_visibility_category_shadow_category_summary",
+          {{"status", category_complete ? "complete" : "incomplete"},
+           {"category", std::to_string(category_index)},
+           {"outcome", SemanticVisibilityPolicyOutcomeName(outcome_index)},
+           {"records", std::to_string(records)},
+           {"input_observations", std::to_string(inputs)},
+           {"comparisons", std::to_string(comparisons)},
+           {"matches", std::to_string(matches)},
+           {"false_result", std::to_string(false_result)},
+           {"invalid_inputs", std::to_string(invalid_inputs)},
+           {"native_policy_execution", "shadow_only"},
+           {"guest_payload_read", "bounded_category_planes"},
+           {"guest_state_changed", "false"},
+           {"xenos_authority", "true"},
+           {"suppression_allowed", "false"}});
+    }
+  }
+  const uint64_t category_shadow_input_without_record =
+      g_semantic_visibility_category_shadow_input_without_record.load(
+          std::memory_order_relaxed);
+  const uint64_t category_shadow_result_without_input =
+      g_semantic_visibility_category_shadow_result_without_input.load(
+          std::memory_order_relaxed);
+  const bool category_shadow_complete =
+      category_shadow_category_accounting_complete &&
+      category_shadow_records == oracle_records &&
+      category_shadow_inputs == oracle_category_observations &&
+      category_shadow_comparisons == category_shadow_inputs &&
+      category_shadow_matches + category_shadow_false_result ==
+          category_shadow_comparisons &&
+      !category_shadow_false_result && !category_shadow_invalid_inputs;
+  pinyon_shift::diagnostics::RecordEvent(
+      "native_renderer.discovery.semantic_visibility_category_shadow_summary",
+      {{"status", category_shadow_complete ? "complete" : "incomplete"},
+       {"records", std::to_string(category_shadow_records)},
+       {"input_observations", std::to_string(category_shadow_inputs)},
+       {"comparisons", std::to_string(category_shadow_comparisons)},
+       {"matches", std::to_string(category_shadow_matches)},
+       {"false_result", std::to_string(category_shadow_false_result)},
+       {"invalid_inputs", std::to_string(category_shadow_invalid_inputs)},
+       {"input_without_record",
+        std::to_string(category_shadow_input_without_record)},
+       {"result_without_input",
+        std::to_string(category_shadow_result_without_input)},
+       {"accounting_complete", category_shadow_complete ? "true" : "false"},
+       {"model", "six_plane_support_point_classifier"},
+       {"scope", "active_title_record_only"},
+       {"unscoped_continuations_excluded", "true"},
+       {"classification", "independent_category_helper_shadow"},
+       {"guest_payload_read", "bounded_category_planes"},
+       {"guest_state_changed", "false"},
+       {"control_flow_changed", "false"},
+       {"native_policy_execution", "shadow_only"},
+       {"native_culling", "false"},
+       {"native_lod", "false"},
+       {"xenos_authority", "true"},
        {"suppression_allowed", "false"}});
 
   const uint64_t category_overflow =
@@ -13059,6 +13328,34 @@ void InstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system,
        {"xenos_authority", "true"},
        {"suppression_allowed", "false"}});
   diagnostics::RecordEvent(
+      "native_renderer.discovery.semantic_visibility_category_shadow_config",
+      {{"status", lineage_armed ? "armed" : "disabled"},
+       {"class", "proceduralGeometry::CProceduralModels"},
+       {"visibility_function", "82E1FD00"},
+       {"input_hook", "82E20364"},
+       {"result_hook", "82E20368"},
+       {"helper", "82441048"},
+       {"plane_vector_offsets", "0,16,32,48,64,80"},
+       {"plane_vector_count", "6"},
+       {"endpoint_registers", "v1,v2"},
+       {"axis_signs", "1,1,-1"},
+       {"support_rule", "plane_axis_nonnegative_selects_v2_for_positive"},
+       {"positive_comparison", "greater_equal_zero_sets_intersection_bit"},
+       {"negative_comparison", "greater_zero_sets_outside_bits"},
+       {"result_mapping", "bits_3_to_0_bits_1_to_1_other_to_2"},
+       {"bounded_guest_payload_bytes", "96"},
+       {"scope", "active_title_record_only"},
+       {"classification", "independent_category_helper_shadow"},
+       {"guest_payload_read", "bounded_category_planes"},
+       {"guest_state_changed", "false"},
+       {"control_flow_changed", "false"},
+       {"native_policy_execution", "shadow_only"},
+       {"native_culling", "false"},
+       {"native_lod", "false"},
+       {"native_draw", "false"},
+       {"xenos_authority", "true"},
+       {"suppression_allowed", "false"}});
+  diagnostics::RecordEvent(
       "native_renderer.discovery.semantic_instance_config",
       {{"status", lineage_armed ? "armed" : "disabled"},
        {"class", "proceduralGeometry::CProceduralModels"},
@@ -14035,6 +14332,11 @@ void PinyonShiftObserveProceduralModelVisibilitySpatialHelperInput(
 void PinyonShiftObserveProceduralModelVisibilitySpatialHelperResult(
     PPCRegister &r3) {
   ObserveSemanticVisibilitySpatialHelperResult(r3.u32);
+}
+
+void PinyonShiftObserveProceduralModelVisibilityCategoryHelperInput(
+    PPCRegister &r3, PPCVRegister &v1, PPCVRegister &v2) {
+  ObserveSemanticVisibilityCategoryHelperInput(r3.u32, v1, v2);
 }
 
 void PinyonShiftObserveProceduralModelVisibilityCategoryHelperResult(

--- a/tools/discover-native-renderer-dispatch.py
+++ b/tools/discover-native-renderer-dispatch.py
@@ -210,6 +210,7 @@ PROCEDURAL_MODEL_RECEIVER = {
     "visibility_local_distance_hook": 0x82E202D8,
     "visibility_spatial_helper_input_hook": 0x82E2034C,
     "visibility_spatial_helper_result_hook": 0x82E20350,
+    "visibility_category_helper_input_hook": 0x82E20364,
     "visibility_category_helper_result_hook": 0x82E20368,
     "render_state_function": 0x824170D8,
     "render_state_vtable_slot": 40,
@@ -1513,6 +1514,36 @@ def procedural_model_receiver_lifecycle(
             "scope": "active_title_record_only",
             "title_result_comparison_required": True,
             "guest_payload_read": "bounded_spatial_helper_inputs",
+            "guest_state_changed": False,
+            "control_flow_changed": False,
+            "native_policy_execution": "shadow_only",
+            "native_culling_enabled": False,
+            "native_lod_enabled": False,
+            "xenos_authority": True,
+            "suppression_allowed": False,
+        },
+        "visibility_category_shadow": {
+            "input_hook_address": "{:08X}".format(
+                spec["visibility_category_helper_input_hook"]
+            ),
+            "result_hook_address": "{:08X}".format(
+                spec["visibility_category_helper_result_hook"]
+            ),
+            "helper_address": "{:08X}".format(
+                spec["visibility_category_helper"]
+            ),
+            "plane_vector_offsets": [0, 16, 32, 48, 64, 80],
+            "plane_vector_count": 6,
+            "endpoint_registers": ["v1", "v2"],
+            "axis_signs": [1, 1, -1],
+            "support_rule": "plane_axis_nonnegative_selects_v2_for_positive",
+            "positive_comparison": "greater_equal_zero_sets_intersection_bit",
+            "negative_comparison": "greater_zero_sets_outside_bits",
+            "result_mapping": "bits_3_to_0_bits_1_to_1_other_to_2",
+            "bounded_guest_payload_bytes": 96,
+            "scope": "active_title_record_only",
+            "title_result_comparison_required": True,
+            "guest_payload_read": "bounded_category_planes",
             "guest_state_changed": False,
             "control_flow_changed": False,
             "native_policy_execution": "shadow_only",

--- a/tools/summarize-native-renderer-visibility-category-shadow.py
+++ b/tools/summarize-native-renderer-visibility-category-shadow.py
@@ -1,0 +1,284 @@
+#!/usr/bin/env python3
+"""Qualify the independent six-plane category-classifier mirror."""
+
+import argparse
+import json
+import pathlib
+import sys
+
+
+SCHEMA = "pinyon-shift.native-renderer-visibility-category-shadow.v1"
+CONFIG = "native_renderer.discovery.semantic_visibility_category_shadow_config"
+CATEGORY = (
+    "native_renderer.discovery."
+    "semantic_visibility_category_shadow_category_summary"
+)
+SUMMARY = "native_renderer.discovery.semantic_visibility_category_shadow_summary"
+ORACLE_CATEGORY = (
+    "native_renderer.discovery.semantic_visibility_oracle_category_summary"
+)
+OUTCOMES = ("early_rejected", "rejected", "selected")
+COUNT_KEYS = (
+    "records",
+    "input_observations",
+    "comparisons",
+    "matches",
+    "false_result",
+    "invalid_inputs",
+)
+
+
+def read_events(paths):
+    events = []
+    for path in paths:
+        for line in path.read_text(encoding="utf-8").splitlines():
+            if line.strip():
+                events.append(json.loads(line))
+    return events
+
+
+def integer(event, key):
+    try:
+        value = int(event[key])
+    except (KeyError, TypeError, ValueError) as error:
+        raise ValueError(f"invalid {key}") from error
+    if value < 0:
+        raise ValueError(f"negative {key}")
+    return value
+
+
+def exact_event(events, name):
+    matches = [event for event in events if event.get("event") == name]
+    if len(matches) != 1:
+        raise ValueError(f"expected exactly one {name} event")
+    return matches[0]
+
+
+def select_session(events, requested):
+    sessions = {
+        event.get("session") for event in events if event.get("event") == CONFIG
+    }
+    sessions.discard(None)
+    if requested:
+        if requested not in sessions:
+            raise ValueError("requested session has no category-shadow config")
+        return requested
+    if len(sessions) != 1:
+        raise ValueError("category-shadow input contains multiple sessions")
+    return next(iter(sessions))
+
+
+def static_contract(document):
+    try:
+        contract = document["procedural_model_receiver_lifecycle"][
+            "visibility_category_shadow"
+        ]
+    except (KeyError, TypeError) as error:
+        raise ValueError("static category-shadow contract is missing") from error
+    expected = {
+        "input_hook_address": "82E20364",
+        "result_hook_address": "82E20368",
+        "helper_address": "82441048",
+        "plane_vector_offsets": [0, 16, 32, 48, 64, 80],
+        "plane_vector_count": 6,
+        "endpoint_registers": ["v1", "v2"],
+        "axis_signs": [1, 1, -1],
+        "support_rule": "plane_axis_nonnegative_selects_v2_for_positive",
+        "positive_comparison": "greater_equal_zero_sets_intersection_bit",
+        "negative_comparison": "greater_zero_sets_outside_bits",
+        "result_mapping": "bits_3_to_0_bits_1_to_1_other_to_2",
+        "bounded_guest_payload_bytes": 96,
+        "scope": "active_title_record_only",
+        "title_result_comparison_required": True,
+        "guest_payload_read": "bounded_category_planes",
+        "guest_state_changed": False,
+        "control_flow_changed": False,
+        "native_policy_execution": "shadow_only",
+        "native_culling_enabled": False,
+        "native_lod_enabled": False,
+        "xenos_authority": True,
+        "suppression_allowed": False,
+    }
+    if any(contract.get(key) != value for key, value in expected.items()):
+        raise ValueError("static category-shadow contract drifted")
+    return contract
+
+
+def validate_counts(item):
+    if (
+        item["comparisons"] != item["input_observations"]
+        or item["matches"] + item["false_result"] != item["comparisons"]
+        or item["false_result"]
+        or item["invalid_inputs"]
+    ):
+        raise ValueError("category-shadow comparison failed")
+
+
+def build(events, static, requested_session=None):
+    contract = static_contract(static)
+    session = select_session(events, requested_session)
+    selected = [event for event in events if event.get("session") == session]
+    config = exact_event(selected, CONFIG)
+    summary = exact_event(selected, SUMMARY)
+    expected_config = {
+        "status": "armed",
+        "class": "proceduralGeometry::CProceduralModels",
+        "visibility_function": "82E1FD00",
+        "input_hook": "82E20364",
+        "result_hook": "82E20368",
+        "helper": "82441048",
+        "plane_vector_offsets": "0,16,32,48,64,80",
+        "plane_vector_count": "6",
+        "endpoint_registers": "v1,v2",
+        "axis_signs": "1,1,-1",
+        "support_rule": "plane_axis_nonnegative_selects_v2_for_positive",
+        "positive_comparison": "greater_equal_zero_sets_intersection_bit",
+        "negative_comparison": "greater_zero_sets_outside_bits",
+        "result_mapping": "bits_3_to_0_bits_1_to_1_other_to_2",
+        "bounded_guest_payload_bytes": "96",
+        "scope": "active_title_record_only",
+        "classification": "independent_category_helper_shadow",
+        "guest_payload_read": "bounded_category_planes",
+        "guest_state_changed": "false",
+        "control_flow_changed": "false",
+        "native_policy_execution": "shadow_only",
+        "native_culling": "false",
+        "native_lod": "false",
+        "native_draw": "false",
+        "xenos_authority": "true",
+        "suppression_allowed": "false",
+    }
+    if any(config.get(key) != value for key, value in expected_config.items()):
+        raise ValueError("category-shadow runtime configuration drifted")
+    expected_summary = {
+        "status": "complete",
+        "accounting_complete": "true",
+        "model": "six_plane_support_point_classifier",
+        "scope": "active_title_record_only",
+        "unscoped_continuations_excluded": "true",
+        "classification": "independent_category_helper_shadow",
+        "guest_payload_read": "bounded_category_planes",
+        "guest_state_changed": "false",
+        "control_flow_changed": "false",
+        "native_policy_execution": "shadow_only",
+        "native_culling": "false",
+        "native_lod": "false",
+        "xenos_authority": "true",
+        "suppression_allowed": "false",
+    }
+    if any(summary.get(key) != value for key, value in expected_summary.items()):
+        raise ValueError("category-shadow summary is incomplete or unsafe")
+    totals = {key: integer(summary, key) for key in COUNT_KEYS}
+    diagnostics = {
+        "input_without_record": integer(summary, "input_without_record"),
+        "result_without_input": integer(summary, "result_without_input"),
+    }
+    validate_counts(totals)
+    if totals["records"] <= 0 or totals["comparisons"] <= 0:
+        raise ValueError("category-shadow has no qualifying comparisons")
+
+    oracle = {}
+    for event in selected:
+        if event.get("event") != ORACLE_CATEGORY:
+            continue
+        key = (integer(event, "category"), event.get("outcome"))
+        if (
+            key in oracle
+            or key[1] not in OUTCOMES
+            or event.get("status") != "complete"
+        ):
+            raise ValueError("visibility-oracle category evidence drifted")
+        oracle[key] = {
+            "records": integer(event, "records"),
+            "input_observations": integer(event, "category_helper_observations"),
+        }
+
+    categories = {}
+    sums = {key: 0 for key in COUNT_KEYS}
+    for event in selected:
+        if event.get("event") != CATEGORY:
+            continue
+        key = (integer(event, "category"), event.get("outcome"))
+        if (
+            key in categories
+            or key not in oracle
+            or event.get("status") != "complete"
+            or event.get("native_policy_execution") != "shadow_only"
+            or event.get("guest_payload_read") != "bounded_category_planes"
+            or event.get("guest_state_changed") != "false"
+            or event.get("xenos_authority") != "true"
+            or event.get("suppression_allowed") != "false"
+        ):
+            raise ValueError("category-shadow category evidence drifted")
+        item = {field: integer(event, field) for field in COUNT_KEYS}
+        validate_counts(item)
+        if item["records"] != oracle[key]["records"] or item[
+            "input_observations"
+        ] != oracle[key]["input_observations"]:
+            raise ValueError("category-shadow oracle reconciliation failed")
+        categories[key] = item
+        for field in COUNT_KEYS:
+            sums[field] += item[field]
+    if set(categories) != set(oracle) or any(
+        sums[key] != totals[key] for key in COUNT_KEYS
+    ):
+        raise ValueError("category-shadow category totals drifted")
+
+    return {
+        "schema": SCHEMA,
+        "status": "complete",
+        "session": session,
+        "static_contract": contract,
+        "totals": {**totals, **diagnostics},
+        "categories": {
+            f"{category}:{outcome}": item
+            for (category, outcome), item in sorted(categories.items())
+        },
+        "qualification": {
+            "independent_category_classifier_shadow_proved": True,
+            "zero_title_mismatches": True,
+            "bounded_plane_reads_proved": True,
+            "ready_for_native_visibility_policy_assembly": True,
+            "native_policy_execution_enabled": False,
+        },
+        "safety": {
+            "guest_payload_read": "bounded_category_planes",
+            "guest_state_changed": False,
+            "control_flow_changed": False,
+            "native_culling": False,
+            "native_lod": False,
+            "xenos_authority": True,
+            "suppression_allowed": False,
+        },
+    }
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser()
+    parser.add_argument("events", nargs="+", type=pathlib.Path)
+    parser.add_argument("--static", required=True, type=pathlib.Path)
+    parser.add_argument("--session")
+    parser.add_argument("--output", required=True, type=pathlib.Path)
+    args = parser.parse_args(argv)
+    try:
+        document = build(
+            read_events(args.events),
+            json.loads(args.static.read_text(encoding="utf-8")),
+            args.session,
+        )
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(
+            json.dumps(document, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        return 0
+    except (OSError, ValueError, json.JSONDecodeError) as error:
+        print(
+            f"native renderer category shadow summary failed: {error}",
+            file=sys.stderr,
+        )
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/tests/test_native_renderer_contract.py
+++ b/tools/tests/test_native_renderer_contract.py
@@ -148,6 +148,9 @@ class NativeRendererContractTests(unittest.TestCase):
             "PinyonShiftObserveProceduralModelVisibilitySpatialHelperResult": (
                 "0x82E20350"
             ),
+            "PinyonShiftObserveProceduralModelVisibilityCategoryHelperInput": (
+                "0x82E20364"
+            ),
             "PinyonShiftObserveProceduralModelVisibilityCategoryHelperResult": (
                 "0x82E20368"
             ),
@@ -212,6 +215,22 @@ class NativeRendererContractTests(unittest.TestCase):
         self.assertIn('"guest_state_changed": False', spatial_shadow_summarizer)
         self.assertIn('"xenos_authority": True', spatial_shadow_summarizer)
         self.assertIn('"suppression_allowed": False', spatial_shadow_summarizer)
+
+        category_shadow_summarizer = (
+            ROOT / "tools/summarize-native-renderer-visibility-category-shadow.py"
+        ).read_text(encoding="utf-8")
+        self.assertIn("independent_category_helper_shadow", source)
+        self.assertIn(
+            "kAxisSigns = {1.0f, 1.0f, -1.0f}", source
+        )
+        self.assertIn('{"axis_signs", "1,1,-1"}', source)
+        self.assertIn(
+            '"guest_payload_read": "bounded_category_planes"',
+            category_shadow_summarizer,
+        )
+        self.assertIn('"guest_state_changed": False', category_shadow_summarizer)
+        self.assertIn('"xenos_authority": True', category_shadow_summarizer)
+        self.assertIn('"suppression_allowed": False', category_shadow_summarizer)
 
     def test_exact_pass_consumer_trace_is_bounded_and_fail_closed(self):
         source = (ROOT / "src/native_renderer/graphics_hooks.cpp").read_text(

--- a/tools/tests/test_native_renderer_dispatch_discovery.py
+++ b/tools/tests/test_native_renderer_dispatch_discovery.py
@@ -1329,6 +1329,23 @@ class NativeRendererDispatchDiscoveryTests(unittest.TestCase):
         self.assertFalse(spatial_shadow["guest_state_changed"])
         self.assertTrue(spatial_shadow["xenos_authority"])
         self.assertFalse(spatial_shadow["suppression_allowed"])
+        category_shadow = lifecycle["visibility_category_shadow"]
+        self.assertEqual("82E20364", category_shadow["input_hook_address"])
+        self.assertEqual("82E20368", category_shadow["result_hook_address"])
+        self.assertEqual("82441048", category_shadow["helper_address"])
+        self.assertEqual(
+            [0, 16, 32, 48, 64, 80],
+            category_shadow["plane_vector_offsets"],
+        )
+        self.assertEqual(["v1", "v2"], category_shadow["endpoint_registers"])
+        self.assertEqual([1, 1, -1], category_shadow["axis_signs"])
+        self.assertEqual(96, category_shadow["bounded_guest_payload_bytes"])
+        self.assertEqual(
+            "bounded_category_planes", category_shadow["guest_payload_read"]
+        )
+        self.assertFalse(category_shadow["guest_state_changed"])
+        self.assertTrue(category_shadow["xenos_authority"])
+        self.assertFalse(category_shadow["suppression_allowed"])
         self.assertEqual(
             92, lifecycle["field_layout"]["descriptor_record_stride"]
         )

--- a/tools/tests/test_native_renderer_visibility_category_shadow.py
+++ b/tools/tests/test_native_renderer_visibility_category_shadow.py
@@ -1,0 +1,182 @@
+import copy
+import importlib.util
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).parents[2]
+TOOL = ROOT / "tools/summarize-native-renderer-visibility-category-shadow.py"
+SPEC = importlib.util.spec_from_file_location("visibility_category_shadow", TOOL)
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+class VisibilityCategoryShadowReportTests(unittest.TestCase):
+    def static(self):
+        return {
+            "procedural_model_receiver_lifecycle": {
+                "visibility_category_shadow": {
+                    "input_hook_address": "82E20364",
+                    "result_hook_address": "82E20368",
+                    "helper_address": "82441048",
+                    "plane_vector_offsets": [0, 16, 32, 48, 64, 80],
+                    "plane_vector_count": 6,
+                    "endpoint_registers": ["v1", "v2"],
+                    "axis_signs": [1, 1, -1],
+                    "support_rule": (
+                        "plane_axis_nonnegative_selects_v2_for_positive"
+                    ),
+                    "positive_comparison": (
+                        "greater_equal_zero_sets_intersection_bit"
+                    ),
+                    "negative_comparison": "greater_zero_sets_outside_bits",
+                    "result_mapping": "bits_3_to_0_bits_1_to_1_other_to_2",
+                    "bounded_guest_payload_bytes": 96,
+                    "scope": "active_title_record_only",
+                    "title_result_comparison_required": True,
+                    "guest_payload_read": "bounded_category_planes",
+                    "guest_state_changed": False,
+                    "control_flow_changed": False,
+                    "native_policy_execution": "shadow_only",
+                    "native_culling_enabled": False,
+                    "native_lod_enabled": False,
+                    "xenos_authority": True,
+                    "suppression_allowed": False,
+                }
+            }
+        }
+
+    def config(self):
+        return {
+            "event": MODULE.CONFIG,
+            "session": "test",
+            "status": "armed",
+            "class": "proceduralGeometry::CProceduralModels",
+            "visibility_function": "82E1FD00",
+            "input_hook": "82E20364",
+            "result_hook": "82E20368",
+            "helper": "82441048",
+            "plane_vector_offsets": "0,16,32,48,64,80",
+            "plane_vector_count": "6",
+            "endpoint_registers": "v1,v2",
+            "axis_signs": "1,1,-1",
+            "support_rule": "plane_axis_nonnegative_selects_v2_for_positive",
+            "positive_comparison": "greater_equal_zero_sets_intersection_bit",
+            "negative_comparison": "greater_zero_sets_outside_bits",
+            "result_mapping": "bits_3_to_0_bits_1_to_1_other_to_2",
+            "bounded_guest_payload_bytes": "96",
+            "scope": "active_title_record_only",
+            "classification": "independent_category_helper_shadow",
+            "guest_payload_read": "bounded_category_planes",
+            "guest_state_changed": "false",
+            "control_flow_changed": "false",
+            "native_policy_execution": "shadow_only",
+            "native_culling": "false",
+            "native_lod": "false",
+            "native_draw": "false",
+            "xenos_authority": "true",
+            "suppression_allowed": "false",
+        }
+
+    def oracle(self, outcome, records, inputs):
+        return {
+            "event": MODULE.ORACLE_CATEGORY,
+            "session": "test",
+            "status": "complete",
+            "category": "9",
+            "outcome": outcome,
+            "records": str(records),
+            "category_helper_observations": str(inputs),
+        }
+
+    def category(self, outcome, records, inputs):
+        return {
+            "event": MODULE.CATEGORY,
+            "session": "test",
+            "status": "complete",
+            "category": "9",
+            "outcome": outcome,
+            "records": str(records),
+            "input_observations": str(inputs),
+            "comparisons": str(inputs),
+            "matches": str(inputs),
+            "false_result": "0",
+            "invalid_inputs": "0",
+            "native_policy_execution": "shadow_only",
+            "guest_payload_read": "bounded_category_planes",
+            "guest_state_changed": "false",
+            "xenos_authority": "true",
+            "suppression_allowed": "false",
+        }
+
+    def events(self):
+        rows = [("early_rejected", 4, 0), ("rejected", 2, 4), ("selected", 1, 3)]
+        summary = {
+            "event": MODULE.SUMMARY,
+            "session": "test",
+            "status": "complete",
+            "records": "7",
+            "input_observations": "7",
+            "comparisons": "7",
+            "matches": "7",
+            "false_result": "0",
+            "invalid_inputs": "0",
+            "input_without_record": "2",
+            "result_without_input": "0",
+            "accounting_complete": "true",
+            "model": "six_plane_support_point_classifier",
+            "scope": "active_title_record_only",
+            "unscoped_continuations_excluded": "true",
+            "classification": "independent_category_helper_shadow",
+            "guest_payload_read": "bounded_category_planes",
+            "guest_state_changed": "false",
+            "control_flow_changed": "false",
+            "native_policy_execution": "shadow_only",
+            "native_culling": "false",
+            "native_lod": "false",
+            "xenos_authority": "true",
+            "suppression_allowed": "false",
+        }
+        return [
+            self.config(),
+            *(self.oracle(*row) for row in rows),
+            *(self.category(*row) for row in rows),
+            summary,
+        ]
+
+    def test_build_qualifies_exact_category_mirror(self):
+        document = MODULE.build(self.events(), self.static())
+        self.assertEqual("complete", document["status"])
+        self.assertEqual(7, document["totals"]["matches"])
+        self.assertTrue(
+            document["qualification"][
+                "independent_category_classifier_shadow_proved"
+            ]
+        )
+        self.assertFalse(document["safety"]["guest_state_changed"])
+        self.assertTrue(document["safety"]["xenos_authority"])
+
+    def test_build_rejects_result_mismatch(self):
+        events = copy.deepcopy(self.events())
+        category = next(
+            event
+            for event in events
+            if event["event"] == MODULE.CATEGORY
+            and event["comparisons"] != "0"
+        )
+        category["matches"] = "0"
+        category["false_result"] = category["comparisons"]
+        with self.assertRaisesRegex(ValueError, "comparison failed"):
+            MODULE.build(events, self.static())
+
+    def test_build_rejects_static_suppression_drift(self):
+        static = self.static()
+        static["procedural_model_receiver_lifecycle"][
+            "visibility_category_shadow"
+        ]["suppression_allowed"] = True
+        with self.assertRaisesRegex(ValueError, "contract drifted"):
+            MODULE.build(self.events(), static)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a pre-call hook for the six-plane category helper and mirror its signed-axis support-point classifier
- reconcile every in-scope prediction with the authoritative title result while keeping Xenos authoritative and suppression disabled
- add static/runtime contract discovery, a fail-closed reporter, tests, and qualification documentation

## Validation
- 70 focused native-renderer tests passed
- Release build passed
- AppData session \20260830T005146Z-p2496\: 212,464/212,464 category matches, 212,464/212,464 spatial matches, 25,650/25,650 title-result matches
- zero invalid inputs, missing pairs, present-deadline misses, or fatal signatures
- 30.570 median FPS over 4,963 frames; 15.451 FPS one-percent low

## Safety
- read-only bounded guest payload access
- no guest state or control-flow changes
- no native culling, LOD, draw, or suppression
- Xenos remains authoritative