### PR TITLE
feat(renderer): resolve vehicle render context callee

### DIFF
--- a/config/rexglue/analysis/main-xex.toml
+++ b/config/rexglue/analysis/main-xex.toml
@@ -191,6 +191,11 @@ address = 0x82418F38
 name = "PinyonShiftObserveIndirectContext82417BC0Exit"
 
 [[midasm_hook]]
+address = 0x8243646C
+name = "PinyonShiftObserveVehicleRenderContextDispatcherEntry"
+registers = ["r8", "r9", "r10", "r12"]
+
+[[midasm_hook]]
 address = 0x824365B4
 name = "PinyonShiftObserveIndirectContext824365B0Entry"
 registers = ["r3", "r4", "r5", "r6", "r7", "r8", "r9", "r10", "r12"]

--- a/docs/native-renderer/VEHICLE_INSTANCE_SEMANTIC_SEED.md
+++ b/docs/native-renderer/VEHICLE_INSTANCE_SEMANTIC_SEED.md
@@ -177,6 +177,45 @@ within the bounded snapshot, so both are rejected for this relationship depth.
 Continue from a typed callee contract or another submission family; native
 vehicle drawing and suppression remain closed.
 
+## Typed render-context callee profiles
+
+Static caller tracing shows `82436468` forwards its guest `r8` and `r9` as
+`824365B0:r7,r8`. Inside `824365B0`, modes `r6 = 0`, `1`, or `2` execute the
+virtual call through `r7` slot 8 before consuming `r7 + 4`, `r7 + 16`, and the
+32-byte vector source at `r8`. A read-only entry probe now captures that exact
+typed contract while both arguments are live. It groups observations by the
+resolved `r7` vtable and slot-8 target, records field and address churn, and
+fingerprints the vector payload without retaining guest bytes.
+
+An upstream hook at `82436468` also records the original caller return address
+for context-path dispatches (`r10 != 0`) and matches its `r8/r9` pair to the
+callee's `r7/r8` pair. The caller address participates in the profile key, so
+one dynamic type shared by several submission families remains partitioned by
+its exact origin. Missing or mismatched dispatcher lineage fails the report.
+
+This is the deliberately narrow typed edge that follows the rejected broad
+child scan. It reads only the statically proven root, nine vtable words needed
+to resolve slot 8, and eight vector words after guest page-range checks. Invalid
+root, vtable, and vector ranges have separate counters; missing coverage,
+accounting drift, invalid reads, or profile overflow fail qualification. The
+probe remains diagnostic-only: it uploads and draws nothing, leaves Xenos
+authoritative, and cannot enable suppression.
+
+Release/AppData session `20260830T104844Z-p14556` qualified 366,786 eligible
+callee observations with 366,786 exact dispatcher matches, no invalid root,
+vtable, or vector range, no mismatch, and no overflow. Two caller families
+were present: `8240ECAC` contributed 80,224 observations and `8243AC64`
+contributed 286,562. Both resolve vtable `820019CC` slot 8 to the single title
+function `8243BC80`.
+
+Static inspection classifies `8243BC80` as a boolean visibility/predicate
+wrapper rather than a transform provider. It first calls the same object's
+vtable slot 5; if that predicate is false and `r7 + 4` is non-null, it calls
+the child object's slot 14 and returns that boolean. This precisely explains
+the live `r7` contract but does not establish vehicle identity or a native draw
+source. Continue from the now-partitioned caller families or the typed child
+predicate edge; native vehicle drawing and suppression remain closed.
+
 Qualify a batched census with:
 
 ```powershell

--- a/src/native_renderer/graphics_hooks.cpp
+++ b/src/native_renderer/graphics_hooks.cpp
@@ -113,6 +113,7 @@ constexpr size_t kVehicleObjectScanWordCount = 128;
 constexpr size_t kVehicleObjectScanCacheCapacity = 16384;
 constexpr size_t kVehicleObjectCorrelationCapacity = 2048;
 constexpr uint32_t kVehicleRenderContextFunction = 0x824365B0;
+constexpr size_t kVehicleRenderContextCalleeProfileCapacity = 32;
 constexpr size_t kSemanticInstanceCapacity = 4096;
 constexpr size_t kSemanticSubmissionCapacity = 8192;
 constexpr size_t kSemanticRenderItemStackCapacity = 32;
@@ -691,6 +692,31 @@ struct VehicleObjectCorrelationEntry {
   bool valid = false;
 };
 
+struct VehicleRenderContextCalleeProfileEntry {
+  uint64_t observations = 0;
+  uint64_t root_address_changes = 0;
+  uint64_t root_field_4_changes = 0;
+  uint64_t root_field_16_changes = 0;
+  uint64_t vector_address_changes = 0;
+  uint64_t vector_hash_changes = 0;
+  uint64_t vector_hash = 0;
+  uint32_t root_address = 0;
+  uint32_t root_vtable = 0;
+  uint32_t slot_8_target = 0;
+  uint32_t root_field_4 = 0;
+  uint32_t root_field_16 = 0;
+  uint32_t vector_address = 0;
+  uint32_t dispatcher_return_address = 0;
+  bool valid = false;
+};
+
+struct PendingVehicleRenderContextDispatcher {
+  uint32_t return_address = 0;
+  uint32_t root_address = 0;
+  uint32_t vector_address = 0;
+  bool valid = false;
+};
+
 std::array<VehicleIdentityEntry, kVehicleIdentityCapacity>
     g_vehicle_identities{};
 std::mutex g_vehicle_identity_mutex;
@@ -749,6 +775,24 @@ uint64_t g_vehicle_object_correlation_count = 0;
 uint64_t g_vehicle_object_correlation_overflow = 0;
 std::array<uint64_t, 2> g_vehicle_render_context_scan_requests{};
 std::array<uint64_t, 2> g_vehicle_render_context_scans{};
+std::array<VehicleRenderContextCalleeProfileEntry,
+           kVehicleRenderContextCalleeProfileCapacity>
+    g_vehicle_render_context_callee_profiles{};
+uint64_t g_vehicle_render_context_callee_observations = 0;
+uint64_t g_vehicle_render_context_callee_eligible_observations = 0;
+uint64_t g_vehicle_render_context_callee_ineligible_observations = 0;
+uint64_t g_vehicle_render_context_callee_valid_observations = 0;
+uint64_t g_vehicle_render_context_callee_invalid_root = 0;
+uint64_t g_vehicle_render_context_callee_invalid_vtable = 0;
+uint64_t g_vehicle_render_context_callee_invalid_vector = 0;
+uint64_t g_vehicle_render_context_callee_profile_count = 0;
+uint64_t g_vehicle_render_context_callee_profile_overflow = 0;
+uint64_t g_vehicle_render_context_dispatcher_observations = 0;
+uint64_t g_vehicle_render_context_dispatcher_eligible_observations = 0;
+uint64_t g_vehicle_render_context_dispatcher_matches = 0;
+uint64_t g_vehicle_render_context_dispatcher_mismatches = 0;
+thread_local PendingVehicleRenderContextDispatcher
+    g_pending_vehicle_render_context_dispatcher{};
 bool g_vehicle_title_provenance_requested = false;
 uint64_t g_title_packets_recorded = 0;
 uint64_t g_title_packets_matched = 0;
@@ -1664,6 +1708,8 @@ uint64_t HashCombine(uint64_t hash, uint64_t value);
 template <size_t N>
 void LoadSemanticGuestWords(rex::memory::Memory *memory, uint32_t address,
                             std::array<uint32_t, N> &words);
+template <size_t N>
+uint64_t HashSemanticWords(const std::array<uint32_t, N> &words);
 
 const char *VehicleIdentityAddressKindName(VehicleIdentityAddressKind kind) {
   switch (kind) {
@@ -1793,6 +1839,114 @@ bool IsReadableVehicleGuestRange(rex::memory::Memory *memory,
   return heap &&
          heap->QueryRangeAccess(address, address + length - 1) !=
              rex::memory::PageAccess::kNoAccess;
+}
+
+void ObserveVehicleRenderContextDispatcher(uint32_t return_address,
+                                           uint32_t root_address,
+                                           uint32_t vector_address,
+                                           bool context_path) {
+  g_pending_vehicle_render_context_dispatcher = {};
+  if (!g_vehicle_discovery_installed.load(std::memory_order_acquire)) {
+    return;
+  }
+  std::scoped_lock lock(g_vehicle_draw_correlation_mutex);
+  ++g_vehicle_render_context_dispatcher_observations;
+  if (!context_path) {
+    return;
+  }
+  ++g_vehicle_render_context_dispatcher_eligible_observations;
+  g_pending_vehicle_render_context_dispatcher = {
+      .return_address = return_address,
+      .root_address = root_address,
+      .vector_address = vector_address,
+      .valid = true,
+  };
+}
+
+void ObserveVehicleRenderContextCallee(uint32_t function_address,
+                                       uint32_t mode, uint32_t root_address,
+                                       uint32_t vector_address) {
+  if (function_address != kVehicleRenderContextFunction ||
+      !g_vehicle_discovery_installed.load(std::memory_order_acquire)) {
+    return;
+  }
+  const PendingVehicleRenderContextDispatcher dispatcher =
+      g_pending_vehicle_render_context_dispatcher;
+  g_pending_vehicle_render_context_dispatcher = {};
+  std::scoped_lock lock(g_vehicle_draw_correlation_mutex);
+  ++g_vehicle_render_context_callee_observations;
+  const bool dispatcher_matches =
+      dispatcher.valid && dispatcher.root_address == root_address &&
+      dispatcher.vector_address == vector_address;
+  if (dispatcher_matches) {
+    ++g_vehicle_render_context_dispatcher_matches;
+  } else {
+    ++g_vehicle_render_context_dispatcher_mismatches;
+  }
+  if (mode > 2) {
+    ++g_vehicle_render_context_callee_ineligible_observations;
+    return;
+  }
+  ++g_vehicle_render_context_callee_eligible_observations;
+  rex::memory::Memory *memory =
+      g_vehicle_discovery_memory.load(std::memory_order_acquire);
+  if (!IsReadableVehicleGuestRange(memory, root_address, 20)) {
+    ++g_vehicle_render_context_callee_invalid_root;
+    return;
+  }
+  std::array<uint32_t, 5> root_words{};
+  LoadSemanticGuestWords(memory, root_address, root_words);
+  const uint32_t root_vtable = root_words[0];
+  if (!IsReadableVehicleGuestRange(memory, root_vtable, 36)) {
+    ++g_vehicle_render_context_callee_invalid_vtable;
+    return;
+  }
+  if (!IsReadableVehicleGuestRange(memory, vector_address, 32)) {
+    ++g_vehicle_render_context_callee_invalid_vector;
+    return;
+  }
+  std::array<uint32_t, 9> vtable_words{};
+  std::array<uint32_t, 8> vector_words{};
+  LoadSemanticGuestWords(memory, root_vtable, vtable_words);
+  LoadSemanticGuestWords(memory, vector_address, vector_words);
+  const uint32_t slot_8_target = vtable_words[8];
+  const uint64_t vector_hash = HashSemanticWords(vector_words);
+  ++g_vehicle_render_context_callee_valid_observations;
+  for (VehicleRenderContextCalleeProfileEntry &entry :
+       g_vehicle_render_context_callee_profiles) {
+    if (!entry.valid) {
+      entry.valid = true;
+      entry.observations = 1;
+      entry.root_address = root_address;
+      entry.root_vtable = root_vtable;
+      entry.slot_8_target = slot_8_target;
+      entry.root_field_4 = root_words[1];
+      entry.root_field_16 = root_words[4];
+      entry.vector_address = vector_address;
+      entry.vector_hash = vector_hash;
+      entry.dispatcher_return_address = dispatcher.return_address;
+      ++g_vehicle_render_context_callee_profile_count;
+      return;
+    }
+    if (entry.root_vtable != root_vtable ||
+        entry.slot_8_target != slot_8_target ||
+        entry.dispatcher_return_address != dispatcher.return_address) {
+      continue;
+    }
+    ++entry.observations;
+    entry.root_address_changes += entry.root_address != root_address;
+    entry.root_field_4_changes += entry.root_field_4 != root_words[1];
+    entry.root_field_16_changes += entry.root_field_16 != root_words[4];
+    entry.vector_address_changes += entry.vector_address != vector_address;
+    entry.vector_hash_changes += entry.vector_hash != vector_hash;
+    entry.root_address = root_address;
+    entry.root_field_4 = root_words[1];
+    entry.root_field_16 = root_words[4];
+    entry.vector_address = vector_address;
+    entry.vector_hash = vector_hash;
+    return;
+  }
+  ++g_vehicle_render_context_callee_profile_overflow;
 }
 
 bool IsSemanticVehicleDrawProvenanceLayer(VehicleDrawProvenanceLayer layer) {
@@ -15781,6 +15935,21 @@ void ConfigureVehicleDiscovery(bool census_requested,
     g_vehicle_object_correlation_overflow = 0;
     g_vehicle_render_context_scan_requests = {};
     g_vehicle_render_context_scans = {};
+    g_vehicle_render_context_callee_profiles = {};
+    g_vehicle_render_context_callee_observations = 0;
+    g_vehicle_render_context_callee_eligible_observations = 0;
+    g_vehicle_render_context_callee_ineligible_observations = 0;
+    g_vehicle_render_context_callee_valid_observations = 0;
+    g_vehicle_render_context_callee_invalid_root = 0;
+    g_vehicle_render_context_callee_invalid_vtable = 0;
+    g_vehicle_render_context_callee_invalid_vector = 0;
+    g_vehicle_render_context_callee_profile_count = 0;
+    g_vehicle_render_context_callee_profile_overflow = 0;
+    g_vehicle_render_context_dispatcher_observations = 0;
+    g_vehicle_render_context_dispatcher_eligible_observations = 0;
+    g_vehicle_render_context_dispatcher_matches = 0;
+    g_vehicle_render_context_dispatcher_mismatches = 0;
+    g_pending_vehicle_render_context_dispatcher = {};
   }
   g_vehicle_title_provenance_requested =
       REXCVAR_GET(pinyon_shift_native_renderer_dispatch_discovery);
@@ -15828,8 +15997,13 @@ void ConfigureVehicleDiscovery(bool census_requested,
        {"targeted_render_context_arguments", "824365B0:r7,r8"},
        {"targeted_render_context_static_contract",
         "r7_vtable_slot_8_and_r8_vector_source"},
+       {"render_context_callee_contract",
+        "824365B0:r6_le_2,r7_vtable_slot_8,r8_32_byte_vector"},
+       {"render_context_dispatcher_hook", "82436468:r8,r9,r10,r12"},
+       {"render_context_callee_profile_capacity",
+        std::to_string(kVehicleRenderContextCalleeProfileCapacity)},
        {"guest_payload_read",
-        "existing_title_pose_hook_values_and_bounded_owner_vtable"},
+        "existing_pose_values,bounded_owner_vtable,typed_context_entry"},
        {"guest_state_changed", "false"},
        {"native_upload", "false"},
        {"native_draw", "false"},
@@ -15943,6 +16117,35 @@ void EmitVehicleDiscoverySummary() {
         std::to_string(g_vehicle_render_context_scan_requests[1])},
        {"targeted_render_context_r8_scans",
         std::to_string(g_vehicle_render_context_scans[1])},
+       {"render_context_callee_observations",
+        std::to_string(g_vehicle_render_context_callee_observations)},
+       {"render_context_callee_eligible_observations",
+        std::to_string(g_vehicle_render_context_callee_eligible_observations)},
+       {"render_context_callee_ineligible_observations",
+        std::to_string(g_vehicle_render_context_callee_ineligible_observations)},
+       {"render_context_callee_valid_observations",
+        std::to_string(g_vehicle_render_context_callee_valid_observations)},
+       {"render_context_callee_invalid_root",
+        std::to_string(g_vehicle_render_context_callee_invalid_root)},
+       {"render_context_callee_invalid_vtable",
+        std::to_string(g_vehicle_render_context_callee_invalid_vtable)},
+       {"render_context_callee_invalid_vector",
+        std::to_string(g_vehicle_render_context_callee_invalid_vector)},
+       {"render_context_callee_profiles",
+        std::to_string(g_vehicle_render_context_callee_profile_count)},
+       {"render_context_callee_profile_capacity",
+        std::to_string(kVehicleRenderContextCalleeProfileCapacity)},
+       {"render_context_callee_profile_overflow",
+        std::to_string(g_vehicle_render_context_callee_profile_overflow)},
+       {"render_context_dispatcher_observations",
+        std::to_string(g_vehicle_render_context_dispatcher_observations)},
+       {"render_context_dispatcher_eligible_observations",
+        std::to_string(
+            g_vehicle_render_context_dispatcher_eligible_observations)},
+       {"render_context_dispatcher_matches",
+        std::to_string(g_vehicle_render_context_dispatcher_matches)},
+       {"render_context_dispatcher_mismatches",
+        std::to_string(g_vehicle_render_context_dispatcher_mismatches)},
        {"title_provenance_requested",
         g_vehicle_title_provenance_requested ? "true" : "false"},
        {"draw_provenance_coverage_complete",
@@ -15958,6 +16161,42 @@ void EmitVehicleDiscoverySummary() {
        {"native_draw", "false"},
        {"xenos_authority", "true"},
        {"suppression_allowed", "false"}});
+  for (const VehicleRenderContextCalleeProfileEntry &entry :
+       g_vehicle_render_context_callee_profiles) {
+    if (!entry.valid) {
+      continue;
+    }
+    pinyon_shift::diagnostics::RecordEvent(
+        "native_renderer.discovery.vehicle_render_context_callee",
+        {{"function_address", "824365B0"},
+         {"mode_contract", "r6_le_2"},
+         {"root_address", fmt::format("{:08X}", entry.root_address)},
+         {"root_vtable", fmt::format("{:08X}", entry.root_vtable)},
+         {"slot_8_target", fmt::format("{:08X}", entry.slot_8_target)},
+         {"root_field_4", fmt::format("{:08X}", entry.root_field_4)},
+         {"root_field_16", fmt::format("{:08X}", entry.root_field_16)},
+         {"vector_address", fmt::format("{:08X}", entry.vector_address)},
+         {"dispatcher_return_address",
+          fmt::format("{:08X}", entry.dispatcher_return_address)},
+         {"vector_hash", fmt::format("{:016X}", entry.vector_hash)},
+         {"observations", std::to_string(entry.observations)},
+         {"root_address_changes",
+          std::to_string(entry.root_address_changes)},
+         {"root_field_4_changes",
+          std::to_string(entry.root_field_4_changes)},
+         {"root_field_16_changes",
+          std::to_string(entry.root_field_16_changes)},
+         {"vector_address_changes",
+          std::to_string(entry.vector_address_changes)},
+         {"vector_hash_changes",
+          std::to_string(entry.vector_hash_changes)},
+         {"classification", "typed_vehicle_render_context_callee_seed"},
+         {"vehicle_draw_identity_proved", "false"},
+         {"guest_state_changed", "false"},
+         {"native_draw", "false"},
+         {"xenos_authority", "true"},
+         {"suppression_allowed", "false"}});
+  }
   size_t emitted = 0;
   for (const VehicleIdentityEntry &entry : g_vehicle_identities) {
     if (!entry.valid || emitted >= kVehicleIdentitySummaryLimit) {
@@ -17723,10 +17962,18 @@ PINYON_SHIFT_INDIRECT_PRODUCER_HOOKS(829F6360)
 
 #undef PINYON_SHIFT_INDIRECT_PRODUCER_HOOKS
 
+void PinyonShiftObserveVehicleRenderContextDispatcherEntry(
+    PPCRegister &r8, PPCRegister &r9, PPCRegister &r10, PPCRegister &r12) {
+  ObserveVehicleRenderContextDispatcher(r12.u32, r8.u32, r9.u32,
+                                        r10.u32 != 0);
+}
+
 void ObserveIndirectContextEntry(
     uint32_t function_address, PPCRegister &r3, PPCRegister &r4,
     PPCRegister &r5, PPCRegister &r6, PPCRegister &r7, PPCRegister &r8,
     PPCRegister &r9, PPCRegister &r10, PPCRegister &r12) {
+  ObserveVehicleRenderContextCallee(function_address, r6.u32, r7.u32,
+                                    r8.u32);
   PushIndirectContextOrigin(function_address, r12.u32, r3.u32, r4.u32,
                             r5.u32, r6.u32, r7.u32, r8.u32, r9.u32,
                             r10.u32);

--- a/tools/summarize-native-renderer-vehicle-pose.py
+++ b/tools/summarize-native-renderer-vehicle-pose.py
@@ -22,6 +22,9 @@ DRAW_ARGUMENT_CORRELATION = (
 DRAW_OBJECT_CORRELATION = (
     "native_renderer.discovery.vehicle_draw_object_correlation"
 )
+RENDER_CONTEXT_CALLEE = (
+    "native_renderer.discovery.vehicle_render_context_callee"
+)
 TITLE_PROVENANCE_CONFIG = (
     "native_renderer.discovery.title_provenance_config"
 )
@@ -187,8 +190,13 @@ def build(events, requested_session=None):
         "targeted_render_context_static_contract": (
             "r7_vtable_slot_8_and_r8_vector_source"
         ),
+        "render_context_callee_contract": (
+            "824365B0:r6_le_2,r7_vtable_slot_8,r8_32_byte_vector"
+        ),
+        "render_context_dispatcher_hook": "82436468:r8,r9,r10,r12",
+        "render_context_callee_profile_capacity": "32",
         "guest_payload_read": (
-            "existing_title_pose_hook_values_and_bounded_owner_vtable"
+            "existing_pose_values,bounded_owner_vtable,typed_context_entry"
         ),
         "guest_state_changed": "false",
         "native_upload": "false",
@@ -229,6 +237,7 @@ def build(events, requested_session=None):
         "object_scan_word_count": "128",
         "object_scan_cache_capacity": "16384",
         "object_correlation_capacity": "2048",
+        "render_context_callee_profile_capacity": "32",
         "guest_state_changed": "false",
         "native_upload": "false",
         "native_draw": "false",
@@ -296,6 +305,20 @@ def build(events, requested_session=None):
         "targeted_render_context_r7_scans",
         "targeted_render_context_r8_scan_requests",
         "targeted_render_context_r8_scans",
+        "render_context_callee_observations",
+        "render_context_callee_eligible_observations",
+        "render_context_callee_ineligible_observations",
+        "render_context_callee_valid_observations",
+        "render_context_callee_invalid_root",
+        "render_context_callee_invalid_vtable",
+        "render_context_callee_invalid_vector",
+        "render_context_callee_profiles",
+        "render_context_callee_profile_capacity",
+        "render_context_callee_profile_overflow",
+        "render_context_dispatcher_observations",
+        "render_context_dispatcher_eligible_observations",
+        "render_context_dispatcher_matches",
+        "render_context_dispatcher_mismatches",
     ):
         totals[key] = integer(summary, key)
     identities = []
@@ -655,6 +678,71 @@ def build(events, requested_session=None):
         )
     )
 
+    render_context_callees = []
+    seen_render_context_callees = set()
+    for event in selected:
+        if event.get("event") != RENDER_CONTEXT_CALLEE:
+            continue
+        key = (
+            hexadecimal(event, "root_vtable"),
+            hexadecimal(event, "slot_8_target"),
+            hexadecimal(event, "dispatcher_return_address"),
+        )
+        if (
+            key in seen_render_context_callees
+            or event.get("function_address") != "824365B0"
+            or event.get("mode_contract") != "r6_le_2"
+            or event.get("classification")
+            != "typed_vehicle_render_context_callee_seed"
+            or event.get("vehicle_draw_identity_proved") != "false"
+            or event.get("guest_state_changed") != "false"
+            or event.get("native_draw") != "false"
+            or event.get("xenos_authority") != "true"
+            or event.get("suppression_allowed") != "false"
+        ):
+            raise ValueError("vehicle render-context callee violates boundary")
+        seen_render_context_callees.add(key)
+        render_context_callees.append(
+            {
+                "function_address": "824365B0",
+                "root_address": hexadecimal(event, "root_address"),
+                "root_vtable": key[0],
+                "slot_8_target": key[1],
+                "dispatcher_return_address": key[2],
+                "root_field_4": hexadecimal_allow_zero(
+                    event, "root_field_4"
+                ),
+                "root_field_16": hexadecimal_allow_zero(
+                    event, "root_field_16"
+                ),
+                "vector_address": hexadecimal(event, "vector_address"),
+                "vector_hash": hexadecimal64(event, "vector_hash"),
+                "observations": integer(event, "observations"),
+                "root_address_changes": integer(
+                    event, "root_address_changes"
+                ),
+                "root_field_4_changes": integer(
+                    event, "root_field_4_changes"
+                ),
+                "root_field_16_changes": integer(
+                    event, "root_field_16_changes"
+                ),
+                "vector_address_changes": integer(
+                    event, "vector_address_changes"
+                ),
+                "vector_hash_changes": integer(
+                    event, "vector_hash_changes"
+                ),
+            }
+        )
+    render_context_callees.sort(
+        key=lambda item: (
+            item["root_vtable"],
+            item["slot_8_target"],
+            item["dispatcher_return_address"],
+        )
+    )
+
     failures = []
     if totals["observations"] != (
         totals["valid_observations"] + totals["invalid_observations"]
@@ -757,6 +845,57 @@ def build(events, requested_session=None):
             failures.append(
                 f"targeted render-context {register} accounting drifted"
             )
+    if totals["render_context_callee_observations"] != (
+        totals["render_context_callee_eligible_observations"]
+        + totals["render_context_callee_ineligible_observations"]
+    ):
+        failures.append("render-context callee mode accounting drifted")
+    if totals["render_context_callee_eligible_observations"] != (
+        totals["render_context_callee_valid_observations"]
+        + totals["render_context_callee_invalid_root"]
+        + totals["render_context_callee_invalid_vtable"]
+        + totals["render_context_callee_invalid_vector"]
+    ):
+        failures.append("render-context callee payload accounting drifted")
+    if (
+        not totals["render_context_callee_observations"]
+        or not totals["render_context_callee_eligible_observations"]
+        or not totals["render_context_callee_valid_observations"]
+        or not render_context_callees
+    ):
+        failures.append("render-context callee coverage was absent")
+    if (
+        totals["render_context_callee_invalid_root"]
+        or totals["render_context_callee_invalid_vtable"]
+        or totals["render_context_callee_invalid_vector"]
+    ):
+        failures.append("render-context callee payload was invalid")
+    if totals["render_context_callee_profile_overflow"]:
+        failures.append("render-context callee profile table overflowed")
+    if len(render_context_callees) != totals["render_context_callee_profiles"]:
+        failures.append("render-context callee profile coverage drifted")
+    if sum(item["observations"] for item in render_context_callees) != totals[
+        "render_context_callee_valid_observations"
+    ]:
+        failures.append("render-context callee profile totals drifted")
+    if totals["render_context_callee_profiles"] > totals[
+        "render_context_callee_profile_capacity"
+    ]:
+        failures.append("render-context callee profile capacity drifted")
+    if totals["render_context_dispatcher_eligible_observations"] > totals[
+        "render_context_dispatcher_observations"
+    ]:
+        failures.append("render-context dispatcher path accounting drifted")
+    if totals["render_context_dispatcher_matches"] + totals[
+        "render_context_dispatcher_mismatches"
+    ] != totals["render_context_callee_observations"]:
+        failures.append("render-context dispatcher match accounting drifted")
+    if totals["render_context_dispatcher_matches"] > totals[
+        "render_context_dispatcher_eligible_observations"
+    ]:
+        failures.append("render-context dispatcher coverage drifted")
+    if totals["render_context_dispatcher_mismatches"]:
+        failures.append("render-context dispatcher lineage mismatched")
     for method in method_correlations:
         if method["status"] != "complete" or method["calls"] != method["exits"]:
             failures.append(
@@ -802,6 +941,7 @@ def build(events, requested_session=None):
         "indirect_targets": indirect_targets,
         "draw_argument_correlations": draw_correlations,
         "draw_object_correlations": object_correlations,
+        "render_context_callees": render_context_callees,
         "coverage": {
             "title_provenance_requested": title_provenance_requested,
             "title_provenance_armed": title_provenance_armed,
@@ -826,6 +966,9 @@ def build(events, requested_session=None):
                 not failures
                 and draw_provenance_coverage_complete
                 and object_candidate_proved
+            ),
+            "render_context_callee_contract_proved": (
+                not failures and bool(render_context_callees)
             ),
             "native_vehicle_rendering_admitted": False,
             "suppression_allowed": False,

--- a/tools/tests/test_native_renderer_vehicle_pose.py
+++ b/tools/tests/test_native_renderer_vehicle_pose.py
@@ -51,8 +51,13 @@ def fixture():
         targeted_render_context_static_contract=(
             "r7_vtable_slot_8_and_r8_vector_source"
         ),
+        render_context_callee_contract=(
+            "824365B0:r6_le_2,r7_vtable_slot_8,r8_32_byte_vector"
+        ),
+        render_context_dispatcher_hook="82436468:r8,r9,r10,r12",
+        render_context_callee_profile_capacity="32",
         guest_payload_read=(
-            "existing_title_pose_hook_values_and_bounded_owner_vtable"
+            "existing_pose_values,bounded_owner_vtable,typed_context_entry"
         ),
         guest_state_changed="false",
         native_upload="false",
@@ -117,11 +122,25 @@ def fixture():
         object_argument_matches="0",
         object_correlations="0",
         object_correlation_capacity="2048",
+        render_context_callee_profile_capacity="32",
         object_correlation_overflow="0",
         targeted_render_context_r7_scan_requests="2",
         targeted_render_context_r7_scans="1",
         targeted_render_context_r8_scan_requests="2",
         targeted_render_context_r8_scans="1",
+        render_context_callee_observations="3",
+        render_context_callee_eligible_observations="2",
+        render_context_callee_ineligible_observations="1",
+        render_context_callee_valid_observations="2",
+        render_context_callee_invalid_root="0",
+        render_context_callee_invalid_vtable="0",
+        render_context_callee_invalid_vector="0",
+        render_context_callee_profiles="1",
+        render_context_callee_profile_overflow="0",
+        render_context_dispatcher_observations="4",
+        render_context_dispatcher_eligible_observations="3",
+        render_context_dispatcher_matches="3",
+        render_context_dispatcher_mismatches="0",
         title_provenance_requested="true",
         draw_provenance_coverage_complete="true",
         guest_state_changed="false",
@@ -179,7 +198,39 @@ def fixture():
                 suppression_allowed="false",
             )
         )
-    return [config, summary, identity, *methods, title_provenance_config]
+    render_context_callee = event(
+        MODULE.RENDER_CONTEXT_CALLEE,
+        function_address="824365B0",
+        mode_contract="r6_le_2",
+        root_address="AB1A7BE4",
+        root_vtable="82143000",
+        slot_8_target="82439000",
+        root_field_4="40400000",
+        root_field_16="703FF2A0",
+        vector_address="703FF2A0",
+        dispatcher_return_address="82DEFA2C",
+        vector_hash="1234567890ABCDEF",
+        observations="2",
+        root_address_changes="1",
+        root_field_4_changes="0",
+        root_field_16_changes="1",
+        vector_address_changes="1",
+        vector_hash_changes="1",
+        classification="typed_vehicle_render_context_callee_seed",
+        vehicle_draw_identity_proved="false",
+        guest_state_changed="false",
+        native_draw="false",
+        xenos_authority="true",
+        suppression_allowed="false",
+    )
+    return [
+        config,
+        summary,
+        identity,
+        *methods,
+        render_context_callee,
+        title_provenance_config,
+    ]
 
 
 class VehiclePoseSummaryTests(unittest.TestCase):
@@ -239,7 +290,16 @@ class VehiclePoseSummaryTests(unittest.TestCase):
             "    return true;",
             hooks,
         )
+        self.assertIn("ObserveVehicleRenderContextCallee", hooks)
+        self.assertIn(
+            "PinyonShiftObserveVehicleRenderContextDispatcherEntry", hooks
+        )
+        self.assertIn(
+            '"native_renderer.discovery.vehicle_render_context_callee"',
+            hooks,
+        )
         self.assertIn("[switch]$VehicleDrawCorrelation", capture)
+        self.assertEqual(1, analysis.count("address = 0x8243646C"))
         for address in (
             "82BC8468",
             "82BC84A4",
@@ -275,6 +335,16 @@ class VehiclePoseSummaryTests(unittest.TestCase):
         )
         self.assertTrue(
             document["coverage"]["draw_provenance_coverage_complete"]
+        )
+        self.assertTrue(
+            document["qualification"][
+                "render_context_callee_contract_proved"
+            ]
+        )
+        self.assertEqual(1, len(document["render_context_callees"]))
+        self.assertEqual(
+            "82439000",
+            document["render_context_callees"][0]["slot_8_target"],
         )
 
     def test_rejects_invalid_or_overflowed_observations(self):


### PR DESCRIPTION
## Summary
- capture the statically typed \824365B0:r7,r8\ contract at function entry
- preserve exact \82436468\ caller lineage and partition profiles by submission origin
- resolve dynamic r7 vtable/slot-8 targets and fingerprint the live r8 vector source
- enforce range, accounting, lineage, overflow, and Xenos-authority qualification boundaries
- document \8243BC80\ as a visibility/predicate wrapper, not a vehicle transform provider

## Qualification
- \python -m unittest discover -s tools/tests -p 'test_*.py'\ — 416 passed
- \python tools/check-markdown-links.py\ — passed
- \.\\tools\\build-preview.ps1 -Parallel 16\ — passed (SHA-256 \9A2C70C662A997416421A8E4DCEF5267346527D4C13AFFA51154DC6D9F22A33A\)
- AppData session \20260830T104844Z-p14556\ — normal exit; 366,786 valid callee observations and exact dispatcher matches; zero invalid ranges, mismatches, overflow, errors, or false vehicle admission

## Evidence
- callers \8240ECAC\ (80,224) and \8243AC64\ (286,562)
- vtable \820019CC\, slot 8 target \8243BC80\
- Xenos remains authoritative; native drawing and suppression remain closed
