### PR TITLE
feat(renderer): trace vehicle object lineage

### DIFF
--- a/docs/native-renderer/VEHICLE_INSTANCE_SEMANTIC_SEED.md
+++ b/docs/native-renderer/VEHICLE_INSTANCE_SEMANTIC_SEED.md
@@ -126,6 +126,22 @@ The render path must therefore be recovered from a deeper object/descriptor
 relationship or a different title submission family. Vehicle draw identity,
 native rendering, publication, and suppression remain unadmitted.
 
+The follow-up samples a single bounded relationship edge from object-like
+dispatch roots: direct and indirect r3, semantic receiver/descriptor/runtime,
+and indirect context roots. Each unique backend-signature, root, and 300-frame
+window scans only the first 128 words (512 bytes), with a fixed 16,384-entry
+cache and 2,048-entry correlation table.
+
+Release/AppData session `20260830T094228Z-p1080` completed normally and
+examined 2,282,451 backend draws. It reduced 7,424,713 eligible requests to
+5,992 unique object scans (766,976 words) across 31 vehicle identities and
+found zero embedded owner, position, or forward-vector addresses. The cache,
+identity index, and correlation table did not overflow, and no invalid pose,
+stack-fault, error, or fatal event occurred. This rejects the first 512 bytes
+of every current object-like provenance root as a one-hop vehicle join. The
+next search must follow typed descriptor graph edges or locate another title
+submission family; native vehicle drawing and suppression remain closed.
+
 Qualify a batched census with:
 
 ```powershell

--- a/src/native_renderer/graphics_hooks.cpp
+++ b/src/native_renderer/graphics_hooks.cpp
@@ -109,6 +109,9 @@ constexpr size_t kVehicleOwnerMethodStackCapacity = 8;
 constexpr size_t kVehicleOwnerIndirectTargetCapacity = 64;
 constexpr size_t kVehicleIdentityAddressCapacity = 512;
 constexpr size_t kVehicleDrawCorrelationCapacity = 1024;
+constexpr size_t kVehicleObjectScanWordCount = 128;
+constexpr size_t kVehicleObjectScanCacheCapacity = 16384;
+constexpr size_t kVehicleObjectCorrelationCapacity = 2048;
 constexpr size_t kSemanticInstanceCapacity = 4096;
 constexpr size_t kSemanticSubmissionCapacity = 8192;
 constexpr size_t kSemanticRenderItemStackCapacity = 32;
@@ -654,6 +657,39 @@ struct VehicleIdentityAddressEntry {
   bool valid = false;
 };
 
+struct VehicleObjectScanCacheEntry {
+  uint64_t backend_signature = 0;
+  uint64_t frame_window = 0;
+  VehicleDrawProvenanceLayer layer =
+      VehicleDrawProvenanceLayer::kDirectArguments;
+  uint32_t function_address = 0;
+  uint32_t return_address = 0;
+  uint32_t argument_index = 0;
+  uint32_t container_address = 0;
+  bool valid = false;
+};
+
+struct VehicleObjectCorrelationEntry {
+  uint64_t backend_signature = 0;
+  uint64_t observations = 0;
+  uint64_t first_frame = 0;
+  uint64_t last_frame = 0;
+  VehicleDrawProvenanceLayer layer =
+      VehicleDrawProvenanceLayer::kDirectArguments;
+  VehicleIdentityAddressKind identity_field =
+      VehicleIdentityAddressKind::kOwner;
+  uint32_t function_address = 0;
+  uint32_t return_address = 0;
+  uint32_t argument_index = 0;
+  uint32_t container_address = 0;
+  uint32_t pointer_offset = 0;
+  uint32_t matched_address = 0;
+  uint32_t identity_generation = 0;
+  uint32_t identity_owner = 0;
+  uint32_t identity_slot = 0;
+  bool valid = false;
+};
+
 std::array<VehicleIdentityEntry, kVehicleIdentityCapacity>
     g_vehicle_identities{};
 std::mutex g_vehicle_identity_mutex;
@@ -693,6 +729,18 @@ uint64_t g_vehicle_draw_argument_probes = 0;
 uint64_t g_vehicle_draw_argument_matches = 0;
 uint64_t g_vehicle_draw_correlation_count = 0;
 uint64_t g_vehicle_draw_correlation_overflow = 0;
+std::array<VehicleObjectScanCacheEntry, kVehicleObjectScanCacheCapacity>
+    g_vehicle_object_scan_cache{};
+std::array<VehicleObjectCorrelationEntry, kVehicleObjectCorrelationCapacity>
+    g_vehicle_object_correlations{};
+uint64_t g_vehicle_object_scan_requests = 0;
+uint64_t g_vehicle_object_scans = 0;
+uint64_t g_vehicle_object_scan_words = 0;
+uint64_t g_vehicle_object_scan_cache_count = 0;
+uint64_t g_vehicle_object_scan_cache_overflow = 0;
+uint64_t g_vehicle_object_argument_matches = 0;
+uint64_t g_vehicle_object_correlation_count = 0;
+uint64_t g_vehicle_object_correlation_overflow = 0;
 uint64_t g_title_packets_recorded = 0;
 uint64_t g_title_packets_matched = 0;
 uint64_t g_title_packet_address_failures = 0;
@@ -1603,6 +1651,10 @@ const char *DrawOutcomeName(uint32_t outcome) {
 }
 
 std::string CensusSceneMarker();
+uint64_t HashCombine(uint64_t hash, uint64_t value);
+template <size_t N>
+void LoadSemanticGuestWords(rex::memory::Memory *memory, uint32_t address,
+                            std::array<uint32_t, N> &words);
 
 const char *VehicleIdentityAddressKindName(VehicleIdentityAddressKind kind) {
   switch (kind) {
@@ -1681,6 +1733,174 @@ void IndexVehicleIdentityAddressLocked(size_t identity_index,
     index = (index + 1) % kVehicleIdentityAddressCapacity;
   }
   ++g_vehicle_identity_address_overflow;
+}
+
+bool ShouldScanVehicleObjectProbe(const VehicleDrawArgumentProbe &probe) {
+  if (probe.value < 0x40000000 || probe.value >= 0x70000000 ||
+      (probe.value & 3) ||
+      probe.value > UINT32_MAX - kVehicleObjectScanWordCount * 4) {
+    return false;
+  }
+  switch (probe.layer) {
+  case VehicleDrawProvenanceLayer::kDirectArguments:
+  case VehicleDrawProvenanceLayer::kIndirectConstructorArguments:
+  case VehicleDrawProvenanceLayer::kIndirectOwnerArguments:
+  case VehicleDrawProvenanceLayer::kIndirectProducerArguments:
+  case VehicleDrawProvenanceLayer::kIndirectContextArguments:
+    return probe.argument_index == 0;
+  case VehicleDrawProvenanceLayer::kSemanticReceiver:
+  case VehicleDrawProvenanceLayer::kSemanticDescriptor:
+  case VehicleDrawProvenanceLayer::kSemanticRuntime:
+  case VehicleDrawProvenanceLayer::kIndirectContextRoot:
+  case VehicleDrawProvenanceLayer::kIndirectSemanticReceiver:
+    return true;
+  }
+  return false;
+}
+
+void RecordVehicleObjectCorrelationLocked(
+    uint64_t backend_signature, uint64_t frame,
+    const VehicleDrawArgumentProbe &probe, uint32_t pointer_offset,
+    const VehicleIdentityAddressEntry &address_entry) {
+  if (address_entry.identity_index >= g_vehicle_identities.size()) {
+    return;
+  }
+  const VehicleIdentityEntry &identity =
+      g_vehicle_identities[address_entry.identity_index];
+  if (!identity.valid) {
+    return;
+  }
+  ++g_vehicle_object_argument_matches;
+  VehicleObjectCorrelationEntry *available = nullptr;
+  for (VehicleObjectCorrelationEntry &entry :
+       g_vehicle_object_correlations) {
+    if (!entry.valid) {
+      if (!available) {
+        available = &entry;
+      }
+      continue;
+    }
+    if (entry.backend_signature == backend_signature &&
+        entry.layer == probe.layer &&
+        entry.identity_field == address_entry.field &&
+        entry.function_address == probe.function_address &&
+        entry.return_address == probe.return_address &&
+        entry.argument_index == probe.argument_index &&
+        entry.container_address == probe.value &&
+        entry.pointer_offset == pointer_offset &&
+        entry.identity_generation == identity.generation &&
+        entry.identity_owner == identity.owner &&
+        entry.identity_slot == identity.slot) {
+      ++entry.observations;
+      entry.last_frame = frame;
+      return;
+    }
+  }
+  if (!available) {
+    ++g_vehicle_object_correlation_overflow;
+    return;
+  }
+  *available = {
+      .backend_signature = backend_signature,
+      .observations = 1,
+      .first_frame = frame,
+      .last_frame = frame,
+      .layer = probe.layer,
+      .identity_field = address_entry.field,
+      .function_address = probe.function_address,
+      .return_address = probe.return_address,
+      .argument_index = probe.argument_index,
+      .container_address = probe.value,
+      .pointer_offset = pointer_offset,
+      .matched_address = address_entry.address,
+      .identity_generation = identity.generation,
+      .identity_owner = identity.owner,
+      .identity_slot = identity.slot,
+      .valid = true,
+  };
+  ++g_vehicle_object_correlation_count;
+}
+
+void ScanVehicleObjectProbeLocked(uint64_t backend_signature, uint64_t frame,
+                                  const VehicleDrawArgumentProbe &probe) {
+  if (!ShouldScanVehicleObjectProbe(probe) ||
+      !g_vehicle_identity_address_count) {
+    return;
+  }
+  ++g_vehicle_object_scan_requests;
+  const uint64_t frame_window = frame / kFrameSummaryInterval;
+  uint64_t key = HashCombine(backend_signature, frame_window);
+  key = HashCombine(key, uint64_t(probe.layer));
+  key = HashCombine(key, probe.function_address);
+  key = HashCombine(key, probe.return_address);
+  key = HashCombine(key, probe.argument_index);
+  key = HashCombine(key, probe.value);
+  size_t cache_index = size_t(key % kVehicleObjectScanCacheCapacity);
+  VehicleObjectScanCacheEntry *available = nullptr;
+  for (size_t cache_probe = 0;
+       cache_probe < kVehicleObjectScanCacheCapacity; ++cache_probe) {
+    VehicleObjectScanCacheEntry &entry =
+        g_vehicle_object_scan_cache[cache_index];
+    if (!entry.valid) {
+      available = &entry;
+      break;
+    }
+    if (entry.backend_signature == backend_signature &&
+        entry.frame_window == frame_window && entry.layer == probe.layer &&
+        entry.function_address == probe.function_address &&
+        entry.return_address == probe.return_address &&
+        entry.argument_index == probe.argument_index &&
+        entry.container_address == probe.value) {
+      return;
+    }
+    cache_index = (cache_index + 1) % kVehicleObjectScanCacheCapacity;
+  }
+  if (!available) {
+    ++g_vehicle_object_scan_cache_overflow;
+    return;
+  }
+  *available = {
+      .backend_signature = backend_signature,
+      .frame_window = frame_window,
+      .layer = probe.layer,
+      .function_address = probe.function_address,
+      .return_address = probe.return_address,
+      .argument_index = probe.argument_index,
+      .container_address = probe.value,
+      .valid = true,
+  };
+  ++g_vehicle_object_scan_cache_count;
+  ++g_vehicle_object_scans;
+  g_vehicle_object_scan_words += kVehicleObjectScanWordCount;
+  rex::memory::Memory *memory =
+      g_vehicle_discovery_memory.load(std::memory_order_acquire);
+  if (!memory) {
+    return;
+  }
+  std::array<uint32_t, kVehicleObjectScanWordCount> words{};
+  LoadSemanticGuestWords(memory, probe.value, words);
+  for (size_t word_index = 0; word_index < words.size(); ++word_index) {
+    const uint32_t word = words[word_index];
+    if (!word) {
+      continue;
+    }
+    size_t address_index = (word >> 4) % kVehicleIdentityAddressCapacity;
+    for (size_t address_probe = 0;
+         address_probe < kVehicleIdentityAddressCapacity; ++address_probe) {
+      const VehicleIdentityAddressEntry &address_entry =
+          g_vehicle_identity_addresses[address_index];
+      if (!address_entry.valid) {
+        break;
+      }
+      if (address_entry.address == word) {
+        RecordVehicleObjectCorrelationLocked(
+            backend_signature, frame, probe, uint32_t(word_index * 4),
+            address_entry);
+      }
+      address_index =
+          (address_index + 1) % kVehicleIdentityAddressCapacity;
+    }
+  }
 }
 
 void ObserveVehicleDrawArgumentCorrelations(
@@ -1867,6 +2087,7 @@ void ObserveVehicleDrawArgumentCorrelations(
       address_index =
           (address_index + 1) % kVehicleIdentityAddressCapacity;
     }
+    ScanVehicleObjectProbeLocked(backend_signature, frame, probe);
   }
 }
 
@@ -15484,6 +15705,16 @@ void ConfigureVehicleDiscovery(bool census_requested,
     g_vehicle_draw_argument_matches = 0;
     g_vehicle_draw_correlation_count = 0;
     g_vehicle_draw_correlation_overflow = 0;
+    g_vehicle_object_scan_cache = {};
+    g_vehicle_object_correlations = {};
+    g_vehicle_object_scan_requests = 0;
+    g_vehicle_object_scans = 0;
+    g_vehicle_object_scan_words = 0;
+    g_vehicle_object_scan_cache_count = 0;
+    g_vehicle_object_scan_cache_overflow = 0;
+    g_vehicle_object_argument_matches = 0;
+    g_vehicle_object_correlation_count = 0;
+    g_vehicle_object_correlation_overflow = 0;
   }
   g_vehicle_discovery_memory.store(census_requested ? memory : nullptr,
                                    std::memory_order_release);
@@ -15516,6 +15747,14 @@ void ConfigureVehicleDiscovery(bool census_requested,
         std::to_string(kVehicleIdentityAddressCapacity)},
        {"draw_correlation",
         "exact_backend_signature_and_provenance_argument_to_vehicle_address"},
+       {"object_scan_word_count",
+        std::to_string(kVehicleObjectScanWordCount)},
+       {"object_scan_cache_capacity",
+        std::to_string(kVehicleObjectScanCacheCapacity)},
+       {"object_correlation_capacity",
+        std::to_string(kVehicleObjectCorrelationCapacity)},
+       {"object_correlation",
+        "sampled_one_hop_pointer_to_vehicle_address"},
        {"guest_payload_read",
         "existing_title_pose_hook_values_and_bounded_owner_vtable"},
        {"guest_state_changed", "false"},
@@ -15592,6 +15831,27 @@ void EmitVehicleDiscoverySummary() {
         std::to_string(kVehicleIdentityAddressCapacity)},
        {"identity_address_overflow",
         std::to_string(g_vehicle_identity_address_overflow)},
+       {"object_scan_requests",
+        std::to_string(g_vehicle_object_scan_requests)},
+       {"object_scans", std::to_string(g_vehicle_object_scans)},
+       {"object_scan_words",
+        std::to_string(g_vehicle_object_scan_words)},
+       {"object_scan_word_count",
+        std::to_string(kVehicleObjectScanWordCount)},
+       {"object_scan_cache_entries",
+        std::to_string(g_vehicle_object_scan_cache_count)},
+       {"object_scan_cache_capacity",
+        std::to_string(kVehicleObjectScanCacheCapacity)},
+       {"object_scan_cache_overflow",
+        std::to_string(g_vehicle_object_scan_cache_overflow)},
+       {"object_argument_matches",
+        std::to_string(g_vehicle_object_argument_matches)},
+       {"object_correlations",
+        std::to_string(g_vehicle_object_correlation_count)},
+       {"object_correlation_capacity",
+        std::to_string(kVehicleObjectCorrelationCapacity)},
+       {"object_correlation_overflow",
+        std::to_string(g_vehicle_object_correlation_overflow)},
        {"guest_state_changed", "false"},
        {"native_upload", "false"},
        {"native_draw", "false"},
@@ -15717,6 +15977,42 @@ void EmitVehicleDiscoverySummary() {
          {"first_frame", std::to_string(entry.first_frame)},
          {"last_frame", std::to_string(entry.last_frame)},
          {"classification", "vehicle_draw_argument_correlation_candidate"},
+         {"vehicle_draw_identity_proved", "false"},
+         {"guest_state_changed", "false"},
+         {"native_draw", "false"},
+         {"xenos_authority", "true"},
+         {"suppression_allowed", "false"}});
+  }
+  for (const VehicleObjectCorrelationEntry &entry :
+       g_vehicle_object_correlations) {
+    if (!entry.valid) {
+      continue;
+    }
+    pinyon_shift::diagnostics::RecordEvent(
+        "native_renderer.discovery.vehicle_draw_object_correlation",
+        {{"backend_signature",
+          fmt::format("{:016X}", entry.backend_signature)},
+         {"provenance_layer",
+          VehicleDrawProvenanceLayerName(entry.layer)},
+         {"function_address",
+          fmt::format("{:08X}", entry.function_address)},
+         {"return_address", fmt::format("{:08X}", entry.return_address)},
+         {"argument_index", std::to_string(entry.argument_index)},
+         {"container_address",
+          fmt::format("{:08X}", entry.container_address)},
+         {"pointer_offset", std::to_string(entry.pointer_offset)},
+         {"identity_field",
+          VehicleIdentityAddressKindName(entry.identity_field)},
+         {"matched_address", fmt::format("{:08X}", entry.matched_address)},
+         {"identity_generation",
+          fmt::format("{:08X}", entry.identity_generation)},
+         {"identity_owner", fmt::format("{:08X}", entry.identity_owner)},
+         {"identity_slot", std::to_string(entry.identity_slot)},
+         {"observations", std::to_string(entry.observations)},
+         {"first_frame", std::to_string(entry.first_frame)},
+         {"last_frame", std::to_string(entry.last_frame)},
+         {"relationship_depth", "1"},
+         {"classification", "vehicle_draw_object_correlation_candidate"},
          {"vehicle_draw_identity_proved", "false"},
          {"guest_state_changed", "false"},
          {"native_draw", "false"},

--- a/tools/summarize-native-renderer-vehicle-pose.py
+++ b/tools/summarize-native-renderer-vehicle-pose.py
@@ -19,6 +19,9 @@ OWNER_INDIRECT_TARGET = (
 DRAW_ARGUMENT_CORRELATION = (
     "native_renderer.discovery.vehicle_draw_argument_correlation"
 )
+DRAW_OBJECT_CORRELATION = (
+    "native_renderer.discovery.vehicle_draw_object_correlation"
+)
 OWNER_METHOD_CANDIDATES = {
     "82BCC368": (14, "82BCCD30"),
     "82BD2DE0": (20, "82BD35B0"),
@@ -172,6 +175,10 @@ def build(events, requested_session=None):
         "draw_correlation": (
             "exact_backend_signature_and_provenance_argument_to_vehicle_address"
         ),
+        "object_scan_word_count": "128",
+        "object_scan_cache_capacity": "16384",
+        "object_correlation_capacity": "2048",
+        "object_correlation": "sampled_one_hop_pointer_to_vehicle_address",
         "guest_payload_read": (
             "existing_title_pose_hook_values_and_bounded_owner_vtable"
         ),
@@ -197,6 +204,9 @@ def build(events, requested_session=None):
         "summary_limit": "64",
         "draw_correlation_capacity": "1024",
         "identity_address_capacity": "512",
+        "object_scan_word_count": "128",
+        "object_scan_cache_capacity": "16384",
+        "object_correlation_capacity": "2048",
         "guest_state_changed": "false",
         "native_upload": "false",
         "native_draw": "false",
@@ -237,6 +247,17 @@ def build(events, requested_session=None):
         "identity_addresses",
         "identity_address_capacity",
         "identity_address_overflow",
+        "object_scan_requests",
+        "object_scans",
+        "object_scan_words",
+        "object_scan_word_count",
+        "object_scan_cache_entries",
+        "object_scan_cache_capacity",
+        "object_scan_cache_overflow",
+        "object_argument_matches",
+        "object_correlations",
+        "object_correlation_capacity",
+        "object_correlation_overflow",
     ):
         totals[key] = integer(summary, key)
     identities = []
@@ -509,6 +530,93 @@ def build(events, requested_session=None):
         )
     )
 
+    object_correlations = []
+    seen_object_correlations = set()
+    for event in selected:
+        if event.get("event") != DRAW_OBJECT_CORRELATION:
+            continue
+        layer = str(event.get("provenance_layer", ""))
+        identity_field = str(event.get("identity_field", ""))
+        identity_key = (
+            hexadecimal(event, "identity_generation"),
+            hexadecimal(event, "identity_owner"),
+            integer(event, "identity_slot"),
+        )
+        identity = identities_by_key.get(identity_key)
+        matched_address = hexadecimal(event, "matched_address")
+        if identity and identity_field in ("position", "forward"):
+            expected_address = identity.get(f"{identity_field}_address")
+        elif identity and identity_field == "owner":
+            expected_address = identity_key[1]
+        else:
+            expected_address = None
+        key = (
+            hexadecimal64(event, "backend_signature"),
+            layer,
+            hexadecimal_allow_zero(event, "function_address"),
+            hexadecimal_allow_zero(event, "return_address"),
+            integer(event, "argument_index"),
+            hexadecimal(event, "container_address"),
+            integer(event, "pointer_offset"),
+            identity_field,
+            matched_address,
+            identity_key,
+        )
+        if (
+            key in seen_object_correlations
+            or layer not in DRAW_PROVENANCE_LAYERS
+            or identity_field not in DRAW_IDENTITY_FIELDS
+            or identity is None
+            or matched_address != expected_address
+            or key[4] > 8
+            or key[6] >= totals["object_scan_word_count"] * 4
+            or key[6] % 4
+            or integer(event, "relationship_depth") != 1
+            or event.get("classification")
+            != "vehicle_draw_object_correlation_candidate"
+            or event.get("vehicle_draw_identity_proved") != "false"
+            or event.get("guest_state_changed") != "false"
+            or event.get("native_draw") != "false"
+            or event.get("xenos_authority") != "true"
+            or event.get("suppression_allowed") != "false"
+        ):
+            raise ValueError("vehicle draw object correlation violates boundary")
+        seen_object_correlations.add(key)
+        first_frame = integer(event, "first_frame")
+        last_frame = integer(event, "last_frame")
+        if first_frame > last_frame:
+            raise ValueError("invalid vehicle object correlation frame range")
+        object_correlations.append(
+            {
+                "backend_signature": key[0],
+                "provenance_layer": layer,
+                "function_address": key[2],
+                "return_address": key[3],
+                "argument_index": key[4],
+                "container_address": key[5],
+                "pointer_offset": key[6],
+                "identity_field": identity_field,
+                "matched_address": matched_address,
+                "identity_generation": identity_key[0],
+                "identity_owner": identity_key[1],
+                "identity_slot": identity_key[2],
+                "observations": integer(event, "observations"),
+                "first_frame": first_frame,
+                "last_frame": last_frame,
+            }
+        )
+    object_correlations.sort(
+        key=lambda item: (
+            item["backend_signature"],
+            item["provenance_layer"],
+            item["function_address"],
+            item["argument_index"],
+            item["container_address"],
+            item["pointer_offset"],
+            item["identity_owner"],
+        )
+    )
+
     failures = []
     if totals["observations"] != (
         totals["valid_observations"] + totals["invalid_observations"]
@@ -569,6 +677,26 @@ def build(events, requested_session=None):
         failures.append("vehicle identity address index coverage drifted")
     if totals["draw_correlations"] > totals["draw_correlation_capacity"]:
         failures.append("vehicle draw correlation capacity drifted")
+    if totals["object_scans"] > totals["object_scan_requests"]:
+        failures.append("vehicle object scan request accounting drifted")
+    if totals["object_scan_words"] != (
+        totals["object_scans"] * totals["object_scan_word_count"]
+    ):
+        failures.append("vehicle object scan word accounting drifted")
+    if totals["object_scan_cache_entries"] != totals["object_scans"]:
+        failures.append("vehicle object scan cache accounting drifted")
+    if totals["object_scan_cache_overflow"]:
+        failures.append("vehicle object scan cache overflowed")
+    if totals["object_argument_matches"] != sum(
+        item["observations"] for item in object_correlations
+    ):
+        failures.append("vehicle object correlation accounting drifted")
+    if len(object_correlations) != totals["object_correlations"]:
+        failures.append("vehicle object correlation coverage drifted")
+    if totals["object_correlation_overflow"]:
+        failures.append("vehicle object correlation table overflowed")
+    if totals["object_correlations"] > totals["object_correlation_capacity"]:
+        failures.append("vehicle object correlation capacity drifted")
     for method in method_correlations:
         if method["status"] != "complete" or method["calls"] != method["exits"]:
             failures.append(
@@ -588,6 +716,7 @@ def build(events, requested_session=None):
         for item in method_correlations
     )
     draw_argument_candidate_proved = bool(draw_correlations)
+    object_candidate_proved = bool(object_correlations)
 
     return {
         "schema": SCHEMA,
@@ -600,6 +729,7 @@ def build(events, requested_session=None):
         "method_correlations": method_correlations,
         "indirect_targets": indirect_targets,
         "draw_argument_correlations": draw_correlations,
+        "draw_object_correlations": object_correlations,
         "qualification": {
             "vehicle_instance_semantic_seed_proved": not failures,
             "vehicle_owner_class_seed_proved": not failures,
@@ -610,6 +740,9 @@ def build(events, requested_session=None):
             "vehicle_draw_identity_proved": False,
             "vehicle_draw_argument_candidate_proved": (
                 not failures and draw_argument_candidate_proved
+            ),
+            "vehicle_draw_object_candidate_proved": (
+                not failures and object_candidate_proved
             ),
             "native_vehicle_rendering_admitted": False,
             "suppression_allowed": False,

--- a/tools/tests/test_native_renderer_vehicle_pose.py
+++ b/tools/tests/test_native_renderer_vehicle_pose.py
@@ -42,6 +42,10 @@ def fixture():
         draw_correlation=(
             "exact_backend_signature_and_provenance_argument_to_vehicle_address"
         ),
+        object_scan_word_count="128",
+        object_scan_cache_capacity="16384",
+        object_correlation_capacity="2048",
+        object_correlation="sampled_one_hop_pointer_to_vehicle_address",
         guest_payload_read=(
             "existing_title_pose_hook_values_and_bounded_owner_vtable"
         ),
@@ -85,6 +89,17 @@ def fixture():
         identity_addresses="3",
         identity_address_capacity="512",
         identity_address_overflow="0",
+        object_scan_requests="2",
+        object_scans="1",
+        object_scan_words="128",
+        object_scan_word_count="128",
+        object_scan_cache_entries="1",
+        object_scan_cache_capacity="16384",
+        object_scan_cache_overflow="0",
+        object_argument_matches="0",
+        object_correlations="0",
+        object_correlation_capacity="2048",
+        object_correlation_overflow="0",
         guest_state_changed="false",
         native_upload="false",
         native_draw="false",
@@ -179,6 +194,11 @@ class VehiclePoseSummaryTests(unittest.TestCase):
         self.assertIn("ObserveVehicleDrawArgumentCorrelations", hooks)
         self.assertIn(
             '"native_renderer.discovery.vehicle_draw_argument_correlation"',
+            hooks,
+        )
+        self.assertIn("ScanVehicleObjectProbeLocked", hooks)
+        self.assertIn(
+            '"native_renderer.discovery.vehicle_draw_object_correlation"',
             hooks,
         )
         for address in (
@@ -366,6 +386,57 @@ class VehiclePoseSummaryTests(unittest.TestCase):
         document = MODULE.build(events)
         self.assertIn(
             "vehicle draw correlation table overflowed", document["failures"]
+        )
+
+    def test_qualifies_one_hop_object_match_as_candidate_only(self):
+        events = fixture()
+        events[1]["object_argument_matches"] = "2"
+        events[1]["object_correlations"] = "1"
+        events.append(
+            event(
+                MODULE.DRAW_OBJECT_CORRELATION,
+                backend_signature="0123456789ABCDEF",
+                provenance_layer="semantic_receiver",
+                function_address="82417BC0",
+                return_address="00000000",
+                argument_index="8",
+                container_address="A0005000",
+                pointer_offset="64",
+                identity_field="owner",
+                matched_address="A0002000",
+                identity_generation="00000001",
+                identity_owner="A0002000",
+                identity_slot="2",
+                observations="2",
+                first_frame="102",
+                last_frame="104",
+                relationship_depth="1",
+                classification="vehicle_draw_object_correlation_candidate",
+                vehicle_draw_identity_proved="false",
+                guest_state_changed="false",
+                native_draw="false",
+                xenos_authority="true",
+                suppression_allowed="false",
+            )
+        )
+        document = MODULE.build(events)
+        self.assertEqual("complete", document["status"])
+        self.assertEqual(1, len(document["draw_object_correlations"]))
+        self.assertTrue(
+            document["qualification"][
+                "vehicle_draw_object_candidate_proved"
+            ]
+        )
+        self.assertFalse(
+            document["qualification"]["vehicle_draw_identity_proved"]
+        )
+
+    def test_rejects_object_scan_cache_overflow(self):
+        events = fixture()
+        events[1]["object_scan_cache_overflow"] = "1"
+        document = MODULE.build(events)
+        self.assertIn(
+            "vehicle object scan cache overflowed", document["failures"]
         )
 
 


### PR DESCRIPTION
## Summary
- scan bounded object-like direct, semantic, and indirect provenance roots
- cache one 512-byte scan per signature/root/frame window
- correlate embedded pointers to exact vehicle identities without changing draws

## Evidence
- release/AppData session `20260830T094228Z-p1080` exited normally
- reduced 7,424,713 eligible requests to 5,992 cached scans (766,976 words)
- found zero one-hop vehicle pointers, ruling out current object roots
- zero cache/table overflow, invalid observations, stack faults, errors, or fatals

## Tests
- `python -m unittest discover -s tools/tests -p 'test_*.py'` (415 passed)
- incremental release build
- AppData-backed festival run