### PR TITLE
feat(native-renderer): report lod admission failures

### DIFF
--- a/docs/native-renderer/VISIBILITY_PREPARED_CANDIDATES.md
+++ b/docs/native-renderer/VISIBILITY_PREPARED_CANDIDATES.md
@@ -48,7 +48,17 @@ variant. The runtime records:
   eligibility;
 - title-LOD-bearing candidate entries and draws, reconciled with the exact
   visibility-record workset lineage;
+- the complete isolated-draw mechanical rejection mask for every ineligible
+  entry, preserving simultaneous failures instead of reporting only the first;
 - table occupancy, overflow, and complete partition accounting.
+
+The `isolated_draw_v1` admission contract assigns independent bits to resolved
+inputs, unsupported geometry, empty draws, vertex-layout/count faults, constant
+or texture overflow, memexport, queries, texture count/layout, missing prepared
+pipeline stages, and unsupported render-target binding. The offline report
+decodes these masks into per-reason entry and draw totals. A zero mask is
+required for `mechanically_eligible=true`; the reporter rejects any disagreement
+or unknown bit. This telemetry diagnoses a gate but never bypasses it.
 
 Generate and qualify the evidence with:
 

--- a/src/native_renderer/graphics_hooks.cpp
+++ b/src/native_renderer/graphics_hooks.cpp
@@ -303,6 +303,7 @@ struct SemanticVisibilityPreparedCandidateEntry {
   uint32_t visibility_category = 0;
   uint32_t visibility_result_mask = 0;
   uint32_t title_lod_index = 0;
+  uint32_t mechanical_rejection_mask = 0;
   bool mechanically_eligible = false;
   bool title_lod_valid = false;
 };
@@ -9605,7 +9606,25 @@ bool IsMechanicallyEligibleCandidate(const DrawSignatureEntry &entry) {
          texture_count <= 4;
 }
 
-bool IsIsolatedDrawEligible(
+enum IsolatedDrawMechanicalRejection : uint32_t {
+  kIsolatedRejectResolvedInput = 1u << 0,
+  kIsolatedRejectUnsupportedGeometry = 1u << 1,
+  kIsolatedRejectEmptyDraw = 1u << 2,
+  kIsolatedRejectVertexBindingCount = 1u << 3,
+  kIsolatedRejectVertexBindingOverflow = 1u << 4,
+  kIsolatedRejectVertexAttributeOverflow = 1u << 5,
+  kIsolatedRejectVertexConstantOverflow = 1u << 6,
+  kIsolatedRejectPixelConstantOverflow = 1u << 7,
+  kIsolatedRejectTextureStateOverflow = 1u << 8,
+  kIsolatedRejectMemexport = 1u << 9,
+  kIsolatedRejectQuery = 1u << 10,
+  kIsolatedRejectTextureCount = 1u << 11,
+  kIsolatedRejectTextureLayout = 1u << 12,
+  kIsolatedRejectPreparedPipeline = 1u << 13,
+  kIsolatedRejectRenderTargets = 1u << 14,
+};
+
+uint32_t IsolatedDrawMechanicalRejectionMask(
     const rex::system::GraphicsDrawObservation &observation,
     bool samples_resolved_target,
     const rex::system::GraphicsPreparedDrawObservation &prepared) {
@@ -9621,18 +9640,52 @@ bool IsIsolatedDrawEligible(
        observation.source_select ==
            uint32_t(rex::graphics::xenos::SourceSelect::kAutoIndex) &&
        prepared.index_buffer_type == 0);
-  return !samples_resolved_target && supported_geometry &&
-         observation.index_count && observation.vertex_binding_count == 1 &&
-         !observation.vertex_binding_overflow &&
-         !observation.vertex_attribute_overflow &&
-         !observation.vertex_float_constant_overflow &&
-         !observation.pixel_float_constant_overflow &&
-         !observation.texture_state_overflow && !observation.vertex_memexport &&
-         !observation.viz_query_condition && !(observation.pa_sc_viz_query & 1) &&
-         texture_count >= 1 && texture_count <= 4 &&
-         (observation.texture_fetch_layout_valid_mask &
-          observation.texture_fetch_mask) == observation.texture_fetch_mask &&
-         (prepared.flags & 3) == 3 && prepared.bound_render_target_bits == 3;
+  uint32_t mask = 0;
+  mask |= samples_resolved_target ? kIsolatedRejectResolvedInput : 0;
+  mask |= !supported_geometry ? kIsolatedRejectUnsupportedGeometry : 0;
+  mask |= !observation.index_count ? kIsolatedRejectEmptyDraw : 0;
+  mask |= observation.vertex_binding_count != 1
+              ? kIsolatedRejectVertexBindingCount
+              : 0;
+  mask |= observation.vertex_binding_overflow
+              ? kIsolatedRejectVertexBindingOverflow
+              : 0;
+  mask |= observation.vertex_attribute_overflow
+              ? kIsolatedRejectVertexAttributeOverflow
+              : 0;
+  mask |= observation.vertex_float_constant_overflow
+              ? kIsolatedRejectVertexConstantOverflow
+              : 0;
+  mask |= observation.pixel_float_constant_overflow
+              ? kIsolatedRejectPixelConstantOverflow
+              : 0;
+  mask |= observation.texture_state_overflow
+              ? kIsolatedRejectTextureStateOverflow
+              : 0;
+  mask |= observation.vertex_memexport ? kIsolatedRejectMemexport : 0;
+  mask |= observation.viz_query_condition || (observation.pa_sc_viz_query & 1)
+              ? kIsolatedRejectQuery
+              : 0;
+  mask |= texture_count < 1 || texture_count > 4
+              ? kIsolatedRejectTextureCount
+              : 0;
+  mask |= (observation.texture_fetch_layout_valid_mask &
+           observation.texture_fetch_mask) != observation.texture_fetch_mask
+              ? kIsolatedRejectTextureLayout
+              : 0;
+  mask |= (prepared.flags & 3) != 3 ? kIsolatedRejectPreparedPipeline : 0;
+  mask |= prepared.bound_render_target_bits != 3
+              ? kIsolatedRejectRenderTargets
+              : 0;
+  return mask;
+}
+
+bool IsIsolatedDrawEligible(
+    const rex::system::GraphicsDrawObservation &observation,
+    bool samples_resolved_target,
+    const rex::system::GraphicsPreparedDrawObservation &prepared) {
+  return !IsolatedDrawMechanicalRejectionMask(
+      observation, samples_resolved_target, prepared);
 }
 
 const char *SemanticBatchRejectionName(SemanticBatchRejection rejection) {
@@ -10112,7 +10165,7 @@ bool RecordSemanticVisibilityPreparedCandidate(
     const rex::system::GraphicsDrawObservation &observation,
     const SemanticDrawIdentity &identity,
     const SemanticPreparedDrawContract &contract,
-    uint64_t prepared_signature, bool mechanically_eligible) {
+    uint64_t prepared_signature, uint32_t mechanical_rejection_mask) {
   ++g_semantic_visibility_prepared_observations;
   if (identity.visibility_workset_join ==
       SemanticVisibilityWorksetJoin::kMissing) {
@@ -10148,7 +10201,8 @@ bool RecordSemanticVisibilityPreparedCandidate(
         uint64_t(identity.visibility_category),
         uint64_t(identity.visibility_result_mask),
         uint64_t(identity.title_lod_valid),
-        uint64_t(identity.title_lod_index)}) {
+        uint64_t(identity.title_lod_index),
+        uint64_t(mechanical_rejection_mask)}) {
     key = HashCombine(key, value);
   }
   key = key ? key : 1;
@@ -10180,7 +10234,8 @@ bool RecordSemanticVisibilityPreparedCandidate(
           .visibility_category = identity.visibility_category,
           .visibility_result_mask = identity.visibility_result_mask,
           .title_lod_index = identity.title_lod_index,
-          .mechanically_eligible = mechanically_eligible,
+          .mechanical_rejection_mask = mechanical_rejection_mask,
+          .mechanically_eligible = !mechanical_rejection_mask,
           .title_lod_valid = identity.title_lod_valid,
       };
       ++g_semantic_visibility_prepared_candidate_count;
@@ -10197,7 +10252,7 @@ bool RecordSemanticVisibilityPreparedCandidate(
             contract.vertex_specialization_mask &&
         entry.pixel_specialization_mask ==
             contract.pixel_specialization_mask &&
-        entry.mechanically_eligible == mechanically_eligible &&
+        entry.mechanical_rejection_mask == mechanical_rejection_mask &&
         entry.receiver_address == identity.receiver_address &&
         entry.receiver_generation == identity.receiver_generation &&
         entry.record_index == identity.record_index &&
@@ -10229,12 +10284,13 @@ bool RecordSemanticBatchOpportunity(
   const SemanticDrawIdentity &identity = origin.semantic_draw;
   const SemanticPreparedDrawContract contract =
       BuildSemanticPreparedDrawContract(observation, prepared);
-  const bool mechanically_eligible = IsIsolatedDrawEligible(
+  const uint32_t mechanical_rejection_mask =
+      IsolatedDrawMechanicalRejectionMask(
       observation, samples_resolved_target, prepared);
   const bool fresh_visibility_candidate =
       RecordSemanticVisibilityPreparedCandidate(observation, identity,
                                                 contract, prepared_signature,
-                                                mechanically_eligible);
+                                                mechanical_rejection_mask);
   const SemanticBatchRejection rejection =
       ClassifySemanticBatchRejection(observation, samples_resolved_target,
                                      prepared, identity, contract);
@@ -11684,6 +11740,8 @@ void EmitSemanticVisibilityPreparedCandidates() {
   uint64_t entry_count = 0;
   uint64_t mechanically_eligible_draws = 0;
   uint64_t mechanically_eligible_entries = 0;
+  uint64_t mechanically_ineligible_draws = 0;
+  uint64_t mechanically_ineligible_entries = 0;
   uint64_t title_lod_draws = 0;
   uint64_t title_lod_entries = 0;
   for (const SemanticVisibilityPreparedCandidateEntry &entry :
@@ -11696,6 +11754,9 @@ void EmitSemanticVisibilityPreparedCandidates() {
     if (entry.mechanically_eligible) {
       mechanically_eligible_draws += entry.draws;
       ++mechanically_eligible_entries;
+    } else {
+      mechanically_ineligible_draws += entry.draws;
+      ++mechanically_ineligible_entries;
     }
     if (entry.title_lod_valid) {
       title_lod_draws += entry.draws;
@@ -11738,6 +11799,9 @@ void EmitSemanticVisibilityPreparedCandidates() {
           std::to_string(entry.maximum_policy_age_frames)},
          {"mechanically_eligible",
           entry.mechanically_eligible ? "true" : "false"},
+         {"mechanical_rejection_mask",
+          fmt::format("{:08X}", entry.mechanical_rejection_mask)},
+         {"mechanical_admission_contract", "isolated_draw_v1"},
          {"policy_age_limit_frames",
           std::to_string(kSemanticVisibilityMaximumPolicyAgeFrames)},
          {"classification", "fresh_visibility_selected_prepared_candidate"},
@@ -11761,6 +11825,10 @@ void EmitSemanticVisibilityPreparedCandidates() {
           entry_draws +
               g_semantic_visibility_prepared_candidate_overflow &&
       g_semantic_visibility_prepared_candidate_count == entry_count &&
+      mechanically_eligible_draws + mechanically_ineligible_draws ==
+          entry_draws &&
+      mechanically_eligible_entries + mechanically_ineligible_entries ==
+          entry_count &&
       title_lod_draws <= entry_draws && title_lod_entries <= entry_count;
   pinyon_shift::diagnostics::RecordEvent(
       "native_renderer.discovery.semantic_visibility_prepared_candidate_summary",
@@ -11788,6 +11856,11 @@ void EmitSemanticVisibilityPreparedCandidates() {
         std::to_string(mechanically_eligible_entries)},
        {"mechanically_eligible_draws",
         std::to_string(mechanically_eligible_draws)},
+       {"mechanically_ineligible_entries",
+        std::to_string(mechanically_ineligible_entries)},
+       {"mechanically_ineligible_draws",
+        std::to_string(mechanically_ineligible_draws)},
+       {"mechanical_admission_contract", "isolated_draw_v1"},
        {"title_lod_entries", std::to_string(title_lod_entries)},
        {"title_lod_draws", std::to_string(title_lod_draws)},
        {"capacity",
@@ -14417,6 +14490,7 @@ void InstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system,
        {"selection", "independent_visibility_selected_and_fresh"},
        {"prepared_lineage", "exact_semantic_pm4_prepared_draw"},
        {"title_lod_lineage", "exact_visibility_identity_to_prepared_draw"},
+       {"mechanical_admission_contract", "isolated_draw_v1"},
        {"guest_state_changed", "false"},
        {"control_flow_changed", "false"},
        {"native_upload", "false"},

--- a/tools/discover-native-renderer-dispatch.py
+++ b/tools/discover-native-renderer-dispatch.py
@@ -1628,6 +1628,7 @@ def procedural_model_receiver_lifecycle(
             "selection": "independent_visibility_selected_and_fresh",
             "prepared_lineage": "exact_semantic_pm4_prepared_draw",
             "title_lod_lineage": "exact_visibility_identity_to_prepared_draw",
+            "mechanical_admission_contract": "isolated_draw_v1",
             "guest_state_changed": False,
             "control_flow_changed": False,
             "native_upload_enabled": False,

--- a/tools/summarize-native-renderer-visibility-prepared-candidates.py
+++ b/tools/summarize-native-renderer-visibility-prepared-candidates.py
@@ -7,7 +7,7 @@ import pathlib
 import sys
 
 
-SCHEMA = "pinyon-shift.native-renderer-visibility-prepared-candidates.v3"
+SCHEMA = "pinyon-shift.native-renderer-visibility-prepared-candidates.v4"
 STATIC_SCHEMA = "pinyon-shift.native-renderer-dispatch-static.v3"
 CONFIG = (
     "native_renderer.discovery."
@@ -22,6 +22,25 @@ SUMMARY = (
     "semantic_visibility_prepared_candidate_summary"
 )
 WORKSET = "native_renderer.discovery.semantic_visibility_workset_summary"
+
+MECHANICAL_REJECTIONS = {
+    0: "resolved_input",
+    1: "unsupported_geometry",
+    2: "empty_draw",
+    3: "vertex_binding_count",
+    4: "vertex_binding_overflow",
+    5: "vertex_attribute_overflow",
+    6: "vertex_constant_overflow",
+    7: "pixel_constant_overflow",
+    8: "texture_state_overflow",
+    9: "memexport",
+    10: "query",
+    11: "texture_count",
+    12: "texture_layout",
+    13: "prepared_pipeline",
+    14: "render_targets",
+}
+MECHANICAL_REJECTION_MASK = sum(1 << bit for bit in MECHANICAL_REJECTIONS)
 
 
 def read_events(paths):
@@ -93,6 +112,7 @@ def static_contract(document):
         "selection": "independent_visibility_selected_and_fresh",
         "prepared_lineage": "exact_semantic_pm4_prepared_draw",
         "title_lod_lineage": "exact_visibility_identity_to_prepared_draw",
+        "mechanical_admission_contract": "isolated_draw_v1",
         "guest_state_changed": False,
         "control_flow_changed": False,
         "native_upload_enabled": False,
@@ -137,6 +157,7 @@ def build(events, static, requested_session=None):
         "selection": "independent_visibility_selected_and_fresh",
         "prepared_lineage": "exact_semantic_pm4_prepared_draw",
         "title_lod_lineage": "exact_visibility_identity_to_prepared_draw",
+        "mechanical_admission_contract": "isolated_draw_v1",
         "guest_state_changed": "false",
         "control_flow_changed": "false",
         "native_upload": "false",
@@ -157,6 +178,7 @@ def build(events, static, requested_session=None):
         != "independent_visibility_selected_and_fresh"
         or summary.get("title_lod_lineage")
         != "exact_visibility_identity_to_prepared_draw"
+        or summary.get("mechanical_admission_contract") != "isolated_draw_v1"
     ):
         raise ValueError("prepared-candidate summary is incomplete")
 
@@ -172,6 +194,8 @@ def build(events, static, requested_session=None):
         "entry_draws",
         "mechanically_eligible_entries",
         "mechanically_eligible_draws",
+        "mechanically_ineligible_entries",
+        "mechanically_ineligible_draws",
         "title_lod_entries",
         "title_lod_draws",
         "capacity",
@@ -182,6 +206,8 @@ def build(events, static, requested_session=None):
     entries = []
     seen_keys = set()
     entry_draws = 0
+    rejection_entry_counts = {name: 0 for name in MECHANICAL_REJECTIONS.values()}
+    rejection_draw_counts = {name: 0 for name in MECHANICAL_REJECTIONS.values()}
     for event in selected:
         if event.get("event") != ENTRY:
             continue
@@ -220,6 +246,13 @@ def build(events, static, requested_session=None):
             ),
             "mechanically_eligible": event.get("mechanically_eligible") == "true",
         }
+        rejection_mask = int(hexadecimal(event, "mechanical_rejection_mask", 8), 16)
+        item["mechanical_rejection_mask"] = rejection_mask
+        item["mechanical_rejections"] = [
+            name
+            for bit, name in MECHANICAL_REJECTIONS.items()
+            if rejection_mask & (1 << bit)
+        ]
         if (
             event.get("status") != "complete"
             or event.get("classification")
@@ -231,6 +264,9 @@ def build(events, static, requested_session=None):
             or item["maximum_policy_age_frames"]
             > totals["policy_age_limit_frames"]
             or event.get("mechanically_eligible") not in ("true", "false")
+            or event.get("mechanical_admission_contract") != "isolated_draw_v1"
+            or rejection_mask & ~MECHANICAL_REJECTION_MASK
+            or item["mechanically_eligible"] != (rejection_mask == 0)
             or event.get("title_lod_valid") not in ("true", "false")
             or event.get("title_lod_lineage")
             != "exact_visibility_identity_to_prepared_draw"
@@ -241,6 +277,9 @@ def build(events, static, requested_session=None):
             raise ValueError("prepared-candidate entry evidence drifted")
         seen_keys.add(key)
         entry_draws += item["draws"]
+        for reason in item["mechanical_rejections"]:
+            rejection_entry_counts[reason] += 1
+            rejection_draw_counts[reason] += item["draws"]
         entries.append(item)
 
     failures = []
@@ -271,6 +310,21 @@ def build(events, static, requested_session=None):
         != sum(entry["draws"] for entry in eligible_entries)
     ):
         failures.append("mechanically eligible candidate totals drifted")
+    ineligible_entries = [
+        entry for entry in entries if not entry["mechanically_eligible"]
+    ]
+    if (
+        totals["mechanically_ineligible_entries"] != len(ineligible_entries)
+        or totals["mechanically_ineligible_draws"]
+        != sum(entry["draws"] for entry in ineligible_entries)
+        or totals["mechanically_eligible_entries"]
+        + totals["mechanically_ineligible_entries"]
+        != totals["candidate_entries"]
+        or totals["mechanically_eligible_draws"]
+        + totals["mechanically_ineligible_draws"]
+        != totals["entry_draws"]
+    ):
+        failures.append("mechanical admission partition drifted")
     lod_entries = [entry for entry in entries if entry["title_lod_valid"]]
     if (
         totals["title_lod_entries"] != len(lod_entries)
@@ -294,6 +348,8 @@ def build(events, static, requested_session=None):
         "static_contract": contract,
         "totals": totals,
         "entries": entries,
+        "mechanical_rejection_entry_counts": rejection_entry_counts,
+        "mechanical_rejection_draw_counts": rejection_draw_counts,
         "qualification": {
             "fresh_visibility_prepared_handoff_proved": not failures,
             "isolated_native_candidate_proved": not failures

--- a/tools/tests/test_native_renderer_dispatch_discovery.py
+++ b/tools/tests/test_native_renderer_dispatch_discovery.py
@@ -1422,6 +1422,10 @@ class NativeRendererDispatchDiscoveryTests(unittest.TestCase):
             "exact_visibility_identity_to_prepared_draw",
             prepared_candidates["title_lod_lineage"],
         )
+        self.assertEqual(
+            "isolated_draw_v1",
+            prepared_candidates["mechanical_admission_contract"],
+        )
         self.assertFalse(prepared_candidates["native_draw_enabled"])
         self.assertTrue(prepared_candidates["xenos_draw_preserved"])
         self.assertFalse(prepared_candidates["suppression_allowed"])

--- a/tools/tests/test_native_renderer_visibility_prepared_candidates.py
+++ b/tools/tests/test_native_renderer_visibility_prepared_candidates.py
@@ -25,6 +25,7 @@ class VisibilityPreparedCandidateReportTests(unittest.TestCase):
                     "selection": "independent_visibility_selected_and_fresh",
                     "prepared_lineage": "exact_semantic_pm4_prepared_draw",
                     "title_lod_lineage": "exact_visibility_identity_to_prepared_draw",
+                    "mechanical_admission_contract": "isolated_draw_v1",
                     "guest_state_changed": False,
                     "control_flow_changed": False,
                     "native_upload_enabled": False,
@@ -60,6 +61,7 @@ class VisibilityPreparedCandidateReportTests(unittest.TestCase):
             "selection": "independent_visibility_selected_and_fresh",
             "prepared_lineage": "exact_semantic_pm4_prepared_draw",
             "title_lod_lineage": "exact_visibility_identity_to_prepared_draw",
+            "mechanical_admission_contract": "isolated_draw_v1",
             **self.safety(),
         }
         entry = {
@@ -88,6 +90,8 @@ class VisibilityPreparedCandidateReportTests(unittest.TestCase):
             "last_frame": "12",
             "maximum_policy_age_frames": "1",
             "mechanically_eligible": "true",
+            "mechanical_rejection_mask": "00000000",
+            "mechanical_admission_contract": "isolated_draw_v1",
             "policy_age_limit_frames": "1",
             "classification": "fresh_visibility_selected_prepared_candidate",
             **self.safety(),
@@ -107,6 +111,9 @@ class VisibilityPreparedCandidateReportTests(unittest.TestCase):
             "entry_draws": "7",
             "mechanically_eligible_entries": "1",
             "mechanically_eligible_draws": "7",
+            "mechanically_ineligible_entries": "0",
+            "mechanically_ineligible_draws": "0",
+            "mechanical_admission_contract": "isolated_draw_v1",
             "title_lod_entries": "1",
             "title_lod_draws": "7",
             "capacity": "4096",
@@ -152,13 +159,44 @@ class VisibilityPreparedCandidateReportTests(unittest.TestCase):
         self.assertEqual("complete", document["status"])
         self.assertFalse(document["qualification"]["title_lod_lineage_proved"])
 
+    def test_build_reports_each_mechanical_rejection_reason(self):
+        events = copy.deepcopy(self.events())
+        entry = next(event for event in events if event["event"] == MODULE.ENTRY)
+        entry["mechanically_eligible"] = "false"
+        entry["mechanical_rejection_mask"] = "00002003"
+        summary = next(event for event in events if event["event"] == MODULE.SUMMARY)
+        summary["mechanically_eligible_entries"] = "0"
+        summary["mechanically_eligible_draws"] = "0"
+        summary["mechanically_ineligible_entries"] = "1"
+        summary["mechanically_ineligible_draws"] = "7"
+        document = MODULE.build(events, self.static())
+        self.assertEqual("complete", document["status"])
+        self.assertEqual(
+            ["resolved_input", "unsupported_geometry", "prepared_pipeline"],
+            document["entries"][0]["mechanical_rejections"],
+        )
+        self.assertEqual(
+            7,
+            document["mechanical_rejection_draw_counts"]["prepared_pipeline"],
+        )
+
+    def test_build_rejects_eligibility_mask_drift(self):
+        events = copy.deepcopy(self.events())
+        entry = next(event for event in events if event["event"] == MODULE.ENTRY)
+        entry["mechanical_rejection_mask"] = "00000001"
+        with self.assertRaisesRegex(ValueError, "entry evidence drifted"):
+            MODULE.build(events, self.static())
+
     def test_build_accepts_fresh_candidate_without_isolated_eligibility(self):
         events = copy.deepcopy(self.events())
         entry = next(event for event in events if event["event"] == MODULE.ENTRY)
         entry["mechanically_eligible"] = "false"
+        entry["mechanical_rejection_mask"] = "00000001"
         summary = next(event for event in events if event["event"] == MODULE.SUMMARY)
         summary["mechanically_eligible_entries"] = "0"
         summary["mechanically_eligible_draws"] = "0"
+        summary["mechanically_ineligible_entries"] = "1"
+        summary["mechanically_ineligible_draws"] = "7"
         document = MODULE.build(events, self.static())
         self.assertEqual("complete", document["status"])
         self.assertFalse(


### PR DESCRIPTION
## Summary
- replace the opaque prepared-candidate eligibility boolean with a complete bounded rejection mask
- distinguish resolved input, geometry, vertex, constant, texture, query, memexport, pipeline, and render-target blockers
- report per-reason entry and draw totals for exact title-selected LOD candidates
- preserve every existing admission rule, Xenos replay, and no-suppression gate

## Validation
- \python -m unittest discover -s tools/tests -p 'test_native_renderer_*.py'\ (314 tests)
- incremental Release build of \pinyon_shift.exe\`n- static dispatch discovery against the real generated image
- scoped \git diff --check\`n
## Runtime qualification
Deferred and batched with the next substantial NR-05D slice. This change is bounded diagnostic metadata only and does not enable native LOD, drawing, control-flow changes, or suppression.