### PR TITLE
feat(native-renderer): compare isolated draw effects

### DIFF
--- a/docs/native-renderer/VISUAL_COMPARISON.md
+++ b/docs/native-renderer/VISUAL_COMPARISON.md
@@ -187,6 +187,37 @@ effect or final-result divergence. All four copies remain asynchronous and
 diagnostic-only. The authoritative draw is preserved, and a failed final
 parity comparison remains a hard suppression blocker.
 
+Checkpoint report schema v2 also compares the native and Xenos draw effects
+directly. For each active depth/stencil byte it checks whether both paths
+changed the byte and, when they did, whether they reached the same post-draw
+value. This separates absolute seed divergence from draw behavior:
+
+- `seed_divergence_with_exact_draw_effect` means the private seed differs but
+  the two draws have identical effects;
+- `draw_effect_divergence` means equal seeds produced different effects; and
+- `seed_and_draw_effect_divergence` means neither boundary is equivalent.
+
+The report classifies effect mismatches into depth and stencil bytes, records
+the first bounded mismatch details, and still returns failure unless the final
+native and Xenos depth/stencil artifacts are exact. Effect equivalence alone
+never enables publication or suppression.
+
+### Qualified visible-world effect result
+
+The 2026-08-30 AppData-backed `open_world_day` capture used the
+title-provenanced procedural-model signature `B0EC5BC78D8B8760`. Its paired
+color output was exact. The private and authoritative depth planes were also
+exact, while 1,586,345 stencil bytes differed at both the seed and post-draw
+checkpoints.
+
+Schema-v2 offline analysis compared all 83,886,080 active depth/stencil bytes.
+Neither draw changed an active byte, so direct draw-effect parity passed with
+zero depth or stencil effect mismatches. The result remains fail-closed with
+diagnosis `seed_divergence_with_exact_draw_effect`; Xenos remains authoritative
+and suppression remains disabled. The 166.5-second session presented at
+59.978 Hz with zero present-deadline misses and no error, fatal, or
+device-removal events.
+
 RenderDoc remains available for visual inspection and external confirmation.
 Capture with both the anchor and follower configured, then export their
 native/Xenos spans:

--- a/tools/compare-native-renderer-pass-readbacks.py
+++ b/tools/compare-native-renderer-pass-readbacks.py
@@ -15,7 +15,10 @@ DEPTH_SCHEMA = (
     "pinyon-shift.native-renderer-pass-depth-readback-comparison.v1"
 )
 DEPTH_CHECKPOINT_SCHEMA = (
-    "pinyon-shift.native-renderer-depth-checkpoint-analysis.v1"
+    "pinyon-shift.native-renderer-depth-checkpoint-analysis.v2"
+)
+DEPTH_EFFECT_SCHEMA = (
+    "pinyon-shift.native-renderer-draw-effect-comparison.v1"
 )
 COLOR_READBACK_SCHEMA = "pinyon-shift.isolated-draw-readback.v1"
 DEPTH_READBACK_SCHEMA = "pinyon-shift.isolated-depth-readback.v1"
@@ -206,6 +209,93 @@ def _compare_planar_depth_components(
             native_data, xenos_data, rows
         )
     return components
+
+
+def _compare_depth_effects(
+    native_seed_data: bytes,
+    native_post_data: bytes,
+    xenos_seed_data: bytes,
+    xenos_post_data: bytes,
+    layout: dict[str, Any],
+) -> dict[str, Any]:
+    encoding = str(layout["encoding"])
+    segments: list[tuple[str | None, int, int, int]] = []
+    for plane_index, plane in enumerate(layout["planes"]):
+        component = None
+        if encoding == "d3d12_texture_planes":
+            component = "depth" if plane_index == 0 else "stencil"
+        for row in range(int(plane["row_count"])):
+            segments.append(
+                (
+                    component,
+                    row,
+                    int(plane["offset"]) + row * int(plane["row_pitch"]),
+                    int(plane["row_size"]),
+                )
+            )
+
+    compared_bytes = 0
+    mismatch_bytes = 0
+    native_changed_bytes = 0
+    xenos_changed_bytes = 0
+    depth_mismatch_bytes = 0
+    stencil_mismatch_bytes = 0
+    first_mismatches: list[dict[str, int | str]] = []
+    for planar_component, row, offset, row_size in segments:
+        for byte_in_row in range(row_size):
+            index = offset + byte_in_row
+            native_seed = native_seed_data[index]
+            native_post = native_post_data[index]
+            xenos_seed = xenos_seed_data[index]
+            xenos_post = xenos_post_data[index]
+            native_changed = native_seed != native_post
+            xenos_changed = xenos_seed != xenos_post
+            native_changed_bytes += native_changed
+            xenos_changed_bytes += xenos_changed
+            compared_bytes += 1
+            effect_matches = native_changed == xenos_changed and (
+                not native_changed or native_post == xenos_post
+            )
+            if effect_matches:
+                continue
+            mismatch_bytes += 1
+            component = planar_component
+            if component is None:
+                component = "depth" if byte_in_row % 8 < 4 else "stencil"
+            if component == "depth":
+                depth_mismatch_bytes += 1
+            else:
+                stencil_mismatch_bytes += 1
+            if len(first_mismatches) < 16:
+                first_mismatches.append(
+                    {
+                        "component": component,
+                        "row": row,
+                        "byte_in_row": byte_in_row,
+                        "native_seed": native_seed,
+                        "native_post": native_post,
+                        "xenos_seed": xenos_seed,
+                        "xenos_post": xenos_post,
+                    }
+                )
+
+    return {
+        "schema": DEPTH_EFFECT_SCHEMA,
+        "result": "pass" if mismatch_bytes == 0 else "fail",
+        "metrics": {
+            "compared_bytes": compared_bytes,
+            "mismatch_bytes": mismatch_bytes,
+            "mismatch_byte_ratio": (
+                mismatch_bytes / compared_bytes if compared_bytes else 0.0
+            ),
+            "native_changed_bytes": native_changed_bytes,
+            "xenos_changed_bytes": xenos_changed_bytes,
+            "depth_mismatch_bytes": depth_mismatch_bytes,
+            "stencil_mismatch_bytes": stencil_mismatch_bytes,
+            "exact_draw_effect": mismatch_bytes == 0,
+            "first_mismatches": first_mismatches,
+        },
+    }
 
 
 def compare(
@@ -400,18 +490,32 @@ def compare_depth_checkpoints(
     final_parity = compare(
         native_root, xenos_root, "depth-stencil", "native", "xenos"
     )
+    _, native_seed_data = _load(
+        native_seed_root, "native_seed", "depth-stencil"
+    )
+    _, native_post_data = _load(native_root, "native", "depth-stencil")
+    _, xenos_seed_data = _load(
+        xenos_seed_root, "xenos_seed", "depth-stencil"
+    )
+    _, xenos_post_data = _load(xenos_root, "xenos", "depth-stencil")
+    draw_effect_parity = _compare_depth_effects(
+        native_seed_data,
+        native_post_data,
+        xenos_seed_data,
+        xenos_post_data,
+        final_parity["layout"],
+    )
     seed_exact = seed_copy["result"] == "pass"
     parity_exact = final_parity["result"] == "pass"
-    native_changed = native_effect["result"] != "pass"
-    xenos_changed = xenos_effect["result"] != "pass"
+    effect_exact = draw_effect_parity["result"] == "pass"
     if parity_exact:
         diagnosis = "exact_post_draw_parity"
-    elif not seed_exact:
-        diagnosis = "private_seed_copy_mismatch"
-    elif native_changed != xenos_changed:
+    elif seed_exact:
         diagnosis = "draw_effect_divergence"
+    elif effect_exact:
+        diagnosis = "seed_divergence_with_exact_draw_effect"
     else:
-        diagnosis = "draw_result_divergence"
+        diagnosis = "seed_and_draw_effect_divergence"
     return {
         "schema": DEPTH_CHECKPOINT_SCHEMA,
         "result": "pass" if parity_exact else "fail",
@@ -420,6 +524,7 @@ def compare_depth_checkpoints(
             "seed_copy": seed_copy,
             "native_draw_effect": native_effect,
             "xenos_draw_effect": xenos_effect,
+            "draw_effect_parity": draw_effect_parity,
             "post_draw_parity": final_parity,
         },
         "safety": {

--- a/tools/tests/test_native_renderer_pass_readbacks.py
+++ b/tools/tests/test_native_renderer_pass_readbacks.py
@@ -264,10 +264,18 @@ class NativeRendererPassReadbackTests(unittest.TestCase):
                 native, xenos, native_seed, xenos_seed
             )
 
+            self.assertEqual(
+                report["schema"],
+                "pinyon-shift.native-renderer-depth-checkpoint-analysis.v2",
+            )
             self.assertEqual(report["result"], "fail")
             self.assertEqual(report["diagnosis"], "draw_effect_divergence")
             self.assertEqual(
                 report["comparisons"]["seed_copy"]["result"], "pass"
+            )
+            self.assertEqual(
+                report["comparisons"]["draw_effect_parity"]["result"],
+                "fail",
             )
             native_components = report["comparisons"]["native_draw_effect"][
                 "metrics"
@@ -296,7 +304,45 @@ class NativeRendererPassReadbackTests(unittest.TestCase):
                 native, xenos, native_seed, xenos_seed
             )
 
-            self.assertEqual(report["diagnosis"], "private_seed_copy_mismatch")
+            self.assertEqual(
+                report["diagnosis"],
+                "seed_divergence_with_exact_draw_effect",
+            )
+            effect = report["comparisons"]["draw_effect_parity"]
+            self.assertEqual(effect["result"], "pass")
+            self.assertTrue(effect["metrics"]["exact_draw_effect"])
+            self.assertEqual(effect["metrics"]["mismatch_bytes"], 0)
+
+    def test_depth_effect_parity_requires_matching_changed_post_values(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            native_seed = root / "pass.depth.seed.native"
+            xenos_seed = root / "pass.depth.seed.xenos"
+            native = root / "pass.depth"
+            xenos = root / "pass.depth.xenos"
+            seed = bytes(64)
+            native_after = bytearray(seed)
+            xenos_after = bytearray(seed)
+            native_after[4] = 7
+            xenos_after[4] = 9
+            write_msaa_depth_readback(native_seed, "native_seed", seed)
+            write_msaa_depth_readback(xenos_seed, "xenos_seed", seed)
+            write_msaa_depth_readback(native, "native", bytes(native_after))
+            write_msaa_depth_readback(xenos, "xenos", bytes(xenos_after))
+
+            report = MODULE.compare_depth_checkpoints(
+                native, xenos, native_seed, xenos_seed
+            )
+
+            effect = report["comparisons"]["draw_effect_parity"]
+            self.assertEqual(effect["result"], "fail")
+            self.assertEqual(effect["metrics"]["mismatch_bytes"], 1)
+            self.assertEqual(effect["metrics"]["depth_mismatch_bytes"], 0)
+            self.assertEqual(effect["metrics"]["stencil_mismatch_bytes"], 1)
+            self.assertEqual(
+                effect["metrics"]["first_mismatches"][0]["component"],
+                "stencil",
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- compare native and Xenos seed-to-post depth/stencil effects directly
- classify effect mismatches by depth and stencil component
- distinguish seed-only divergence from actual draw divergence
- preserve final artifact parity as the fail-closed acceptance gate

## Evidence

The existing AppData visible-world capture for signature
`B0EC5BC78D8B8760` was replayed through the schema-v2 analyzer. Across all
83,886,080 active bytes, neither renderer changed depth/stencil and direct
draw-effect parity was exact. The report still fails overall because
1,586,345 stencil seed bytes differ, with diagnosis
`seed_divergence_with_exact_draw_effect`.

Xenos remains authoritative and suppression remains disabled.

## Validation

- `python -m unittest discover -s tools/tests -p 'test_native_renderer*.py'`
  (323 tests)
- full 83,886,080-byte AppData artifact replay
