### PR TITLE
fix(renderer): require full vehicle provenance coverage

### DIFF
--- a/docs/native-renderer/VEHICLE_INSTANCE_SEMANTIC_SEED.md
+++ b/docs/native-renderer/VEHICLE_INSTANCE_SEMANTIC_SEED.md
@@ -117,14 +117,9 @@ frame span. A fixed address index and fixed 1,024-entry result table keep this
 discovery path bounded. No guest payload is read and no draw is changed.
 
 Release/AppData session `20260830T093251Z-p42128` completed normally at the
-festival with the player car visible. It examined 3,285,123 backend draws and
-83,516,951 populated provenance probes against 32 vehicle identities. It found
-zero exact owner or transform-address matches, with no invalid pose,
-owner-dispatch, overflow, stack-fault, error, or fatal event. This rejects the
-current direct and indirect dispatch arguments as an exact vehicle draw join.
-The render path must therefore be recovered from a deeper object/descriptor
-relationship or a different title submission family. Vehicle draw identity,
-native rendering, publication, and suppression remain unadmitted.
+festival and found no exact match, but later audit proved title provenance was
+disabled for that run. Its 83,516,951 probes qualify only the indirect lineage;
+they do not support the original direct-coverage claim.
 
 The follow-up samples a single bounded relationship edge from object-like
 dispatch roots: direct and indirect r3, semantic receiver/descriptor/runtime,
@@ -135,11 +130,17 @@ cache and 2,048-entry correlation table.
 Release/AppData session `20260830T094228Z-p1080` completed normally and
 examined 2,282,451 backend draws. It reduced 7,424,713 eligible requests to
 5,992 unique object scans (766,976 words) across 31 vehicle identities and
-found zero embedded owner, position, or forward-vector addresses. The cache,
-identity index, and correlation table did not overflow, and no invalid pose,
-stack-fault, error, or fatal event occurred. This rejects the first 512 bytes
-of every current object-like provenance root as a one-hop vehicle join. The
-next search must follow typed descriptor graph edges or locate another title
+found zero embedded owner, position, or forward-vector addresses. This run was
+also indirect-only and is retained as bounded partial evidence.
+
+The corrected release/AppData session `20260830T094940Z-p26892` explicitly
+armed title provenance. It covered 205,181 direct title draws, 505,770 semantic
+probes, and 2,053,311 indirect draws across 31 vehicle identities. It found
+zero exact or one-hop owner/position/forward matches. The pose, identity index,
+scan cache, and correlation tables had no invalid observation, overflow, or
+stack fault, and the log had no error or fatal event. This fully rejects the
+current direct, semantic, and indirect arguments and the first 512 bytes of
+their object-like roots. Follow typed descriptor graph edges or locate another
 submission family; native vehicle drawing and suppression remain closed.
 
 Qualify a batched census with:
@@ -147,7 +148,8 @@ Qualify a batched census with:
 ```powershell
 .\tools\capture-native-renderer-census.ps1 `
   -StateRoot $stateRoot `
-  -Scene open_world_day
+  -Scene open_world_day `
+  -VehicleDrawCorrelation
 
 python .\tools\summarize-native-renderer-vehicle-pose.py `
   $eventLog `

--- a/src/native_renderer/graphics_hooks.cpp
+++ b/src/native_renderer/graphics_hooks.cpp
@@ -725,7 +725,12 @@ std::array<VehicleDrawCorrelationEntry, kVehicleDrawCorrelationCapacity>
     g_vehicle_draw_correlations{};
 std::mutex g_vehicle_draw_correlation_mutex;
 uint64_t g_vehicle_draws_examined = 0;
+uint64_t g_vehicle_direct_draws_examined = 0;
+uint64_t g_vehicle_indirect_draws_examined = 0;
 uint64_t g_vehicle_draw_argument_probes = 0;
+uint64_t g_vehicle_direct_argument_probes = 0;
+uint64_t g_vehicle_semantic_argument_probes = 0;
+uint64_t g_vehicle_indirect_argument_probes = 0;
 uint64_t g_vehicle_draw_argument_matches = 0;
 uint64_t g_vehicle_draw_correlation_count = 0;
 uint64_t g_vehicle_draw_correlation_overflow = 0;
@@ -741,6 +746,7 @@ uint64_t g_vehicle_object_scan_cache_overflow = 0;
 uint64_t g_vehicle_object_argument_matches = 0;
 uint64_t g_vehicle_object_correlation_count = 0;
 uint64_t g_vehicle_object_correlation_overflow = 0;
+bool g_vehicle_title_provenance_requested = false;
 uint64_t g_title_packets_recorded = 0;
 uint64_t g_title_packets_matched = 0;
 uint64_t g_title_packet_address_failures = 0;
@@ -1758,6 +1764,16 @@ bool ShouldScanVehicleObjectProbe(const VehicleDrawArgumentProbe &probe) {
   return false;
 }
 
+bool IsDirectVehicleDrawProvenanceLayer(VehicleDrawProvenanceLayer layer) {
+  return layer == VehicleDrawProvenanceLayer::kDirectArguments;
+}
+
+bool IsSemanticVehicleDrawProvenanceLayer(VehicleDrawProvenanceLayer layer) {
+  return layer == VehicleDrawProvenanceLayer::kSemanticReceiver ||
+         layer == VehicleDrawProvenanceLayer::kSemanticDescriptor ||
+         layer == VehicleDrawProvenanceLayer::kSemanticRuntime;
+}
+
 void RecordVehicleObjectCorrelationLocked(
     uint64_t backend_signature, uint64_t frame,
     const VehicleDrawArgumentProbe &probe, uint32_t pointer_offset,
@@ -1992,9 +2008,18 @@ void ObserveVehicleDrawArgumentCorrelations(
   std::scoped_lock lock(g_vehicle_identity_mutex,
                         g_vehicle_draw_correlation_mutex);
   ++g_vehicle_draws_examined;
+  g_vehicle_direct_draws_examined += direct_origin.valid ? 1 : 0;
+  g_vehicle_indirect_draws_examined += indirect_origin ? 1 : 0;
   g_vehicle_draw_argument_probes += probe_count;
   for (size_t probe_index = 0; probe_index < probe_count; ++probe_index) {
     const VehicleDrawArgumentProbe &probe = probes[probe_index];
+    if (IsDirectVehicleDrawProvenanceLayer(probe.layer)) {
+      ++g_vehicle_direct_argument_probes;
+    } else if (IsSemanticVehicleDrawProvenanceLayer(probe.layer)) {
+      ++g_vehicle_semantic_argument_probes;
+    } else {
+      ++g_vehicle_indirect_argument_probes;
+    }
     if (!probe.value) {
       continue;
     }
@@ -15701,7 +15726,12 @@ void ConfigureVehicleDiscovery(bool census_requested,
     std::scoped_lock lock(g_vehicle_draw_correlation_mutex);
     g_vehicle_draw_correlations = {};
     g_vehicle_draws_examined = 0;
+    g_vehicle_direct_draws_examined = 0;
+    g_vehicle_indirect_draws_examined = 0;
     g_vehicle_draw_argument_probes = 0;
+    g_vehicle_direct_argument_probes = 0;
+    g_vehicle_semantic_argument_probes = 0;
+    g_vehicle_indirect_argument_probes = 0;
     g_vehicle_draw_argument_matches = 0;
     g_vehicle_draw_correlation_count = 0;
     g_vehicle_draw_correlation_overflow = 0;
@@ -15716,6 +15746,8 @@ void ConfigureVehicleDiscovery(bool census_requested,
     g_vehicle_object_correlation_count = 0;
     g_vehicle_object_correlation_overflow = 0;
   }
+  g_vehicle_title_provenance_requested =
+      REXCVAR_GET(pinyon_shift_native_renderer_dispatch_discovery);
   g_vehicle_discovery_memory.store(census_requested ? memory : nullptr,
                                    std::memory_order_release);
   g_vehicle_discovery_installed.store(census_requested && memory,
@@ -15747,6 +15779,8 @@ void ConfigureVehicleDiscovery(bool census_requested,
         std::to_string(kVehicleIdentityAddressCapacity)},
        {"draw_correlation",
         "exact_backend_signature_and_provenance_argument_to_vehicle_address"},
+       {"title_provenance_requested",
+        g_vehicle_title_provenance_requested ? "true" : "false"},
        {"object_scan_word_count",
         std::to_string(kVehicleObjectScanWordCount)},
        {"object_scan_cache_capacity",
@@ -15815,8 +15849,18 @@ void EmitVehicleDiscoverySummary() {
        {"owner_indirect_target_overflow",
         std::to_string(g_vehicle_owner_indirect_target_overflow)},
        {"draws_examined", std::to_string(g_vehicle_draws_examined)},
+       {"direct_draws_examined",
+        std::to_string(g_vehicle_direct_draws_examined)},
+       {"indirect_draws_examined",
+        std::to_string(g_vehicle_indirect_draws_examined)},
        {"draw_argument_probes",
         std::to_string(g_vehicle_draw_argument_probes)},
+       {"direct_argument_probes",
+        std::to_string(g_vehicle_direct_argument_probes)},
+       {"semantic_argument_probes",
+        std::to_string(g_vehicle_semantic_argument_probes)},
+       {"indirect_argument_probes",
+        std::to_string(g_vehicle_indirect_argument_probes)},
        {"draw_argument_matches",
         std::to_string(g_vehicle_draw_argument_matches)},
        {"draw_correlations",
@@ -15852,6 +15896,16 @@ void EmitVehicleDiscoverySummary() {
         std::to_string(kVehicleObjectCorrelationCapacity)},
        {"object_correlation_overflow",
         std::to_string(g_vehicle_object_correlation_overflow)},
+       {"title_provenance_requested",
+        g_vehicle_title_provenance_requested ? "true" : "false"},
+       {"draw_provenance_coverage_complete",
+        g_vehicle_title_provenance_requested &&
+                g_vehicle_direct_draws_examined &&
+                g_vehicle_indirect_draws_examined &&
+                g_vehicle_direct_argument_probes &&
+                g_vehicle_indirect_argument_probes
+            ? "true"
+            : "false"},
        {"guest_state_changed", "false"},
        {"native_upload", "false"},
        {"native_draw", "false"},

--- a/tools/capture-native-renderer-census.ps1
+++ b/tools/capture-native-renderer-census.ps1
@@ -21,6 +21,7 @@ param(
     [switch]$AutoSelectFreshVisibilityCandidate,
     [switch]$RequireTitleLodCandidate,
     [switch]$VisibilityShadowReplay,
+    [switch]$VehicleDrawCorrelation,
     [ValidatePattern('^[0-9A-Fa-f]{16}$')]
     [string]$PassAnchorSignature,
     [switch]$PublishRetainedPass,
@@ -187,7 +188,9 @@ $savedConsumerReadbackSamples = $env:PINYON_SHIFT_NATIVE_RENDERER_CONSUMER_READB
 try {
     $env:REX_PINYON_SHIFT_NATIVE_RENDERER_CENSUS = 'true'
     $env:REX_PINYON_SHIFT_NATIVE_RENDERER_DISPATCH_DISCOVERY =
-        if ($VisibilityShadowReplay) { 'true' } else { $savedDiscovery }
+        if ($VisibilityShadowReplay -or $VehicleDrawCorrelation) {
+            'true'
+        } else { $savedDiscovery }
     $env:PINYON_SHIFT_NATIVE_RENDERER_SCENE = $Scene
     $env:PINYON_SHIFT_NATIVE_RENDERER_INDEX_SCAN_SIGNATURE = $IndexScanSignature
     $env:PINYON_SHIFT_NATIVE_RENDERER_TEXTURE_SCAN_SIGNATURE = $TextureScanSignature

--- a/tools/summarize-native-renderer-vehicle-pose.py
+++ b/tools/summarize-native-renderer-vehicle-pose.py
@@ -22,6 +22,9 @@ DRAW_ARGUMENT_CORRELATION = (
 DRAW_OBJECT_CORRELATION = (
     "native_renderer.discovery.vehicle_draw_object_correlation"
 )
+TITLE_PROVENANCE_CONFIG = (
+    "native_renderer.discovery.title_provenance_config"
+)
 OWNER_METHOD_CANDIDATES = {
     "82BCC368": (14, "82BCCD30"),
     "82BD2DE0": (20, "82BD35B0"),
@@ -153,6 +156,7 @@ def build(events, requested_session=None):
     selected = [event for event in events if event.get("session") == session]
     config = exact(selected, CONFIG)
     summary = exact(selected, SUMMARY)
+    title_provenance_config = exact(selected, TITLE_PROVENANCE_CONFIG)
     expected_config = {
         "status": "armed",
         "hook": "82BC5A3C",
@@ -190,6 +194,20 @@ def build(events, requested_session=None):
     }
     if any(config.get(key) != value for key, value in expected_config.items()):
         raise ValueError("vehicle-pose configuration drifted")
+    if config.get("title_provenance_requested") not in ("true", "false"):
+        raise ValueError("vehicle title provenance configuration drifted")
+    title_provenance_requested = (
+        config["title_provenance_requested"] == "true"
+    )
+    title_provenance_armed = title_provenance_config.get("status") == "armed"
+    if (
+        title_provenance_config.get("guest_state_changed") != "false"
+        or title_provenance_config.get("control_flow_changed") != "false"
+        or title_provenance_config.get("xenos_authority") != "true"
+        or title_provenance_config.get("suppression_allowed") != "false"
+        or title_provenance_armed != title_provenance_requested
+    ):
+        raise ValueError("vehicle title provenance arm state drifted")
     expected_summary = {
         "status": "complete",
         "accounting_complete": "true",
@@ -215,6 +233,13 @@ def build(events, requested_session=None):
     }
     if any(summary.get(key) != value for key, value in expected_summary.items()):
         raise ValueError("vehicle-pose summary drifted")
+    if summary.get("title_provenance_requested") != config.get(
+        "title_provenance_requested"
+    ) or summary.get("draw_provenance_coverage_complete") not in (
+        "true",
+        "false",
+    ):
+        raise ValueError("vehicle draw provenance coverage drifted")
 
     totals = {
         key: integer(summary, key)
@@ -239,7 +264,12 @@ def build(events, requested_session=None):
         "owner_indirect_target_capacity",
         "owner_indirect_target_overflow",
         "draws_examined",
+        "direct_draws_examined",
+        "indirect_draws_examined",
         "draw_argument_probes",
+        "direct_argument_probes",
+        "semantic_argument_probes",
+        "indirect_argument_probes",
         "draw_argument_matches",
         "draw_correlations",
         "draw_correlation_capacity",
@@ -667,6 +697,17 @@ def build(events, requested_session=None):
         item["observations"] for item in draw_correlations
     ):
         failures.append("vehicle draw correlation observation accounting drifted")
+    if totals["draw_argument_probes"] != (
+        totals["direct_argument_probes"]
+        + totals["semantic_argument_probes"]
+        + totals["indirect_argument_probes"]
+    ):
+        failures.append("vehicle draw provenance probe accounting drifted")
+    if (
+        totals["direct_draws_examined"] > totals["draws_examined"]
+        or totals["indirect_draws_examined"] > totals["draws_examined"]
+    ):
+        failures.append("vehicle draw provenance coverage accounting drifted")
     if len(draw_correlations) != totals["draw_correlations"]:
         failures.append("vehicle draw correlation coverage drifted")
     if totals["draw_correlation_overflow"]:
@@ -717,6 +758,18 @@ def build(events, requested_session=None):
     )
     draw_argument_candidate_proved = bool(draw_correlations)
     object_candidate_proved = bool(object_correlations)
+    draw_provenance_coverage_complete = (
+        title_provenance_requested
+        and title_provenance_armed
+        and totals["direct_draws_examined"] > 0
+        and totals["indirect_draws_examined"] > 0
+        and totals["direct_argument_probes"] > 0
+        and totals["indirect_argument_probes"] > 0
+    )
+    if summary["draw_provenance_coverage_complete"] != (
+        "true" if draw_provenance_coverage_complete else "false"
+    ):
+        failures.append("vehicle draw provenance coverage result drifted")
 
     return {
         "schema": SCHEMA,
@@ -730,6 +783,13 @@ def build(events, requested_session=None):
         "indirect_targets": indirect_targets,
         "draw_argument_correlations": draw_correlations,
         "draw_object_correlations": object_correlations,
+        "coverage": {
+            "title_provenance_requested": title_provenance_requested,
+            "title_provenance_armed": title_provenance_armed,
+            "draw_provenance_coverage_complete": (
+                draw_provenance_coverage_complete
+            ),
+        },
         "qualification": {
             "vehicle_instance_semantic_seed_proved": not failures,
             "vehicle_owner_class_seed_proved": not failures,
@@ -739,10 +799,14 @@ def build(events, requested_session=None):
             "player_vehicle_identity_proved": False,
             "vehicle_draw_identity_proved": False,
             "vehicle_draw_argument_candidate_proved": (
-                not failures and draw_argument_candidate_proved
+                not failures
+                and draw_provenance_coverage_complete
+                and draw_argument_candidate_proved
             ),
             "vehicle_draw_object_candidate_proved": (
-                not failures and object_candidate_proved
+                not failures
+                and draw_provenance_coverage_complete
+                and object_candidate_proved
             ),
             "native_vehicle_rendering_admitted": False,
             "suppression_allowed": False,

--- a/tools/tests/test_native_renderer_vehicle_pose.py
+++ b/tools/tests/test_native_renderer_vehicle_pose.py
@@ -42,6 +42,7 @@ def fixture():
         draw_correlation=(
             "exact_backend_signature_and_provenance_argument_to_vehicle_address"
         ),
+        title_provenance_requested="true",
         object_scan_word_count="128",
         object_scan_cache_capacity="16384",
         object_correlation_capacity="2048",
@@ -52,6 +53,14 @@ def fixture():
         guest_state_changed="false",
         native_upload="false",
         native_draw="false",
+        xenos_authority="true",
+        suppression_allowed="false",
+    )
+    title_provenance_config = event(
+        MODULE.TITLE_PROVENANCE_CONFIG,
+        status="armed",
+        guest_state_changed="false",
+        control_flow_changed="false",
         xenos_authority="true",
         suppression_allowed="false",
     )
@@ -81,7 +90,12 @@ def fixture():
         owner_indirect_target_capacity="64",
         owner_indirect_target_overflow="0",
         draws_examined="4",
+        direct_draws_examined="2",
+        indirect_draws_examined="4",
         draw_argument_probes="32",
+        direct_argument_probes="8",
+        semantic_argument_probes="0",
+        indirect_argument_probes="24",
         draw_argument_matches="0",
         draw_correlations="0",
         draw_correlation_capacity="1024",
@@ -100,6 +114,8 @@ def fixture():
         object_correlations="0",
         object_correlation_capacity="2048",
         object_correlation_overflow="0",
+        title_provenance_requested="true",
+        draw_provenance_coverage_complete="true",
         guest_state_changed="false",
         native_upload="false",
         native_draw="false",
@@ -155,7 +171,7 @@ def fixture():
                 suppression_allowed="false",
             )
         )
-    return [config, summary, identity, *methods]
+    return [config, summary, identity, *methods, title_provenance_config]
 
 
 class VehiclePoseSummaryTests(unittest.TestCase):
@@ -170,6 +186,9 @@ class VehiclePoseSummaryTests(unittest.TestCase):
             encoding="utf-8"
         )
         analysis = (ROOT / "config/rexglue/analysis/main-xex.toml").read_text(
+            encoding="utf-8"
+        )
+        capture = (ROOT / "tools/capture-native-renderer-census.ps1").read_text(
             encoding="utf-8"
         )
         self.assertIn("struct VehiclePoseObservation", header)
@@ -201,6 +220,7 @@ class VehiclePoseSummaryTests(unittest.TestCase):
             '"native_renderer.discovery.vehicle_draw_object_correlation"',
             hooks,
         )
+        self.assertIn("[switch]$VehicleDrawCorrelation", capture)
         for address in (
             "82BC8468",
             "82BC84A4",
@@ -233,6 +253,9 @@ class VehiclePoseSummaryTests(unittest.TestCase):
         self.assertEqual(1, document["owner_classes"][0]["identity_count"])
         self.assertFalse(
             document["qualification"]["native_vehicle_rendering_admitted"]
+        )
+        self.assertTrue(
+            document["coverage"]["draw_provenance_coverage_complete"]
         )
 
     def test_rejects_invalid_or_overflowed_observations(self):
@@ -437,6 +460,52 @@ class VehiclePoseSummaryTests(unittest.TestCase):
         document = MODULE.build(events)
         self.assertIn(
             "vehicle object scan cache overflowed", document["failures"]
+        )
+
+    def test_does_not_promote_candidate_without_direct_coverage(self):
+        events = fixture()
+        events[0]["title_provenance_requested"] = "false"
+        events[1]["title_provenance_requested"] = "false"
+        events[-1]["status"] = "disabled"
+        events[1]["draw_provenance_coverage_complete"] = "false"
+        events[1]["direct_draws_examined"] = "0"
+        events[1]["direct_argument_probes"] = "0"
+        events[1]["draw_argument_probes"] = "24"
+        events[1]["draw_argument_matches"] = "1"
+        events[1]["draw_correlations"] = "1"
+        events.append(
+            event(
+                MODULE.DRAW_ARGUMENT_CORRELATION,
+                backend_signature="0123456789ABCDEF",
+                provenance_layer="indirect_owner_arguments",
+                function_address="82409668",
+                return_address="8240D1B0",
+                argument_index="3",
+                identity_field="owner",
+                matched_address="A0002000",
+                identity_generation="00000001",
+                identity_owner="A0002000",
+                identity_slot="2",
+                observations="1",
+                first_frame="102",
+                last_frame="102",
+                classification="vehicle_draw_argument_correlation_candidate",
+                vehicle_draw_identity_proved="false",
+                guest_state_changed="false",
+                native_draw="false",
+                xenos_authority="true",
+                suppression_allowed="false",
+            )
+        )
+        document = MODULE.build(events)
+        self.assertEqual("complete", document["status"])
+        self.assertFalse(
+            document["coverage"]["draw_provenance_coverage_complete"]
+        )
+        self.assertFalse(
+            document["qualification"][
+                "vehicle_draw_argument_candidate_proved"
+            ]
         )
 
 


### PR DESCRIPTION
## Summary
- add an explicit fully armed vehicle-correlation capture mode
- account direct, semantic, and indirect draw probes independently
- verify the authoritative title-provenance config event before candidate promotion
- correct earlier documentation that overstated direct coverage

## Evidence
- release/AppData session `20260830T094940Z-p26892` exited normally
- covered 205,181 direct title draws, 505,770 semantic probes, and 2,053,311 indirect draws
- found zero exact or one-hop vehicle-address matches across 31 identities
- zero invalid observations, cache/table overflow, stack faults, errors, or fatals

## Tests
- `python -m unittest discover -s tools/tests -p 'test_*.py'` (416 passed)
- incremental release build
- fully armed AppData-backed festival run