### PR TITLE
feat(native-renderer): carry visibility into prepared draws

### DIFF
--- a/docs/native-renderer/VISIBILITY_PREPARED_CANDIDATES.md
+++ b/docs/native-renderer/VISIBILITY_PREPARED_CANDIDATES.md
@@ -1,0 +1,85 @@
+# Visibility-selected prepared candidates
+
+The native visibility workset is produced at the title's slot-14 record
+completion boundary. The semantic-instance helper at `8241741C` is an upstream
+superset, so a workset join there is not yet evidence that a record reached a
+prepared graphics draw. This checkpoint carries the independent selection
+through the already-qualified semantic submission lineage without changing
+the title or issuing native work.
+
+## Exact handoff
+
+The semantic-instance scope copies the latest workset result into its immutable
+draw identity:
+
+- receiver address, receiver generation, and record index;
+- selected, rejected, or missing workset result;
+- policy frame, visibility category, and predicted category-result mask.
+
+That identity already follows the title's submission at `82417B60` into the
+physical `PM4_DRAW_INDX` stores at `82416260` and `824162F4`. The backend joins
+the exact physical header address and address generation to its prepared draw.
+No timing, FIFO, signature-only, or global-order attribution is accepted.
+
+At the prepared boundary, only an independently selected decision whose policy
+frame is the current frame or the immediately preceding frame becomes a host
+candidate. A selected decision older than one frame is stale and excluded. A
+prepared frame earlier than its policy frame is a causality fault. Rejected and
+missing workset results are expected fail-closed exclusions from the semantic
+superset.
+
+## Bounded evidence
+
+Fresh candidates are aggregated in a fixed 4,096-entry table keyed by exact
+semantic identity plus immutable prepared template, geometry-resource, texture-
+resource, visibility-category, and result-mask identities. The runtime records:
+
+- all semantic prepared observations;
+- selected, rejected, and missing workset joins;
+- fresh, stale, and future selected decisions;
+- per-candidate draw/frame coverage and maximum policy age;
+- table occupancy, overflow, and complete partition accounting.
+
+Generate and qualify the evidence with:
+
+```powershell
+python tools/discover-native-renderer-dispatch.py `
+  .local/generated/default `
+  --image .local/analysis/default-image.bin `
+  --output .local/qualification/native-renderer-visibility-lineage-static.json
+
+python tools/summarize-native-renderer-visibility-prepared-candidates.py `
+  <diagnostic-jsonl> `
+  --static .local/qualification/native-renderer-visibility-lineage-static.json `
+  --session <session> `
+  --output .local/qualification/native-renderer-visibility-prepared-candidates.json
+```
+
+Qualification requires exact accounting, at least one fresh prepared
+candidate, zero future decisions, and zero table overflow. Stale, rejected, and
+missing observations remain measured exclusions and never enter the candidate
+table.
+
+## Safety boundary
+
+This checkpoint only carries host metadata. It writes no guest state, changes
+no title control flow, uploads no resource, issues no native draw, and cannot
+suppress Xenos. Xenos remains the sole rendering authority. The candidate
+table is an admission input for a later native consumer, not permission to draw
+or suppress by itself.
+
+## AppData qualification
+
+Release session `20260830T015106Z-p25800` ran against the installed `0.1.0`
+preview save and exited normally. It partitioned 363,948 exact semantic
+prepared observations into 9,921 selected joins, 33,390 rejected exclusions,
+and 320,637 missing-workset exclusions. Of the selected joins, 8,561 were
+current- or one-frame-old candidates retained across 13 exact entries and
+1,360 were stale exclusions. Future decisions and table overflow were zero.
+
+The prepared-candidate, workset, every visibility shadow, semantic instance,
+semantic submission, semantic draw, semantic batch, and command-lineage
+reports all completed from the same capture. Median performance was 29.750 FPS
+over 2,802 frames, with a 15.224 FPS one-percent low, 58.633 Hz presentation,
+and zero present-deadline misses. The fatal-signature scan was clean. Native
+upload, native draw, and suppression remained disabled throughout.

--- a/src/native_renderer/graphics_hooks.cpp
+++ b/src/native_renderer/graphics_hooks.cpp
@@ -95,6 +95,8 @@ constexpr size_t kSemanticVisibilityResultValueCapacity = 256;
 constexpr size_t kSemanticVisibilityPolicyOutcomeCapacity = 3;
 constexpr size_t kSemanticVisibilitySpatialExponentCapacity = 256;
 constexpr size_t kSemanticVisibilityWorksetCapacity = 4096;
+constexpr size_t kSemanticVisibilityPreparedCandidateCapacity = 4096;
+constexpr uint64_t kSemanticVisibilityMaximumPolicyAgeFrames = 1;
 constexpr size_t kSemanticInstanceCapacity = 4096;
 constexpr size_t kSemanticSubmissionCapacity = 8192;
 constexpr size_t kSemanticRenderItemStackCapacity = 32;
@@ -155,8 +157,15 @@ std::array<DispatchCallerEntry, kDispatchCallerCapacity> g_dispatch_callers;
 std::atomic<uint64_t> g_dispatch_caller_overflow{};
 std::atomic<bool> g_dispatch_discovery_installed{};
 
+enum class SemanticVisibilityWorksetJoin : uint32_t {
+  kMissing = 0,
+  kSelected = 1,
+  kRejected = 2,
+};
+
 struct SemanticDrawIdentity {
   uint64_t submission_key = 0;
+  uint64_t visibility_policy_frame = 0;
   uint32_t receiver_address = 0;
   uint32_t receiver_generation = 0;
   uint32_t record_index = 0;
@@ -166,8 +175,12 @@ struct SemanticDrawIdentity {
   uint32_t helper_state = 0;
   uint32_t primary_resource_key = 0;
   uint32_t secondary_resource_key = 0;
+  uint32_t visibility_category = 0;
+  uint32_t visibility_result_mask = 0;
   uint32_t direct_title_origins = 0;
   uint32_t indirect_packet_origins = 0;
+  SemanticVisibilityWorksetJoin visibility_workset_join =
+      SemanticVisibilityWorksetJoin::kMissing;
   bool secondary_resource_present = false;
   bool valid = false;
 };
@@ -266,6 +279,22 @@ struct SemanticBatchOpportunityEntry {
   uint32_t secondary_resource_key = 0;
   SemanticBatchRejection rejection = SemanticBatchRejection::kNone;
   bool secondary_resource_present = false;
+};
+
+struct SemanticVisibilityPreparedCandidateEntry {
+  uint64_t key = 0;
+  uint64_t template_key = 0;
+  uint64_t geometry_resource_hash = 0;
+  uint64_t texture_resource_hash = 0;
+  uint64_t draws = 0;
+  uint64_t first_frame = 0;
+  uint64_t last_frame = 0;
+  uint64_t maximum_policy_age_frames = 0;
+  uint32_t receiver_address = 0;
+  uint32_t receiver_generation = 0;
+  uint32_t record_index = 0;
+  uint32_t visibility_category = 0;
+  uint32_t visibility_result_mask = 0;
 };
 
 struct SemanticBatchRun {
@@ -451,6 +480,9 @@ std::array<TitleDrawProvenanceEntry, kTitleDrawProvenanceCapacity>
 std::array<SemanticBatchOpportunityEntry,
            kSemanticBatchOpportunityCapacity>
     g_semantic_batch_opportunities{};
+std::array<SemanticVisibilityPreparedCandidateEntry,
+           kSemanticVisibilityPreparedCandidateCapacity>
+    g_semantic_visibility_prepared_candidates{};
 std::array<std::array<SemanticBatchEquivalenceEntry,
                       kSemanticBatchOpportunityCapacity>,
            size_t(SemanticBatchEquivalence::kCount)>
@@ -491,6 +523,15 @@ std::atomic<uint64_t> g_title_packets_without_origin{};
 uint64_t g_title_draw_provenance_count = 0;
 uint64_t g_title_draw_provenance_overflow = 0;
 uint64_t g_semantic_batch_observations = 0;
+uint64_t g_semantic_visibility_prepared_observations = 0;
+uint64_t g_semantic_visibility_prepared_selected_joins = 0;
+uint64_t g_semantic_visibility_prepared_fresh_candidates = 0;
+uint64_t g_semantic_visibility_prepared_stale_exclusions = 0;
+uint64_t g_semantic_visibility_prepared_future_exclusions = 0;
+uint64_t g_semantic_visibility_prepared_rejected_exclusions = 0;
+uint64_t g_semantic_visibility_prepared_missing_exclusions = 0;
+uint64_t g_semantic_visibility_prepared_candidate_count = 0;
+uint64_t g_semantic_visibility_prepared_candidate_overflow = 0;
 uint64_t g_semantic_batch_eligible_draws = 0;
 uint64_t g_semantic_batch_rejected_draws = 0;
 uint64_t g_semantic_batch_opportunity_count = 0;
@@ -1136,12 +1177,6 @@ struct ActiveSemanticVisibilityRecord {
 thread_local ActiveSemanticVisibilityRecord
     g_active_semantic_visibility_record{};
 
-enum class SemanticVisibilityWorksetJoin {
-  kMissing,
-  kSelected,
-  kRejected,
-};
-
 uint64_t SemanticVisibilityWorksetKey(uint32_t receiver_address,
                                       uint32_t receiver_generation,
                                       uint32_t record_index) {
@@ -1222,7 +1257,7 @@ void PublishSemanticVisibilityWorkset(
 
 SemanticVisibilityWorksetJoin JoinSemanticVisibilityWorkset(
     uint32_t receiver_address, uint32_t receiver_generation,
-    uint32_t record_index) {
+    uint32_t record_index, SemanticDrawIdentity *semantic_draw) {
   const uint64_t key = SemanticVisibilityWorksetKey(
       receiver_address, receiver_generation, record_index);
   std::scoped_lock lock(g_semantic_visibility_workset_mutex);
@@ -1240,11 +1275,19 @@ SemanticVisibilityWorksetJoin JoinSemanticVisibilityWorkset(
         entry.receiver_generation == receiver_generation &&
         entry.record_index == record_index) {
       ++entry.semantic_instance_joins;
+      semantic_draw->visibility_policy_frame = entry.last_frame;
+      semantic_draw->visibility_category = entry.category;
+      semantic_draw->visibility_result_mask =
+          entry.latest_category_result_mask;
       if (entry.latest_selected) {
         ++g_semantic_visibility_workset_selected_joins;
+        semantic_draw->visibility_workset_join =
+            SemanticVisibilityWorksetJoin::kSelected;
         return SemanticVisibilityWorksetJoin::kSelected;
       }
       ++g_semantic_visibility_workset_rejected_joins;
+      semantic_draw->visibility_workset_join =
+          SemanticVisibilityWorksetJoin::kRejected;
       return SemanticVisibilityWorksetJoin::kRejected;
     }
     index = (index + 1) % kSemanticVisibilityWorksetCapacity;
@@ -1391,6 +1434,10 @@ void ResetTitleDrawProvenance() {
        g_semantic_batch_opportunities) {
     entry = {};
   }
+  for (SemanticVisibilityPreparedCandidateEntry &entry :
+       g_semantic_visibility_prepared_candidates) {
+    entry = {};
+  }
   for (auto &level : g_semantic_batch_equivalence_opportunities) {
     for (SemanticBatchEquivalenceEntry &entry : level) {
       entry = {};
@@ -1426,6 +1473,15 @@ void ResetTitleDrawProvenance() {
   g_title_draw_provenance_count = 0;
   g_title_draw_provenance_overflow = 0;
   g_semantic_batch_observations = 0;
+  g_semantic_visibility_prepared_observations = 0;
+  g_semantic_visibility_prepared_selected_joins = 0;
+  g_semantic_visibility_prepared_fresh_candidates = 0;
+  g_semantic_visibility_prepared_stale_exclusions = 0;
+  g_semantic_visibility_prepared_future_exclusions = 0;
+  g_semantic_visibility_prepared_rejected_exclusions = 0;
+  g_semantic_visibility_prepared_missing_exclusions = 0;
+  g_semantic_visibility_prepared_candidate_count = 0;
+  g_semantic_visibility_prepared_candidate_overflow = 0;
   g_semantic_batch_eligible_draws = 0;
   g_semantic_batch_rejected_draws = 0;
   g_semantic_batch_opportunity_count = 0;
@@ -5008,7 +5064,7 @@ bool RecordProceduralModelSemanticInstance(
   const uint64_t runtime_hash = HashSemanticWords(runtime_words);
   const uint64_t transform_hash = HashSemanticWords(transform_words);
   JoinSemanticVisibilityWorkset(receiver_address, receiver_generation,
-                                record_index);
+                                record_index, semantic_draw);
   ++g_semantic_instance_live_observations;
   g_semantic_instance_payload_bytes += kSemanticObservationPayloadBytes;
   ++g_semantic_instance_replay_fallbacks;
@@ -9961,6 +10017,92 @@ void RecordSemanticBatchEquivalenceOpportunity(
   };
 }
 
+void RecordSemanticVisibilityPreparedCandidate(
+    const rex::system::GraphicsDrawObservation &observation,
+    const SemanticDrawIdentity &identity,
+    const SemanticPreparedDrawContract &contract) {
+  ++g_semantic_visibility_prepared_observations;
+  if (identity.visibility_workset_join ==
+      SemanticVisibilityWorksetJoin::kMissing) {
+    ++g_semantic_visibility_prepared_missing_exclusions;
+    return;
+  }
+  if (identity.visibility_workset_join ==
+      SemanticVisibilityWorksetJoin::kRejected) {
+    ++g_semantic_visibility_prepared_rejected_exclusions;
+    return;
+  }
+
+  ++g_semantic_visibility_prepared_selected_joins;
+  if (observation.frame_sequence < identity.visibility_policy_frame) {
+    ++g_semantic_visibility_prepared_future_exclusions;
+    return;
+  }
+  const uint64_t policy_age_frames =
+      observation.frame_sequence - identity.visibility_policy_frame;
+  if (policy_age_frames > kSemanticVisibilityMaximumPolicyAgeFrames) {
+    ++g_semantic_visibility_prepared_stale_exclusions;
+    return;
+  }
+  ++g_semantic_visibility_prepared_fresh_candidates;
+
+  uint64_t key = UINT64_C(0xCBF29CE484222325);
+  for (uint64_t value :
+       {uint64_t(identity.receiver_address),
+        uint64_t(identity.receiver_generation),
+        uint64_t(identity.record_index), contract.template_key,
+        contract.geometry_resource_hash, contract.texture_resource_hash,
+        uint64_t(identity.visibility_category),
+        uint64_t(identity.visibility_result_mask)}) {
+    key = HashCombine(key, value);
+  }
+  key = key ? key : 1;
+  size_t index =
+      size_t(key % kSemanticVisibilityPreparedCandidateCapacity);
+  for (size_t probe = 0;
+       probe < kSemanticVisibilityPreparedCandidateCapacity; ++probe) {
+    SemanticVisibilityPreparedCandidateEntry &entry =
+        g_semantic_visibility_prepared_candidates[index];
+    if (!entry.key) {
+      entry = {
+          .key = key,
+          .template_key = contract.template_key,
+          .geometry_resource_hash = contract.geometry_resource_hash,
+          .texture_resource_hash = contract.texture_resource_hash,
+          .draws = 1,
+          .first_frame = observation.frame_sequence,
+          .last_frame = observation.frame_sequence,
+          .maximum_policy_age_frames = policy_age_frames,
+          .receiver_address = identity.receiver_address,
+          .receiver_generation = identity.receiver_generation,
+          .record_index = identity.record_index,
+          .visibility_category = identity.visibility_category,
+          .visibility_result_mask = identity.visibility_result_mask,
+      };
+      ++g_semantic_visibility_prepared_candidate_count;
+      return;
+    }
+    if (entry.key == key &&
+        entry.template_key == contract.template_key &&
+        entry.geometry_resource_hash == contract.geometry_resource_hash &&
+        entry.texture_resource_hash == contract.texture_resource_hash &&
+        entry.receiver_address == identity.receiver_address &&
+        entry.receiver_generation == identity.receiver_generation &&
+        entry.record_index == identity.record_index &&
+        entry.visibility_category == identity.visibility_category &&
+        entry.visibility_result_mask == identity.visibility_result_mask) {
+      ++entry.draws;
+      entry.last_frame = observation.frame_sequence;
+      entry.maximum_policy_age_frames =
+          std::max(entry.maximum_policy_age_frames, policy_age_frames);
+      return;
+    }
+    index =
+        (index + 1) % kSemanticVisibilityPreparedCandidateCapacity;
+  }
+  ++g_semantic_visibility_prepared_candidate_overflow;
+}
+
 void RecordSemanticBatchOpportunity(
     const rex::system::GraphicsDrawObservation &observation,
     bool samples_resolved_target,
@@ -9972,6 +10114,8 @@ void RecordSemanticBatchOpportunity(
   const SemanticDrawIdentity &identity = origin.semantic_draw;
   const SemanticPreparedDrawContract contract =
       BuildSemanticPreparedDrawContract(observation, prepared);
+  RecordSemanticVisibilityPreparedCandidate(observation, identity,
+                                            contract);
   const SemanticBatchRejection rejection =
       ClassifySemanticBatchRejection(observation, samples_resolved_target,
                                      prepared, identity, contract);
@@ -11415,9 +11559,106 @@ void EmitSemanticVisibilityCensus() {
        {"suppression_allowed", "false"}});
 }
 
+void EmitSemanticVisibilityPreparedCandidates() {
+  uint64_t entry_draws = 0;
+  uint64_t entry_count = 0;
+  for (const SemanticVisibilityPreparedCandidateEntry &entry :
+       g_semantic_visibility_prepared_candidates) {
+    if (!entry.key) {
+      continue;
+    }
+    ++entry_count;
+    entry_draws += entry.draws;
+    pinyon_shift::diagnostics::RecordEvent(
+        "native_renderer.discovery.semantic_visibility_prepared_candidate_entry",
+        {{"status", "complete"},
+         {"candidate_key", fmt::format("{:016X}", entry.key)},
+         {"template_key", fmt::format("{:016X}", entry.template_key)},
+         {"geometry_resource_hash",
+          fmt::format("{:016X}", entry.geometry_resource_hash)},
+         {"texture_resource_hash",
+          fmt::format("{:016X}", entry.texture_resource_hash)},
+         {"receiver_address",
+          fmt::format("{:08X}", entry.receiver_address)},
+         {"receiver_generation",
+          std::to_string(entry.receiver_generation)},
+         {"record_index", std::to_string(entry.record_index)},
+         {"visibility_category",
+          std::to_string(entry.visibility_category)},
+         {"visibility_result_mask",
+          std::to_string(entry.visibility_result_mask)},
+         {"draws", std::to_string(entry.draws)},
+         {"first_frame", std::to_string(entry.first_frame)},
+         {"last_frame", std::to_string(entry.last_frame)},
+         {"maximum_policy_age_frames",
+          std::to_string(entry.maximum_policy_age_frames)},
+         {"policy_age_limit_frames",
+          std::to_string(kSemanticVisibilityMaximumPolicyAgeFrames)},
+         {"classification", "fresh_visibility_selected_prepared_candidate"},
+         {"guest_state_changed", "false"},
+         {"control_flow_changed", "false"},
+         {"native_upload", "false"},
+         {"native_draw", "false"},
+         {"xenos_draw", "preserved"},
+         {"suppression_allowed", "false"}});
+  }
+  const bool accounting_complete =
+      g_semantic_visibility_prepared_observations ==
+          g_semantic_visibility_prepared_selected_joins +
+              g_semantic_visibility_prepared_rejected_exclusions +
+              g_semantic_visibility_prepared_missing_exclusions &&
+      g_semantic_visibility_prepared_selected_joins ==
+          g_semantic_visibility_prepared_fresh_candidates +
+              g_semantic_visibility_prepared_stale_exclusions +
+              g_semantic_visibility_prepared_future_exclusions &&
+      g_semantic_visibility_prepared_fresh_candidates ==
+          entry_draws +
+              g_semantic_visibility_prepared_candidate_overflow &&
+      g_semantic_visibility_prepared_candidate_count == entry_count;
+  pinyon_shift::diagnostics::RecordEvent(
+      "native_renderer.discovery.semantic_visibility_prepared_candidate_summary",
+      {{"status", !g_semantic_visibility_prepared_observations
+                       ? "not_observed"
+                       : (accounting_complete ? "complete" : "incomplete")},
+       {"observations",
+        std::to_string(g_semantic_visibility_prepared_observations)},
+       {"selected_joins",
+        std::to_string(g_semantic_visibility_prepared_selected_joins)},
+       {"fresh_candidates",
+        std::to_string(g_semantic_visibility_prepared_fresh_candidates)},
+       {"stale_exclusions",
+        std::to_string(g_semantic_visibility_prepared_stale_exclusions)},
+       {"future_exclusions",
+        std::to_string(g_semantic_visibility_prepared_future_exclusions)},
+       {"rejected_exclusions",
+        std::to_string(g_semantic_visibility_prepared_rejected_exclusions)},
+       {"missing_exclusions",
+        std::to_string(g_semantic_visibility_prepared_missing_exclusions)},
+       {"candidate_entries",
+        std::to_string(g_semantic_visibility_prepared_candidate_count)},
+       {"entry_draws", std::to_string(entry_draws)},
+       {"capacity",
+        std::to_string(kSemanticVisibilityPreparedCandidateCapacity)},
+       {"overflow",
+        std::to_string(g_semantic_visibility_prepared_candidate_overflow)},
+       {"policy_age_limit_frames",
+        std::to_string(kSemanticVisibilityMaximumPolicyAgeFrames)},
+       {"accounting_complete", accounting_complete ? "true" : "false"},
+       {"identity", "receiver_generation_record_index"},
+       {"prepared_lineage", "exact_semantic_pm4_prepared_draw"},
+       {"selection", "independent_visibility_selected_and_fresh"},
+       {"guest_state_changed", "false"},
+       {"control_flow_changed", "false"},
+       {"native_upload", "false"},
+       {"native_draw", "false"},
+       {"xenos_draw", "preserved"},
+       {"suppression_allowed", "false"}});
+}
+
 void EmitSemanticBatchOpportunitySummary() {
   FinalizeSemanticBatchRun();
   FinalizeSemanticBatchFrame();
+  EmitSemanticVisibilityPreparedCandidates();
   EmitSemanticBatchEquivalenceSummary();
   EmitSemanticStateCacheSummary();
   uint64_t entry_draws = 0;
@@ -13931,6 +14172,26 @@ void InstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system,
        {"native_lod", "false"},
        {"native_draw", "false"},
        {"xenos_authority", "true"},
+       {"suppression_allowed", "false"}});
+  diagnostics::RecordEvent(
+      "native_renderer.discovery.semantic_visibility_prepared_candidate_config",
+      {{"status", lineage_armed ? "armed" : "disabled"},
+       {"class", "proceduralGeometry::CProceduralModels"},
+       {"semantic_instance_hook", "8241741C"},
+       {"semantic_packet_hooks", "82416260,824162F4"},
+       {"prepared_draw_join", "physical_pm4_header_generation"},
+       {"capacity",
+        std::to_string(kSemanticVisibilityPreparedCandidateCapacity)},
+       {"policy_age_limit_frames",
+        std::to_string(kSemanticVisibilityMaximumPolicyAgeFrames)},
+       {"identity", "receiver_generation_record_index"},
+       {"selection", "independent_visibility_selected_and_fresh"},
+       {"prepared_lineage", "exact_semantic_pm4_prepared_draw"},
+       {"guest_state_changed", "false"},
+       {"control_flow_changed", "false"},
+       {"native_upload", "false"},
+       {"native_draw", "false"},
+       {"xenos_draw", "preserved"},
        {"suppression_allowed", "false"}});
   diagnostics::RecordEvent(
       "native_renderer.discovery.semantic_instance_config",

--- a/tools/discover-native-renderer-dispatch.py
+++ b/tools/discover-native-renderer-dispatch.py
@@ -1609,6 +1609,26 @@ def procedural_model_receiver_lifecycle(
             "xenos_authority": True,
             "suppression_allowed": False,
         },
+        "visibility_prepared_candidates": {
+            "semantic_instance_hook_address": "{:08X}".format(
+                spec["render_item_entry_hook"]
+            ),
+            "semantic_packet_hook_addresses": [
+                "{:08X}".format(address)
+                for address in spec["semantic_draw_packet_hooks"]
+            ],
+            "capacity": 4096,
+            "maximum_policy_age_frames": 1,
+            "identity": "receiver_generation_record_index",
+            "selection": "independent_visibility_selected_and_fresh",
+            "prepared_lineage": "exact_semantic_pm4_prepared_draw",
+            "guest_state_changed": False,
+            "control_flow_changed": False,
+            "native_upload_enabled": False,
+            "native_draw_enabled": False,
+            "xenos_draw_preserved": True,
+            "suppression_allowed": False,
+        },
         "render_state_function_address": "{:08X}".format(
             spec["render_state_function"]
         ),

--- a/tools/summarize-native-renderer-visibility-prepared-candidates.py
+++ b/tools/summarize-native-renderer-visibility-prepared-candidates.py
@@ -1,0 +1,304 @@
+#!/usr/bin/env python3
+"""Qualify visibility-selected records at the exact prepared-draw boundary."""
+
+import argparse
+import json
+import pathlib
+import sys
+
+
+SCHEMA = "pinyon-shift.native-renderer-visibility-prepared-candidates.v1"
+STATIC_SCHEMA = "pinyon-shift.native-renderer-dispatch-static.v3"
+CONFIG = (
+    "native_renderer.discovery."
+    "semantic_visibility_prepared_candidate_config"
+)
+ENTRY = (
+    "native_renderer.discovery."
+    "semantic_visibility_prepared_candidate_entry"
+)
+SUMMARY = (
+    "native_renderer.discovery."
+    "semantic_visibility_prepared_candidate_summary"
+)
+WORKSET = "native_renderer.discovery.semantic_visibility_workset_summary"
+
+
+def read_events(paths):
+    events = []
+    for path in paths:
+        for line in path.read_text(encoding="utf-8").splitlines():
+            if line.strip():
+                events.append(json.loads(line))
+    return events
+
+
+def integer(mapping, key):
+    try:
+        value = int(mapping[key])
+    except (KeyError, TypeError, ValueError) as error:
+        raise ValueError(f"invalid {key}") from error
+    if value < 0:
+        raise ValueError(f"negative {key}")
+    return value
+
+
+def hexadecimal(mapping, key, width):
+    value = str(mapping.get(key, "")).upper()
+    if len(value) != width:
+        raise ValueError(f"invalid {key}")
+    try:
+        int(value, 16)
+    except ValueError as error:
+        raise ValueError(f"invalid {key}") from error
+    return value
+
+
+def exact_event(events, name):
+    matches = [event for event in events if event.get("event") == name]
+    if len(matches) != 1:
+        raise ValueError(f"expected exactly one {name} event")
+    return matches[0]
+
+
+def select_session(events, requested):
+    sessions = {
+        event.get("session") for event in events if event.get("event") == CONFIG
+    }
+    sessions.discard(None)
+    if requested:
+        if requested not in sessions:
+            raise ValueError("requested session has no prepared-candidate config")
+        return requested
+    if len(sessions) != 1:
+        raise ValueError("prepared-candidate input contains multiple sessions")
+    return next(iter(sessions))
+
+
+def static_contract(document):
+    if document.get("schema") != STATIC_SCHEMA:
+        raise ValueError("unsupported static dispatch inventory schema")
+    try:
+        contract = document["procedural_model_receiver_lifecycle"][
+            "visibility_prepared_candidates"
+        ]
+    except (KeyError, TypeError) as error:
+        raise ValueError("static prepared-candidate contract is missing") from error
+    expected = {
+        "semantic_instance_hook_address": "8241741C",
+        "semantic_packet_hook_addresses": ["82416260", "824162F4"],
+        "capacity": 4096,
+        "maximum_policy_age_frames": 1,
+        "identity": "receiver_generation_record_index",
+        "selection": "independent_visibility_selected_and_fresh",
+        "prepared_lineage": "exact_semantic_pm4_prepared_draw",
+        "guest_state_changed": False,
+        "control_flow_changed": False,
+        "native_upload_enabled": False,
+        "native_draw_enabled": False,
+        "xenos_draw_preserved": True,
+        "suppression_allowed": False,
+    }
+    if any(contract.get(key) != value for key, value in expected.items()):
+        raise ValueError("static prepared-candidate contract drifted")
+    return contract
+
+
+def require_safety(event):
+    expected = {
+        "guest_state_changed": "false",
+        "control_flow_changed": "false",
+        "native_upload": "false",
+        "native_draw": "false",
+        "xenos_draw": "preserved",
+        "suppression_allowed": "false",
+    }
+    if any(event.get(key) != value for key, value in expected.items()):
+        raise ValueError("prepared-candidate evidence violates safety boundary")
+
+
+def build(events, static, requested_session=None):
+    contract = static_contract(static)
+    session = select_session(events, requested_session)
+    selected = [event for event in events if event.get("session") == session]
+    config = exact_event(selected, CONFIG)
+    summary = exact_event(selected, SUMMARY)
+    workset = exact_event(selected, WORKSET)
+    expected_config = {
+        "status": "armed",
+        "class": "proceduralGeometry::CProceduralModels",
+        "semantic_instance_hook": "8241741C",
+        "semantic_packet_hooks": "82416260,824162F4",
+        "prepared_draw_join": "physical_pm4_header_generation",
+        "capacity": "4096",
+        "policy_age_limit_frames": "1",
+        "identity": "receiver_generation_record_index",
+        "selection": "independent_visibility_selected_and_fresh",
+        "prepared_lineage": "exact_semantic_pm4_prepared_draw",
+        "guest_state_changed": "false",
+        "control_flow_changed": "false",
+        "native_upload": "false",
+        "native_draw": "false",
+        "xenos_draw": "preserved",
+        "suppression_allowed": "false",
+    }
+    if any(config.get(key) != value for key, value in expected_config.items()):
+        raise ValueError("prepared-candidate runtime configuration drifted")
+    require_safety(summary)
+    if (
+        summary.get("status") != "complete"
+        or summary.get("accounting_complete") != "true"
+        or summary.get("identity") != "receiver_generation_record_index"
+        or summary.get("prepared_lineage")
+        != "exact_semantic_pm4_prepared_draw"
+        or summary.get("selection")
+        != "independent_visibility_selected_and_fresh"
+    ):
+        raise ValueError("prepared-candidate summary is incomplete")
+
+    count_keys = (
+        "observations",
+        "selected_joins",
+        "fresh_candidates",
+        "stale_exclusions",
+        "future_exclusions",
+        "rejected_exclusions",
+        "missing_exclusions",
+        "candidate_entries",
+        "entry_draws",
+        "capacity",
+        "overflow",
+        "policy_age_limit_frames",
+    )
+    totals = {key: integer(summary, key) for key in count_keys}
+    entries = []
+    seen_keys = set()
+    entry_draws = 0
+    for event in selected:
+        if event.get("event") != ENTRY:
+            continue
+        require_safety(event)
+        key = hexadecimal(event, "candidate_key", 16)
+        item = {
+            "candidate_key": key,
+            "template_key": hexadecimal(event, "template_key", 16),
+            "geometry_resource_hash": hexadecimal(
+                event, "geometry_resource_hash", 16
+            ),
+            "texture_resource_hash": hexadecimal(
+                event, "texture_resource_hash", 16
+            ),
+            "receiver_address": hexadecimal(event, "receiver_address", 8),
+            "receiver_generation": integer(event, "receiver_generation"),
+            "record_index": integer(event, "record_index"),
+            "visibility_category": integer(event, "visibility_category"),
+            "visibility_result_mask": integer(event, "visibility_result_mask"),
+            "draws": integer(event, "draws"),
+            "first_frame": integer(event, "first_frame"),
+            "last_frame": integer(event, "last_frame"),
+            "maximum_policy_age_frames": integer(
+                event, "maximum_policy_age_frames"
+            ),
+        }
+        if (
+            event.get("status") != "complete"
+            or event.get("classification")
+            != "fresh_visibility_selected_prepared_candidate"
+            or key in seen_keys
+            or not item["draws"]
+            or item["first_frame"] > item["last_frame"]
+            or item["visibility_result_mask"] > 7
+            or item["maximum_policy_age_frames"]
+            > totals["policy_age_limit_frames"]
+            or integer(event, "policy_age_limit_frames")
+            != totals["policy_age_limit_frames"]
+        ):
+            raise ValueError("prepared-candidate entry evidence drifted")
+        seen_keys.add(key)
+        entry_draws += item["draws"]
+        entries.append(item)
+
+    failures = []
+    if totals["observations"] <= 0 or totals["fresh_candidates"] <= 0:
+        failures.append("prepared visibility handoff was not exercised")
+    if (
+        totals["observations"]
+        != totals["selected_joins"]
+        + totals["rejected_exclusions"]
+        + totals["missing_exclusions"]
+    ):
+        failures.append("prepared observation accounting drifted")
+    if (
+        totals["selected_joins"]
+        != totals["fresh_candidates"]
+        + totals["stale_exclusions"]
+        + totals["future_exclusions"]
+    ):
+        failures.append("selected policy-age accounting drifted")
+    if totals["fresh_candidates"] != totals["entry_draws"] + totals["overflow"]:
+        failures.append("fresh candidate accounting drifted")
+    if totals["candidate_entries"] != len(entries) or entry_draws != totals["entry_draws"]:
+        failures.append("prepared-candidate entry totals drifted")
+    if totals["capacity"] != 4096 or totals["policy_age_limit_frames"] != 1:
+        failures.append("prepared-candidate bounds drifted")
+    if totals["selected_joins"] > integer(workset, "selected_joins"):
+        failures.append("prepared selected joins exceed workset joins")
+    for key in ("future_exclusions", "overflow"):
+        if totals[key]:
+            failures.append(f"{key} is nonzero")
+
+    return {
+        "schema": SCHEMA,
+        "session": session,
+        "status": "complete" if not failures else "incomplete",
+        "failures": failures,
+        "static_contract": contract,
+        "totals": totals,
+        "entries": entries,
+        "qualification": {
+            "fresh_visibility_prepared_handoff_proved": not failures,
+            "native_draw_enabled": False,
+            "suppression_allowed": False,
+        },
+        "safety": {
+            "guest_state_changed": False,
+            "control_flow_changed": False,
+            "native_upload": False,
+            "native_draw": False,
+            "xenos_draw_preserved": True,
+            "suppression_allowed": False,
+        },
+    }
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser()
+    parser.add_argument("events", nargs="+", type=pathlib.Path)
+    parser.add_argument("--static", required=True, type=pathlib.Path)
+    parser.add_argument("--session")
+    parser.add_argument("--output", required=True, type=pathlib.Path)
+    args = parser.parse_args(argv)
+    try:
+        document = build(
+            read_events(args.events),
+            json.loads(args.static.read_text(encoding="utf-8")),
+            args.session,
+        )
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(
+            json.dumps(document, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        if document["status"] != "complete":
+            raise ValueError("; ".join(document["failures"]))
+        return 0
+    except (OSError, ValueError, json.JSONDecodeError) as error:
+        print(
+            f"native renderer prepared visibility summary failed: {error}",
+            file=sys.stderr,
+        )
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/tests/test_native_renderer_contract.py
+++ b/tools/tests/test_native_renderer_contract.py
@@ -607,6 +607,19 @@ class NativeRendererContractTests(unittest.TestCase):
         self.assertIn("ResolveSemanticReceiver", source)
         self.assertIn("semantic_receiver_unregistered_dispatches", source)
         self.assertIn("semantic_visibility_epoch", source)
+        self.assertIn(
+            "SemanticVisibilityPreparedCandidateEntry", source
+        )
+        self.assertIn(
+            "RecordSemanticVisibilityPreparedCandidate", source
+        )
+        self.assertIn(
+            "independent_visibility_selected_and_fresh", source
+        )
+        self.assertIn("exact_semantic_pm4_prepared_draw", source)
+        self.assertIn(
+            "kSemanticVisibilityMaximumPolicyAgeFrames = 1", source
+        )
         self.assertIn("semantic_render_state_epoch", source)
         self.assertIn("BeginSemanticReceiverStage", source)
         self.assertIn("semantic_stage_unknown_receivers", source)

--- a/tools/tests/test_native_renderer_dispatch_discovery.py
+++ b/tools/tests/test_native_renderer_dispatch_discovery.py
@@ -1389,6 +1389,30 @@ class NativeRendererDispatchDiscoveryTests(unittest.TestCase):
         self.assertFalse(workset["native_draw_enabled"])
         self.assertTrue(workset["xenos_authority"])
         self.assertFalse(workset["suppression_allowed"])
+        prepared_candidates = lifecycle["visibility_prepared_candidates"]
+        self.assertEqual(
+            "8241741C",
+            prepared_candidates["semantic_instance_hook_address"],
+        )
+        self.assertEqual(
+            ["82416260", "824162F4"],
+            prepared_candidates["semantic_packet_hook_addresses"],
+        )
+        self.assertEqual(4096, prepared_candidates["capacity"])
+        self.assertEqual(
+            1, prepared_candidates["maximum_policy_age_frames"]
+        )
+        self.assertEqual(
+            "independent_visibility_selected_and_fresh",
+            prepared_candidates["selection"],
+        )
+        self.assertEqual(
+            "exact_semantic_pm4_prepared_draw",
+            prepared_candidates["prepared_lineage"],
+        )
+        self.assertFalse(prepared_candidates["native_draw_enabled"])
+        self.assertTrue(prepared_candidates["xenos_draw_preserved"])
+        self.assertFalse(prepared_candidates["suppression_allowed"])
         self.assertEqual(
             92, lifecycle["field_layout"]["descriptor_record_stride"]
         )

--- a/tools/tests/test_native_renderer_visibility_prepared_candidates.py
+++ b/tools/tests/test_native_renderer_visibility_prepared_candidates.py
@@ -1,0 +1,164 @@
+import copy
+import importlib.util
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).parents[2]
+TOOL = ROOT / "tools/summarize-native-renderer-visibility-prepared-candidates.py"
+SPEC = importlib.util.spec_from_file_location("visibility_prepared", TOOL)
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+class VisibilityPreparedCandidateReportTests(unittest.TestCase):
+    def static(self):
+        return {
+            "schema": MODULE.STATIC_SCHEMA,
+            "procedural_model_receiver_lifecycle": {
+                "visibility_prepared_candidates": {
+                    "semantic_instance_hook_address": "8241741C",
+                    "semantic_packet_hook_addresses": ["82416260", "824162F4"],
+                    "capacity": 4096,
+                    "maximum_policy_age_frames": 1,
+                    "identity": "receiver_generation_record_index",
+                    "selection": "independent_visibility_selected_and_fresh",
+                    "prepared_lineage": "exact_semantic_pm4_prepared_draw",
+                    "guest_state_changed": False,
+                    "control_flow_changed": False,
+                    "native_upload_enabled": False,
+                    "native_draw_enabled": False,
+                    "xenos_draw_preserved": True,
+                    "suppression_allowed": False,
+                }
+            },
+        }
+
+    def safety(self):
+        return {
+            "guest_state_changed": "false",
+            "control_flow_changed": "false",
+            "native_upload": "false",
+            "native_draw": "false",
+            "xenos_draw": "preserved",
+            "suppression_allowed": "false",
+        }
+
+    def events(self):
+        config = {
+            "event": MODULE.CONFIG,
+            "session": "test",
+            "status": "armed",
+            "class": "proceduralGeometry::CProceduralModels",
+            "semantic_instance_hook": "8241741C",
+            "semantic_packet_hooks": "82416260,824162F4",
+            "prepared_draw_join": "physical_pm4_header_generation",
+            "capacity": "4096",
+            "policy_age_limit_frames": "1",
+            "identity": "receiver_generation_record_index",
+            "selection": "independent_visibility_selected_and_fresh",
+            "prepared_lineage": "exact_semantic_pm4_prepared_draw",
+            **self.safety(),
+        }
+        entry = {
+            "event": MODULE.ENTRY,
+            "session": "test",
+            "status": "complete",
+            "candidate_key": "1111111111111111",
+            "template_key": "2222222222222222",
+            "geometry_resource_hash": "3333333333333333",
+            "texture_resource_hash": "4444444444444444",
+            "receiver_address": "10001000",
+            "receiver_generation": "2",
+            "record_index": "4",
+            "visibility_category": "9",
+            "visibility_result_mask": "6",
+            "draws": "7",
+            "first_frame": "10",
+            "last_frame": "12",
+            "maximum_policy_age_frames": "1",
+            "policy_age_limit_frames": "1",
+            "classification": "fresh_visibility_selected_prepared_candidate",
+            **self.safety(),
+        }
+        summary = {
+            "event": MODULE.SUMMARY,
+            "session": "test",
+            "status": "complete",
+            "observations": "15",
+            "selected_joins": "9",
+            "fresh_candidates": "7",
+            "stale_exclusions": "2",
+            "future_exclusions": "0",
+            "rejected_exclusions": "3",
+            "missing_exclusions": "3",
+            "candidate_entries": "1",
+            "entry_draws": "7",
+            "capacity": "4096",
+            "overflow": "0",
+            "policy_age_limit_frames": "1",
+            "accounting_complete": "true",
+            "identity": "receiver_generation_record_index",
+            "prepared_lineage": "exact_semantic_pm4_prepared_draw",
+            "selection": "independent_visibility_selected_and_fresh",
+            **self.safety(),
+        }
+        workset = {
+            "event": MODULE.WORKSET,
+            "session": "test",
+            "selected_joins": "10",
+        }
+        return [config, entry, summary, workset]
+
+    def test_build_qualifies_fresh_prepared_handoff(self):
+        document = MODULE.build(self.events(), self.static())
+        self.assertEqual("complete", document["status"])
+        self.assertTrue(
+            document["qualification"][
+                "fresh_visibility_prepared_handoff_proved"
+            ]
+        )
+        self.assertEqual(2, document["totals"]["stale_exclusions"])
+
+    def test_build_rejects_future_policy_decision(self):
+        events = copy.deepcopy(self.events())
+        summary = next(event for event in events if event["event"] == MODULE.SUMMARY)
+        summary["fresh_candidates"] = "6"
+        summary["future_exclusions"] = "1"
+        summary["entry_draws"] = "6"
+        entry = next(event for event in events if event["event"] == MODULE.ENTRY)
+        entry["draws"] = "6"
+        document = MODULE.build(events, self.static())
+        self.assertEqual("incomplete", document["status"])
+        self.assertIn("future_exclusions is nonzero", document["failures"])
+
+    def test_build_rejects_overflow(self):
+        events = copy.deepcopy(self.events())
+        summary = next(event for event in events if event["event"] == MODULE.SUMMARY)
+        summary["fresh_candidates"] = "8"
+        summary["overflow"] = "1"
+        document = MODULE.build(events, self.static())
+        self.assertEqual("incomplete", document["status"])
+        self.assertIn("overflow is nonzero", document["failures"])
+
+    def test_build_rejects_workset_join_drift(self):
+        events = copy.deepcopy(self.events())
+        workset = next(event for event in events if event["event"] == MODULE.WORKSET)
+        workset["selected_joins"] = "8"
+        document = MODULE.build(events, self.static())
+        self.assertEqual("incomplete", document["status"])
+        self.assertIn(
+            "prepared selected joins exceed workset joins", document["failures"]
+        )
+
+    def test_build_rejects_static_suppression_drift(self):
+        static = self.static()
+        static["procedural_model_receiver_lifecycle"][
+            "visibility_prepared_candidates"
+        ]["suppression_allowed"] = True
+        with self.assertRaisesRegex(ValueError, "contract drifted"):
+            MODULE.build(self.events(), static)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- propagate independent visibility-workset decisions through semantic submission and exact PM4 prepared-draw lineage
- admit only current or one-frame-old selected decisions to a bounded host candidate table
- fail closed for stale, rejected, missing, future, or overflowing candidates while preserving Xenos

## Validation
- 309 native-renderer tests pass
- Release build succeeds
- AppData session \20260830T015106Z-p25800\: 363,948 prepared observations, 8,561 fresh candidates, 1,360 stale exclusions, zero future decisions/overflow
- all 14 visibility, semantic, batch, and lineage reports complete
- 29.750 median FPS, 15.224 1% low, zero present-deadline misses
- normal exit and clean fatal scan