### PR TITLE
feat(native-renderer): materialize visibility candidate workset

### DIFF
--- a/docs/native-renderer/VISIBILITY_POLICY_ABI.md
+++ b/docs/native-renderer/VISIBILITY_POLICY_ABI.md
@@ -270,3 +270,40 @@ performance was 30.318 FPS over 8,063 frames, with a 19.396 FPS one-percent low
 and zero present-deadline misses. This qualifies the independent assembly for
 conservative native policy-execution design while execution and suppression
 remain disabled and Xenos stays authoritative.
+
+## Bounded native visibility workset
+
+The first policy-execution boundary materializes every valid independent
+record decision into a fixed 4,096-entry host workset keyed by receiver
+address, receiver generation, and record index. Only the qualified spatial and
+category inputs feed the decision. The title result remains a comparison
+oracle and is never used to select the workset outcome.
+
+The semantic-instance extraction hook is an upstream superset boundary. It
+joins each observed record back to the latest workset entry using the same
+exact identity. A selected join admits the record to the native
+semantic-candidate stream. Rejected joins and missing joins are deliberately
+excluded from that stream and retain Xenos replay; they describe records that
+reach the broad helper boundary without an independently selected workset
+decision, rather than native admission failures.
+
+This is a real host-side policy handoff, but not title-side culling. It writes
+no guest state, changes no title control flow, chooses no native LOD, uploads no
+resource, issues no native draw, and cannot suppress Xenos. The workset,
+assembly shadow, and semantic-instance summaries must reconcile in one runtime
+session with zero overflow, invalid records, or title mismatches, and at least
+one exact selected join, before a native drawing consumer may rely on the
+filtered candidate stream. Rejected and missing observations remain accounted
+fail-closed exclusions and can never enter that stream.
+
+Release/AppData session `20260830T012818Z-p42316` proved that the semantic
+helper is a superset boundary rather than a post-cull draw boundary. The
+workset materialized 20,013 independently modelled decisions (8,920 selected
+and 11,093 rejected) across 11 exact identities, with zero overflow, invalid
+records, or title mismatches. Of 398,460 semantic-instance observations,
+9,983 exact selected joins entered the candidate stream; 33,610 exact rejected
+joins and 354,867 observations without a workset identity were excluded and
+left on Xenos replay. All visibility reports reconciled, the process exited
+normally with a clean fatal scan, and median performance was 30.241 FPS over
+8,762 frames with a 19.518 FPS one-percent low and zero present-deadline
+misses.

--- a/src/native_renderer/graphics_hooks.cpp
+++ b/src/native_renderer/graphics_hooks.cpp
@@ -94,6 +94,7 @@ constexpr size_t kSemanticVisibilityLodCapacity = 32;
 constexpr size_t kSemanticVisibilityResultValueCapacity = 256;
 constexpr size_t kSemanticVisibilityPolicyOutcomeCapacity = 3;
 constexpr size_t kSemanticVisibilitySpatialExponentCapacity = 256;
+constexpr size_t kSemanticVisibilityWorksetCapacity = 4096;
 constexpr size_t kSemanticInstanceCapacity = 4096;
 constexpr size_t kSemanticSubmissionCapacity = 8192;
 constexpr size_t kSemanticRenderItemStackCapacity = 32;
@@ -695,6 +696,24 @@ struct SemanticVisibilityAssemblyShadowStats {
   std::atomic<uint64_t> invalid_inputs{};
 };
 
+struct SemanticVisibilityWorksetEntry {
+  uint64_t key = 0;
+  uint64_t observations = 0;
+  uint64_t first_frame = 0;
+  uint64_t last_frame = 0;
+  uint64_t predicted_selected = 0;
+  uint64_t predicted_rejected = 0;
+  uint64_t title_matches = 0;
+  uint64_t title_mismatches = 0;
+  uint64_t semantic_instance_joins = 0;
+  uint32_t receiver_address = 0;
+  uint32_t receiver_generation = 0;
+  uint32_t record_index = 0;
+  uint32_t category = 0;
+  uint32_t latest_category_result_mask = 0;
+  bool latest_selected = false;
+};
+
 std::atomic<uint64_t> g_semantic_visibility_record_entries{};
 std::atomic<uint64_t> g_semantic_visibility_record_completions{};
 std::atomic<uint64_t> g_semantic_visibility_records_open{};
@@ -772,6 +791,22 @@ std::array<std::array<SemanticVisibilityAssemblyShadowStats,
                       kSemanticVisibilityPolicyOutcomeCapacity>,
            kSemanticVisibilityCategoryCapacity>
     g_semantic_visibility_assembly_shadow_categories{};
+std::array<SemanticVisibilityWorksetEntry,
+           kSemanticVisibilityWorksetCapacity>
+    g_semantic_visibility_workset{};
+std::mutex g_semantic_visibility_workset_mutex;
+uint64_t g_semantic_visibility_workset_modelled_records = 0;
+uint64_t g_semantic_visibility_workset_predicted_selected = 0;
+uint64_t g_semantic_visibility_workset_predicted_rejected = 0;
+uint64_t g_semantic_visibility_workset_title_matches = 0;
+uint64_t g_semantic_visibility_workset_title_mismatches = 0;
+uint64_t g_semantic_visibility_workset_invalid_records = 0;
+uint64_t g_semantic_visibility_workset_entries = 0;
+uint64_t g_semantic_visibility_workset_overflow = 0;
+uint64_t g_semantic_visibility_workset_semantic_instance_lookups = 0;
+uint64_t g_semantic_visibility_workset_selected_joins = 0;
+uint64_t g_semantic_visibility_workset_rejected_joins = 0;
+uint64_t g_semantic_visibility_workset_missing_joins = 0;
 
 struct SemanticInstanceEntry {
   uint64_t key = 0;
@@ -1100,6 +1135,123 @@ struct ActiveSemanticVisibilityRecord {
 };
 thread_local ActiveSemanticVisibilityRecord
     g_active_semantic_visibility_record{};
+
+enum class SemanticVisibilityWorksetJoin {
+  kMissing,
+  kSelected,
+  kRejected,
+};
+
+uint64_t SemanticVisibilityWorksetKey(uint32_t receiver_address,
+                                      uint32_t receiver_generation,
+                                      uint32_t record_index) {
+  uint64_t hash = UINT64_C(0xCBF29CE484222325);
+  for (uint32_t value :
+       {receiver_address, receiver_generation, record_index}) {
+    hash ^= value;
+    hash *= UINT64_C(0x100000001B3);
+  }
+  return hash ? hash : 1;
+}
+
+void PublishSemanticVisibilityWorkset(
+    const ActiveSemanticVisibilityRecord &record,
+    uint32_t invalid_inputs) {
+  if (!record.category_shadow_input_observations || !record.joined ||
+      invalid_inputs) {
+    if (record.category_shadow_input_observations) {
+      std::scoped_lock lock(g_semantic_visibility_workset_mutex);
+      ++g_semantic_visibility_workset_invalid_records;
+    }
+    return;
+  }
+  const bool predicted_selected =
+      record.assembly_category_predictions[1] != 0 ||
+      record.assembly_category_predictions[2] != 0;
+  const bool title_selected = record.result_seen && record.selected;
+  const uint32_t result_mask =
+      uint32_t(record.assembly_category_predictions[0] != 0) |
+      (uint32_t(record.assembly_category_predictions[1] != 0) << 1) |
+      (uint32_t(record.assembly_category_predictions[2] != 0) << 2);
+  const uint64_t key = SemanticVisibilityWorksetKey(
+      record.receiver_address, record.receiver_generation,
+      record.record_index);
+  const uint64_t frame = g_frame_sequence.load(std::memory_order_relaxed);
+
+  std::scoped_lock lock(g_semantic_visibility_workset_mutex);
+  ++g_semantic_visibility_workset_modelled_records;
+  ++(predicted_selected
+         ? g_semantic_visibility_workset_predicted_selected
+         : g_semantic_visibility_workset_predicted_rejected);
+  ++(predicted_selected == title_selected
+         ? g_semantic_visibility_workset_title_matches
+         : g_semantic_visibility_workset_title_mismatches);
+  size_t index = size_t(key % kSemanticVisibilityWorksetCapacity);
+  for (size_t probe = 0; probe < kSemanticVisibilityWorksetCapacity;
+       ++probe) {
+    SemanticVisibilityWorksetEntry &entry =
+        g_semantic_visibility_workset[index];
+    if (!entry.key) {
+      entry.key = key;
+      entry.first_frame = frame;
+      entry.receiver_address = record.receiver_address;
+      entry.receiver_generation = record.receiver_generation;
+      entry.record_index = record.record_index;
+      entry.category = record.category;
+      ++g_semantic_visibility_workset_entries;
+    }
+    if (entry.key == key &&
+        entry.receiver_address == record.receiver_address &&
+        entry.receiver_generation == record.receiver_generation &&
+        entry.record_index == record.record_index) {
+      ++entry.observations;
+      entry.last_frame = frame;
+      ++(predicted_selected ? entry.predicted_selected
+                            : entry.predicted_rejected);
+      ++(predicted_selected == title_selected ? entry.title_matches
+                                              : entry.title_mismatches);
+      entry.category = record.category;
+      entry.latest_category_result_mask = result_mask;
+      entry.latest_selected = predicted_selected;
+      return;
+    }
+    index = (index + 1) % kSemanticVisibilityWorksetCapacity;
+  }
+  ++g_semantic_visibility_workset_overflow;
+}
+
+SemanticVisibilityWorksetJoin JoinSemanticVisibilityWorkset(
+    uint32_t receiver_address, uint32_t receiver_generation,
+    uint32_t record_index) {
+  const uint64_t key = SemanticVisibilityWorksetKey(
+      receiver_address, receiver_generation, record_index);
+  std::scoped_lock lock(g_semantic_visibility_workset_mutex);
+  ++g_semantic_visibility_workset_semantic_instance_lookups;
+  size_t index = size_t(key % kSemanticVisibilityWorksetCapacity);
+  for (size_t probe = 0; probe < kSemanticVisibilityWorksetCapacity;
+       ++probe) {
+    SemanticVisibilityWorksetEntry &entry =
+        g_semantic_visibility_workset[index];
+    if (!entry.key) {
+      ++g_semantic_visibility_workset_missing_joins;
+      return SemanticVisibilityWorksetJoin::kMissing;
+    }
+    if (entry.key == key && entry.receiver_address == receiver_address &&
+        entry.receiver_generation == receiver_generation &&
+        entry.record_index == record_index) {
+      ++entry.semantic_instance_joins;
+      if (entry.latest_selected) {
+        ++g_semantic_visibility_workset_selected_joins;
+        return SemanticVisibilityWorksetJoin::kSelected;
+      }
+      ++g_semantic_visibility_workset_rejected_joins;
+      return SemanticVisibilityWorksetJoin::kRejected;
+    }
+    index = (index + 1) % kSemanticVisibilityWorksetCapacity;
+  }
+  ++g_semantic_visibility_workset_missing_joins;
+  return SemanticVisibilityWorksetJoin::kMissing;
+}
 thread_local std::array<SemanticReceiverStageScope,
                         kSemanticReceiverStackCapacity>
     g_semantic_render_state_stack{};
@@ -1497,6 +1649,22 @@ void ResetTitleDrawProvenance() {
       0, std::memory_order_relaxed);
   g_semantic_visibility_duplicate_descriptor_threshold.store(
       0, std::memory_order_relaxed);
+  {
+    std::scoped_lock lock(g_semantic_visibility_workset_mutex);
+    g_semantic_visibility_workset = {};
+    g_semantic_visibility_workset_modelled_records = 0;
+    g_semantic_visibility_workset_predicted_selected = 0;
+    g_semantic_visibility_workset_predicted_rejected = 0;
+    g_semantic_visibility_workset_title_matches = 0;
+    g_semantic_visibility_workset_title_mismatches = 0;
+    g_semantic_visibility_workset_invalid_records = 0;
+    g_semantic_visibility_workset_entries = 0;
+    g_semantic_visibility_workset_overflow = 0;
+    g_semantic_visibility_workset_semantic_instance_lookups = 0;
+    g_semantic_visibility_workset_selected_joins = 0;
+    g_semantic_visibility_workset_rejected_joins = 0;
+    g_semantic_visibility_workset_missing_joins = 0;
+  }
   {
     std::scoped_lock lock(g_semantic_instance_mutex);
     std::memset(g_semantic_instances.data(), 0, sizeof(g_semantic_instances));
@@ -2948,6 +3116,7 @@ void EndSemanticVisibilityRecord(uint32_t receiver_address,
                  record.category_shadow_comparisons);
     assembly.invalid_inputs.fetch_add(assembly_invalid_inputs,
                                       std::memory_order_relaxed);
+    PublishSemanticVisibilityWorkset(record, assembly_invalid_inputs);
     if (record.category_shadow_input_observations) {
       assembly.modelled_records.fetch_add(1, std::memory_order_relaxed);
       const bool predicted_selected =
@@ -4838,6 +5007,8 @@ bool RecordProceduralModelSemanticInstance(
   const uint64_t descriptor_hash = HashSemanticWords(descriptor_words);
   const uint64_t runtime_hash = HashSemanticWords(runtime_words);
   const uint64_t transform_hash = HashSemanticWords(transform_words);
+  JoinSemanticVisibilityWorkset(receiver_address, receiver_generation,
+                                record_index);
   ++g_semantic_instance_live_observations;
   g_semantic_instance_payload_bytes += kSemanticObservationPayloadBytes;
   ++g_semantic_instance_replay_fallbacks;
@@ -4951,6 +5122,118 @@ void EndProceduralModelRenderItem() {
   }
   --g_semantic_render_item_stack_depth;
   g_semantic_render_items_open.fetch_sub(1, std::memory_order_relaxed);
+}
+
+void EmitSemanticVisibilityWorkset() {
+  std::scoped_lock lock(g_semantic_visibility_workset_mutex);
+  uint64_t entry_observations = 0;
+  uint64_t entry_selected = 0;
+  uint64_t entry_rejected = 0;
+  uint64_t entry_title_matches = 0;
+  uint64_t entry_title_mismatches = 0;
+  uint64_t entry_semantic_joins = 0;
+  for (const SemanticVisibilityWorksetEntry &entry :
+       g_semantic_visibility_workset) {
+    if (!entry.key) {
+      continue;
+    }
+    entry_observations += entry.observations;
+    entry_selected += entry.predicted_selected;
+    entry_rejected += entry.predicted_rejected;
+    entry_title_matches += entry.title_matches;
+    entry_title_mismatches += entry.title_mismatches;
+    entry_semantic_joins += entry.semantic_instance_joins;
+    pinyon_shift::diagnostics::RecordEvent(
+        "native_renderer.discovery.semantic_visibility_workset_entry",
+        {{"status", "complete"},
+         {"key", fmt::format("{:016X}", entry.key)},
+         {"receiver_address",
+          fmt::format("{:08X}", entry.receiver_address)},
+         {"receiver_generation",
+          std::to_string(entry.receiver_generation)},
+         {"record_index", std::to_string(entry.record_index)},
+         {"category", std::to_string(entry.category)},
+         {"observations", std::to_string(entry.observations)},
+         {"first_frame", std::to_string(entry.first_frame)},
+         {"last_frame", std::to_string(entry.last_frame)},
+         {"predicted_selected",
+          std::to_string(entry.predicted_selected)},
+         {"predicted_rejected",
+          std::to_string(entry.predicted_rejected)},
+         {"title_matches", std::to_string(entry.title_matches)},
+         {"title_mismatches", std::to_string(entry.title_mismatches)},
+         {"semantic_instance_joins",
+          std::to_string(entry.semantic_instance_joins)},
+         {"latest_category_result_mask",
+          std::to_string(entry.latest_category_result_mask)},
+         {"latest_selected", entry.latest_selected ? "true" : "false"},
+         {"execution", "bounded_host_visibility_workset"},
+         {"guest_state_changed", "false"},
+         {"title_culling_changed", "false"},
+         {"native_draw", "false"},
+         {"xenos_authority", "true"},
+         {"suppression_allowed", "false"}});
+  }
+  const bool accounting_complete =
+      g_semantic_visibility_workset_modelled_records ==
+          g_semantic_visibility_workset_predicted_selected +
+              g_semantic_visibility_workset_predicted_rejected &&
+      g_semantic_visibility_workset_modelled_records ==
+          g_semantic_visibility_workset_title_matches +
+              g_semantic_visibility_workset_title_mismatches &&
+      g_semantic_visibility_workset_modelled_records ==
+          entry_observations + g_semantic_visibility_workset_overflow &&
+      g_semantic_visibility_workset_predicted_selected == entry_selected &&
+      g_semantic_visibility_workset_predicted_rejected == entry_rejected &&
+      g_semantic_visibility_workset_title_matches == entry_title_matches &&
+      g_semantic_visibility_workset_title_mismatches ==
+          entry_title_mismatches &&
+      g_semantic_visibility_workset_semantic_instance_lookups ==
+          g_semantic_visibility_workset_selected_joins +
+              g_semantic_visibility_workset_rejected_joins +
+              g_semantic_visibility_workset_missing_joins &&
+      entry_semantic_joins ==
+          g_semantic_visibility_workset_selected_joins +
+              g_semantic_visibility_workset_rejected_joins;
+  pinyon_shift::diagnostics::RecordEvent(
+      "native_renderer.discovery.semantic_visibility_workset_summary",
+      {{"status", accounting_complete ? "complete" : "incomplete"},
+       {"modelled_records",
+        std::to_string(g_semantic_visibility_workset_modelled_records)},
+       {"predicted_selected",
+        std::to_string(g_semantic_visibility_workset_predicted_selected)},
+       {"predicted_rejected",
+        std::to_string(g_semantic_visibility_workset_predicted_rejected)},
+       {"title_matches",
+        std::to_string(g_semantic_visibility_workset_title_matches)},
+       {"title_mismatches",
+        std::to_string(g_semantic_visibility_workset_title_mismatches)},
+       {"invalid_records",
+        std::to_string(g_semantic_visibility_workset_invalid_records)},
+       {"entries", std::to_string(g_semantic_visibility_workset_entries)},
+       {"entry_observations", std::to_string(entry_observations)},
+       {"capacity", std::to_string(kSemanticVisibilityWorksetCapacity)},
+       {"overflow", std::to_string(g_semantic_visibility_workset_overflow)},
+       {"semantic_instance_lookups",
+        std::to_string(
+            g_semantic_visibility_workset_semantic_instance_lookups)},
+       {"selected_joins",
+        std::to_string(g_semantic_visibility_workset_selected_joins)},
+       {"rejected_joins",
+        std::to_string(g_semantic_visibility_workset_rejected_joins)},
+       {"missing_joins",
+        std::to_string(g_semantic_visibility_workset_missing_joins)},
+       {"accounting_complete", accounting_complete ? "true" : "false"},
+       {"model", "independent_policy_to_semantic_candidate_handoff"},
+       {"identity", "receiver_generation_record_index"},
+       {"execution", "bounded_host_visibility_workset"},
+       {"guest_state_changed", "false"},
+       {"control_flow_changed", "false"},
+       {"title_culling_changed", "false"},
+       {"native_lod", "false"},
+       {"native_draw", "false"},
+       {"xenos_authority", "true"},
+       {"suppression_allowed", "false"}});
 }
 
 void EmitProceduralModelSemanticInstances() {
@@ -7615,6 +7898,7 @@ void RecordPreparedCommandBufferLineage(
 }
 
 void EmitCommandBufferLineageSummary() {
+  EmitSemanticVisibilityWorkset();
   EmitProceduralModelSemanticInstances();
   EmitProceduralModelSemanticSubmissions();
   for (const CommandBufferLineageEntry &entry : g_command_buffer_lineages) {
@@ -13625,6 +13909,25 @@ void InstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system,
        {"control_flow_changed", "false"},
        {"native_policy_execution", "shadow_only"},
        {"native_culling", "false"},
+       {"native_lod", "false"},
+       {"native_draw", "false"},
+       {"xenos_authority", "true"},
+       {"suppression_allowed", "false"}});
+  diagnostics::RecordEvent(
+      "native_renderer.discovery.semantic_visibility_workset_config",
+      {{"status", lineage_armed ? "armed" : "disabled"},
+       {"class", "proceduralGeometry::CProceduralModels"},
+       {"record_completion_hook", "82E2084C"},
+       {"semantic_instance_hook", "8241741C"},
+       {"capacity", std::to_string(kSemanticVisibilityWorksetCapacity)},
+       {"model", "independent_policy_to_semantic_candidate_handoff"},
+       {"identity", "receiver_generation_record_index"},
+       {"selection_rule", "any_nonzero_predicted_category_result_selects"},
+       {"execution", "bounded_host_visibility_workset"},
+       {"guest_payload_read", "qualified_policy_inputs_only"},
+       {"guest_state_changed", "false"},
+       {"control_flow_changed", "false"},
+       {"title_culling_changed", "false"},
        {"native_lod", "false"},
        {"native_draw", "false"},
        {"xenos_authority", "true"},

--- a/tools/discover-native-renderer-dispatch.py
+++ b/tools/discover-native-renderer-dispatch.py
@@ -1588,6 +1588,27 @@ def procedural_model_receiver_lifecycle(
             "xenos_authority": True,
             "suppression_allowed": False,
         },
+        "visibility_policy_workset": {
+            "record_completion_hook_address": "{:08X}".format(
+                spec["visibility_record_exit"]
+            ),
+            "semantic_instance_hook_address": "{:08X}".format(
+                spec["render_item_entry_hook"]
+            ),
+            "capacity": 4096,
+            "model": "independent_policy_to_semantic_candidate_handoff",
+            "identity": "receiver_generation_record_index",
+            "selection_rule": "any_nonzero_predicted_category_result_selects",
+            "execution": "bounded_host_visibility_workset",
+            "guest_payload_read": "qualified_policy_inputs_only",
+            "guest_state_changed": False,
+            "control_flow_changed": False,
+            "title_culling_changed": False,
+            "native_lod_enabled": False,
+            "native_draw_enabled": False,
+            "xenos_authority": True,
+            "suppression_allowed": False,
+        },
         "render_state_function_address": "{:08X}".format(
             spec["render_state_function"]
         ),

--- a/tools/summarize-native-renderer-visibility-workset.py
+++ b/tools/summarize-native-renderer-visibility-workset.py
@@ -1,0 +1,340 @@
+#!/usr/bin/env python3
+"""Qualify the native visibility workset and semantic-instance handoff."""
+
+import argparse
+import json
+import pathlib
+import sys
+
+
+SCHEMA = "pinyon-shift.native-renderer-visibility-workset.v1"
+STATIC_SCHEMA = "pinyon-shift.native-renderer-dispatch-static.v3"
+CONFIG = "native_renderer.discovery.semantic_visibility_workset_config"
+ENTRY = "native_renderer.discovery.semantic_visibility_workset_entry"
+SUMMARY = "native_renderer.discovery.semantic_visibility_workset_summary"
+ASSEMBLY = (
+    "native_renderer.discovery.semantic_visibility_assembly_shadow_summary"
+)
+SEMANTIC_INSTANCES = "native_renderer.discovery.semantic_instance_summary"
+
+
+def read_events(paths):
+    events = []
+    for path in paths:
+        for line in path.read_text(encoding="utf-8").splitlines():
+            if line.strip():
+                events.append(json.loads(line))
+    return events
+
+
+def integer(mapping, key):
+    try:
+        value = int(mapping[key])
+    except (KeyError, TypeError, ValueError) as error:
+        raise ValueError(f"invalid {key}") from error
+    if value < 0:
+        raise ValueError(f"negative {key}")
+    return value
+
+
+def hexadecimal(mapping, key, width):
+    value = str(mapping.get(key, "")).upper()
+    if len(value) != width:
+        raise ValueError(f"invalid {key}")
+    try:
+        int(value, 16)
+    except ValueError as error:
+        raise ValueError(f"invalid {key}") from error
+    return value
+
+
+def exact_event(events, name):
+    matches = [event for event in events if event.get("event") == name]
+    if len(matches) != 1:
+        raise ValueError(f"expected exactly one {name} event")
+    return matches[0]
+
+
+def select_session(events, requested):
+    sessions = {
+        event.get("session") for event in events if event.get("event") == CONFIG
+    }
+    sessions.discard(None)
+    if requested:
+        if requested not in sessions:
+            raise ValueError("requested session has no visibility-workset config")
+        return requested
+    if len(sessions) != 1:
+        raise ValueError("visibility-workset input contains multiple sessions")
+    return next(iter(sessions))
+
+
+def static_contract(document):
+    if document.get("schema") != STATIC_SCHEMA:
+        raise ValueError("unsupported static dispatch inventory schema")
+    try:
+        contract = document["procedural_model_receiver_lifecycle"][
+            "visibility_policy_workset"
+        ]
+    except (KeyError, TypeError) as error:
+        raise ValueError("static visibility-workset contract is missing") from error
+    expected = {
+        "record_completion_hook_address": "82E2084C",
+        "semantic_instance_hook_address": "8241741C",
+        "capacity": 4096,
+        "model": "independent_policy_to_semantic_candidate_handoff",
+        "identity": "receiver_generation_record_index",
+        "selection_rule": "any_nonzero_predicted_category_result_selects",
+        "execution": "bounded_host_visibility_workset",
+        "guest_payload_read": "qualified_policy_inputs_only",
+        "guest_state_changed": False,
+        "control_flow_changed": False,
+        "title_culling_changed": False,
+        "native_lod_enabled": False,
+        "native_draw_enabled": False,
+        "xenos_authority": True,
+        "suppression_allowed": False,
+    }
+    if any(contract.get(key) != value for key, value in expected.items()):
+        raise ValueError("static visibility-workset contract drifted")
+    return contract
+
+
+def require_safety(event, *, entry=False):
+    expected = {
+        "execution": "bounded_host_visibility_workset",
+        "guest_state_changed": "false",
+        "title_culling_changed": "false",
+        "native_draw": "false",
+        "xenos_authority": "true",
+        "suppression_allowed": "false",
+    }
+    if not entry:
+        expected.update(
+            {
+                "control_flow_changed": "false",
+                "native_lod": "false",
+            }
+        )
+    if any(event.get(key) != value for key, value in expected.items()):
+        raise ValueError("visibility-workset evidence violates the safety boundary")
+
+
+def build(events, static, requested_session=None):
+    contract = static_contract(static)
+    session = select_session(events, requested_session)
+    selected = [event for event in events if event.get("session") == session]
+    config = exact_event(selected, CONFIG)
+    summary = exact_event(selected, SUMMARY)
+    assembly = exact_event(selected, ASSEMBLY)
+    semantic_instances = exact_event(selected, SEMANTIC_INSTANCES)
+    expected_config = {
+        "status": "armed",
+        "class": "proceduralGeometry::CProceduralModels",
+        "record_completion_hook": "82E2084C",
+        "semantic_instance_hook": "8241741C",
+        "capacity": "4096",
+        "model": "independent_policy_to_semantic_candidate_handoff",
+        "identity": "receiver_generation_record_index",
+        "selection_rule": "any_nonzero_predicted_category_result_selects",
+        "execution": "bounded_host_visibility_workset",
+        "guest_payload_read": "qualified_policy_inputs_only",
+        "guest_state_changed": "false",
+        "control_flow_changed": "false",
+        "title_culling_changed": "false",
+        "native_lod": "false",
+        "native_draw": "false",
+        "xenos_authority": "true",
+        "suppression_allowed": "false",
+    }
+    if any(config.get(key) != value for key, value in expected_config.items()):
+        raise ValueError("visibility-workset runtime configuration drifted")
+    require_safety(summary)
+    if (
+        summary.get("status") != "complete"
+        or summary.get("accounting_complete") != "true"
+        or summary.get("model")
+        != "independent_policy_to_semantic_candidate_handoff"
+        or summary.get("identity") != "receiver_generation_record_index"
+    ):
+        raise ValueError("visibility-workset summary is incomplete")
+
+    count_keys = (
+        "modelled_records",
+        "predicted_selected",
+        "predicted_rejected",
+        "title_matches",
+        "title_mismatches",
+        "invalid_records",
+        "entries",
+        "entry_observations",
+        "capacity",
+        "overflow",
+        "semantic_instance_lookups",
+        "selected_joins",
+        "rejected_joins",
+        "missing_joins",
+    )
+    totals = {key: integer(summary, key) for key in count_keys}
+    entries = []
+    seen_keys = set()
+    seen_identities = set()
+    sums = {
+        "observations": 0,
+        "predicted_selected": 0,
+        "predicted_rejected": 0,
+        "title_matches": 0,
+        "title_mismatches": 0,
+        "semantic_instance_joins": 0,
+    }
+    for event in selected:
+        if event.get("event") != ENTRY:
+            continue
+        require_safety(event, entry=True)
+        key = hexadecimal(event, "key", 16)
+        identity = (
+            hexadecimal(event, "receiver_address", 8),
+            integer(event, "receiver_generation"),
+            integer(event, "record_index"),
+        )
+        item = {
+            field: integer(event, field)
+            for field in (
+                "observations",
+                "predicted_selected",
+                "predicted_rejected",
+                "title_matches",
+                "title_mismatches",
+                "semantic_instance_joins",
+            )
+        }
+        if (
+            event.get("status") != "complete"
+            or key in seen_keys
+            or identity in seen_identities
+            or not item["observations"]
+            or item["observations"]
+            != item["predicted_selected"] + item["predicted_rejected"]
+            or item["observations"]
+            != item["title_matches"] + item["title_mismatches"]
+            or integer(event, "first_frame") > integer(event, "last_frame")
+            or integer(event, "latest_category_result_mask") > 7
+            or event.get("latest_selected") not in ("true", "false")
+        ):
+            raise ValueError("visibility-workset entry evidence drifted")
+        seen_keys.add(key)
+        seen_identities.add(identity)
+        entries.append({"key": key, "identity": identity, **item})
+        for field in sums:
+            sums[field] += item[field]
+
+    assembly_totals = {
+        key: integer(assembly, key)
+        for key in (
+            "modelled_records",
+            "predicted_selected",
+            "predicted_rejected",
+            "title_matches",
+            "false_positive",
+            "false_negative",
+            "invalid_inputs",
+        )
+    }
+    semantic_live = integer(semantic_instances, "live_observations")
+    failures = []
+    if totals["modelled_records"] <= 0 or totals["selected_joins"] <= 0:
+        failures.append("visibility workset did not exercise policy handoff")
+    if totals["predicted_selected"] + totals["predicted_rejected"] != totals["modelled_records"]:
+        failures.append("policy decision accounting drifted")
+    if totals["title_matches"] + totals["title_mismatches"] != totals["modelled_records"]:
+        failures.append("title comparison accounting drifted")
+    if totals["semantic_instance_lookups"] != totals["selected_joins"] + totals["rejected_joins"] + totals["missing_joins"]:
+        failures.append("semantic-instance join accounting drifted")
+    if totals["entries"] != len(entries) or totals["capacity"] != 4096:
+        failures.append("workset capacity accounting drifted")
+    for field in sums:
+        summary_field = "entry_observations" if field == "observations" else field
+        if field == "semantic_instance_joins":
+            expected = totals["selected_joins"] + totals["rejected_joins"]
+        else:
+            expected = totals[summary_field]
+        if sums[field] != expected:
+            failures.append(f"entry {field} totals drifted")
+    if totals["entry_observations"] + totals["overflow"] != totals["modelled_records"]:
+        failures.append("workset observation accounting drifted")
+    if semantic_live != totals["semantic_instance_lookups"]:
+        failures.append("semantic-instance summary did not reconcile")
+    if (
+        assembly_totals["modelled_records"] != totals["modelled_records"]
+        or assembly_totals["predicted_selected"] != totals["predicted_selected"]
+        or assembly_totals["predicted_rejected"] != totals["predicted_rejected"]
+        or assembly_totals["title_matches"] != totals["title_matches"]
+        or assembly_totals["false_positive"] + assembly_totals["false_negative"]
+        != totals["title_mismatches"]
+    ):
+        failures.append("assembled policy did not reconcile with workset")
+    for key in (
+        "title_mismatches",
+        "invalid_records",
+        "overflow",
+    ):
+        if totals[key]:
+            failures.append(f"{key} is nonzero")
+    if assembly_totals["invalid_inputs"]:
+        failures.append("assembled policy contains invalid inputs")
+
+    return {
+        "schema": SCHEMA,
+        "session": session,
+        "status": "complete" if not failures else "incomplete",
+        "failures": failures,
+        "static_contract": contract,
+        "totals": totals,
+        "entries": entries,
+        "qualification": {
+            "independent_policy_materialized": not failures,
+            "semantic_candidate_handoff_proved": not failures,
+            "superset_filter_accounting_proved": not failures,
+            "native_draw_enabled": False,
+            "title_culling_changed": False,
+        },
+        "safety": {
+            "guest_state_changed": False,
+            "control_flow_changed": False,
+            "title_culling_changed": False,
+            "native_lod": False,
+            "native_draw": False,
+            "xenos_authority": True,
+            "suppression_allowed": False,
+        },
+    }
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser()
+    parser.add_argument("events", nargs="+", type=pathlib.Path)
+    parser.add_argument("--static", required=True, type=pathlib.Path)
+    parser.add_argument("--session")
+    parser.add_argument("--output", required=True, type=pathlib.Path)
+    args = parser.parse_args(argv)
+    try:
+        document = build(
+            read_events(args.events),
+            json.loads(args.static.read_text(encoding="utf-8")),
+            args.session,
+        )
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(
+            json.dumps(document, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        if document["status"] != "complete":
+            raise ValueError("; ".join(document["failures"]))
+        return 0
+    except (OSError, ValueError, json.JSONDecodeError) as error:
+        print(f"native renderer visibility workset summary failed: {error}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/tests/test_native_renderer_contract.py
+++ b/tools/tests/test_native_renderer_contract.py
@@ -245,6 +245,16 @@ class NativeRendererContractTests(unittest.TestCase):
         self.assertIn('"xenos_authority": True', assembly_shadow_summarizer)
         self.assertIn('"suppression_allowed": False', assembly_shadow_summarizer)
 
+        workset_summarizer = (
+            ROOT / "tools/summarize-native-renderer-visibility-workset.py"
+        ).read_text(encoding="utf-8")
+        self.assertIn("bounded_host_visibility_workset", source)
+        self.assertIn("JoinSemanticVisibilityWorkset", source)
+        self.assertIn('"title_culling_changed": False', workset_summarizer)
+        self.assertIn('"native_draw": False', workset_summarizer)
+        self.assertIn('"xenos_authority": True', workset_summarizer)
+        self.assertIn('"suppression_allowed": False', workset_summarizer)
+
     def test_exact_pass_consumer_trace_is_bounded_and_fail_closed(self):
         source = (ROOT / "src/native_renderer/graphics_hooks.cpp").read_text(
             encoding="utf-8"

--- a/tools/tests/test_native_renderer_dispatch_discovery.py
+++ b/tools/tests/test_native_renderer_dispatch_discovery.py
@@ -1373,6 +1373,22 @@ class NativeRendererDispatchDiscoveryTests(unittest.TestCase):
         self.assertFalse(assembly_shadow["guest_state_changed"])
         self.assertTrue(assembly_shadow["xenos_authority"])
         self.assertFalse(assembly_shadow["suppression_allowed"])
+        workset = lifecycle["visibility_policy_workset"]
+        self.assertEqual("82E2084C", workset["record_completion_hook_address"])
+        self.assertEqual("8241741C", workset["semantic_instance_hook_address"])
+        self.assertEqual(4096, workset["capacity"])
+        self.assertEqual(
+            "independent_policy_to_semantic_candidate_handoff",
+            workset["model"],
+        )
+        self.assertEqual(
+            "receiver_generation_record_index", workset["identity"]
+        )
+        self.assertEqual("bounded_host_visibility_workset", workset["execution"])
+        self.assertFalse(workset["title_culling_changed"])
+        self.assertFalse(workset["native_draw_enabled"])
+        self.assertTrue(workset["xenos_authority"])
+        self.assertFalse(workset["suppression_allowed"])
         self.assertEqual(
             92, lifecycle["field_layout"]["descriptor_record_stride"]
         )

--- a/tools/tests/test_native_renderer_visibility_workset.py
+++ b/tools/tests/test_native_renderer_visibility_workset.py
@@ -1,0 +1,199 @@
+import copy
+import importlib.util
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).parents[2]
+TOOL = ROOT / "tools/summarize-native-renderer-visibility-workset.py"
+SPEC = importlib.util.spec_from_file_location("visibility_workset", TOOL)
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+class VisibilityWorksetReportTests(unittest.TestCase):
+    def static(self):
+        return {
+            "schema": MODULE.STATIC_SCHEMA,
+            "procedural_model_receiver_lifecycle": {
+                "visibility_policy_workset": {
+                    "record_completion_hook_address": "82E2084C",
+                    "semantic_instance_hook_address": "8241741C",
+                    "capacity": 4096,
+                    "model": "independent_policy_to_semantic_candidate_handoff",
+                    "identity": "receiver_generation_record_index",
+                    "selection_rule": (
+                        "any_nonzero_predicted_category_result_selects"
+                    ),
+                    "execution": "bounded_host_visibility_workset",
+                    "guest_payload_read": "qualified_policy_inputs_only",
+                    "guest_state_changed": False,
+                    "control_flow_changed": False,
+                    "title_culling_changed": False,
+                    "native_lod_enabled": False,
+                    "native_draw_enabled": False,
+                    "xenos_authority": True,
+                    "suppression_allowed": False,
+                }
+            },
+        }
+
+    def safety(self, entry=False):
+        value = {
+            "execution": "bounded_host_visibility_workset",
+            "guest_state_changed": "false",
+            "title_culling_changed": "false",
+            "native_draw": "false",
+            "xenos_authority": "true",
+            "suppression_allowed": "false",
+        }
+        if not entry:
+            value.update(
+                {"control_flow_changed": "false", "native_lod": "false"}
+            )
+        return value
+
+    def events(self):
+        config = {
+            "event": MODULE.CONFIG,
+            "session": "test",
+            "status": "armed",
+            "class": "proceduralGeometry::CProceduralModels",
+            "record_completion_hook": "82E2084C",
+            "semantic_instance_hook": "8241741C",
+            "capacity": "4096",
+            "model": "independent_policy_to_semantic_candidate_handoff",
+            "identity": "receiver_generation_record_index",
+            "selection_rule": "any_nonzero_predicted_category_result_selects",
+            "guest_payload_read": "qualified_policy_inputs_only",
+            **self.safety(),
+        }
+        selected = {
+            "event": MODULE.ENTRY,
+            "session": "test",
+            "status": "complete",
+            "key": "1111111111111111",
+            "receiver_address": "10001000",
+            "receiver_generation": "2",
+            "record_index": "4",
+            "category": "9",
+            "observations": "3",
+            "first_frame": "10",
+            "last_frame": "12",
+            "predicted_selected": "3",
+            "predicted_rejected": "0",
+            "title_matches": "3",
+            "title_mismatches": "0",
+            "semantic_instance_joins": "7",
+            "latest_category_result_mask": "6",
+            "latest_selected": "true",
+            **self.safety(entry=True),
+        }
+        rejected = {
+            **selected,
+            "key": "2222222222222222",
+            "record_index": "5",
+            "observations": "2",
+            "predicted_selected": "0",
+            "predicted_rejected": "2",
+            "title_matches": "2",
+            "semantic_instance_joins": "0",
+            "latest_category_result_mask": "1",
+            "latest_selected": "false",
+        }
+        summary = {
+            "event": MODULE.SUMMARY,
+            "session": "test",
+            "status": "complete",
+            "modelled_records": "5",
+            "predicted_selected": "3",
+            "predicted_rejected": "2",
+            "title_matches": "5",
+            "title_mismatches": "0",
+            "invalid_records": "0",
+            "entries": "2",
+            "entry_observations": "5",
+            "capacity": "4096",
+            "overflow": "0",
+            "semantic_instance_lookups": "7",
+            "selected_joins": "7",
+            "rejected_joins": "0",
+            "missing_joins": "0",
+            "accounting_complete": "true",
+            "model": "independent_policy_to_semantic_candidate_handoff",
+            "identity": "receiver_generation_record_index",
+            **self.safety(),
+        }
+        assembly = {
+            "event": MODULE.ASSEMBLY,
+            "session": "test",
+            "modelled_records": "5",
+            "predicted_selected": "3",
+            "predicted_rejected": "2",
+            "title_matches": "5",
+            "false_positive": "0",
+            "false_negative": "0",
+            "invalid_inputs": "0",
+        }
+        semantic = {
+            "event": MODULE.SEMANTIC_INSTANCES,
+            "session": "test",
+            "live_observations": "7",
+        }
+        return [config, selected, rejected, summary, assembly, semantic]
+
+    def test_build_qualifies_exact_semantic_handoff(self):
+        document = MODULE.build(self.events(), self.static())
+        self.assertEqual("complete", document["status"])
+        self.assertTrue(
+            document["qualification"]["semantic_candidate_handoff_proved"]
+        )
+        self.assertFalse(document["safety"]["title_culling_changed"])
+        self.assertTrue(document["safety"]["xenos_authority"])
+
+    def test_build_filters_missing_superset_observation(self):
+        events = copy.deepcopy(self.events())
+        summary = next(event for event in events if event["event"] == MODULE.SUMMARY)
+        summary["selected_joins"] = "6"
+        summary["missing_joins"] = "1"
+        selected = next(event for event in events if event["event"] == MODULE.ENTRY)
+        selected["semantic_instance_joins"] = "6"
+        document = MODULE.build(events, self.static())
+        self.assertEqual("complete", document["status"])
+        self.assertEqual(1, document["totals"]["missing_joins"])
+
+    def test_build_filters_rejected_superset_observation(self):
+        events = copy.deepcopy(self.events())
+        summary = next(event for event in events if event["event"] == MODULE.SUMMARY)
+        summary["selected_joins"] = "6"
+        summary["rejected_joins"] = "1"
+        selected = next(event for event in events if event["event"] == MODULE.ENTRY)
+        selected["semantic_instance_joins"] = "6"
+        rejected = [event for event in events if event["event"] == MODULE.ENTRY][1]
+        rejected["semantic_instance_joins"] = "1"
+        document = MODULE.build(events, self.static())
+        self.assertEqual("complete", document["status"])
+        self.assertEqual(1, document["totals"]["rejected_joins"])
+
+    def test_build_rejects_assembly_drift(self):
+        events = copy.deepcopy(self.events())
+        assembly = next(event for event in events if event["event"] == MODULE.ASSEMBLY)
+        assembly["predicted_selected"] = "2"
+        document = MODULE.build(events, self.static())
+        self.assertEqual("incomplete", document["status"])
+        self.assertIn(
+            "assembled policy did not reconcile with workset",
+            document["failures"],
+        )
+
+    def test_build_rejects_static_suppression_drift(self):
+        static = self.static()
+        static["procedural_model_receiver_lifecycle"][
+            "visibility_policy_workset"
+        ]["suppression_allowed"] = True
+        with self.assertRaisesRegex(ValueError, "contract drifted"):
+            MODULE.build(self.events(), static)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- materialize independently assembled visibility decisions in a bounded host workset
- join the exact selected subset to semantic-instance extraction while rejecting unmatched records to Xenos
- add fail-closed static/runtime qualification and document the AppData result

## Validation
- 304 native-renderer tests pass
- Release build succeeds
- AppData session \20260830T012818Z-p42316\: 20,013 modelled decisions, 9,983 selected semantic joins, zero mismatches/invalid records/overflow
- 30.241 median FPS, 19.518 1% low, zero present-deadline misses
- normal exit and clean fatal scan