### PR TITLE
feat(renderer): trace targeted vehicle render context

### DIFF
--- a/docs/native-renderer/VEHICLE_INSTANCE_SEMANTIC_SEED.md
+++ b/docs/native-renderer/VEHICLE_INSTANCE_SEMANTIC_SEED.md
@@ -143,6 +143,40 @@ current direct, semantic, and indirect arguments and the first 512 bytes of
 their object-like roots. Follow typed descriptor graph edges or locate another
 submission family; native vehicle drawing and suppression remain closed.
 
+## Statically targeted render-context arguments
+
+The next relationship layer is derived from generated title instructions
+rather than address-shape heuristics. Function `824365B0` preserves guest `r7`
+as an object, loads its first word as a vtable, loads virtual slot 8, and calls
+that target. The same function consumes guest `r8` directly as vector source
+data. Those exact arguments are therefore admitted to the existing bounded
+512-byte one-hop correlation cache in addition to each provenance family's
+original `r3` root. They may bypass the generic `0x40000000`–`0x6fffffff`
+address-shape heuristic, but still require a nonzero aligned value and a
+readable guest page range before the snapshot is copied. Separate request and
+unique-scan counters prove both arguments were exercised by a qualification
+session.
+
+A broader experimental child scan was rejected before publication: guest
+object lifetime can change between a page-access check and a payload read, and
+common floating-point bit patterns occupy the same numeric range as guest
+addresses. The retained path never dereferences a candidate child and makes no
+type claim from its numeric value. It reads only the already-bounded root
+snapshot, keeps Xenos authoritative, and leaves native vehicle drawing and
+suppression closed until an exact owner, position, or forward-vector join is
+proved.
+
+Release/AppData session `20260830T103151Z-p43600` qualified the targeted
+slice in stable festival gameplay. Both arguments were present outside the
+generic address band: `r7` produced 692,963 scan requests and 3,660 unique
+cache entries, while `r8` produced 692,963 requests and 424 unique entries.
+The session covered 2,483,488 indirect draws and 31 vehicle identities with
+complete provenance, zero overflow, no error or fatal event, and a normal
+exit. Neither root contained an exact owner, position, or forward-vector join
+within the bounded snapshot, so both are rejected for this relationship depth.
+Continue from a typed callee contract or another submission family; native
+vehicle drawing and suppression remain closed.
+
 Qualify a batched census with:
 
 ```powershell

--- a/src/native_renderer/graphics_hooks.cpp
+++ b/src/native_renderer/graphics_hooks.cpp
@@ -112,6 +112,7 @@ constexpr size_t kVehicleDrawCorrelationCapacity = 1024;
 constexpr size_t kVehicleObjectScanWordCount = 128;
 constexpr size_t kVehicleObjectScanCacheCapacity = 16384;
 constexpr size_t kVehicleObjectCorrelationCapacity = 2048;
+constexpr uint32_t kVehicleRenderContextFunction = 0x824365B0;
 constexpr size_t kSemanticInstanceCapacity = 4096;
 constexpr size_t kSemanticSubmissionCapacity = 8192;
 constexpr size_t kSemanticRenderItemStackCapacity = 32;
@@ -746,6 +747,8 @@ uint64_t g_vehicle_object_scan_cache_overflow = 0;
 uint64_t g_vehicle_object_argument_matches = 0;
 uint64_t g_vehicle_object_correlation_count = 0;
 uint64_t g_vehicle_object_correlation_overflow = 0;
+std::array<uint64_t, 2> g_vehicle_render_context_scan_requests{};
+std::array<uint64_t, 2> g_vehicle_render_context_scans{};
 bool g_vehicle_title_provenance_requested = false;
 uint64_t g_title_packets_recorded = 0;
 uint64_t g_title_packets_matched = 0;
@@ -1741,10 +1744,23 @@ void IndexVehicleIdentityAddressLocked(size_t identity_index,
   ++g_vehicle_identity_address_overflow;
 }
 
+bool IsTargetedVehicleRenderContextProbe(
+    const VehicleDrawArgumentProbe &probe) {
+  return probe.layer ==
+             VehicleDrawProvenanceLayer::kIndirectContextArguments &&
+         probe.function_address == kVehicleRenderContextFunction &&
+         (probe.argument_index == 4 || probe.argument_index == 5);
+}
+
 bool ShouldScanVehicleObjectProbe(const VehicleDrawArgumentProbe &probe) {
-  if (probe.value < 0x40000000 || probe.value >= 0x70000000 ||
-      (probe.value & 3) ||
+  if (!probe.value || (probe.value & 3) ||
       probe.value > UINT32_MAX - kVehicleObjectScanWordCount * 4) {
+    return false;
+  }
+  if (IsTargetedVehicleRenderContextProbe(probe)) {
+    return true;
+  }
+  if (probe.value < 0x40000000 || probe.value >= 0x70000000) {
     return false;
   }
   switch (probe.layer) {
@@ -1766,6 +1782,17 @@ bool ShouldScanVehicleObjectProbe(const VehicleDrawArgumentProbe &probe) {
 
 bool IsDirectVehicleDrawProvenanceLayer(VehicleDrawProvenanceLayer layer) {
   return layer == VehicleDrawProvenanceLayer::kDirectArguments;
+}
+
+bool IsReadableVehicleGuestRange(rex::memory::Memory *memory,
+                                 uint32_t address, uint32_t length) {
+  if (!memory || !length || address > UINT32_MAX - (length - 1)) {
+    return false;
+  }
+  rex::memory::BaseHeap *heap = memory->LookupHeap(address);
+  return heap &&
+         heap->QueryRangeAccess(address, address + length - 1) !=
+             rex::memory::PageAccess::kNoAccess;
 }
 
 bool IsSemanticVehicleDrawProvenanceLayer(VehicleDrawProvenanceLayer layer) {
@@ -1844,6 +1871,9 @@ void ScanVehicleObjectProbeLocked(uint64_t backend_signature, uint64_t frame,
     return;
   }
   ++g_vehicle_object_scan_requests;
+  if (IsTargetedVehicleRenderContextProbe(probe)) {
+    ++g_vehicle_render_context_scan_requests[probe.argument_index - 4];
+  }
   const uint64_t frame_window = frame / kFrameSummaryInterval;
   uint64_t key = HashCombine(backend_signature, frame_window);
   key = HashCombine(key, uint64_t(probe.layer));
@@ -1887,10 +1917,14 @@ void ScanVehicleObjectProbeLocked(uint64_t backend_signature, uint64_t frame,
   };
   ++g_vehicle_object_scan_cache_count;
   ++g_vehicle_object_scans;
+  if (IsTargetedVehicleRenderContextProbe(probe)) {
+    ++g_vehicle_render_context_scans[probe.argument_index - 4];
+  }
   g_vehicle_object_scan_words += kVehicleObjectScanWordCount;
   rex::memory::Memory *memory =
       g_vehicle_discovery_memory.load(std::memory_order_acquire);
-  if (!memory) {
+  if (!IsReadableVehicleGuestRange(memory, probe.value,
+                                   kVehicleObjectScanWordCount * 4)) {
     return;
   }
   std::array<uint32_t, kVehicleObjectScanWordCount> words{};
@@ -15745,6 +15779,8 @@ void ConfigureVehicleDiscovery(bool census_requested,
     g_vehicle_object_argument_matches = 0;
     g_vehicle_object_correlation_count = 0;
     g_vehicle_object_correlation_overflow = 0;
+    g_vehicle_render_context_scan_requests = {};
+    g_vehicle_render_context_scans = {};
   }
   g_vehicle_title_provenance_requested =
       REXCVAR_GET(pinyon_shift_native_renderer_dispatch_discovery);
@@ -15789,6 +15825,9 @@ void ConfigureVehicleDiscovery(bool census_requested,
         std::to_string(kVehicleObjectCorrelationCapacity)},
        {"object_correlation",
         "sampled_one_hop_pointer_to_vehicle_address"},
+       {"targeted_render_context_arguments", "824365B0:r7,r8"},
+       {"targeted_render_context_static_contract",
+        "r7_vtable_slot_8_and_r8_vector_source"},
        {"guest_payload_read",
         "existing_title_pose_hook_values_and_bounded_owner_vtable"},
        {"guest_state_changed", "false"},
@@ -15896,6 +15935,14 @@ void EmitVehicleDiscoverySummary() {
         std::to_string(kVehicleObjectCorrelationCapacity)},
        {"object_correlation_overflow",
         std::to_string(g_vehicle_object_correlation_overflow)},
+       {"targeted_render_context_r7_scan_requests",
+        std::to_string(g_vehicle_render_context_scan_requests[0])},
+       {"targeted_render_context_r7_scans",
+        std::to_string(g_vehicle_render_context_scans[0])},
+       {"targeted_render_context_r8_scan_requests",
+        std::to_string(g_vehicle_render_context_scan_requests[1])},
+       {"targeted_render_context_r8_scans",
+        std::to_string(g_vehicle_render_context_scans[1])},
        {"title_provenance_requested",
         g_vehicle_title_provenance_requested ? "true" : "false"},
        {"draw_provenance_coverage_complete",

--- a/tools/summarize-native-renderer-vehicle-pose.py
+++ b/tools/summarize-native-renderer-vehicle-pose.py
@@ -183,6 +183,10 @@ def build(events, requested_session=None):
         "object_scan_cache_capacity": "16384",
         "object_correlation_capacity": "2048",
         "object_correlation": "sampled_one_hop_pointer_to_vehicle_address",
+        "targeted_render_context_arguments": "824365B0:r7,r8",
+        "targeted_render_context_static_contract": (
+            "r7_vtable_slot_8_and_r8_vector_source"
+        ),
         "guest_payload_read": (
             "existing_title_pose_hook_values_and_bounded_owner_vtable"
         ),
@@ -288,6 +292,10 @@ def build(events, requested_session=None):
         "object_correlations",
         "object_correlation_capacity",
         "object_correlation_overflow",
+        "targeted_render_context_r7_scan_requests",
+        "targeted_render_context_r7_scans",
+        "targeted_render_context_r8_scan_requests",
+        "targeted_render_context_r8_scans",
     ):
         totals[key] = integer(summary, key)
     identities = []
@@ -738,6 +746,17 @@ def build(events, requested_session=None):
         failures.append("vehicle object correlation table overflowed")
     if totals["object_correlations"] > totals["object_correlation_capacity"]:
         failures.append("vehicle object correlation capacity drifted")
+    for register in ("r7", "r8"):
+        requests = totals[f"targeted_render_context_{register}_scan_requests"]
+        scans = totals[f"targeted_render_context_{register}_scans"]
+        if not requests or not scans:
+            failures.append(
+                f"targeted render-context {register} coverage was absent"
+            )
+        if scans > requests:
+            failures.append(
+                f"targeted render-context {register} accounting drifted"
+            )
     for method in method_correlations:
         if method["status"] != "complete" or method["calls"] != method["exits"]:
             failures.append(

--- a/tools/tests/test_native_renderer_vehicle_pose.py
+++ b/tools/tests/test_native_renderer_vehicle_pose.py
@@ -47,6 +47,10 @@ def fixture():
         object_scan_cache_capacity="16384",
         object_correlation_capacity="2048",
         object_correlation="sampled_one_hop_pointer_to_vehicle_address",
+        targeted_render_context_arguments="824365B0:r7,r8",
+        targeted_render_context_static_contract=(
+            "r7_vtable_slot_8_and_r8_vector_source"
+        ),
         guest_payload_read=(
             "existing_title_pose_hook_values_and_bounded_owner_vtable"
         ),
@@ -114,6 +118,10 @@ def fixture():
         object_correlations="0",
         object_correlation_capacity="2048",
         object_correlation_overflow="0",
+        targeted_render_context_r7_scan_requests="2",
+        targeted_render_context_r7_scans="1",
+        targeted_render_context_r8_scan_requests="2",
+        targeted_render_context_r8_scans="1",
         title_provenance_requested="true",
         draw_provenance_coverage_complete="true",
         guest_state_changed="false",
@@ -218,6 +226,17 @@ class VehiclePoseSummaryTests(unittest.TestCase):
         self.assertIn("ScanVehicleObjectProbeLocked", hooks)
         self.assertIn(
             '"native_renderer.discovery.vehicle_draw_object_correlation"',
+            hooks,
+        )
+        self.assertNotIn("ScanVehicleDescriptorEdgeLocked", hooks)
+        self.assertNotIn("VehicleDescriptorCorrelationEntry", hooks)
+        self.assertIn(
+            "probe.function_address == kVehicleRenderContextFunction",
+            hooks,
+        )
+        self.assertIn(
+            "if (IsTargetedVehicleRenderContextProbe(probe)) {\n"
+            "    return true;",
             hooks,
         )
         self.assertIn("[switch]$VehicleDrawCorrelation", capture)


### PR DESCRIPTION
## Summary
- extend the bounded vehicle-address census to the statically proven \824365B0:r7,r8\ render-context arguments
- admit those exact roots through guest page-range checks while retaining the generic address heuristic everywhere else
- require and report per-register request/unique-scan coverage
- document the clean AppData result and keep Xenos authoritative with native draw/suppression closed

## Qualification
- \python -m unittest discover -s tools/tests -p 'test_*.py'\ — 416 passed
- \python tools/check-markdown-links.py\ — passed
- \.\\tools\\build-preview.ps1 -Parallel 16\ — passed (SHA-256 \