### PR TITLE
feat(renderer): qualify exact isolated replay parity

### DIFF
--- a/docs/native-renderer/VISUAL_COMPARISON.md
+++ b/docs/native-renderer/VISUAL_COMPARISON.md
@@ -256,6 +256,53 @@ error, fatal, or device-loss events. Median frame rate was 30.640 FPS, the 1%
 low was 19.487 FPS, presentation cadence was 59.699 Hz, and there were zero
 present-deadline misses.
 
+The follow-up checkpoint order records the authoritative copy source and the
+private copy destination consecutively after `BeginIsolatedReplayTarget`
+finishes the full resource copy and before the native draw. This removes the
+earlier interval in which the authoritative seed was sampled only after the
+private draw and target restoration. Runtime summary `status` now follows the
+same strict final-output gate as the offline report: paired post-draw color and
+depth/stencil must both be exact. Seed and draw-effect comparisons remain
+separate diagnostics and cannot enable publication or suppression.
+
+After the one-shot comparison completes, matching eligible draws continue to
+execute on the private target without additional readbacks. Shutdown telemetry
+reconciles every shadow-replay request as recorded, unsupported, or target-
+creation failure and separately counts title/mechanical gate rejections. This
+turns the existing frame-debugger replay into bounded long-session evidence;
+the original Xenos draw still executes and remains the only output authority.
+
+The explicit plane-copy follow-up produced the first fully exact four-way
+capture for signature `B0EC5BC78D8B8760`. The private and authoritative seeds
+were byte-exact across all 83,886,080 active depth/stencil bytes. Both draws
+then changed the same 1,586,291 stencil bytes, reached identical values, and
+left post-draw depth/stencil byte-exact; paired color output was also exact.
+The private-only `0xA5` sentinel was overwritten at every active stencil
+sample, independently confirming complete copy coverage. Runtime session
+`20260830T074501Z-p43940` reported exact seed, draw-effect, color, and final
+depth/stencil status, reconciled its shadow replay, exited normally, and kept
+Xenos authoritative with suppression disabled. The matching offline report is
+`.local/qualification/native-paired-seed-shadow-20260830-pr137-debug-checkpoints.json`.
+
+This capture qualifies the explicit depth/stencil plane-copy boundary and the
+paired asynchronous comparison path. It does not by itself promote the
+signature for publication or suppression: earlier captures exposed
+stencil-only diagnostic variance, so repeated representative-scene evidence
+and the remaining consumer/CPU-visibility gates are still required.
+
+The paired checkpoint run for signature `B0EC5BC78D8B8760` then proved the
+private and authoritative depth/stencil seeds byte-exact across all 83,886,080
+active bytes. Depth and post-draw color also remained exact. The remaining
+12,739-byte post-draw mismatch was stencil-only and spatially diagnostic: the
+private replay affected a 126-by-126 sample-zero footprint while the
+authoritative draw affected only a 16-by-16 footprint. MSAA checkpoint
+extraction records compute descriptors after the guest graphics bindings have
+already been finalized, which may switch descriptor heaps and invalidate every
+graphics root table. The follow-up restoration patch therefore forces all
+cached guest root parameters to be rebound after diagnostic compute work and
+before both private and authoritative draws. It does not publish native output,
+enable suppression, or alter Xenos authority.
+
 RenderDoc remains available for visual inspection and external confirmation.
 Capture with both the anchor and follower configured, then export their
 native/Xenos spans:

--- a/patches/rexglue/0086-d3d12-paired-seed-checkpoint-order.patch
+++ b/patches/rexglue/0086-d3d12-paired-seed-checkpoint-order.patch
@@ -1,0 +1,110 @@
+diff --git a/include/rex/system/interfaces/graphics.h b/include/rex/system/interfaces/graphics.h
+--- a/include/rex/system/interfaces/graphics.h
++++ b/include/rex/system/interfaces/graphics.h
+@@ -484,7 +484,8 @@ struct GraphicsIsolatedDrawRequest {
+   bool depth_readback_requested = false;
+   bool reference_depth_readback_requested = false;
+-  // Capture both depth/stencil resources immediately after the private target
+-  // is seeded and before either duplicate draw is recorded. These checkpoints
+-  // distinguish copy/initialization faults from draw-state divergence.
++  // Capture the authoritative copy source and private copy destination
++  // consecutively after the private target is seeded and before either
++  // duplicate draw is recorded. These checkpoints distinguish copy or
++  // initialization faults from draw-state divergence.
+   bool seed_depth_readback_requested = false;
+   bool reference_seed_depth_readback_requested = false;
+diff --git a/src/graphics/d3d12/command_processor.cpp b/src/graphics/d3d12/command_processor.cpp
+--- a/src/graphics/d3d12/command_processor.cpp
++++ b/src/graphics/d3d12/command_processor.cpp
+@@ -3448,6 +3448,22 @@ bool D3D12CommandProcessor::IssueDraw(xenos::PrimitiveType primitive_type, uint3
+                   render_target_cache_->ResumeIsolatedReplayTarget(
+                       isolated_result.target_width,
+                       isolated_result.target_height))) {
++        if (isolated_draw_request.reference_seed_depth_readback_requested &&
++            isolated_draw_request.reference_seed_depth_readback_completion) {
++          uint32_t readback_detail = 0;
++          auto readback_status =
++              render_target_cache_->QueueGuestSeedDepthReadback(
++                  isolated_draw_request.reference_seed_depth_readback_completion,
++                  &readback_detail);
++          if (readback_status !=
++              system::GraphicsIsolatedDrawReadbackStatus::kReady) {
++            system::GraphicsIsolatedDrawReadback readback_result;
++            readback_result.status = readback_status;
++            readback_result.detail = readback_detail;
++            isolated_draw_request.reference_seed_depth_readback_completion(
++                readback_result);
++          }
++        }
+         if (isolated_draw_request.seed_depth_readback_requested &&
+             isolated_draw_request.seed_depth_readback_completion) {
+           uint32_t readback_detail = 0;
+@@ -3505,22 +3521,6 @@ bool D3D12CommandProcessor::IssueDraw(xenos::PrimitiveType primitive_type, uint3
+         }
+         render_target_cache_->EndIsolatedReplayTarget(
+             isolated_draw_request.frame_sequence);
+-        if (isolated_draw_request.reference_seed_depth_readback_requested &&
+-            isolated_draw_request.reference_seed_depth_readback_completion) {
+-          uint32_t readback_detail = 0;
+-          auto readback_status =
+-              render_target_cache_->QueueGuestSeedDepthReadback(
+-                  isolated_draw_request.reference_seed_depth_readback_completion,
+-                  &readback_detail);
+-          if (readback_status !=
+-              system::GraphicsIsolatedDrawReadbackStatus::kReady) {
+-            system::GraphicsIsolatedDrawReadback readback_result;
+-            readback_result.status = readback_status;
+-            readback_result.detail = readback_detail;
+-            isolated_draw_request.reference_seed_depth_readback_completion(
+-                readback_result);
+-          }
+-        }
+         isolated_replay_recorded = true;
+         isolated_result.status =
+             system::GraphicsIsolatedDrawStatus::kRecorded;
+@@ -3664,6 +3664,22 @@ bool D3D12CommandProcessor::IssueDraw(xenos::PrimitiveType primitive_type, uint3
+                   render_target_cache_->ResumeIsolatedReplayTarget(
+                       isolated_result.target_width,
+                       isolated_result.target_height))) {
++        if (isolated_draw_request.reference_seed_depth_readback_requested &&
++            isolated_draw_request.reference_seed_depth_readback_completion) {
++          uint32_t readback_detail = 0;
++          auto readback_status =
++              render_target_cache_->QueueGuestSeedDepthReadback(
++                  isolated_draw_request.reference_seed_depth_readback_completion,
++                  &readback_detail);
++          if (readback_status !=
++              system::GraphicsIsolatedDrawReadbackStatus::kReady) {
++            system::GraphicsIsolatedDrawReadback readback_result;
++            readback_result.status = readback_status;
++            readback_result.detail = readback_detail;
++            isolated_draw_request.reference_seed_depth_readback_completion(
++                readback_result);
++          }
++        }
+         if (isolated_draw_request.seed_depth_readback_requested &&
+             isolated_draw_request.seed_depth_readback_completion) {
+           uint32_t readback_detail = 0;
+@@ -3721,22 +3737,6 @@ bool D3D12CommandProcessor::IssueDraw(xenos::PrimitiveType primitive_type, uint3
+         }
+         render_target_cache_->EndIsolatedReplayTarget(
+             isolated_draw_request.frame_sequence);
+-        if (isolated_draw_request.reference_seed_depth_readback_requested &&
+-            isolated_draw_request.reference_seed_depth_readback_completion) {
+-          uint32_t readback_detail = 0;
+-          auto readback_status =
+-              render_target_cache_->QueueGuestSeedDepthReadback(
+-                  isolated_draw_request.reference_seed_depth_readback_completion,
+-                  &readback_detail);
+-          if (readback_status !=
+-              system::GraphicsIsolatedDrawReadbackStatus::kReady) {
+-            system::GraphicsIsolatedDrawReadback readback_result;
+-            readback_result.status = readback_status;
+-            readback_result.detail = readback_detail;
+-            isolated_draw_request.reference_seed_depth_readback_completion(
+-                readback_result);
+-          }
+-        }
+         isolated_replay_recorded = true;
+         isolated_result.status =
+             system::GraphicsIsolatedDrawStatus::kRecorded;

--- a/patches/rexglue/0087-d3d12-restore-graphics-bindings-after-readback.patch
+++ b/patches/rexglue/0087-d3d12-restore-graphics-bindings-after-readback.patch
@@ -1,0 +1,93 @@
+diff --git a/src/graphics/d3d12/command_processor.cpp b/src/graphics/d3d12/command_processor.cpp
+--- a/src/graphics/d3d12/command_processor.cpp
++++ b/src/graphics/d3d12/command_processor.cpp
+@@ -3202,6 +3202,19 @@ bool D3D12CommandProcessor::IssueDraw(xenos::PrimitiveType primitive_type,
+     return observe_draw_outcome(
+         system::GraphicsDrawOutcomeStatus::kBindingUpdateFailed, false);
+   }
++  const auto restore_prepared_guest_graphics_state = [&]() -> bool {
++    // Diagnostic MSAA depth extraction records compute descriptors after the
++    // guest bindings have been prepared. A descriptor-heap switch invalidates
++    // graphics root tables even though the graphics root signature itself is
++    // unchanged, so force every cached root parameter to be rebound.
++    current_graphics_root_up_to_date_ = 0;
++    if (!UpdateBindings(vertex_shader, pixel_shader, root_signature,
++                        memexport_used)) {
++      return false;
++    }
++    bind_prepared_guest_pipeline();
++    return true;
++  };
+   // Must not call anything that can change the descriptor heap from now on!
+ 
+   // Ensure vertex buffers are resident.
+@@ -3482,7 +3495,17 @@ bool D3D12CommandProcessor::IssueDraw(xenos::PrimitiveType primitive_type,
+                 readback_result);
+           }
+         }
+-        bind_prepared_guest_pipeline();
++        if (!restore_prepared_guest_graphics_state()) {
++          render_target_cache_->EndIsolatedReplayTarget(
++              isolated_draw_request.frame_sequence);
++          isolated_result.status =
++              system::GraphicsIsolatedDrawStatus::kUnsupportedState;
++          if (isolated_draw_request.completion) {
++            isolated_draw_request.completion(isolated_result);
++          }
++          return observe_draw_outcome(
++              system::GraphicsDrawOutcomeStatus::kBindingUpdateFailed, false);
++        }
+         deferred_command_list_.BeginDebugMarker(
+             isolated_draw_request.reuse_target
+                 ? "PinyonShift NR-02F isolated native pass follower"
+@@ -3547,7 +3570,14 @@ bool D3D12CommandProcessor::IssueDraw(xenos::PrimitiveType primitive_type,
+               : "PinyonShift NR-02F authoritative Xenos auto-index draw");
+     }
+     if (!suppress_guest_draw) {
+-      bind_prepared_guest_pipeline();
++      if (isolated_draw_request.requested) {
++        if (!restore_prepared_guest_graphics_state()) {
++          return observe_draw_outcome(
++              system::GraphicsDrawOutcomeStatus::kBindingUpdateFailed, false);
++        }
++      } else {
++        bind_prepared_guest_pipeline();
++      }
+       PROFILE_DRAW_CALL();
+       PROFILE_VERTICES(primitive_processing_result.host_draw_vertex_count);
+       deferred_command_list_.D3DDrawInstanced(
+@@ -3698,7 +3728,17 @@ bool D3D12CommandProcessor::IssueDraw(xenos::PrimitiveType primitive_type,
+                 readback_result);
+           }
+         }
+-        bind_prepared_guest_pipeline();
++        if (!restore_prepared_guest_graphics_state()) {
++          render_target_cache_->EndIsolatedReplayTarget(
++              isolated_draw_request.frame_sequence);
++          isolated_result.status =
++              system::GraphicsIsolatedDrawStatus::kUnsupportedState;
++          if (isolated_draw_request.completion) {
++            isolated_draw_request.completion(isolated_result);
++          }
++          return observe_draw_outcome(
++              system::GraphicsDrawOutcomeStatus::kBindingUpdateFailed, false);
++        }
+         deferred_command_list_.BeginDebugMarker(
+             isolated_draw_request.retain_target
+                 ? "PinyonShift NR-02F isolated native pass anchor"
+@@ -3763,7 +3803,14 @@ bool D3D12CommandProcessor::IssueDraw(xenos::PrimitiveType primitive_type,
+               : "PinyonShift NR-02E authoritative Xenos draw");
+     }
+     if (!suppress_guest_draw) {
+-      bind_prepared_guest_pipeline();
++      if (isolated_draw_request.requested) {
++        if (!restore_prepared_guest_graphics_state()) {
++          return observe_draw_outcome(
++              system::GraphicsDrawOutcomeStatus::kBindingUpdateFailed, false);
++        }
++      } else {
++        bind_prepared_guest_pipeline();
++      }
+       PROFILE_DRAW_CALL();
+       PROFILE_VERTICES(primitive_processing_result.host_draw_vertex_count);
+       deferred_command_list_.D3DDrawIndexedInstanced(

--- a/patches/rexglue/0088-d3d12-copy-isolated-depth-stencil-planes.patch
+++ b/patches/rexglue/0088-d3d12-copy-isolated-depth-stencil-planes.patch
@@ -1,0 +1,46 @@
+diff --git a/src/graphics/d3d12/render_target_cache.cpp b/src/graphics/d3d12/render_target_cache.cpp
+--- a/src/graphics/d3d12/render_target_cache.cpp
++++ b/src/graphics/d3d12/render_target_cache.cpp
+@@ -1850,14 +1850,38 @@ bool D3D12RenderTargetCache::BeginIsolatedReplayTarget(
+       isolated_color->resource(), isolated_color_state,
+       D3D12_RESOURCE_STATE_COPY_DEST);
+   command_processor_.SubmitBarriers();
+ 
+   DeferredCommandList& command_list =
+       command_processor_.GetDeferredCommandList();
+-  // Copy the complete compatible resource so both depth and stencil planes
+-  // must replace the private diagnostic sentinel.
+-  command_list.D3DCopyResource(isolated_depth->resource(),
+-                               guest_depth->resource());
++  // Copy depth/stencil plane-by-plane so the diagnostic replay contract
++  // explicitly covers every plane of the typeless MSAA target. This also
++  // makes plane coverage independently reviewable from the readback path.
++  const D3D12_RESOURCE_DESC depth_desc =
++      isolated_depth->resource()->GetDesc();
++  D3D12_FEATURE_DATA_FORMAT_INFO depth_format_info = {depth_desc.Format, 0};
++  ID3D12Device* device = command_processor_.GetD3D12Provider().GetDevice();
++  if (!device ||
++      FAILED(device->CheckFeatureSupport(D3D12_FEATURE_FORMAT_INFO,
++                                         &depth_format_info,
++                                         sizeof(depth_format_info))) ||
++      !depth_format_info.PlaneCount) {
++    return false;
++  }
++  for (uint32_t plane = 0; plane < depth_format_info.PlaneCount; ++plane) {
++    D3D12_TEXTURE_COPY_LOCATION destination = {};
++    destination.pResource = isolated_depth->resource();
++    destination.Type = D3D12_TEXTURE_COPY_TYPE_SUBRESOURCE_INDEX;
++    destination.SubresourceIndex =
++        plane * uint32_t(depth_desc.MipLevels) *
++        uint32_t(depth_desc.DepthOrArraySize);
++    D3D12_TEXTURE_COPY_LOCATION source = {};
++    source.pResource = guest_depth->resource();
++    source.Type = D3D12_TEXTURE_COPY_TYPE_SUBRESOURCE_INDEX;
++    source.SubresourceIndex = destination.SubresourceIndex;
++    command_list.D3DCopyTextureRegion(&destination, 0, 0, 0, &source,
++                                       nullptr);
++  }
+   command_list.D3DCopyResource(isolated_color->resource(),
+                                guest_color->resource());
+ 
+   guest_depth->SetResourceState(guest_depth_state);

--- a/src/native_renderer/graphics_hooks.cpp
+++ b/src/native_renderer/graphics_hooks.cpp
@@ -4078,6 +4078,11 @@ struct IsolatedDrawState {
   uint64_t captured_draw = 0;
   uint64_t pass_anchor_frame = 0;
   uint64_t pass_anchor_draw = 0;
+  uint64_t shadow_replay_requests = 0;
+  uint64_t shadow_replay_recorded = 0;
+  uint64_t shadow_replay_target_failures = 0;
+  uint64_t shadow_replay_unsupported = 0;
+  uint64_t shadow_replay_gate_rejections = 0;
   uint32_t prepared_title_lod_index = 0;
   rex::system::GraphicsDrawObservation prepared_sample;
   std::filesystem::path output_root;
@@ -6986,12 +6991,19 @@ void EmitIsolatedReadbackParitySummary() {
   const bool complete = color.readable && seed.readable && post.readable &&
                         native_effect.readable && xenos_effect.readable &&
                         draw_effect.readable;
-  const bool exact = complete && color.exact() && seed.exact() && post.exact();
+  const bool final_output_exact =
+      complete && color.exact() && post.exact();
   pinyon_shift::diagnostics::RecordEvent(
       "native_renderer.isolated_draw.parity_summary",
       {{"signature",
         fmt::format("{:016X}", g_isolated_draw.captured_signature)},
-       {"status", complete ? (exact ? "exact" : "mismatch") : "incomplete"},
+       {"status",
+        complete ? (final_output_exact ? "exact" : "mismatch")
+                 : "incomplete"},
+       {"result_gate", "post_draw_output"},
+       {"seed_status", seed.exact() ? "exact" : "diagnostic_mismatch"},
+       {"draw_effect_status",
+        draw_effect.exact() ? "exact" : "diagnostic_mismatch"},
        {"frame", std::to_string(g_isolated_draw.captured_frame)},
        {"draw", std::to_string(g_isolated_draw.captured_draw)},
        {"color_post_exact", color.exact() ? "true" : "false"},
@@ -13533,6 +13545,19 @@ void CompleteIsolatedDraw(
        {"suppression_eligible", "false"}});
 }
 
+void CompleteIsolatedShadowReplay(
+    const rex::system::GraphicsIsolatedDrawResult &result) {
+  if (result.status == rex::system::GraphicsIsolatedDrawStatus::kRecorded) {
+    ++g_isolated_draw.shadow_replay_recorded;
+  } else if (result.status == rex::system::
+                                  GraphicsIsolatedDrawStatus::
+                                      kTargetCreationFailed) {
+    ++g_isolated_draw.shadow_replay_target_failures;
+  } else {
+    ++g_isolated_draw.shadow_replay_unsupported;
+  }
+}
+
 void CompleteIsolatedPassAnchor(
     const rex::system::GraphicsIsolatedDrawResult &result) {
   g_isolated_draw.pass_anchor_recorded =
@@ -13914,11 +13939,17 @@ void RequestIsolatedDraw(
   }
   request.reference_marker_requested = true;
   if (g_isolated_draw.completed) {
-    // Keep the private replay visible to frame debuggers after the one-shot
-    // result has been recorded. This path has no readback or completion
-    // callback, and the authoritative Xenos draw still follows unmodified.
+    // Continue the qualified private replay after the one-shot comparison so
+    // long-session execution can be reconciled without further readbacks.
+    // The authoritative Xenos draw still follows unmodified.
     request.requested = candidate_eligible;
     request.frame_sequence = request.requested ? g_isolated_draw.frame : 0;
+    if (request.requested) {
+      ++g_isolated_draw.shadow_replay_requests;
+      request.completion = &CompleteIsolatedShadowReplay;
+    } else {
+      ++g_isolated_draw.shadow_replay_gate_rejections;
+    }
     return;
   }
   if (g_isolated_draw.prepared_candidate_eligible &&
@@ -15171,6 +15202,10 @@ void InstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system,
                     ? "retained_pass"
                     : "single_draw"},
        {"native_draw", "isolated_only"},
+       {"continuous_shadow_replay",
+        g_pass_follower.valid && g_pass_follower.requested
+            ? "retained_pass_contract"
+            : "enabled_after_one_shot"},
        {"readback", g_isolated_draw.readback_requested ? "asynchronous"
                                                         : "disabled"},
        {"stencil_seed_probe",
@@ -15712,6 +15747,40 @@ void UninstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system) {
          {"native_draw", "false"},
          {"xenos_draw", "preserved"},
          {"output_authority", "xenos"},
+         {"suppression_eligible", "false"}});
+  }
+  const bool isolated_single_draw_mode =
+      !g_pass_follower.requested || !g_pass_follower.valid ||
+      g_pass_follower.target_signature == g_isolated_draw.target_signature;
+  if (g_isolated_draw.requested && g_isolated_draw.valid &&
+      g_isolated_draw.completed && isolated_single_draw_mode) {
+    const uint64_t shadow_replay_outcomes =
+        g_isolated_draw.shadow_replay_recorded +
+        g_isolated_draw.shadow_replay_target_failures +
+        g_isolated_draw.shadow_replay_unsupported;
+    diagnostics::RecordEvent(
+        "native_renderer.isolated_draw.shadow_replay_summary",
+        {{"signature",
+          fmt::format("{:016X}", g_isolated_draw.target_signature)},
+         {"requests",
+          std::to_string(g_isolated_draw.shadow_replay_requests)},
+         {"recorded",
+          std::to_string(g_isolated_draw.shadow_replay_recorded)},
+         {"target_creation_failures",
+          std::to_string(g_isolated_draw.shadow_replay_target_failures)},
+         {"unsupported",
+          std::to_string(g_isolated_draw.shadow_replay_unsupported)},
+         {"gate_rejections",
+          std::to_string(g_isolated_draw.shadow_replay_gate_rejections)},
+         {"accounting_complete",
+          shadow_replay_outcomes == g_isolated_draw.shadow_replay_requests
+              ? "true"
+              : "false"},
+         {"readback", "one_shot_only"},
+         {"native_draw", "private_shadow_replay"},
+         {"xenos_draw", "preserved"},
+         {"output_authority", "xenos"},
+         {"draw_suppression", "false"},
          {"suppression_eligible", "false"}});
   }
   diagnostics::RecordEvent(

--- a/tools/tests/test_native_renderer_contract.py
+++ b/tools/tests/test_native_renderer_contract.py
@@ -7,6 +7,85 @@ ROOT = pathlib.Path(__file__).resolve().parents[2]
 
 
 class NativeRendererContractTests(unittest.TestCase):
+    def test_isolated_depth_seed_copies_every_d3d12_plane(self) -> None:
+        patch = (
+            ROOT
+            / "patches/rexglue"
+            / "0088-d3d12-copy-isolated-depth-stencil-planes.patch"
+        ).read_text(encoding="utf-8")
+        added = "\n".join(
+            line[1:] for line in patch.splitlines() if line.startswith("+")
+        )
+        self.assertIn("depth_format_info.PlaneCount", added)
+        self.assertIn("plane * uint32_t(depth_desc.MipLevels)", added)
+        self.assertIn("D3DCopyTextureRegion", added)
+        self.assertNotIn(
+            "D3DCopyResource(isolated_depth->resource(),", added
+        )
+        self.assertNotIn("SetDrawSuppression", patch)
+
+    def test_readback_replay_restores_graphics_root_bindings(self) -> None:
+        patch = (
+            ROOT
+            / "patches/rexglue"
+            / "0087-d3d12-restore-graphics-bindings-after-readback.patch"
+        ).read_text(encoding="utf-8")
+
+        self.assertIn("restore_prepared_guest_graphics_state", patch)
+        self.assertIn("current_graphics_root_up_to_date_ = 0", patch)
+        self.assertEqual(
+            patch.count(
+                "UpdateBindings(vertex_shader, pixel_shader, root_signature,"
+            ),
+            1,
+        )
+        self.assertEqual(
+            patch.count("if (!restore_prepared_guest_graphics_state())"),
+            4,
+        )
+        self.assertIn("kBindingUpdateFailed", patch)
+        self.assertNotIn("SetDrawSuppression", patch)
+        self.assertNotIn("suppress_guest_draw_if_published = true", patch)
+
+    def test_continuous_shadow_replay_is_reconciled_and_safe(self) -> None:
+        source = (ROOT / "src/native_renderer/graphics_hooks.cpp").read_text(
+            encoding="utf-8"
+        )
+        start = source.index("void CompleteIsolatedShadowReplay(")
+        end = source.index("void CompleteIsolatedPassAnchor(", start)
+        completion = source[start:end]
+        self.assertIn("shadow_replay_recorded", completion)
+        self.assertIn("shadow_replay_target_failures", completion)
+        self.assertIn("shadow_replay_unsupported", completion)
+        self.assertNotIn("RecordEvent", completion)
+        self.assertIn(
+            '"native_renderer.isolated_draw.shadow_replay_summary"', source
+        )
+        self.assertIn('"accounting_complete"', source)
+        self.assertIn('{"readback", "one_shot_only"}', source)
+        self.assertIn('{"xenos_draw", "preserved"}', source)
+        self.assertIn('{"draw_suppression", "false"}', source)
+
+    def test_seed_checkpoints_are_paired_before_native_draw(self) -> None:
+        patch = (
+            ROOT
+            / "patches/rexglue/0086-d3d12-paired-seed-checkpoint-order.patch"
+        ).read_text(encoding="utf-8")
+
+        added = "\n".join(
+            line[1:] for line in patch.splitlines() if line.startswith("+")
+        )
+        removed = "\n".join(
+            line[1:] for line in patch.splitlines() if line.startswith("-")
+        )
+        self.assertEqual(added.count("QueueGuestSeedDepthReadback("), 2)
+        self.assertEqual(removed.count("QueueGuestSeedDepthReadback("), 2)
+        self.assertEqual(
+            added.count("QueueIsolatedReplaySeedDepthReadback("), 0
+        )
+        self.assertEqual(added.count("EndIsolatedReplayTarget("), 0)
+        self.assertNotIn("SetDrawSuppression", patch)
+
     def test_stencil_seed_probe_is_bounded_and_preserves_xenos(self) -> None:
         source = (ROOT / "src/native_renderer/graphics_hooks.cpp").read_text(
             encoding="utf-8"

--- a/tools/tests/test_native_renderer_readback_parity_contract.py
+++ b/tools/tests/test_native_renderer_readback_parity_contract.py
@@ -53,6 +53,19 @@ class NativeRendererReadbackParityContractTests(unittest.TestCase):
         self.assertIn(
             "asynchronous_artifact_exact_depth_stencil_effects", self.scanner
         )
+        self.assertIn('{"result_gate", "post_draw_output"}', self.scanner)
+        self.assertIn('{"seed_status", seed.exact()', self.scanner)
+        self.assertIn(
+            '{"draw_effect_status",\n        draw_effect.exact()',
+            self.scanner,
+        )
+        self.assertIn(
+            "complete && color.exact() && post.exact()", self.scanner
+        )
+        self.assertNotIn(
+            "complete && color.exact() && seed.exact() && post.exact()",
+            self.scanner,
+        )
 
     def test_depth_stencil_tuple_comparison_classifies_each_lane(self):
         self.assertIn("depth_mismatch_bytes", self.scanner)

--- a/tools/tests/test_release_contract.py
+++ b/tools/tests/test_release_contract.py
@@ -43,10 +43,10 @@ class ReleaseContractTests(unittest.TestCase):
 
     def test_rexglue_patches_have_stable_order_and_no_binary_payload(self):
         patches = sorted((ROOT / "patches/rexglue").glob("*.patch"))
-        self.assertEqual(len(patches), 85)
+        self.assertEqual(len(patches), 88)
         self.assertEqual(
             patches[-1].name,
-            "0085-d3d12-isolated-stencil-seed-probe.patch",
+            "0088-d3d12-copy-isolated-depth-stencil-planes.patch",
         )
         self.assertEqual(len(patches), len({path.name[:4] for path in patches}))
         for path in patches:


### PR DESCRIPTION
## Summary

- pair authoritative and private depth/stencil seed checkpoints before either draw
- restore D3D12 guest graphics bindings after diagnostic compute readbacks
- copy every typeless MSAA depth/stencil plane explicitly
- keep exact-signature native replay private after the one-shot capture and reconcile every outcome
- preserve the Xenos draw, Xenos output authority, and every no-suppression gate

## Qualification

- python -m unittest discover -s tools/tests -p 'test_*.py': 393 passed
- Release preview build: passed
- AppData session 20260830T074501Z-p43940: exact color, seed, draw-effect, and post-draw depth/stencil parity
- offline depth/stencil comparison: 83,886,080 exact active bytes; both draws changed the same 1,586,291 stencil bytes
- shadow replay accounting complete; normal exit; suppression remained disabled

This is qualification evidence for the isolated replay boundary, not Xenos-retirement admission. Repeated representative-scene parity and the remaining consumer/CPU-visibility gates are still required.