### PR TITLE
feat(native-renderer): auto-capture fresh world draws

### DIFF
--- a/docs/native-renderer/ISOLATED_DRAW_REPLAY.md
+++ b/docs/native-renderer/ISOLATED_DRAW_REPLAY.md
@@ -10,9 +10,10 @@ frame.
 
 ## Ownership and safety gates
 
-The path is disabled unless the native-renderer census and an exact 16-digit
-candidate signature are both supplied. Pinyon requests a draw only when the
-live observation still satisfies the qualified candidate boundary:
+The path is disabled unless the native-renderer census and either an exact
+16-digit candidate signature or the startup-only fresh-candidate auto-selector
+are supplied. Pinyon requests a draw only when the live observation still
+satisfies the qualified candidate boundary:
 
 - direct DMA indexed geometry with supported index format and endianness, or
   the exact non-indexed AutoIndex follower contract;
@@ -29,6 +30,14 @@ missing, rejected, stale, future, or table-overflow decision cannot issue the
 isolated native draw. An early matching signature without a fresh decision is
 reported once and remains armed for a later fresh occurrence; it is not a
 terminal rejection. The exact-signature and mechanical gates remain required.
+
+For discovery captures, `-AutoSelectFreshVisibilityCandidate` waits for the
+first prepared draw that passes both the mechanical boundary and the fresh
+visibility gate, locks its exact prepared signature, and captures
+only that signature from then on. It is mutually exclusive with an explicit
+signature, retained-pass capture, and sky/horizon suppression. A rejected,
+missing, stale, future, or mechanically unsupported observation cannot lock
+the selector or issue native work.
 
 ReXGlue independently requires host render targets, rasterization, and no
 memexport. Indexed requests require a direct guest DMA index buffer; AutoIndex
@@ -59,6 +68,18 @@ For a visibility-selected semantic candidate, add:
   -RequireFreshVisibilityCandidate
 ```
 
+To avoid a separate discovery run, capture the first admissible semantic world
+draw and its paired native/Xenos color and depth evidence with:
+
+```powershell
+.\tools\capture-native-renderer-census.ps1 `
+  -StateRoot $stateRoot `
+  -Scene open_world_day `
+  -AutoSelectFreshVisibilityCandidate `
+  -IsolatedDrawDir .local\qualification\native-visible-world-auto `
+  -Json
+```
+
 This option is intended for semantic world bring-up and is not used by the
 already-qualified sky/horizon replay family.
 
@@ -76,6 +97,7 @@ visually unchanged, census frames continued through frame 5700, and the
 process exited normally with code zero. The structured log contained no fatal,
 device-loss, D3D12 error, exception, access-violation, or crash events.
 
-This milestone proves authentic GPU draw recording and target isolation. A
-later NR-02E pull request must add asynchronous readback and image comparison
-before visual equivalence is claimed.
+This milestone proves authentic GPU draw recording and target isolation.
+Single-draw and retained-pass captures asynchronously write paired native and
+authoritative Xenos color/depth artifacts for later image comparison; a
+successful replay is not by itself a claim of visual equivalence.

--- a/docs/native-renderer/VISIBILITY_PREPARED_CANDIDATES.md
+++ b/docs/native-renderer/VISIBILITY_PREPARED_CANDIDATES.md
@@ -70,9 +70,13 @@ table.
 The normal checkpoint only carries host metadata. When an operator separately
 arms an exact isolated-draw signature with the fresh-visibility gate, the table
 can admit one private-target native replay through all existing mechanical
-safety checks. The original Xenos draw and displayed frame remain authoritative;
-this path cannot suppress Xenos. Without that explicit startup-only request,
-the table issues no native work.
+safety checks. A startup-only auto-selector may instead lock the first exact
+signature that is both fresh and mechanically eligible, eliminating a separate
+candidate-discovery run without weakening admission. It is incompatible with
+retained-pass publication and suppression. The original Xenos draw and
+displayed frame remain authoritative; this path cannot suppress Xenos. Without
+an explicit exact-signature or auto-selection request, the table issues no
+native work.
 
 ## AppData qualification
 

--- a/src/native_renderer/graphics_hooks.cpp
+++ b/src/native_renderer/graphics_hooks.cpp
@@ -4074,6 +4074,7 @@ struct IsolatedDrawState {
   bool prepared_candidate_eligible = false;
   bool prepared_visibility_candidate_fresh = false;
   bool require_fresh_visibility_candidate = false;
+  bool auto_select_fresh_visibility_candidate = false;
   bool visibility_wait_reported = false;
   bool awaiting_pass_follower = false;
   bool pass_anchor_recorded = false;
@@ -4347,6 +4348,10 @@ void ConfigurePassFollower() {
     g_pass_follower.target_signature = kSkyHorizonAnchorSignature;
     g_pass_follower.requested = true;
   }
+  if (g_isolated_draw.auto_select_fresh_visibility_candidate &&
+      g_pass_follower.requested) {
+    g_pass_follower.valid = false;
+  }
 }
 
 void ConfigureConsumerFamilyMarker() {
@@ -4489,25 +4494,50 @@ void ConfigureIsolatedDraw() {
       "PINYON_SHIFT_NATIVE_RENDERER_ISOLATED_DRAW_SIGNATURE",
       g_isolated_draw.target_signature, g_isolated_draw.requested,
       g_isolated_draw.valid);
+  const bool signature_requested = g_isolated_draw.requested;
+  char *value = nullptr;
+  size_t length = 0;
+  if (_dupenv_s(
+          &value, &length,
+          "PINYON_SHIFT_NATIVE_RENDERER_AUTO_SELECT_FRESH_VISIBILITY_CANDIDATE") ==
+          0 &&
+      value && length > 1) {
+    const std::string setting(value);
+    g_isolated_draw.auto_select_fresh_visibility_candidate = setting == "true";
+    if (setting != "true" && setting != "false") {
+      g_isolated_draw.valid = false;
+    }
+  }
+  std::free(value);
+  if (g_isolated_draw.auto_select_fresh_visibility_candidate) {
+    g_isolated_draw.requested = true;
+    g_isolated_draw.require_fresh_visibility_candidate = true;
+    if (signature_requested || g_sky_horizon_suppression.requested) {
+      g_isolated_draw.valid = false;
+    }
+  }
   if (!g_isolated_draw.requested &&
       g_sky_horizon_suppression.requested) {
     g_isolated_draw.target_signature = kSkyHorizonFollowerSignature;
     g_isolated_draw.requested = true;
   }
-  const bool signature_requested = g_isolated_draw.requested;
-  char *value = nullptr;
-  size_t length = 0;
+  const bool draw_requested = g_isolated_draw.requested;
+  value = nullptr;
+  length = 0;
   if (_dupenv_s(&value, &length,
                 "PINYON_SHIFT_NATIVE_RENDERER_ISOLATED_DRAW_DIR") != 0 ||
       !value || length <= 1) {
     std::free(value);
+    if (g_isolated_draw.auto_select_fresh_visibility_candidate) {
+      g_isolated_draw.valid = false;
+    }
     return;
   }
   g_isolated_draw.readback_requested = true;
   g_isolated_draw.output_root =
       std::filesystem::absolute(std::filesystem::path(value)).lexically_normal();
   std::free(value);
-  if (!signature_requested ||
+  if (!draw_requested ||
       !IsLocalArtifactRoot(g_isolated_draw.output_root)) {
     g_isolated_draw.valid = false;
   }
@@ -4519,7 +4549,12 @@ void ConfigureIsolatedDraw() {
           0 &&
       value && length > 1) {
     const std::string setting(value);
-    g_isolated_draw.require_fresh_visibility_candidate = setting == "true";
+    const bool require_fresh = setting == "true";
+    if (!g_isolated_draw.auto_select_fresh_visibility_candidate) {
+      g_isolated_draw.require_fresh_visibility_candidate = require_fresh;
+    } else if (!require_fresh) {
+      g_isolated_draw.valid = false;
+    }
     if (setting != "true" && setting != "false") {
       g_isolated_draw.valid = false;
     }
@@ -13180,6 +13215,8 @@ void RequestIsolatedDraw(
   }
   const bool pass_mode = g_pass_follower.requested &&
                          g_pass_follower.valid &&
+                         !g_isolated_draw
+                              .auto_select_fresh_visibility_candidate &&
                          g_pass_follower.target_signature !=
                              g_isolated_draw.target_signature;
   const bool candidate_eligible =
@@ -13268,6 +13305,26 @@ void RequestIsolatedDraw(
     }
     return;
   }
+  if (g_isolated_draw.auto_select_fresh_visibility_candidate &&
+      !g_isolated_draw.target_signature) {
+    if (!candidate_eligible) {
+      return;
+    }
+    g_isolated_draw.target_signature = g_isolated_draw.prepared_signature;
+    pinyon_shift::diagnostics::RecordEvent(
+        "native_renderer.isolated_draw.auto_selection",
+        {{"signature",
+          fmt::format("{:016X}", g_isolated_draw.target_signature)},
+         {"status", "locked_first_fresh_eligible_candidate"},
+         {"frame", std::to_string(g_isolated_draw.frame)},
+         {"draw", std::to_string(g_isolated_draw.draw)},
+         {"mechanically_eligible", "true"},
+         {"fresh_visibility_candidate", "true"},
+         {"native_draw", "isolated_only"},
+         {"xenos_draw", "preserved"},
+         {"output_authority", "xenos"},
+         {"suppression_eligible", "false"}});
+  }
   if (g_isolated_draw.prepared_signature !=
       g_isolated_draw.target_signature) {
     return;
@@ -13331,10 +13388,26 @@ void RequestIsolatedDraw(
   request.requested = true;
   request.frame_sequence = g_isolated_draw.frame;
   request.readback_requested = g_isolated_draw.readback_requested;
+  request.reference_readback_requested =
+      g_isolated_draw.readback_requested;
+  request.depth_readback_requested = g_isolated_draw.readback_requested;
+  request.reference_depth_readback_requested =
+      g_isolated_draw.readback_requested;
   request.completion = &CompleteIsolatedDraw;
   request.readback_completion = g_isolated_draw.readback_requested
                                     ? &CompleteIsolatedDrawReadback
                                     : nullptr;
+  request.reference_readback_completion =
+      g_isolated_draw.readback_requested
+          ? &CompleteIsolatedReferenceReadback
+          : nullptr;
+  request.depth_readback_completion =
+      g_isolated_draw.readback_requested ? &CompleteIsolatedDepthReadback
+                                         : nullptr;
+  request.reference_depth_readback_completion =
+      g_isolated_draw.readback_requested
+          ? &CompleteIsolatedReferenceDepthReadback
+          : nullptr;
 }
 
 void EmitDrawCensusWindow(uint64_t last_frame_value) {
@@ -14498,6 +14571,10 @@ void InstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system,
        {"readback", g_isolated_draw.readback_requested ? "asynchronous"
                                                         : "disabled"},
        {"reference_marker", "exact_signature"},
+       {"selection",
+        g_isolated_draw.auto_select_fresh_visibility_candidate
+            ? "first_fresh_mechanically_eligible_candidate"
+            : "exact_signature"},
        {"visibility_gate",
         g_isolated_draw.require_fresh_visibility_candidate
             ? "fresh_selected_semantic_candidate"

--- a/tools/capture-native-renderer-census.ps1
+++ b/tools/capture-native-renderer-census.ps1
@@ -17,6 +17,7 @@ param(
     [string]$IsolatedDrawSignature,
     [string]$IsolatedDrawDir,
     [switch]$RequireFreshVisibilityCandidate,
+    [switch]$AutoSelectFreshVisibilityCandidate,
     [ValidatePattern('^[0-9A-Fa-f]{16}$')]
     [string]$PassAnchorSignature,
     [switch]$PublishRetainedPass,
@@ -62,6 +63,15 @@ if (@(Get-Process -Name 'pinyon_shift' -ErrorAction SilentlyContinue).Count -ne 
 if ([bool]$ReplaySnapshotSignature -xor [bool]$ReplaySnapshotDir) {
     throw 'ReplaySnapshotSignature and ReplaySnapshotDir must be supplied together.'
 }
+if ($AutoSelectFreshVisibilityCandidate -and $IsolatedDrawSignature) {
+    throw 'AutoSelectFreshVisibilityCandidate and IsolatedDrawSignature are mutually exclusive.'
+}
+if ($AutoSelectFreshVisibilityCandidate -and -not $IsolatedDrawDir) {
+    throw 'AutoSelectFreshVisibilityCandidate requires IsolatedDrawDir.'
+}
+if ($AutoSelectFreshVisibilityCandidate -and $PassAnchorSignature) {
+    throw 'AutoSelectFreshVisibilityCandidate does not support PassAnchorSignature.'
+}
 if ($PublishRetainedPass -and
     (-not $IsolatedDrawSignature -or -not $PassAnchorSignature)) {
     throw 'PublishRetainedPass requires IsolatedDrawSignature and PassAnchorSignature.'
@@ -86,8 +96,8 @@ if ($ReplaySnapshotDir) {
 }
 
 if ($IsolatedDrawDir) {
-    if (-not $IsolatedDrawSignature) {
-        throw 'IsolatedDrawDir requires IsolatedDrawSignature'
+    if (-not $IsolatedDrawSignature -and -not $AutoSelectFreshVisibilityCandidate) {
+        throw 'IsolatedDrawDir requires IsolatedDrawSignature or AutoSelectFreshVisibilityCandidate'
     }
     $repositoryRoot = Split-Path $PSScriptRoot -Parent
     $localRoot = [IO.Path]::GetFullPath((Join-Path $repositoryRoot '.local'))
@@ -106,8 +116,9 @@ if ($IsolatedDrawDir) {
     }
     $IsolatedDrawDir = $resolvedIsolatedDrawDir
 }
-if ($RequireFreshVisibilityCandidate -and -not $IsolatedDrawSignature) {
-    throw 'RequireFreshVisibilityCandidate requires IsolatedDrawSignature'
+if ($RequireFreshVisibilityCandidate -and
+    -not $IsolatedDrawSignature -and -not $AutoSelectFreshVisibilityCandidate) {
+    throw 'RequireFreshVisibilityCandidate requires IsolatedDrawSignature or AutoSelectFreshVisibilityCandidate'
 }
 
 if ($ConsumerReadbackDir) {
@@ -141,6 +152,8 @@ $savedReplaySnapshotDir = $env:PINYON_SHIFT_NATIVE_RENDERER_SNAPSHOT_DIR
 $savedIsolatedDraw = $env:PINYON_SHIFT_NATIVE_RENDERER_ISOLATED_DRAW_SIGNATURE
 $savedIsolatedDrawDir = $env:PINYON_SHIFT_NATIVE_RENDERER_ISOLATED_DRAW_DIR
 $savedVisibilityGate = $env:PINYON_SHIFT_NATIVE_RENDERER_REQUIRE_FRESH_VISIBILITY_CANDIDATE
+$savedAutoVisibilityCandidate =
+    $env:PINYON_SHIFT_NATIVE_RENDERER_AUTO_SELECT_FRESH_VISIBILITY_CANDIDATE
 $savedPassAnchor = $env:PINYON_SHIFT_NATIVE_RENDERER_PASS_ANCHOR_SIGNATURE
 $savedPassPublication = $env:PINYON_SHIFT_NATIVE_RENDERER_PUBLISH_RETAINED_PASS
 $savedConsumerFamily = $env:PINYON_SHIFT_NATIVE_RENDERER_CONSUMER_FAMILY
@@ -156,7 +169,11 @@ try {
     $env:PINYON_SHIFT_NATIVE_RENDERER_ISOLATED_DRAW_SIGNATURE = $IsolatedDrawSignature
     $env:PINYON_SHIFT_NATIVE_RENDERER_ISOLATED_DRAW_DIR = $IsolatedDrawDir
     $env:PINYON_SHIFT_NATIVE_RENDERER_REQUIRE_FRESH_VISIBILITY_CANDIDATE =
-        if ($RequireFreshVisibilityCandidate) { 'true' } else { $null }
+        if ($RequireFreshVisibilityCandidate -or $AutoSelectFreshVisibilityCandidate) {
+            'true'
+        } else { $null }
+    $env:PINYON_SHIFT_NATIVE_RENDERER_AUTO_SELECT_FRESH_VISIBILITY_CANDIDATE =
+        if ($AutoSelectFreshVisibilityCandidate) { 'true' } else { $null }
     $env:PINYON_SHIFT_NATIVE_RENDERER_PASS_ANCHOR_SIGNATURE = $PassAnchorSignature
     $env:PINYON_SHIFT_NATIVE_RENDERER_PUBLISH_RETAINED_PASS =
         if ($PublishRetainedPass) { 'true' } else { $null }
@@ -179,6 +196,8 @@ finally {
     $env:PINYON_SHIFT_NATIVE_RENDERER_ISOLATED_DRAW_DIR = $savedIsolatedDrawDir
     $env:PINYON_SHIFT_NATIVE_RENDERER_REQUIRE_FRESH_VISIBILITY_CANDIDATE =
         $savedVisibilityGate
+    $env:PINYON_SHIFT_NATIVE_RENDERER_AUTO_SELECT_FRESH_VISIBILITY_CANDIDATE =
+        $savedAutoVisibilityCandidate
     $env:PINYON_SHIFT_NATIVE_RENDERER_PASS_ANCHOR_SIGNATURE = $savedPassAnchor
     $env:PINYON_SHIFT_NATIVE_RENDERER_PUBLISH_RETAINED_PASS = $savedPassPublication
     $env:PINYON_SHIFT_NATIVE_RENDERER_CONSUMER_FAMILY = $savedConsumerFamily

--- a/tools/tests/test_native_renderer_contract.py
+++ b/tools/tests/test_native_renderer_contract.py
@@ -1597,14 +1597,36 @@ class NativeRendererContractTests(unittest.TestCase):
             "PINYON_SHIFT_NATIVE_RENDERER_REQUIRE_FRESH_VISIBILITY_CANDIDATE",
             scanner,
         )
+        self.assertIn(
+            "PINYON_SHIFT_NATIVE_RENDERER_AUTO_SELECT_FRESH_VISIBILITY_CANDIDATE",
+            scanner,
+        )
+        self.assertIn("locked_first_fresh_eligible_candidate", scanner)
+        self.assertIn("auto_select_fresh_visibility_candidate", scanner)
         self.assertIn("waiting_for_fresh_selected_candidate", scanner)
         self.assertIn("visibility_wait_reported", scanner)
+        single_draw_request = scanner.split(
+            "g_isolated_draw.captured_signature = g_isolated_draw.prepared_signature;",
+            1,
+        )[1].split("void EmitDrawCensusWindow", 1)[0]
+        self.assertIn(
+            "request.reference_readback_requested", single_draw_request
+        )
+        self.assertIn("request.depth_readback_requested", single_draw_request)
+        self.assertIn(
+            "request.reference_depth_readback_requested", single_draw_request
+        )
         census_capture = (
             ROOT / "tools/capture-native-renderer-census.ps1"
         ).read_text(encoding="utf-8")
         self.assertIn("RequireFreshVisibilityCandidate", census_capture)
+        self.assertIn("AutoSelectFreshVisibilityCandidate", census_capture)
         self.assertIn(
-            "RequireFreshVisibilityCandidate requires IsolatedDrawSignature",
+            "AutoSelectFreshVisibilityCandidate and IsolatedDrawSignature are mutually exclusive",
+            census_capture,
+        )
+        self.assertIn(
+            "RequireFreshVisibilityCandidate requires IsolatedDrawSignature or AutoSelectFreshVisibilityCandidate",
             census_capture,
         )
         self.assertIn("authoritative Xenos draw still follows unmodified", scanner)


### PR DESCRIPTION
## Summary
- lock the first fresh, mechanically eligible prepared world draw at startup
- request paired native/Xenos color and depth readbacks from the exact draw
- keep Xenos authoritative and reject incompatible capture/suppression modes
- document and test the capture contract

## Validation
- python -m unittest discover -s tools/tests -p 'test_native_renderer*.py' (310 passed)
- cmake --build --preset win-amd64-release --parallel 16
- AppData session 20260830T022615Z-p38848: normal exit, zero fatal signatures; no fresh eligible draw observed, so no native work/readback and Xenos remained authoritative
- performance: 17,545 frames, 29.765 median FPS, 19.179 FPS 1% low, one present-deadline miss over 607.420 seconds