### PR TITLE
test(renderer): probe isolated stencil seed copies

### DIFF
--- a/docs/native-renderer/VISUAL_COMPARISON.md
+++ b/docs/native-renderer/VISUAL_COMPARISON.md
@@ -202,6 +202,22 @@ the first bounded mismatch details, and still returns failure unless the final
 native and Xenos depth/stencil artifacts are exact. Effect equivalence alone
 never enables publication or suppression.
 
+For a single-draw copy-provenance capture, add `-StencilSeedProbe` to
+`capture-native-renderer-census.ps1`. The option requires an isolated readback
+directory and rejects retained-pass mode. Immediately before the normal
+guest-to-private resource copy, the diagnostic clears only the private
+target's stencil plane to `0xA5`; it never clears or otherwise modifies the
+authoritative guest target. The checkpoint analyzer then inspects active
+stencil values in the native and Xenos seed artifacts.
+
+`sentinel_survived_guest_copy` proves that at least one private sentinel value
+survived where the guest source held a different value, producing the bounded
+diagnosis `stencil_copy_omission_confirmed`. `sentinel_overwritten` only rules
+out that specific omission and leaves the existing seed/draw-effect diagnosis
+in force. The probe remains diagnostic-only: final post-draw parity is still
+the result gate, Xenos remains authoritative, and no publication or suppression
+is enabled by either outcome.
+
 ### Qualified visible-world effect result
 
 The 2026-08-30 AppData-backed `open_world_day` capture used the
@@ -217,6 +233,28 @@ diagnosis `seed_divergence_with_exact_draw_effect`; Xenos remains authoritative
 and suppression remains disabled. The 166.5-second session presented at
 59.978 Hz with zero present-deadline misses and no error, fatal, or
 device-removal events.
+
+### Qualified stencil-copy provenance result
+
+The 2026-08-30 AppData-backed follow-up repeated signature
+`B0EC5BC78D8B8760` with the private-only `0xA5` stencil seed probe. The full
+guest-to-private resource copy overwrote the sentinel in all 10,485,760 active
+stencil sample values; neither seed artifact contained the sentinel. This rules
+out omission of the stencil plane by that copy, but does not by itself identify
+the remaining pre-draw seed divergence.
+
+The private and Xenos seeds still differed in 1,586,537 stencil values with
+exact depth. In this capture, the authoritative Xenos draw changed those same
+stencil values while the private draw did not, and both paths converged to
+exact post-draw depth/stencil output across all 83,886,080 active bytes. The
+offline checkpoint result therefore passed as `exact_post_draw_parity`; the
+probe evidence was `sentinel_overwritten`. Paired color output was also exact.
+Xenos remained authoritative and suppression remained disabled.
+
+The 155.0-second session exited normally with six committed readbacks and no
+error, fatal, or device-loss events. Median frame rate was 30.640 FPS, the 1%
+low was 19.487 FPS, presentation cadence was 59.699 Hz, and there were zero
+present-deadline misses.
 
 RenderDoc remains available for visual inspection and external confirmation.
 Capture with both the anchor and follower configured, then export their

--- a/patches/rexglue/0085-d3d12-isolated-stencil-seed-probe.patch
+++ b/patches/rexglue/0085-d3d12-isolated-stencil-seed-probe.patch
@@ -1,0 +1,92 @@
+diff --git a/include/rex/system/interfaces/graphics.h b/include/rex/system/interfaces/graphics.h
+--- a/include/rex/system/interfaces/graphics.h
++++ b/include/rex/system/interfaces/graphics.h
+@@ -487,6 +487,10 @@ struct GraphicsIsolatedDrawRequest {
+   // distinguish copy/initialization faults from draw-state divergence.
+   bool seed_depth_readback_requested = false;
+   bool reference_seed_depth_readback_requested = false;
++  // Before seeding the private target, clear only its stencil plane to a
++  // sentinel. The subsequent guest-to-private copy must overwrite it. This is
++  // a one-shot diagnostic and never touches the authoritative guest target.
++  bool stencil_seed_probe_requested = false;
+   bool reference_marker_requested = false;
+   // Mark the authoritative guest draw as an exact later-consumer-family
+   // target. This never duplicates, redirects, or suppresses the draw.
+diff --git a/include/rex/graphics/d3d12/render_target_cache.h b/include/rex/graphics/d3d12/render_target_cache.h
+--- a/include/rex/graphics/d3d12/render_target_cache.h
++++ b/include/rex/graphics/d3d12/render_target_cache.h
+@@ -99,7 +99,8 @@ class D3D12RenderTargetCache final : public RenderTargetCache {
+   // Seeds and binds private clones of the current depth and first color target.
+   // EndIsolatedReplayTarget restores the guest bindings without changing the
+   // guest attachments or ownership.
+-  bool BeginIsolatedReplayTarget(uint32_t& width_out, uint32_t& height_out);
++  bool BeginIsolatedReplayTarget(uint32_t& width_out, uint32_t& height_out,
++                                 bool stencil_seed_probe_requested);
+   bool ResumeIsolatedReplayTarget(uint32_t& width_out, uint32_t& height_out);
+   system::GraphicsIsolatedDrawReadbackStatus QueueIsolatedReplayReadback(
+       system::GraphicsIsolatedDrawReadbackCompletion completion,
+diff --git a/src/graphics/d3d12/render_target_cache.cpp b/src/graphics/d3d12/render_target_cache.cpp
+--- a/src/graphics/d3d12/render_target_cache.cpp
++++ b/src/graphics/d3d12/render_target_cache.cpp
+@@ -1770,7 +1770,8 @@ D3D12RenderTarget* D3D12RenderTargetCache::CreateIsolatedReplayTarget(
+ }
+ 
+ bool D3D12RenderTargetCache::BeginIsolatedReplayTarget(
+-    uint32_t& width_out, uint32_t& height_out) {
++    uint32_t& width_out, uint32_t& height_out,
++    bool stencil_seed_probe_requested) {
+   width_out = 0;
+   height_out = 0;
+   if (GetPath() != Path::kHostRenderTargets) {
+@@ -1814,6 +1815,19 @@ bool D3D12RenderTargetCache::BeginIsolatedReplayTarget(
+   width_out = uint32_t(color_desc.Width);
+   height_out = color_desc.Height;
+ 
++  if (stencil_seed_probe_requested) {
++    constexpr uint8_t kStencilSeedProbeValue = 0xA5;
++    const D3D12_RESOURCE_STATES isolated_probe_state =
++        isolated_depth->SetResourceState(D3D12_RESOURCE_STATE_DEPTH_WRITE);
++    command_processor_.PushTransitionBarrier(
++        isolated_depth->resource(), isolated_probe_state,
++        D3D12_RESOURCE_STATE_DEPTH_WRITE);
++    command_processor_.SubmitBarriers();
++    command_processor_.GetDeferredCommandList().D3DClearDepthStencilView(
++        isolated_depth->descriptor_draw().GetHandle(),
++        D3D12_CLEAR_FLAG_STENCIL, 0.0f, kStencilSeedProbeValue, 0, nullptr);
++  }
++
+   const D3D12_RESOURCE_STATES guest_depth_state =
+       guest_depth->SetResourceState(D3D12_RESOURCE_STATE_COPY_SOURCE);
+   const D3D12_RESOURCE_STATES guest_color_state =
+@@ -1841,6 +1855,8 @@ bool D3D12RenderTargetCache::BeginIsolatedReplayTarget(
+ 
+   DeferredCommandList& command_list =
+       command_processor_.GetDeferredCommandList();
++  // Copy the complete compatible resource so both depth and stencil planes
++  // must replace the private diagnostic sentinel.
+   command_list.D3DCopyResource(isolated_depth->resource(),
+                                guest_depth->resource());
+   command_list.D3DCopyResource(isolated_color->resource(),
+diff --git a/src/graphics/d3d12/command_processor.cpp b/src/graphics/d3d12/command_processor.cpp
+--- a/src/graphics/d3d12/command_processor.cpp
++++ b/src/graphics/d3d12/command_processor.cpp
+@@ -3442,7 +3442,8 @@ bool D3D12CommandProcessor::IssueDraw(PrimitiveType primitive_type,
+       } else if ((!isolated_draw_request.reuse_target &&
+                   render_target_cache_->BeginIsolatedReplayTarget(
+                       isolated_result.target_width,
+-                      isolated_result.target_height)) ||
++                      isolated_result.target_height,
++                      isolated_draw_request.stencil_seed_probe_requested)) ||
+                  (isolated_draw_request.reuse_target &&
+                   render_target_cache_->ResumeIsolatedReplayTarget(
+                       isolated_result.target_width,
+@@ -3658,7 +3659,8 @@ bool D3D12CommandProcessor::IssueDraw(PrimitiveType primitive_type,
+       } else if ((!isolated_draw_request.reuse_target &&
+                   render_target_cache_->BeginIsolatedReplayTarget(
+                       isolated_result.target_width,
+-                      isolated_result.target_height)) ||
++                      isolated_result.target_height,
++                      isolated_draw_request.stencil_seed_probe_requested)) ||
+                  (isolated_draw_request.reuse_target &&
+                   render_target_cache_->ResumeIsolatedReplayTarget(
+                       isolated_result.target_width,

--- a/src/native_renderer/graphics_hooks.cpp
+++ b/src/native_renderer/graphics_hooks.cpp
@@ -4098,6 +4098,7 @@ struct IsolatedDrawState {
   bool require_fresh_visibility_candidate = false;
   bool require_title_lod_candidate = false;
   bool auto_select_fresh_visibility_candidate = false;
+  bool stencil_seed_probe_requested = false;
   bool visibility_wait_reported = false;
   bool title_lod_wait_reported = false;
   bool awaiting_pass_follower = false;
@@ -4558,6 +4559,19 @@ void ConfigureIsolatedDraw() {
     }
   }
   std::free(value);
+  value = nullptr;
+  length = 0;
+  if (_dupenv_s(
+          &value, &length,
+          "PINYON_SHIFT_NATIVE_RENDERER_STENCIL_SEED_PROBE") == 0 &&
+      value && length > 1) {
+    const std::string setting(value);
+    g_isolated_draw.stencil_seed_probe_requested = setting == "true";
+    if (setting != "true" && setting != "false") {
+      g_isolated_draw.valid = false;
+    }
+  }
+  std::free(value);
   if (!g_isolated_draw.requested &&
       g_sky_horizon_suppression.requested) {
     g_isolated_draw.target_signature = kSkyHorizonFollowerSignature;
@@ -4570,7 +4584,8 @@ void ConfigureIsolatedDraw() {
                 "PINYON_SHIFT_NATIVE_RENDERER_ISOLATED_DRAW_DIR") != 0 ||
       !value || length <= 1) {
     std::free(value);
-    if (g_isolated_draw.auto_select_fresh_visibility_candidate) {
+    if (g_isolated_draw.auto_select_fresh_visibility_candidate ||
+        g_isolated_draw.stencil_seed_probe_requested) {
       g_isolated_draw.valid = false;
     }
     return;
@@ -4581,6 +4596,10 @@ void ConfigureIsolatedDraw() {
   std::free(value);
   if (!draw_requested ||
       !IsLocalArtifactRoot(g_isolated_draw.output_root)) {
+    g_isolated_draw.valid = false;
+  }
+  if (g_isolated_draw.stencil_seed_probe_requested &&
+      !g_isolated_draw.readback_requested) {
     g_isolated_draw.valid = false;
   }
   value = nullptr;
@@ -7019,6 +7038,10 @@ void EmitIsolatedReadbackParitySummary() {
         std::to_string(draw_effect.stencil_mismatch_bytes)},
        {"draw_effect_first_mismatch",
         EffectComparisonFirstMismatch(draw_effect)},
+       {"stencil_seed_probe_enabled",
+        g_isolated_draw.stencil_seed_probe_requested ? "true" : "false"},
+       {"stencil_seed_probe_value",
+        g_isolated_draw.stencil_seed_probe_requested ? "A5" : ""},
        {"comparison",
         "asynchronous_artifact_exact_depth_stencil_effects"},
        {"output_authority", "xenos"},
@@ -13341,6 +13364,8 @@ void CompleteIsolatedDepthReadbackArtifact(
   const uint32_t format = readback.format;
   const uint32_t sample_count = readback.sample_count;
   const uint32_t plane_count = readback.plane_count;
+  const bool stencil_seed_probe_requested =
+      g_isolated_draw.stencil_seed_probe_requested;
   std::array<uint64_t, rex::system::GraphicsIsolatedDrawReadback::kMaxPlanes>
       plane_offsets = {};
   std::array<uint32_t, rex::system::GraphicsIsolatedDrawReadback::kMaxPlanes>
@@ -13358,6 +13383,7 @@ void CompleteIsolatedDepthReadbackArtifact(
       [bytes = std::move(bytes), signature, frame, draw, output_root, width,
        height, format, sample_count, plane_count, plane_offsets,
        plane_row_pitches, plane_row_sizes, plane_row_counts,
+       stencil_seed_probe_requested,
        capture_role = std::string(capture_role)]() {
         std::string planes;
         for (uint32_t plane = 0; plane < plane_count; ++plane) {
@@ -13396,13 +13422,16 @@ void CompleteIsolatedDepthReadbackArtifact(
             "\"dxgi_format\":{},\"sample_count\":{},"
             "\"encoding\":\"{}\",\"bytes\":{},\"hash\":\"{:016X}\","
             "\"planes\":[{}]}},\n"
+            "  \"diagnostic\": {{\"stencil_seed_probe\":{},"
+            "\"stencil_seed_probe_value\":165}},\n"
             "  \"safety\": {{\"output_authority\":\"xenos\","
             "\"suppression_allowed\":false}}\n}}\n",
             signature, frame, draw, capture_role, width, height, format,
             sample_count,
             sample_count > 1 ? "depth32_stencil8_sample_tuples"
                              : "d3d12_texture_planes",
-            bytes.size(), HashBytes(bytes.data(), bytes.size()), planes);
+            bytes.size(), HashBytes(bytes.data(), bytes.size()), planes,
+            stencil_seed_probe_requested ? "true" : "false");
         const auto metadata_bytes =
             std::span(reinterpret_cast<const uint8_t *>(metadata.data()),
                       metadata.size());
@@ -13950,6 +13979,8 @@ void RequestIsolatedDraw(
   request.seed_depth_readback_requested = g_isolated_draw.readback_requested;
   request.reference_seed_depth_readback_requested =
       g_isolated_draw.readback_requested;
+  request.stencil_seed_probe_requested =
+      g_isolated_draw.stencil_seed_probe_requested;
   request.completion = &CompleteIsolatedDraw;
   request.readback_completion = g_isolated_draw.readback_requested
                                     ? &CompleteIsolatedDrawReadback
@@ -14628,6 +14659,10 @@ void InstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system,
   ConfigureReplaySnapshot();
   ConfigureIsolatedDraw();
   ConfigurePassFollower();
+  if (g_isolated_draw.stencil_seed_probe_requested &&
+      g_pass_follower.requested) {
+    g_isolated_draw.valid = false;
+  }
   ConfigurePassPublication();
   ArmSkyHorizonSuppression();
   EmitSkyHorizonSuppressionControl();
@@ -15138,6 +15173,16 @@ void InstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system,
        {"native_draw", "isolated_only"},
        {"readback", g_isolated_draw.readback_requested ? "asynchronous"
                                                         : "disabled"},
+       {"stencil_seed_probe",
+        g_isolated_draw.stencil_seed_probe_requested ? "enabled"
+                                                      : "disabled"},
+       {"stencil_seed_probe_value",
+        g_isolated_draw.stencil_seed_probe_requested ? "A5" : ""},
+       {"stencil_seed_probe_scope",
+        g_isolated_draw.stencil_seed_probe_requested
+            ? "private_target_before_guest_copy"
+            : ""},
+       {"stencil_seed_probe_guest_target", "untouched"},
        {"reference_marker", "exact_signature"},
        {"selection",
         g_isolated_draw.auto_select_fresh_visibility_candidate

--- a/tools/capture-native-renderer-census.ps1
+++ b/tools/capture-native-renderer-census.ps1
@@ -16,6 +16,7 @@ param(
     [ValidatePattern('^[0-9A-Fa-f]{16}$')]
     [string]$IsolatedDrawSignature,
     [string]$IsolatedDrawDir,
+    [switch]$StencilSeedProbe,
     [switch]$RequireFreshVisibilityCandidate,
     [switch]$AutoSelectFreshVisibilityCandidate,
     [switch]$RequireTitleLodCandidate,
@@ -72,6 +73,12 @@ if ($AutoSelectFreshVisibilityCandidate -and -not $IsolatedDrawDir) {
 }
 if ($AutoSelectFreshVisibilityCandidate -and $PassAnchorSignature) {
     throw 'AutoSelectFreshVisibilityCandidate does not support PassAnchorSignature.'
+}
+if ($StencilSeedProbe -and -not $IsolatedDrawDir) {
+    throw 'StencilSeedProbe requires IsolatedDrawDir.'
+}
+if ($StencilSeedProbe -and $PassAnchorSignature) {
+    throw 'StencilSeedProbe supports single-draw captures only.'
 }
 if ($RequireTitleLodCandidate -and -not $AutoSelectFreshVisibilityCandidate) {
     throw 'RequireTitleLodCandidate requires AutoSelectFreshVisibilityCandidate.'
@@ -155,6 +162,7 @@ $savedReplaySnapshot = $env:PINYON_SHIFT_NATIVE_RENDERER_SNAPSHOT_SIGNATURE
 $savedReplaySnapshotDir = $env:PINYON_SHIFT_NATIVE_RENDERER_SNAPSHOT_DIR
 $savedIsolatedDraw = $env:PINYON_SHIFT_NATIVE_RENDERER_ISOLATED_DRAW_SIGNATURE
 $savedIsolatedDrawDir = $env:PINYON_SHIFT_NATIVE_RENDERER_ISOLATED_DRAW_DIR
+$savedStencilSeedProbe = $env:PINYON_SHIFT_NATIVE_RENDERER_STENCIL_SEED_PROBE
 $savedVisibilityGate = $env:PINYON_SHIFT_NATIVE_RENDERER_REQUIRE_FRESH_VISIBILITY_CANDIDATE
 $savedAutoVisibilityCandidate =
     $env:PINYON_SHIFT_NATIVE_RENDERER_AUTO_SELECT_FRESH_VISIBILITY_CANDIDATE
@@ -174,6 +182,8 @@ try {
     $env:PINYON_SHIFT_NATIVE_RENDERER_SNAPSHOT_DIR = $ReplaySnapshotDir
     $env:PINYON_SHIFT_NATIVE_RENDERER_ISOLATED_DRAW_SIGNATURE = $IsolatedDrawSignature
     $env:PINYON_SHIFT_NATIVE_RENDERER_ISOLATED_DRAW_DIR = $IsolatedDrawDir
+    $env:PINYON_SHIFT_NATIVE_RENDERER_STENCIL_SEED_PROBE =
+        if ($StencilSeedProbe) { 'true' } else { $null }
     $env:PINYON_SHIFT_NATIVE_RENDERER_REQUIRE_FRESH_VISIBILITY_CANDIDATE =
         if ($RequireFreshVisibilityCandidate -or $AutoSelectFreshVisibilityCandidate) {
             'true'
@@ -202,6 +212,7 @@ finally {
     $env:PINYON_SHIFT_NATIVE_RENDERER_SNAPSHOT_DIR = $savedReplaySnapshotDir
     $env:PINYON_SHIFT_NATIVE_RENDERER_ISOLATED_DRAW_SIGNATURE = $savedIsolatedDraw
     $env:PINYON_SHIFT_NATIVE_RENDERER_ISOLATED_DRAW_DIR = $savedIsolatedDrawDir
+    $env:PINYON_SHIFT_NATIVE_RENDERER_STENCIL_SEED_PROBE = $savedStencilSeedProbe
     $env:PINYON_SHIFT_NATIVE_RENDERER_REQUIRE_FRESH_VISIBILITY_CANDIDATE =
         $savedVisibilityGate
     $env:PINYON_SHIFT_NATIVE_RENDERER_AUTO_SELECT_FRESH_VISIBILITY_CANDIDATE =

--- a/tools/compare-native-renderer-pass-readbacks.py
+++ b/tools/compare-native-renderer-pass-readbacks.py
@@ -298,6 +298,68 @@ def _compare_depth_effects(
     }
 
 
+def _analyze_stencil_seed_probe(
+    native_seed_data: bytes,
+    xenos_seed_data: bytes,
+    layout: dict[str, Any],
+    sentinel: int,
+) -> dict[str, Any]:
+    encoding = str(layout["encoding"])
+    native_sentinel_values = 0
+    xenos_sentinel_values = 0
+    sentinel_survivors = 0
+    inspected_stencil_values = 0
+
+    def inspect(index: int) -> None:
+        nonlocal native_sentinel_values
+        nonlocal xenos_sentinel_values
+        nonlocal sentinel_survivors
+        nonlocal inspected_stencil_values
+        native_value = native_seed_data[index]
+        xenos_value = xenos_seed_data[index]
+        inspected_stencil_values += 1
+        native_sentinel_values += native_value == sentinel
+        xenos_sentinel_values += xenos_value == sentinel
+        sentinel_survivors += (
+            native_value == sentinel and xenos_value != sentinel
+        )
+
+    if encoding == "depth32_stencil8_sample_tuples":
+        plane = layout["planes"][0]
+        width = int(layout["width"])
+        height = int(layout["height"])
+        sample_count = int(layout["sample_count"])
+        for y in range(height):
+            row = int(plane["offset"]) + y * int(plane["row_pitch"])
+            for value_index in range(width * sample_count):
+                inspect(row + value_index * 8 + 4)
+    elif encoding == "d3d12_texture_planes":
+        planes = layout["planes"]
+        if len(planes) < 2:
+            raise ValueError("stencil seed probe requires a stencil plane")
+        plane = planes[1]
+        for row_index in range(int(plane["row_count"])):
+            row = int(plane["offset"]) + row_index * int(plane["row_pitch"])
+            for byte_index in range(int(plane["row_size"])):
+                inspect(row + byte_index)
+    else:
+        raise ValueError("unsupported stencil seed probe encoding")
+
+    return {
+        "enabled": True,
+        "sentinel": sentinel,
+        "inspected_stencil_values": inspected_stencil_values,
+        "native_sentinel_values": native_sentinel_values,
+        "xenos_sentinel_values": xenos_sentinel_values,
+        "sentinel_survivors": sentinel_survivors,
+        "evidence": (
+            "sentinel_survived_guest_copy"
+            if sentinel_survivors
+            else "sentinel_overwritten"
+        ),
+    }
+
+
 def compare(
     native_root: Path,
     xenos_root: Path,
@@ -490,14 +552,18 @@ def compare_depth_checkpoints(
     final_parity = compare(
         native_root, xenos_root, "depth-stencil", "native", "xenos"
     )
-    _, native_seed_data = _load(
+    native_seed_metadata, native_seed_data = _load(
         native_seed_root, "native_seed", "depth-stencil"
     )
-    _, native_post_data = _load(native_root, "native", "depth-stencil")
-    _, xenos_seed_data = _load(
+    native_post_metadata, native_post_data = _load(
+        native_root, "native", "depth-stencil"
+    )
+    xenos_seed_metadata, xenos_seed_data = _load(
         xenos_seed_root, "xenos_seed", "depth-stencil"
     )
-    _, xenos_post_data = _load(xenos_root, "xenos", "depth-stencil")
+    xenos_post_metadata, xenos_post_data = _load(
+        xenos_root, "xenos", "depth-stencil"
+    )
     draw_effect_parity = _compare_depth_effects(
         native_seed_data,
         native_post_data,
@@ -508,8 +574,45 @@ def compare_depth_checkpoints(
     seed_exact = seed_copy["result"] == "pass"
     parity_exact = final_parity["result"] == "pass"
     effect_exact = draw_effect_parity["result"] == "pass"
+    diagnostic_metadata = [
+        metadata.get("diagnostic", {})
+        for metadata in (
+            native_seed_metadata,
+            native_post_metadata,
+            xenos_seed_metadata,
+            xenos_post_metadata,
+        )
+    ]
+    probe_flags = [
+        diagnostic.get("stencil_seed_probe") is True
+        for diagnostic in diagnostic_metadata
+    ]
+    if any(probe_flags) and not all(probe_flags):
+        raise ValueError("stencil seed probe metadata is inconsistent")
+    if all(probe_flags):
+        probe_values = {
+            diagnostic.get("stencil_seed_probe_value")
+            for diagnostic in diagnostic_metadata
+        }
+        probe_value = next(iter(probe_values))
+        if (
+            len(probe_values) != 1
+            or type(probe_value) is not int
+            or not 0 <= probe_value <= 255
+        ):
+            raise ValueError("stencil seed probe value metadata is inconsistent")
+        stencil_seed_probe = _analyze_stencil_seed_probe(
+            native_seed_data,
+            xenos_seed_data,
+            final_parity["layout"],
+            probe_value,
+        )
+    else:
+        stencil_seed_probe = {"enabled": False}
     if parity_exact:
         diagnosis = "exact_post_draw_parity"
+    elif stencil_seed_probe.get("sentinel_survivors", 0) > 0:
+        diagnosis = "stencil_copy_omission_confirmed"
     elif seed_exact:
         diagnosis = "draw_effect_divergence"
     elif effect_exact:
@@ -520,6 +623,7 @@ def compare_depth_checkpoints(
         "schema": DEPTH_CHECKPOINT_SCHEMA,
         "result": "pass" if parity_exact else "fail",
         "diagnosis": diagnosis,
+        "stencil_seed_probe": stencil_seed_probe,
         "comparisons": {
             "seed_copy": seed_copy,
             "native_draw_effect": native_effect,

--- a/tools/tests/test_native_renderer_contract.py
+++ b/tools/tests/test_native_renderer_contract.py
@@ -7,6 +7,35 @@ ROOT = pathlib.Path(__file__).resolve().parents[2]
 
 
 class NativeRendererContractTests(unittest.TestCase):
+    def test_stencil_seed_probe_is_bounded_and_preserves_xenos(self) -> None:
+        source = (ROOT / "src/native_renderer/graphics_hooks.cpp").read_text(
+            encoding="utf-8"
+        )
+        capture = (
+            ROOT / "tools/capture-native-renderer-census.ps1"
+        ).read_text(encoding="utf-8")
+        patch = (
+            ROOT
+            / "patches/rexglue/0085-d3d12-isolated-stencil-seed-probe.patch"
+        ).read_text(encoding="utf-8")
+
+        self.assertIn("stencil_seed_probe_requested", patch)
+        self.assertIn("kStencilSeedProbeValue = 0xA5", patch)
+        self.assertIn("D3D12_CLEAR_FLAG_STENCIL", patch)
+        self.assertIn("D3DCopyResource(isolated_depth->resource()", patch)
+        self.assertNotIn("guest_depth->descriptor_draw().GetHandle()", patch)
+        self.assertNotIn("SetDrawSuppression", patch)
+        self.assertIn(
+            "PINYON_SHIFT_NATIVE_RENDERER_STENCIL_SEED_PROBE", source
+        )
+        self.assertIn("request.stencil_seed_probe_requested", source)
+        self.assertIn('"stencil_seed_probe_guest_target", "untouched"', source)
+        self.assertIn("[switch]$StencilSeedProbe", capture)
+        self.assertIn("StencilSeedProbe requires IsolatedDrawDir", capture)
+        self.assertIn(
+            "StencilSeedProbe supports single-draw captures only", capture
+        )
+
     def test_census_storage_is_reset_without_large_stack_temporaries(self) -> None:
         source = (ROOT / "src/native_renderer/graphics_hooks.cpp").read_text(
             encoding="utf-8"

--- a/tools/tests/test_native_renderer_pass_readbacks.py
+++ b/tools/tests/test_native_renderer_pass_readbacks.py
@@ -81,7 +81,13 @@ def write_depth_readback(root: Path, role: str, data: bytes) -> None:
     (root / "isolated.bin").write_bytes(data)
 
 
-def write_msaa_depth_readback(root: Path, role: str, data: bytes) -> None:
+def write_msaa_depth_readback(
+    root: Path,
+    role: str,
+    data: bytes,
+    *,
+    stencil_seed_probe: bool | None = None,
+) -> None:
     root.mkdir()
     metadata = {
         "schema": "pinyon-shift.isolated-depth-readback.v1",
@@ -112,6 +118,11 @@ def write_msaa_depth_readback(root: Path, role: str, data: bytes) -> None:
             "suppression_allowed": False,
         },
     }
+    if stencil_seed_probe is not None:
+        metadata["diagnostic"] = {
+            "stencil_seed_probe": stencil_seed_probe,
+            "stencil_seed_probe_value": 0xA5,
+        }
     (root / "readback.json").write_text(json.dumps(metadata), encoding="utf-8")
     (root / "isolated.bin").write_bytes(data)
 
@@ -343,6 +354,100 @@ class NativeRendererPassReadbackTests(unittest.TestCase):
                 effect["metrics"]["first_mismatches"][0]["component"],
                 "stencil",
             )
+
+    def test_stencil_seed_probe_confirms_copy_omission(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            native_seed = root / "pass.depth.seed.native"
+            xenos_seed = root / "pass.depth.seed.xenos"
+            native = root / "pass.depth"
+            xenos = root / "pass.depth.xenos"
+            guest = bytes(64)
+            private = bytearray(guest)
+            private[4] = 0xA5
+            for path, role, data in (
+                (native_seed, "native_seed", bytes(private)),
+                (xenos_seed, "xenos_seed", guest),
+                (native, "native", bytes(private)),
+                (xenos, "xenos", guest),
+            ):
+                write_msaa_depth_readback(
+                    path, role, data, stencil_seed_probe=True
+                )
+
+            report = MODULE.compare_depth_checkpoints(
+                native, xenos, native_seed, xenos_seed
+            )
+
+            self.assertEqual(
+                report["diagnosis"], "stencil_copy_omission_confirmed"
+            )
+            probe = report["stencil_seed_probe"]
+            self.assertEqual(probe["sentinel_survivors"], 1)
+            self.assertEqual(
+                probe["evidence"], "sentinel_survived_guest_copy"
+            )
+            self.assertEqual(probe["inspected_stencil_values"], 8)
+
+    def test_stencil_seed_probe_preserves_existing_diagnosis_when_overwritten(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            native_seed = root / "pass.depth.seed.native"
+            xenos_seed = root / "pass.depth.seed.xenos"
+            native = root / "pass.depth"
+            xenos = root / "pass.depth.xenos"
+            guest = bytes(64)
+            private = bytearray(guest)
+            private[4] = 7
+            for path, role, data in (
+                (native_seed, "native_seed", bytes(private)),
+                (xenos_seed, "xenos_seed", guest),
+                (native, "native", bytes(private)),
+                (xenos, "xenos", guest),
+            ):
+                write_msaa_depth_readback(
+                    path, role, data, stencil_seed_probe=True
+                )
+
+            report = MODULE.compare_depth_checkpoints(
+                native, xenos, native_seed, xenos_seed
+            )
+
+            self.assertEqual(
+                report["diagnosis"],
+                "seed_divergence_with_exact_draw_effect",
+            )
+            self.assertEqual(
+                report["stencil_seed_probe"]["sentinel_survivors"], 0
+            )
+            self.assertEqual(
+                report["stencil_seed_probe"]["evidence"],
+                "sentinel_overwritten",
+            )
+
+    def test_stencil_seed_probe_rejects_inconsistent_metadata(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            native_seed = root / "pass.depth.seed.native"
+            xenos_seed = root / "pass.depth.seed.xenos"
+            native = root / "pass.depth"
+            xenos = root / "pass.depth.xenos"
+            for path, role in (
+                (native_seed, "native_seed"),
+                (xenos_seed, "xenos_seed"),
+                (native, "native"),
+            ):
+                write_msaa_depth_readback(
+                    path, role, bytes(64), stencil_seed_probe=True
+                )
+            write_msaa_depth_readback(xenos, "xenos", bytes(64))
+
+            with self.assertRaisesRegex(
+                ValueError, "stencil seed probe metadata is inconsistent"
+            ):
+                MODULE.compare_depth_checkpoints(
+                    native, xenos, native_seed, xenos_seed
+                )
 
 
 if __name__ == "__main__":

--- a/tools/tests/test_native_renderer_readback_parity_contract.py
+++ b/tools/tests/test_native_renderer_readback_parity_contract.py
@@ -46,6 +46,8 @@ class NativeRendererReadbackParityContractTests(unittest.TestCase):
             '"draw_effect_depth_mismatch_bytes"',
             '"draw_effect_stencil_mismatch_bytes"',
             '"draw_effect_first_mismatch"',
+            '"stencil_seed_probe_enabled"',
+            '"stencil_seed_probe_value"',
         ):
             self.assertIn(field, self.scanner)
         self.assertIn(

--- a/tools/tests/test_release_contract.py
+++ b/tools/tests/test_release_contract.py
@@ -43,10 +43,10 @@ class ReleaseContractTests(unittest.TestCase):
 
     def test_rexglue_patches_have_stable_order_and_no_binary_payload(self):
         patches = sorted((ROOT / "patches/rexglue").glob("*.patch"))
-        self.assertEqual(len(patches), 84)
+        self.assertEqual(len(patches), 85)
         self.assertEqual(
             patches[-1].name,
-            "0084-d3d12-isolated-depth-seed-readback.patch",
+            "0085-d3d12-isolated-stencil-seed-probe.patch",
         )
         self.assertEqual(len(patches), len({path.name[:4] for path in patches}))
         for path in patches:


### PR DESCRIPTION
## Summary
- seed only the private isolated stencil plane before the guest-to-private depth copy
- classify sentinel survival in the offline checkpoint report
- preserve guest resources, Xenos execution, and the existing fail-closed gates
- document the visible-world result: the copy overwrites the sentinel and final post-draw output is exact

## Evidence
- full suite: 389 tests passed
- supported preview build completed with 85 ReXGlue patches
- AppData-backed open_world_day capture committed all six artifacts
- offline report: exact_post_draw_parity; 0 sentinel survivors across 10,485,760 inspected stencil values
- runtime log: 0 errors, 0 fatals, 0 device losses
- performance: median 30.640 FPS, 1% low 19.487 FPS, zero presentation deadline misses

## Safety
The probe writes only the private isolated stencil resource. The subsequent full guest-to-private copy remains authoritative. No guest resource is changed and no Xenos draw is suppressed.