### PR TITLE
feat(native-renderer): carry title lod into prepared draws

### DIFF
--- a/docs/native-renderer/VISIBILITY_PREPARED_CANDIDATES.md
+++ b/docs/native-renderer/VISIBILITY_PREPARED_CANDIDATES.md
@@ -15,6 +15,7 @@ draw identity:
 - receiver address, receiver generation, and record index;
 - selected, rejected, or missing workset result;
 - policy frame, visibility category, and predicted category-result mask.
+- the title's latest exact LOD index observation and an explicit validity bit.
 
 That identity already follows the title's submission at `82417B60` into the
 physical `PM4_DRAW_INDX` stores at `82416260` and `824162F4`. The backend joins
@@ -32,7 +33,9 @@ superset.
 
 Fresh candidates are aggregated in a fixed 4,096-entry table keyed by exact
 semantic identity plus immutable prepared template, geometry-resource, texture-
-resource, prepared-signature, visibility-category, and result-mask identities.
+resource, prepared-signature, visibility-category, result-mask, and title-LOD
+identities. A record without an observed title LOD remains a distinct candidate
+with `title_lod_valid=false`; zero is never inferred to be a valid LOD.
 The exact prepared signature prevents a resource family from merging a
 replayable draw with a resolved-input or otherwise mechanically ineligible
 variant. The runtime records:
@@ -43,6 +46,8 @@ variant. The runtime records:
 - per-candidate draw/frame coverage and maximum policy age;
 - exact shader identities, specialization masks, and isolated-draw mechanical
   eligibility;
+- title-LOD-bearing candidate entries and draws, reconciled with the exact
+  visibility-record workset lineage;
 - table occupancy, overflow, and complete partition accounting.
 
 Generate and qualify the evidence with:

--- a/src/native_renderer/graphics_hooks.cpp
+++ b/src/native_renderer/graphics_hooks.cpp
@@ -177,11 +177,13 @@ struct SemanticDrawIdentity {
   uint32_t secondary_resource_key = 0;
   uint32_t visibility_category = 0;
   uint32_t visibility_result_mask = 0;
+  uint32_t title_lod_index = 0;
   uint32_t direct_title_origins = 0;
   uint32_t indirect_packet_origins = 0;
   SemanticVisibilityWorksetJoin visibility_workset_join =
       SemanticVisibilityWorksetJoin::kMissing;
   bool secondary_resource_present = false;
+  bool title_lod_valid = false;
   bool valid = false;
 };
 
@@ -300,7 +302,9 @@ struct SemanticVisibilityPreparedCandidateEntry {
   uint32_t record_index = 0;
   uint32_t visibility_category = 0;
   uint32_t visibility_result_mask = 0;
+  uint32_t title_lod_index = 0;
   bool mechanically_eligible = false;
+  bool title_lod_valid = false;
 };
 
 struct SemanticBatchRun {
@@ -753,12 +757,15 @@ struct SemanticVisibilityWorksetEntry {
   uint64_t title_matches = 0;
   uint64_t title_mismatches = 0;
   uint64_t semantic_instance_joins = 0;
+  uint64_t title_lod_observations = 0;
   uint32_t receiver_address = 0;
   uint32_t receiver_generation = 0;
   uint32_t record_index = 0;
   uint32_t category = 0;
   uint32_t latest_category_result_mask = 0;
+  uint32_t latest_title_lod_index = 0;
   bool latest_selected = false;
+  bool latest_title_lod_valid = false;
 };
 
 std::atomic<uint64_t> g_semantic_visibility_record_entries{};
@@ -847,6 +854,7 @@ uint64_t g_semantic_visibility_workset_predicted_selected = 0;
 uint64_t g_semantic_visibility_workset_predicted_rejected = 0;
 uint64_t g_semantic_visibility_workset_title_matches = 0;
 uint64_t g_semantic_visibility_workset_title_mismatches = 0;
+uint64_t g_semantic_visibility_workset_title_lod_records = 0;
 uint64_t g_semantic_visibility_workset_invalid_records = 0;
 uint64_t g_semantic_visibility_workset_entries = 0;
 uint64_t g_semantic_visibility_workset_overflow = 0;
@@ -1227,6 +1235,9 @@ void PublishSemanticVisibilityWorkset(
   ++(predicted_selected == title_selected
          ? g_semantic_visibility_workset_title_matches
          : g_semantic_visibility_workset_title_mismatches);
+  if (record.lod_seen) {
+    ++g_semantic_visibility_workset_title_lod_records;
+  }
   size_t index = size_t(key % kSemanticVisibilityWorksetCapacity);
   for (size_t probe = 0; probe < kSemanticVisibilityWorksetCapacity;
        ++probe) {
@@ -1254,6 +1265,9 @@ void PublishSemanticVisibilityWorkset(
       entry.category = record.category;
       entry.latest_category_result_mask = result_mask;
       entry.latest_selected = predicted_selected;
+      entry.title_lod_observations += uint64_t(record.lod_seen);
+      entry.latest_title_lod_index = record.lod_index;
+      entry.latest_title_lod_valid = record.lod_seen;
       return;
     }
     index = (index + 1) % kSemanticVisibilityWorksetCapacity;
@@ -1285,6 +1299,8 @@ SemanticVisibilityWorksetJoin JoinSemanticVisibilityWorkset(
       semantic_draw->visibility_category = entry.category;
       semantic_draw->visibility_result_mask =
           entry.latest_category_result_mask;
+      semantic_draw->title_lod_index = entry.latest_title_lod_index;
+      semantic_draw->title_lod_valid = entry.latest_title_lod_valid;
       if (entry.latest_selected) {
         ++g_semantic_visibility_workset_selected_joins;
         semantic_draw->visibility_workset_join =
@@ -1719,6 +1735,7 @@ void ResetTitleDrawProvenance() {
     g_semantic_visibility_workset_predicted_rejected = 0;
     g_semantic_visibility_workset_title_matches = 0;
     g_semantic_visibility_workset_title_mismatches = 0;
+    g_semantic_visibility_workset_title_lod_records = 0;
     g_semantic_visibility_workset_invalid_records = 0;
     g_semantic_visibility_workset_entries = 0;
     g_semantic_visibility_workset_overflow = 0;
@@ -5246,6 +5263,7 @@ void EmitSemanticVisibilityWorkset() {
   uint64_t entry_title_matches = 0;
   uint64_t entry_title_mismatches = 0;
   uint64_t entry_semantic_joins = 0;
+  uint64_t entry_title_lod_observations = 0;
   for (const SemanticVisibilityWorksetEntry &entry :
        g_semantic_visibility_workset) {
     if (!entry.key) {
@@ -5257,6 +5275,7 @@ void EmitSemanticVisibilityWorkset() {
     entry_title_matches += entry.title_matches;
     entry_title_mismatches += entry.title_mismatches;
     entry_semantic_joins += entry.semantic_instance_joins;
+    entry_title_lod_observations += entry.title_lod_observations;
     pinyon_shift::diagnostics::RecordEvent(
         "native_renderer.discovery.semantic_visibility_workset_entry",
         {{"status", "complete"},
@@ -5281,6 +5300,13 @@ void EmitSemanticVisibilityWorkset() {
          {"latest_category_result_mask",
           std::to_string(entry.latest_category_result_mask)},
          {"latest_selected", entry.latest_selected ? "true" : "false"},
+         {"title_lod_observations",
+          std::to_string(entry.title_lod_observations)},
+         {"latest_title_lod_index",
+          std::to_string(entry.latest_title_lod_index)},
+         {"latest_title_lod_valid",
+          entry.latest_title_lod_valid ? "true" : "false"},
+         {"title_lod_lineage", "latest_exact_title_record_observation"},
          {"execution", "bounded_host_visibility_workset"},
          {"guest_state_changed", "false"},
          {"title_culling_changed", "false"},
@@ -5302,6 +5328,8 @@ void EmitSemanticVisibilityWorkset() {
       g_semantic_visibility_workset_title_matches == entry_title_matches &&
       g_semantic_visibility_workset_title_mismatches ==
           entry_title_mismatches &&
+      g_semantic_visibility_workset_title_lod_records ==
+          entry_title_lod_observations &&
       g_semantic_visibility_workset_semantic_instance_lookups ==
           g_semantic_visibility_workset_selected_joins +
               g_semantic_visibility_workset_rejected_joins +
@@ -5322,6 +5350,10 @@ void EmitSemanticVisibilityWorkset() {
         std::to_string(g_semantic_visibility_workset_title_matches)},
        {"title_mismatches",
         std::to_string(g_semantic_visibility_workset_title_mismatches)},
+       {"title_lod_records",
+        std::to_string(g_semantic_visibility_workset_title_lod_records)},
+       {"entry_title_lod_observations",
+        std::to_string(entry_title_lod_observations)},
        {"invalid_records",
         std::to_string(g_semantic_visibility_workset_invalid_records)},
        {"entries", std::to_string(g_semantic_visibility_workset_entries)},
@@ -5340,6 +5372,7 @@ void EmitSemanticVisibilityWorkset() {
        {"accounting_complete", accounting_complete ? "true" : "false"},
        {"model", "independent_policy_to_semantic_candidate_handoff"},
        {"identity", "receiver_generation_record_index"},
+       {"title_lod_lineage", "latest_exact_title_record_observation"},
        {"execution", "bounded_host_visibility_workset"},
        {"guest_state_changed", "false"},
        {"control_flow_changed", "false"},
@@ -10113,7 +10146,9 @@ bool RecordSemanticVisibilityPreparedCandidate(
         contract.geometry_resource_hash, contract.texture_resource_hash,
         prepared_signature,
         uint64_t(identity.visibility_category),
-        uint64_t(identity.visibility_result_mask)}) {
+        uint64_t(identity.visibility_result_mask),
+        uint64_t(identity.title_lod_valid),
+        uint64_t(identity.title_lod_index)}) {
     key = HashCombine(key, value);
   }
   key = key ? key : 1;
@@ -10144,7 +10179,9 @@ bool RecordSemanticVisibilityPreparedCandidate(
           .record_index = identity.record_index,
           .visibility_category = identity.visibility_category,
           .visibility_result_mask = identity.visibility_result_mask,
+          .title_lod_index = identity.title_lod_index,
           .mechanically_eligible = mechanically_eligible,
+          .title_lod_valid = identity.title_lod_valid,
       };
       ++g_semantic_visibility_prepared_candidate_count;
       return true;
@@ -10165,7 +10202,9 @@ bool RecordSemanticVisibilityPreparedCandidate(
         entry.receiver_generation == identity.receiver_generation &&
         entry.record_index == identity.record_index &&
         entry.visibility_category == identity.visibility_category &&
-        entry.visibility_result_mask == identity.visibility_result_mask) {
+        entry.visibility_result_mask == identity.visibility_result_mask &&
+        entry.title_lod_index == identity.title_lod_index &&
+        entry.title_lod_valid == identity.title_lod_valid) {
       ++entry.draws;
       entry.last_frame = observation.frame_sequence;
       entry.maximum_policy_age_frames =
@@ -11645,6 +11684,8 @@ void EmitSemanticVisibilityPreparedCandidates() {
   uint64_t entry_count = 0;
   uint64_t mechanically_eligible_draws = 0;
   uint64_t mechanically_eligible_entries = 0;
+  uint64_t title_lod_draws = 0;
+  uint64_t title_lod_entries = 0;
   for (const SemanticVisibilityPreparedCandidateEntry &entry :
        g_semantic_visibility_prepared_candidates) {
     if (!entry.key) {
@@ -11655,6 +11696,10 @@ void EmitSemanticVisibilityPreparedCandidates() {
     if (entry.mechanically_eligible) {
       mechanically_eligible_draws += entry.draws;
       ++mechanically_eligible_entries;
+    }
+    if (entry.title_lod_valid) {
+      title_lod_draws += entry.draws;
+      ++title_lod_entries;
     }
     pinyon_shift::diagnostics::RecordEvent(
         "native_renderer.discovery.semantic_visibility_prepared_candidate_entry",
@@ -11683,6 +11728,9 @@ void EmitSemanticVisibilityPreparedCandidates() {
           std::to_string(entry.visibility_category)},
          {"visibility_result_mask",
           std::to_string(entry.visibility_result_mask)},
+         {"title_lod_index", std::to_string(entry.title_lod_index)},
+         {"title_lod_valid", entry.title_lod_valid ? "true" : "false"},
+         {"title_lod_lineage", "exact_visibility_identity_to_prepared_draw"},
          {"draws", std::to_string(entry.draws)},
          {"first_frame", std::to_string(entry.first_frame)},
          {"last_frame", std::to_string(entry.last_frame)},
@@ -11712,7 +11760,8 @@ void EmitSemanticVisibilityPreparedCandidates() {
       g_semantic_visibility_prepared_fresh_candidates ==
           entry_draws +
               g_semantic_visibility_prepared_candidate_overflow &&
-      g_semantic_visibility_prepared_candidate_count == entry_count;
+      g_semantic_visibility_prepared_candidate_count == entry_count &&
+      title_lod_draws <= entry_draws && title_lod_entries <= entry_count;
   pinyon_shift::diagnostics::RecordEvent(
       "native_renderer.discovery.semantic_visibility_prepared_candidate_summary",
       {{"status", !g_semantic_visibility_prepared_observations
@@ -11739,6 +11788,8 @@ void EmitSemanticVisibilityPreparedCandidates() {
         std::to_string(mechanically_eligible_entries)},
        {"mechanically_eligible_draws",
         std::to_string(mechanically_eligible_draws)},
+       {"title_lod_entries", std::to_string(title_lod_entries)},
+       {"title_lod_draws", std::to_string(title_lod_draws)},
        {"capacity",
         std::to_string(kSemanticVisibilityPreparedCandidateCapacity)},
        {"overflow",
@@ -11749,6 +11800,7 @@ void EmitSemanticVisibilityPreparedCandidates() {
        {"identity", "receiver_generation_record_index"},
        {"prepared_lineage", "exact_semantic_pm4_prepared_draw"},
        {"selection", "independent_visibility_selected_and_fresh"},
+       {"title_lod_lineage", "exact_visibility_identity_to_prepared_draw"},
        {"guest_state_changed", "false"},
        {"control_flow_changed", "false"},
        {"native_upload", "false"},
@@ -14334,10 +14386,12 @@ void InstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system,
       {{"status", lineage_armed ? "armed" : "disabled"},
        {"class", "proceduralGeometry::CProceduralModels"},
        {"record_completion_hook", "82E2084C"},
+       {"title_lod_write_hooks", "82E205E4,82E206DC"},
        {"semantic_instance_hook", "8241741C"},
        {"capacity", std::to_string(kSemanticVisibilityWorksetCapacity)},
        {"model", "independent_policy_to_semantic_candidate_handoff"},
        {"identity", "receiver_generation_record_index"},
+       {"title_lod_lineage", "latest_exact_title_record_observation"},
        {"selection_rule", "any_nonzero_predicted_category_result_selects"},
        {"execution", "bounded_host_visibility_workset"},
        {"guest_payload_read", "qualified_policy_inputs_only"},
@@ -14362,6 +14416,7 @@ void InstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system,
        {"identity", "receiver_generation_record_index"},
        {"selection", "independent_visibility_selected_and_fresh"},
        {"prepared_lineage", "exact_semantic_pm4_prepared_draw"},
+       {"title_lod_lineage", "exact_visibility_identity_to_prepared_draw"},
        {"guest_state_changed", "false"},
        {"control_flow_changed", "false"},
        {"native_upload", "false"},

--- a/tools/discover-native-renderer-dispatch.py
+++ b/tools/discover-native-renderer-dispatch.py
@@ -1592,12 +1592,17 @@ def procedural_model_receiver_lifecycle(
             "record_completion_hook_address": "{:08X}".format(
                 spec["visibility_record_exit"]
             ),
+            "title_lod_write_hook_addresses": [
+                "{:08X}".format(address)
+                for address in spec["visibility_lod_hooks"]
+            ],
             "semantic_instance_hook_address": "{:08X}".format(
                 spec["render_item_entry_hook"]
             ),
             "capacity": 4096,
             "model": "independent_policy_to_semantic_candidate_handoff",
             "identity": "receiver_generation_record_index",
+            "title_lod_lineage": "latest_exact_title_record_observation",
             "selection_rule": "any_nonzero_predicted_category_result_selects",
             "execution": "bounded_host_visibility_workset",
             "guest_payload_read": "qualified_policy_inputs_only",
@@ -1622,6 +1627,7 @@ def procedural_model_receiver_lifecycle(
             "identity": "receiver_generation_record_index",
             "selection": "independent_visibility_selected_and_fresh",
             "prepared_lineage": "exact_semantic_pm4_prepared_draw",
+            "title_lod_lineage": "exact_visibility_identity_to_prepared_draw",
             "guest_state_changed": False,
             "control_flow_changed": False,
             "native_upload_enabled": False,

--- a/tools/summarize-native-renderer-visibility-prepared-candidates.py
+++ b/tools/summarize-native-renderer-visibility-prepared-candidates.py
@@ -7,7 +7,7 @@ import pathlib
 import sys
 
 
-SCHEMA = "pinyon-shift.native-renderer-visibility-prepared-candidates.v2"
+SCHEMA = "pinyon-shift.native-renderer-visibility-prepared-candidates.v3"
 STATIC_SCHEMA = "pinyon-shift.native-renderer-dispatch-static.v3"
 CONFIG = (
     "native_renderer.discovery."
@@ -92,6 +92,7 @@ def static_contract(document):
         "identity": "receiver_generation_record_index",
         "selection": "independent_visibility_selected_and_fresh",
         "prepared_lineage": "exact_semantic_pm4_prepared_draw",
+        "title_lod_lineage": "exact_visibility_identity_to_prepared_draw",
         "guest_state_changed": False,
         "control_flow_changed": False,
         "native_upload_enabled": False,
@@ -135,6 +136,7 @@ def build(events, static, requested_session=None):
         "identity": "receiver_generation_record_index",
         "selection": "independent_visibility_selected_and_fresh",
         "prepared_lineage": "exact_semantic_pm4_prepared_draw",
+        "title_lod_lineage": "exact_visibility_identity_to_prepared_draw",
         "guest_state_changed": "false",
         "control_flow_changed": "false",
         "native_upload": "false",
@@ -153,6 +155,8 @@ def build(events, static, requested_session=None):
         != "exact_semantic_pm4_prepared_draw"
         or summary.get("selection")
         != "independent_visibility_selected_and_fresh"
+        or summary.get("title_lod_lineage")
+        != "exact_visibility_identity_to_prepared_draw"
     ):
         raise ValueError("prepared-candidate summary is incomplete")
 
@@ -168,6 +172,8 @@ def build(events, static, requested_session=None):
         "entry_draws",
         "mechanically_eligible_entries",
         "mechanically_eligible_draws",
+        "title_lod_entries",
+        "title_lod_draws",
         "capacity",
         "overflow",
         "policy_age_limit_frames",
@@ -204,6 +210,8 @@ def build(events, static, requested_session=None):
             "record_index": integer(event, "record_index"),
             "visibility_category": integer(event, "visibility_category"),
             "visibility_result_mask": integer(event, "visibility_result_mask"),
+            "title_lod_index": integer(event, "title_lod_index"),
+            "title_lod_valid": event.get("title_lod_valid") == "true",
             "draws": integer(event, "draws"),
             "first_frame": integer(event, "first_frame"),
             "last_frame": integer(event, "last_frame"),
@@ -223,6 +231,10 @@ def build(events, static, requested_session=None):
             or item["maximum_policy_age_frames"]
             > totals["policy_age_limit_frames"]
             or event.get("mechanically_eligible") not in ("true", "false")
+            or event.get("title_lod_valid") not in ("true", "false")
+            or event.get("title_lod_lineage")
+            != "exact_visibility_identity_to_prepared_draw"
+            or (item["title_lod_valid"] and item["title_lod_index"] >= 32)
             or integer(event, "policy_age_limit_frames")
             != totals["policy_age_limit_frames"]
         ):
@@ -259,6 +271,13 @@ def build(events, static, requested_session=None):
         != sum(entry["draws"] for entry in eligible_entries)
     ):
         failures.append("mechanically eligible candidate totals drifted")
+    lod_entries = [entry for entry in entries if entry["title_lod_valid"]]
+    if (
+        totals["title_lod_entries"] != len(lod_entries)
+        or totals["title_lod_draws"]
+        != sum(entry["draws"] for entry in lod_entries)
+    ):
+        failures.append("title LOD candidate totals drifted")
     if totals["capacity"] != 4096 or totals["policy_age_limit_frames"] != 1:
         failures.append("prepared-candidate bounds drifted")
     if totals["selected_joins"] > integer(workset, "selected_joins"):
@@ -279,6 +298,7 @@ def build(events, static, requested_session=None):
             "fresh_visibility_prepared_handoff_proved": not failures,
             "isolated_native_candidate_proved": not failures
             and bool(eligible_entries),
+            "title_lod_lineage_proved": not failures and bool(lod_entries),
             "native_draw_enabled": False,
             "suppression_allowed": False,
         },

--- a/tools/summarize-native-renderer-visibility-workset.py
+++ b/tools/summarize-native-renderer-visibility-workset.py
@@ -7,7 +7,7 @@ import pathlib
 import sys
 
 
-SCHEMA = "pinyon-shift.native-renderer-visibility-workset.v1"
+SCHEMA = "pinyon-shift.native-renderer-visibility-workset.v2"
 STATIC_SCHEMA = "pinyon-shift.native-renderer-dispatch-static.v3"
 CONFIG = "native_renderer.discovery.semantic_visibility_workset_config"
 ENTRY = "native_renderer.discovery.semantic_visibility_workset_entry"
@@ -80,10 +80,12 @@ def static_contract(document):
         raise ValueError("static visibility-workset contract is missing") from error
     expected = {
         "record_completion_hook_address": "82E2084C",
+        "title_lod_write_hook_addresses": ["82E205E4", "82E206DC"],
         "semantic_instance_hook_address": "8241741C",
         "capacity": 4096,
         "model": "independent_policy_to_semantic_candidate_handoff",
         "identity": "receiver_generation_record_index",
+        "title_lod_lineage": "latest_exact_title_record_observation",
         "selection_rule": "any_nonzero_predicted_category_result_selects",
         "execution": "bounded_host_visibility_workset",
         "guest_payload_read": "qualified_policy_inputs_only",
@@ -132,10 +134,12 @@ def build(events, static, requested_session=None):
         "status": "armed",
         "class": "proceduralGeometry::CProceduralModels",
         "record_completion_hook": "82E2084C",
+        "title_lod_write_hooks": "82E205E4,82E206DC",
         "semantic_instance_hook": "8241741C",
         "capacity": "4096",
         "model": "independent_policy_to_semantic_candidate_handoff",
         "identity": "receiver_generation_record_index",
+        "title_lod_lineage": "latest_exact_title_record_observation",
         "selection_rule": "any_nonzero_predicted_category_result_selects",
         "execution": "bounded_host_visibility_workset",
         "guest_payload_read": "qualified_policy_inputs_only",
@@ -156,6 +160,8 @@ def build(events, static, requested_session=None):
         or summary.get("model")
         != "independent_policy_to_semantic_candidate_handoff"
         or summary.get("identity") != "receiver_generation_record_index"
+        or summary.get("title_lod_lineage")
+        != "latest_exact_title_record_observation"
     ):
         raise ValueError("visibility-workset summary is incomplete")
 
@@ -168,6 +174,8 @@ def build(events, static, requested_session=None):
         "invalid_records",
         "entries",
         "entry_observations",
+        "title_lod_records",
+        "entry_title_lod_observations",
         "capacity",
         "overflow",
         "semantic_instance_lookups",
@@ -186,6 +194,7 @@ def build(events, static, requested_session=None):
         "title_matches": 0,
         "title_mismatches": 0,
         "semantic_instance_joins": 0,
+        "title_lod_observations": 0,
     }
     for event in selected:
         if event.get("event") != ENTRY:
@@ -206,8 +215,10 @@ def build(events, static, requested_session=None):
                 "title_matches",
                 "title_mismatches",
                 "semantic_instance_joins",
+                "title_lod_observations",
             )
         }
+        latest_title_lod_valid = event.get("latest_title_lod_valid") == "true"
         if (
             event.get("status") != "complete"
             or key in seen_keys
@@ -220,11 +231,29 @@ def build(events, static, requested_session=None):
             or integer(event, "first_frame") > integer(event, "last_frame")
             or integer(event, "latest_category_result_mask") > 7
             or event.get("latest_selected") not in ("true", "false")
+            or event.get("latest_title_lod_valid") not in ("true", "false")
+            or event.get("title_lod_lineage")
+            != "latest_exact_title_record_observation"
+            or item["title_lod_observations"] > item["observations"]
+            or (
+                latest_title_lod_valid
+                and integer(event, "latest_title_lod_index") >= 32
+            )
         ):
             raise ValueError("visibility-workset entry evidence drifted")
         seen_keys.add(key)
         seen_identities.add(identity)
-        entries.append({"key": key, "identity": identity, **item})
+        entries.append(
+            {
+                "key": key,
+                "identity": identity,
+                "latest_title_lod_index": integer(
+                    event, "latest_title_lod_index"
+                ),
+                "latest_title_lod_valid": latest_title_lod_valid,
+                **item,
+            }
+        )
         for field in sums:
             sums[field] += item[field]
 
@@ -256,12 +285,16 @@ def build(events, static, requested_session=None):
         summary_field = "entry_observations" if field == "observations" else field
         if field == "semantic_instance_joins":
             expected = totals["selected_joins"] + totals["rejected_joins"]
+        elif field == "title_lod_observations":
+            expected = totals["entry_title_lod_observations"]
         else:
             expected = totals[summary_field]
         if sums[field] != expected:
             failures.append(f"entry {field} totals drifted")
     if totals["entry_observations"] + totals["overflow"] != totals["modelled_records"]:
         failures.append("workset observation accounting drifted")
+    if totals["title_lod_records"] != totals["entry_title_lod_observations"]:
+        failures.append("title LOD lineage accounting drifted")
     if semantic_live != totals["semantic_instance_lookups"]:
         failures.append("semantic-instance summary did not reconcile")
     if (

--- a/tools/tests/test_native_renderer_dispatch_discovery.py
+++ b/tools/tests/test_native_renderer_dispatch_discovery.py
@@ -1375,6 +1375,10 @@ class NativeRendererDispatchDiscoveryTests(unittest.TestCase):
         self.assertFalse(assembly_shadow["suppression_allowed"])
         workset = lifecycle["visibility_policy_workset"]
         self.assertEqual("82E2084C", workset["record_completion_hook_address"])
+        self.assertEqual(
+            ["82E205E4", "82E206DC"],
+            workset["title_lod_write_hook_addresses"],
+        )
         self.assertEqual("8241741C", workset["semantic_instance_hook_address"])
         self.assertEqual(4096, workset["capacity"])
         self.assertEqual(
@@ -1383,6 +1387,10 @@ class NativeRendererDispatchDiscoveryTests(unittest.TestCase):
         )
         self.assertEqual(
             "receiver_generation_record_index", workset["identity"]
+        )
+        self.assertEqual(
+            "latest_exact_title_record_observation",
+            workset["title_lod_lineage"],
         )
         self.assertEqual("bounded_host_visibility_workset", workset["execution"])
         self.assertFalse(workset["title_culling_changed"])
@@ -1409,6 +1417,10 @@ class NativeRendererDispatchDiscoveryTests(unittest.TestCase):
         self.assertEqual(
             "exact_semantic_pm4_prepared_draw",
             prepared_candidates["prepared_lineage"],
+        )
+        self.assertEqual(
+            "exact_visibility_identity_to_prepared_draw",
+            prepared_candidates["title_lod_lineage"],
         )
         self.assertFalse(prepared_candidates["native_draw_enabled"])
         self.assertTrue(prepared_candidates["xenos_draw_preserved"])

--- a/tools/tests/test_native_renderer_visibility_prepared_candidates.py
+++ b/tools/tests/test_native_renderer_visibility_prepared_candidates.py
@@ -24,6 +24,7 @@ class VisibilityPreparedCandidateReportTests(unittest.TestCase):
                     "identity": "receiver_generation_record_index",
                     "selection": "independent_visibility_selected_and_fresh",
                     "prepared_lineage": "exact_semantic_pm4_prepared_draw",
+                    "title_lod_lineage": "exact_visibility_identity_to_prepared_draw",
                     "guest_state_changed": False,
                     "control_flow_changed": False,
                     "native_upload_enabled": False,
@@ -58,6 +59,7 @@ class VisibilityPreparedCandidateReportTests(unittest.TestCase):
             "identity": "receiver_generation_record_index",
             "selection": "independent_visibility_selected_and_fresh",
             "prepared_lineage": "exact_semantic_pm4_prepared_draw",
+            "title_lod_lineage": "exact_visibility_identity_to_prepared_draw",
             **self.safety(),
         }
         entry = {
@@ -78,6 +80,9 @@ class VisibilityPreparedCandidateReportTests(unittest.TestCase):
             "record_index": "4",
             "visibility_category": "9",
             "visibility_result_mask": "6",
+            "title_lod_index": "2",
+            "title_lod_valid": "true",
+            "title_lod_lineage": "exact_visibility_identity_to_prepared_draw",
             "draws": "7",
             "first_frame": "10",
             "last_frame": "12",
@@ -102,6 +107,8 @@ class VisibilityPreparedCandidateReportTests(unittest.TestCase):
             "entry_draws": "7",
             "mechanically_eligible_entries": "1",
             "mechanically_eligible_draws": "7",
+            "title_lod_entries": "1",
+            "title_lod_draws": "7",
             "capacity": "4096",
             "overflow": "0",
             "policy_age_limit_frames": "1",
@@ -109,6 +116,7 @@ class VisibilityPreparedCandidateReportTests(unittest.TestCase):
             "identity": "receiver_generation_record_index",
             "prepared_lineage": "exact_semantic_pm4_prepared_draw",
             "selection": "independent_visibility_selected_and_fresh",
+            "title_lod_lineage": "exact_visibility_identity_to_prepared_draw",
             **self.safety(),
         }
         workset = {
@@ -130,6 +138,19 @@ class VisibilityPreparedCandidateReportTests(unittest.TestCase):
         self.assertTrue(
             document["qualification"]["isolated_native_candidate_proved"]
         )
+        self.assertTrue(document["qualification"]["title_lod_lineage_proved"])
+
+    def test_build_accepts_candidate_without_title_lod(self):
+        events = copy.deepcopy(self.events())
+        entry = next(event for event in events if event["event"] == MODULE.ENTRY)
+        entry["title_lod_index"] = "0"
+        entry["title_lod_valid"] = "false"
+        summary = next(event for event in events if event["event"] == MODULE.SUMMARY)
+        summary["title_lod_entries"] = "0"
+        summary["title_lod_draws"] = "0"
+        document = MODULE.build(events, self.static())
+        self.assertEqual("complete", document["status"])
+        self.assertFalse(document["qualification"]["title_lod_lineage_proved"])
 
     def test_build_accepts_fresh_candidate_without_isolated_eligibility(self):
         events = copy.deepcopy(self.events())

--- a/tools/tests/test_native_renderer_visibility_workset.py
+++ b/tools/tests/test_native_renderer_visibility_workset.py
@@ -18,10 +18,12 @@ class VisibilityWorksetReportTests(unittest.TestCase):
             "procedural_model_receiver_lifecycle": {
                 "visibility_policy_workset": {
                     "record_completion_hook_address": "82E2084C",
+                    "title_lod_write_hook_addresses": ["82E205E4", "82E206DC"],
                     "semantic_instance_hook_address": "8241741C",
                     "capacity": 4096,
                     "model": "independent_policy_to_semantic_candidate_handoff",
                     "identity": "receiver_generation_record_index",
+                    "title_lod_lineage": "latest_exact_title_record_observation",
                     "selection_rule": (
                         "any_nonzero_predicted_category_result_selects"
                     ),
@@ -60,10 +62,12 @@ class VisibilityWorksetReportTests(unittest.TestCase):
             "status": "armed",
             "class": "proceduralGeometry::CProceduralModels",
             "record_completion_hook": "82E2084C",
+            "title_lod_write_hooks": "82E205E4,82E206DC",
             "semantic_instance_hook": "8241741C",
             "capacity": "4096",
             "model": "independent_policy_to_semantic_candidate_handoff",
             "identity": "receiver_generation_record_index",
+            "title_lod_lineage": "latest_exact_title_record_observation",
             "selection_rule": "any_nonzero_predicted_category_result_selects",
             "guest_payload_read": "qualified_policy_inputs_only",
             **self.safety(),
@@ -85,6 +89,10 @@ class VisibilityWorksetReportTests(unittest.TestCase):
             "title_matches": "3",
             "title_mismatches": "0",
             "semantic_instance_joins": "7",
+            "title_lod_observations": "3",
+            "latest_title_lod_index": "2",
+            "latest_title_lod_valid": "true",
+            "title_lod_lineage": "latest_exact_title_record_observation",
             "latest_category_result_mask": "6",
             "latest_selected": "true",
             **self.safety(entry=True),
@@ -98,6 +106,9 @@ class VisibilityWorksetReportTests(unittest.TestCase):
             "predicted_rejected": "2",
             "title_matches": "2",
             "semantic_instance_joins": "0",
+            "title_lod_observations": "0",
+            "latest_title_lod_index": "0",
+            "latest_title_lod_valid": "false",
             "latest_category_result_mask": "1",
             "latest_selected": "false",
         }
@@ -113,6 +124,8 @@ class VisibilityWorksetReportTests(unittest.TestCase):
             "invalid_records": "0",
             "entries": "2",
             "entry_observations": "5",
+            "title_lod_records": "3",
+            "entry_title_lod_observations": "3",
             "capacity": "4096",
             "overflow": "0",
             "semantic_instance_lookups": "7",
@@ -122,6 +135,7 @@ class VisibilityWorksetReportTests(unittest.TestCase):
             "accounting_complete": "true",
             "model": "independent_policy_to_semantic_candidate_handoff",
             "identity": "receiver_generation_record_index",
+            "title_lod_lineage": "latest_exact_title_record_observation",
             **self.safety(),
         }
         assembly = {
@@ -150,6 +164,15 @@ class VisibilityWorksetReportTests(unittest.TestCase):
         )
         self.assertFalse(document["safety"]["title_culling_changed"])
         self.assertTrue(document["safety"]["xenos_authority"])
+        self.assertEqual(3, document["totals"]["title_lod_records"])
+
+    def test_build_rejects_title_lod_accounting_drift(self):
+        events = copy.deepcopy(self.events())
+        summary = next(event for event in events if event["event"] == MODULE.SUMMARY)
+        summary["title_lod_records"] = "2"
+        document = MODULE.build(events, self.static())
+        self.assertEqual("incomplete", document["status"])
+        self.assertIn("title LOD lineage accounting drifted", document["failures"])
 
     def test_build_filters_missing_superset_observation(self):
         events = copy.deepcopy(self.events())


### PR DESCRIPTION
## Summary
- preserve the title's exact LOD observation through the bounded visibility workset
- carry LOD identity through semantic submission and the exact prepared-draw join
- extend static discovery, runtime accounting, offline qualification, and rollback documentation
- keep native LOD, native drawing, guest control-flow changes, and Xenos suppression disabled

## Validation
- \python -m unittest discover -s tools/tests -p 'test_native_renderer_*.py'\ (312 tests)
- incremental Release build of \pinyon_shift.exe\`n- static dispatch discovery against the real generated image
- \git diff --check\ on the renderer change set

## Runtime qualification
Deferred and intentionally batched with the next substantial NR-05D slice; this change only propagates bounded host metadata and leaves Xenos authoritative.