### PR TITLE
feat(native-renderer): gate isolated draws on fresh visibility

### DIFF
--- a/docs/native-renderer/ISOLATED_DRAW_REPLAY.md
+++ b/docs/native-renderer/ISOLATED_DRAW_REPLAY.md
@@ -21,6 +21,15 @@ live observation still satisfies the qualified candidate boundary:
 - active host rasterization; and
 - exactly one depth target and the first color target.
 
+Semantic world candidates can add a stricter, fail-closed admission gate with
+`-RequireFreshVisibilityCandidate`. In that mode, the exact prepared draw must
+also carry a selected game visibility decision from the current or immediately
+preceding frame through the semantic submission and physical PM4 lineage. A
+missing, rejected, stale, future, or table-overflow decision cannot issue the
+isolated native draw. An early matching signature without a fresh decision is
+reported once and remains armed for a later fresh occurrence; it is not a
+terminal rejection. The exact-signature and mechanical gates remain required.
+
 ReXGlue independently requires host render targets, rasterization, and no
 memexport. Indexed requests require a direct guest DMA index buffer; AutoIndex
 requests use the already prepared host vertex count. It creates private clones
@@ -43,6 +52,15 @@ $stateRoot = Join-Path $env:LOCALAPPDATA `
   -IsolatedDrawSignature 747837906D0BF484 `
   -Json
 ```
+
+For a visibility-selected semantic candidate, add:
+
+```powershell
+  -RequireFreshVisibilityCandidate
+```
+
+This option is intended for semantic world bring-up and is not used by the
+already-qualified sky/horizon replay family.
 
 The expected result is one `native_renderer.isolated_draw.result` event with
 `status=recorded`, non-zero target dimensions, `native_draw=isolated_only`,

--- a/docs/native-renderer/VISIBILITY_PREPARED_CANDIDATES.md
+++ b/docs/native-renderer/VISIBILITY_PREPARED_CANDIDATES.md
@@ -32,12 +32,17 @@ superset.
 
 Fresh candidates are aggregated in a fixed 4,096-entry table keyed by exact
 semantic identity plus immutable prepared template, geometry-resource, texture-
-resource, visibility-category, and result-mask identities. The runtime records:
+resource, prepared-signature, visibility-category, and result-mask identities.
+The exact prepared signature prevents a resource family from merging a
+replayable draw with a resolved-input or otherwise mechanically ineligible
+variant. The runtime records:
 
 - all semantic prepared observations;
 - selected, rejected, and missing workset joins;
 - fresh, stale, and future selected decisions;
 - per-candidate draw/frame coverage and maximum policy age;
+- exact shader identities, specialization masks, and isolated-draw mechanical
+  eligibility;
 - table occupancy, overflow, and complete partition accounting.
 
 Generate and qualify the evidence with:
@@ -62,11 +67,12 @@ table.
 
 ## Safety boundary
 
-This checkpoint only carries host metadata. It writes no guest state, changes
-no title control flow, uploads no resource, issues no native draw, and cannot
-suppress Xenos. Xenos remains the sole rendering authority. The candidate
-table is an admission input for a later native consumer, not permission to draw
-or suppress by itself.
+The normal checkpoint only carries host metadata. When an operator separately
+arms an exact isolated-draw signature with the fresh-visibility gate, the table
+can admit one private-target native replay through all existing mechanical
+safety checks. The original Xenos draw and displayed frame remain authoritative;
+this path cannot suppress Xenos. Without that explicit startup-only request,
+the table issues no native work.
 
 ## AppData qualification
 

--- a/src/native_renderer/graphics_hooks.cpp
+++ b/src/native_renderer/graphics_hooks.cpp
@@ -283,6 +283,7 @@ struct SemanticBatchOpportunityEntry {
 
 struct SemanticVisibilityPreparedCandidateEntry {
   uint64_t key = 0;
+  uint64_t prepared_signature = 0;
   uint64_t template_key = 0;
   uint64_t geometry_resource_hash = 0;
   uint64_t texture_resource_hash = 0;
@@ -290,11 +291,16 @@ struct SemanticVisibilityPreparedCandidateEntry {
   uint64_t first_frame = 0;
   uint64_t last_frame = 0;
   uint64_t maximum_policy_age_frames = 0;
+  uint64_t vertex_shader_hash = 0;
+  uint64_t pixel_shader_hash = 0;
+  uint64_t vertex_specialization_mask = 0;
+  uint64_t pixel_specialization_mask = 0;
   uint32_t receiver_address = 0;
   uint32_t receiver_generation = 0;
   uint32_t record_index = 0;
   uint32_t visibility_category = 0;
   uint32_t visibility_result_mask = 0;
+  bool mechanically_eligible = false;
 };
 
 struct SemanticBatchRun {
@@ -4066,6 +4072,9 @@ struct IsolatedDrawState {
   bool valid = true;
   bool prepared_candidate_valid = false;
   bool prepared_candidate_eligible = false;
+  bool prepared_visibility_candidate_fresh = false;
+  bool require_fresh_visibility_candidate = false;
+  bool visibility_wait_reported = false;
   bool awaiting_pass_follower = false;
   bool pass_anchor_recorded = false;
   bool pass_repeat_reported = false;
@@ -4502,6 +4511,20 @@ void ConfigureIsolatedDraw() {
       !IsLocalArtifactRoot(g_isolated_draw.output_root)) {
     g_isolated_draw.valid = false;
   }
+  value = nullptr;
+  length = 0;
+  if (_dupenv_s(
+          &value, &length,
+          "PINYON_SHIFT_NATIVE_RENDERER_REQUIRE_FRESH_VISIBILITY_CANDIDATE") ==
+          0 &&
+      value && length > 1) {
+    const std::string setting(value);
+    g_isolated_draw.require_fresh_visibility_candidate = setting == "true";
+    if (setting != "true" && setting != "false") {
+      g_isolated_draw.valid = false;
+    }
+  }
+  std::free(value);
 }
 
 void ConfigurePassPublication() {
@@ -10017,32 +10040,33 @@ void RecordSemanticBatchEquivalenceOpportunity(
   };
 }
 
-void RecordSemanticVisibilityPreparedCandidate(
+bool RecordSemanticVisibilityPreparedCandidate(
     const rex::system::GraphicsDrawObservation &observation,
     const SemanticDrawIdentity &identity,
-    const SemanticPreparedDrawContract &contract) {
+    const SemanticPreparedDrawContract &contract,
+    uint64_t prepared_signature, bool mechanically_eligible) {
   ++g_semantic_visibility_prepared_observations;
   if (identity.visibility_workset_join ==
       SemanticVisibilityWorksetJoin::kMissing) {
     ++g_semantic_visibility_prepared_missing_exclusions;
-    return;
+    return false;
   }
   if (identity.visibility_workset_join ==
       SemanticVisibilityWorksetJoin::kRejected) {
     ++g_semantic_visibility_prepared_rejected_exclusions;
-    return;
+    return false;
   }
 
   ++g_semantic_visibility_prepared_selected_joins;
   if (observation.frame_sequence < identity.visibility_policy_frame) {
     ++g_semantic_visibility_prepared_future_exclusions;
-    return;
+    return false;
   }
   const uint64_t policy_age_frames =
       observation.frame_sequence - identity.visibility_policy_frame;
   if (policy_age_frames > kSemanticVisibilityMaximumPolicyAgeFrames) {
     ++g_semantic_visibility_prepared_stale_exclusions;
-    return;
+    return false;
   }
   ++g_semantic_visibility_prepared_fresh_candidates;
 
@@ -10052,6 +10076,7 @@ void RecordSemanticVisibilityPreparedCandidate(
         uint64_t(identity.receiver_generation),
         uint64_t(identity.record_index), contract.template_key,
         contract.geometry_resource_hash, contract.texture_resource_hash,
+        prepared_signature,
         uint64_t(identity.visibility_category),
         uint64_t(identity.visibility_result_mask)}) {
     key = HashCombine(key, value);
@@ -10066,6 +10091,7 @@ void RecordSemanticVisibilityPreparedCandidate(
     if (!entry.key) {
       entry = {
           .key = key,
+          .prepared_signature = prepared_signature,
           .template_key = contract.template_key,
           .geometry_resource_hash = contract.geometry_resource_hash,
           .texture_resource_hash = contract.texture_resource_hash,
@@ -10073,19 +10099,33 @@ void RecordSemanticVisibilityPreparedCandidate(
           .first_frame = observation.frame_sequence,
           .last_frame = observation.frame_sequence,
           .maximum_policy_age_frames = policy_age_frames,
+          .vertex_shader_hash = contract.vertex_shader_hash,
+          .pixel_shader_hash = contract.pixel_shader_hash,
+          .vertex_specialization_mask =
+              contract.vertex_specialization_mask,
+          .pixel_specialization_mask = contract.pixel_specialization_mask,
           .receiver_address = identity.receiver_address,
           .receiver_generation = identity.receiver_generation,
           .record_index = identity.record_index,
           .visibility_category = identity.visibility_category,
           .visibility_result_mask = identity.visibility_result_mask,
+          .mechanically_eligible = mechanically_eligible,
       };
       ++g_semantic_visibility_prepared_candidate_count;
-      return;
+      return true;
     }
     if (entry.key == key &&
+        entry.prepared_signature == prepared_signature &&
         entry.template_key == contract.template_key &&
         entry.geometry_resource_hash == contract.geometry_resource_hash &&
         entry.texture_resource_hash == contract.texture_resource_hash &&
+        entry.vertex_shader_hash == contract.vertex_shader_hash &&
+        entry.pixel_shader_hash == contract.pixel_shader_hash &&
+        entry.vertex_specialization_mask ==
+            contract.vertex_specialization_mask &&
+        entry.pixel_specialization_mask ==
+            contract.pixel_specialization_mask &&
+        entry.mechanically_eligible == mechanically_eligible &&
         entry.receiver_address == identity.receiver_address &&
         entry.receiver_generation == identity.receiver_generation &&
         entry.record_index == identity.record_index &&
@@ -10095,27 +10135,32 @@ void RecordSemanticVisibilityPreparedCandidate(
       entry.last_frame = observation.frame_sequence;
       entry.maximum_policy_age_frames =
           std::max(entry.maximum_policy_age_frames, policy_age_frames);
-      return;
+      return true;
     }
     index =
         (index + 1) % kSemanticVisibilityPreparedCandidateCapacity;
   }
   ++g_semantic_visibility_prepared_candidate_overflow;
+  return false;
 }
 
-void RecordSemanticBatchOpportunity(
+bool RecordSemanticBatchOpportunity(
     const rex::system::GraphicsDrawObservation &observation,
     bool samples_resolved_target,
     const rex::system::GraphicsPreparedDrawObservation &prepared,
-    const TitleDrawOrigin &origin) {
+    const TitleDrawOrigin &origin, uint64_t prepared_signature) {
   if (!origin.semantic_draw.valid) {
-    return;
+    return false;
   }
   const SemanticDrawIdentity &identity = origin.semantic_draw;
   const SemanticPreparedDrawContract contract =
       BuildSemanticPreparedDrawContract(observation, prepared);
-  RecordSemanticVisibilityPreparedCandidate(observation, identity,
-                                            contract);
+  const bool mechanically_eligible = IsIsolatedDrawEligible(
+      observation, samples_resolved_target, prepared);
+  const bool fresh_visibility_candidate =
+      RecordSemanticVisibilityPreparedCandidate(observation, identity,
+                                                contract, prepared_signature,
+                                                mechanically_eligible);
   const SemanticBatchRejection rejection =
       ClassifySemanticBatchRejection(observation, samples_resolved_target,
                                      prepared, identity, contract);
@@ -10143,7 +10188,7 @@ void RecordSemanticBatchOpportunity(
     FinalizeSemanticBatchEquivalenceRuns();
     BreakSemanticStateCacheContinuity();
     g_semantic_batch_previous_eligible = false;
-    return;
+    return fresh_visibility_candidate;
   }
   SemanticBatchOpportunityEntry &entry =
       g_semantic_batch_opportunities[opportunity_index];
@@ -10163,7 +10208,7 @@ void RecordSemanticBatchOpportunity(
     FinalizeSemanticBatchEquivalenceRuns();
     BreakSemanticStateCacheContinuity();
     g_semantic_batch_previous_eligible = false;
-    return;
+    return fresh_visibility_candidate;
   }
   ++g_semantic_batch_eligible_draws;
   const uint64_t parameter_hash =
@@ -10224,7 +10269,7 @@ void RecordSemanticBatchOpportunity(
     g_semantic_batch_run.receiver_address = identity.receiver_address;
     g_semantic_batch_run.receiver_generation = identity.receiver_generation;
     g_semantic_batch_run.record_index = identity.record_index;
-    return;
+    return fresh_visibility_candidate;
   }
   FinalizeSemanticBatchRun();
   g_semantic_batch_run = {
@@ -10237,6 +10282,7 @@ void RecordSemanticBatchOpportunity(
       .record_index = identity.record_index,
       .valid = true,
   };
+  return fresh_visibility_candidate;
 }
 
 void EmitSemanticBatchEquivalenceSummary() {
@@ -11562,6 +11608,8 @@ void EmitSemanticVisibilityCensus() {
 void EmitSemanticVisibilityPreparedCandidates() {
   uint64_t entry_draws = 0;
   uint64_t entry_count = 0;
+  uint64_t mechanically_eligible_draws = 0;
+  uint64_t mechanically_eligible_entries = 0;
   for (const SemanticVisibilityPreparedCandidateEntry &entry :
        g_semantic_visibility_prepared_candidates) {
     if (!entry.key) {
@@ -11569,15 +11617,28 @@ void EmitSemanticVisibilityPreparedCandidates() {
     }
     ++entry_count;
     entry_draws += entry.draws;
+    if (entry.mechanically_eligible) {
+      mechanically_eligible_draws += entry.draws;
+      ++mechanically_eligible_entries;
+    }
     pinyon_shift::diagnostics::RecordEvent(
         "native_renderer.discovery.semantic_visibility_prepared_candidate_entry",
         {{"status", "complete"},
          {"candidate_key", fmt::format("{:016X}", entry.key)},
+         {"prepared_signature",
+          fmt::format("{:016X}", entry.prepared_signature)},
          {"template_key", fmt::format("{:016X}", entry.template_key)},
          {"geometry_resource_hash",
           fmt::format("{:016X}", entry.geometry_resource_hash)},
          {"texture_resource_hash",
           fmt::format("{:016X}", entry.texture_resource_hash)},
+         {"vertex_shader",
+          fmt::format("{:016X}", entry.vertex_shader_hash)},
+         {"pixel_shader", fmt::format("{:016X}", entry.pixel_shader_hash)},
+         {"vertex_specialization_mask",
+          fmt::format("{:016X}", entry.vertex_specialization_mask)},
+         {"pixel_specialization_mask",
+          fmt::format("{:016X}", entry.pixel_specialization_mask)},
          {"receiver_address",
           fmt::format("{:08X}", entry.receiver_address)},
          {"receiver_generation",
@@ -11592,6 +11653,8 @@ void EmitSemanticVisibilityPreparedCandidates() {
          {"last_frame", std::to_string(entry.last_frame)},
          {"maximum_policy_age_frames",
           std::to_string(entry.maximum_policy_age_frames)},
+         {"mechanically_eligible",
+          entry.mechanically_eligible ? "true" : "false"},
          {"policy_age_limit_frames",
           std::to_string(kSemanticVisibilityMaximumPolicyAgeFrames)},
          {"classification", "fresh_visibility_selected_prepared_candidate"},
@@ -11637,6 +11700,10 @@ void EmitSemanticVisibilityPreparedCandidates() {
        {"candidate_entries",
         std::to_string(g_semantic_visibility_prepared_candidate_count)},
        {"entry_draws", std::to_string(entry_draws)},
+       {"mechanically_eligible_entries",
+        std::to_string(mechanically_eligible_entries)},
+       {"mechanically_eligible_draws",
+        std::to_string(mechanically_eligible_draws)},
        {"capacity",
         std::to_string(kSemanticVisibilityPreparedCandidateCapacity)},
        {"overflow",
@@ -11864,15 +11931,17 @@ void ObservePreparedDraw(
     RecordTitleDrawProvenance(prepared_signature, true, 0, sample,
                               g_pending_candidate.title_origin,
                               &observation);
-    RecordSemanticBatchOpportunity(
+    const bool fresh_visibility_candidate = RecordSemanticBatchOpportunity(
         sample, g_pending_candidate.samples_resolved_target, observation,
-        g_pending_candidate.title_origin);
+        g_pending_candidate.title_origin, prepared_signature);
     g_isolated_draw.prepared_signature = prepared_signature;
     g_isolated_draw.frame = sample.frame_sequence;
     g_isolated_draw.draw = sample.draw_sequence;
     g_isolated_draw.prepared_sample = sample;
     g_isolated_draw.prepared_candidate_eligible = IsIsolatedDrawEligible(
         sample, g_pending_candidate.samples_resolved_target, observation);
+    g_isolated_draw.prepared_visibility_candidate_fresh =
+        fresh_visibility_candidate;
     g_isolated_draw.prepared_candidate_valid = true;
     if (g_pass_follower.requested && g_pass_follower.valid &&
         !g_pass_follower.completed) {
@@ -13113,12 +13182,16 @@ void RequestIsolatedDraw(
                          g_pass_follower.valid &&
                          g_pass_follower.target_signature !=
                              g_isolated_draw.target_signature;
+  const bool candidate_eligible =
+      g_isolated_draw.prepared_candidate_eligible &&
+      (!g_isolated_draw.require_fresh_visibility_candidate ||
+       g_isolated_draw.prepared_visibility_candidate_fresh);
   if (pass_mode) {
     const uint64_t signature = g_isolated_draw.prepared_signature;
     if (signature == g_pass_follower.target_signature) {
       g_isolated_draw.awaiting_pass_follower = false;
       g_isolated_draw.pass_anchor_recorded = false;
-      if (!g_isolated_draw.prepared_candidate_eligible) {
+      if (!candidate_eligible) {
         return;
       }
       g_isolated_draw.pass_anchor_frame = g_isolated_draw.frame;
@@ -13143,7 +13216,7 @@ void RequestIsolatedDraw(
         g_isolated_draw.draw == g_isolated_draw.pass_anchor_draw + 1;
     g_isolated_draw.awaiting_pass_follower = false;
     if (!adjacent || !g_isolated_draw.pass_anchor_recorded ||
-        !g_isolated_draw.prepared_candidate_eligible) {
+        !candidate_eligible) {
       return;
     }
     if (g_pass_consumer_trace.pending) {
@@ -13204,12 +13277,33 @@ void RequestIsolatedDraw(
     // Keep the private replay visible to frame debuggers after the one-shot
     // result has been recorded. This path has no readback or completion
     // callback, and the authoritative Xenos draw still follows unmodified.
-    request.requested = g_isolated_draw.prepared_candidate_eligible;
+    request.requested = candidate_eligible;
     request.frame_sequence = request.requested ? g_isolated_draw.frame : 0;
     return;
   }
+  if (g_isolated_draw.prepared_candidate_eligible &&
+      g_isolated_draw.require_fresh_visibility_candidate &&
+      !g_isolated_draw.prepared_visibility_candidate_fresh) {
+    if (!g_isolated_draw.visibility_wait_reported) {
+      pinyon_shift::diagnostics::RecordEvent(
+          "native_renderer.isolated_draw.visibility_gate",
+          {{"signature",
+            fmt::format("{:016X}", g_isolated_draw.prepared_signature)},
+           {"status", "waiting_for_fresh_selected_candidate"},
+           {"frame", std::to_string(g_isolated_draw.frame)},
+           {"draw", std::to_string(g_isolated_draw.draw)},
+           {"mechanically_eligible", "true"},
+           {"fresh_visibility_candidate", "false"},
+           {"native_draw", "false"},
+           {"xenos_draw", "preserved"},
+           {"output_authority", "xenos"},
+           {"suppression_eligible", "false"}});
+      g_isolated_draw.visibility_wait_reported = true;
+    }
+    return;
+  }
   g_isolated_draw.completed = true;
-  if (!g_isolated_draw.prepared_candidate_eligible) {
+  if (!candidate_eligible) {
     pinyon_shift::diagnostics::RecordEvent(
         "native_renderer.isolated_draw.result",
         {{"signature",
@@ -13218,6 +13312,14 @@ void RequestIsolatedDraw(
          {"frame", std::to_string(g_isolated_draw.frame)},
          {"draw", std::to_string(g_isolated_draw.draw)},
          {"native_draw", "false"},
+         {"mechanically_eligible",
+          g_isolated_draw.prepared_candidate_eligible ? "true" : "false"},
+         {"fresh_visibility_candidate",
+          g_isolated_draw.prepared_visibility_candidate_fresh ? "true"
+                                                              : "false"},
+         {"visibility_gate_required",
+          g_isolated_draw.require_fresh_visibility_candidate ? "true"
+                                                             : "false"},
          {"xenos_draw", "preserved"},
          {"output_authority", "xenos"},
          {"suppression_eligible", "false"}});
@@ -14396,6 +14498,10 @@ void InstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system,
        {"readback", g_isolated_draw.readback_requested ? "asynchronous"
                                                         : "disabled"},
        {"reference_marker", "exact_signature"},
+       {"visibility_gate",
+        g_isolated_draw.require_fresh_visibility_candidate
+            ? "fresh_selected_semantic_candidate"
+            : "disabled"},
        {"xenos_draw", "preserved"},
        {"output_authority", "xenos"},
        {"suppression_eligible", "false"}});

--- a/tools/capture-native-renderer-census.ps1
+++ b/tools/capture-native-renderer-census.ps1
@@ -16,6 +16,7 @@ param(
     [ValidatePattern('^[0-9A-Fa-f]{16}$')]
     [string]$IsolatedDrawSignature,
     [string]$IsolatedDrawDir,
+    [switch]$RequireFreshVisibilityCandidate,
     [ValidatePattern('^[0-9A-Fa-f]{16}$')]
     [string]$PassAnchorSignature,
     [switch]$PublishRetainedPass,
@@ -105,6 +106,9 @@ if ($IsolatedDrawDir) {
     }
     $IsolatedDrawDir = $resolvedIsolatedDrawDir
 }
+if ($RequireFreshVisibilityCandidate -and -not $IsolatedDrawSignature) {
+    throw 'RequireFreshVisibilityCandidate requires IsolatedDrawSignature'
+}
 
 if ($ConsumerReadbackDir) {
     if (-not $ConsumerFamily) {
@@ -136,6 +140,7 @@ $savedReplaySnapshot = $env:PINYON_SHIFT_NATIVE_RENDERER_SNAPSHOT_SIGNATURE
 $savedReplaySnapshotDir = $env:PINYON_SHIFT_NATIVE_RENDERER_SNAPSHOT_DIR
 $savedIsolatedDraw = $env:PINYON_SHIFT_NATIVE_RENDERER_ISOLATED_DRAW_SIGNATURE
 $savedIsolatedDrawDir = $env:PINYON_SHIFT_NATIVE_RENDERER_ISOLATED_DRAW_DIR
+$savedVisibilityGate = $env:PINYON_SHIFT_NATIVE_RENDERER_REQUIRE_FRESH_VISIBILITY_CANDIDATE
 $savedPassAnchor = $env:PINYON_SHIFT_NATIVE_RENDERER_PASS_ANCHOR_SIGNATURE
 $savedPassPublication = $env:PINYON_SHIFT_NATIVE_RENDERER_PUBLISH_RETAINED_PASS
 $savedConsumerFamily = $env:PINYON_SHIFT_NATIVE_RENDERER_CONSUMER_FAMILY
@@ -150,6 +155,8 @@ try {
     $env:PINYON_SHIFT_NATIVE_RENDERER_SNAPSHOT_DIR = $ReplaySnapshotDir
     $env:PINYON_SHIFT_NATIVE_RENDERER_ISOLATED_DRAW_SIGNATURE = $IsolatedDrawSignature
     $env:PINYON_SHIFT_NATIVE_RENDERER_ISOLATED_DRAW_DIR = $IsolatedDrawDir
+    $env:PINYON_SHIFT_NATIVE_RENDERER_REQUIRE_FRESH_VISIBILITY_CANDIDATE =
+        if ($RequireFreshVisibilityCandidate) { 'true' } else { $null }
     $env:PINYON_SHIFT_NATIVE_RENDERER_PASS_ANCHOR_SIGNATURE = $PassAnchorSignature
     $env:PINYON_SHIFT_NATIVE_RENDERER_PUBLISH_RETAINED_PASS =
         if ($PublishRetainedPass) { 'true' } else { $null }
@@ -170,6 +177,8 @@ finally {
     $env:PINYON_SHIFT_NATIVE_RENDERER_SNAPSHOT_DIR = $savedReplaySnapshotDir
     $env:PINYON_SHIFT_NATIVE_RENDERER_ISOLATED_DRAW_SIGNATURE = $savedIsolatedDraw
     $env:PINYON_SHIFT_NATIVE_RENDERER_ISOLATED_DRAW_DIR = $savedIsolatedDrawDir
+    $env:PINYON_SHIFT_NATIVE_RENDERER_REQUIRE_FRESH_VISIBILITY_CANDIDATE =
+        $savedVisibilityGate
     $env:PINYON_SHIFT_NATIVE_RENDERER_PASS_ANCHOR_SIGNATURE = $savedPassAnchor
     $env:PINYON_SHIFT_NATIVE_RENDERER_PUBLISH_RETAINED_PASS = $savedPassPublication
     $env:PINYON_SHIFT_NATIVE_RENDERER_CONSUMER_FAMILY = $savedConsumerFamily

--- a/tools/summarize-native-renderer-visibility-prepared-candidates.py
+++ b/tools/summarize-native-renderer-visibility-prepared-candidates.py
@@ -7,7 +7,7 @@ import pathlib
 import sys
 
 
-SCHEMA = "pinyon-shift.native-renderer-visibility-prepared-candidates.v1"
+SCHEMA = "pinyon-shift.native-renderer-visibility-prepared-candidates.v2"
 STATIC_SCHEMA = "pinyon-shift.native-renderer-dispatch-static.v3"
 CONFIG = (
     "native_renderer.discovery."
@@ -166,6 +166,8 @@ def build(events, static, requested_session=None):
         "missing_exclusions",
         "candidate_entries",
         "entry_draws",
+        "mechanically_eligible_entries",
+        "mechanically_eligible_draws",
         "capacity",
         "overflow",
         "policy_age_limit_frames",
@@ -181,12 +183,21 @@ def build(events, static, requested_session=None):
         key = hexadecimal(event, "candidate_key", 16)
         item = {
             "candidate_key": key,
+            "prepared_signature": hexadecimal(event, "prepared_signature", 16),
             "template_key": hexadecimal(event, "template_key", 16),
             "geometry_resource_hash": hexadecimal(
                 event, "geometry_resource_hash", 16
             ),
             "texture_resource_hash": hexadecimal(
                 event, "texture_resource_hash", 16
+            ),
+            "vertex_shader": hexadecimal(event, "vertex_shader", 16),
+            "pixel_shader": hexadecimal(event, "pixel_shader", 16),
+            "vertex_specialization_mask": hexadecimal(
+                event, "vertex_specialization_mask", 16
+            ),
+            "pixel_specialization_mask": hexadecimal(
+                event, "pixel_specialization_mask", 16
             ),
             "receiver_address": hexadecimal(event, "receiver_address", 8),
             "receiver_generation": integer(event, "receiver_generation"),
@@ -199,6 +210,7 @@ def build(events, static, requested_session=None):
             "maximum_policy_age_frames": integer(
                 event, "maximum_policy_age_frames"
             ),
+            "mechanically_eligible": event.get("mechanically_eligible") == "true",
         }
         if (
             event.get("status") != "complete"
@@ -210,6 +222,7 @@ def build(events, static, requested_session=None):
             or item["visibility_result_mask"] > 7
             or item["maximum_policy_age_frames"]
             > totals["policy_age_limit_frames"]
+            or event.get("mechanically_eligible") not in ("true", "false")
             or integer(event, "policy_age_limit_frames")
             != totals["policy_age_limit_frames"]
         ):
@@ -239,6 +252,13 @@ def build(events, static, requested_session=None):
         failures.append("fresh candidate accounting drifted")
     if totals["candidate_entries"] != len(entries) or entry_draws != totals["entry_draws"]:
         failures.append("prepared-candidate entry totals drifted")
+    eligible_entries = [entry for entry in entries if entry["mechanically_eligible"]]
+    if (
+        totals["mechanically_eligible_entries"] != len(eligible_entries)
+        or totals["mechanically_eligible_draws"]
+        != sum(entry["draws"] for entry in eligible_entries)
+    ):
+        failures.append("mechanically eligible candidate totals drifted")
     if totals["capacity"] != 4096 or totals["policy_age_limit_frames"] != 1:
         failures.append("prepared-candidate bounds drifted")
     if totals["selected_joins"] > integer(workset, "selected_joins"):
@@ -257,6 +277,8 @@ def build(events, static, requested_session=None):
         "entries": entries,
         "qualification": {
             "fresh_visibility_prepared_handoff_proved": not failures,
+            "isolated_native_candidate_proved": not failures
+            and bool(eligible_entries),
             "native_draw_enabled": False,
             "suppression_allowed": False,
         },

--- a/tools/tests/test_native_renderer_contract.py
+++ b/tools/tests/test_native_renderer_contract.py
@@ -1589,8 +1589,23 @@ class NativeRendererContractTests(unittest.TestCase):
         self.assertIn("reference_marker_requested", visual_marker_patch)
         self.assertNotIn("SetDrawSuppression", visual_marker_patch)
         self.assertIn("request.reference_marker_requested = true", scanner)
+        self.assertIn("request.requested = candidate_eligible", scanner)
         self.assertIn(
-            "request.requested = g_isolated_draw.prepared_candidate_eligible", scanner
+            "g_isolated_draw.prepared_visibility_candidate_fresh", scanner
+        )
+        self.assertIn(
+            "PINYON_SHIFT_NATIVE_RENDERER_REQUIRE_FRESH_VISIBILITY_CANDIDATE",
+            scanner,
+        )
+        self.assertIn("waiting_for_fresh_selected_candidate", scanner)
+        self.assertIn("visibility_wait_reported", scanner)
+        census_capture = (
+            ROOT / "tools/capture-native-renderer-census.ps1"
+        ).read_text(encoding="utf-8")
+        self.assertIn("RequireFreshVisibilityCandidate", census_capture)
+        self.assertIn(
+            "RequireFreshVisibilityCandidate requires IsolatedDrawSignature",
+            census_capture,
         )
         self.assertIn("authoritative Xenos draw still follows unmodified", scanner)
 

--- a/tools/tests/test_native_renderer_visibility_prepared_candidates.py
+++ b/tools/tests/test_native_renderer_visibility_prepared_candidates.py
@@ -65,9 +65,14 @@ class VisibilityPreparedCandidateReportTests(unittest.TestCase):
             "session": "test",
             "status": "complete",
             "candidate_key": "1111111111111111",
+            "prepared_signature": "AAAAAAAAAAAAAAAA",
             "template_key": "2222222222222222",
             "geometry_resource_hash": "3333333333333333",
             "texture_resource_hash": "4444444444444444",
+            "vertex_shader": "5555555555555555",
+            "pixel_shader": "6666666666666666",
+            "vertex_specialization_mask": "000000000000007F",
+            "pixel_specialization_mask": "0000000F001D007F",
             "receiver_address": "10001000",
             "receiver_generation": "2",
             "record_index": "4",
@@ -77,6 +82,7 @@ class VisibilityPreparedCandidateReportTests(unittest.TestCase):
             "first_frame": "10",
             "last_frame": "12",
             "maximum_policy_age_frames": "1",
+            "mechanically_eligible": "true",
             "policy_age_limit_frames": "1",
             "classification": "fresh_visibility_selected_prepared_candidate",
             **self.safety(),
@@ -94,6 +100,8 @@ class VisibilityPreparedCandidateReportTests(unittest.TestCase):
             "missing_exclusions": "3",
             "candidate_entries": "1",
             "entry_draws": "7",
+            "mechanically_eligible_entries": "1",
+            "mechanically_eligible_draws": "7",
             "capacity": "4096",
             "overflow": "0",
             "policy_age_limit_frames": "1",
@@ -119,6 +127,22 @@ class VisibilityPreparedCandidateReportTests(unittest.TestCase):
             ]
         )
         self.assertEqual(2, document["totals"]["stale_exclusions"])
+        self.assertTrue(
+            document["qualification"]["isolated_native_candidate_proved"]
+        )
+
+    def test_build_accepts_fresh_candidate_without_isolated_eligibility(self):
+        events = copy.deepcopy(self.events())
+        entry = next(event for event in events if event["event"] == MODULE.ENTRY)
+        entry["mechanically_eligible"] = "false"
+        summary = next(event for event in events if event["event"] == MODULE.SUMMARY)
+        summary["mechanically_eligible_entries"] = "0"
+        summary["mechanically_eligible_draws"] = "0"
+        document = MODULE.build(events, self.static())
+        self.assertEqual("complete", document["status"])
+        self.assertFalse(
+            document["qualification"]["isolated_native_candidate_proved"]
+        )
 
     def test_build_rejects_future_policy_decision(self):
         events = copy.deepcopy(self.events())


### PR DESCRIPTION
## Summary
- carry exact prepared signatures, shader identities, specialization masks, and mechanical eligibility through fresh visibility candidates
- add an opt-in fail-closed visibility gate for isolated semantic world draws
- preserve the authoritative Xenos draw and report early stale matches without disarming the capture

## Validation
- 310 native-renderer tests pass
- Release build succeeds
- AppData gated capture exits normally; stale lineage is rejected with no native draw or Xenos suppression