### PR TITLE
feat(native-renderer): classify depth stencil parity

### DIFF
--- a/docs/native-renderer/VISUAL_COMPARISON.md
+++ b/docs/native-renderer/VISUAL_COMPARISON.md
@@ -156,6 +156,15 @@ draw, dimensions, sample count, encoding, layout, format, role, or safety
 metadata, and requires exact active bytes. Xenos remains the displayed and
 authoritative output throughout.
 
+The report also classifies depth and stencil parity independently. Planar
+captures report each active plane separately. Multisample tuple captures report
+changed pixels and samples, independent depth and stencil tuple/byte counts, a
+per-sample change histogram, a changed-pixel bounding box, and at most the first
+16 changed sample coordinates and bit patterns. Suppression still requires
+exact active bytes; the component breakdown only distinguishes geometry/depth
+divergence from a narrow stencil-state mismatch without requiring another GPU
+capture.
+
 RenderDoc remains available for visual inspection and external confirmation.
 Capture with both the anchor and follower configured, then export their
 native/Xenos spans:

--- a/tools/compare-native-renderer-pass-readbacks.py
+++ b/tools/compare-native-renderer-pass-readbacks.py
@@ -58,7 +58,7 @@ def _compare_rows(
     native_data: bytes,
     xenos_data: bytes,
     rows: list[tuple[int, int, int]],
-) -> dict[str, int | float | bool]:
+) -> dict[str, Any]:
     compared_bytes = 0
     different_bytes = 0
     absolute_error = 0
@@ -89,6 +89,122 @@ def _compare_rows(
     }
 
 
+def _compare_depth_tuple_components(
+    native_data: bytes,
+    xenos_data: bytes,
+    width: int,
+    height: int,
+    sample_count: int,
+    plane: dict[str, Any],
+) -> dict[str, Any]:
+    changed_pixels = 0
+    changed_samples = 0
+    depth_tuple_changes = 0
+    stencil_tuple_changes = 0
+    depth_different_bytes = 0
+    stencil_different_bytes = 0
+    changed_sample_histogram = [0] * sample_count
+    left, top, right, bottom = width, height, -1, -1
+    first_changed_samples: list[dict[str, int | str]] = []
+    for y in range(height):
+        row = int(plane["offset"]) + y * int(plane["row_pitch"])
+        for x in range(width):
+            pixel_changed = False
+            for sample in range(sample_count):
+                offset = row + (x * sample_count + sample) * 8
+                native_depth = native_data[offset : offset + 4]
+                xenos_depth = xenos_data[offset : offset + 4]
+                native_stencil = native_data[offset + 4 : offset + 8]
+                xenos_stencil = xenos_data[offset + 4 : offset + 8]
+                depth_changed = native_depth != xenos_depth
+                stencil_changed = native_stencil != xenos_stencil
+                if not depth_changed and not stencil_changed:
+                    continue
+                changed_samples += 1
+                changed_sample_histogram[sample] += 1
+                pixel_changed = True
+                depth_tuple_changes += depth_changed
+                stencil_tuple_changes += stencil_changed
+                depth_different_bytes += sum(
+                    left_byte != right_byte
+                    for left_byte, right_byte in zip(
+                        native_depth, xenos_depth, strict=True
+                    )
+                )
+                stencil_different_bytes += sum(
+                    left_byte != right_byte
+                    for left_byte, right_byte in zip(
+                        native_stencil, xenos_stencil, strict=True
+                    )
+                )
+                if len(first_changed_samples) < 16:
+                    first_changed_samples.append(
+                        {
+                            "x": x,
+                            "y": y,
+                            "sample": sample,
+                            "native_depth_word": format(
+                                int.from_bytes(native_depth, "little"), "08X"
+                            ),
+                            "xenos_depth_word": format(
+                                int.from_bytes(xenos_depth, "little"), "08X"
+                            ),
+                            "native_stencil": int.from_bytes(
+                                native_stencil, "little"
+                            ),
+                            "xenos_stencil": int.from_bytes(
+                                xenos_stencil, "little"
+                            ),
+                        }
+                    )
+            if pixel_changed:
+                changed_pixels += 1
+                left = min(left, x)
+                top = min(top, y)
+                right = max(right, x)
+                bottom = max(bottom, y)
+    return {
+        "changed_pixels": changed_pixels,
+        "total_pixels": width * height,
+        "changed_samples": changed_samples,
+        "total_samples": width * height * sample_count,
+        "depth_tuple_changes": depth_tuple_changes,
+        "stencil_tuple_changes": stencil_tuple_changes,
+        "depth_different_bytes": depth_different_bytes,
+        "stencil_different_bytes": stencil_different_bytes,
+        "changed_sample_histogram": changed_sample_histogram,
+        "exact_depth": depth_tuple_changes == 0,
+        "exact_stencil": stencil_tuple_changes == 0,
+        "changed_bounds": (
+            {"left": left, "top": top, "right": right, "bottom": bottom}
+            if changed_pixels
+            else None
+        ),
+        "first_changed_samples": first_changed_samples,
+    }
+
+
+def _compare_planar_depth_components(
+    native_data: bytes,
+    xenos_data: bytes,
+    planes: list[dict[str, Any]],
+) -> dict[str, Any]:
+    components: dict[str, Any] = {}
+    for index, plane in enumerate(planes):
+        rows = [
+            (
+                int(plane["offset"]) + row * int(plane["row_pitch"]),
+                int(plane["row_pitch"]),
+                int(plane["row_size"]),
+            )
+            for row in range(int(plane["row_count"]))
+        ]
+        components["depth" if index == 0 else "stencil"] = _compare_rows(
+            native_data, xenos_data, rows
+        )
+    return components
+
+
 def compare(
     native_root: Path, xenos_root: Path, content: str = "color"
 ) -> dict[str, Any]:
@@ -116,6 +232,7 @@ def compare(
         raise ValueError("invalid readback dimensions")
 
     rows: list[tuple[int, int, int]] = []
+    component_metrics: dict[str, Any] | None = None
     if content == "color":
         bytes_per_pixel = BYTES_PER_PIXEL.get(dxgi_format)
         if bytes_per_pixel is None:
@@ -197,8 +314,23 @@ def compare(
             "encoding": encoding,
             "planes": native_planes,
         }
+        if encoding == "depth32_stencil8_sample_tuples":
+            component_metrics = _compare_depth_tuple_components(
+                native_data,
+                xenos_data,
+                width,
+                height,
+                sample_count,
+                native_planes[0],
+            )
+        else:
+            component_metrics = _compare_planar_depth_components(
+                native_data, xenos_data, native_planes
+            )
 
     metrics = _compare_rows(native_data, xenos_data, rows)
+    if component_metrics is not None:
+        metrics["components"] = component_metrics
     exact = bool(metrics["exact_active_bytes"])
     return {
         "schema": COLOR_SCHEMA if content == "color" else DEPTH_SCHEMA,

--- a/tools/tests/test_native_renderer_pass_readbacks.py
+++ b/tools/tests/test_native_renderer_pass_readbacks.py
@@ -170,6 +170,9 @@ class NativeRendererPassReadbackTests(unittest.TestCase):
             self.assertEqual(report["result"], "pass")
             self.assertEqual(report["scope"]["content"], "depth-stencil")
             self.assertEqual(report["metrics"]["compared_bytes"], 10)
+            components = report["metrics"]["components"]
+            self.assertTrue(components["depth"]["exact_active_bytes"])
+            self.assertTrue(components["stencil"]["exact_active_bytes"])
 
     def test_depth_padding_is_excluded(self):
         with tempfile.TemporaryDirectory() as directory:
@@ -196,6 +199,9 @@ class NativeRendererPassReadbackTests(unittest.TestCase):
             report = MODULE.compare(native, xenos, "depth-stencil")
             self.assertEqual(report["result"], "fail")
             self.assertEqual(report["metrics"]["different_bytes"], 1)
+            components = report["metrics"]["components"]
+            self.assertTrue(components["depth"]["exact_active_bytes"])
+            self.assertEqual(components["stencil"]["different_bytes"], 1)
 
     def test_exact_msaa_depth_sample_tuples_pass(self):
         with tempfile.TemporaryDirectory() as directory:
@@ -208,6 +214,36 @@ class NativeRendererPassReadbackTests(unittest.TestCase):
             self.assertEqual(report["result"], "pass")
             self.assertEqual(report["metrics"]["compared_bytes"], 64)
             self.assertEqual(report["layout"]["sample_count"], 2)
+            components = report["metrics"]["components"]
+            self.assertTrue(components["exact_depth"])
+            self.assertTrue(components["exact_stencil"])
+            self.assertEqual(components["changed_samples"], 0)
+
+    def test_msaa_depth_and_stencil_deltas_are_classified(self):
+        with tempfile.TemporaryDirectory() as directory:
+            native = Path(directory) / "pass.depth"
+            xenos = Path(str(native) + ".xenos")
+            native_data = bytes(64)
+            xenos_data = bytearray(native_data)
+            xenos_data[0] = 1
+            xenos_data[28] = 2
+            write_msaa_depth_readback(native, "native", native_data)
+            write_msaa_depth_readback(xenos, "xenos", bytes(xenos_data))
+            report = MODULE.compare(native, xenos, "depth-stencil")
+            components = report["metrics"]["components"]
+            self.assertFalse(components["exact_depth"])
+            self.assertFalse(components["exact_stencil"])
+            self.assertEqual(components["depth_tuple_changes"], 1)
+            self.assertEqual(components["stencil_tuple_changes"], 1)
+            self.assertEqual(components["depth_different_bytes"], 1)
+            self.assertEqual(components["stencil_different_bytes"], 1)
+            self.assertEqual(components["changed_samples"], 2)
+            self.assertEqual(components["changed_sample_histogram"], [1, 1])
+            self.assertEqual(
+                components["changed_bounds"],
+                {"left": 0, "top": 0, "right": 1, "bottom": 0},
+            )
+            self.assertEqual(len(components["first_changed_samples"]), 2)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- classify planar depth and stencil parity independently
- decode multisample depth/stencil tuples into bounded component diagnostics
- report changed pixels/samples, per-sample histogram, bounds, and up to 16 exact coordinates
- keep the existing byte-exact combined parity gate unchanged

## Captured evidence
For world signature B0EC5BC78D8B8760 at frame 5803:
- color: 20,971,520 exact bytes
- depth: 10,485,760 exact sample values
- stencil: 151 changed sample-zero tuples
- changed bounds: top-left 16x16 tile
- Xenos remained authoritative; suppression remained disabled

## Validation
- 377 Python tests
- re-analysis of the existing AppData paired readback corpus