### PR TITLE
feat(renderer): correlate typed vehicle matrix caller

### DIFF
--- a/config/rexglue/analysis/main-xex.toml
+++ b/config/rexglue/analysis/main-xex.toml
@@ -190,6 +190,16 @@ registers = ["r3", "r4", "r5", "r6", "r7", "r8", "r9", "r10", "r12"]
 address = 0x82418F38
 name = "PinyonShiftObserveIndirectContext82417BC0Exit"
 
+# NR-05E typed vehicle-matrix caller correlation. Generated instructions in
+# 8240E7B0 consume r6 as a live 4x4 matrix before dispatching the qualified
+# 8240ECAC render-context family. This entry hook compares that read-only
+# payload with already-admitted vehicle poses; it never changes guest state,
+# submits a native draw, or permits Xenos suppression.
+[[midasm_hook]]
+address = 0x8240E7B4
+name = "PinyonShiftObserveVehicleMatrixCallerEntry"
+registers = ["r6", "r12"]
+
 [[midasm_hook]]
 address = 0x8243646C
 name = "PinyonShiftObserveVehicleRenderContextDispatcherEntry"

--- a/docs/native-renderer/VEHICLE_INSTANCE_SEMANTIC_SEED.md
+++ b/docs/native-renderer/VEHICLE_INSTANCE_SEMANTIC_SEED.md
@@ -216,6 +216,57 @@ the live `r7` contract but does not establish vehicle identity or a native draw
 source. Continue from the now-partitioned caller families or the typed child
 predicate edge; native vehicle drawing and suppression remain closed.
 
+## Typed vehicle-matrix caller correlation
+
+The `8240ECAC` family resolves to title function `8240E7B0`. Its prologue
+preserves guest `r6` and immediately loads four 16-byte rows from that address,
+establishing a live 4x4 matrix contract before the already-qualified
+render-context dispatch. A read-only entry hook at `8240E7B4` now captures the
+matrix address and exact caller return address while the original arguments are
+still live.
+
+Each finite 64-byte matrix is compared with the latest position and forward
+vector from every already-admitted vehicle identity. The diagnostic evaluates
+both conventional 4x4 interpretations—translation in row 3 with forward in
+row 2, and translation in column 3 with forward in column 2—and both forward
+axis signs. For each of those four routes it retains only the closest current
+identity, using independently reported position and forward deltas. A tight
+candidate requires position delta squared no greater than `0.25` and forward
+delta squared no greater than `0.04`; the report still retains the best miss so
+an incorrect layout or axis hypothesis can be rejected from evidence rather
+than hidden by the threshold.
+
+The correlation table is fixed at 512 entries and partitions candidates by
+caller return address, matrix convention, forward sign, and exact vehicle
+identity. Separate counters cover invalid ranges, non-finite payloads, identity
+comparisons, routes with no identity, tight matches, table overflow, and both
+matrix-address and content churn. Qualification requires complete caller and
+four-route accounting, valid payloads, nonzero typed coverage, exact result
+totals, and no overflow. Even a tight match remains a render-transform
+candidate: it does not yet prove a complete vehicle draw, upload data, publish
+native output, or permit suppression. Xenos remains authoritative.
+
+Release/AppData session `20260830T110601Z-p40476` completed the typed caller
+qualification in stable festival gameplay. It observed 1,220 matrices, all
+finite and readable, and performed 134,356 comparisons across 33 admitted
+vehicle identities. All 4,880 layout/sign routes were accounted for in 14
+bounded correlation records with no invalid payload, table overflow, error,
+fatal, or crash event. The process exited normally. Median simulation cadence
+was 29.264 FPS and presentation cadence was 59.968 Hz during the diagnostic
+run.
+
+No route produced a tight match. The closest column-translation candidate was
+still `755569.20` squared position units away. The row-forward convention came
+within `0.01067` squared direction units, but its corresponding position was
+`1104221.95` squared units away. All observations came from caller return
+`8240437C`; static tracing resolves that site to `sub_82403C38`, where the
+matrix passed as `r6` is `r30 + 1008` from the render/system object returned by
+`82460500`, not from an admitted vehicle owner. This rejects the direct vehicle
+world-transform hypothesis and classifies the matrix as camera/reference-space
+state. The next typed step must follow the composition that combines this
+reference matrix with an object transform rather than widening heuristic
+scans. Native vehicle rendering and suppression remain closed.
+
 Qualify a batched census with:
 
 ```powershell

--- a/src/native_renderer/graphics_hooks.cpp
+++ b/src/native_renderer/graphics_hooks.cpp
@@ -114,6 +114,10 @@ constexpr size_t kVehicleObjectScanCacheCapacity = 16384;
 constexpr size_t kVehicleObjectCorrelationCapacity = 2048;
 constexpr uint32_t kVehicleRenderContextFunction = 0x824365B0;
 constexpr size_t kVehicleRenderContextCalleeProfileCapacity = 32;
+constexpr uint32_t kVehicleMatrixCallerFunction = 0x8240E7B0;
+constexpr size_t kVehicleMatrixCorrelationCapacity = 512;
+constexpr double kVehicleMatrixPositionDeltaSquaredThreshold = 0.25;
+constexpr double kVehicleMatrixForwardDeltaSquaredThreshold = 0.04;
 constexpr size_t kSemanticInstanceCapacity = 4096;
 constexpr size_t kSemanticSubmissionCapacity = 8192;
 constexpr size_t kSemanticRenderItemStackCapacity = 32;
@@ -717,6 +721,37 @@ struct PendingVehicleRenderContextDispatcher {
   bool valid = false;
 };
 
+enum class VehicleMatrixLayout : uint32_t {
+  kRowMajorTranslationRow3ForwardRow2 = 1,
+  kColumnMajorTranslationColumn3ForwardColumn2 = 2,
+};
+
+struct VehicleMatrixCorrelationEntry {
+  uint64_t observations = 0;
+  uint64_t tight_matches = 0;
+  uint64_t first_frame = 0;
+  uint64_t last_frame = 0;
+  uint64_t matrix_address_changes = 0;
+  uint64_t matrix_hash_changes = 0;
+  uint64_t last_matrix_hash = 0;
+  uint64_t best_matrix_hash = 0;
+  double best_position_delta_squared =
+      std::numeric_limits<double>::infinity();
+  double best_forward_delta_squared =
+      std::numeric_limits<double>::infinity();
+  double best_normalized_score = std::numeric_limits<double>::infinity();
+  uint32_t caller_return_address = 0;
+  uint32_t last_matrix_address = 0;
+  uint32_t best_matrix_address = 0;
+  uint32_t identity_generation = 0;
+  uint32_t identity_owner = 0;
+  uint32_t identity_slot = 0;
+  VehicleMatrixLayout layout =
+      VehicleMatrixLayout::kRowMajorTranslationRow3ForwardRow2;
+  int32_t forward_sign = 1;
+  bool valid = false;
+};
+
 std::array<VehicleIdentityEntry, kVehicleIdentityCapacity>
     g_vehicle_identities{};
 std::mutex g_vehicle_identity_mutex;
@@ -793,6 +828,18 @@ uint64_t g_vehicle_render_context_dispatcher_matches = 0;
 uint64_t g_vehicle_render_context_dispatcher_mismatches = 0;
 thread_local PendingVehicleRenderContextDispatcher
     g_pending_vehicle_render_context_dispatcher{};
+std::array<VehicleMatrixCorrelationEntry, kVehicleMatrixCorrelationCapacity>
+    g_vehicle_matrix_correlations{};
+uint64_t g_vehicle_matrix_caller_observations = 0;
+uint64_t g_vehicle_matrix_caller_valid_observations = 0;
+uint64_t g_vehicle_matrix_caller_invalid_range = 0;
+uint64_t g_vehicle_matrix_caller_non_finite = 0;
+uint64_t g_vehicle_matrix_identity_comparisons = 0;
+uint64_t g_vehicle_matrix_candidate_observations = 0;
+uint64_t g_vehicle_matrix_routes_without_identity = 0;
+uint64_t g_vehicle_matrix_tight_matches = 0;
+uint64_t g_vehicle_matrix_correlation_count = 0;
+uint64_t g_vehicle_matrix_correlation_overflow = 0;
 bool g_vehicle_title_provenance_requested = false;
 uint64_t g_title_packets_recorded = 0;
 uint64_t g_title_packets_matched = 0;
@@ -1839,6 +1886,174 @@ bool IsReadableVehicleGuestRange(rex::memory::Memory *memory,
   return heap &&
          heap->QueryRangeAccess(address, address + length - 1) !=
              rex::memory::PageAccess::kNoAccess;
+}
+
+const char *VehicleMatrixLayoutName(VehicleMatrixLayout layout) {
+  switch (layout) {
+  case VehicleMatrixLayout::kRowMajorTranslationRow3ForwardRow2:
+    return "row_major_translation_row3_forward_row2";
+  case VehicleMatrixLayout::kColumnMajorTranslationColumn3ForwardColumn2:
+    return "column_major_translation_column3_forward_column2";
+  }
+  return "unknown";
+}
+
+void ObserveVehicleMatrixCaller(uint32_t function_address,
+                                uint32_t matrix_address,
+                                uint32_t caller_return_address) {
+  if (function_address != kVehicleMatrixCallerFunction ||
+      !g_vehicle_discovery_installed.load(std::memory_order_acquire)) {
+    return;
+  }
+  rex::memory::Memory *memory =
+      g_vehicle_discovery_memory.load(std::memory_order_acquire);
+  std::scoped_lock lock(g_vehicle_identity_mutex);
+  ++g_vehicle_matrix_caller_observations;
+  if (!IsReadableVehicleGuestRange(memory, matrix_address, 64)) {
+    ++g_vehicle_matrix_caller_invalid_range;
+    return;
+  }
+  std::array<uint32_t, 16> matrix_words{};
+  LoadSemanticGuestWords(memory, matrix_address, matrix_words);
+  std::array<float, 16> matrix{};
+  for (size_t index = 0; index < matrix.size(); ++index) {
+    matrix[index] = std::bit_cast<float>(matrix_words[index]);
+    if (!std::isfinite(matrix[index])) {
+      ++g_vehicle_matrix_caller_non_finite;
+      return;
+    }
+  }
+  ++g_vehicle_matrix_caller_valid_observations;
+  const uint64_t matrix_hash = HashSemanticWords(matrix_words);
+  const uint64_t frame = g_frame_sequence.load(std::memory_order_relaxed);
+  constexpr std::array<VehicleMatrixLayout, 2> layouts{{
+      VehicleMatrixLayout::kRowMajorTranslationRow3ForwardRow2,
+      VehicleMatrixLayout::kColumnMajorTranslationColumn3ForwardColumn2,
+  }};
+  constexpr std::array<int32_t, 2> forward_signs{{1, -1}};
+  for (VehicleMatrixLayout layout : layouts) {
+    const std::array<float, 3> position =
+        layout == VehicleMatrixLayout::kRowMajorTranslationRow3ForwardRow2
+            ? std::array<float, 3>{{matrix[12], matrix[13], matrix[14]}}
+            : std::array<float, 3>{{matrix[3], matrix[7], matrix[11]}};
+    const std::array<float, 3> forward =
+        layout == VehicleMatrixLayout::kRowMajorTranslationRow3ForwardRow2
+            ? std::array<float, 3>{{matrix[8], matrix[9], matrix[10]}}
+            : std::array<float, 3>{{matrix[2], matrix[6], matrix[10]}};
+    for (int32_t forward_sign : forward_signs) {
+      const VehicleIdentityEntry *best_identity = nullptr;
+      double best_position_delta_squared =
+          std::numeric_limits<double>::infinity();
+      double best_forward_delta_squared =
+          std::numeric_limits<double>::infinity();
+      double best_normalized_score = std::numeric_limits<double>::infinity();
+      for (const VehicleIdentityEntry &identity : g_vehicle_identities) {
+        if (!identity.valid) {
+          continue;
+        }
+        ++g_vehicle_matrix_identity_comparisons;
+        const double position_dx = double(position[0]) - identity.last_x;
+        const double position_dy = double(position[1]) - identity.last_y;
+        const double position_dz = double(position[2]) - identity.last_z;
+        const double forward_dx =
+            double(forward_sign) * forward[0] - identity.last_forward_x;
+        const double forward_dy =
+            double(forward_sign) * forward[1] - identity.last_forward_y;
+        const double forward_dz =
+            double(forward_sign) * forward[2] - identity.last_forward_z;
+        const double position_delta_squared =
+            position_dx * position_dx + position_dy * position_dy +
+            position_dz * position_dz;
+        const double forward_delta_squared =
+            forward_dx * forward_dx + forward_dy * forward_dy +
+            forward_dz * forward_dz;
+        const double normalized_score =
+            position_delta_squared /
+                kVehicleMatrixPositionDeltaSquaredThreshold +
+            forward_delta_squared /
+                kVehicleMatrixForwardDeltaSquaredThreshold;
+        if (normalized_score < best_normalized_score) {
+          best_identity = &identity;
+          best_position_delta_squared = position_delta_squared;
+          best_forward_delta_squared = forward_delta_squared;
+          best_normalized_score = normalized_score;
+        }
+      }
+      if (!best_identity) {
+        ++g_vehicle_matrix_routes_without_identity;
+        continue;
+      }
+      ++g_vehicle_matrix_candidate_observations;
+      const bool tight_match =
+          best_position_delta_squared <=
+              kVehicleMatrixPositionDeltaSquaredThreshold &&
+          best_forward_delta_squared <=
+              kVehicleMatrixForwardDeltaSquaredThreshold;
+      g_vehicle_matrix_tight_matches += tight_match ? 1 : 0;
+      VehicleMatrixCorrelationEntry *available = nullptr;
+      VehicleMatrixCorrelationEntry *matched = nullptr;
+      for (VehicleMatrixCorrelationEntry &entry :
+           g_vehicle_matrix_correlations) {
+        if (!entry.valid) {
+          if (!available) {
+            available = &entry;
+          }
+          continue;
+        }
+        if (entry.caller_return_address == caller_return_address &&
+            entry.identity_generation == best_identity->generation &&
+            entry.identity_owner == best_identity->owner &&
+            entry.identity_slot == best_identity->slot &&
+            entry.layout == layout && entry.forward_sign == forward_sign) {
+          matched = &entry;
+          break;
+        }
+      }
+      if (!matched) {
+        if (!available) {
+          ++g_vehicle_matrix_correlation_overflow;
+          continue;
+        }
+        *available = {
+            .observations = 1,
+            .tight_matches = tight_match ? 1u : 0u,
+            .first_frame = frame,
+            .last_frame = frame,
+            .last_matrix_hash = matrix_hash,
+            .best_matrix_hash = matrix_hash,
+            .best_position_delta_squared = best_position_delta_squared,
+            .best_forward_delta_squared = best_forward_delta_squared,
+            .best_normalized_score = best_normalized_score,
+            .caller_return_address = caller_return_address,
+            .last_matrix_address = matrix_address,
+            .best_matrix_address = matrix_address,
+            .identity_generation = best_identity->generation,
+            .identity_owner = best_identity->owner,
+            .identity_slot = best_identity->slot,
+            .layout = layout,
+            .forward_sign = forward_sign,
+            .valid = true,
+        };
+        ++g_vehicle_matrix_correlation_count;
+        continue;
+      }
+      ++matched->observations;
+      matched->tight_matches += tight_match ? 1 : 0;
+      matched->last_frame = frame;
+      matched->matrix_address_changes +=
+          matched->last_matrix_address != matrix_address;
+      matched->matrix_hash_changes += matched->last_matrix_hash != matrix_hash;
+      matched->last_matrix_address = matrix_address;
+      matched->last_matrix_hash = matrix_hash;
+      if (best_normalized_score < matched->best_normalized_score) {
+        matched->best_position_delta_squared = best_position_delta_squared;
+        matched->best_forward_delta_squared = best_forward_delta_squared;
+        matched->best_normalized_score = best_normalized_score;
+        matched->best_matrix_address = matrix_address;
+        matched->best_matrix_hash = matrix_hash;
+      }
+    }
+  }
 }
 
 void ObserveVehicleRenderContextDispatcher(uint32_t return_address,
@@ -15889,6 +16104,17 @@ void ConfigureVehicleDiscovery(bool census_requested,
     g_vehicle_identity_addresses = {};
     g_vehicle_identity_address_count = 0;
     g_vehicle_identity_address_overflow = 0;
+    g_vehicle_matrix_correlations = {};
+    g_vehicle_matrix_caller_observations = 0;
+    g_vehicle_matrix_caller_valid_observations = 0;
+    g_vehicle_matrix_caller_invalid_range = 0;
+    g_vehicle_matrix_caller_non_finite = 0;
+    g_vehicle_matrix_identity_comparisons = 0;
+    g_vehicle_matrix_candidate_observations = 0;
+    g_vehicle_matrix_routes_without_identity = 0;
+    g_vehicle_matrix_tight_matches = 0;
+    g_vehicle_matrix_correlation_count = 0;
+    g_vehicle_matrix_correlation_overflow = 0;
   }
   for (VehicleOwnerMethodStats &stats : g_vehicle_owner_method_stats) {
     stats.calls.store(0, std::memory_order_relaxed);
@@ -16002,8 +16228,18 @@ void ConfigureVehicleDiscovery(bool census_requested,
        {"render_context_dispatcher_hook", "82436468:r8,r9,r10,r12"},
        {"render_context_callee_profile_capacity",
         std::to_string(kVehicleRenderContextCalleeProfileCapacity)},
+       {"vehicle_matrix_caller_contract", "8240E7B0:r6_4x4_matrix,r12"},
+       {"vehicle_matrix_layouts",
+        "row_major_translation_row3_forward_row2,"
+        "column_major_translation_column3_forward_column2"},
+       {"vehicle_matrix_forward_signs", "positive,negative"},
+       {"vehicle_matrix_match_thresholds",
+        "position_delta_squared<=0.25,forward_delta_squared<=0.04"},
+       {"vehicle_matrix_correlation_capacity",
+        std::to_string(kVehicleMatrixCorrelationCapacity)},
        {"guest_payload_read",
-        "existing_pose_values,bounded_owner_vtable,typed_context_entry"},
+        "existing_pose_values,bounded_owner_vtable,typed_context_entry,"
+        "typed_4x4_caller_matrix"},
        {"guest_state_changed", "false"},
        {"native_upload", "false"},
        {"native_draw", "false"},
@@ -16022,6 +16258,15 @@ void EmitVehicleDiscoverySummary() {
   const bool accounting_complete =
       g_vehicle_valid_observations + g_vehicle_invalid_observations ==
       g_vehicle_observations;
+  const bool vehicle_matrix_accounting_complete =
+      g_vehicle_matrix_caller_valid_observations +
+          g_vehicle_matrix_caller_invalid_range +
+          g_vehicle_matrix_caller_non_finite ==
+      g_vehicle_matrix_caller_observations;
+  const bool vehicle_matrix_route_accounting_complete =
+      g_vehicle_matrix_candidate_observations +
+          g_vehicle_matrix_routes_without_identity ==
+      g_vehicle_matrix_caller_valid_observations * 4;
   pinyon_shift::diagnostics::RecordEvent(
       "native_renderer.discovery.vehicle_pose_summary",
       {{"status", !g_vehicle_observations
@@ -16146,6 +16391,32 @@ void EmitVehicleDiscoverySummary() {
         std::to_string(g_vehicle_render_context_dispatcher_matches)},
        {"render_context_dispatcher_mismatches",
         std::to_string(g_vehicle_render_context_dispatcher_mismatches)},
+       {"vehicle_matrix_caller_observations",
+        std::to_string(g_vehicle_matrix_caller_observations)},
+       {"vehicle_matrix_caller_valid_observations",
+        std::to_string(g_vehicle_matrix_caller_valid_observations)},
+       {"vehicle_matrix_caller_invalid_range",
+        std::to_string(g_vehicle_matrix_caller_invalid_range)},
+       {"vehicle_matrix_caller_non_finite",
+        std::to_string(g_vehicle_matrix_caller_non_finite)},
+       {"vehicle_matrix_caller_accounting_complete",
+        vehicle_matrix_accounting_complete ? "true" : "false"},
+       {"vehicle_matrix_identity_comparisons",
+        std::to_string(g_vehicle_matrix_identity_comparisons)},
+       {"vehicle_matrix_candidate_observations",
+        std::to_string(g_vehicle_matrix_candidate_observations)},
+       {"vehicle_matrix_routes_without_identity",
+        std::to_string(g_vehicle_matrix_routes_without_identity)},
+       {"vehicle_matrix_route_accounting_complete",
+        vehicle_matrix_route_accounting_complete ? "true" : "false"},
+       {"vehicle_matrix_tight_matches",
+        std::to_string(g_vehicle_matrix_tight_matches)},
+       {"vehicle_matrix_correlations",
+        std::to_string(g_vehicle_matrix_correlation_count)},
+       {"vehicle_matrix_correlation_capacity",
+        std::to_string(kVehicleMatrixCorrelationCapacity)},
+       {"vehicle_matrix_correlation_overflow",
+        std::to_string(g_vehicle_matrix_correlation_overflow)},
        {"title_provenance_requested",
         g_vehicle_title_provenance_requested ? "true" : "false"},
        {"draw_provenance_coverage_complete",
@@ -16191,6 +16462,50 @@ void EmitVehicleDiscoverySummary() {
          {"vector_hash_changes",
           std::to_string(entry.vector_hash_changes)},
          {"classification", "typed_vehicle_render_context_callee_seed"},
+         {"vehicle_draw_identity_proved", "false"},
+         {"guest_state_changed", "false"},
+         {"native_draw", "false"},
+         {"xenos_authority", "true"},
+         {"suppression_allowed", "false"}});
+  }
+  for (const VehicleMatrixCorrelationEntry &entry :
+       g_vehicle_matrix_correlations) {
+    if (!entry.valid) {
+      continue;
+    }
+    pinyon_shift::diagnostics::RecordEvent(
+        "native_renderer.discovery.vehicle_matrix_correlation",
+        {{"function_address", "8240E7B0"},
+         {"caller_return_address",
+          fmt::format("{:08X}", entry.caller_return_address)},
+         {"matrix_layout", VehicleMatrixLayoutName(entry.layout)},
+         {"forward_sign", entry.forward_sign > 0 ? "positive" : "negative"},
+         {"identity_generation",
+          fmt::format("{:08X}", entry.identity_generation)},
+         {"identity_owner", fmt::format("{:08X}", entry.identity_owner)},
+         {"identity_slot", std::to_string(entry.identity_slot)},
+         {"observations", std::to_string(entry.observations)},
+         {"tight_matches", std::to_string(entry.tight_matches)},
+         {"first_frame", std::to_string(entry.first_frame)},
+         {"last_frame", std::to_string(entry.last_frame)},
+         {"matrix_address_changes",
+          std::to_string(entry.matrix_address_changes)},
+         {"matrix_hash_changes", std::to_string(entry.matrix_hash_changes)},
+         {"last_matrix_address",
+          fmt::format("{:08X}", entry.last_matrix_address)},
+         {"last_matrix_hash", fmt::format("{:016X}", entry.last_matrix_hash)},
+         {"best_matrix_address",
+          fmt::format("{:08X}", entry.best_matrix_address)},
+         {"best_matrix_hash", fmt::format("{:016X}", entry.best_matrix_hash)},
+         {"best_position_delta_squared",
+          fmt::format("{}", entry.best_position_delta_squared)},
+         {"best_forward_delta_squared",
+          fmt::format("{}", entry.best_forward_delta_squared)},
+         {"best_normalized_score",
+          fmt::format("{}", entry.best_normalized_score)},
+         {"classification", "vehicle_render_matrix_correlation_candidate"},
+         {"vehicle_render_transform_candidate_proved",
+          entry.tight_matches ? "true" : "false"},
          {"vehicle_draw_identity_proved", "false"},
          {"guest_state_changed", "false"},
          {"native_draw", "false"},
@@ -17961,6 +18276,11 @@ PINYON_SHIFT_INDIRECT_PRODUCER_HOOKS(82417060)
 PINYON_SHIFT_INDIRECT_PRODUCER_HOOKS(829F6360)
 
 #undef PINYON_SHIFT_INDIRECT_PRODUCER_HOOKS
+
+void PinyonShiftObserveVehicleMatrixCallerEntry(PPCRegister &r6,
+                                                PPCRegister &r12) {
+  ObserveVehicleMatrixCaller(kVehicleMatrixCallerFunction, r6.u32, r12.u32);
+}
 
 void PinyonShiftObserveVehicleRenderContextDispatcherEntry(
     PPCRegister &r8, PPCRegister &r9, PPCRegister &r10, PPCRegister &r12) {

--- a/tools/summarize-native-renderer-vehicle-pose.py
+++ b/tools/summarize-native-renderer-vehicle-pose.py
@@ -25,6 +25,9 @@ DRAW_OBJECT_CORRELATION = (
 RENDER_CONTEXT_CALLEE = (
     "native_renderer.discovery.vehicle_render_context_callee"
 )
+VEHICLE_MATRIX_CORRELATION = (
+    "native_renderer.discovery.vehicle_matrix_correlation"
+)
 TITLE_PROVENANCE_CONFIG = (
     "native_renderer.discovery.title_provenance_config"
 )
@@ -54,6 +57,11 @@ DRAW_PROVENANCE_LAYERS = {
     "indirect_semantic_receiver",
 }
 DRAW_IDENTITY_FIELDS = {"owner", "position", "forward"}
+VEHICLE_MATRIX_LAYOUTS = {
+    "row_major_translation_row3_forward_row2",
+    "column_major_translation_column3_forward_column2",
+}
+VEHICLE_MATRIX_FORWARD_SIGNS = {"positive", "negative"}
 
 
 def read_events(paths):
@@ -195,8 +203,19 @@ def build(events, requested_session=None):
         ),
         "render_context_dispatcher_hook": "82436468:r8,r9,r10,r12",
         "render_context_callee_profile_capacity": "32",
+        "vehicle_matrix_caller_contract": "8240E7B0:r6_4x4_matrix,r12",
+        "vehicle_matrix_layouts": (
+            "row_major_translation_row3_forward_row2,"
+            "column_major_translation_column3_forward_column2"
+        ),
+        "vehicle_matrix_forward_signs": "positive,negative",
+        "vehicle_matrix_match_thresholds": (
+            "position_delta_squared<=0.25,forward_delta_squared<=0.04"
+        ),
+        "vehicle_matrix_correlation_capacity": "512",
         "guest_payload_read": (
-            "existing_pose_values,bounded_owner_vtable,typed_context_entry"
+            "existing_pose_values,bounded_owner_vtable,typed_context_entry,"
+            "typed_4x4_caller_matrix"
         ),
         "guest_state_changed": "false",
         "native_upload": "false",
@@ -238,6 +257,7 @@ def build(events, requested_session=None):
         "object_scan_cache_capacity": "16384",
         "object_correlation_capacity": "2048",
         "render_context_callee_profile_capacity": "32",
+        "vehicle_matrix_correlation_capacity": "512",
         "guest_state_changed": "false",
         "native_upload": "false",
         "native_draw": "false",
@@ -319,8 +339,26 @@ def build(events, requested_session=None):
         "render_context_dispatcher_eligible_observations",
         "render_context_dispatcher_matches",
         "render_context_dispatcher_mismatches",
+        "vehicle_matrix_caller_observations",
+        "vehicle_matrix_caller_valid_observations",
+        "vehicle_matrix_caller_invalid_range",
+        "vehicle_matrix_caller_non_finite",
+        "vehicle_matrix_identity_comparisons",
+        "vehicle_matrix_candidate_observations",
+        "vehicle_matrix_routes_without_identity",
+        "vehicle_matrix_tight_matches",
+        "vehicle_matrix_correlations",
+        "vehicle_matrix_correlation_capacity",
+        "vehicle_matrix_correlation_overflow",
     ):
         totals[key] = integer(summary, key)
+    for key in (
+        "vehicle_matrix_caller_accounting_complete",
+        "vehicle_matrix_route_accounting_complete",
+    ):
+        if summary.get(key) not in ("true", "false"):
+            raise ValueError(f"invalid {key}")
+        totals[key] = summary[key] == "true"
     identities = []
     seen = set()
     for event in selected:
@@ -743,6 +781,99 @@ def build(events, requested_session=None):
         )
     )
 
+    matrix_correlations = []
+    seen_matrix_correlations = set()
+    for event in selected:
+        if event.get("event") != VEHICLE_MATRIX_CORRELATION:
+            continue
+        layout = event.get("matrix_layout")
+        forward_sign = event.get("forward_sign")
+        identity_key = (
+            hexadecimal(event, "identity_generation"),
+            hexadecimal(event, "identity_owner"),
+            integer(event, "identity_slot"),
+        )
+        key = (
+            hexadecimal(event, "caller_return_address"),
+            layout,
+            forward_sign,
+            *identity_key,
+        )
+        observations = integer(event, "observations")
+        tight_matches = integer(event, "tight_matches")
+        first_frame = integer(event, "first_frame")
+        last_frame = integer(event, "last_frame")
+        candidate_proved = tight_matches > 0
+        if (
+            key in seen_matrix_correlations
+            or event.get("function_address") != "8240E7B0"
+            or layout not in VEHICLE_MATRIX_LAYOUTS
+            or forward_sign not in VEHICLE_MATRIX_FORWARD_SIGNS
+            or identity_key not in identities_by_key
+            or not observations
+            or tight_matches > observations
+            or first_frame > last_frame
+            or event.get("classification")
+            != "vehicle_render_matrix_correlation_candidate"
+            or event.get("vehicle_render_transform_candidate_proved")
+            != ("true" if candidate_proved else "false")
+            or event.get("vehicle_draw_identity_proved") != "false"
+            or event.get("guest_state_changed") != "false"
+            or event.get("native_draw") != "false"
+            or event.get("xenos_authority") != "true"
+            or event.get("suppression_allowed") != "false"
+        ):
+            raise ValueError("vehicle matrix correlation violates boundary")
+        seen_matrix_correlations.add(key)
+        matrix_correlations.append(
+            {
+                "function_address": "8240E7B0",
+                "caller_return_address": key[0],
+                "matrix_layout": layout,
+                "forward_sign": forward_sign,
+                "identity_generation": identity_key[0],
+                "identity_owner": identity_key[1],
+                "identity_slot": identity_key[2],
+                "observations": observations,
+                "tight_matches": tight_matches,
+                "first_frame": first_frame,
+                "last_frame": last_frame,
+                "matrix_address_changes": integer(
+                    event, "matrix_address_changes"
+                ),
+                "matrix_hash_changes": integer(event, "matrix_hash_changes"),
+                "last_matrix_address": hexadecimal(
+                    event, "last_matrix_address"
+                ),
+                "last_matrix_hash": hexadecimal64(event, "last_matrix_hash"),
+                "best_matrix_address": hexadecimal(
+                    event, "best_matrix_address"
+                ),
+                "best_matrix_hash": hexadecimal64(event, "best_matrix_hash"),
+                "best_position_delta_squared": finite_number(
+                    event, "best_position_delta_squared"
+                ),
+                "best_forward_delta_squared": finite_number(
+                    event, "best_forward_delta_squared"
+                ),
+                "best_normalized_score": finite_number(
+                    event, "best_normalized_score"
+                ),
+                "vehicle_render_transform_candidate_proved": (
+                    candidate_proved
+                ),
+            }
+        )
+    matrix_correlations.sort(
+        key=lambda item: (
+            item["caller_return_address"],
+            item["matrix_layout"],
+            item["forward_sign"],
+            item["identity_owner"],
+            item["identity_slot"],
+        )
+    )
+
     failures = []
     if totals["observations"] != (
         totals["valid_observations"] + totals["invalid_observations"]
@@ -896,6 +1027,55 @@ def build(events, requested_session=None):
         failures.append("render-context dispatcher coverage drifted")
     if totals["render_context_dispatcher_mismatches"]:
         failures.append("render-context dispatcher lineage mismatched")
+    matrix_caller_accounting_complete = totals[
+        "vehicle_matrix_caller_valid_observations"
+    ] + totals["vehicle_matrix_caller_invalid_range"] + totals[
+        "vehicle_matrix_caller_non_finite"
+    ] == totals["vehicle_matrix_caller_observations"]
+    if (
+        not matrix_caller_accounting_complete
+        or not totals["vehicle_matrix_caller_accounting_complete"]
+    ):
+        failures.append("vehicle matrix caller accounting drifted")
+    matrix_route_accounting_complete = totals[
+        "vehicle_matrix_candidate_observations"
+    ] + totals["vehicle_matrix_routes_without_identity"] == (
+        totals["vehicle_matrix_caller_valid_observations"] * 4
+    )
+    if (
+        not matrix_route_accounting_complete
+        or not totals["vehicle_matrix_route_accounting_complete"]
+    ):
+        failures.append("vehicle matrix route accounting drifted")
+    if (
+        not totals["vehicle_matrix_caller_observations"]
+        or not totals["vehicle_matrix_caller_valid_observations"]
+        or not totals["vehicle_matrix_identity_comparisons"]
+        or not totals["vehicle_matrix_candidate_observations"]
+        or not matrix_correlations
+    ):
+        failures.append("vehicle matrix caller coverage was absent")
+    if (
+        totals["vehicle_matrix_caller_invalid_range"]
+        or totals["vehicle_matrix_caller_non_finite"]
+    ):
+        failures.append("vehicle matrix caller payload was invalid")
+    if sum(item["observations"] for item in matrix_correlations) != totals[
+        "vehicle_matrix_candidate_observations"
+    ]:
+        failures.append("vehicle matrix candidate totals drifted")
+    if sum(item["tight_matches"] for item in matrix_correlations) != totals[
+        "vehicle_matrix_tight_matches"
+    ]:
+        failures.append("vehicle matrix tight-match totals drifted")
+    if len(matrix_correlations) != totals["vehicle_matrix_correlations"]:
+        failures.append("vehicle matrix correlation coverage drifted")
+    if totals["vehicle_matrix_correlation_overflow"]:
+        failures.append("vehicle matrix correlation table overflowed")
+    if totals["vehicle_matrix_correlations"] > totals[
+        "vehicle_matrix_correlation_capacity"
+    ]:
+        failures.append("vehicle matrix correlation capacity drifted")
     for method in method_correlations:
         if method["status"] != "complete" or method["calls"] != method["exits"]:
             failures.append(
@@ -916,6 +1096,10 @@ def build(events, requested_session=None):
     )
     draw_argument_candidate_proved = bool(draw_correlations)
     object_candidate_proved = bool(object_correlations)
+    matrix_candidate_proved = any(
+        item["vehicle_render_transform_candidate_proved"]
+        for item in matrix_correlations
+    )
     draw_provenance_coverage_complete = (
         title_provenance_requested
         and title_provenance_armed
@@ -942,6 +1126,7 @@ def build(events, requested_session=None):
         "draw_argument_correlations": draw_correlations,
         "draw_object_correlations": object_correlations,
         "render_context_callees": render_context_callees,
+        "vehicle_matrix_correlations": matrix_correlations,
         "coverage": {
             "title_provenance_requested": title_provenance_requested,
             "title_provenance_armed": title_provenance_armed,
@@ -969,6 +1154,9 @@ def build(events, requested_session=None):
             ),
             "render_context_callee_contract_proved": (
                 not failures and bool(render_context_callees)
+            ),
+            "vehicle_render_matrix_candidate_proved": (
+                not failures and matrix_candidate_proved
             ),
             "native_vehicle_rendering_admitted": False,
             "suppression_allowed": False,

--- a/tools/tests/test_native_renderer_vehicle_pose.py
+++ b/tools/tests/test_native_renderer_vehicle_pose.py
@@ -56,8 +56,19 @@ def fixture():
         ),
         render_context_dispatcher_hook="82436468:r8,r9,r10,r12",
         render_context_callee_profile_capacity="32",
+        vehicle_matrix_caller_contract="8240E7B0:r6_4x4_matrix,r12",
+        vehicle_matrix_layouts=(
+            "row_major_translation_row3_forward_row2,"
+            "column_major_translation_column3_forward_column2"
+        ),
+        vehicle_matrix_forward_signs="positive,negative",
+        vehicle_matrix_match_thresholds=(
+            "position_delta_squared<=0.25,forward_delta_squared<=0.04"
+        ),
+        vehicle_matrix_correlation_capacity="512",
         guest_payload_read=(
-            "existing_pose_values,bounded_owner_vtable,typed_context_entry"
+            "existing_pose_values,bounded_owner_vtable,typed_context_entry,"
+            "typed_4x4_caller_matrix"
         ),
         guest_state_changed="false",
         native_upload="false",
@@ -141,6 +152,19 @@ def fixture():
         render_context_dispatcher_eligible_observations="3",
         render_context_dispatcher_matches="3",
         render_context_dispatcher_mismatches="0",
+        vehicle_matrix_caller_observations="1",
+        vehicle_matrix_caller_valid_observations="1",
+        vehicle_matrix_caller_invalid_range="0",
+        vehicle_matrix_caller_non_finite="0",
+        vehicle_matrix_caller_accounting_complete="true",
+        vehicle_matrix_identity_comparisons="4",
+        vehicle_matrix_candidate_observations="4",
+        vehicle_matrix_routes_without_identity="0",
+        vehicle_matrix_route_accounting_complete="true",
+        vehicle_matrix_tight_matches="1",
+        vehicle_matrix_correlations="4",
+        vehicle_matrix_correlation_capacity="512",
+        vehicle_matrix_correlation_overflow="0",
         title_provenance_requested="true",
         draw_provenance_coverage_complete="true",
         guest_state_changed="false",
@@ -223,12 +247,62 @@ def fixture():
         xenos_authority="true",
         suppression_allowed="false",
     )
+    matrix_correlations = []
+    for layout in sorted(MODULE.VEHICLE_MATRIX_LAYOUTS):
+        for forward_sign in sorted(MODULE.VEHICLE_MATRIX_FORWARD_SIGNS):
+            tight_match = (
+                layout == "row_major_translation_row3_forward_row2"
+                and forward_sign == "positive"
+            )
+            matrix_correlations.append(
+                event(
+                    MODULE.VEHICLE_MATRIX_CORRELATION,
+                    function_address="8240E7B0",
+                    caller_return_address="8240F004",
+                    matrix_layout=layout,
+                    forward_sign=forward_sign,
+                    identity_generation="00000001",
+                    identity_owner="A0002000",
+                    identity_slot="2",
+                    observations="1",
+                    tight_matches="1" if tight_match else "0",
+                    first_frame="104",
+                    last_frame="104",
+                    matrix_address_changes="0",
+                    matrix_hash_changes="0",
+                    last_matrix_address="703FF000",
+                    last_matrix_hash="1234567890ABCDEF",
+                    best_matrix_address="703FF000",
+                    best_matrix_hash="1234567890ABCDEF",
+                    best_position_delta_squared=(
+                        "0.01" if tight_match else "100.0"
+                    ),
+                    best_forward_delta_squared=(
+                        "0.001" if tight_match else "1.0"
+                    ),
+                    best_normalized_score=(
+                        "0.065" if tight_match else "425.0"
+                    ),
+                    classification=(
+                        "vehicle_render_matrix_correlation_candidate"
+                    ),
+                    vehicle_render_transform_candidate_proved=(
+                        "true" if tight_match else "false"
+                    ),
+                    vehicle_draw_identity_proved="false",
+                    guest_state_changed="false",
+                    native_draw="false",
+                    xenos_authority="true",
+                    suppression_allowed="false",
+                )
+            )
     return [
         config,
         summary,
         identity,
         *methods,
         render_context_callee,
+        *matrix_correlations,
         title_provenance_config,
     ]
 
@@ -298,7 +372,12 @@ class VehiclePoseSummaryTests(unittest.TestCase):
             '"native_renderer.discovery.vehicle_render_context_callee"',
             hooks,
         )
+        self.assertIn("ObserveVehicleMatrixCaller", hooks)
+        self.assertIn(
+            '"native_renderer.discovery.vehicle_matrix_correlation"', hooks
+        )
         self.assertIn("[switch]$VehicleDrawCorrelation", capture)
+        self.assertEqual(1, analysis.count("address = 0x8240E7B4"))
         self.assertEqual(1, analysis.count("address = 0x8243646C"))
         for address in (
             "82BC8468",
@@ -345,6 +424,28 @@ class VehiclePoseSummaryTests(unittest.TestCase):
         self.assertEqual(
             "82439000",
             document["render_context_callees"][0]["slot_8_target"],
+        )
+        self.assertTrue(
+            document["qualification"][
+                "vehicle_render_matrix_candidate_proved"
+            ]
+        )
+        self.assertEqual(4, len(document["vehicle_matrix_correlations"]))
+
+    def test_rejects_vehicle_matrix_accounting_or_overflow(self):
+        events = fixture()
+        events[1]["vehicle_matrix_caller_valid_observations"] = "0"
+        document = MODULE.build(events)
+        self.assertIn(
+            "vehicle matrix caller accounting drifted", document["failures"]
+        )
+
+        events = fixture()
+        events[1]["vehicle_matrix_correlation_overflow"] = "1"
+        document = MODULE.build(events)
+        self.assertIn(
+            "vehicle matrix correlation table overflowed",
+            document["failures"],
         )
 
     def test_rejects_invalid_or_overflowed_observations(self):


### PR DESCRIPTION
## Summary

- hook the exact 8240E7B0 typed 4x4 matrix caller without changing guest state
- compare both conventional matrix layouts and forward signs against admitted vehicle poses in a bounded 512-entry table
- extend qualification reporting with strict caller, route, payload, and overflow accounting
- document the qualified negative result and the next object/reference composition boundary

## Runtime evidence

AppData session \20260830T110601Z-p40476\ completed normally in festival gameplay:

- 1,220/1,220 valid finite matrices
- 134,356 vehicle identity comparisons across 33 identities
- 4,880/4,880 layout/sign routes accounted for
- 14 correlation records, zero tight matches, zero overflow
- zero error/fatal/crash-like events
- 29.264 median simulation FPS and 59.968 Hz presentation cadence

The closest forward-axis candidate did not share the vehicle world position. Static caller tracing resolves the matrix to render/system state at \30 + 1008\, so this PR rejects direct vehicle-world-transform identity and leaves native vehicle output and suppression closed.

## Tests

- \python -m unittest discover -s tools/tests -p test_*.py\ (417 passed)
- \python tools/check-markdown-links.py\
- \.\\tools\\build-preview.ps1 -Parallel 16 -JsonEvents\
- AppData-backed native-renderer census (normal exit)