### PR TITLE
feat(renderer): correlate vehicle draw arguments

### DIFF
--- a/docs/native-renderer/VEHICLE_INSTANCE_SEMANTIC_SEED.md
+++ b/docs/native-renderer/VEHICLE_INSTANCE_SEMANTIC_SEED.md
@@ -105,6 +105,27 @@ bounded static call graph. This evidence further classifies slot 22 as a
 component update/presentation dispatcher; it does not prove a vehicle render
 method. Native vehicle rendering and suppression therefore remain closed.
 
+## Exact draw-argument correlation
+
+The next join checks every exact title/backend draw against the already
+captured vehicle owner, position, and forward-vector addresses. It covers the
+direct wrapper arguments and semantic receiver, descriptor, and runtime, plus
+the indirect constructor, owner, producer, context, context root, and semantic
+receiver lineage. Each candidate would retain the exact backend signature,
+provenance function and return address, argument index, vehicle identity, and
+frame span. A fixed address index and fixed 1,024-entry result table keep this
+discovery path bounded. No guest payload is read and no draw is changed.
+
+Release/AppData session `20260830T093251Z-p42128` completed normally at the
+festival with the player car visible. It examined 3,285,123 backend draws and
+83,516,951 populated provenance probes against 32 vehicle identities. It found
+zero exact owner or transform-address matches, with no invalid pose,
+owner-dispatch, overflow, stack-fault, error, or fatal event. This rejects the
+current direct and indirect dispatch arguments as an exact vehicle draw join.
+The render path must therefore be recovered from a deeper object/descriptor
+relationship or a different title submission family. Vehicle draw identity,
+native rendering, publication, and suppression remain unadmitted.
+
 Qualify a batched census with:
 
 ```powershell

--- a/src/native_renderer/graphics_hooks.cpp
+++ b/src/native_renderer/graphics_hooks.cpp
@@ -17,6 +17,7 @@
 #include <string>
 #include <thread>
 #include <type_traits>
+#include <utility>
 #include <vector>
 
 #include <fmt/format.h>
@@ -106,6 +107,8 @@ constexpr size_t kVehicleOwnerVtableMethodCount = 32;
 constexpr size_t kVehicleOwnerMethodCandidateCount = 3;
 constexpr size_t kVehicleOwnerMethodStackCapacity = 8;
 constexpr size_t kVehicleOwnerIndirectTargetCapacity = 64;
+constexpr size_t kVehicleIdentityAddressCapacity = 512;
+constexpr size_t kVehicleDrawCorrelationCapacity = 1024;
 constexpr size_t kSemanticInstanceCapacity = 4096;
 constexpr size_t kSemanticSubmissionCapacity = 8192;
 constexpr size_t kSemanticRenderItemStackCapacity = 32;
@@ -597,6 +600,60 @@ struct VehicleOwnerIndirectTargetEntry {
   bool valid = false;
 };
 
+enum class VehicleIdentityAddressKind : uint32_t {
+  kOwner = 1,
+  kPosition = 2,
+  kForward = 3,
+};
+
+enum class VehicleDrawProvenanceLayer : uint32_t {
+  kDirectArguments,
+  kSemanticReceiver,
+  kSemanticDescriptor,
+  kSemanticRuntime,
+  kIndirectConstructorArguments,
+  kIndirectOwnerArguments,
+  kIndirectProducerArguments,
+  kIndirectContextArguments,
+  kIndirectContextRoot,
+  kIndirectSemanticReceiver,
+};
+
+struct VehicleDrawArgumentProbe {
+  VehicleDrawProvenanceLayer layer =
+      VehicleDrawProvenanceLayer::kDirectArguments;
+  uint32_t function_address = 0;
+  uint32_t return_address = 0;
+  uint32_t argument_index = 0;
+  uint32_t value = 0;
+};
+
+struct VehicleDrawCorrelationEntry {
+  uint64_t backend_signature = 0;
+  uint64_t observations = 0;
+  uint64_t first_frame = 0;
+  uint64_t last_frame = 0;
+  VehicleDrawProvenanceLayer layer =
+      VehicleDrawProvenanceLayer::kDirectArguments;
+  VehicleIdentityAddressKind identity_field =
+      VehicleIdentityAddressKind::kOwner;
+  uint32_t function_address = 0;
+  uint32_t return_address = 0;
+  uint32_t argument_index = 0;
+  uint32_t matched_address = 0;
+  uint32_t identity_generation = 0;
+  uint32_t identity_owner = 0;
+  uint32_t identity_slot = 0;
+  bool valid = false;
+};
+
+struct VehicleIdentityAddressEntry {
+  uint32_t address = 0;
+  uint32_t identity_index = 0;
+  VehicleIdentityAddressKind field = VehicleIdentityAddressKind::kOwner;
+  bool valid = false;
+};
+
 std::array<VehicleIdentityEntry, kVehicleIdentityCapacity>
     g_vehicle_identities{};
 std::mutex g_vehicle_identity_mutex;
@@ -624,6 +681,18 @@ uint64_t g_vehicle_owner_indirect_valid_observations = 0;
 uint64_t g_vehicle_owner_indirect_invalid_observations = 0;
 uint64_t g_vehicle_owner_indirect_target_count = 0;
 uint64_t g_vehicle_owner_indirect_target_overflow = 0;
+std::array<VehicleIdentityAddressEntry, kVehicleIdentityAddressCapacity>
+    g_vehicle_identity_addresses{};
+uint64_t g_vehicle_identity_address_count = 0;
+uint64_t g_vehicle_identity_address_overflow = 0;
+std::array<VehicleDrawCorrelationEntry, kVehicleDrawCorrelationCapacity>
+    g_vehicle_draw_correlations{};
+std::mutex g_vehicle_draw_correlation_mutex;
+uint64_t g_vehicle_draws_examined = 0;
+uint64_t g_vehicle_draw_argument_probes = 0;
+uint64_t g_vehicle_draw_argument_matches = 0;
+uint64_t g_vehicle_draw_correlation_count = 0;
+uint64_t g_vehicle_draw_correlation_overflow = 0;
 uint64_t g_title_packets_recorded = 0;
 uint64_t g_title_packets_matched = 0;
 uint64_t g_title_packet_address_failures = 0;
@@ -1534,6 +1603,272 @@ const char *DrawOutcomeName(uint32_t outcome) {
 }
 
 std::string CensusSceneMarker();
+
+const char *VehicleIdentityAddressKindName(VehicleIdentityAddressKind kind) {
+  switch (kind) {
+  case VehicleIdentityAddressKind::kOwner:
+    return "owner";
+  case VehicleIdentityAddressKind::kPosition:
+    return "position";
+  case VehicleIdentityAddressKind::kForward:
+    return "forward";
+  }
+  return "unknown";
+}
+
+const char *VehicleDrawProvenanceLayerName(
+    VehicleDrawProvenanceLayer layer) {
+  switch (layer) {
+  case VehicleDrawProvenanceLayer::kDirectArguments:
+    return "direct_arguments";
+  case VehicleDrawProvenanceLayer::kSemanticReceiver:
+    return "semantic_receiver";
+  case VehicleDrawProvenanceLayer::kSemanticDescriptor:
+    return "semantic_descriptor";
+  case VehicleDrawProvenanceLayer::kSemanticRuntime:
+    return "semantic_runtime";
+  case VehicleDrawProvenanceLayer::kIndirectConstructorArguments:
+    return "indirect_constructor_arguments";
+  case VehicleDrawProvenanceLayer::kIndirectOwnerArguments:
+    return "indirect_owner_arguments";
+  case VehicleDrawProvenanceLayer::kIndirectProducerArguments:
+    return "indirect_producer_arguments";
+  case VehicleDrawProvenanceLayer::kIndirectContextArguments:
+    return "indirect_context_arguments";
+  case VehicleDrawProvenanceLayer::kIndirectContextRoot:
+    return "indirect_context_root";
+  case VehicleDrawProvenanceLayer::kIndirectSemanticReceiver:
+    return "indirect_semantic_receiver";
+  }
+  return "unknown";
+}
+
+void AppendVehicleDrawArgumentProbes(
+    std::array<VehicleDrawArgumentProbe, 48> &probes, size_t &probe_count,
+    VehicleDrawProvenanceLayer layer, uint32_t function_address,
+    uint32_t return_address, const std::array<uint32_t, 8> &arguments) {
+  for (size_t index = 0; index < arguments.size(); ++index) {
+    probes[probe_count++] = {
+        .layer = layer,
+        .function_address = function_address,
+        .return_address = return_address,
+        .argument_index = uint32_t(index),
+        .value = arguments[index],
+    };
+  }
+}
+
+void IndexVehicleIdentityAddressLocked(size_t identity_index,
+                                       VehicleIdentityAddressKind field,
+                                       uint32_t address) {
+  size_t index = (address >> 4) % kVehicleIdentityAddressCapacity;
+  for (size_t probe = 0; probe < kVehicleIdentityAddressCapacity; ++probe) {
+    VehicleIdentityAddressEntry &entry = g_vehicle_identity_addresses[index];
+    if (!entry.valid) {
+      entry = {
+          .address = address,
+          .identity_index = uint32_t(identity_index),
+          .field = field,
+          .valid = true,
+      };
+      ++g_vehicle_identity_address_count;
+      return;
+    }
+    if (entry.address == address && entry.identity_index == identity_index &&
+        entry.field == field) {
+      return;
+    }
+    index = (index + 1) % kVehicleIdentityAddressCapacity;
+  }
+  ++g_vehicle_identity_address_overflow;
+}
+
+void ObserveVehicleDrawArgumentCorrelations(
+    uint64_t backend_signature, uint64_t frame,
+    const TitleDrawOrigin &direct_origin,
+    const ActiveTitleIndirectBuffer *indirect_origin) {
+  if (!g_vehicle_discovery_installed.load(std::memory_order_acquire)) {
+    return;
+  }
+  std::array<VehicleDrawArgumentProbe, 48> probes{};
+  size_t probe_count = 0;
+  if (direct_origin.valid) {
+    AppendVehicleDrawArgumentProbes(
+        probes, probe_count, VehicleDrawProvenanceLayer::kDirectArguments,
+        direct_origin.caller, 0, direct_origin.arguments);
+    if (direct_origin.semantic_draw.valid) {
+      probes[probe_count++] = {
+          .layer = VehicleDrawProvenanceLayer::kSemanticReceiver,
+          .function_address = direct_origin.caller,
+          .argument_index = 8,
+          .value = direct_origin.semantic_draw.receiver_address,
+      };
+      probes[probe_count++] = {
+          .layer = VehicleDrawProvenanceLayer::kSemanticDescriptor,
+          .function_address = direct_origin.caller,
+          .argument_index = 8,
+          .value = direct_origin.semantic_draw.descriptor_address,
+      };
+      probes[probe_count++] = {
+          .layer = VehicleDrawProvenanceLayer::kSemanticRuntime,
+          .function_address = direct_origin.caller,
+          .argument_index = 8,
+          .value = direct_origin.semantic_draw.runtime_address,
+      };
+    }
+  }
+  if (indirect_origin) {
+    const IndirectConstructorOrigin &constructor =
+        indirect_origin->constructor_origin;
+    if (constructor.valid) {
+      AppendVehicleDrawArgumentProbes(
+          probes, probe_count,
+          VehicleDrawProvenanceLayer::kIndirectConstructorArguments,
+          constructor.function_address, constructor.return_address,
+          constructor.arguments);
+    }
+    if (constructor.owner.valid) {
+      AppendVehicleDrawArgumentProbes(
+          probes, probe_count,
+          VehicleDrawProvenanceLayer::kIndirectOwnerArguments,
+          constructor.owner.function_address, constructor.owner.return_address,
+          constructor.owner.arguments);
+    }
+    if (constructor.owner.producer.valid) {
+      AppendVehicleDrawArgumentProbes(
+          probes, probe_count,
+          VehicleDrawProvenanceLayer::kIndirectProducerArguments,
+          constructor.owner.producer.function_address,
+          constructor.owner.producer.return_address,
+          constructor.owner.producer.arguments);
+    }
+    const IndirectConstructorOrigin::Owner::Producer::Context &context =
+        constructor.owner.producer.context;
+    if (context.valid) {
+      AppendVehicleDrawArgumentProbes(
+          probes, probe_count,
+          VehicleDrawProvenanceLayer::kIndirectContextArguments,
+          context.function_address, context.return_address,
+          context.arguments);
+      probes[probe_count++] = {
+          .layer = VehicleDrawProvenanceLayer::kIndirectContextRoot,
+          .function_address = context.function_address,
+          .return_address = context.return_address,
+          .argument_index = 8,
+          .value = context.root_address,
+      };
+      if (context.semantic_receiver_known) {
+        probes[probe_count++] = {
+            .layer = VehicleDrawProvenanceLayer::kIndirectSemanticReceiver,
+            .function_address = context.function_address,
+            .return_address = context.return_address,
+            .argument_index = 8,
+            .value = context.semantic_receiver_address,
+        };
+      }
+    }
+  }
+
+  std::scoped_lock lock(g_vehicle_identity_mutex,
+                        g_vehicle_draw_correlation_mutex);
+  ++g_vehicle_draws_examined;
+  g_vehicle_draw_argument_probes += probe_count;
+  for (size_t probe_index = 0; probe_index < probe_count; ++probe_index) {
+    const VehicleDrawArgumentProbe &probe = probes[probe_index];
+    if (!probe.value) {
+      continue;
+    }
+    size_t address_index =
+        (probe.value >> 4) % kVehicleIdentityAddressCapacity;
+    for (size_t address_probe = 0;
+         address_probe < kVehicleIdentityAddressCapacity; ++address_probe) {
+      const VehicleIdentityAddressEntry &address_entry =
+          g_vehicle_identity_addresses[address_index];
+      if (!address_entry.valid) {
+        break;
+      }
+      if (address_entry.address == probe.value &&
+          address_entry.identity_index < g_vehicle_identities.size()) {
+        const VehicleIdentityEntry &identity =
+            g_vehicle_identities[address_entry.identity_index];
+        const VehicleIdentityAddressKind identity_field = address_entry.field;
+        const uint32_t identity_address = address_entry.address;
+        if (!identity.valid) {
+          address_index =
+              (address_index + 1) % kVehicleIdentityAddressCapacity;
+          continue;
+        }
+        ++g_vehicle_draw_argument_matches;
+        VehicleDrawCorrelationEntry *available = nullptr;
+        for (VehicleDrawCorrelationEntry &entry :
+             g_vehicle_draw_correlations) {
+          if (!entry.valid) {
+            if (!available) {
+              available = &entry;
+            }
+            continue;
+          }
+          if (entry.backend_signature == backend_signature &&
+              entry.layer == probe.layer &&
+              entry.identity_field == identity_field &&
+              entry.function_address == probe.function_address &&
+              entry.return_address == probe.return_address &&
+              entry.argument_index == probe.argument_index &&
+              entry.identity_generation == identity.generation &&
+              entry.identity_owner == identity.owner &&
+              entry.identity_slot == identity.slot) {
+            ++entry.observations;
+            entry.last_frame = frame;
+            available = nullptr;
+            break;
+          }
+        }
+        if (!available) {
+          bool existing = false;
+          for (const VehicleDrawCorrelationEntry &entry :
+               g_vehicle_draw_correlations) {
+            if (entry.valid && entry.backend_signature == backend_signature &&
+                entry.layer == probe.layer &&
+                entry.identity_field == identity_field &&
+                entry.function_address == probe.function_address &&
+                entry.return_address == probe.return_address &&
+                entry.argument_index == probe.argument_index &&
+                entry.identity_generation == identity.generation &&
+                entry.identity_owner == identity.owner &&
+                entry.identity_slot == identity.slot) {
+              existing = true;
+              break;
+            }
+          }
+          if (existing) {
+            continue;
+          }
+          ++g_vehicle_draw_correlation_overflow;
+          continue;
+        }
+        *available = {
+            .backend_signature = backend_signature,
+            .observations = 1,
+            .first_frame = frame,
+            .last_frame = frame,
+            .layer = probe.layer,
+            .identity_field = identity_field,
+            .function_address = probe.function_address,
+            .return_address = probe.return_address,
+            .argument_index = probe.argument_index,
+            .matched_address = identity_address,
+            .identity_generation = identity.generation,
+            .identity_owner = identity.owner,
+            .identity_slot = identity.slot,
+            .valid = true,
+        };
+        ++g_vehicle_draw_correlation_count;
+      }
+      address_index =
+          (address_index + 1) % kVehicleIdentityAddressCapacity;
+    }
+  }
+}
 
 size_t VehicleOwnerMethodCandidateIndex(uint32_t method_address) {
   for (size_t index = 0; index < kVehicleOwnerMethodCandidates.size();
@@ -15029,6 +15364,14 @@ void ObserveDraw(const rex::system::GraphicsDrawObservation &observation) {
   candidate.sample = observation;
   ConsumeTitleDrawPacket(observation.packet_physical_address,
                          candidate.title_origin);
+  const uint64_t signature = DrawSignature(observation);
+  const ActiveTitleIndirectBuffer *vehicle_indirect_origin =
+      observation.command_buffer_depth
+          ? CurrentTitleIndirectBuffer(observation)
+          : nullptr;
+  ObserveVehicleDrawArgumentCorrelations(
+      signature, observation.frame_sequence, candidate.title_origin,
+      vehicle_indirect_origin);
   for (uint32_t fetch_index = 0; fetch_index < 32; ++fetch_index) {
     if (!(observation.texture_fetch_mask & (uint32_t(1) << fetch_index))) {
       continue;
@@ -15074,7 +15417,6 @@ void ObserveDraw(const rex::system::GraphicsDrawObservation &observation) {
   candidate.samples_resolved_target = samples_resolved_target;
   g_pending_candidate = candidate;
   g_pending_candidate.valid = true;
-  const uint64_t signature = DrawSignature(observation);
   size_t index = size_t(signature % kSignatureCapacity);
   for (size_t probe = 0; probe < kSignatureCapacity; ++probe) {
     DrawSignatureEntry &entry = g_draw_census.entries[index];
@@ -15110,6 +15452,9 @@ void ConfigureVehicleDiscovery(bool census_requested,
     g_vehicle_invalid_observations = 0;
     g_vehicle_identity_count = 0;
     g_vehicle_identity_overflow = 0;
+    g_vehicle_identity_addresses = {};
+    g_vehicle_identity_address_count = 0;
+    g_vehicle_identity_address_overflow = 0;
   }
   for (VehicleOwnerMethodStats &stats : g_vehicle_owner_method_stats) {
     stats.calls.store(0, std::memory_order_relaxed);
@@ -15130,6 +15475,15 @@ void ConfigureVehicleDiscovery(bool census_requested,
     g_vehicle_owner_indirect_invalid_observations = 0;
     g_vehicle_owner_indirect_target_count = 0;
     g_vehicle_owner_indirect_target_overflow = 0;
+  }
+  {
+    std::scoped_lock lock(g_vehicle_draw_correlation_mutex);
+    g_vehicle_draw_correlations = {};
+    g_vehicle_draws_examined = 0;
+    g_vehicle_draw_argument_probes = 0;
+    g_vehicle_draw_argument_matches = 0;
+    g_vehicle_draw_correlation_count = 0;
+    g_vehicle_draw_correlation_overflow = 0;
   }
   g_vehicle_discovery_memory.store(census_requested ? memory : nullptr,
                                    std::memory_order_release);
@@ -15156,6 +15510,12 @@ void ConfigureVehicleDiscovery(bool census_requested,
         "82BC8468,82BC84A4,82BC84DC,82BC8688,82BC86BC,82BC86E4"},
        {"owner_indirect_target_capacity",
         std::to_string(kVehicleOwnerIndirectTargetCapacity)},
+       {"draw_correlation_capacity",
+        std::to_string(kVehicleDrawCorrelationCapacity)},
+       {"identity_address_capacity",
+        std::to_string(kVehicleIdentityAddressCapacity)},
+       {"draw_correlation",
+        "exact_backend_signature_and_provenance_argument_to_vehicle_address"},
        {"guest_payload_read",
         "existing_title_pose_hook_values_and_bounded_owner_vtable"},
        {"guest_state_changed", "false"},
@@ -15171,7 +15531,8 @@ void EmitVehicleDiscoverySummary() {
     return;
   }
   std::scoped_lock lock(g_vehicle_identity_mutex,
-                        g_vehicle_owner_indirect_mutex);
+                        g_vehicle_owner_indirect_mutex,
+                        g_vehicle_draw_correlation_mutex);
   const bool accounting_complete =
       g_vehicle_valid_observations + g_vehicle_invalid_observations ==
       g_vehicle_observations;
@@ -15214,6 +15575,23 @@ void EmitVehicleDiscoverySummary() {
         std::to_string(kVehicleOwnerIndirectTargetCapacity)},
        {"owner_indirect_target_overflow",
         std::to_string(g_vehicle_owner_indirect_target_overflow)},
+       {"draws_examined", std::to_string(g_vehicle_draws_examined)},
+       {"draw_argument_probes",
+        std::to_string(g_vehicle_draw_argument_probes)},
+       {"draw_argument_matches",
+        std::to_string(g_vehicle_draw_argument_matches)},
+       {"draw_correlations",
+        std::to_string(g_vehicle_draw_correlation_count)},
+       {"draw_correlation_capacity",
+        std::to_string(kVehicleDrawCorrelationCapacity)},
+       {"draw_correlation_overflow",
+        std::to_string(g_vehicle_draw_correlation_overflow)},
+       {"identity_addresses",
+        std::to_string(g_vehicle_identity_address_count)},
+       {"identity_address_capacity",
+        std::to_string(kVehicleIdentityAddressCapacity)},
+       {"identity_address_overflow",
+        std::to_string(g_vehicle_identity_address_overflow)},
        {"guest_state_changed", "false"},
        {"native_upload", "false"},
        {"native_draw", "false"},
@@ -15307,6 +15685,38 @@ void EmitVehicleDiscoverySummary() {
          {"last_frame", std::to_string(entry.last_frame)},
          {"classification", "vehicle_owner_component_dispatch_seed"},
          {"vehicle_render_method_identity_proved", "false"},
+         {"vehicle_draw_identity_proved", "false"},
+         {"guest_state_changed", "false"},
+         {"native_draw", "false"},
+         {"xenos_authority", "true"},
+         {"suppression_allowed", "false"}});
+  }
+  for (const VehicleDrawCorrelationEntry &entry :
+       g_vehicle_draw_correlations) {
+    if (!entry.valid) {
+      continue;
+    }
+    pinyon_shift::diagnostics::RecordEvent(
+        "native_renderer.discovery.vehicle_draw_argument_correlation",
+        {{"backend_signature",
+          fmt::format("{:016X}", entry.backend_signature)},
+         {"provenance_layer",
+          VehicleDrawProvenanceLayerName(entry.layer)},
+         {"function_address",
+          fmt::format("{:08X}", entry.function_address)},
+         {"return_address", fmt::format("{:08X}", entry.return_address)},
+         {"argument_index", std::to_string(entry.argument_index)},
+         {"identity_field",
+          VehicleIdentityAddressKindName(entry.identity_field)},
+         {"matched_address", fmt::format("{:08X}", entry.matched_address)},
+         {"identity_generation",
+          fmt::format("{:08X}", entry.identity_generation)},
+         {"identity_owner", fmt::format("{:08X}", entry.identity_owner)},
+         {"identity_slot", std::to_string(entry.identity_slot)},
+         {"observations", std::to_string(entry.observations)},
+         {"first_frame", std::to_string(entry.first_frame)},
+         {"last_frame", std::to_string(entry.last_frame)},
+         {"classification", "vehicle_draw_argument_correlation_candidate"},
          {"vehicle_draw_identity_proved", "false"},
          {"guest_state_changed", "false"},
          {"native_draw", "false"},
@@ -15538,6 +15948,17 @@ void ObserveVehiclePose(const VehiclePoseObservation &observation) {
                            matched->owner_vtable_methods);
     matched->owner_vtable_hash =
         HashSemanticWords(matched->owner_vtable_methods);
+    const size_t identity_index =
+        size_t(matched - g_vehicle_identities.data());
+    IndexVehicleIdentityAddressLocked(identity_index,
+                                      VehicleIdentityAddressKind::kOwner,
+                                      matched->owner);
+    IndexVehicleIdentityAddressLocked(identity_index,
+                                      VehicleIdentityAddressKind::kPosition,
+                                      matched->position_address);
+    IndexVehicleIdentityAddressLocked(identity_index,
+                                      VehicleIdentityAddressKind::kForward,
+                                      matched->forward_address);
     ++g_vehicle_identity_count;
   } else {
     const double delta_x = double(observation.x) - matched->last_x;

--- a/tools/summarize-native-renderer-vehicle-pose.py
+++ b/tools/summarize-native-renderer-vehicle-pose.py
@@ -16,6 +16,9 @@ OWNER_METHOD = "native_renderer.discovery.vehicle_owner_method"
 OWNER_INDIRECT_TARGET = (
     "native_renderer.discovery.vehicle_owner_indirect_target"
 )
+DRAW_ARGUMENT_CORRELATION = (
+    "native_renderer.discovery.vehicle_draw_argument_correlation"
+)
 OWNER_METHOD_CANDIDATES = {
     "82BCC368": (14, "82BCCD30"),
     "82BD2DE0": (20, "82BD35B0"),
@@ -29,6 +32,19 @@ OWNER_INDIRECT_CALLSITES = {
     "82BC86BC",
     "82BC86E4",
 }
+DRAW_PROVENANCE_LAYERS = {
+    "direct_arguments",
+    "semantic_receiver",
+    "semantic_descriptor",
+    "semantic_runtime",
+    "indirect_constructor_arguments",
+    "indirect_owner_arguments",
+    "indirect_producer_arguments",
+    "indirect_context_arguments",
+    "indirect_context_root",
+    "indirect_semantic_receiver",
+}
+DRAW_IDENTITY_FIELDS = {"owner", "position", "forward"}
 
 
 def read_events(paths):
@@ -86,6 +102,17 @@ def hexadecimal64(mapping, key):
     return value
 
 
+def hexadecimal_allow_zero(mapping, key):
+    value = str(mapping.get(key, "")).upper()
+    if len(value) != 8:
+        raise ValueError(f"invalid {key}")
+    try:
+        int(value, 16)
+    except ValueError as error:
+        raise ValueError(f"invalid {key}") from error
+    return value
+
+
 def hexadecimal_words(mapping, key, expected_count):
     values = str(mapping.get(key, "")).upper().split(",")
     if len(values) != expected_count:
@@ -140,6 +167,11 @@ def build(events, requested_session=None):
             "82BC8468,82BC84A4,82BC84DC,82BC8688,82BC86BC,82BC86E4"
         ),
         "owner_indirect_target_capacity": "64",
+        "draw_correlation_capacity": "1024",
+        "identity_address_capacity": "512",
+        "draw_correlation": (
+            "exact_backend_signature_and_provenance_argument_to_vehicle_address"
+        ),
         "guest_payload_read": (
             "existing_title_pose_hook_values_and_bounded_owner_vtable"
         ),
@@ -163,6 +195,8 @@ def build(events, requested_session=None):
         "owner_method_exit_hooks": "82BCCD30,82BD35B0,82BC86F0",
         "capacity": "64",
         "summary_limit": "64",
+        "draw_correlation_capacity": "1024",
+        "identity_address_capacity": "512",
         "guest_state_changed": "false",
         "native_upload": "false",
         "native_draw": "false",
@@ -194,6 +228,15 @@ def build(events, requested_session=None):
         "owner_indirect_targets",
         "owner_indirect_target_capacity",
         "owner_indirect_target_overflow",
+        "draws_examined",
+        "draw_argument_probes",
+        "draw_argument_matches",
+        "draw_correlations",
+        "draw_correlation_capacity",
+        "draw_correlation_overflow",
+        "identity_addresses",
+        "identity_address_capacity",
+        "identity_address_overflow",
     ):
         totals[key] = integer(summary, key)
     identities = []
@@ -382,6 +425,90 @@ def build(events, requested_session=None):
         )
     )
 
+    identities_by_key = {
+        (item["generation"], item["owner"], item["slot"]): item
+        for item in identities
+    }
+    draw_correlations = []
+    seen_draw_correlations = set()
+    for event in selected:
+        if event.get("event") != DRAW_ARGUMENT_CORRELATION:
+            continue
+        layer = str(event.get("provenance_layer", ""))
+        identity_field = str(event.get("identity_field", ""))
+        identity_key = (
+            hexadecimal(event, "identity_generation"),
+            hexadecimal(event, "identity_owner"),
+            integer(event, "identity_slot"),
+        )
+        identity = identities_by_key.get(identity_key)
+        matched_address = hexadecimal(event, "matched_address")
+        if identity and identity_field in ("position", "forward"):
+            expected_address = identity.get(f"{identity_field}_address")
+        elif identity and identity_field == "owner":
+            expected_address = identity_key[1]
+        else:
+            expected_address = None
+        key = (
+            hexadecimal64(event, "backend_signature"),
+            layer,
+            hexadecimal_allow_zero(event, "function_address"),
+            hexadecimal_allow_zero(event, "return_address"),
+            integer(event, "argument_index"),
+            identity_field,
+            matched_address,
+            identity_key,
+        )
+        if (
+            key in seen_draw_correlations
+            or layer not in DRAW_PROVENANCE_LAYERS
+            or identity_field not in DRAW_IDENTITY_FIELDS
+            or identity is None
+            or matched_address != expected_address
+            or key[4] > 8
+            or event.get("classification")
+            != "vehicle_draw_argument_correlation_candidate"
+            or event.get("vehicle_draw_identity_proved") != "false"
+            or event.get("guest_state_changed") != "false"
+            or event.get("native_draw") != "false"
+            or event.get("xenos_authority") != "true"
+            or event.get("suppression_allowed") != "false"
+        ):
+            raise ValueError("vehicle draw correlation violates boundary")
+        seen_draw_correlations.add(key)
+        first_frame = integer(event, "first_frame")
+        last_frame = integer(event, "last_frame")
+        if first_frame > last_frame:
+            raise ValueError("invalid vehicle draw correlation frame range")
+        draw_correlations.append(
+            {
+                "backend_signature": key[0],
+                "provenance_layer": layer,
+                "function_address": key[2],
+                "return_address": key[3],
+                "argument_index": key[4],
+                "identity_field": identity_field,
+                "matched_address": matched_address,
+                "identity_generation": identity_key[0],
+                "identity_owner": identity_key[1],
+                "identity_slot": identity_key[2],
+                "observations": integer(event, "observations"),
+                "first_frame": first_frame,
+                "last_frame": last_frame,
+            }
+        )
+    draw_correlations.sort(
+        key=lambda item: (
+            item["backend_signature"],
+            item["provenance_layer"],
+            item["function_address"],
+            item["return_address"],
+            item["argument_index"],
+            item["identity_owner"],
+            item["identity_slot"],
+        )
+    )
+
     failures = []
     if totals["observations"] != (
         totals["valid_observations"] + totals["invalid_observations"]
@@ -426,6 +553,22 @@ def build(events, requested_session=None):
         "owner_indirect_valid_observations"
     ]:
         failures.append("vehicle owner indirect target totals drifted")
+    if not totals["draws_examined"] or not totals["draw_argument_probes"]:
+        failures.append("no title draw arguments were examined")
+    if totals["draw_argument_matches"] != sum(
+        item["observations"] for item in draw_correlations
+    ):
+        failures.append("vehicle draw correlation observation accounting drifted")
+    if len(draw_correlations) != totals["draw_correlations"]:
+        failures.append("vehicle draw correlation coverage drifted")
+    if totals["draw_correlation_overflow"]:
+        failures.append("vehicle draw correlation table overflowed")
+    if totals["identity_address_overflow"]:
+        failures.append("vehicle identity address index overflowed")
+    if totals["identity_addresses"] != totals["identities"] * 3:
+        failures.append("vehicle identity address index coverage drifted")
+    if totals["draw_correlations"] > totals["draw_correlation_capacity"]:
+        failures.append("vehicle draw correlation capacity drifted")
     for method in method_correlations:
         if method["status"] != "complete" or method["calls"] != method["exits"]:
             failures.append(
@@ -444,6 +587,7 @@ def build(events, requested_session=None):
         item["vehicle_render_method_candidate_proved"]
         for item in method_correlations
     )
+    draw_argument_candidate_proved = bool(draw_correlations)
 
     return {
         "schema": SCHEMA,
@@ -455,6 +599,7 @@ def build(events, requested_session=None):
         "owner_classes": owner_classes,
         "method_correlations": method_correlations,
         "indirect_targets": indirect_targets,
+        "draw_argument_correlations": draw_correlations,
         "qualification": {
             "vehicle_instance_semantic_seed_proved": not failures,
             "vehicle_owner_class_seed_proved": not failures,
@@ -463,6 +608,9 @@ def build(events, requested_session=None):
             ),
             "player_vehicle_identity_proved": False,
             "vehicle_draw_identity_proved": False,
+            "vehicle_draw_argument_candidate_proved": (
+                not failures and draw_argument_candidate_proved
+            ),
             "native_vehicle_rendering_admitted": False,
             "suppression_allowed": False,
         },

--- a/tools/tests/test_native_renderer_vehicle_pose.py
+++ b/tools/tests/test_native_renderer_vehicle_pose.py
@@ -37,6 +37,11 @@ def fixture():
             "82BC8468,82BC84A4,82BC84DC,82BC8688,82BC86BC,82BC86E4"
         ),
         owner_indirect_target_capacity="64",
+        draw_correlation_capacity="1024",
+        identity_address_capacity="512",
+        draw_correlation=(
+            "exact_backend_signature_and_provenance_argument_to_vehicle_address"
+        ),
         guest_payload_read=(
             "existing_title_pose_hook_values_and_bounded_owner_vtable"
         ),
@@ -71,6 +76,15 @@ def fixture():
         owner_indirect_targets="0",
         owner_indirect_target_capacity="64",
         owner_indirect_target_overflow="0",
+        draws_examined="4",
+        draw_argument_probes="32",
+        draw_argument_matches="0",
+        draw_correlations="0",
+        draw_correlation_capacity="1024",
+        draw_correlation_overflow="0",
+        identity_addresses="3",
+        identity_address_capacity="512",
+        identity_address_overflow="0",
         guest_state_changed="false",
         native_upload="false",
         native_draw="false",
@@ -160,6 +174,11 @@ class VehiclePoseSummaryTests(unittest.TestCase):
         self.assertIn("ObserveVehicleOwnerIndirectCall", hooks)
         self.assertIn(
             '"native_renderer.discovery.vehicle_owner_indirect_target"',
+            hooks,
+        )
+        self.assertIn("ObserveVehicleDrawArgumentCorrelations", hooks)
+        self.assertIn(
+            '"native_renderer.discovery.vehicle_draw_argument_correlation"',
             hooks,
         )
         for address in (
@@ -296,6 +315,57 @@ class VehiclePoseSummaryTests(unittest.TestCase):
         )
         self.assertFalse(
             document["qualification"]["vehicle_draw_identity_proved"]
+        )
+
+    def test_qualifies_draw_argument_match_as_candidate_only(self):
+        events = fixture()
+        events[1]["draw_argument_matches"] = "3"
+        events[1]["draw_correlations"] = "1"
+        events.append(
+            event(
+                MODULE.DRAW_ARGUMENT_CORRELATION,
+                backend_signature="0123456789ABCDEF",
+                provenance_layer="indirect_owner_arguments",
+                function_address="82409668",
+                return_address="8240D1B0",
+                argument_index="3",
+                identity_field="owner",
+                matched_address="A0002000",
+                identity_generation="00000001",
+                identity_owner="A0002000",
+                identity_slot="2",
+                observations="3",
+                first_frame="102",
+                last_frame="104",
+                classification="vehicle_draw_argument_correlation_candidate",
+                vehicle_draw_identity_proved="false",
+                guest_state_changed="false",
+                native_draw="false",
+                xenos_authority="true",
+                suppression_allowed="false",
+            )
+        )
+        document = MODULE.build(events)
+        self.assertEqual("complete", document["status"])
+        self.assertEqual(1, len(document["draw_argument_correlations"]))
+        self.assertTrue(
+            document["qualification"][
+                "vehicle_draw_argument_candidate_proved"
+            ]
+        )
+        self.assertFalse(
+            document["qualification"]["vehicle_draw_identity_proved"]
+        )
+        self.assertFalse(
+            document["qualification"]["native_vehicle_rendering_admitted"]
+        )
+
+    def test_rejects_draw_argument_correlation_overflow(self):
+        events = fixture()
+        events[1]["draw_correlation_overflow"] = "1"
+        document = MODULE.build(events)
+        self.assertIn(
+            "vehicle draw correlation table overflowed", document["failures"]
         )
 
 


### PR DESCRIPTION
## Summary
- join direct, semantic, and indirect title provenance arguments to exact vehicle identity addresses
- key every candidate by exact backend signature and vehicle instance
- use fixed address/result tables and keep all native publication gates closed

## Evidence
- release/AppData session `20260830T093251Z-p42128` exited normally with the player car visible
- examined 3,285,123 backend draws and 83,516,951 provenance probes
- found zero exact owner/position/forward matches, ruling out current dispatch arguments
- zero invalid observations, overflow, stack faults, error events, or fatal events

## Tests
- `python -m unittest discover -s tools/tests -p 'test_*.py'` (413 passed)
- incremental release build
- AppData-backed festival run