### PR TITLE
fix(native-renderer): restore guest pso after depth readback

### DIFF
--- a/docs/native-renderer/VISUAL_COMPARISON.md
+++ b/docs/native-renderer/VISUAL_COMPARISON.md
@@ -165,6 +165,28 @@ exact active bytes; the component breakdown only distinguishes geometry/depth
 divergence from a narrow stencil-state mismatch without requiring another GPU
 capture.
 
+Targeted captures also emit two pre-draw depth/stencil checkpoints beside the
+post-draw pair: `.depth.seed.native` is the private target immediately after
+the guest resource copy, and `.depth.seed.xenos` is the still-authoritative
+guest target immediately before its original draw. Analyze all four artifacts
+in one report with:
+
+```powershell
+python .\tools\compare-native-renderer-pass-readbacks.py `
+  '.local\qualification\nr04d-pass-readback.depth' `
+  --content depth-stencil `
+  --native-seed-root `
+    '.local\qualification\nr04d-pass-readback.depth.seed.native' `
+  --xenos-seed-root `
+    '.local\qualification\nr04d-pass-readback.depth.seed.xenos' `
+  --output '.local\qualification\nr04d-depth-checkpoints.json'
+```
+
+The checkpoint diagnosis separates a private seed-copy mismatch from a draw
+effect or final-result divergence. All four copies remain asynchronous and
+diagnostic-only. The authoritative draw is preserved, and a failed final
+parity comparison remains a hard suppression blocker.
+
 RenderDoc remains available for visual inspection and external confirmation.
 Capture with both the anchor and follower configured, then export their
 native/Xenos spans:

--- a/patches/rexglue/0084-d3d12-isolated-depth-seed-readback.patch
+++ b/patches/rexglue/0084-d3d12-isolated-depth-seed-readback.patch
@@ -1,0 +1,247 @@
+diff --git a/include/rex/system/interfaces/graphics.h b/include/rex/system/interfaces/graphics.h
+index 887a91a..ae61c8b 100644
+--- a/include/rex/system/interfaces/graphics.h
++++ b/include/rex/system/interfaces/graphics.h
+@@ -484,6 +484,11 @@ struct GraphicsIsolatedDrawRequest {
+   // or redirect the guest draw.
+   bool depth_readback_requested = false;
+   bool reference_depth_readback_requested = false;
++  // Capture both depth/stencil resources immediately after the private target
++  // is seeded and before either duplicate draw is recorded. These checkpoints
++  // distinguish copy/initialization faults from draw-state divergence.
++  bool seed_depth_readback_requested = false;
++  bool reference_seed_depth_readback_requested = false;
+   bool reference_marker_requested = false;
+   // Mark the authoritative guest draw as an exact later-consumer-family
+   // target. This never duplicates, redirects, or suppresses the draw.
+@@ -517,6 +522,10 @@ struct GraphicsIsolatedDrawRequest {
+   GraphicsIsolatedDrawReadbackCompletion depth_readback_completion = nullptr;
+   GraphicsIsolatedDrawReadbackCompletion
+       reference_depth_readback_completion = nullptr;
++  GraphicsIsolatedDrawReadbackCompletion seed_depth_readback_completion =
++      nullptr;
++  GraphicsIsolatedDrawReadbackCompletion
++      reference_seed_depth_readback_completion = nullptr;
+   GraphicsIsolatedDrawReadbackCompletion
+       consumer_reference_before_readback_completion = nullptr;
+   GraphicsIsolatedDrawReadbackCompletion
+diff --git a/include/rex/graphics/d3d12/render_target_cache.h b/include/rex/graphics/d3d12/render_target_cache.h
+index 6d38697..074b354 100644
+--- a/include/rex/graphics/d3d12/render_target_cache.h
++++ b/include/rex/graphics/d3d12/render_target_cache.h
+@@ -118,6 +118,13 @@ class D3D12RenderTargetCache final : public RenderTargetCache {
+   system::GraphicsIsolatedDrawReadbackStatus QueueIsolatedReplayDepthReadback(
+       system::GraphicsIsolatedDrawReadbackCompletion completion,
+       uint32_t* failure_detail_out);
++  system::GraphicsIsolatedDrawReadbackStatus
++  QueueIsolatedReplaySeedDepthReadback(
++      system::GraphicsIsolatedDrawReadbackCompletion completion,
++      uint32_t* failure_detail_out);
++  system::GraphicsIsolatedDrawReadbackStatus QueueGuestSeedDepthReadback(
++      system::GraphicsIsolatedDrawReadbackCompletion completion,
++      uint32_t* failure_detail_out);
+   system::GraphicsIsolatedDrawReadbackStatus QueueGuestDepthReadback(
+       system::GraphicsIsolatedDrawReadbackCompletion completion,
+       uint32_t* failure_detail_out);
+@@ -748,6 +755,8 @@ class D3D12RenderTargetCache final : public RenderTargetCache {
+   IsolatedReplayReadback guest_consumer_after_depth_readback_;
+   IsolatedReplayReadback isolated_replay_depth_readback_;
+   IsolatedReplayReadback guest_depth_reference_readback_;
++  IsolatedReplayReadback isolated_replay_seed_depth_readback_;
++  IsolatedReplayReadback guest_seed_depth_readback_;
+   system::GraphicsIsolatedDrawReadbackStatus QueueRenderTargetReadback(
+       D3D12RenderTarget* target, IsolatedReplayReadback& pending_readback,
+       system::GraphicsIsolatedDrawReadbackCompletion completion,
+diff --git a/src/graphics/d3d12/render_target_cache.cpp b/src/graphics/d3d12/render_target_cache.cpp
+index cd423bf..9027d43 100644
+--- a/src/graphics/d3d12/render_target_cache.cpp
++++ b/src/graphics/d3d12/render_target_cache.cpp
+@@ -1039,6 +1039,8 @@ void D3D12RenderTargetCache::Shutdown(bool from_destructor) {
+   release_isolated_readback(guest_consumer_after_depth_readback_);
+   release_isolated_readback(isolated_replay_depth_readback_);
+   release_isolated_readback(guest_depth_reference_readback_);
++  release_isolated_readback(isolated_replay_seed_depth_readback_);
++  release_isolated_readback(guest_seed_depth_readback_);
+   isolated_replay_preview_resolved_target_.Reset();
+   isolated_replay_preview_resolved_target_state_ =
+       D3D12_RESOURCE_STATE_RESOLVE_DEST;
+@@ -1108,6 +1110,8 @@ void D3D12RenderTargetCache::CompletedSubmissionUpdated() {
+   complete_isolated_readback(guest_consumer_after_depth_readback_);
+   complete_isolated_readback(isolated_replay_depth_readback_);
+   complete_isolated_readback(guest_depth_reference_readback_);
++  complete_isolated_readback(isolated_replay_seed_depth_readback_);
++  complete_isolated_readback(guest_seed_depth_readback_);
+ }
+ 
+ void D3D12RenderTargetCache::BeginSubmission() {
+@@ -1988,6 +1992,35 @@ D3D12RenderTargetCache::QueueIsolatedReplayDepthReadback(
+       isolated_replay_depth_readback_, completion, failure_detail_out);
+ }
+ 
++system::GraphicsIsolatedDrawReadbackStatus
++D3D12RenderTargetCache::QueueIsolatedReplaySeedDepthReadback(
++    system::GraphicsIsolatedDrawReadbackCompletion completion,
++    uint32_t* failure_detail_out) {
++  if (!isolated_replay_depth_target_) {
++    return system::GraphicsIsolatedDrawReadbackStatus::kUnsupportedTarget;
++  }
++  return QueueRenderTargetReadback(
++      static_cast<D3D12RenderTarget*>(isolated_replay_depth_target_.get()),
++      isolated_replay_seed_depth_readback_, completion, failure_detail_out);
++}
++
++system::GraphicsIsolatedDrawReadbackStatus
++D3D12RenderTargetCache::QueueGuestSeedDepthReadback(
++    system::GraphicsIsolatedDrawReadbackCompletion completion,
++    uint32_t* failure_detail_out) {
++  if (GetPath() != Path::kHostRenderTargets) {
++    return system::GraphicsIsolatedDrawReadbackStatus::kUnsupportedTarget;
++  }
++  RenderTarget* const* guest_targets =
++      last_update_accumulated_render_targets();
++  if (!guest_targets[0]) {
++    return system::GraphicsIsolatedDrawReadbackStatus::kUnsupportedTarget;
++  }
++  return QueueRenderTargetReadback(
++      static_cast<D3D12RenderTarget*>(guest_targets[0]),
++      guest_seed_depth_readback_, completion, failure_detail_out);
++}
++
+ system::GraphicsIsolatedDrawReadbackStatus
+ D3D12RenderTargetCache::QueueGuestDepthReadback(
+     system::GraphicsIsolatedDrawReadbackCompletion completion,
+diff --git a/src/graphics/d3d12/command_processor.cpp b/src/graphics/d3d12/command_processor.cpp
+index 99eac74..9fbda22 100644
+--- a/src/graphics/d3d12/command_processor.cpp
++++ b/src/graphics/d3d12/command_processor.cpp
+@@ -3135,11 +3135,15 @@ bool D3D12CommandProcessor::IssueDraw(xenos::PrimitiveType primitive_type, uint3
+ 
+   // Bind the pipeline after configuring it and doing everything that may bind
+   // other pipelines.
+-  if (current_guest_pipeline_ != pipeline_handle) {
+-    deferred_command_list_.SetPipelineStateHandle(reinterpret_cast<void*>(pipeline_handle));
+-    current_guest_pipeline_ = pipeline_handle;
+-    current_external_pipeline_ = nullptr;
+-  }
++  const auto bind_prepared_guest_pipeline = [this, pipeline_handle]() {
++    if (current_guest_pipeline_ != pipeline_handle) {
++      deferred_command_list_.SetPipelineStateHandle(
++          reinterpret_cast<void*>(pipeline_handle));
++      current_guest_pipeline_ = pipeline_handle;
++      current_external_pipeline_ = nullptr;
++    }
++  };
++  bind_prepared_guest_pipeline();
+ 
+   // Get dynamic rasterizer state.
+   uint32_t draw_resolution_scale_x = texture_cache_->draw_resolution_scale_x();
+@@ -3445,6 +3449,23 @@ bool D3D12CommandProcessor::IssueDraw(xenos::PrimitiveType primitive_type, uint3
+                   render_target_cache_->ResumeIsolatedReplayTarget(
+                       isolated_result.target_width,
+                       isolated_result.target_height))) {
++        if (isolated_draw_request.seed_depth_readback_requested &&
++            isolated_draw_request.seed_depth_readback_completion) {
++          uint32_t readback_detail = 0;
++          auto readback_status =
++              render_target_cache_->QueueIsolatedReplaySeedDepthReadback(
++                  isolated_draw_request.seed_depth_readback_completion,
++                  &readback_detail);
++          if (readback_status !=
++              system::GraphicsIsolatedDrawReadbackStatus::kReady) {
++            system::GraphicsIsolatedDrawReadback readback_result;
++            readback_result.status = readback_status;
++            readback_result.detail = readback_detail;
++            isolated_draw_request.seed_depth_readback_completion(
++                readback_result);
++          }
++        }
++        bind_prepared_guest_pipeline();
+         deferred_command_list_.BeginDebugMarker(
+             isolated_draw_request.reuse_target
+                 ? "PinyonShift NR-02F isolated native pass follower"
+@@ -3484,6 +3505,22 @@ bool D3D12CommandProcessor::IssueDraw(xenos::PrimitiveType primitive_type, uint3
+         }
+         render_target_cache_->EndIsolatedReplayTarget(
+             isolated_draw_request.frame_sequence);
++        if (isolated_draw_request.reference_seed_depth_readback_requested &&
++            isolated_draw_request.reference_seed_depth_readback_completion) {
++          uint32_t readback_detail = 0;
++          auto readback_status =
++              render_target_cache_->QueueGuestSeedDepthReadback(
++                  isolated_draw_request.reference_seed_depth_readback_completion,
++                  &readback_detail);
++          if (readback_status !=
++              system::GraphicsIsolatedDrawReadbackStatus::kReady) {
++            system::GraphicsIsolatedDrawReadback readback_result;
++            readback_result.status = readback_status;
++            readback_result.detail = readback_detail;
++            isolated_draw_request.reference_seed_depth_readback_completion(
++                readback_result);
++          }
++        }
+         isolated_replay_recorded = true;
+         isolated_result.status =
+             system::GraphicsIsolatedDrawStatus::kRecorded;
+@@ -3511,6 +3548,7 @@ bool D3D12CommandProcessor::IssueDraw(xenos::PrimitiveType primitive_type, uint3
+               : "PinyonShift NR-02F authoritative Xenos auto-index draw");
+     }
+     if (!suppress_guest_draw) {
++      bind_prepared_guest_pipeline();
+       PROFILE_DRAW_CALL();
+       PROFILE_VERTICES(primitive_processing_result.host_draw_vertex_count);
+       deferred_command_list_.D3DDrawInstanced(
+@@ -3626,6 +3664,23 @@ bool D3D12CommandProcessor::IssueDraw(xenos::PrimitiveType primitive_type, uint3
+                   render_target_cache_->ResumeIsolatedReplayTarget(
+                       isolated_result.target_width,
+                       isolated_result.target_height))) {
++        if (isolated_draw_request.seed_depth_readback_requested &&
++            isolated_draw_request.seed_depth_readback_completion) {
++          uint32_t readback_detail = 0;
++          auto readback_status =
++              render_target_cache_->QueueIsolatedReplaySeedDepthReadback(
++                  isolated_draw_request.seed_depth_readback_completion,
++                  &readback_detail);
++          if (readback_status !=
++              system::GraphicsIsolatedDrawReadbackStatus::kReady) {
++            system::GraphicsIsolatedDrawReadback readback_result;
++            readback_result.status = readback_status;
++            readback_result.detail = readback_detail;
++            isolated_draw_request.seed_depth_readback_completion(
++                readback_result);
++          }
++        }
++        bind_prepared_guest_pipeline();
+         deferred_command_list_.BeginDebugMarker(
+             isolated_draw_request.retain_target
+                 ? "PinyonShift NR-02F isolated native pass anchor"
+@@ -3665,6 +3720,22 @@ bool D3D12CommandProcessor::IssueDraw(xenos::PrimitiveType primitive_type, uint3
+         }
+         render_target_cache_->EndIsolatedReplayTarget(
+             isolated_draw_request.frame_sequence);
++        if (isolated_draw_request.reference_seed_depth_readback_requested &&
++            isolated_draw_request.reference_seed_depth_readback_completion) {
++          uint32_t readback_detail = 0;
++          auto readback_status =
++              render_target_cache_->QueueGuestSeedDepthReadback(
++                  isolated_draw_request.reference_seed_depth_readback_completion,
++                  &readback_detail);
++          if (readback_status !=
++              system::GraphicsIsolatedDrawReadbackStatus::kReady) {
++            system::GraphicsIsolatedDrawReadback readback_result;
++            readback_result.status = readback_status;
++            readback_result.detail = readback_detail;
++            isolated_draw_request.reference_seed_depth_readback_completion(
++                readback_result);
++          }
++        }
+         isolated_replay_recorded = true;
+         isolated_result.status =
+             system::GraphicsIsolatedDrawStatus::kRecorded;
+@@ -3692,6 +3763,7 @@ bool D3D12CommandProcessor::IssueDraw(xenos::PrimitiveType primitive_type, uint3
+               : "PinyonShift NR-02E authoritative Xenos draw");
+     }
+     if (!suppress_guest_draw) {
++      bind_prepared_guest_pipeline();
+       PROFILE_DRAW_CALL();
+       PROFILE_VERTICES(primitive_processing_result.host_draw_vertex_count);
+       deferred_command_list_.D3DDrawIndexedInstanced(

--- a/src/native_renderer/graphics_hooks.cpp
+++ b/src/native_renderer/graphics_hooks.cpp
@@ -4085,6 +4085,8 @@ struct IsolatedDrawState {
   std::jthread reference_artifact_writer;
   std::jthread depth_artifact_writer;
   std::jthread reference_depth_artifact_writer;
+  std::jthread seed_depth_artifact_writer;
+  std::jthread reference_seed_depth_artifact_writer;
   bool requested = false;
   bool readback_requested = false;
   bool completed = false;
@@ -13115,6 +13117,24 @@ void CompleteIsolatedDepthReadback(
       readback, "native", depth_root, g_isolated_draw.depth_artifact_writer);
 }
 
+void CompleteIsolatedSeedDepthReadback(
+    const rex::system::GraphicsIsolatedDrawReadback &readback) {
+  std::filesystem::path depth_root = g_isolated_draw.output_root;
+  depth_root += L".depth.seed.native";
+  CompleteIsolatedDepthReadbackArtifact(
+      readback, "native_seed", depth_root,
+      g_isolated_draw.seed_depth_artifact_writer);
+}
+
+void CompleteIsolatedReferenceSeedDepthReadback(
+    const rex::system::GraphicsIsolatedDrawReadback &readback) {
+  std::filesystem::path depth_root = g_isolated_draw.output_root;
+  depth_root += L".depth.seed.xenos";
+  CompleteIsolatedDepthReadbackArtifact(
+      readback, "xenos_seed", depth_root,
+      g_isolated_draw.reference_seed_depth_artifact_writer);
+}
+
 void CompleteIsolatedReferenceDepthReadback(
     const rex::system::GraphicsIsolatedDrawReadback &readback) {
   std::filesystem::path depth_root = g_isolated_draw.output_root;
@@ -13446,6 +13466,10 @@ void RequestIsolatedDraw(
       request.depth_readback_requested = g_isolated_draw.readback_requested;
       request.reference_depth_readback_requested =
           g_isolated_draw.readback_requested;
+      request.seed_depth_readback_requested =
+          g_isolated_draw.readback_requested;
+      request.reference_seed_depth_readback_requested =
+          g_isolated_draw.readback_requested;
       request.completion = &CompleteIsolatedPassFollower;
       request.readback_completion = g_isolated_draw.readback_requested
                                         ? &CompleteIsolatedDrawReadback
@@ -13461,6 +13485,14 @@ void RequestIsolatedDraw(
       request.reference_depth_readback_completion =
           g_isolated_draw.readback_requested
               ? &CompleteIsolatedReferenceDepthReadback
+              : nullptr;
+      request.seed_depth_readback_completion =
+          g_isolated_draw.readback_requested
+              ? &CompleteIsolatedSeedDepthReadback
+              : nullptr;
+      request.reference_seed_depth_readback_completion =
+          g_isolated_draw.readback_requested
+              ? &CompleteIsolatedReferenceSeedDepthReadback
               : nullptr;
     } else if (!g_isolated_draw.pass_repeat_reported) {
       request.completion = &CompleteIsolatedPassRepeat;
@@ -13583,6 +13615,9 @@ void RequestIsolatedDraw(
   request.depth_readback_requested = g_isolated_draw.readback_requested;
   request.reference_depth_readback_requested =
       g_isolated_draw.readback_requested;
+  request.seed_depth_readback_requested = g_isolated_draw.readback_requested;
+  request.reference_seed_depth_readback_requested =
+      g_isolated_draw.readback_requested;
   request.completion = &CompleteIsolatedDraw;
   request.readback_completion = g_isolated_draw.readback_requested
                                     ? &CompleteIsolatedDrawReadback
@@ -13597,6 +13632,13 @@ void RequestIsolatedDraw(
   request.reference_depth_readback_completion =
       g_isolated_draw.readback_requested
           ? &CompleteIsolatedReferenceDepthReadback
+          : nullptr;
+  request.seed_depth_readback_completion =
+      g_isolated_draw.readback_requested ? &CompleteIsolatedSeedDepthReadback
+                                         : nullptr;
+  request.reference_seed_depth_readback_completion =
+      g_isolated_draw.readback_requested
+          ? &CompleteIsolatedReferenceSeedDepthReadback
           : nullptr;
 }
 
@@ -14856,6 +14898,12 @@ void UninstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system) {
   }
   if (g_isolated_draw.reference_depth_artifact_writer.joinable()) {
     g_isolated_draw.reference_depth_artifact_writer.join();
+  }
+  if (g_isolated_draw.seed_depth_artifact_writer.joinable()) {
+    g_isolated_draw.seed_depth_artifact_writer.join();
+  }
+  if (g_isolated_draw.reference_seed_depth_artifact_writer.joinable()) {
+    g_isolated_draw.reference_seed_depth_artifact_writer.join();
   }
   for (std::jthread &artifact_writer :
        g_consumer_family_marker.artifact_writers) {

--- a/tools/compare-native-renderer-pass-readbacks.py
+++ b/tools/compare-native-renderer-pass-readbacks.py
@@ -14,6 +14,9 @@ COLOR_SCHEMA = "pinyon-shift.native-renderer-pass-readback-comparison.v1"
 DEPTH_SCHEMA = (
     "pinyon-shift.native-renderer-pass-depth-readback-comparison.v1"
 )
+DEPTH_CHECKPOINT_SCHEMA = (
+    "pinyon-shift.native-renderer-depth-checkpoint-analysis.v1"
+)
 COLOR_READBACK_SCHEMA = "pinyon-shift.isolated-draw-readback.v1"
 DEPTH_READBACK_SCHEMA = "pinyon-shift.isolated-depth-readback.v1"
 BYTES_PER_PIXEL = {10: 8, 28: 4}
@@ -206,10 +209,14 @@ def _compare_planar_depth_components(
 
 
 def compare(
-    native_root: Path, xenos_root: Path, content: str = "color"
+    native_root: Path,
+    xenos_root: Path,
+    content: str = "color",
+    native_role: str = "native",
+    xenos_role: str = "xenos",
 ) -> dict[str, Any]:
-    native, native_data = _load(native_root, "native", content)
-    xenos, xenos_data = _load(xenos_root, "xenos", content)
+    native, native_data = _load(native_root, native_role, content)
+    xenos, xenos_data = _load(xenos_root, xenos_role, content)
     for field in ("signature", "frame", "draw"):
         if native.get(field) != xenos.get(field):
             raise ValueError(f"readback {field} values differ")
@@ -363,6 +370,67 @@ def compare(
     }
 
 
+def compare_depth_checkpoints(
+    native_root: Path,
+    xenos_root: Path,
+    native_seed_root: Path,
+    xenos_seed_root: Path,
+) -> dict[str, Any]:
+    seed_copy = compare(
+        native_seed_root,
+        xenos_seed_root,
+        "depth-stencil",
+        "native_seed",
+        "xenos_seed",
+    )
+    native_effect = compare(
+        native_seed_root,
+        native_root,
+        "depth-stencil",
+        "native_seed",
+        "native",
+    )
+    xenos_effect = compare(
+        xenos_seed_root,
+        xenos_root,
+        "depth-stencil",
+        "xenos_seed",
+        "xenos",
+    )
+    final_parity = compare(
+        native_root, xenos_root, "depth-stencil", "native", "xenos"
+    )
+    seed_exact = seed_copy["result"] == "pass"
+    parity_exact = final_parity["result"] == "pass"
+    native_changed = native_effect["result"] != "pass"
+    xenos_changed = xenos_effect["result"] != "pass"
+    if parity_exact:
+        diagnosis = "exact_post_draw_parity"
+    elif not seed_exact:
+        diagnosis = "private_seed_copy_mismatch"
+    elif native_changed != xenos_changed:
+        diagnosis = "draw_effect_divergence"
+    else:
+        diagnosis = "draw_result_divergence"
+    return {
+        "schema": DEPTH_CHECKPOINT_SCHEMA,
+        "result": "pass" if parity_exact else "fail",
+        "diagnosis": diagnosis,
+        "comparisons": {
+            "seed_copy": seed_copy,
+            "native_draw_effect": native_effect,
+            "xenos_draw_effect": xenos_effect,
+            "post_draw_parity": final_parity,
+        },
+        "safety": {
+            "xenos_draw_preserved": True,
+            "output_authority": "xenos",
+            "suppression_allowed": False,
+            "gpu_wait_added": False,
+        },
+    }
+
+
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("native_root", type=Path)
@@ -372,6 +440,8 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         help="defaults to the native root with '.xenos' appended",
     )
     parser.add_argument("--output", "-o", type=Path)
+    parser.add_argument("--native-seed-root", type=Path)
+    parser.add_argument("--xenos-seed-root", type=Path)
     parser.add_argument(
         "--content", choices=("color", "depth-stencil"), default="color"
     )
@@ -381,7 +451,19 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
 def main(argv: list[str] | None = None) -> int:
     args = parse_args(argv)
     xenos_root = args.xenos_root or Path(str(args.native_root) + ".xenos")
-    report = compare(args.native_root, xenos_root, args.content)
+    if bool(args.native_seed_root) != bool(args.xenos_seed_root):
+        raise ValueError("both seed roots are required for checkpoint analysis")
+    if args.native_seed_root:
+        if args.content != "depth-stencil":
+            raise ValueError("seed checkpoint analysis requires depth-stencil")
+        report = compare_depth_checkpoints(
+            args.native_root,
+            xenos_root,
+            args.native_seed_root,
+            args.xenos_seed_root,
+        )
+    else:
+        report = compare(args.native_root, xenos_root, args.content)
     rendered = json.dumps(report, indent=2) + "\n"
     if args.output:
         args.output.parent.mkdir(parents=True, exist_ok=True)

--- a/tools/tests/test_native_renderer_contract.py
+++ b/tools/tests/test_native_renderer_contract.py
@@ -1539,6 +1539,32 @@ class NativeRendererContractTests(unittest.TestCase):
         self.assertIn("request.reference_depth_readback_requested", scanner)
         self.assertIn("CompleteIsolatedReferenceDepthReadback", scanner)
         self.assertIn('"capture_content", "depth_stencil"', scanner)
+        seed_depth_patch = (
+            ROOT
+            / "patches/rexglue/0084-d3d12-isolated-depth-seed-readback.patch"
+        ).read_text(encoding="utf-8")
+        self.assertIn(
+            "QueueIsolatedReplaySeedDepthReadback", seed_depth_patch
+        )
+        self.assertIn("QueueGuestSeedDepthReadback", seed_depth_patch)
+        self.assertEqual(
+            seed_depth_patch.count(
+                "isolated_draw_request.seed_depth_readback_requested"
+            ),
+            2,
+        )
+        self.assertEqual(
+            seed_depth_patch.count(
+                "reference_seed_depth_readback_requested &&"
+            ),
+            2,
+        )
+        self.assertNotIn("SetDrawSuppression", seed_depth_patch)
+        self.assertNotIn("AwaitAllQueueOperationsCompletion", seed_depth_patch)
+        self.assertIn("CompleteIsolatedSeedDepthReadback", scanner)
+        self.assertIn("CompleteIsolatedReferenceSeedDepthReadback", scanner)
+        self.assertIn('readback, "native_seed"', scanner)
+        self.assertIn('readback, "xenos_seed"', scanner)
 
         texture_resource_patch = (
             ROOT

--- a/tools/tests/test_native_renderer_pass_readbacks.py
+++ b/tools/tests/test_native_renderer_pass_readbacks.py
@@ -245,6 +245,59 @@ class NativeRendererPassReadbackTests(unittest.TestCase):
             )
             self.assertEqual(len(components["first_changed_samples"]), 2)
 
+    def test_depth_checkpoints_localize_draw_effect_divergence(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            native_seed = root / "pass.depth.seed.native"
+            xenos_seed = root / "pass.depth.seed.xenos"
+            native = root / "pass.depth"
+            xenos = root / "pass.depth.xenos"
+            seed = bytes(64)
+            native_after = bytearray(seed)
+            native_after[4] = 129
+            write_msaa_depth_readback(native_seed, "native_seed", seed)
+            write_msaa_depth_readback(xenos_seed, "xenos_seed", seed)
+            write_msaa_depth_readback(native, "native", bytes(native_after))
+            write_msaa_depth_readback(xenos, "xenos", seed)
+
+            report = MODULE.compare_depth_checkpoints(
+                native, xenos, native_seed, xenos_seed
+            )
+
+            self.assertEqual(report["result"], "fail")
+            self.assertEqual(report["diagnosis"], "draw_effect_divergence")
+            self.assertEqual(
+                report["comparisons"]["seed_copy"]["result"], "pass"
+            )
+            native_components = report["comparisons"]["native_draw_effect"][
+                "metrics"
+            ]["components"]
+            self.assertTrue(native_components["exact_depth"])
+            self.assertFalse(native_components["exact_stencil"])
+
+    def test_depth_checkpoints_identify_seed_copy_mismatch(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            native_seed = root / "pass.depth.seed.native"
+            xenos_seed = root / "pass.depth.seed.xenos"
+            native = root / "pass.depth"
+            xenos = root / "pass.depth.xenos"
+            seed = bytes(64)
+            bad_seed = bytearray(seed)
+            bad_seed[4] = 7
+            write_msaa_depth_readback(
+                native_seed, "native_seed", bytes(bad_seed)
+            )
+            write_msaa_depth_readback(xenos_seed, "xenos_seed", seed)
+            write_msaa_depth_readback(native, "native", bytes(bad_seed))
+            write_msaa_depth_readback(xenos, "xenos", seed)
+
+            report = MODULE.compare_depth_checkpoints(
+                native, xenos, native_seed, xenos_seed
+            )
+
+            self.assertEqual(report["diagnosis"], "private_seed_copy_mismatch")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tools/tests/test_release_contract.py
+++ b/tools/tests/test_release_contract.py
@@ -43,10 +43,10 @@ class ReleaseContractTests(unittest.TestCase):
 
     def test_rexglue_patches_have_stable_order_and_no_binary_payload(self):
         patches = sorted((ROOT / "patches/rexglue").glob("*.patch"))
-        self.assertEqual(len(patches), 83)
+        self.assertEqual(len(patches), 84)
         self.assertEqual(
             patches[-1].name,
-            "0083-graphics-indirect-buffer-observer.patch",
+            "0084-d3d12-isolated-depth-seed-readback.patch",
         )
         self.assertEqual(len(patches), len({path.name[:4] for path in patches}))
         for path in patches:


### PR DESCRIPTION
## Summary
- rebind the prepared guest graphics PSO after diagnostic MSAA depth extraction before both native replay and authoritative Xenos draws
- capture private and guest depth/stencil seed checkpoints before either draw
- add four-way seed/effect/final parity analysis and documentation

## Evidence
The previous title-LOD capture had bit-exact color and depth but 151 sample-zero stencil differences in a 16x16 region. Source tracing showed depth extraction binds a compute PSO and invalidates the cached guest PSO; both following draw sites recorded directly without restoring it. This change restores the prepared pipeline and adds checkpoints that can prove seed-copy versus draw-effect behavior in the next consolidated AppData run.

## Safety
- Xenos output remains authoritative
- no draw or resolve suppression
- no GPU/CPU wait
- failed final parity remains a hard blocker

## Validation
- 379 Python tests pass
- Release pinyon_shift target builds
- patch 0084 applies cleanly against the post-0083 ReXGlue tree