### PR TITLE
feat(renderer): replay bounded visibility worksets

### DIFF
--- a/docs/native-renderer/VISIBILITY_PREPARED_CANDIDATES.md
+++ b/docs/native-renderer/VISIBILITY_PREPARED_CANDIDATES.md
@@ -101,6 +101,57 @@ is valid only with `-AutoSelectFreshVisibilityCandidate`, is startup-only, and
 does not infer LOD zero. The lock event records the exact LOD index while Xenos
 remains authoritative.
 
+### Bounded workset shadow replay
+
+After one exact-signature candidate has proved the replay boundary, the
+default-off `-VisibilityShadowReplay` census mode exercises the broader
+visibility-selected workset without locking one signature. It accepts only a
+prepared draw that is mechanically eligible, carries a current or one-frame-
+old independent visibility selection, and has exact semantic PM4 provenance.
+At most the first such candidate in each frame is replayed into a private
+target; later eligible candidates in that frame are counted as quota yields.
+
+Exact title LOD remains bounded metadata rather than an admission predicate.
+Runtime evidence showed that the mechanically replayable category-11 draws do
+not execute either title LOD write hook, while exact-LOD category-9 draws fail
+the independent mechanical replay contract. Requiring both therefore produced
+an empty intersection. The workset replay records explicit LOD values when the
+title wrote one and separately accounts requests without LOD; it never infers
+LOD zero.
+
+The mode keeps a fixed 256-signature request table with first/last frame,
+request count, exact title-LOD observations, missing-LOD requests, and the
+observed LOD range when one exists. Shutdown telemetry partitions every
+prepared observation into mechanical rejection, stale/unselected rejection,
+per-frame quota yield, or native replay request. Every request is reconciled
+both by LOD evidence and as recorded, target-creation failure, or unsupported.
+Any table overflow or incomplete accounting fails the evidence report.
+
+This mode adds no readback, native publication, draw suppression, or guest
+state mutation. Each native draw is discarded with its private target and the
+original Xenos draw executes normally. It is mutually exclusive with exact
+isolated capture, retained-pass replay/publication, and suppression. The
+capture wrapper also arms dispatch discovery because admission requires
+exact semantic PM4 provenance. Runtime configuration fails closed when that
+provenance is unavailable rather than reporting a healthy zero-draw session.
+Capture a batched AppData session with:
+
+```powershell
+.\tools\capture-native-renderer-census.ps1 `
+  -StateRoot $stateRoot `
+  -Scene open_world_day `
+  -VisibilityShadowReplay
+
+python .\tools\summarize-native-renderer-visibility-shadow-replay.py `
+  $eventLog `
+  --output `
+    .local\qualification\native-renderer-visibility-shadow-replay.json
+```
+
+The resulting signature coverage and outcome accounting determine whether the
+qualified one-draw path generalizes across the selected procedural workset;
+they do not admit publication or suppression.
+
 ## AppData qualification
 
 Release session `20260830T015106Z-p25800` ran against the installed `0.1.0`
@@ -116,3 +167,15 @@ reports all completed from the same capture. Median performance was 29.750 FPS
 over 2,802 frames, with a 15.224 FPS one-percent low, 58.633 Hz presentation,
 and zero present-deadline misses. The fatal-signature scan was clean. Native
 upload, native draw, and suppression remained disabled throughout.
+
+Release/AppData session `20260830T081921Z-p13044` qualified the bounded
+workset replay itself. It recorded all 25 requested private native draws across
+two exact prepared signatures, with zero target-creation failures, unsupported
+draws, signature overflow, error events, or fatal events. Selection accounting
+partitioned 3,978,187 prepared observations into 3,662,084 mechanical
+rejections, 316,078 stale/unselected exclusions, and 25 requests. All requests
+lacked a title LOD because their category-11 title path executed no LOD write;
+that absence was explicitly reconciled without inferring an index. The game
+loaded the installed AppData festival save and remained visually stable.
+Native output stayed private, the original Xenos draws remained authoritative,
+and publication and suppression stayed disabled.

--- a/src/native_renderer/graphics_hooks.cpp
+++ b/src/native_renderer/graphics_hooks.cpp
@@ -97,6 +97,9 @@ constexpr size_t kSemanticVisibilitySpatialExponentCapacity = 256;
 constexpr size_t kSemanticVisibilityWorksetCapacity = 4096;
 constexpr size_t kSemanticVisibilityPreparedCandidateCapacity = 4096;
 constexpr uint64_t kSemanticVisibilityMaximumPolicyAgeFrames = 1;
+constexpr size_t kVisibilityShadowReplaySignatureCapacity = 256;
+constexpr size_t kVisibilityShadowReplaySignatureSummaryLimit = 16;
+constexpr uint64_t kVisibilityShadowReplayMaximumDrawsPerFrame = 1;
 constexpr size_t kSemanticInstanceCapacity = 4096;
 constexpr size_t kSemanticSubmissionCapacity = 8192;
 constexpr size_t kSemanticRenderItemStackCapacity = 32;
@@ -4114,6 +4117,40 @@ struct IsolatedDrawState {
 IsolatedDrawState g_isolated_draw;
 std::atomic<uint32_t> g_isolated_readback_artifacts_committed = 0;
 
+struct VisibilityShadowReplaySignatureEntry {
+  uint64_t signature = 0;
+  uint64_t requests = 0;
+  uint64_t first_frame = 0;
+  uint64_t last_frame = 0;
+  uint32_t minimum_title_lod = UINT32_MAX;
+  uint32_t maximum_title_lod = 0;
+  uint64_t title_lod_observations = 0;
+  uint64_t missing_title_lod_requests = 0;
+};
+
+struct VisibilityShadowReplayState {
+  std::array<VisibilityShadowReplaySignatureEntry,
+             kVisibilityShadowReplaySignatureCapacity>
+      signatures{};
+  uint64_t prepared_observations = 0;
+  uint64_t requests = 0;
+  uint64_t recorded = 0;
+  uint64_t target_creation_failures = 0;
+  uint64_t unsupported = 0;
+  uint64_t mechanical_rejections = 0;
+  uint64_t stale_or_unselected_rejections = 0;
+  uint64_t requests_with_title_lod = 0;
+  uint64_t requests_without_title_lod = 0;
+  uint64_t per_frame_quota_yields = 0;
+  uint64_t signature_count = 0;
+  uint64_t signature_overflow = 0;
+  uint64_t last_request_frame = UINT64_MAX;
+  bool requested = false;
+  bool valid = true;
+};
+
+VisibilityShadowReplayState g_visibility_shadow_replay;
+
 struct PassFollowerState {
   uint64_t target_signature = 0;
   uint64_t anchor_frame = 0;
@@ -4626,6 +4663,68 @@ void ConfigureIsolatedDraw() {
     }
   }
   std::free(value);
+}
+
+void ConfigureVisibilityShadowReplay() {
+  g_visibility_shadow_replay = {};
+  g_visibility_shadow_replay.last_request_frame = UINT64_MAX;
+  char *value = nullptr;
+  size_t length = 0;
+  if (_dupenv_s(
+          &value, &length,
+          "PINYON_SHIFT_NATIVE_RENDERER_VISIBILITY_SHADOW_REPLAY") != 0 ||
+      !value || length <= 1) {
+    std::free(value);
+    return;
+  }
+  const std::string setting(value);
+  std::free(value);
+  if (setting == "false") {
+    return;
+  }
+  g_visibility_shadow_replay.requested = true;
+  g_visibility_shadow_replay.valid = setting == "true";
+}
+
+void ValidateAndEmitVisibilityShadowReplayConfiguration() {
+  if (g_visibility_shadow_replay.requested &&
+      (g_isolated_draw.requested || g_pass_follower.requested ||
+       g_pass_publication.requested ||
+       g_sky_horizon_suppression.requested)) {
+    g_visibility_shadow_replay.valid = false;
+  }
+  const bool semantic_lineage_armed =
+      g_title_provenance_installed.load(std::memory_order_acquire);
+  if (g_visibility_shadow_replay.requested && !semantic_lineage_armed) {
+    g_visibility_shadow_replay.valid = false;
+  }
+  pinyon_shift::diagnostics::RecordEvent(
+      "native_renderer.visibility_shadow_replay.config",
+      {{"status", !g_visibility_shadow_replay.requested
+                      ? "disabled"
+                      : (g_visibility_shadow_replay.valid
+                             ? "armed_private_replay"
+                             : "blocked_invalid_configuration")},
+       {"activation", "startup_environment_only"},
+       {"default_enabled", "false"},
+       {"selection", "fresh_visibility_and_mechanical"},
+       {"title_lod", "optional_exact_metadata_no_inference"},
+       {"maximum_draws_per_frame",
+        std::to_string(kVisibilityShadowReplayMaximumDrawsPerFrame)},
+       {"signature_capacity",
+        std::to_string(kVisibilityShadowReplaySignatureCapacity)},
+       {"semantic_lineage",
+        semantic_lineage_armed ? "armed" : "unavailable"},
+       {"readback", "disabled"},
+       {"publication", "disabled"},
+       {"native_draw", g_visibility_shadow_replay.valid &&
+                               g_visibility_shadow_replay.requested
+                           ? "private_shadow_replay"
+                           : "false"},
+       {"xenos_draw", "preserved"},
+       {"output_authority", "xenos"},
+       {"draw_suppression", "false"},
+       {"suppression_eligible", "false"}});
 }
 
 void ConfigurePassPublication() {
@@ -13558,6 +13657,159 @@ void CompleteIsolatedShadowReplay(
   }
 }
 
+void RecordVisibilityShadowReplaySignature(uint64_t signature, uint64_t frame,
+                                           bool title_lod_valid,
+                                           uint32_t title_lod_index) {
+  size_t index = size_t(signature % kVisibilityShadowReplaySignatureCapacity);
+  for (size_t probe = 0; probe < kVisibilityShadowReplaySignatureCapacity;
+       ++probe) {
+    VisibilityShadowReplaySignatureEntry &entry =
+        g_visibility_shadow_replay.signatures[index];
+    if (!entry.signature) {
+      entry.signature = signature;
+      entry.requests = 1;
+      entry.first_frame = frame;
+      entry.last_frame = frame;
+      if (title_lod_valid) {
+        entry.minimum_title_lod = title_lod_index;
+        entry.maximum_title_lod = title_lod_index;
+        entry.title_lod_observations = 1;
+      } else {
+        entry.missing_title_lod_requests = 1;
+      }
+      ++g_visibility_shadow_replay.signature_count;
+      return;
+    }
+    if (entry.signature == signature) {
+      ++entry.requests;
+      entry.last_frame = frame;
+      if (title_lod_valid) {
+        entry.minimum_title_lod =
+            std::min(entry.minimum_title_lod, title_lod_index);
+        entry.maximum_title_lod =
+            std::max(entry.maximum_title_lod, title_lod_index);
+        ++entry.title_lod_observations;
+      } else {
+        ++entry.missing_title_lod_requests;
+      }
+      return;
+    }
+    index = (index + 1) % kVisibilityShadowReplaySignatureCapacity;
+  }
+  ++g_visibility_shadow_replay.signature_overflow;
+}
+
+void CompleteVisibilityShadowReplay(
+    const rex::system::GraphicsIsolatedDrawResult &result) {
+  if (result.status == rex::system::GraphicsIsolatedDrawStatus::kRecorded) {
+    ++g_visibility_shadow_replay.recorded;
+  } else if (result.status == rex::system::
+                                  GraphicsIsolatedDrawStatus::
+                                      kTargetCreationFailed) {
+    ++g_visibility_shadow_replay.target_creation_failures;
+  } else {
+    ++g_visibility_shadow_replay.unsupported;
+  }
+}
+
+void EmitVisibilityShadowReplaySummary() {
+  if (!g_visibility_shadow_replay.requested) {
+    return;
+  }
+  const uint64_t outcomes = g_visibility_shadow_replay.recorded +
+                            g_visibility_shadow_replay.target_creation_failures +
+                            g_visibility_shadow_replay.unsupported;
+  const uint64_t selections =
+      g_visibility_shadow_replay.requests +
+      g_visibility_shadow_replay.mechanical_rejections +
+      g_visibility_shadow_replay.stale_or_unselected_rejections +
+      g_visibility_shadow_replay.per_frame_quota_yields;
+  const uint64_t title_lod_accounting =
+      g_visibility_shadow_replay.requests_with_title_lod +
+      g_visibility_shadow_replay.requests_without_title_lod;
+  pinyon_shift::diagnostics::RecordEvent(
+      "native_renderer.visibility_shadow_replay.summary",
+      {{"status", g_visibility_shadow_replay.valid ? "complete"
+                                                   : "invalid_configuration"},
+       {"prepared_observations",
+        std::to_string(g_visibility_shadow_replay.prepared_observations)},
+       {"requests", std::to_string(g_visibility_shadow_replay.requests)},
+       {"recorded", std::to_string(g_visibility_shadow_replay.recorded)},
+       {"target_creation_failures",
+        std::to_string(
+            g_visibility_shadow_replay.target_creation_failures)},
+       {"unsupported",
+        std::to_string(g_visibility_shadow_replay.unsupported)},
+       {"mechanical_rejections",
+        std::to_string(g_visibility_shadow_replay.mechanical_rejections)},
+       {"stale_or_unselected_rejections",
+        std::to_string(
+            g_visibility_shadow_replay.stale_or_unselected_rejections)},
+       {"requests_with_title_lod",
+        std::to_string(g_visibility_shadow_replay.requests_with_title_lod)},
+       {"requests_without_title_lod",
+        std::to_string(g_visibility_shadow_replay.requests_without_title_lod)},
+       {"per_frame_quota_yields",
+        std::to_string(g_visibility_shadow_replay.per_frame_quota_yields)},
+       {"unique_signatures",
+        std::to_string(g_visibility_shadow_replay.signature_count)},
+       {"signature_capacity",
+        std::to_string(kVisibilityShadowReplaySignatureCapacity)},
+       {"signature_overflow",
+        std::to_string(g_visibility_shadow_replay.signature_overflow)},
+       {"accounting_complete",
+        outcomes == g_visibility_shadow_replay.requests ? "true" : "false"},
+       {"selection_accounting_complete",
+        selections == g_visibility_shadow_replay.prepared_observations
+            ? "true"
+            : "false"},
+       {"title_lod_accounting_complete",
+        title_lod_accounting == g_visibility_shadow_replay.requests ? "true"
+                                                                    : "false"},
+       {"maximum_draws_per_frame",
+        std::to_string(kVisibilityShadowReplayMaximumDrawsPerFrame)},
+       {"selection", "fresh_visibility_and_mechanical"},
+       {"title_lod", "optional_exact_metadata_no_inference"},
+       {"readback", "disabled"},
+       {"native_draw", "private_shadow_replay"},
+       {"xenos_draw", "preserved"},
+       {"output_authority", "xenos"},
+       {"draw_suppression", "false"},
+       {"suppression_eligible", "false"}});
+
+  size_t emitted = 0;
+  for (const VisibilityShadowReplaySignatureEntry &entry :
+       g_visibility_shadow_replay.signatures) {
+    if (!entry.signature ||
+        emitted >= kVisibilityShadowReplaySignatureSummaryLimit) {
+      continue;
+    }
+    pinyon_shift::diagnostics::RecordEvent(
+        "native_renderer.visibility_shadow_replay.signature",
+        {{"signature", fmt::format("{:016X}", entry.signature)},
+         {"requests", std::to_string(entry.requests)},
+         {"first_frame", std::to_string(entry.first_frame)},
+         {"last_frame", std::to_string(entry.last_frame)},
+         {"title_lod_observations",
+          std::to_string(entry.title_lod_observations)},
+         {"missing_title_lod_requests",
+          std::to_string(entry.missing_title_lod_requests)},
+         {"minimum_title_lod",
+          entry.title_lod_observations
+              ? std::to_string(entry.minimum_title_lod)
+              : ""},
+         {"maximum_title_lod",
+          entry.title_lod_observations
+              ? std::to_string(entry.maximum_title_lod)
+              : ""},
+         {"native_draw", "private_shadow_replay"},
+         {"xenos_draw", "preserved"},
+         {"output_authority", "xenos"},
+         {"suppression_eligible", "false"}});
+    ++emitted;
+  }
+}
+
 void CompleteIsolatedPassAnchor(
     const rex::system::GraphicsIsolatedDrawResult &result) {
   g_isolated_draw.pass_anchor_recorded =
@@ -13774,6 +14026,40 @@ void RequestIsolatedDraw(
       request.consumer_reference_after_depth_readback_completion =
           &CompleteConsumerFamilyAfterDepthReadback;
     }
+  }
+  if (g_visibility_shadow_replay.requested &&
+      g_visibility_shadow_replay.valid &&
+      g_isolated_draw.prepared_candidate_valid) {
+    ++g_visibility_shadow_replay.prepared_observations;
+    if (!g_isolated_draw.prepared_candidate_eligible) {
+      ++g_visibility_shadow_replay.mechanical_rejections;
+      return;
+    }
+    if (!g_isolated_draw.prepared_visibility_candidate_fresh) {
+      ++g_visibility_shadow_replay.stale_or_unselected_rejections;
+      return;
+    }
+    if (g_visibility_shadow_replay.last_request_frame ==
+        g_isolated_draw.frame) {
+      ++g_visibility_shadow_replay.per_frame_quota_yields;
+      return;
+    }
+    g_visibility_shadow_replay.last_request_frame = g_isolated_draw.frame;
+    ++g_visibility_shadow_replay.requests;
+    if (g_isolated_draw.prepared_title_lod_valid) {
+      ++g_visibility_shadow_replay.requests_with_title_lod;
+    } else {
+      ++g_visibility_shadow_replay.requests_without_title_lod;
+    }
+    RecordVisibilityShadowReplaySignature(
+        g_isolated_draw.prepared_signature, g_isolated_draw.frame,
+        g_isolated_draw.prepared_title_lod_valid,
+        g_isolated_draw.prepared_title_lod_index);
+    request.requested = true;
+    request.frame_sequence = g_isolated_draw.frame;
+    request.reference_marker_requested = true;
+    request.completion = &CompleteVisibilityShadowReplay;
+    return;
   }
   if (!g_isolated_draw.requested || !g_isolated_draw.valid ||
       !g_isolated_draw.prepared_candidate_valid) {
@@ -14689,12 +14975,14 @@ void InstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system,
   ConfigureTextureScan();
   ConfigureReplaySnapshot();
   ConfigureIsolatedDraw();
+  ConfigureVisibilityShadowReplay();
   ConfigurePassFollower();
   if (g_isolated_draw.stencil_seed_probe_requested &&
       g_pass_follower.requested) {
     g_isolated_draw.valid = false;
   }
   ConfigurePassPublication();
+  ValidateAndEmitVisibilityShadowReplayConfiguration();
   ArmSkyHorizonSuppression();
   EmitSkyHorizonSuppressionControl();
   ConfigureConsumerFamilyMarker();
@@ -15749,6 +16037,7 @@ void UninstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system) {
          {"output_authority", "xenos"},
          {"suppression_eligible", "false"}});
   }
+  EmitVisibilityShadowReplaySummary();
   const bool isolated_single_draw_mode =
       !g_pass_follower.requested || !g_pass_follower.valid ||
       g_pass_follower.target_signature == g_isolated_draw.target_signature;

--- a/tools/capture-native-renderer-census.ps1
+++ b/tools/capture-native-renderer-census.ps1
@@ -20,6 +20,7 @@ param(
     [switch]$RequireFreshVisibilityCandidate,
     [switch]$AutoSelectFreshVisibilityCandidate,
     [switch]$RequireTitleLodCandidate,
+    [switch]$VisibilityShadowReplay,
     [ValidatePattern('^[0-9A-Fa-f]{16}$')]
     [string]$PassAnchorSignature,
     [switch]$PublishRetainedPass,
@@ -82,6 +83,13 @@ if ($StencilSeedProbe -and $PassAnchorSignature) {
 }
 if ($RequireTitleLodCandidate -and -not $AutoSelectFreshVisibilityCandidate) {
     throw 'RequireTitleLodCandidate requires AutoSelectFreshVisibilityCandidate.'
+}
+if ($VisibilityShadowReplay -and
+    ($IsolatedDrawSignature -or $IsolatedDrawDir -or $StencilSeedProbe -or
+        $RequireFreshVisibilityCandidate -or
+        $AutoSelectFreshVisibilityCandidate -or $RequireTitleLodCandidate -or
+        $PassAnchorSignature -or $PublishRetainedPass)) {
+    throw 'VisibilityShadowReplay is mutually exclusive with isolated/pass replay options.'
 }
 if ($PublishRetainedPass -and
     (-not $IsolatedDrawSignature -or -not $PassAnchorSignature)) {
@@ -155,6 +163,7 @@ if ($ConsumerReadbackDir) {
 }
 
 $savedCensus = $env:REX_PINYON_SHIFT_NATIVE_RENDERER_CENSUS
+$savedDiscovery = $env:REX_PINYON_SHIFT_NATIVE_RENDERER_DISPATCH_DISCOVERY
 $savedScene = $env:PINYON_SHIFT_NATIVE_RENDERER_SCENE
 $savedIndexScan = $env:PINYON_SHIFT_NATIVE_RENDERER_INDEX_SCAN_SIGNATURE
 $savedTextureScan = $env:PINYON_SHIFT_NATIVE_RENDERER_TEXTURE_SCAN_SIGNATURE
@@ -168,6 +177,8 @@ $savedAutoVisibilityCandidate =
     $env:PINYON_SHIFT_NATIVE_RENDERER_AUTO_SELECT_FRESH_VISIBILITY_CANDIDATE
 $savedTitleLodCandidate =
     $env:PINYON_SHIFT_NATIVE_RENDERER_REQUIRE_TITLE_LOD_CANDIDATE
+$savedVisibilityShadowReplay =
+    $env:PINYON_SHIFT_NATIVE_RENDERER_VISIBILITY_SHADOW_REPLAY
 $savedPassAnchor = $env:PINYON_SHIFT_NATIVE_RENDERER_PASS_ANCHOR_SIGNATURE
 $savedPassPublication = $env:PINYON_SHIFT_NATIVE_RENDERER_PUBLISH_RETAINED_PASS
 $savedConsumerFamily = $env:PINYON_SHIFT_NATIVE_RENDERER_CONSUMER_FAMILY
@@ -175,6 +186,8 @@ $savedConsumerReadbackDir = $env:PINYON_SHIFT_NATIVE_RENDERER_CONSUMER_READBACK_
 $savedConsumerReadbackSamples = $env:PINYON_SHIFT_NATIVE_RENDERER_CONSUMER_READBACK_SAMPLES
 try {
     $env:REX_PINYON_SHIFT_NATIVE_RENDERER_CENSUS = 'true'
+    $env:REX_PINYON_SHIFT_NATIVE_RENDERER_DISPATCH_DISCOVERY =
+        if ($VisibilityShadowReplay) { 'true' } else { $savedDiscovery }
     $env:PINYON_SHIFT_NATIVE_RENDERER_SCENE = $Scene
     $env:PINYON_SHIFT_NATIVE_RENDERER_INDEX_SCAN_SIGNATURE = $IndexScanSignature
     $env:PINYON_SHIFT_NATIVE_RENDERER_TEXTURE_SCAN_SIGNATURE = $TextureScanSignature
@@ -192,6 +205,8 @@ try {
         if ($AutoSelectFreshVisibilityCandidate) { 'true' } else { $null }
     $env:PINYON_SHIFT_NATIVE_RENDERER_REQUIRE_TITLE_LOD_CANDIDATE =
         if ($RequireTitleLodCandidate) { 'true' } else { $null }
+    $env:PINYON_SHIFT_NATIVE_RENDERER_VISIBILITY_SHADOW_REPLAY =
+        if ($VisibilityShadowReplay) { 'true' } else { $null }
     $env:PINYON_SHIFT_NATIVE_RENDERER_PASS_ANCHOR_SIGNATURE = $PassAnchorSignature
     $env:PINYON_SHIFT_NATIVE_RENDERER_PUBLISH_RETAINED_PASS =
         if ($PublishRetainedPass) { 'true' } else { $null }
@@ -205,6 +220,7 @@ try {
 }
 finally {
     $env:REX_PINYON_SHIFT_NATIVE_RENDERER_CENSUS = $savedCensus
+    $env:REX_PINYON_SHIFT_NATIVE_RENDERER_DISPATCH_DISCOVERY = $savedDiscovery
     $env:PINYON_SHIFT_NATIVE_RENDERER_SCENE = $savedScene
     $env:PINYON_SHIFT_NATIVE_RENDERER_INDEX_SCAN_SIGNATURE = $savedIndexScan
     $env:PINYON_SHIFT_NATIVE_RENDERER_TEXTURE_SCAN_SIGNATURE = $savedTextureScan
@@ -219,6 +235,8 @@ finally {
         $savedAutoVisibilityCandidate
     $env:PINYON_SHIFT_NATIVE_RENDERER_REQUIRE_TITLE_LOD_CANDIDATE =
         $savedTitleLodCandidate
+    $env:PINYON_SHIFT_NATIVE_RENDERER_VISIBILITY_SHADOW_REPLAY =
+        $savedVisibilityShadowReplay
     $env:PINYON_SHIFT_NATIVE_RENDERER_PASS_ANCHOR_SIGNATURE = $savedPassAnchor
     $env:PINYON_SHIFT_NATIVE_RENDERER_PUBLISH_RETAINED_PASS = $savedPassPublication
     $env:PINYON_SHIFT_NATIVE_RENDERER_CONSUMER_FAMILY = $savedConsumerFamily

--- a/tools/summarize-native-renderer-visibility-shadow-replay.py
+++ b/tools/summarize-native-renderer-visibility-shadow-replay.py
@@ -1,0 +1,270 @@
+#!/usr/bin/env python3
+"""Qualify bounded private replay of visibility-selected prepared draws."""
+
+import argparse
+import json
+import pathlib
+import sys
+
+
+SCHEMA = "pinyon-shift.native-renderer-visibility-shadow-replay.v1"
+CONFIG = "native_renderer.visibility_shadow_replay.config"
+SUMMARY = "native_renderer.visibility_shadow_replay.summary"
+SIGNATURE = "native_renderer.visibility_shadow_replay.signature"
+SIGNATURE_SUMMARY_LIMIT = 16
+
+
+def read_events(paths):
+    events = []
+    for path in paths:
+        for line in path.read_text(encoding="utf-8").splitlines():
+            if line.strip():
+                events.append(json.loads(line))
+    return events
+
+
+def integer(mapping, key):
+    try:
+        value = int(mapping[key])
+    except (KeyError, TypeError, ValueError) as error:
+        raise ValueError(f"invalid {key}") from error
+    if value < 0:
+        raise ValueError(f"negative {key}")
+    return value
+
+
+def hexadecimal(mapping, key, width=16):
+    value = str(mapping.get(key, "")).upper()
+    if len(value) != width:
+        raise ValueError(f"invalid {key}")
+    try:
+        int(value, 16)
+    except ValueError as error:
+        raise ValueError(f"invalid {key}") from error
+    return value
+
+
+def exact_event(events, name):
+    matches = [event for event in events if event.get("event") == name]
+    if len(matches) != 1:
+        raise ValueError(f"expected exactly one {name} event")
+    return matches[0]
+
+
+def select_session(events, requested):
+    sessions = {
+        event.get("session") for event in events if event.get("event") == CONFIG
+    }
+    sessions.discard(None)
+    if requested:
+        if requested not in sessions:
+            raise ValueError("requested session has no shadow-replay config")
+        return requested
+    if len(sessions) != 1:
+        raise ValueError("shadow-replay input contains multiple sessions")
+    return next(iter(sessions))
+
+
+def require_safety(event):
+    expected = {
+        "readback": "disabled",
+        "native_draw": "private_shadow_replay",
+        "xenos_draw": "preserved",
+        "output_authority": "xenos",
+        "draw_suppression": "false",
+        "suppression_eligible": "false",
+    }
+    if any(event.get(key) != value for key, value in expected.items()):
+        raise ValueError("shadow-replay evidence violates safety boundary")
+
+
+def build(events, requested_session=None):
+    session = select_session(events, requested_session)
+    selected = [event for event in events if event.get("session") == session]
+    config = exact_event(selected, CONFIG)
+    summary = exact_event(selected, SUMMARY)
+    expected_config = {
+        "status": "armed_private_replay",
+        "activation": "startup_environment_only",
+        "default_enabled": "false",
+        "selection": "fresh_visibility_and_mechanical",
+        "title_lod": "optional_exact_metadata_no_inference",
+        "maximum_draws_per_frame": "1",
+        "signature_capacity": "256",
+        "semantic_lineage": "armed",
+        "readback": "disabled",
+        "publication": "disabled",
+        "native_draw": "private_shadow_replay",
+        "xenos_draw": "preserved",
+        "output_authority": "xenos",
+        "draw_suppression": "false",
+        "suppression_eligible": "false",
+    }
+    if any(config.get(key) != value for key, value in expected_config.items()):
+        raise ValueError("shadow-replay runtime configuration drifted")
+    require_safety(summary)
+    if (
+        summary.get("status") != "complete"
+        or summary.get("accounting_complete") != "true"
+        or summary.get("selection_accounting_complete") != "true"
+        or summary.get("title_lod_accounting_complete") != "true"
+        or summary.get("selection") != "fresh_visibility_and_mechanical"
+        or summary.get("title_lod")
+        != "optional_exact_metadata_no_inference"
+        or summary.get("maximum_draws_per_frame") != "1"
+        or summary.get("signature_capacity") != "256"
+    ):
+        raise ValueError("shadow-replay summary is incomplete")
+
+    count_keys = (
+        "prepared_observations",
+        "requests",
+        "recorded",
+        "target_creation_failures",
+        "unsupported",
+        "mechanical_rejections",
+        "stale_or_unselected_rejections",
+        "requests_with_title_lod",
+        "requests_without_title_lod",
+        "per_frame_quota_yields",
+        "unique_signatures",
+        "signature_capacity",
+        "signature_overflow",
+        "maximum_draws_per_frame",
+    )
+    totals = {key: integer(summary, key) for key in count_keys}
+    signatures = []
+    seen = set()
+    for event in selected:
+        if event.get("event") != SIGNATURE:
+            continue
+        expected_safety = {
+            "native_draw": "private_shadow_replay",
+            "xenos_draw": "preserved",
+            "output_authority": "xenos",
+            "suppression_eligible": "false",
+        }
+        if any(event.get(key) != value for key, value in expected_safety.items()):
+            raise ValueError("signature evidence violates safety boundary")
+        signature = hexadecimal(event, "signature")
+        if signature in seen:
+            raise ValueError("duplicate shadow-replay signature")
+        seen.add(signature)
+        title_lod_observations = integer(event, "title_lod_observations")
+        missing_title_lod_requests = integer(
+            event, "missing_title_lod_requests"
+        )
+        minimum_lod = None
+        maximum_lod = None
+        if title_lod_observations:
+            minimum_lod = integer(event, "minimum_title_lod")
+            maximum_lod = integer(event, "maximum_title_lod")
+            if minimum_lod > maximum_lod:
+                raise ValueError("invalid title LOD range")
+        elif event.get("minimum_title_lod") or event.get("maximum_title_lod"):
+            raise ValueError("title LOD range exists without observations")
+        requests = integer(event, "requests")
+        if title_lod_observations + missing_title_lod_requests != requests:
+            raise ValueError("signature title LOD accounting drifted")
+        signatures.append(
+            {
+                "signature": signature,
+                "requests": requests,
+                "first_frame": integer(event, "first_frame"),
+                "last_frame": integer(event, "last_frame"),
+                "minimum_title_lod": minimum_lod,
+                "maximum_title_lod": maximum_lod,
+                "title_lod_observations": title_lod_observations,
+                "missing_title_lod_requests": missing_title_lod_requests,
+            }
+        )
+
+    failures = []
+    selections = (
+        totals["requests"]
+        + totals["mechanical_rejections"]
+        + totals["stale_or_unselected_rejections"]
+        + totals["per_frame_quota_yields"]
+    )
+    if selections != totals["prepared_observations"]:
+        failures.append("prepared selection accounting drifted")
+    outcomes = (
+        totals["recorded"]
+        + totals["target_creation_failures"]
+        + totals["unsupported"]
+    )
+    if outcomes != totals["requests"]:
+        failures.append("replay outcome accounting drifted")
+    if (
+        totals["requests_with_title_lod"]
+        + totals["requests_without_title_lod"]
+        != totals["requests"]
+    ):
+        failures.append("title LOD accounting drifted")
+    if not totals["requests"] or not totals["recorded"]:
+        failures.append("no visibility-selected private replay was recorded")
+    if totals["target_creation_failures"] or totals["unsupported"]:
+        failures.append("one or more private replays failed")
+    if totals["signature_overflow"]:
+        failures.append("signature table overflowed")
+    expected_signature_events = min(
+        totals["unique_signatures"], SIGNATURE_SUMMARY_LIMIT
+    )
+    if len(signatures) != expected_signature_events:
+        failures.append("signature summary coverage drifted")
+    if totals["unique_signatures"] > totals["requests"]:
+        failures.append("unique signatures exceed replay requests")
+    if totals["signature_capacity"] != 256:
+        failures.append("signature capacity drifted")
+    if totals["maximum_draws_per_frame"] != 1:
+        failures.append("per-frame replay bound drifted")
+
+    return {
+        "schema": SCHEMA,
+        "session": session,
+        "status": "complete" if not failures else "incomplete",
+        "failures": failures,
+        "totals": totals,
+        "signatures": signatures,
+        "qualification": {
+            "broad_visibility_workset_replay_proved": not failures,
+            "publication_admitted": False,
+            "suppression_allowed": False,
+        },
+        "safety": {
+            "readback": False,
+            "native_publication": False,
+            "native_draw_private_only": True,
+            "xenos_draw_preserved": True,
+            "output_authority": "xenos",
+            "suppression_allowed": False,
+        },
+    }
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser()
+    parser.add_argument("events", nargs="+", type=pathlib.Path)
+    parser.add_argument("--session")
+    parser.add_argument("--output", required=True, type=pathlib.Path)
+    args = parser.parse_args(argv)
+    try:
+        document = build(read_events(args.events), args.session)
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(
+            json.dumps(document, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        if document["status"] != "complete":
+            raise ValueError("; ".join(document["failures"]))
+        return 0
+    except (OSError, ValueError, json.JSONDecodeError) as error:
+        print(
+            f"native renderer visibility shadow replay summary failed: {error}",
+            file=sys.stderr,
+        )
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/tests/test_native_renderer_contract.py
+++ b/tools/tests/test_native_renderer_contract.py
@@ -52,7 +52,9 @@ class NativeRendererContractTests(unittest.TestCase):
             encoding="utf-8"
         )
         start = source.index("void CompleteIsolatedShadowReplay(")
-        end = source.index("void CompleteIsolatedPassAnchor(", start)
+        end = source.index(
+            "void RecordVisibilityShadowReplaySignature(", start
+        )
         completion = source[start:end]
         self.assertIn("shadow_replay_recorded", completion)
         self.assertIn("shadow_replay_target_failures", completion)
@@ -65,6 +67,64 @@ class NativeRendererContractTests(unittest.TestCase):
         self.assertIn('{"readback", "one_shot_only"}', source)
         self.assertIn('{"xenos_draw", "preserved"}', source)
         self.assertIn('{"draw_suppression", "false"}', source)
+
+    def test_visibility_workset_shadow_replay_is_bounded_and_safe(self) -> None:
+        source = (ROOT / "src/native_renderer/graphics_hooks.cpp").read_text(
+            encoding="utf-8"
+        )
+        start = source.index(
+            "if (g_visibility_shadow_replay.requested &&\n"
+            "      g_visibility_shadow_replay.valid &&"
+        )
+        end = source.index(
+            "if (!g_isolated_draw.requested || !g_isolated_draw.valid ||",
+            start,
+        )
+        request = source[start:end]
+        self.assertIn("prepared_visibility_candidate_fresh", request)
+        self.assertIn("prepared_title_lod_valid", request)
+        self.assertIn("prepared_candidate_eligible", request)
+        self.assertIn("last_request_frame", request)
+        self.assertIn("request.requested = true", request)
+        self.assertIn("request.reference_marker_requested = true", request)
+        self.assertIn("CompleteVisibilityShadowReplay", request)
+        self.assertNotIn("readback_requested", request)
+        self.assertNotIn("publish_to_guest_requested", request)
+        self.assertNotIn("suppress_guest_draw", request)
+        self.assertIn("requests_without_title_lod", request)
+
+        self.assertIn(
+            '"native_renderer.visibility_shadow_replay.summary"', source
+        )
+        self.assertIn('"selection_accounting_complete"', source)
+        self.assertIn('"maximum_draws_per_frame"', source)
+        self.assertIn('"optional_exact_metadata_no_inference"', source)
+        self.assertIn(
+            "g_title_provenance_installed.load(std::memory_order_acquire)",
+            source,
+        )
+        self.assertIn('semantic_lineage_armed ? "armed" : "unavailable"', source)
+        self.assertIn('{"readback", "disabled"}', source)
+        self.assertIn('{"xenos_draw", "preserved"}', source)
+        self.assertIn('{"draw_suppression", "false"}', source)
+
+        capture = (
+            ROOT / "tools/capture-native-renderer-census.ps1"
+        ).read_text(encoding="utf-8")
+        self.assertIn("[switch]$VisibilityShadowReplay", capture)
+        self.assertIn(
+            "PINYON_SHIFT_NATIVE_RENDERER_VISIBILITY_SHADOW_REPLAY",
+            capture,
+        )
+        self.assertIn(
+            "REX_PINYON_SHIFT_NATIVE_RENDERER_DISPATCH_DISCOVERY",
+            capture,
+        )
+        self.assertIn(
+            "VisibilityShadowReplay is mutually exclusive with "
+            "isolated/pass replay options.",
+            capture,
+        )
 
     def test_seed_checkpoints_are_paired_before_native_draw(self) -> None:
         patch = (

--- a/tools/tests/test_native_renderer_visibility_shadow_replay.py
+++ b/tools/tests/test_native_renderer_visibility_shadow_replay.py
@@ -1,0 +1,146 @@
+import copy
+import importlib.util
+import pathlib
+import unittest
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+TOOL = ROOT / "tools/summarize-native-renderer-visibility-shadow-replay.py"
+SPEC = importlib.util.spec_from_file_location(
+    "summarize_native_renderer_visibility_shadow_replay", TOOL
+)
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+def event(name, **values):
+    return {"event": name, "session": "session-1", **values}
+
+
+def fixture():
+    config = event(
+        MODULE.CONFIG,
+        status="armed_private_replay",
+        activation="startup_environment_only",
+        default_enabled="false",
+        selection="fresh_visibility_and_mechanical",
+        title_lod="optional_exact_metadata_no_inference",
+        maximum_draws_per_frame="1",
+        signature_capacity="256",
+        semantic_lineage="armed",
+        readback="disabled",
+        publication="disabled",
+        native_draw="private_shadow_replay",
+        xenos_draw="preserved",
+        output_authority="xenos",
+        draw_suppression="false",
+        suppression_eligible="false",
+    )
+    summary = event(
+        MODULE.SUMMARY,
+        status="complete",
+        prepared_observations="14",
+        requests="3",
+        recorded="3",
+        target_creation_failures="0",
+        unsupported="0",
+        mechanical_rejections="4",
+        stale_or_unselected_rejections="2",
+        requests_with_title_lod="2",
+        requests_without_title_lod="1",
+        per_frame_quota_yields="5",
+        unique_signatures="2",
+        signature_capacity="256",
+        signature_overflow="0",
+        accounting_complete="true",
+        selection_accounting_complete="true",
+        title_lod_accounting_complete="true",
+        maximum_draws_per_frame="1",
+        selection="fresh_visibility_and_mechanical",
+        title_lod="optional_exact_metadata_no_inference",
+        readback="disabled",
+        native_draw="private_shadow_replay",
+        xenos_draw="preserved",
+        output_authority="xenos",
+        draw_suppression="false",
+        suppression_eligible="false",
+    )
+    signatures = [
+        event(
+            MODULE.SIGNATURE,
+            signature="0123456789ABCDEF",
+            requests="2",
+            first_frame="10",
+            last_frame="12",
+            minimum_title_lod="0",
+            maximum_title_lod="1",
+            title_lod_observations="1",
+            missing_title_lod_requests="1",
+            native_draw="private_shadow_replay",
+            xenos_draw="preserved",
+            output_authority="xenos",
+            suppression_eligible="false",
+        ),
+        event(
+            MODULE.SIGNATURE,
+            signature="FEDCBA9876543210",
+            requests="1",
+            first_frame="11",
+            last_frame="11",
+            minimum_title_lod="2",
+            maximum_title_lod="2",
+            title_lod_observations="1",
+            missing_title_lod_requests="0",
+            native_draw="private_shadow_replay",
+            xenos_draw="preserved",
+            output_authority="xenos",
+            suppression_eligible="false",
+        ),
+    ]
+    return [config, summary, *signatures]
+
+
+class VisibilityShadowReplayTests(unittest.TestCase):
+    def test_qualifies_complete_bounded_private_replay(self):
+        document = MODULE.build(fixture())
+        self.assertEqual("complete", document["status"])
+        self.assertTrue(
+            document["qualification"]["broad_visibility_workset_replay_proved"]
+        )
+        self.assertFalse(document["qualification"]["suppression_allowed"])
+        self.assertEqual(2, len(document["signatures"]))
+
+    def test_fails_when_any_replay_is_unsupported(self):
+        events = fixture()
+        summary = events[1]
+        summary["recorded"] = "2"
+        summary["unsupported"] = "1"
+        document = MODULE.build(events)
+        self.assertEqual("incomplete", document["status"])
+        self.assertIn("one or more private replays failed", document["failures"])
+
+    def test_rejects_safety_or_accounting_drift(self):
+        unsafe = fixture()
+        unsafe[1]["draw_suppression"] = "true"
+        with self.assertRaisesRegex(ValueError, "safety boundary"):
+            MODULE.build(unsafe)
+
+        drifted = fixture()
+        drifted[1]["prepared_observations"] = "15"
+        document = MODULE.build(drifted)
+        self.assertEqual("incomplete", document["status"])
+        self.assertIn(
+            "prepared selection accounting drifted", document["failures"]
+        )
+
+    def test_rejects_duplicate_signature_summary(self):
+        events = fixture()
+        duplicate = copy.deepcopy(events[-1])
+        duplicate["signature"] = events[-2]["signature"]
+        events[-1] = duplicate
+        with self.assertRaisesRegex(ValueError, "duplicate"):
+            MODULE.build(events)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- replay at most one fresh mechanically safe semantic prepared draw per frame on private native targets
- preserve exact optional title-LOD evidence without inferring missing values
- arm and validate required semantic PM4 provenance, with bounded qualification reporting

## Safety
- original Xenos draws remain authoritative
- no native publication or draw suppression
- no readback or guest-state mutation in workset mode

## Validation
- 398 Python contract tests passed
- Release preview build passed
- AppData session 20260830T081921Z-p13044: 25/25 private native draws recorded across 2 signatures, 0 target failures, 0 unsupported draws, 0 error/fatal events