### PR TITLE
feat(renderer): trace vehicle instance semantics

### DIFF
--- a/docs/native-renderer/VEHICLE_INSTANCE_SEMANTIC_SEED.md
+++ b/docs/native-renderer/VEHICLE_INSTANCE_SEMANTIC_SEED.md
@@ -1,0 +1,53 @@
+# Vehicle-instance semantic seed
+
+NR-05E starts from the title's vehicle-pose stream at `82BC5A3C`. Runtime
+qualification proved that this boundary is shared by the player car, traffic,
+and other live vehicle instances; it must not be described as player-only. The
+boundary resolves each active vehicle slot and the exact position and
+forward-vector addresses consumed by the title. The native renderer receives
+the same already-read values through a read-only host observation, performs no
+additional guest read, and cannot modify title state.
+
+The census identity is the exact tuple of title generation, source object,
+owner object, and active slot. A fixed 64-entry table records transform
+addresses, observation and motion counts, frame span, maximum position delta,
+and whether the optional presentation stabilizer supplied an effective pose.
+An address change within one identity is a qualification failure rather than a
+silent update. Shutdown emits every captured identity, and qualification fails
+on overflow, truncation, invalid values, or incomplete accounting.
+
+This is a vehicle-instance semantic seed, not vehicle draw identity or a
+player-car classifier. It establishes the per-instance transform and lifetime
+boundary needed to correlate later vehicle render submissions. Player priority
+remains explicitly unadmitted until a separate title-semantic discriminator is
+proved. The census does not identify materials, wheels, suspension, traffic
+classes, reflection inputs, or a suppressible draw family. Native upload,
+native drawing, publication, and suppression remain disabled; Xenos stays
+authoritative.
+
+## Qualification evidence
+
+The AppData-backed `open_world_day` run
+`20260830T083911Z-p9532` completed normally with the release executable. It
+recorded 15,587 valid observations and no invalid observations across 31 exact
+vehicle identities. Twenty identities changed position, all 31 changed their
+forward vector, transform addresses remained stable, the 64-entry table did
+not overflow, and the log contained no error- or fatal-like events. The
+machine-readable report is generated locally at
+`.local/qualification/native-renderer-vehicle-pose-20260830-pr139.json`.
+
+This evidence proves only the read-only vehicle-instance transform boundary.
+It does not prove which identity is the player car or correlate any identity
+to a draw.
+
+Qualify a batched census with:
+
+```powershell
+.\tools\capture-native-renderer-census.ps1 `
+  -StateRoot $stateRoot `
+  -Scene open_world_day
+
+python .\tools\summarize-native-renderer-vehicle-pose.py `
+  $eventLog `
+  --output .local\qualification\native-renderer-vehicle-pose.json
+```

--- a/src/native_renderer/graphics_hooks.cpp
+++ b/src/native_renderer/graphics_hooks.cpp
@@ -100,6 +100,8 @@ constexpr uint64_t kSemanticVisibilityMaximumPolicyAgeFrames = 1;
 constexpr size_t kVisibilityShadowReplaySignatureCapacity = 256;
 constexpr size_t kVisibilityShadowReplaySignatureSummaryLimit = 16;
 constexpr uint64_t kVisibilityShadowReplayMaximumDrawsPerFrame = 1;
+constexpr size_t kVehicleIdentityCapacity = 64;
+constexpr size_t kVehicleIdentitySummaryLimit = kVehicleIdentityCapacity;
 constexpr size_t kSemanticInstanceCapacity = 4096;
 constexpr size_t kSemanticSubmissionCapacity = 8192;
 constexpr size_t kSemanticRenderItemStackCapacity = 32;
@@ -517,6 +519,40 @@ std::atomic<bool> g_title_provenance_installed{};
 std::atomic<rex::memory::Memory *> g_title_provenance_memory{};
 std::atomic<bool> g_command_buffer_lineage_installed{};
 std::atomic<rex::memory::Memory *> g_command_buffer_lineage_memory{};
+
+struct VehicleIdentityEntry {
+  uint64_t observations = 0;
+  uint64_t first_frame = 0;
+  uint64_t last_frame = 0;
+  uint64_t position_changes = 0;
+  uint64_t forward_changes = 0;
+  uint64_t stabilized_observations = 0;
+  uint64_t address_mismatches = 0;
+  double maximum_position_delta_squared = 0.0;
+  uint32_t generation = 0;
+  uint32_t source = 0;
+  uint32_t owner = 0;
+  uint32_t slot = 0;
+  uint32_t position_address = 0;
+  uint32_t forward_address = 0;
+  float last_x = 0.0f;
+  float last_y = 0.0f;
+  float last_z = 0.0f;
+  float last_forward_x = 0.0f;
+  float last_forward_y = 0.0f;
+  float last_forward_z = 0.0f;
+  bool valid = false;
+};
+
+std::array<VehicleIdentityEntry, kVehicleIdentityCapacity>
+    g_vehicle_identities{};
+std::mutex g_vehicle_identity_mutex;
+std::atomic<bool> g_vehicle_discovery_installed{};
+uint64_t g_vehicle_observations = 0;
+uint64_t g_vehicle_valid_observations = 0;
+uint64_t g_vehicle_invalid_observations = 0;
+uint64_t g_vehicle_identity_count = 0;
+uint64_t g_vehicle_identity_overflow = 0;
 uint64_t g_title_packets_recorded = 0;
 uint64_t g_title_packets_matched = 0;
 uint64_t g_title_packet_address_failures = 0;
@@ -14943,9 +14979,204 @@ void ObserveDraw(const rex::system::GraphicsDrawObservation &observation) {
   ++g_draw_census.overflow_draw_count;
 }
 
+void ConfigureVehicleDiscovery(bool census_requested) {
+  g_vehicle_discovery_installed.store(false, std::memory_order_release);
+  {
+    std::scoped_lock lock(g_vehicle_identity_mutex);
+    g_vehicle_identities = {};
+    g_vehicle_observations = 0;
+    g_vehicle_valid_observations = 0;
+    g_vehicle_invalid_observations = 0;
+    g_vehicle_identity_count = 0;
+    g_vehicle_identity_overflow = 0;
+  }
+  g_vehicle_discovery_installed.store(census_requested,
+                                      std::memory_order_release);
+  pinyon_shift::diagnostics::RecordEvent(
+      "native_renderer.discovery.vehicle_pose_config",
+      {{"status", census_requested ? "armed" : "disabled"},
+       {"hook", "82BC5A3C"},
+       {"identity", "title_generation,source,owner,active_slot"},
+       {"transform", "exact_active_slot_position_and_forward"},
+       {"capacity", std::to_string(kVehicleIdentityCapacity)},
+       {"summary_limit",
+        std::to_string(kVehicleIdentitySummaryLimit)},
+       {"classification", "unclassified_vehicle_pose_stream"},
+       {"player_priority_admitted", "false"},
+       {"guest_payload_read", "existing_title_pose_hook_values"},
+       {"guest_state_changed", "false"},
+       {"native_upload", "false"},
+       {"native_draw", "false"},
+       {"xenos_authority", "true"},
+       {"suppression_allowed", "false"}});
+}
+
+void EmitVehicleDiscoverySummary() {
+  if (!g_vehicle_discovery_installed.exchange(false,
+                                               std::memory_order_acq_rel)) {
+    return;
+  }
+  std::scoped_lock lock(g_vehicle_identity_mutex);
+  const bool accounting_complete =
+      g_vehicle_valid_observations + g_vehicle_invalid_observations ==
+      g_vehicle_observations;
+  pinyon_shift::diagnostics::RecordEvent(
+      "native_renderer.discovery.vehicle_pose_summary",
+      {{"status", !g_vehicle_observations
+                      ? "not_observed"
+                      : (accounting_complete ? "complete" : "incomplete")},
+       {"observations", std::to_string(g_vehicle_observations)},
+       {"valid_observations",
+        std::to_string(g_vehicle_valid_observations)},
+       {"invalid_observations",
+        std::to_string(g_vehicle_invalid_observations)},
+       {"identities", std::to_string(g_vehicle_identity_count)},
+       {"capacity", std::to_string(kVehicleIdentityCapacity)},
+       {"summary_limit",
+        std::to_string(kVehicleIdentitySummaryLimit)},
+       {"overflow", std::to_string(g_vehicle_identity_overflow)},
+       {"accounting_complete", accounting_complete ? "true" : "false"},
+       {"identity", "title_generation,source,owner,active_slot"},
+       {"transform", "exact_active_slot_position_and_forward"},
+       {"classification", "vehicle_instance_semantic_seed"},
+       {"player_priority_admitted", "false"},
+       {"guest_state_changed", "false"},
+       {"native_upload", "false"},
+       {"native_draw", "false"},
+       {"xenos_authority", "true"},
+       {"suppression_allowed", "false"}});
+  size_t emitted = 0;
+  for (const VehicleIdentityEntry &entry : g_vehicle_identities) {
+    if (!entry.valid || emitted >= kVehicleIdentitySummaryLimit) {
+      continue;
+    }
+    pinyon_shift::diagnostics::RecordEvent(
+        "native_renderer.discovery.vehicle_pose_identity",
+        {{"generation", fmt::format("{:08X}", entry.generation)},
+         {"source", fmt::format("{:08X}", entry.source)},
+         {"owner", fmt::format("{:08X}", entry.owner)},
+         {"slot", std::to_string(entry.slot)},
+         {"position_address",
+          fmt::format("{:08X}", entry.position_address)},
+         {"forward_address", fmt::format("{:08X}", entry.forward_address)},
+         {"observations", std::to_string(entry.observations)},
+         {"first_frame", std::to_string(entry.first_frame)},
+         {"last_frame", std::to_string(entry.last_frame)},
+         {"position_changes", std::to_string(entry.position_changes)},
+         {"forward_changes", std::to_string(entry.forward_changes)},
+         {"stabilized_observations",
+          std::to_string(entry.stabilized_observations)},
+         {"address_mismatches", std::to_string(entry.address_mismatches)},
+         {"maximum_position_delta_squared",
+          fmt::format("{}", entry.maximum_position_delta_squared)},
+         {"classification", "vehicle_instance_semantic_seed"},
+         {"player_priority_admitted", "false"},
+         {"native_draw", "false"},
+         {"xenos_authority", "true"},
+         {"suppression_allowed", "false"}});
+    ++emitted;
+  }
+}
+
 } // namespace
 
 namespace pinyon_shift::native_renderer {
+
+void ObserveVehiclePose(const VehiclePoseObservation &observation) {
+  if (!g_vehicle_discovery_installed.load(std::memory_order_acquire)) {
+    return;
+  }
+  const bool valid = observation.generation && observation.source &&
+                     observation.owner && observation.position_address &&
+                     observation.forward_address &&
+                     std::isfinite(observation.x) &&
+                     std::isfinite(observation.y) &&
+                     std::isfinite(observation.z) &&
+                     std::isfinite(observation.w) &&
+                     std::isfinite(observation.forward_x) &&
+                     std::isfinite(observation.forward_y) &&
+                     std::isfinite(observation.forward_z) &&
+                     std::isfinite(observation.forward_w);
+  std::scoped_lock lock(g_vehicle_identity_mutex);
+  if (!g_vehicle_discovery_installed.load(std::memory_order_acquire)) {
+    return;
+  }
+  ++g_vehicle_observations;
+  if (!valid) {
+    ++g_vehicle_invalid_observations;
+    return;
+  }
+  ++g_vehicle_valid_observations;
+  VehicleIdentityEntry *available = nullptr;
+  VehicleIdentityEntry *matched = nullptr;
+  for (VehicleIdentityEntry &entry : g_vehicle_identities) {
+    if (!entry.valid) {
+      if (!available) {
+        available = &entry;
+      }
+      continue;
+    }
+    if (entry.generation == observation.generation &&
+        entry.source == observation.source && entry.owner == observation.owner &&
+        entry.slot == observation.slot) {
+      matched = &entry;
+      break;
+    }
+  }
+  if (!matched) {
+    if (!available) {
+      ++g_vehicle_identity_overflow;
+      return;
+    }
+    matched = available;
+    matched->valid = true;
+    matched->generation = observation.generation;
+    matched->source = observation.source;
+    matched->owner = observation.owner;
+    matched->slot = observation.slot;
+    matched->position_address = observation.position_address;
+    matched->forward_address = observation.forward_address;
+    matched->first_frame = g_frame_sequence.load(std::memory_order_relaxed);
+    matched->last_x = observation.x;
+    matched->last_y = observation.y;
+    matched->last_z = observation.z;
+    matched->last_forward_x = observation.forward_x;
+    matched->last_forward_y = observation.forward_y;
+    matched->last_forward_z = observation.forward_z;
+    ++g_vehicle_identity_count;
+  } else {
+    const double delta_x = double(observation.x) - matched->last_x;
+    const double delta_y = double(observation.y) - matched->last_y;
+    const double delta_z = double(observation.z) - matched->last_z;
+    const double delta_squared =
+        delta_x * delta_x + delta_y * delta_y + delta_z * delta_z;
+    if (delta_squared != 0.0) {
+      ++matched->position_changes;
+      matched->maximum_position_delta_squared =
+          std::max(matched->maximum_position_delta_squared, delta_squared);
+    }
+    if (observation.forward_x != matched->last_forward_x ||
+        observation.forward_y != matched->last_forward_y ||
+        observation.forward_z != matched->last_forward_z) {
+      ++matched->forward_changes;
+    }
+    if (observation.position_address != matched->position_address ||
+        observation.forward_address != matched->forward_address) {
+      ++matched->address_mismatches;
+    }
+    matched->last_x = observation.x;
+    matched->last_y = observation.y;
+    matched->last_z = observation.z;
+    matched->last_forward_x = observation.forward_x;
+    matched->last_forward_y = observation.forward_y;
+    matched->last_forward_z = observation.forward_z;
+  }
+  ++matched->observations;
+  matched->last_frame = g_frame_sequence.load(std::memory_order_relaxed);
+  if (observation.presentation_stabilized) {
+    ++matched->stabilized_observations;
+  }
+}
 
 void InstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system,
                            rex::memory::Memory *memory) {
@@ -14958,6 +15189,7 @@ void InstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system,
       REXCVAR_GET(pinyon_shift_native_renderer_sky_horizon_suppression);
   const bool census_requested =
       REXCVAR_GET(pinyon_shift_native_renderer_census);
+  ConfigureVehicleDiscovery(census_requested);
   ConfigureTitleDrawProvenance(census_requested, memory);
   const bool lineage_armed = census_requested && memory;
   g_command_buffer_lineage_installed.store(false, std::memory_order_release);
@@ -15574,6 +15806,7 @@ void UninstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system) {
     graphics_system->SetDrawOutcomeObserver(nullptr);
     graphics_system->SetIsolatedDrawRequestObserver(nullptr);
   }
+  EmitVehicleDiscoverySummary();
   g_command_buffer_lineage_installed.store(false, std::memory_order_release);
   g_command_buffer_lineage_memory.store(nullptr, std::memory_order_release);
   EmitDispatchDiscoverySummary();

--- a/src/native_renderer/graphics_hooks.h
+++ b/src/native_renderer/graphics_hooks.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <cstdint>
+
 namespace rex::system {
 class IGraphicsSystem;
 }
@@ -8,6 +10,26 @@ class Memory;
 }
 
 namespace pinyon_shift::native_renderer {
+
+struct VehiclePoseObservation {
+  uint32_t generation = 0;
+  uint32_t source = 0;
+  uint32_t owner = 0;
+  uint32_t slot = 0;
+  uint32_t position_address = 0;
+  uint32_t forward_address = 0;
+  float x = 0.0f;
+  float y = 0.0f;
+  float z = 0.0f;
+  float w = 0.0f;
+  float forward_x = 0.0f;
+  float forward_y = 0.0f;
+  float forward_z = 0.0f;
+  float forward_w = 0.0f;
+  bool presentation_stabilized = false;
+};
+
+void ObserveVehiclePose(const VehiclePoseObservation& observation);
 
 void InstallGraphicsCensus(rex::system::IGraphicsSystem* graphics_system,
                            rex::memory::Memory* memory);

--- a/src/pinyon_shift_runtime_hooks.cpp
+++ b/src/pinyon_shift_runtime_hooks.cpp
@@ -18,6 +18,7 @@
 #include <rex/system/xmemory.h>
 
 #include "pinyon_shift_diagnostics.h"
+#include "native_renderer/graphics_hooks.h"
 
 REXCVAR_DEFINE_BOOL(pinyon_shift_skip_opening_movies, false, "Pinyon Shift",
                     "Complete XMedia-backed movies immediately");
@@ -492,6 +493,23 @@ void PinyonShiftTraceVehiclePose(PPCRegister& r1, PPCRegister& r30,
   if (suppressed) {
     StoreVehiclePose(position_address, forward_address, effective);
   }
+
+  pinyon_shift::native_renderer::ObserveVehiclePose(
+      {.generation = generation,
+       .source = r30.u32,
+       .owner = r31.u32,
+       .slot = slot,
+       .position_address = position_address,
+       .forward_address = forward_address,
+       .x = effective.x,
+       .y = effective.y,
+       .z = effective.z,
+       .w = effective.w,
+       .forward_x = effective.forward_x,
+       .forward_y = effective.forward_y,
+       .forward_z = effective.forward_z,
+       .forward_w = effective.forward_w,
+       .presentation_stabilized = suppressed});
 
   if (suppressed && FrameTelemetryEnabled()) {
     uint64_t previous_discontinuity_ms =

--- a/tools/summarize-native-renderer-vehicle-pose.py
+++ b/tools/summarize-native-renderer-vehicle-pose.py
@@ -1,0 +1,240 @@
+#!/usr/bin/env python3
+"""Qualify the read-only vehicle-instance semantic seed."""
+
+import argparse
+import json
+import math
+import pathlib
+import sys
+
+
+SCHEMA = "pinyon-shift.native-renderer-vehicle-pose.v1"
+CONFIG = "native_renderer.discovery.vehicle_pose_config"
+SUMMARY = "native_renderer.discovery.vehicle_pose_summary"
+IDENTITY = "native_renderer.discovery.vehicle_pose_identity"
+
+
+def read_events(paths):
+    events = []
+    for path in paths:
+        for line in path.read_text(encoding="utf-8").splitlines():
+            if line.strip():
+                events.append(json.loads(line))
+    return events
+
+
+def integer(mapping, key):
+    try:
+        value = int(mapping[key])
+    except (KeyError, TypeError, ValueError) as error:
+        raise ValueError(f"invalid {key}") from error
+    if value < 0:
+        raise ValueError(f"negative {key}")
+    return value
+
+
+def finite_number(mapping, key):
+    try:
+        value = float(mapping[key])
+    except (KeyError, TypeError, ValueError) as error:
+        raise ValueError(f"invalid {key}") from error
+    if not math.isfinite(value) or value < 0:
+        raise ValueError(f"invalid {key}")
+    return value
+
+
+def hexadecimal(mapping, key):
+    value = str(mapping.get(key, "")).upper()
+    if len(value) != 8:
+        raise ValueError(f"invalid {key}")
+    try:
+        parsed = int(value, 16)
+    except ValueError as error:
+        raise ValueError(f"invalid {key}") from error
+    if not parsed:
+        raise ValueError(f"zero {key}")
+    return value
+
+
+def exact(events, name):
+    matches = [event for event in events if event.get("event") == name]
+    if len(matches) != 1:
+        raise ValueError(f"expected exactly one {name}")
+    return matches[0]
+
+
+def build(events, requested_session=None):
+    sessions = {
+        event.get("session") for event in events if event.get("event") == CONFIG
+    }
+    sessions.discard(None)
+    if requested_session:
+        if requested_session not in sessions:
+            raise ValueError("requested session has no vehicle-pose config")
+        session = requested_session
+    elif len(sessions) == 1:
+        session = next(iter(sessions))
+    else:
+        raise ValueError("vehicle-pose input contains multiple sessions")
+    selected = [event for event in events if event.get("session") == session]
+    config = exact(selected, CONFIG)
+    summary = exact(selected, SUMMARY)
+    expected_config = {
+        "status": "armed",
+        "hook": "82BC5A3C",
+        "identity": "title_generation,source,owner,active_slot",
+        "transform": "exact_active_slot_position_and_forward",
+        "capacity": "64",
+        "summary_limit": "64",
+        "classification": "unclassified_vehicle_pose_stream",
+        "player_priority_admitted": "false",
+        "guest_payload_read": "existing_title_pose_hook_values",
+        "guest_state_changed": "false",
+        "native_upload": "false",
+        "native_draw": "false",
+        "xenos_authority": "true",
+        "suppression_allowed": "false",
+    }
+    if any(config.get(key) != value for key, value in expected_config.items()):
+        raise ValueError("vehicle-pose configuration drifted")
+    expected_summary = {
+        "status": "complete",
+        "accounting_complete": "true",
+        "identity": "title_generation,source,owner,active_slot",
+        "transform": "exact_active_slot_position_and_forward",
+        "classification": "vehicle_instance_semantic_seed",
+        "player_priority_admitted": "false",
+        "capacity": "64",
+        "summary_limit": "64",
+        "guest_state_changed": "false",
+        "native_upload": "false",
+        "native_draw": "false",
+        "xenos_authority": "true",
+        "suppression_allowed": "false",
+    }
+    if any(summary.get(key) != value for key, value in expected_summary.items()):
+        raise ValueError("vehicle-pose summary drifted")
+
+    totals = {
+        key: integer(summary, key)
+        for key in (
+            "observations",
+            "valid_observations",
+            "invalid_observations",
+            "identities",
+            "capacity",
+            "summary_limit",
+            "overflow",
+        )
+    }
+    identities = []
+    seen = set()
+    for event in selected:
+        if event.get("event") != IDENTITY:
+            continue
+        if (
+            event.get("classification") != "vehicle_instance_semantic_seed"
+            or event.get("player_priority_admitted") != "false"
+            or event.get("native_draw") != "false"
+            or event.get("xenos_authority") != "true"
+            or event.get("suppression_allowed") != "false"
+        ):
+            raise ValueError("vehicle identity violates safety boundary")
+        key = (
+            hexadecimal(event, "generation"),
+            hexadecimal(event, "source"),
+            hexadecimal(event, "owner"),
+            integer(event, "slot"),
+        )
+        if key in seen:
+            raise ValueError("duplicate vehicle identity")
+        seen.add(key)
+        first_frame = integer(event, "first_frame")
+        last_frame = integer(event, "last_frame")
+        if first_frame > last_frame:
+            raise ValueError("invalid vehicle frame range")
+        identities.append(
+            {
+                "generation": key[0],
+                "source": key[1],
+                "owner": key[2],
+                "slot": key[3],
+                "position_address": hexadecimal(event, "position_address"),
+                "forward_address": hexadecimal(event, "forward_address"),
+                "observations": integer(event, "observations"),
+                "first_frame": first_frame,
+                "last_frame": last_frame,
+                "position_changes": integer(event, "position_changes"),
+                "forward_changes": integer(event, "forward_changes"),
+                "stabilized_observations": integer(
+                    event, "stabilized_observations"
+                ),
+                "address_mismatches": integer(event, "address_mismatches"),
+                "maximum_position_delta_squared": finite_number(
+                    event, "maximum_position_delta_squared"
+                ),
+            }
+        )
+
+    failures = []
+    if totals["observations"] != (
+        totals["valid_observations"] + totals["invalid_observations"]
+    ):
+        failures.append("observation accounting drifted")
+    if not totals["observations"] or not totals["valid_observations"]:
+        failures.append("no valid vehicle-pose observation")
+    if totals["invalid_observations"]:
+        failures.append("invalid vehicle-pose observations occurred")
+    if totals["overflow"]:
+        failures.append("vehicle identity table overflowed")
+    if totals["identities"] > totals["summary_limit"]:
+        failures.append("vehicle identity evidence was truncated")
+    if len(identities) != totals["identities"]:
+        failures.append("vehicle identity coverage drifted")
+    if sum(item["observations"] for item in identities) != totals[
+        "valid_observations"
+    ]:
+        failures.append("identity observation accounting drifted")
+    if any(item["address_mismatches"] for item in identities):
+        failures.append("vehicle transform addresses changed")
+
+    return {
+        "schema": SCHEMA,
+        "session": session,
+        "status": "complete" if not failures else "incomplete",
+        "failures": failures,
+        "totals": totals,
+        "identities": identities,
+        "qualification": {
+            "vehicle_instance_semantic_seed_proved": not failures,
+            "player_vehicle_identity_proved": False,
+            "vehicle_draw_identity_proved": False,
+            "native_vehicle_rendering_admitted": False,
+            "suppression_allowed": False,
+        },
+    }
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser()
+    parser.add_argument("events", nargs="+", type=pathlib.Path)
+    parser.add_argument("--session")
+    parser.add_argument("--output", required=True, type=pathlib.Path)
+    args = parser.parse_args(argv)
+    try:
+        document = build(read_events(args.events), args.session)
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(
+            json.dumps(document, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        if document["status"] != "complete":
+            raise ValueError("; ".join(document["failures"]))
+        return 0
+    except (OSError, ValueError, json.JSONDecodeError) as error:
+        print(f"vehicle-pose summary failed: {error}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/tests/test_native_renderer_vehicle_pose.py
+++ b/tools/tests/test_native_renderer_vehicle_pose.py
@@ -1,0 +1,159 @@
+import copy
+import importlib.util
+import pathlib
+import unittest
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+TOOL = ROOT / "tools/summarize-native-renderer-vehicle-pose.py"
+SPEC = importlib.util.spec_from_file_location(
+    "summarize_native_renderer_vehicle_pose", TOOL
+)
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+def event(name, **values):
+    return {"event": name, "session": "session-1", **values}
+
+
+def fixture():
+    config = event(
+        MODULE.CONFIG,
+        status="armed",
+        hook="82BC5A3C",
+        identity="title_generation,source,owner,active_slot",
+        transform="exact_active_slot_position_and_forward",
+        capacity="64",
+        summary_limit="64",
+        classification="unclassified_vehicle_pose_stream",
+        player_priority_admitted="false",
+        guest_payload_read="existing_title_pose_hook_values",
+        guest_state_changed="false",
+        native_upload="false",
+        native_draw="false",
+        xenos_authority="true",
+        suppression_allowed="false",
+    )
+    summary = event(
+        MODULE.SUMMARY,
+        status="complete",
+        observations="10",
+        valid_observations="10",
+        invalid_observations="0",
+        identities="1",
+        capacity="64",
+        summary_limit="64",
+        overflow="0",
+        accounting_complete="true",
+        identity="title_generation,source,owner,active_slot",
+        transform="exact_active_slot_position_and_forward",
+        classification="vehicle_instance_semantic_seed",
+        player_priority_admitted="false",
+        guest_state_changed="false",
+        native_upload="false",
+        native_draw="false",
+        xenos_authority="true",
+        suppression_allowed="false",
+    )
+    identity = event(
+        MODULE.IDENTITY,
+        generation="00000001",
+        source="A0001000",
+        owner="A0002000",
+        slot="2",
+        position_address="A0003000",
+        forward_address="A0003040",
+        observations="10",
+        first_frame="100",
+        last_frame="109",
+        position_changes="9",
+        forward_changes="4",
+        stabilized_observations="0",
+        address_mismatches="0",
+        maximum_position_delta_squared="2.5",
+        classification="vehicle_instance_semantic_seed",
+        player_priority_admitted="false",
+        native_draw="false",
+        xenos_authority="true",
+        suppression_allowed="false",
+    )
+    return [config, summary, identity]
+
+
+class VehiclePoseSummaryTests(unittest.TestCase):
+    def test_runtime_hook_feeds_read_only_renderer_discovery(self):
+        runtime = (ROOT / "src/pinyon_shift_runtime_hooks.cpp").read_text(
+            encoding="utf-8"
+        )
+        hooks = (ROOT / "src/native_renderer/graphics_hooks.cpp").read_text(
+            encoding="utf-8"
+        )
+        header = (ROOT / "src/native_renderer/graphics_hooks.h").read_text(
+            encoding="utf-8"
+        )
+        self.assertIn("struct VehiclePoseObservation", header)
+        self.assertIn("ObserveVehiclePose", runtime)
+        self.assertIn(".presentation_stabilized = suppressed", runtime)
+        self.assertIn("ConfigureVehicleDiscovery(census_requested)", hooks)
+        self.assertIn("EmitVehicleDiscoverySummary()", hooks)
+        self.assertIn('"vehicle_instance_semantic_seed"', hooks)
+        self.assertIn('{"native_draw", "false"}', hooks)
+        self.assertIn('{"xenos_authority", "true"}', hooks)
+        self.assertIn('{"suppression_allowed", "false"}', hooks)
+
+    def test_qualifies_exact_vehicle_instance_seed(self):
+        document = MODULE.build(fixture())
+        self.assertEqual("complete", document["status"])
+        self.assertTrue(
+            document["qualification"]["vehicle_instance_semantic_seed_proved"]
+        )
+        self.assertFalse(
+            document["qualification"]["player_vehicle_identity_proved"]
+        )
+        self.assertFalse(
+            document["qualification"]["native_vehicle_rendering_admitted"]
+        )
+
+    def test_rejects_invalid_or_overflowed_observations(self):
+        events = fixture()
+        events[1]["invalid_observations"] = "1"
+        events[1]["valid_observations"] = "9"
+        events[2]["observations"] = "9"
+        document = MODULE.build(events)
+        self.assertEqual("incomplete", document["status"])
+        self.assertIn(
+            "invalid vehicle-pose observations occurred", document["failures"]
+        )
+
+        events = fixture()
+        events[1]["overflow"] = "1"
+        document = MODULE.build(events)
+        self.assertIn(
+            "vehicle identity table overflowed", document["failures"]
+        )
+
+    def test_rejects_address_or_safety_drift(self):
+        events = fixture()
+        events[2]["address_mismatches"] = "1"
+        document = MODULE.build(events)
+        self.assertIn(
+            "vehicle transform addresses changed", document["failures"]
+        )
+
+        unsafe = fixture()
+        unsafe[2]["suppression_allowed"] = "true"
+        with self.assertRaisesRegex(ValueError, "safety boundary"):
+            MODULE.build(unsafe)
+
+    def test_rejects_duplicate_identity(self):
+        events = fixture()
+        duplicate = copy.deepcopy(events[2])
+        events[1]["identities"] = "2"
+        events.append(duplicate)
+        with self.assertRaisesRegex(ValueError, "duplicate"):
+            MODULE.build(events)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- capture the shared title vehicle-pose stream as exact generation/source/owner/slot identities
- qualify stable per-instance position and forward-vector addresses without guest writes or native draws
- fail closed on invalid values, overflow, truncation, address drift, player classification, or suppression

## Runtime evidence
AppData-backed `open_world_day` session `20260830T083911Z-p9532` completed normally with 15,587 valid observations across 31 identities. Twenty identities changed position, all 31 changed forward vectors, and there were zero invalid observations, overflow, address mismatches, or error/fatal-like events.

This PR deliberately does not claim player-car identity, vehicle draw identity, native vehicle rendering, publication, or suppression. Xenos remains authoritative.

## Tests
- `python -m unittest discover -s tools/tests -p 'test_*.py'` (403 passed)
- `.\tools\build-preview.ps1 -Parallel 16`
- AppData-backed `open_world_day` vehicle-pose census and local qualifier