### PR TITLE
feat(native-renderer): assemble visibility policy shadow

### DIFF
--- a/docs/native-renderer/VISIBILITY_POLICY_ABI.md
+++ b/docs/native-renderer/VISIBILITY_POLICY_ABI.md
@@ -240,3 +240,33 @@ FPS over 4,963 frames, with a 15.451 FPS one-percent low and zero
 present-deadline misses. This qualifies the independent category classifier for
 native visibility-policy assembly while native policy execution remains
 disabled and Xenos remains authoritative.
+
+## Independent policy-assembly shadow
+
+The fourth model assembles the two independent mirrors into one record-level
+decision. A native spatial prediction admits a candidate to the native category
+classifier; category results 1 or 2 select the record, while records with only
+result 0 are rejected. The title helper returns are no longer inputs to this
+decision. Only the title's final record result is retained as the oracle used to
+score the assembled native prediction.
+
+Each candidate reads at most the already-qualified 52-byte spatial payload and
+96-byte category payload. Category/outcome telemetry independently reconciles
+spatial inputs and passes, category inputs and predicted result distribution,
+model coverage, and final false-positive and false-negative counts against the
+three prior qualified datasets. Any missing pair, invalid input, accounting
+drift, or title-result mismatch fails qualification closed.
+
+This remains a shadow checkpoint. It changes no guest state or control flow,
+does not enable native culling or LOD, performs no native draw, and cannot
+suppress Xenos.
+
+The batched Release/AppData session `20260830T011157Z-p1896` reconciled
+1,572,434 title records. Both independent mirrors matched all 223,473 in-scope
+spatial and category calls, and the assembled model matched all 26,979 modelled
+record outcomes with zero false positives, false negatives, invalid inputs, or
+accounting faults. The process exited normally with no fatal signatures. Median
+performance was 30.318 FPS over 8,063 frames, with a 19.396 FPS one-percent low
+and zero present-deadline misses. This qualifies the independent assembly for
+conservative native policy-execution design while execution and suppression
+remain disabled and Xenos stays authoritative.

--- a/src/native_renderer/graphics_hooks.cpp
+++ b/src/native_renderer/graphics_hooks.cpp
@@ -680,6 +680,21 @@ struct SemanticVisibilityCategoryShadowStats {
   std::atomic<uint64_t> invalid_inputs{};
 };
 
+struct SemanticVisibilityAssemblyShadowStats {
+  std::atomic<uint64_t> records{};
+  std::atomic<uint64_t> modelled_records{};
+  std::atomic<uint64_t> predicted_selected{};
+  std::atomic<uint64_t> predicted_rejected{};
+  std::atomic<uint64_t> title_matches{};
+  std::atomic<uint64_t> false_positive{};
+  std::atomic<uint64_t> false_negative{};
+  std::atomic<uint64_t> spatial_input_observations{};
+  std::atomic<uint64_t> spatial_predicted_passes{};
+  std::atomic<uint64_t> category_input_observations{};
+  std::array<std::atomic<uint64_t>, 3> category_predictions{};
+  std::atomic<uint64_t> invalid_inputs{};
+};
+
 std::atomic<uint64_t> g_semantic_visibility_record_entries{};
 std::atomic<uint64_t> g_semantic_visibility_record_completions{};
 std::atomic<uint64_t> g_semantic_visibility_records_open{};
@@ -753,6 +768,10 @@ std::array<std::array<SemanticVisibilityCategoryShadowStats,
     g_semantic_visibility_category_shadow_categories{};
 std::atomic<uint64_t> g_semantic_visibility_category_shadow_input_without_record{};
 std::atomic<uint64_t> g_semantic_visibility_category_shadow_result_without_input{};
+std::array<std::array<SemanticVisibilityAssemblyShadowStats,
+                      kSemanticVisibilityPolicyOutcomeCapacity>,
+           kSemanticVisibilityCategoryCapacity>
+    g_semantic_visibility_assembly_shadow_categories{};
 
 struct SemanticInstanceEntry {
   uint64_t key = 0;
@@ -1069,6 +1088,8 @@ struct ActiveSemanticVisibilityRecord {
   uint32_t category_shadow_matches = 0;
   uint32_t category_shadow_false_result = 0;
   uint32_t category_shadow_invalid_inputs = 0;
+  uint32_t assembly_spatial_predicted_passes = 0;
+  std::array<uint32_t, 3> assembly_category_predictions{};
   bool spatial_shadow_pending = false;
   bool spatial_shadow_valid = false;
   bool spatial_shadow_prediction = false;
@@ -2349,7 +2370,9 @@ void ObserveSemanticVisibilityCategoryHelperInput(
   ++record.category_shadow_input_observations;
   if (record.category_shadow_pending ||
       record.category_shadow_input_observations >
-          record.spatial_helper_passes) {
+          record.spatial_helper_passes ||
+      record.category_shadow_input_observations >
+          record.assembly_spatial_predicted_passes) {
     g_semantic_visibility_policy_hook_faults.fetch_add(
         1, std::memory_order_relaxed);
     ++record.category_shadow_invalid_inputs;
@@ -2577,6 +2600,9 @@ void ObserveSemanticVisibilitySpatialHelperResult(uint32_t result) {
     if (record.spatial_shadow_valid) {
       ++record.spatial_shadow_comparisons;
       const bool title_result = (result & 0xFF) != 0;
+      if (record.spatial_shadow_prediction) {
+        ++record.assembly_spatial_predicted_passes;
+      }
       if (record.spatial_shadow_prediction == title_result) {
         ++record.spatial_shadow_matches;
       } else if (record.spatial_shadow_prediction) {
@@ -2614,6 +2640,13 @@ void ObserveSemanticVisibilityCategoryHelperResult(uint32_t result) {
   } else {
     if (record.category_shadow_valid) {
       ++record.category_shadow_comparisons;
+      if (record.category_shadow_prediction <
+          record.assembly_category_predictions.size()) {
+        ++record.assembly_category_predictions[
+            record.category_shadow_prediction];
+      } else {
+        ++record.category_shadow_invalid_inputs;
+      }
       if (record.category_shadow_prediction == result) {
         ++record.category_shadow_matches;
       } else {
@@ -2887,6 +2920,50 @@ void EndSemanticVisibilityRecord(uint32_t receiver_address,
           record.category_shadow_false_result, std::memory_order_relaxed);
       category_shadow.invalid_inputs.fetch_add(
           record.category_shadow_invalid_inputs, std::memory_order_relaxed);
+    }
+    SemanticVisibilityAssemblyShadowStats &assembly =
+        g_semantic_visibility_assembly_shadow_categories[record.category]
+                                                        [policy_outcome_index];
+    assembly.records.fetch_add(1, std::memory_order_relaxed);
+    assembly.spatial_input_observations.fetch_add(
+        record.spatial_shadow_input_observations, std::memory_order_relaxed);
+    assembly.spatial_predicted_passes.fetch_add(
+        record.assembly_spatial_predicted_passes, std::memory_order_relaxed);
+    assembly.category_input_observations.fetch_add(
+        record.category_shadow_input_observations, std::memory_order_relaxed);
+    uint32_t assembly_category_predictions = 0;
+    for (size_t result = 0;
+         result < record.assembly_category_predictions.size(); ++result) {
+      const uint32_t count = record.assembly_category_predictions[result];
+      assembly.category_predictions[result].fetch_add(
+          count, std::memory_order_relaxed);
+      assembly_category_predictions += count;
+    }
+    const uint32_t assembly_invalid_inputs =
+        record.spatial_shadow_invalid_inputs +
+        record.category_shadow_invalid_inputs +
+        uint32_t(record.assembly_spatial_predicted_passes !=
+                 record.category_shadow_input_observations) +
+        uint32_t(assembly_category_predictions !=
+                 record.category_shadow_comparisons);
+    assembly.invalid_inputs.fetch_add(assembly_invalid_inputs,
+                                      std::memory_order_relaxed);
+    if (record.category_shadow_input_observations) {
+      assembly.modelled_records.fetch_add(1, std::memory_order_relaxed);
+      const bool predicted_selected =
+          record.assembly_category_predictions[1] != 0 ||
+          record.assembly_category_predictions[2] != 0;
+      const bool title_selected = record.result_seen && record.selected;
+      (predicted_selected ? assembly.predicted_selected
+                          : assembly.predicted_rejected)
+          .fetch_add(1, std::memory_order_relaxed);
+      if (predicted_selected == title_selected) {
+        assembly.title_matches.fetch_add(1, std::memory_order_relaxed);
+      } else if (predicted_selected) {
+        assembly.false_positive.fetch_add(1, std::memory_order_relaxed);
+      } else {
+        assembly.false_negative.fetch_add(1, std::memory_order_relaxed);
+      }
     }
   }
   if (record.spatial_sample_valid) {
@@ -10781,6 +10858,177 @@ void EmitSemanticVisibilityCensus() {
        {"xenos_authority", "true"},
        {"suppression_allowed", "false"}});
 
+  uint64_t assembly_records = 0;
+  uint64_t assembly_modelled_records = 0;
+  uint64_t assembly_predicted_selected = 0;
+  uint64_t assembly_predicted_rejected = 0;
+  uint64_t assembly_title_matches = 0;
+  uint64_t assembly_false_positive = 0;
+  uint64_t assembly_false_negative = 0;
+  uint64_t assembly_spatial_inputs = 0;
+  uint64_t assembly_spatial_passes = 0;
+  uint64_t assembly_category_inputs = 0;
+  std::array<uint64_t, 3> assembly_category_predictions{};
+  uint64_t assembly_invalid_inputs = 0;
+  bool assembly_category_accounting_complete = true;
+  for (size_t category_index = 0;
+       category_index < kSemanticVisibilityCategoryCapacity;
+       ++category_index) {
+    for (size_t outcome_index = 0;
+         outcome_index < kSemanticVisibilityPolicyOutcomeCapacity;
+         ++outcome_index) {
+      const SemanticVisibilityAssemblyShadowStats &assembly =
+          g_semantic_visibility_assembly_shadow_categories[category_index]
+                                                              [outcome_index];
+      const SemanticVisibilityOracleStats &oracle =
+          g_semantic_visibility_oracle_categories[category_index]
+                                                 [outcome_index];
+      const SemanticVisibilitySpatialShadowStats &spatial_shadow =
+          g_semantic_visibility_spatial_shadow_categories[category_index]
+                                                         [outcome_index];
+      const SemanticVisibilityCategoryShadowStats &category_shadow =
+          g_semantic_visibility_category_shadow_categories[category_index]
+                                                           [outcome_index];
+      const uint64_t records =
+          assembly.records.load(std::memory_order_relaxed);
+      if (!records) {
+        continue;
+      }
+      const uint64_t expected_records =
+          oracle.records.load(std::memory_order_relaxed);
+      const uint64_t modelled_records =
+          assembly.modelled_records.load(std::memory_order_relaxed);
+      const uint64_t predicted_selected =
+          assembly.predicted_selected.load(std::memory_order_relaxed);
+      const uint64_t predicted_rejected =
+          assembly.predicted_rejected.load(std::memory_order_relaxed);
+      const uint64_t title_matches =
+          assembly.title_matches.load(std::memory_order_relaxed);
+      const uint64_t false_positive =
+          assembly.false_positive.load(std::memory_order_relaxed);
+      const uint64_t false_negative =
+          assembly.false_negative.load(std::memory_order_relaxed);
+      const uint64_t spatial_inputs =
+          assembly.spatial_input_observations.load(std::memory_order_relaxed);
+      const uint64_t spatial_passes =
+          assembly.spatial_predicted_passes.load(std::memory_order_relaxed);
+      const uint64_t category_inputs =
+          assembly.category_input_observations.load(std::memory_order_relaxed);
+      std::array<uint64_t, 3> category_predictions{};
+      uint64_t category_prediction_total = 0;
+      bool category_predictions_match = true;
+      for (size_t result = 0; result < category_predictions.size(); ++result) {
+        category_predictions[result] =
+            assembly.category_predictions[result].load(
+                std::memory_order_relaxed);
+        category_prediction_total += category_predictions[result];
+        category_predictions_match &=
+            category_predictions[result] ==
+            oracle.category_results[result].load(std::memory_order_relaxed);
+      }
+      const uint64_t invalid_inputs =
+          assembly.invalid_inputs.load(std::memory_order_relaxed);
+      const bool category_complete =
+          records == expected_records && modelled_records <= records &&
+          predicted_selected + predicted_rejected == modelled_records &&
+          title_matches + false_positive + false_negative == modelled_records &&
+          spatial_inputs == spatial_shadow.input_observations.load(
+                                std::memory_order_relaxed) &&
+          spatial_passes == category_inputs &&
+          category_inputs == category_shadow.input_observations.load(
+                                 std::memory_order_relaxed) &&
+          category_prediction_total == category_inputs &&
+          category_predictions_match && !false_positive && !false_negative &&
+          !invalid_inputs;
+      assembly_category_accounting_complete &= category_complete;
+      assembly_records += records;
+      assembly_modelled_records += modelled_records;
+      assembly_predicted_selected += predicted_selected;
+      assembly_predicted_rejected += predicted_rejected;
+      assembly_title_matches += title_matches;
+      assembly_false_positive += false_positive;
+      assembly_false_negative += false_negative;
+      assembly_spatial_inputs += spatial_inputs;
+      assembly_spatial_passes += spatial_passes;
+      assembly_category_inputs += category_inputs;
+      assembly_invalid_inputs += invalid_inputs;
+      for (size_t result = 0; result < category_predictions.size(); ++result) {
+        assembly_category_predictions[result] += category_predictions[result];
+      }
+      pinyon_shift::diagnostics::RecordEvent(
+          "native_renderer.discovery.semantic_visibility_assembly_shadow_category_summary",
+          {{"status", category_complete ? "complete" : "incomplete"},
+           {"category", std::to_string(category_index)},
+           {"outcome", SemanticVisibilityPolicyOutcomeName(outcome_index)},
+           {"records", std::to_string(records)},
+           {"modelled_records", std::to_string(modelled_records)},
+           {"predicted_selected", std::to_string(predicted_selected)},
+           {"predicted_rejected", std::to_string(predicted_rejected)},
+           {"title_matches", std::to_string(title_matches)},
+           {"false_positive", std::to_string(false_positive)},
+           {"false_negative", std::to_string(false_negative)},
+           {"spatial_input_observations", std::to_string(spatial_inputs)},
+           {"spatial_predicted_passes", std::to_string(spatial_passes)},
+           {"category_input_observations", std::to_string(category_inputs)},
+           {"category_result_0", std::to_string(category_predictions[0])},
+           {"category_result_1", std::to_string(category_predictions[1])},
+           {"category_result_2", std::to_string(category_predictions[2])},
+           {"invalid_inputs", std::to_string(invalid_inputs)},
+           {"native_policy_execution", "shadow_only"},
+           {"guest_payload_read", "bounded_spatial_and_category_inputs"},
+           {"guest_state_changed", "false"},
+           {"xenos_authority", "true"},
+           {"suppression_allowed", "false"}});
+    }
+  }
+  const bool assembly_complete =
+      assembly_category_accounting_complete &&
+      assembly_records == oracle_records &&
+      assembly_spatial_inputs == oracle_spatial_observations &&
+      assembly_spatial_passes == oracle_category_observations &&
+      assembly_category_inputs == oracle_category_observations &&
+      assembly_category_predictions[0] == oracle_category_results[0] &&
+      assembly_category_predictions[1] == oracle_category_results[1] &&
+      assembly_category_predictions[2] == oracle_category_results[2] &&
+      assembly_predicted_selected + assembly_predicted_rejected ==
+          assembly_modelled_records &&
+      assembly_title_matches == assembly_modelled_records &&
+      !assembly_false_positive && !assembly_false_negative &&
+      !assembly_invalid_inputs;
+  pinyon_shift::diagnostics::RecordEvent(
+      "native_renderer.discovery.semantic_visibility_assembly_shadow_summary",
+      {{"status", assembly_complete ? "complete" : "incomplete"},
+       {"records", std::to_string(assembly_records)},
+       {"modelled_records", std::to_string(assembly_modelled_records)},
+       {"unmodelled_records",
+        std::to_string(assembly_records >= assembly_modelled_records
+                           ? assembly_records - assembly_modelled_records
+                           : 0)},
+       {"predicted_selected", std::to_string(assembly_predicted_selected)},
+       {"predicted_rejected", std::to_string(assembly_predicted_rejected)},
+       {"title_matches", std::to_string(assembly_title_matches)},
+       {"false_positive", std::to_string(assembly_false_positive)},
+       {"false_negative", std::to_string(assembly_false_negative)},
+       {"spatial_input_observations", std::to_string(assembly_spatial_inputs)},
+       {"spatial_predicted_passes", std::to_string(assembly_spatial_passes)},
+       {"category_input_observations", std::to_string(assembly_category_inputs)},
+       {"category_result_0", std::to_string(assembly_category_predictions[0])},
+       {"category_result_1", std::to_string(assembly_category_predictions[1])},
+       {"category_result_2", std::to_string(assembly_category_predictions[2])},
+       {"invalid_inputs", std::to_string(assembly_invalid_inputs)},
+       {"accounting_complete", assembly_complete ? "true" : "false"},
+       {"model", "independent_spatial_then_category_selection"},
+       {"scope", "active_title_record_only"},
+       {"classification", "independent_visibility_policy_assembly_shadow"},
+       {"guest_payload_read", "bounded_spatial_and_category_inputs"},
+       {"guest_state_changed", "false"},
+       {"control_flow_changed", "false"},
+       {"native_policy_execution", "shadow_only"},
+       {"native_culling", "false"},
+       {"native_lod", "false"},
+       {"xenos_authority", "true"},
+       {"suppression_allowed", "false"}});
+
   const uint64_t category_overflow =
       g_semantic_visibility_category_overflow.load(
           std::memory_order_relaxed);
@@ -13347,6 +13595,32 @@ void InstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system,
        {"scope", "active_title_record_only"},
        {"classification", "independent_category_helper_shadow"},
        {"guest_payload_read", "bounded_category_planes"},
+       {"guest_state_changed", "false"},
+       {"control_flow_changed", "false"},
+       {"native_policy_execution", "shadow_only"},
+       {"native_culling", "false"},
+       {"native_lod", "false"},
+       {"native_draw", "false"},
+       {"xenos_authority", "true"},
+       {"suppression_allowed", "false"}});
+  diagnostics::RecordEvent(
+      "native_renderer.discovery.semantic_visibility_assembly_shadow_config",
+      {{"status", lineage_armed ? "armed" : "disabled"},
+       {"class", "proceduralGeometry::CProceduralModels"},
+       {"visibility_function", "82E1FD00"},
+       {"record_entry_hook", "82E20094"},
+       {"spatial_input_hook", "82E2034C"},
+       {"spatial_result_hook", "82E20350"},
+       {"category_input_hook", "82E20364"},
+       {"category_result_hook", "82E20368"},
+       {"title_result_hook", "82E206F8"},
+       {"record_completion_hook", "82E2084C"},
+       {"model", "independent_spatial_then_category_selection"},
+       {"selection_rule", "any_nonzero_predicted_category_result_selects"},
+       {"bounded_guest_payload_bytes_per_candidate", "148"},
+       {"scope", "active_title_record_only"},
+       {"classification", "independent_visibility_policy_assembly_shadow"},
+       {"guest_payload_read", "bounded_spatial_and_category_inputs"},
        {"guest_state_changed", "false"},
        {"control_flow_changed", "false"},
        {"native_policy_execution", "shadow_only"},

--- a/tools/discover-native-renderer-dispatch.py
+++ b/tools/discover-native-renderer-dispatch.py
@@ -1552,6 +1552,42 @@ def procedural_model_receiver_lifecycle(
             "xenos_authority": True,
             "suppression_allowed": False,
         },
+        "visibility_policy_assembly_shadow": {
+            "record_entry_hook_address": "{:08X}".format(
+                spec["visibility_record_entry"]
+            ),
+            "spatial_input_hook_address": "{:08X}".format(
+                spec["visibility_spatial_helper_input_hook"]
+            ),
+            "spatial_result_hook_address": "{:08X}".format(
+                spec["visibility_spatial_helper_result_hook"]
+            ),
+            "category_input_hook_address": "{:08X}".format(
+                spec["visibility_category_helper_input_hook"]
+            ),
+            "category_result_hook_address": "{:08X}".format(
+                spec["visibility_category_helper_result_hook"]
+            ),
+            "title_result_hook_address": "{:08X}".format(
+                spec["visibility_result"]
+            ),
+            "record_exit_hook_address": "{:08X}".format(
+                spec["visibility_record_exit"]
+            ),
+            "model": "independent_spatial_then_category_selection",
+            "selection_rule": "any_nonzero_predicted_category_result_selects",
+            "bounded_guest_payload_bytes_per_candidate": 148,
+            "scope": "active_title_record_only",
+            "title_outcome_comparison_required": True,
+            "guest_payload_read": "bounded_spatial_and_category_inputs",
+            "guest_state_changed": False,
+            "control_flow_changed": False,
+            "native_policy_execution": "shadow_only",
+            "native_culling_enabled": False,
+            "native_lod_enabled": False,
+            "xenos_authority": True,
+            "suppression_allowed": False,
+        },
         "render_state_function_address": "{:08X}".format(
             spec["render_state_function"]
         ),

--- a/tools/summarize-native-renderer-visibility-assembly-shadow.py
+++ b/tools/summarize-native-renderer-visibility-assembly-shadow.py
@@ -1,0 +1,330 @@
+#!/usr/bin/env python3
+"""Qualify the assembled independent visibility-policy shadow."""
+
+import argparse
+import json
+import pathlib
+import sys
+
+
+SCHEMA = "pinyon-shift.native-renderer-visibility-assembly-shadow.v1"
+CONFIG = (
+    "native_renderer.discovery.semantic_visibility_assembly_shadow_config"
+)
+CATEGORY = (
+    "native_renderer.discovery."
+    "semantic_visibility_assembly_shadow_category_summary"
+)
+SUMMARY = (
+    "native_renderer.discovery.semantic_visibility_assembly_shadow_summary"
+)
+ORACLE_CATEGORY = (
+    "native_renderer.discovery.semantic_visibility_oracle_category_summary"
+)
+SPATIAL_CATEGORY = (
+    "native_renderer.discovery."
+    "semantic_visibility_spatial_shadow_category_summary"
+)
+CATEGORY_SHADOW_CATEGORY = (
+    "native_renderer.discovery."
+    "semantic_visibility_category_shadow_category_summary"
+)
+OUTCOMES = ("early_rejected", "rejected", "selected")
+COUNT_KEYS = (
+    "records",
+    "modelled_records",
+    "predicted_selected",
+    "predicted_rejected",
+    "title_matches",
+    "false_positive",
+    "false_negative",
+    "spatial_input_observations",
+    "spatial_predicted_passes",
+    "category_input_observations",
+    "category_result_0",
+    "category_result_1",
+    "category_result_2",
+    "invalid_inputs",
+)
+
+
+def read_events(paths):
+    events = []
+    for path in paths:
+        for line in path.read_text(encoding="utf-8").splitlines():
+            if line.strip():
+                events.append(json.loads(line))
+    return events
+
+
+def integer(event, key):
+    try:
+        value = int(event[key])
+    except (KeyError, TypeError, ValueError) as error:
+        raise ValueError(f"invalid {key}") from error
+    if value < 0:
+        raise ValueError(f"negative {key}")
+    return value
+
+
+def exact_event(events, name):
+    matches = [event for event in events if event.get("event") == name]
+    if len(matches) != 1:
+        raise ValueError(f"expected exactly one {name} event")
+    return matches[0]
+
+
+def select_session(events, requested):
+    sessions = {
+        event.get("session") for event in events if event.get("event") == CONFIG
+    }
+    sessions.discard(None)
+    if requested:
+        if requested not in sessions:
+            raise ValueError("requested session has no assembly-shadow config")
+        return requested
+    if len(sessions) != 1:
+        raise ValueError("assembly-shadow input contains multiple sessions")
+    return next(iter(sessions))
+
+
+def static_contract(document):
+    try:
+        contract = document["procedural_model_receiver_lifecycle"][
+            "visibility_policy_assembly_shadow"
+        ]
+    except (KeyError, TypeError) as error:
+        raise ValueError("static assembly-shadow contract is missing") from error
+    expected = {
+        "record_entry_hook_address": "82E20094",
+        "spatial_input_hook_address": "82E2034C",
+        "spatial_result_hook_address": "82E20350",
+        "category_input_hook_address": "82E20364",
+        "category_result_hook_address": "82E20368",
+        "title_result_hook_address": "82E206F8",
+        "record_exit_hook_address": "82E2084C",
+        "model": "independent_spatial_then_category_selection",
+        "selection_rule": "any_nonzero_predicted_category_result_selects",
+        "bounded_guest_payload_bytes_per_candidate": 148,
+        "scope": "active_title_record_only",
+        "title_outcome_comparison_required": True,
+        "guest_payload_read": "bounded_spatial_and_category_inputs",
+        "guest_state_changed": False,
+        "control_flow_changed": False,
+        "native_policy_execution": "shadow_only",
+        "native_culling_enabled": False,
+        "native_lod_enabled": False,
+        "xenos_authority": True,
+        "suppression_allowed": False,
+    }
+    if any(contract.get(key) != value for key, value in expected.items()):
+        raise ValueError("static assembly-shadow contract drifted")
+    return contract
+
+
+def validate_counts(item):
+    if (
+        item["modelled_records"] > item["records"]
+        or item["predicted_selected"] + item["predicted_rejected"]
+        != item["modelled_records"]
+        or item["title_matches"]
+        + item["false_positive"]
+        + item["false_negative"]
+        != item["modelled_records"]
+        or item["spatial_predicted_passes"]
+        > item["spatial_input_observations"]
+        or item["category_input_observations"]
+        != item["spatial_predicted_passes"]
+        or item["category_result_0"]
+        + item["category_result_1"]
+        + item["category_result_2"]
+        != item["category_input_observations"]
+        or item["false_positive"]
+        or item["false_negative"]
+        or item["invalid_inputs"]
+    ):
+        raise ValueError("assembly-shadow comparison failed")
+
+
+def indexed(events, name, fields):
+    result = {}
+    for event in events:
+        if event.get("event") != name:
+            continue
+        key = (integer(event, "category"), event.get("outcome"))
+        if key in result or key[1] not in OUTCOMES or event.get("status") != "complete":
+            raise ValueError(f"{name} evidence drifted")
+        result[key] = {field: integer(event, field) for field in fields}
+    return result
+
+
+def build(events, static, requested_session=None):
+    contract = static_contract(static)
+    session = select_session(events, requested_session)
+    selected = [event for event in events if event.get("session") == session]
+    config = exact_event(selected, CONFIG)
+    summary = exact_event(selected, SUMMARY)
+    expected_config = {
+        "status": "armed",
+        "class": "proceduralGeometry::CProceduralModels",
+        "visibility_function": "82E1FD00",
+        "record_entry_hook": "82E20094",
+        "spatial_input_hook": "82E2034C",
+        "spatial_result_hook": "82E20350",
+        "category_input_hook": "82E20364",
+        "category_result_hook": "82E20368",
+        "title_result_hook": "82E206F8",
+        "record_completion_hook": "82E2084C",
+        "model": "independent_spatial_then_category_selection",
+        "selection_rule": "any_nonzero_predicted_category_result_selects",
+        "bounded_guest_payload_bytes_per_candidate": "148",
+        "scope": "active_title_record_only",
+        "classification": "independent_visibility_policy_assembly_shadow",
+        "guest_payload_read": "bounded_spatial_and_category_inputs",
+        "guest_state_changed": "false",
+        "control_flow_changed": "false",
+        "native_policy_execution": "shadow_only",
+        "native_culling": "false",
+        "native_lod": "false",
+        "native_draw": "false",
+        "xenos_authority": "true",
+        "suppression_allowed": "false",
+    }
+    if any(config.get(key) != value for key, value in expected_config.items()):
+        raise ValueError("assembly-shadow runtime configuration drifted")
+    expected_summary = {
+        "status": "complete",
+        "accounting_complete": "true",
+        "model": "independent_spatial_then_category_selection",
+        "scope": "active_title_record_only",
+        "classification": "independent_visibility_policy_assembly_shadow",
+        "guest_payload_read": "bounded_spatial_and_category_inputs",
+        "guest_state_changed": "false",
+        "control_flow_changed": "false",
+        "native_policy_execution": "shadow_only",
+        "native_culling": "false",
+        "native_lod": "false",
+        "xenos_authority": "true",
+        "suppression_allowed": "false",
+    }
+    if any(summary.get(key) != value for key, value in expected_summary.items()):
+        raise ValueError("assembly-shadow summary is incomplete or unsafe")
+    totals = {key: integer(summary, key) for key in COUNT_KEYS}
+    unmodelled_records = integer(summary, "unmodelled_records")
+    validate_counts(totals)
+    if (
+        totals["records"] <= 0
+        or totals["modelled_records"] <= 0
+        or unmodelled_records != totals["records"] - totals["modelled_records"]
+    ):
+        raise ValueError("assembly-shadow aggregate qualification failed")
+
+    oracle = indexed(
+        selected,
+        ORACLE_CATEGORY,
+        ("records", "category_result_0", "category_result_1", "category_result_2"),
+    )
+    spatial = indexed(selected, SPATIAL_CATEGORY, ("input_observations",))
+    category_shadow = indexed(
+        selected, CATEGORY_SHADOW_CATEGORY, ("input_observations",)
+    )
+    categories = {}
+    sums = {key: 0 for key in COUNT_KEYS}
+    for event in selected:
+        if event.get("event") != CATEGORY:
+            continue
+        key = (integer(event, "category"), event.get("outcome"))
+        if (
+            key in categories
+            or key not in oracle
+            or key not in spatial
+            or key not in category_shadow
+            or event.get("status") != "complete"
+            or event.get("native_policy_execution") != "shadow_only"
+            or event.get("guest_payload_read")
+            != "bounded_spatial_and_category_inputs"
+            or event.get("guest_state_changed") != "false"
+            or event.get("xenos_authority") != "true"
+            or event.get("suppression_allowed") != "false"
+        ):
+            raise ValueError("assembly-shadow category evidence drifted")
+        item = {field: integer(event, field) for field in COUNT_KEYS}
+        validate_counts(item)
+        if (
+            item["records"] != oracle[key]["records"]
+            or item["spatial_input_observations"]
+            != spatial[key]["input_observations"]
+            or item["category_input_observations"]
+            != category_shadow[key]["input_observations"]
+            or any(
+                item[f"category_result_{result}"]
+                != oracle[key][f"category_result_{result}"]
+                for result in range(3)
+            )
+        ):
+            raise ValueError("assembly-shadow oracle reconciliation failed")
+        categories[key] = item
+        for field in COUNT_KEYS:
+            sums[field] += item[field]
+    if set(categories) != set(oracle) or any(
+        sums[key] != totals[key] for key in COUNT_KEYS
+    ):
+        raise ValueError("assembly-shadow category totals drifted")
+
+    return {
+        "schema": SCHEMA,
+        "status": "complete",
+        "session": session,
+        "static_contract": contract,
+        "totals": {**totals, "unmodelled_records": unmodelled_records},
+        "categories": {
+            f"{category}:{outcome}": item
+            for (category, outcome), item in sorted(categories.items())
+        },
+        "qualification": {
+            "independent_visibility_policy_assembly_shadow_proved": True,
+            "zero_title_mismatches": True,
+            "ready_for_conservative_native_policy_execution_design": True,
+            "native_policy_execution_enabled": False,
+        },
+        "safety": {
+            "guest_payload_read": "bounded_spatial_and_category_inputs",
+            "guest_state_changed": False,
+            "control_flow_changed": False,
+            "native_culling": False,
+            "native_lod": False,
+            "xenos_authority": True,
+            "suppression_allowed": False,
+        },
+    }
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser()
+    parser.add_argument("events", nargs="+", type=pathlib.Path)
+    parser.add_argument("--static", required=True, type=pathlib.Path)
+    parser.add_argument("--session")
+    parser.add_argument("--output", required=True, type=pathlib.Path)
+    args = parser.parse_args(argv)
+    try:
+        document = build(
+            read_events(args.events),
+            json.loads(args.static.read_text(encoding="utf-8")),
+            args.session,
+        )
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(
+            json.dumps(document, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        return 0
+    except (OSError, ValueError, json.JSONDecodeError) as error:
+        print(
+            f"native renderer visibility assembly shadow summary failed: {error}",
+            file=sys.stderr,
+        )
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/tests/test_native_renderer_contract.py
+++ b/tools/tests/test_native_renderer_contract.py
@@ -232,6 +232,19 @@ class NativeRendererContractTests(unittest.TestCase):
         self.assertIn('"xenos_authority": True', category_shadow_summarizer)
         self.assertIn('"suppression_allowed": False', category_shadow_summarizer)
 
+        assembly_shadow_summarizer = (
+            ROOT
+            / "tools/summarize-native-renderer-visibility-assembly-shadow.py"
+        ).read_text(encoding="utf-8")
+        self.assertIn("independent_visibility_policy_assembly_shadow", source)
+        self.assertIn(
+            '"guest_payload_read": "bounded_spatial_and_category_inputs"',
+            assembly_shadow_summarizer,
+        )
+        self.assertIn('"guest_state_changed": False', assembly_shadow_summarizer)
+        self.assertIn('"xenos_authority": True', assembly_shadow_summarizer)
+        self.assertIn('"suppression_allowed": False', assembly_shadow_summarizer)
+
     def test_exact_pass_consumer_trace_is_bounded_and_fail_closed(self):
         source = (ROOT / "src/native_renderer/graphics_hooks.cpp").read_text(
             encoding="utf-8"

--- a/tools/tests/test_native_renderer_dispatch_discovery.py
+++ b/tools/tests/test_native_renderer_dispatch_discovery.py
@@ -1346,6 +1346,33 @@ class NativeRendererDispatchDiscoveryTests(unittest.TestCase):
         self.assertFalse(category_shadow["guest_state_changed"])
         self.assertTrue(category_shadow["xenos_authority"])
         self.assertFalse(category_shadow["suppression_allowed"])
+        assembly_shadow = lifecycle["visibility_policy_assembly_shadow"]
+        self.assertEqual("82E20094", assembly_shadow["record_entry_hook_address"])
+        self.assertEqual("82E2034C", assembly_shadow["spatial_input_hook_address"])
+        self.assertEqual("82E20350", assembly_shadow["spatial_result_hook_address"])
+        self.assertEqual("82E20364", assembly_shadow["category_input_hook_address"])
+        self.assertEqual("82E20368", assembly_shadow["category_result_hook_address"])
+        self.assertEqual("82E206F8", assembly_shadow["title_result_hook_address"])
+        self.assertEqual("82E2084C", assembly_shadow["record_exit_hook_address"])
+        self.assertEqual(
+            "independent_spatial_then_category_selection",
+            assembly_shadow["model"],
+        )
+        self.assertEqual(
+            "any_nonzero_predicted_category_result_selects",
+            assembly_shadow["selection_rule"],
+        )
+        self.assertEqual(
+            148, assembly_shadow["bounded_guest_payload_bytes_per_candidate"]
+        )
+        self.assertEqual(
+            "bounded_spatial_and_category_inputs",
+            assembly_shadow["guest_payload_read"],
+        )
+        self.assertEqual("shadow_only", assembly_shadow["native_policy_execution"])
+        self.assertFalse(assembly_shadow["guest_state_changed"])
+        self.assertTrue(assembly_shadow["xenos_authority"])
+        self.assertFalse(assembly_shadow["suppression_allowed"])
         self.assertEqual(
             92, lifecycle["field_layout"]["descriptor_record_stride"]
         )

--- a/tools/tests/test_native_renderer_visibility_assembly_shadow.py
+++ b/tools/tests/test_native_renderer_visibility_assembly_shadow.py
@@ -1,0 +1,235 @@
+import copy
+import importlib.util
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).parents[2]
+TOOL = ROOT / "tools/summarize-native-renderer-visibility-assembly-shadow.py"
+SPEC = importlib.util.spec_from_file_location("visibility_assembly_shadow", TOOL)
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+class VisibilityAssemblyShadowReportTests(unittest.TestCase):
+    def static(self):
+        return {
+            "procedural_model_receiver_lifecycle": {
+                "visibility_policy_assembly_shadow": {
+                    "record_entry_hook_address": "82E20094",
+                    "spatial_input_hook_address": "82E2034C",
+                    "spatial_result_hook_address": "82E20350",
+                    "category_input_hook_address": "82E20364",
+                    "category_result_hook_address": "82E20368",
+                    "title_result_hook_address": "82E206F8",
+                    "record_exit_hook_address": "82E2084C",
+                    "model": "independent_spatial_then_category_selection",
+                    "selection_rule": (
+                        "any_nonzero_predicted_category_result_selects"
+                    ),
+                    "bounded_guest_payload_bytes_per_candidate": 148,
+                    "scope": "active_title_record_only",
+                    "title_outcome_comparison_required": True,
+                    "guest_payload_read": "bounded_spatial_and_category_inputs",
+                    "guest_state_changed": False,
+                    "control_flow_changed": False,
+                    "native_policy_execution": "shadow_only",
+                    "native_culling_enabled": False,
+                    "native_lod_enabled": False,
+                    "xenos_authority": True,
+                    "suppression_allowed": False,
+                }
+            }
+        }
+
+    def config(self):
+        return {
+            "event": MODULE.CONFIG,
+            "session": "test",
+            "status": "armed",
+            "class": "proceduralGeometry::CProceduralModels",
+            "visibility_function": "82E1FD00",
+            "record_entry_hook": "82E20094",
+            "spatial_input_hook": "82E2034C",
+            "spatial_result_hook": "82E20350",
+            "category_input_hook": "82E20364",
+            "category_result_hook": "82E20368",
+            "title_result_hook": "82E206F8",
+            "record_completion_hook": "82E2084C",
+            "model": "independent_spatial_then_category_selection",
+            "selection_rule": "any_nonzero_predicted_category_result_selects",
+            "bounded_guest_payload_bytes_per_candidate": "148",
+            "scope": "active_title_record_only",
+            "classification": "independent_visibility_policy_assembly_shadow",
+            "guest_payload_read": "bounded_spatial_and_category_inputs",
+            "guest_state_changed": "false",
+            "control_flow_changed": "false",
+            "native_policy_execution": "shadow_only",
+            "native_culling": "false",
+            "native_lod": "false",
+            "native_draw": "false",
+            "xenos_authority": "true",
+            "suppression_allowed": "false",
+        }
+
+    def row(self, outcome, records, modelled, selected, results):
+        rejected = modelled - selected
+        spatial_inputs = sum(results) + (1 if outcome == "early_rejected" else 2)
+        base = {
+            "session": "test",
+            "status": "complete",
+            "category": "9",
+            "outcome": outcome,
+        }
+        return [
+            {
+                **base,
+                "event": MODULE.ORACLE_CATEGORY,
+                "records": str(records),
+                "category_result_0": str(results[0]),
+                "category_result_1": str(results[1]),
+                "category_result_2": str(results[2]),
+            },
+            {
+                **base,
+                "event": MODULE.SPATIAL_CATEGORY,
+                "input_observations": str(spatial_inputs),
+            },
+            {
+                **base,
+                "event": MODULE.CATEGORY_SHADOW_CATEGORY,
+                "input_observations": str(sum(results)),
+            },
+            {
+                **base,
+                "event": MODULE.CATEGORY,
+                "records": str(records),
+                "modelled_records": str(modelled),
+                "predicted_selected": str(selected),
+                "predicted_rejected": str(rejected),
+                "title_matches": str(modelled),
+                "false_positive": "0",
+                "false_negative": "0",
+                "spatial_input_observations": str(spatial_inputs),
+                "spatial_predicted_passes": str(sum(results)),
+                "category_input_observations": str(sum(results)),
+                "category_result_0": str(results[0]),
+                "category_result_1": str(results[1]),
+                "category_result_2": str(results[2]),
+                "invalid_inputs": "0",
+                "native_policy_execution": "shadow_only",
+                "guest_payload_read": "bounded_spatial_and_category_inputs",
+                "guest_state_changed": "false",
+                "xenos_authority": "true",
+                "suppression_allowed": "false",
+            },
+        ]
+
+    def events(self):
+        rows = [
+            ("early_rejected", 4, 0, 0, (0, 0, 0)),
+            ("rejected", 2, 2, 0, (4, 0, 0)),
+            ("selected", 1, 1, 1, (0, 1, 2)),
+        ]
+        events = [self.config()]
+        for row in rows:
+            events.extend(self.row(*row))
+        events.append(
+            {
+                "event": MODULE.SUMMARY,
+                "session": "test",
+                "status": "complete",
+                "records": "7",
+                "modelled_records": "3",
+                "unmodelled_records": "4",
+                "predicted_selected": "1",
+                "predicted_rejected": "2",
+                "title_matches": "3",
+                "false_positive": "0",
+                "false_negative": "0",
+                "spatial_input_observations": "12",
+                "spatial_predicted_passes": "7",
+                "category_input_observations": "7",
+                "category_result_0": "4",
+                "category_result_1": "1",
+                "category_result_2": "2",
+                "invalid_inputs": "0",
+                "accounting_complete": "true",
+                "model": "independent_spatial_then_category_selection",
+                "scope": "active_title_record_only",
+                "classification": "independent_visibility_policy_assembly_shadow",
+                "guest_payload_read": "bounded_spatial_and_category_inputs",
+                "guest_state_changed": "false",
+                "control_flow_changed": "false",
+                "native_policy_execution": "shadow_only",
+                "native_culling": "false",
+                "native_lod": "false",
+                "xenos_authority": "true",
+                "suppression_allowed": "false",
+            }
+        )
+        return events
+
+    def assembly_event(self, events, outcome="selected"):
+        return next(
+            event
+            for event in events
+            if event.get("event") == MODULE.CATEGORY
+            and event.get("outcome") == outcome
+        )
+
+    def test_build_qualifies_independent_policy_assembly(self):
+        document = MODULE.build(self.events(), self.static())
+        self.assertEqual("complete", document["status"])
+        self.assertEqual(3, document["totals"]["title_matches"])
+        self.assertTrue(
+            document["qualification"][
+                "independent_visibility_policy_assembly_shadow_proved"
+            ]
+        )
+        self.assertFalse(document["safety"]["guest_state_changed"])
+        self.assertTrue(document["safety"]["xenos_authority"])
+
+    def test_build_rejects_false_positive(self):
+        events = copy.deepcopy(self.events())
+        item = self.assembly_event(events)
+        item["title_matches"] = "0"
+        item["false_positive"] = "1"
+        with self.assertRaisesRegex(ValueError, "comparison failed"):
+            MODULE.build(events, self.static())
+
+    def test_build_rejects_invalid_input(self):
+        events = copy.deepcopy(self.events())
+        self.assembly_event(events)["invalid_inputs"] = "1"
+        with self.assertRaisesRegex(ValueError, "comparison failed"):
+            MODULE.build(events, self.static())
+
+    def test_build_rejects_oracle_result_drift(self):
+        events = copy.deepcopy(self.events())
+        oracle = next(
+            event
+            for event in events
+            if event.get("event") == MODULE.ORACLE_CATEGORY
+            and event.get("outcome") == "selected"
+        )
+        oracle["category_result_2"] = "1"
+        with self.assertRaisesRegex(ValueError, "oracle reconciliation failed"):
+            MODULE.build(events, self.static())
+
+    def test_build_rejects_static_contract_drift(self):
+        static = self.static()
+        static["procedural_model_receiver_lifecycle"][
+            "visibility_policy_assembly_shadow"
+        ]["suppression_allowed"] = True
+        with self.assertRaisesRegex(ValueError, "contract drifted"):
+            MODULE.build(self.events(), static)
+
+    def test_build_rejects_runtime_safety_drift(self):
+        events = copy.deepcopy(self.events())
+        events[0]["xenos_authority"] = "false"
+        with self.assertRaisesRegex(ValueError, "configuration drifted"):
+            MODULE.build(events, self.static())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- assemble independent spatial and category mirrors into a record-level visibility decision
- reconcile category/outcome accounting against the title oracle and prior qualified shadows
- keep native culling, LOD, drawing, control-flow changes, and Xenos suppression disabled

## Validation
- 299 native-renderer tests passed
- Release build passed
- AppData session \20260830T011157Z-p1896\: 1,572,434 records, 223,473 spatial/category comparisons, 26,979 assembled decisions, zero mismatches or invalid inputs
- 30.318 median FPS, 19.396 FPS 1% low, zero present-deadline misses
- normal exit and clean fatal-log scan