### PR TITLE
feat(renderer): correlate composed vehicle matrices

### DIFF
--- a/config/rexglue/analysis/main-xex.toml
+++ b/config/rexglue/analysis/main-xex.toml
@@ -210,6 +210,15 @@ address = 0x8240EC18
 name = "PinyonShiftObserveVehicleTypedRenderItem"
 registers = ["r11", "r31"]
 
+# Immediately before 8240E7B0 submits its 64-byte matrix payload to 82435E78,
+# r22 still owns the original r7 object/reference matrix and r5 points at the
+# fully composed stack payload. Compare both exact live matrices with admitted
+# vehicle poses without changing the title call or retaining stack storage.
+[[midasm_hook]]
+address = 0x8240EB5C
+name = "PinyonShiftObserveVehicleComposedMatrix"
+registers = ["r5", "r22"]
+
 [[midasm_hook]]
 address = 0x8243646C
 name = "PinyonShiftObserveVehicleRenderContextDispatcherEntry"

--- a/docs/native-renderer/VEHICLE_INSTANCE_SEMANTIC_SEED.md
+++ b/docs/native-renderer/VEHICLE_INSTANCE_SEMANTIC_SEED.md
@@ -311,6 +311,44 @@ vehicle identity bridge. Continue at the explicit `8240E7B0` matrix composition
 that writes the 64-byte payload passed to `82435E78`; do not widen heuristic
 object scans. Native vehicle drawing and suppression remain closed.
 
+## Object/reference composed matrix
+
+Static instruction flow now closes the next transform boundary inside
+`8240E7B0`. The function preserves its original `r7` argument in `r22`, reads
+that argument as a complete 4×4 matrix, multiplies it with the transformed
+reference state derived from the already-qualified `r6` matrix, writes the
+64-byte result at stack offsets 240–303, and passes that exact address as `r5`
+to `82435E78`. Immediately before the call, `r22` still names the live object
+input matrix and `r5` names the fully written composed payload.
+
+A read-only hook at `8240EB5C` compares both matrices independently with every
+admitted vehicle pose. Each source evaluates the same two conventional matrix
+layouts and both forward-axis signs, producing eight strictly accounted routes
+per valid pair. The fixed 1,024-entry result table partitions observations by
+source, layout, sign, and exact vehicle identity; it retains closest misses as
+well as tight matches so the object-input and composed-output hypotheses can be
+rejected separately.
+
+The hook validates both 64-byte ranges and every floating-point component
+before comparison. Invalid ranges, non-finite values, missing source coverage,
+pair or route accounting drift, and result-table overflow fail qualification.
+It retains no stack pointer after the synchronous observation, changes no guest
+state, performs no native upload or draw, leaves Xenos authoritative, and cannot
+enable suppression.
+
+The AppData-backed `20260830T114202Z-p31280` census qualified this contract with
+899 observations and 899 valid input/output pairs. All 7,192 candidate routes
+and 185,952 exact-identity comparisons were accounted for, with zero invalid
+range, non-finite, missing-identity-route, overflow, error, fatal, or crash
+result. The eight retained source/layout/sign correlations produced zero tight
+matches. The closest object-input and composed-output results remained about
+755,541 position-delta-squared units away, so both hypotheses are rejected as
+the vehicle pose bridge. The process exited normally at frame 7,293; median
+derived performance was 30.384 FPS, with 29.735 Hz simulation and 59.978 Hz
+presentation cadence. Continue downstream of `82435E78` at the first consumer
+that converts this reference-space payload into the render-instance transform;
+do not widen object scans. Native drawing and suppression remain closed.
+
 Qualify a batched census with:
 
 ```powershell

--- a/src/native_renderer/graphics_hooks.cpp
+++ b/src/native_renderer/graphics_hooks.cpp
@@ -121,6 +121,9 @@ constexpr double kVehicleMatrixForwardDeltaSquaredThreshold = 0.04;
 constexpr size_t kVehicleTypedRenderItemProfileCapacity = 32;
 constexpr size_t kVehicleTypedDescriptorWordCount = 62;
 constexpr size_t kVehicleTypedDescriptorCorrelationCapacity = 512;
+constexpr uint32_t kVehicleComposedMatrixHook = 0x8240EB5C;
+constexpr uint32_t kVehicleComposedMatrixCallee = 0x82435E78;
+constexpr size_t kVehicleComposedMatrixCorrelationCapacity = 1024;
 constexpr size_t kSemanticInstanceCapacity = 4096;
 constexpr size_t kSemanticSubmissionCapacity = 8192;
 constexpr size_t kSemanticRenderItemStackCapacity = 32;
@@ -729,6 +732,12 @@ enum class VehicleMatrixLayout : uint32_t {
   kColumnMajorTranslationColumn3ForwardColumn2 = 2,
 };
 
+enum class VehicleMatrixSource : uint32_t {
+  kCallerReference = 1,
+  kObjectInput = 2,
+  kComposedUpload = 3,
+};
+
 struct VehicleMatrixCorrelationEntry {
   uint64_t observations = 0;
   uint64_t tight_matches = 0;
@@ -751,6 +760,7 @@ struct VehicleMatrixCorrelationEntry {
   uint32_t identity_slot = 0;
   VehicleMatrixLayout layout =
       VehicleMatrixLayout::kRowMajorTranslationRow3ForwardRow2;
+  VehicleMatrixSource source = VehicleMatrixSource::kCallerReference;
   int32_t forward_sign = 1;
   bool valid = false;
 };
@@ -895,6 +905,21 @@ uint64_t g_vehicle_typed_descriptor_scan_words = 0;
 uint64_t g_vehicle_typed_descriptor_matches = 0;
 uint64_t g_vehicle_typed_descriptor_correlation_count = 0;
 uint64_t g_vehicle_typed_descriptor_correlation_overflow = 0;
+std::array<VehicleMatrixCorrelationEntry,
+           kVehicleComposedMatrixCorrelationCapacity>
+    g_vehicle_composed_matrix_correlations{};
+uint64_t g_vehicle_composed_matrix_observations = 0;
+uint64_t g_vehicle_composed_matrix_valid_pairs = 0;
+uint64_t g_vehicle_composed_matrix_invalid_object_range = 0;
+uint64_t g_vehicle_composed_matrix_invalid_output_range = 0;
+uint64_t g_vehicle_composed_matrix_object_non_finite = 0;
+uint64_t g_vehicle_composed_matrix_output_non_finite = 0;
+uint64_t g_vehicle_composed_matrix_identity_comparisons = 0;
+uint64_t g_vehicle_composed_matrix_candidate_observations = 0;
+uint64_t g_vehicle_composed_matrix_routes_without_identity = 0;
+uint64_t g_vehicle_composed_matrix_tight_matches = 0;
+uint64_t g_vehicle_composed_matrix_correlation_count = 0;
+uint64_t g_vehicle_composed_matrix_correlation_overflow = 0;
 bool g_vehicle_title_provenance_requested = false;
 uint64_t g_title_packets_recorded = 0;
 uint64_t g_title_packets_matched = 0;
@@ -1953,6 +1978,18 @@ const char *VehicleMatrixLayoutName(VehicleMatrixLayout layout) {
   return "unknown";
 }
 
+const char *VehicleMatrixSourceName(VehicleMatrixSource source) {
+  switch (source) {
+  case VehicleMatrixSource::kCallerReference:
+    return "caller_reference_matrix";
+  case VehicleMatrixSource::kObjectInput:
+    return "object_input_matrix";
+  case VehicleMatrixSource::kComposedUpload:
+    return "composed_upload_matrix";
+  }
+  return "unknown";
+}
+
 void ObserveVehicleMatrixCaller(uint32_t function_address,
                                 uint32_t matrix_address,
                                 uint32_t caller_return_address) {
@@ -2106,6 +2143,191 @@ void ObserveVehicleMatrixCaller(uint32_t function_address,
         matched->best_normalized_score = best_normalized_score;
         matched->best_matrix_address = matrix_address;
         matched->best_matrix_hash = matrix_hash;
+      }
+    }
+  }
+}
+
+void ObserveVehicleComposedMatrix(uint32_t object_matrix_address,
+                                  uint32_t composed_matrix_address) {
+  if (!g_vehicle_discovery_installed.load(std::memory_order_acquire)) {
+    return;
+  }
+  rex::memory::Memory *memory =
+      g_vehicle_discovery_memory.load(std::memory_order_acquire);
+  std::scoped_lock lock(g_vehicle_identity_mutex);
+  ++g_vehicle_composed_matrix_observations;
+  if (!IsReadableVehicleGuestRange(memory, object_matrix_address, 64)) {
+    ++g_vehicle_composed_matrix_invalid_object_range;
+    return;
+  }
+  if (!IsReadableVehicleGuestRange(memory, composed_matrix_address, 64)) {
+    ++g_vehicle_composed_matrix_invalid_output_range;
+    return;
+  }
+  std::array<std::array<uint32_t, 16>, 2> matrix_words{};
+  LoadSemanticGuestWords(memory, object_matrix_address, matrix_words[0]);
+  LoadSemanticGuestWords(memory, composed_matrix_address, matrix_words[1]);
+  std::array<std::array<float, 16>, 2> matrices{};
+  for (size_t source_index = 0; source_index < matrices.size();
+       ++source_index) {
+    for (size_t word_index = 0; word_index < matrices[source_index].size();
+         ++word_index) {
+      matrices[source_index][word_index] =
+          std::bit_cast<float>(matrix_words[source_index][word_index]);
+      if (!std::isfinite(matrices[source_index][word_index])) {
+        if (source_index == 0) {
+          ++g_vehicle_composed_matrix_object_non_finite;
+        } else {
+          ++g_vehicle_composed_matrix_output_non_finite;
+        }
+        return;
+      }
+    }
+  }
+  ++g_vehicle_composed_matrix_valid_pairs;
+  const uint64_t frame = g_frame_sequence.load(std::memory_order_relaxed);
+  constexpr std::array<VehicleMatrixSource, 2> sources{{
+      VehicleMatrixSource::kObjectInput,
+      VehicleMatrixSource::kComposedUpload,
+  }};
+  const std::array<uint32_t, 2> addresses{{
+      object_matrix_address,
+      composed_matrix_address,
+  }};
+  constexpr std::array<VehicleMatrixLayout, 2> layouts{{
+      VehicleMatrixLayout::kRowMajorTranslationRow3ForwardRow2,
+      VehicleMatrixLayout::kColumnMajorTranslationColumn3ForwardColumn2,
+  }};
+  constexpr std::array<int32_t, 2> forward_signs{{1, -1}};
+  for (size_t source_index = 0; source_index < sources.size();
+       ++source_index) {
+    const VehicleMatrixSource source = sources[source_index];
+    const std::array<float, 16> &matrix = matrices[source_index];
+    const uint32_t matrix_address = addresses[source_index];
+    const uint64_t matrix_hash = HashSemanticWords(matrix_words[source_index]);
+    for (VehicleMatrixLayout layout : layouts) {
+      const std::array<float, 3> position =
+          layout == VehicleMatrixLayout::kRowMajorTranslationRow3ForwardRow2
+              ? std::array<float, 3>{{matrix[12], matrix[13], matrix[14]}}
+              : std::array<float, 3>{{matrix[3], matrix[7], matrix[11]}};
+      const std::array<float, 3> forward =
+          layout == VehicleMatrixLayout::kRowMajorTranslationRow3ForwardRow2
+              ? std::array<float, 3>{{matrix[8], matrix[9], matrix[10]}}
+              : std::array<float, 3>{{matrix[2], matrix[6], matrix[10]}};
+      for (int32_t forward_sign : forward_signs) {
+        const VehicleIdentityEntry *best_identity = nullptr;
+        double best_position_delta_squared =
+            std::numeric_limits<double>::infinity();
+        double best_forward_delta_squared =
+            std::numeric_limits<double>::infinity();
+        double best_normalized_score = std::numeric_limits<double>::infinity();
+        for (const VehicleIdentityEntry &identity : g_vehicle_identities) {
+          if (!identity.valid) {
+            continue;
+          }
+          ++g_vehicle_composed_matrix_identity_comparisons;
+          const double position_dx = double(position[0]) - identity.last_x;
+          const double position_dy = double(position[1]) - identity.last_y;
+          const double position_dz = double(position[2]) - identity.last_z;
+          const double forward_dx =
+              double(forward_sign) * forward[0] - identity.last_forward_x;
+          const double forward_dy =
+              double(forward_sign) * forward[1] - identity.last_forward_y;
+          const double forward_dz =
+              double(forward_sign) * forward[2] - identity.last_forward_z;
+          const double position_delta_squared =
+              position_dx * position_dx + position_dy * position_dy +
+              position_dz * position_dz;
+          const double forward_delta_squared =
+              forward_dx * forward_dx + forward_dy * forward_dy +
+              forward_dz * forward_dz;
+          const double normalized_score =
+              position_delta_squared /
+                  kVehicleMatrixPositionDeltaSquaredThreshold +
+              forward_delta_squared /
+                  kVehicleMatrixForwardDeltaSquaredThreshold;
+          if (normalized_score < best_normalized_score) {
+            best_identity = &identity;
+            best_position_delta_squared = position_delta_squared;
+            best_forward_delta_squared = forward_delta_squared;
+            best_normalized_score = normalized_score;
+          }
+        }
+        if (!best_identity) {
+          ++g_vehicle_composed_matrix_routes_without_identity;
+          continue;
+        }
+        ++g_vehicle_composed_matrix_candidate_observations;
+        const bool tight_match =
+            best_position_delta_squared <=
+                kVehicleMatrixPositionDeltaSquaredThreshold &&
+            best_forward_delta_squared <=
+                kVehicleMatrixForwardDeltaSquaredThreshold;
+        g_vehicle_composed_matrix_tight_matches += tight_match ? 1 : 0;
+        VehicleMatrixCorrelationEntry *available = nullptr;
+        VehicleMatrixCorrelationEntry *matched = nullptr;
+        for (VehicleMatrixCorrelationEntry &entry :
+             g_vehicle_composed_matrix_correlations) {
+          if (!entry.valid) {
+            if (!available) {
+              available = &entry;
+            }
+            continue;
+          }
+          if (entry.source == source && entry.layout == layout &&
+              entry.forward_sign == forward_sign &&
+              entry.identity_generation == best_identity->generation &&
+              entry.identity_owner == best_identity->owner &&
+              entry.identity_slot == best_identity->slot) {
+            matched = &entry;
+            break;
+          }
+        }
+        if (!matched) {
+          if (!available) {
+            ++g_vehicle_composed_matrix_correlation_overflow;
+            continue;
+          }
+          *available = {
+              .observations = 1,
+              .tight_matches = tight_match ? 1u : 0u,
+              .first_frame = frame,
+              .last_frame = frame,
+              .last_matrix_hash = matrix_hash,
+              .best_matrix_hash = matrix_hash,
+              .best_position_delta_squared = best_position_delta_squared,
+              .best_forward_delta_squared = best_forward_delta_squared,
+              .best_normalized_score = best_normalized_score,
+              .last_matrix_address = matrix_address,
+              .best_matrix_address = matrix_address,
+              .identity_generation = best_identity->generation,
+              .identity_owner = best_identity->owner,
+              .identity_slot = best_identity->slot,
+              .layout = layout,
+              .source = source,
+              .forward_sign = forward_sign,
+              .valid = true,
+          };
+          ++g_vehicle_composed_matrix_correlation_count;
+          continue;
+        }
+        ++matched->observations;
+        matched->tight_matches += tight_match ? 1u : 0u;
+        matched->last_frame = frame;
+        matched->matrix_address_changes +=
+            matched->last_matrix_address != matrix_address;
+        matched->matrix_hash_changes +=
+            matched->last_matrix_hash != matrix_hash;
+        matched->last_matrix_address = matrix_address;
+        matched->last_matrix_hash = matrix_hash;
+        if (best_normalized_score < matched->best_normalized_score) {
+          matched->best_position_delta_squared = best_position_delta_squared;
+          matched->best_forward_delta_squared = best_forward_delta_squared;
+          matched->best_normalized_score = best_normalized_score;
+          matched->best_matrix_address = matrix_address;
+          matched->best_matrix_hash = matrix_hash;
+        }
       }
     }
   }
@@ -16354,6 +16576,19 @@ void ConfigureVehicleDiscovery(bool census_requested,
     g_vehicle_typed_descriptor_matches = 0;
     g_vehicle_typed_descriptor_correlation_count = 0;
     g_vehicle_typed_descriptor_correlation_overflow = 0;
+    g_vehicle_composed_matrix_correlations = {};
+    g_vehicle_composed_matrix_observations = 0;
+    g_vehicle_composed_matrix_valid_pairs = 0;
+    g_vehicle_composed_matrix_invalid_object_range = 0;
+    g_vehicle_composed_matrix_invalid_output_range = 0;
+    g_vehicle_composed_matrix_object_non_finite = 0;
+    g_vehicle_composed_matrix_output_non_finite = 0;
+    g_vehicle_composed_matrix_identity_comparisons = 0;
+    g_vehicle_composed_matrix_candidate_observations = 0;
+    g_vehicle_composed_matrix_routes_without_identity = 0;
+    g_vehicle_composed_matrix_tight_matches = 0;
+    g_vehicle_composed_matrix_correlation_count = 0;
+    g_vehicle_composed_matrix_correlation_overflow = 0;
   }
   for (VehicleOwnerMethodStats &stats : g_vehicle_owner_method_stats) {
     stats.calls.store(0, std::memory_order_relaxed);
@@ -16485,9 +16720,16 @@ void ConfigureVehicleDiscovery(bool census_requested,
         std::to_string(kVehicleTypedDescriptorWordCount)},
        {"typed_descriptor_correlation_capacity",
         std::to_string(kVehicleTypedDescriptorCorrelationCapacity)},
+       {"composed_matrix_hook", "8240EB5C:r22_object_matrix,r5_output_matrix"},
+       {"composed_matrix_contract",
+        "8240E7B0_live_r7_input_and_64_byte_payload_to_82435E78"},
+       {"composed_matrix_sources", "object_input_matrix,composed_upload_matrix"},
+       {"composed_matrix_correlation_capacity",
+        std::to_string(kVehicleComposedMatrixCorrelationCapacity)},
        {"guest_payload_read",
         "existing_pose_values,bounded_owner_vtable,typed_context_entry,"
-        "typed_4x4_caller_matrix,typed_render_item_descriptor"},
+        "typed_4x4_caller_matrix,typed_render_item_descriptor,"
+        "object_and_composed_4x4_matrices"},
        {"guest_state_changed", "false"},
        {"native_upload", "false"},
        {"native_draw", "false"},
@@ -16521,6 +16763,17 @@ void EmitVehicleDiscoverySummary() {
           g_vehicle_typed_render_item_invalid_child +
           g_vehicle_typed_render_item_invalid_descriptor ==
       g_vehicle_typed_render_item_observations;
+  const bool vehicle_composed_matrix_accounting_complete =
+      g_vehicle_composed_matrix_valid_pairs +
+          g_vehicle_composed_matrix_invalid_object_range +
+          g_vehicle_composed_matrix_invalid_output_range +
+          g_vehicle_composed_matrix_object_non_finite +
+          g_vehicle_composed_matrix_output_non_finite ==
+      g_vehicle_composed_matrix_observations;
+  const bool vehicle_composed_matrix_route_accounting_complete =
+      g_vehicle_composed_matrix_candidate_observations +
+          g_vehicle_composed_matrix_routes_without_identity ==
+      g_vehicle_composed_matrix_valid_pairs * 8;
   pinyon_shift::diagnostics::RecordEvent(
       "native_renderer.discovery.vehicle_pose_summary",
       {{"status", !g_vehicle_observations
@@ -16701,6 +16954,36 @@ void EmitVehicleDiscoverySummary() {
         std::to_string(kVehicleTypedDescriptorCorrelationCapacity)},
        {"typed_descriptor_correlation_overflow",
         std::to_string(g_vehicle_typed_descriptor_correlation_overflow)},
+       {"composed_matrix_observations",
+        std::to_string(g_vehicle_composed_matrix_observations)},
+       {"composed_matrix_valid_pairs",
+        std::to_string(g_vehicle_composed_matrix_valid_pairs)},
+       {"composed_matrix_invalid_object_range",
+        std::to_string(g_vehicle_composed_matrix_invalid_object_range)},
+       {"composed_matrix_invalid_output_range",
+        std::to_string(g_vehicle_composed_matrix_invalid_output_range)},
+       {"composed_matrix_object_non_finite",
+        std::to_string(g_vehicle_composed_matrix_object_non_finite)},
+       {"composed_matrix_output_non_finite",
+        std::to_string(g_vehicle_composed_matrix_output_non_finite)},
+       {"composed_matrix_accounting_complete",
+        vehicle_composed_matrix_accounting_complete ? "true" : "false"},
+       {"composed_matrix_identity_comparisons",
+        std::to_string(g_vehicle_composed_matrix_identity_comparisons)},
+       {"composed_matrix_candidate_observations",
+        std::to_string(g_vehicle_composed_matrix_candidate_observations)},
+       {"composed_matrix_routes_without_identity",
+        std::to_string(g_vehicle_composed_matrix_routes_without_identity)},
+       {"composed_matrix_route_accounting_complete",
+        vehicle_composed_matrix_route_accounting_complete ? "true" : "false"},
+       {"composed_matrix_tight_matches",
+        std::to_string(g_vehicle_composed_matrix_tight_matches)},
+       {"composed_matrix_correlations",
+        std::to_string(g_vehicle_composed_matrix_correlation_count)},
+       {"composed_matrix_correlation_capacity",
+        std::to_string(kVehicleComposedMatrixCorrelationCapacity)},
+       {"composed_matrix_correlation_overflow",
+        std::to_string(g_vehicle_composed_matrix_correlation_overflow)},
        {"title_provenance_requested",
         g_vehicle_title_provenance_requested ? "true" : "false"},
        {"draw_provenance_coverage_complete",
@@ -16792,6 +17075,53 @@ void EmitVehicleDiscoverySummary() {
           entry.tight_matches ? "true" : "false"},
          {"vehicle_draw_identity_proved", "false"},
          {"guest_state_changed", "false"},
+         {"native_draw", "false"},
+         {"xenos_authority", "true"},
+         {"suppression_allowed", "false"}});
+  }
+  for (const VehicleMatrixCorrelationEntry &entry :
+       g_vehicle_composed_matrix_correlations) {
+    if (!entry.valid) {
+      continue;
+    }
+    pinyon_shift::diagnostics::RecordEvent(
+        "native_renderer.discovery.vehicle_composed_matrix_correlation",
+        {{"function_address", "8240E7B0"},
+         {"hook_address", fmt::format("{:08X}", kVehicleComposedMatrixHook)},
+         {"callee_address",
+          fmt::format("{:08X}", kVehicleComposedMatrixCallee)},
+         {"matrix_source", VehicleMatrixSourceName(entry.source)},
+         {"matrix_layout", VehicleMatrixLayoutName(entry.layout)},
+         {"forward_sign", entry.forward_sign > 0 ? "positive" : "negative"},
+         {"identity_generation",
+          fmt::format("{:08X}", entry.identity_generation)},
+         {"identity_owner", fmt::format("{:08X}", entry.identity_owner)},
+         {"identity_slot", std::to_string(entry.identity_slot)},
+         {"observations", std::to_string(entry.observations)},
+         {"tight_matches", std::to_string(entry.tight_matches)},
+         {"first_frame", std::to_string(entry.first_frame)},
+         {"last_frame", std::to_string(entry.last_frame)},
+         {"matrix_address_changes",
+          std::to_string(entry.matrix_address_changes)},
+         {"matrix_hash_changes", std::to_string(entry.matrix_hash_changes)},
+         {"last_matrix_address",
+          fmt::format("{:08X}", entry.last_matrix_address)},
+         {"last_matrix_hash", fmt::format("{:016X}", entry.last_matrix_hash)},
+         {"best_matrix_address",
+          fmt::format("{:08X}", entry.best_matrix_address)},
+         {"best_matrix_hash", fmt::format("{:016X}", entry.best_matrix_hash)},
+         {"best_position_delta_squared",
+          fmt::format("{}", entry.best_position_delta_squared)},
+         {"best_forward_delta_squared",
+          fmt::format("{}", entry.best_forward_delta_squared)},
+         {"best_normalized_score",
+          fmt::format("{}", entry.best_normalized_score)},
+         {"classification", "vehicle_composed_matrix_correlation_candidate"},
+         {"vehicle_render_transform_candidate_proved",
+          entry.tight_matches ? "true" : "false"},
+         {"vehicle_draw_identity_proved", "false"},
+         {"guest_state_changed", "false"},
+         {"native_upload", "false"},
          {"native_draw", "false"},
          {"xenos_authority", "true"},
          {"suppression_allowed", "false"}});
@@ -18635,6 +18965,11 @@ void PinyonShiftObserveVehicleMatrixCallerEntry(PPCRegister &r6,
 void PinyonShiftObserveVehicleTypedRenderItem(PPCRegister &r11,
                                               PPCRegister &r31) {
   ObserveVehicleTypedRenderItem(r31.u32, r11.u32);
+}
+
+void PinyonShiftObserveVehicleComposedMatrix(PPCRegister &r5,
+                                             PPCRegister &r22) {
+  ObserveVehicleComposedMatrix(r22.u32, r5.u32);
 }
 
 void PinyonShiftObserveVehicleRenderContextDispatcherEntry(

--- a/tools/summarize-native-renderer-vehicle-pose.py
+++ b/tools/summarize-native-renderer-vehicle-pose.py
@@ -28,6 +28,9 @@ RENDER_CONTEXT_CALLEE = (
 VEHICLE_MATRIX_CORRELATION = (
     "native_renderer.discovery.vehicle_matrix_correlation"
 )
+VEHICLE_COMPOSED_MATRIX_CORRELATION = (
+    "native_renderer.discovery.vehicle_composed_matrix_correlation"
+)
 TYPED_RENDER_ITEM_PROFILE = (
     "native_renderer.discovery.vehicle_typed_render_item_profile"
 )
@@ -68,6 +71,10 @@ VEHICLE_MATRIX_LAYOUTS = {
     "column_major_translation_column3_forward_column2",
 }
 VEHICLE_MATRIX_FORWARD_SIGNS = {"positive", "negative"}
+VEHICLE_COMPOSED_MATRIX_SOURCES = {
+    "object_input_matrix",
+    "composed_upload_matrix",
+}
 
 
 def read_events(paths):
@@ -226,9 +233,18 @@ def build(events, requested_session=None):
         "typed_render_item_profile_capacity": "32",
         "typed_descriptor_word_count": "62",
         "typed_descriptor_correlation_capacity": "512",
+        "composed_matrix_hook": "8240EB5C:r22_object_matrix,r5_output_matrix",
+        "composed_matrix_contract": (
+            "8240E7B0_live_r7_input_and_64_byte_payload_to_82435E78"
+        ),
+        "composed_matrix_sources": (
+            "object_input_matrix,composed_upload_matrix"
+        ),
+        "composed_matrix_correlation_capacity": "1024",
         "guest_payload_read": (
             "existing_pose_values,bounded_owner_vtable,typed_context_entry,"
-            "typed_4x4_caller_matrix,typed_render_item_descriptor"
+            "typed_4x4_caller_matrix,typed_render_item_descriptor,"
+            "object_and_composed_4x4_matrices"
         ),
         "guest_state_changed": "false",
         "native_upload": "false",
@@ -274,6 +290,7 @@ def build(events, requested_session=None):
         "typed_render_item_profile_capacity": "32",
         "typed_descriptor_word_count": "62",
         "typed_descriptor_correlation_capacity": "512",
+        "composed_matrix_correlation_capacity": "1024",
         "guest_state_changed": "false",
         "native_upload": "false",
         "native_draw": "false",
@@ -380,12 +397,27 @@ def build(events, requested_session=None):
         "typed_descriptor_correlations",
         "typed_descriptor_correlation_capacity",
         "typed_descriptor_correlation_overflow",
+        "composed_matrix_observations",
+        "composed_matrix_valid_pairs",
+        "composed_matrix_invalid_object_range",
+        "composed_matrix_invalid_output_range",
+        "composed_matrix_object_non_finite",
+        "composed_matrix_output_non_finite",
+        "composed_matrix_identity_comparisons",
+        "composed_matrix_candidate_observations",
+        "composed_matrix_routes_without_identity",
+        "composed_matrix_tight_matches",
+        "composed_matrix_correlations",
+        "composed_matrix_correlation_capacity",
+        "composed_matrix_correlation_overflow",
     ):
         totals[key] = integer(summary, key)
     for key in (
         "vehicle_matrix_caller_accounting_complete",
         "vehicle_matrix_route_accounting_complete",
         "typed_render_item_accounting_complete",
+        "composed_matrix_accounting_complete",
+        "composed_matrix_route_accounting_complete",
     ):
         if summary.get(key) not in ("true", "false"):
             raise ValueError(f"invalid {key}")
@@ -905,6 +937,103 @@ def build(events, requested_session=None):
         )
     )
 
+    composed_matrix_correlations = []
+    seen_composed_matrix_correlations = set()
+    for event in selected:
+        if event.get("event") != VEHICLE_COMPOSED_MATRIX_CORRELATION:
+            continue
+        source = event.get("matrix_source")
+        layout = event.get("matrix_layout")
+        forward_sign = event.get("forward_sign")
+        identity_key = (
+            hexadecimal(event, "identity_generation"),
+            hexadecimal(event, "identity_owner"),
+            integer(event, "identity_slot"),
+        )
+        key = (source, layout, forward_sign, *identity_key)
+        observations = integer(event, "observations")
+        tight_matches = integer(event, "tight_matches")
+        first_frame = integer(event, "first_frame")
+        last_frame = integer(event, "last_frame")
+        candidate_proved = tight_matches > 0
+        if (
+            key in seen_composed_matrix_correlations
+            or event.get("function_address") != "8240E7B0"
+            or event.get("hook_address") != "8240EB5C"
+            or event.get("callee_address") != "82435E78"
+            or source not in VEHICLE_COMPOSED_MATRIX_SOURCES
+            or layout not in VEHICLE_MATRIX_LAYOUTS
+            or forward_sign not in VEHICLE_MATRIX_FORWARD_SIGNS
+            or identity_key not in identities_by_key
+            or not observations
+            or tight_matches > observations
+            or first_frame > last_frame
+            or event.get("classification")
+            != "vehicle_composed_matrix_correlation_candidate"
+            or event.get("vehicle_render_transform_candidate_proved")
+            != ("true" if candidate_proved else "false")
+            or event.get("vehicle_draw_identity_proved") != "false"
+            or event.get("guest_state_changed") != "false"
+            or event.get("native_upload") != "false"
+            or event.get("native_draw") != "false"
+            or event.get("xenos_authority") != "true"
+            or event.get("suppression_allowed") != "false"
+        ):
+            raise ValueError(
+                "vehicle composed matrix correlation violates boundary"
+            )
+        seen_composed_matrix_correlations.add(key)
+        composed_matrix_correlations.append(
+            {
+                "function_address": "8240E7B0",
+                "hook_address": "8240EB5C",
+                "callee_address": "82435E78",
+                "matrix_source": source,
+                "matrix_layout": layout,
+                "forward_sign": forward_sign,
+                "identity_generation": identity_key[0],
+                "identity_owner": identity_key[1],
+                "identity_slot": identity_key[2],
+                "observations": observations,
+                "tight_matches": tight_matches,
+                "first_frame": first_frame,
+                "last_frame": last_frame,
+                "matrix_address_changes": integer(
+                    event, "matrix_address_changes"
+                ),
+                "matrix_hash_changes": integer(event, "matrix_hash_changes"),
+                "last_matrix_address": hexadecimal(
+                    event, "last_matrix_address"
+                ),
+                "last_matrix_hash": hexadecimal64(event, "last_matrix_hash"),
+                "best_matrix_address": hexadecimal(
+                    event, "best_matrix_address"
+                ),
+                "best_matrix_hash": hexadecimal64(event, "best_matrix_hash"),
+                "best_position_delta_squared": finite_number(
+                    event, "best_position_delta_squared"
+                ),
+                "best_forward_delta_squared": finite_number(
+                    event, "best_forward_delta_squared"
+                ),
+                "best_normalized_score": finite_number(
+                    event, "best_normalized_score"
+                ),
+                "vehicle_render_transform_candidate_proved": (
+                    candidate_proved
+                ),
+            }
+        )
+    composed_matrix_correlations.sort(
+        key=lambda item: (
+            item["matrix_source"],
+            item["matrix_layout"],
+            item["forward_sign"],
+            item["identity_owner"],
+            item["identity_slot"],
+        )
+    )
+
     typed_render_item_profiles = []
     seen_typed_render_item_profiles = set()
     for event in selected:
@@ -1312,6 +1441,68 @@ def build(events, requested_session=None):
         "typed_descriptor_correlation_capacity"
     ]:
         failures.append("typed descriptor correlation capacity drifted")
+    composed_matrix_accounting_complete = totals[
+        "composed_matrix_valid_pairs"
+    ] + totals["composed_matrix_invalid_object_range"] + totals[
+        "composed_matrix_invalid_output_range"
+    ] + totals[
+        "composed_matrix_object_non_finite"
+    ] + totals[
+        "composed_matrix_output_non_finite"
+    ] == totals[
+        "composed_matrix_observations"
+    ]
+    if (
+        not composed_matrix_accounting_complete
+        or not totals["composed_matrix_accounting_complete"]
+    ):
+        failures.append("vehicle composed matrix accounting drifted")
+    composed_matrix_route_accounting_complete = totals[
+        "composed_matrix_candidate_observations"
+    ] + totals["composed_matrix_routes_without_identity"] == (
+        totals["composed_matrix_valid_pairs"] * 8
+    )
+    if (
+        not composed_matrix_route_accounting_complete
+        or not totals["composed_matrix_route_accounting_complete"]
+    ):
+        failures.append("vehicle composed matrix route accounting drifted")
+    composed_matrix_sources = {
+        item["matrix_source"] for item in composed_matrix_correlations
+    }
+    if (
+        not totals["composed_matrix_observations"]
+        or not totals["composed_matrix_valid_pairs"]
+        or not totals["composed_matrix_identity_comparisons"]
+        or not totals["composed_matrix_candidate_observations"]
+        or composed_matrix_sources != VEHICLE_COMPOSED_MATRIX_SOURCES
+    ):
+        failures.append("vehicle composed matrix coverage was absent")
+    if (
+        totals["composed_matrix_invalid_object_range"]
+        or totals["composed_matrix_invalid_output_range"]
+        or totals["composed_matrix_object_non_finite"]
+        or totals["composed_matrix_output_non_finite"]
+    ):
+        failures.append("vehicle composed matrix payload was invalid")
+    if sum(
+        item["observations"] for item in composed_matrix_correlations
+    ) != totals["composed_matrix_candidate_observations"]:
+        failures.append("vehicle composed matrix candidate totals drifted")
+    if sum(
+        item["tight_matches"] for item in composed_matrix_correlations
+    ) != totals["composed_matrix_tight_matches"]:
+        failures.append("vehicle composed matrix tight-match totals drifted")
+    if len(composed_matrix_correlations) != totals[
+        "composed_matrix_correlations"
+    ]:
+        failures.append("vehicle composed matrix correlation coverage drifted")
+    if totals["composed_matrix_correlation_overflow"]:
+        failures.append("vehicle composed matrix correlation table overflowed")
+    if totals["composed_matrix_correlations"] > totals[
+        "composed_matrix_correlation_capacity"
+    ]:
+        failures.append("vehicle composed matrix correlation capacity drifted")
     for method in method_correlations:
         if method["status"] != "complete" or method["calls"] != method["exits"]:
             failures.append(
@@ -1337,6 +1528,10 @@ def build(events, requested_session=None):
         for item in matrix_correlations
     )
     typed_descriptor_candidate_proved = bool(typed_descriptor_correlations)
+    composed_matrix_candidate_proved = any(
+        item["vehicle_render_transform_candidate_proved"]
+        for item in composed_matrix_correlations
+    )
     draw_provenance_coverage_complete = (
         title_provenance_requested
         and title_provenance_armed
@@ -1364,6 +1559,7 @@ def build(events, requested_session=None):
         "draw_object_correlations": object_correlations,
         "render_context_callees": render_context_callees,
         "vehicle_matrix_correlations": matrix_correlations,
+        "composed_matrix_correlations": composed_matrix_correlations,
         "typed_render_item_profiles": typed_render_item_profiles,
         "typed_descriptor_correlations": typed_descriptor_correlations,
         "coverage": {
@@ -1402,6 +1598,13 @@ def build(events, requested_session=None):
             ),
             "typed_vehicle_descriptor_candidate_proved": (
                 not failures and typed_descriptor_candidate_proved
+            ),
+            "vehicle_composed_matrix_contract_proved": (
+                not failures
+                and composed_matrix_sources == VEHICLE_COMPOSED_MATRIX_SOURCES
+            ),
+            "vehicle_composed_matrix_candidate_proved": (
+                not failures and composed_matrix_candidate_proved
             ),
             "native_vehicle_rendering_admitted": False,
             "suppression_allowed": False,

--- a/tools/tests/test_native_renderer_vehicle_pose.py
+++ b/tools/tests/test_native_renderer_vehicle_pose.py
@@ -73,9 +73,18 @@ def fixture():
         typed_render_item_profile_capacity="32",
         typed_descriptor_word_count="62",
         typed_descriptor_correlation_capacity="512",
+        composed_matrix_hook="8240EB5C:r22_object_matrix,r5_output_matrix",
+        composed_matrix_contract=(
+            "8240E7B0_live_r7_input_and_64_byte_payload_to_82435E78"
+        ),
+        composed_matrix_sources=(
+            "object_input_matrix,composed_upload_matrix"
+        ),
+        composed_matrix_correlation_capacity="1024",
         guest_payload_read=(
             "existing_pose_values,bounded_owner_vtable,typed_context_entry,"
-            "typed_4x4_caller_matrix,typed_render_item_descriptor"
+            "typed_4x4_caller_matrix,typed_render_item_descriptor,"
+            "object_and_composed_4x4_matrices"
         ),
         guest_state_changed="false",
         native_upload="false",
@@ -187,6 +196,21 @@ def fixture():
         typed_descriptor_correlations="1",
         typed_descriptor_correlation_capacity="512",
         typed_descriptor_correlation_overflow="0",
+        composed_matrix_observations="1",
+        composed_matrix_valid_pairs="1",
+        composed_matrix_invalid_object_range="0",
+        composed_matrix_invalid_output_range="0",
+        composed_matrix_object_non_finite="0",
+        composed_matrix_output_non_finite="0",
+        composed_matrix_accounting_complete="true",
+        composed_matrix_identity_comparisons="8",
+        composed_matrix_candidate_observations="8",
+        composed_matrix_routes_without_identity="0",
+        composed_matrix_route_accounting_complete="true",
+        composed_matrix_tight_matches="1",
+        composed_matrix_correlations="8",
+        composed_matrix_correlation_capacity="1024",
+        composed_matrix_correlation_overflow="0",
         title_provenance_requested="true",
         draw_provenance_coverage_complete="true",
         guest_state_changed="false",
@@ -318,6 +342,68 @@ def fixture():
                     suppression_allowed="false",
                 )
             )
+    composed_matrix_correlations = []
+    for source in sorted(MODULE.VEHICLE_COMPOSED_MATRIX_SOURCES):
+        for layout in sorted(MODULE.VEHICLE_MATRIX_LAYOUTS):
+            for forward_sign in sorted(MODULE.VEHICLE_MATRIX_FORWARD_SIGNS):
+                tight_match = (
+                    source == "composed_upload_matrix"
+                    and layout == "row_major_translation_row3_forward_row2"
+                    and forward_sign == "positive"
+                )
+                composed_matrix_correlations.append(
+                    event(
+                        MODULE.VEHICLE_COMPOSED_MATRIX_CORRELATION,
+                        function_address="8240E7B0",
+                        hook_address="8240EB5C",
+                        callee_address="82435E78",
+                        matrix_source=source,
+                        matrix_layout=layout,
+                        forward_sign=forward_sign,
+                        identity_generation="00000001",
+                        identity_owner="A0002000",
+                        identity_slot="2",
+                        observations="1",
+                        tight_matches="1" if tight_match else "0",
+                        first_frame="104",
+                        last_frame="104",
+                        matrix_address_changes="0",
+                        matrix_hash_changes="0",
+                        last_matrix_address=(
+                            "703FE000"
+                            if source == "object_input_matrix"
+                            else "703FF000"
+                        ),
+                        last_matrix_hash="1234567890ABCDEF",
+                        best_matrix_address=(
+                            "703FE000"
+                            if source == "object_input_matrix"
+                            else "703FF000"
+                        ),
+                        best_matrix_hash="1234567890ABCDEF",
+                        best_position_delta_squared=(
+                            "0.01" if tight_match else "100.0"
+                        ),
+                        best_forward_delta_squared=(
+                            "0.001" if tight_match else "1.0"
+                        ),
+                        best_normalized_score=(
+                            "0.065" if tight_match else "425.0"
+                        ),
+                        classification=(
+                            "vehicle_composed_matrix_correlation_candidate"
+                        ),
+                        vehicle_render_transform_candidate_proved=(
+                            "true" if tight_match else "false"
+                        ),
+                        vehicle_draw_identity_proved="false",
+                        guest_state_changed="false",
+                        native_upload="false",
+                        native_draw="false",
+                        xenos_authority="true",
+                        suppression_allowed="false",
+                    )
+                )
     typed_render_item_profile = event(
         MODULE.TYPED_RENDER_ITEM_PROFILE,
         function_address="8240E7B0",
@@ -373,6 +459,7 @@ def fixture():
         *methods,
         render_context_callee,
         *matrix_correlations,
+        *composed_matrix_correlations,
         typed_render_item_profile,
         typed_descriptor_correlation,
         title_provenance_config,
@@ -457,9 +544,15 @@ class VehiclePoseSummaryTests(unittest.TestCase):
             '"native_renderer.discovery.vehicle_typed_descriptor_correlation"',
             hooks,
         )
+        self.assertIn("ObserveVehicleComposedMatrix", hooks)
+        self.assertIn(
+            '"native_renderer.discovery.vehicle_composed_matrix_correlation"',
+            hooks,
+        )
         self.assertIn("[switch]$VehicleDrawCorrelation", capture)
         self.assertEqual(1, analysis.count("address = 0x8240E7B4"))
         self.assertEqual(1, analysis.count("address = 0x8240EC18"))
+        self.assertEqual(1, analysis.count("address = 0x8240EB5C"))
         self.assertEqual(1, analysis.count("address = 0x8243646C"))
         for address in (
             "82BC8468",
@@ -523,6 +616,33 @@ class VehiclePoseSummaryTests(unittest.TestCase):
         )
         self.assertEqual(1, len(document["typed_render_item_profiles"]))
         self.assertEqual(1, len(document["typed_descriptor_correlations"]))
+        self.assertTrue(
+            document["qualification"][
+                "vehicle_composed_matrix_contract_proved"
+            ]
+        )
+        self.assertTrue(
+            document["qualification"][
+                "vehicle_composed_matrix_candidate_proved"
+            ]
+        )
+        self.assertEqual(8, len(document["composed_matrix_correlations"]))
+
+    def test_rejects_composed_matrix_accounting_or_overflow(self):
+        events = fixture()
+        events[1]["composed_matrix_valid_pairs"] = "0"
+        document = MODULE.build(events)
+        self.assertIn(
+            "vehicle composed matrix accounting drifted", document["failures"]
+        )
+
+        events = fixture()
+        events[1]["composed_matrix_correlation_overflow"] = "1"
+        document = MODULE.build(events)
+        self.assertIn(
+            "vehicle composed matrix correlation table overflowed",
+            document["failures"],
+        )
 
     def test_rejects_typed_render_item_accounting_or_overflow(self):
         events = fixture()


### PR DESCRIPTION
## Summary
- instrument the exact `8240EB5C` object/reference composition boundary
- correlate both the live input matrix and composed upload matrix with admitted vehicle poses
- enforce strict range, finite-value, route, capacity, and no-suppression accounting
- document the AppData runtime result rejecting both matrices as the vehicle pose bridge

## Validation
- 419 automated tests passed
- Release build linked cleanly
- AppData-backed census `20260830T114202Z-p31280` exited normally
- 899/899 valid pairs; 7,192/7,192 routes accounted; zero invalid, overflow, error, fatal, or crash events
- median 30.384 FPS; simulation 29.735 Hz; presentation 59.978 Hz

Xenos remains authoritative. Native upload, native draw, and suppression remain disabled.