### PR TITLE
feat(renderer): exhaust vehicle owner method correlation

### DIFF
--- a/config/rexglue/analysis/main-xex.toml
+++ b/config/rexglue/analysis/main-xex.toml
@@ -627,11 +627,75 @@ name = "PinyonShiftTraceVehiclePose"
 registers = ["r1", "r30", "r31"]
 
 # NR-05E owner-vtable draw correlation. Runtime-qualified vtable 0x8213BA54
-# maps slots 14, 20, and 22 to these three bounded candidates. Entry hooks
-# preserve r3 as the owner identity; balanced hooks run on each candidate's
-# sole tail-return path. The host only correlates exact, already-observed
-# vehicle owners with title draw origins and backend packet matches. No guest
-# register, packet, render state, native publication, or control flow changes.
+# contains 19 nontrivial method bodies after trivial getters, null handlers,
+# and aliases are excluded. Entry hooks preserve r3 as the owner identity;
+# balanced hooks run on each candidate's sole tail-return path. The host only
+# correlates exact, already-observed vehicle owners with title draw origins and
+# backend packet matches. No guest register, packet, render state, native
+# publication, or control flow changes.
+[[midasm_hook]]
+address = 0x82BD2BD0
+name = "PinyonShiftObserveVehicleOwnerMethod82BD2BD0Entry"
+registers = ["r3"]
+
+[[midasm_hook]]
+address = 0x82BD2C20
+name = "PinyonShiftObserveVehicleOwnerMethod82BD2BD0Exit"
+
+[[midasm_hook]]
+address = 0x82BD2B58
+name = "PinyonShiftObserveVehicleOwnerMethod82BD2B58Entry"
+registers = ["r3"]
+
+[[midasm_hook]]
+address = 0x82BD2BC0
+name = "PinyonShiftObserveVehicleOwnerMethod82BD2B58Exit"
+
+[[midasm_hook]]
+address = 0x82BCFDD8
+name = "PinyonShiftObserveVehicleOwnerMethod82BCFDD8Entry"
+registers = ["r3"]
+
+[[midasm_hook]]
+address = 0x82BCFE10
+name = "PinyonShiftObserveVehicleOwnerMethod82BCFDD8Exit"
+
+[[midasm_hook]]
+address = 0x82BCFE18
+name = "PinyonShiftObserveVehicleOwnerMethod82BCFE18Entry"
+registers = ["r3"]
+
+[[midasm_hook]]
+address = 0x82BCFE50
+name = "PinyonShiftObserveVehicleOwnerMethod82BCFE18Exit"
+
+[[midasm_hook]]
+address = 0x82BCFE58
+name = "PinyonShiftObserveVehicleOwnerMethod82BCFE58Entry"
+registers = ["r3"]
+
+[[midasm_hook]]
+address = 0x82BCFE70
+name = "PinyonShiftObserveVehicleOwnerMethod82BCFE58Exit"
+
+[[midasm_hook]]
+address = 0x82BC1D90
+name = "PinyonShiftObserveVehicleOwnerMethod82BC1D90Entry"
+registers = ["r3"]
+
+[[midasm_hook]]
+address = 0x82BC1DC0
+name = "PinyonShiftObserveVehicleOwnerMethod82BC1D90Exit"
+
+[[midasm_hook]]
+address = 0x82BBDD38
+name = "PinyonShiftObserveVehicleOwnerMethod82BBDD38Entry"
+registers = ["r3"]
+
+[[midasm_hook]]
+address = 0x82BBDE40
+name = "PinyonShiftObserveVehicleOwnerMethod82BBDD38Exit"
+
 [[midasm_hook]]
 address = 0x82BCC368
 name = "PinyonShiftObserveVehicleOwnerMethod82BCC368Entry"
@@ -640,6 +704,51 @@ registers = ["r3"]
 [[midasm_hook]]
 address = 0x82BCCD30
 name = "PinyonShiftObserveVehicleOwnerMethod82BCC368Exit"
+
+[[midasm_hook]]
+address = 0x82BCD780
+name = "PinyonShiftObserveVehicleOwnerMethod82BCD780Entry"
+registers = ["r3"]
+
+[[midasm_hook]]
+address = 0x82BCD9A8
+name = "PinyonShiftObserveVehicleOwnerMethod82BCD780Exit"
+
+[[midasm_hook]]
+address = 0x82BCD9B0
+name = "PinyonShiftObserveVehicleOwnerMethod82BCD9B0Entry"
+registers = ["r3"]
+
+[[midasm_hook]]
+address = 0x82BCDA90
+name = "PinyonShiftObserveVehicleOwnerMethod82BCD9B0Exit"
+
+[[midasm_hook]]
+address = 0x82BD0548
+name = "PinyonShiftObserveVehicleOwnerMethod82BD0548Entry"
+registers = ["r3"]
+
+[[midasm_hook]]
+address = 0x82BD05D0
+name = "PinyonShiftObserveVehicleOwnerMethod82BD0548Exit"
+
+[[midasm_hook]]
+address = 0x82BD05D8
+name = "PinyonShiftObserveVehicleOwnerMethod82BD05D8Entry"
+registers = ["r3"]
+
+[[midasm_hook]]
+address = 0x82BD0640
+name = "PinyonShiftObserveVehicleOwnerMethod82BD05D8Exit"
+
+[[midasm_hook]]
+address = 0x82BD0648
+name = "PinyonShiftObserveVehicleOwnerMethod82BD0648Entry"
+registers = ["r3"]
+
+[[midasm_hook]]
+address = 0x82BD06B0
+name = "PinyonShiftObserveVehicleOwnerMethod82BD0648Exit"
 
 [[midasm_hook]]
 address = 0x82BD2DE0
@@ -651,6 +760,15 @@ address = 0x82BD35B0
 name = "PinyonShiftObserveVehicleOwnerMethod82BD2DE0Exit"
 
 [[midasm_hook]]
+address = 0x82BBA9C0
+name = "PinyonShiftObserveVehicleOwnerMethod82BBA9C0Entry"
+registers = ["r3"]
+
+[[midasm_hook]]
+address = 0x82BBAB28
+name = "PinyonShiftObserveVehicleOwnerMethod82BBA9C0Exit"
+
+[[midasm_hook]]
 address = 0x82BC8410
 name = "PinyonShiftObserveVehicleOwnerMethod82BC8410Entry"
 registers = ["r3"]
@@ -658,6 +776,33 @@ registers = ["r3"]
 [[midasm_hook]]
 address = 0x82BC86F0
 name = "PinyonShiftObserveVehicleOwnerMethod82BC8410Exit"
+
+[[midasm_hook]]
+address = 0x82BB94D8
+name = "PinyonShiftObserveVehicleOwnerMethod82BB94D8Entry"
+registers = ["r3"]
+
+[[midasm_hook]]
+address = 0x82BB9568
+name = "PinyonShiftObserveVehicleOwnerMethod82BB94D8Exit"
+
+[[midasm_hook]]
+address = 0x82BBC1B0
+name = "PinyonShiftObserveVehicleOwnerMethod82BBC1B0Entry"
+registers = ["r3"]
+
+[[midasm_hook]]
+address = 0x82BBC2C8
+name = "PinyonShiftObserveVehicleOwnerMethod82BBC1B0Exit"
+
+[[midasm_hook]]
+address = 0x82BD0918
+name = "PinyonShiftObserveVehicleOwnerMethod82BD0918Entry"
+registers = ["r3"]
+
+[[midasm_hook]]
+address = 0x82BD0968
+name = "PinyonShiftObserveVehicleOwnerMethod82BD0918Exit"
 
 # Slot 22 is a high-frequency, balanced vehicle-owner update scope rather than
 # a proven renderer method. Capture its six exact virtual targets before each

--- a/docs/native-renderer/VEHICLE_INSTANCE_SEMANTIC_SEED.md
+++ b/docs/native-renderer/VEHICLE_INSTANCE_SEMANTIC_SEED.md
@@ -349,6 +349,61 @@ presentation cadence. Continue downstream of `82435E78` at the first consumer
 that converts this reference-space payload into the render-instance transform;
 do not widen object scans. Native drawing and suppression remain closed.
 
+## Exhaustive nontrivial owner-method correlation
+
+Static inspection closes the apparent downstream `82435E78` CPU edge. That
+function is a generic constant-buffer writer: it copies `r6` 16-byte vectors
+from `r5` into the buffer selected by `r3` and `r4`, then ORs the `r7` dirty
+mask into the buffer header. At the `8240EB5C` call, this places four vectors
+in constant register block 208. The following `8243D2A0` call forwards the
+render request through a graphics-manager virtual method; neither boundary
+converts the reference-space payload into a CPU vehicle transform. Repeating
+the rejected absolute-pose comparison after the byte-for-byte copy would add
+no information.
+
+The next bounded batch therefore completes runtime coverage of the exact
+vehicle-owner vtable instead. Of its 32 slots, 19 have nontrivial generated
+method bodies; the other slots are trivial getters, null handlers, or aliases.
+Balanced entry and sole-tail-return hooks now cover slots 0, 3, 7–9, 12–23,
+25, and 27. Each entry is admitted only when `r3` exactly matches an active
+vehicle owner whose captured vtable slot names that method. Existing title and
+backend packet lineage then attributes any enclosed draw without scanning new
+guest memory or inferring identity from address shape.
+
+The candidate table and per-thread scope stack are fixed at 19 and 32 entries.
+Qualification requires one summary for every candidate, balanced call/exit
+counts, bounded draw accounting, and zero stack fault. The hooks change no
+guest state, issue no upload or draw, leave Xenos authoritative, and cannot
+enable suppression.
+
+Release/AppData session `20260830T120509Z-p33140` completed normally in stable
+festival gameplay. All 19 candidate summaries were present; 16 methods ran and
+slots 7–9 were not called. The run recorded 61,941 calls and exactly 61,941
+exits, 59,907 exact-owner admissions, zero stack faults, zero direct draw
+origins, and zero backend draw matches. This exhausts and rejects every
+nontrivial method on the exact owner vtable as the vehicle renderer bridge.
+
+The same run exposed obsolete work in the already-rejected one-hop object
+scan: its 16,384-entry cache saturated and discarded 384,136 later requests
+without producing a correlation. That diagnostic had already rejected the
+generic and statically targeted roots in earlier qualified sessions, so it is
+now explicitly disabled. The verifier requires every object-scan, cache,
+targeted-scan, and correlation counter to remain zero; any retired-path event
+fails qualification. This removes the saturated-cache probe loop without
+changing guest state, native publication, Xenos authority, or suppression.
+The session sustained 30.677 median derived FPS, 29.638 Hz simulation, and
+59.710 Hz presentation, with no error, fatal, assertion, or crash event.
+
+Release/AppData confirmation session `20260830T121257Z-p33888` then exercised
+all 19 methods with the retired scan disabled. Its 42,086 calls balanced
+exactly with 42,086 exits, 40,256 calls matched exact active owners, and every
+object-scan, cache, targeted-scan, correlation, direct-draw, backend-draw, and
+stack-fault counter remained zero. Native vehicle publication and suppression
+remained closed while Xenos rendered the scene. The run exited normally at
+31.378 median derived FPS, 29.533 Hz simulation, and 59.625 Hz presentation,
+with zero presentation deadline misses and no error, fatal, assertion, or
+crash event.
+
 Qualify a batched census with:
 
 ```powershell

--- a/src/native_renderer/graphics_hooks.cpp
+++ b/src/native_renderer/graphics_hooks.cpp
@@ -104,14 +104,15 @@ constexpr uint64_t kVisibilityShadowReplayMaximumDrawsPerFrame = 1;
 constexpr size_t kVehicleIdentityCapacity = 64;
 constexpr size_t kVehicleIdentitySummaryLimit = kVehicleIdentityCapacity;
 constexpr size_t kVehicleOwnerVtableMethodCount = 32;
-constexpr size_t kVehicleOwnerMethodCandidateCount = 3;
-constexpr size_t kVehicleOwnerMethodStackCapacity = 8;
+constexpr size_t kVehicleOwnerMethodCandidateCount = 19;
+constexpr size_t kVehicleOwnerMethodStackCapacity = 32;
 constexpr size_t kVehicleOwnerIndirectTargetCapacity = 64;
 constexpr size_t kVehicleIdentityAddressCapacity = 512;
 constexpr size_t kVehicleDrawCorrelationCapacity = 1024;
 constexpr size_t kVehicleObjectScanWordCount = 128;
 constexpr size_t kVehicleObjectScanCacheCapacity = 16384;
 constexpr size_t kVehicleObjectCorrelationCapacity = 2048;
+constexpr bool kVehicleObjectScanEnabled = false;
 constexpr uint32_t kVehicleRenderContextFunction = 0x824365B0;
 constexpr size_t kVehicleRenderContextCalleeProfileCapacity = 32;
 constexpr uint32_t kVehicleMatrixCallerFunction = 0x8240E7B0;
@@ -583,9 +584,25 @@ struct VehicleOwnerMethodCandidate {
 constexpr std::array<VehicleOwnerMethodCandidate,
                      kVehicleOwnerMethodCandidateCount>
     kVehicleOwnerMethodCandidates{{
+        {0x82BD2BD0, 0x82BD2C20, 0},
+        {0x82BD2B58, 0x82BD2BC0, 3},
+        {0x82BCFDD8, 0x82BCFE10, 7},
+        {0x82BCFE18, 0x82BCFE50, 8},
+        {0x82BCFE58, 0x82BCFE70, 9},
+        {0x82BC1D90, 0x82BC1DC0, 12},
+        {0x82BBDD38, 0x82BBDE40, 13},
         {0x82BCC368, 0x82BCCD30, 14},
+        {0x82BCD780, 0x82BCD9A8, 15},
+        {0x82BCD9B0, 0x82BCDA90, 16},
+        {0x82BD0548, 0x82BD05D0, 17},
+        {0x82BD05D8, 0x82BD0640, 18},
+        {0x82BD0648, 0x82BD06B0, 19},
         {0x82BD2DE0, 0x82BD35B0, 20},
+        {0x82BBA9C0, 0x82BBAB28, 21},
         {0x82BC8410, 0x82BC86F0, 22},
+        {0x82BB94D8, 0x82BB9568, 23},
+        {0x82BBC1B0, 0x82BBC2C8, 25},
+        {0x82BD0918, 0x82BD0968, 27},
     }};
 
 struct VehicleOwnerMethodStats {
@@ -1926,6 +1943,9 @@ bool IsTargetedVehicleRenderContextProbe(
 }
 
 bool ShouldScanVehicleObjectProbe(const VehicleDrawArgumentProbe &probe) {
+  if (!kVehicleObjectScanEnabled) {
+    return false;
+  }
   if (!probe.value || (probe.value & 3) ||
       probe.value > UINT32_MAX - kVehicleObjectScanWordCount * 4) {
     return false;
@@ -16670,8 +16690,16 @@ void ConfigureVehicleDiscovery(bool census_requested,
        {"player_priority_admitted", "false"},
        {"owner_vtable_method_count",
         std::to_string(kVehicleOwnerVtableMethodCount)},
-       {"owner_method_candidates", "82BCC368:14,82BD2DE0:20,82BC8410:22"},
-       {"owner_method_exit_hooks", "82BCCD30,82BD35B0,82BC86F0"},
+       {"owner_method_candidates",
+        "82BD2BD0:0,82BD2B58:3,82BCFDD8:7,82BCFE18:8,82BCFE58:9,"
+        "82BC1D90:12,82BBDD38:13,82BCC368:14,82BCD780:15,82BCD9B0:16,"
+        "82BD0548:17,82BD05D8:18,82BD0648:19,82BD2DE0:20,82BBA9C0:21,"
+        "82BC8410:22,82BB94D8:23,82BBC1B0:25,82BD0918:27"},
+       {"owner_method_exit_hooks",
+        "82BD2C20,82BD2BC0,82BCFE10,82BCFE50,82BCFE70,82BC1DC0,"
+        "82BBDE40,82BCCD30,82BCD9A8,82BCDA90,82BD05D0,82BD0640,"
+        "82BD06B0,82BD35B0,82BBAB28,82BC86F0,82BB9568,82BBC2C8,"
+        "82BD0968"},
        {"owner_method_stack_capacity",
         std::to_string(kVehicleOwnerMethodStackCapacity)},
        {"owner_indirect_callsites",
@@ -16686,6 +16714,7 @@ void ConfigureVehicleDiscovery(bool census_requested,
         "exact_backend_signature_and_provenance_argument_to_vehicle_address"},
        {"title_provenance_requested",
         g_vehicle_title_provenance_requested ? "true" : "false"},
+       {"object_scan_enabled", kVehicleObjectScanEnabled ? "true" : "false"},
        {"object_scan_word_count",
         std::to_string(kVehicleObjectScanWordCount)},
        {"object_scan_cache_capacity",
@@ -16796,8 +16825,16 @@ void EmitVehicleDiscoverySummary() {
        {"player_priority_admitted", "false"},
        {"owner_vtable_method_count",
         std::to_string(kVehicleOwnerVtableMethodCount)},
-       {"owner_method_candidates", "82BCC368:14,82BD2DE0:20,82BC8410:22"},
-       {"owner_method_exit_hooks", "82BCCD30,82BD35B0,82BC86F0"},
+       {"owner_method_candidates",
+        "82BD2BD0:0,82BD2B58:3,82BCFDD8:7,82BCFE18:8,82BCFE58:9,"
+        "82BC1D90:12,82BBDD38:13,82BCC368:14,82BCD780:15,82BCD9B0:16,"
+        "82BD0548:17,82BD05D8:18,82BD0648:19,82BD2DE0:20,82BBA9C0:21,"
+        "82BC8410:22,82BB94D8:23,82BBC1B0:25,82BD0918:27"},
+       {"owner_method_exit_hooks",
+        "82BD2C20,82BD2BC0,82BCFE10,82BCFE50,82BCFE70,82BC1DC0,"
+        "82BBDE40,82BCCD30,82BCD9A8,82BCDA90,82BD05D0,82BD0640,"
+        "82BD06B0,82BD35B0,82BBAB28,82BC86F0,82BB9568,82BBC2C8,"
+        "82BD0968"},
        {"owner_method_stack_faults",
         std::to_string(g_vehicle_owner_method_stack_faults.load(
             std::memory_order_relaxed))},
@@ -16840,6 +16877,7 @@ void EmitVehicleDiscoverySummary() {
         std::to_string(kVehicleIdentityAddressCapacity)},
        {"identity_address_overflow",
         std::to_string(g_vehicle_identity_address_overflow)},
+       {"object_scan_enabled", kVehicleObjectScanEnabled ? "true" : "false"},
        {"object_scan_requests",
         std::to_string(g_vehicle_object_scan_requests)},
        {"object_scans", std::to_string(g_vehicle_object_scans)},
@@ -18779,9 +18817,25 @@ void UninstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system) {
     pinyon_shift::native_renderer::EndVehicleOwnerMethod(0x##address);      \
   }
 
+PINYON_SHIFT_VEHICLE_OWNER_METHOD_HOOKS(82BD2BD0)
+PINYON_SHIFT_VEHICLE_OWNER_METHOD_HOOKS(82BD2B58)
+PINYON_SHIFT_VEHICLE_OWNER_METHOD_HOOKS(82BCFDD8)
+PINYON_SHIFT_VEHICLE_OWNER_METHOD_HOOKS(82BCFE18)
+PINYON_SHIFT_VEHICLE_OWNER_METHOD_HOOKS(82BCFE58)
+PINYON_SHIFT_VEHICLE_OWNER_METHOD_HOOKS(82BC1D90)
+PINYON_SHIFT_VEHICLE_OWNER_METHOD_HOOKS(82BBDD38)
 PINYON_SHIFT_VEHICLE_OWNER_METHOD_HOOKS(82BCC368)
+PINYON_SHIFT_VEHICLE_OWNER_METHOD_HOOKS(82BCD780)
+PINYON_SHIFT_VEHICLE_OWNER_METHOD_HOOKS(82BCD9B0)
+PINYON_SHIFT_VEHICLE_OWNER_METHOD_HOOKS(82BD0548)
+PINYON_SHIFT_VEHICLE_OWNER_METHOD_HOOKS(82BD05D8)
+PINYON_SHIFT_VEHICLE_OWNER_METHOD_HOOKS(82BD0648)
 PINYON_SHIFT_VEHICLE_OWNER_METHOD_HOOKS(82BD2DE0)
+PINYON_SHIFT_VEHICLE_OWNER_METHOD_HOOKS(82BBA9C0)
 PINYON_SHIFT_VEHICLE_OWNER_METHOD_HOOKS(82BC8410)
+PINYON_SHIFT_VEHICLE_OWNER_METHOD_HOOKS(82BB94D8)
+PINYON_SHIFT_VEHICLE_OWNER_METHOD_HOOKS(82BBC1B0)
+PINYON_SHIFT_VEHICLE_OWNER_METHOD_HOOKS(82BD0918)
 
 #undef PINYON_SHIFT_VEHICLE_OWNER_METHOD_HOOKS
 

--- a/tools/summarize-native-renderer-vehicle-pose.py
+++ b/tools/summarize-native-renderer-vehicle-pose.py
@@ -41,9 +41,25 @@ TITLE_PROVENANCE_CONFIG = (
     "native_renderer.discovery.title_provenance_config"
 )
 OWNER_METHOD_CANDIDATES = {
+    "82BD2BD0": (0, "82BD2C20"),
+    "82BD2B58": (3, "82BD2BC0"),
+    "82BCFDD8": (7, "82BCFE10"),
+    "82BCFE18": (8, "82BCFE50"),
+    "82BCFE58": (9, "82BCFE70"),
+    "82BC1D90": (12, "82BC1DC0"),
+    "82BBDD38": (13, "82BBDE40"),
     "82BCC368": (14, "82BCCD30"),
+    "82BCD780": (15, "82BCD9A8"),
+    "82BCD9B0": (16, "82BCDA90"),
+    "82BD0548": (17, "82BD05D0"),
+    "82BD05D8": (18, "82BD0640"),
+    "82BD0648": (19, "82BD06B0"),
     "82BD2DE0": (20, "82BD35B0"),
+    "82BBA9C0": (21, "82BBAB28"),
     "82BC8410": (22, "82BC86F0"),
+    "82BB94D8": (23, "82BB9568"),
+    "82BBC1B0": (25, "82BBC2C8"),
+    "82BD0918": (27, "82BD0968"),
 }
 OWNER_INDIRECT_CALLSITES = {
     "82BC8468",
@@ -191,9 +207,20 @@ def build(events, requested_session=None):
         "classification": "unclassified_vehicle_pose_stream",
         "player_priority_admitted": "false",
         "owner_vtable_method_count": "32",
-        "owner_method_candidates": "82BCC368:14,82BD2DE0:20,82BC8410:22",
-        "owner_method_exit_hooks": "82BCCD30,82BD35B0,82BC86F0",
-        "owner_method_stack_capacity": "8",
+        "owner_method_candidates": (
+            "82BD2BD0:0,82BD2B58:3,82BCFDD8:7,82BCFE18:8,"
+            "82BCFE58:9,82BC1D90:12,82BBDD38:13,82BCC368:14,"
+            "82BCD780:15,82BCD9B0:16,82BD0548:17,82BD05D8:18,"
+            "82BD0648:19,82BD2DE0:20,82BBA9C0:21,82BC8410:22,"
+            "82BB94D8:23,82BBC1B0:25,82BD0918:27"
+        ),
+        "owner_method_exit_hooks": (
+            "82BD2C20,82BD2BC0,82BCFE10,82BCFE50,82BCFE70,"
+            "82BC1DC0,82BBDE40,82BCCD30,82BCD9A8,82BCDA90,"
+            "82BD05D0,82BD0640,82BD06B0,82BD35B0,82BBAB28,"
+            "82BC86F0,82BB9568,82BBC2C8,82BD0968"
+        ),
+        "owner_method_stack_capacity": "32",
         "owner_indirect_callsites": (
             "82BC8468,82BC84A4,82BC84DC,82BC8688,82BC86BC,82BC86E4"
         ),
@@ -203,6 +230,7 @@ def build(events, requested_session=None):
         "draw_correlation": (
             "exact_backend_signature_and_provenance_argument_to_vehicle_address"
         ),
+        "object_scan_enabled": "false",
         "object_scan_word_count": "128",
         "object_scan_cache_capacity": "16384",
         "object_correlation_capacity": "2048",
@@ -276,12 +304,24 @@ def build(events, requested_session=None):
         "classification": "vehicle_instance_semantic_seed",
         "player_priority_admitted": "false",
         "owner_vtable_method_count": "32",
-        "owner_method_candidates": "82BCC368:14,82BD2DE0:20,82BC8410:22",
-        "owner_method_exit_hooks": "82BCCD30,82BD35B0,82BC86F0",
+        "owner_method_candidates": (
+            "82BD2BD0:0,82BD2B58:3,82BCFDD8:7,82BCFE18:8,"
+            "82BCFE58:9,82BC1D90:12,82BBDD38:13,82BCC368:14,"
+            "82BCD780:15,82BCD9B0:16,82BD0548:17,82BD05D8:18,"
+            "82BD0648:19,82BD2DE0:20,82BBA9C0:21,82BC8410:22,"
+            "82BB94D8:23,82BBC1B0:25,82BD0918:27"
+        ),
+        "owner_method_exit_hooks": (
+            "82BD2C20,82BD2BC0,82BCFE10,82BCFE50,82BCFE70,"
+            "82BC1DC0,82BBDE40,82BCCD30,82BCD9A8,82BCDA90,"
+            "82BD05D0,82BD0640,82BD06B0,82BD35B0,82BBAB28,"
+            "82BC86F0,82BB9568,82BBC2C8,82BD0968"
+        ),
         "capacity": "64",
         "summary_limit": "64",
         "draw_correlation_capacity": "1024",
         "identity_address_capacity": "512",
+        "object_scan_enabled": "false",
         "object_scan_word_count": "128",
         "object_scan_cache_capacity": "16384",
         "object_correlation_capacity": "2048",
@@ -1255,6 +1295,7 @@ def build(events, requested_session=None):
         failures.append("vehicle identity address index coverage drifted")
     if totals["draw_correlations"] > totals["draw_correlation_capacity"]:
         failures.append("vehicle draw correlation capacity drifted")
+    object_scan_enabled = config["object_scan_enabled"] == "true"
     if totals["object_scans"] > totals["object_scan_requests"]:
         failures.append("vehicle object scan request accounting drifted")
     if totals["object_scan_words"] != (
@@ -1275,17 +1316,38 @@ def build(events, requested_session=None):
         failures.append("vehicle object correlation table overflowed")
     if totals["object_correlations"] > totals["object_correlation_capacity"]:
         failures.append("vehicle object correlation capacity drifted")
-    for register in ("r7", "r8"):
-        requests = totals[f"targeted_render_context_{register}_scan_requests"]
-        scans = totals[f"targeted_render_context_{register}_scans"]
-        if not requests or not scans:
-            failures.append(
-                f"targeted render-context {register} coverage was absent"
-            )
-        if scans > requests:
-            failures.append(
-                f"targeted render-context {register} accounting drifted"
-            )
+    if object_scan_enabled:
+        for register in ("r7", "r8"):
+            requests = totals[
+                f"targeted_render_context_{register}_scan_requests"
+            ]
+            scans = totals[f"targeted_render_context_{register}_scans"]
+            if not requests or not scans:
+                failures.append(
+                    f"targeted render-context {register} coverage was absent"
+                )
+            if scans > requests:
+                failures.append(
+                    f"targeted render-context {register} accounting drifted"
+                )
+    elif any(
+        totals[key]
+        for key in (
+            "object_scan_requests",
+            "object_scans",
+            "object_scan_words",
+            "object_scan_cache_entries",
+            "object_scan_cache_overflow",
+            "object_argument_matches",
+            "object_correlations",
+            "object_correlation_overflow",
+            "targeted_render_context_r7_scan_requests",
+            "targeted_render_context_r7_scans",
+            "targeted_render_context_r8_scan_requests",
+            "targeted_render_context_r8_scans",
+        )
+    ):
+        failures.append("retired vehicle object scan emitted evidence")
     if totals["render_context_callee_observations"] != (
         totals["render_context_callee_eligible_observations"]
         + totals["render_context_callee_ineligible_observations"]

--- a/tools/tests/test_native_renderer_vehicle_pose.py
+++ b/tools/tests/test_native_renderer_vehicle_pose.py
@@ -30,9 +30,20 @@ def fixture():
         classification="unclassified_vehicle_pose_stream",
         player_priority_admitted="false",
         owner_vtable_method_count="32",
-        owner_method_candidates="82BCC368:14,82BD2DE0:20,82BC8410:22",
-        owner_method_exit_hooks="82BCCD30,82BD35B0,82BC86F0",
-        owner_method_stack_capacity="8",
+        owner_method_candidates=(
+            "82BD2BD0:0,82BD2B58:3,82BCFDD8:7,82BCFE18:8,"
+            "82BCFE58:9,82BC1D90:12,82BBDD38:13,82BCC368:14,"
+            "82BCD780:15,82BCD9B0:16,82BD0548:17,82BD05D8:18,"
+            "82BD0648:19,82BD2DE0:20,82BBA9C0:21,82BC8410:22,"
+            "82BB94D8:23,82BBC1B0:25,82BD0918:27"
+        ),
+        owner_method_exit_hooks=(
+            "82BD2C20,82BD2BC0,82BCFE10,82BCFE50,82BCFE70,"
+            "82BC1DC0,82BBDE40,82BCCD30,82BCD9A8,82BCDA90,"
+            "82BD05D0,82BD0640,82BD06B0,82BD35B0,82BBAB28,"
+            "82BC86F0,82BB9568,82BBC2C8,82BD0968"
+        ),
+        owner_method_stack_capacity="32",
         owner_indirect_callsites=(
             "82BC8468,82BC84A4,82BC84DC,82BC8688,82BC86BC,82BC86E4"
         ),
@@ -43,6 +54,7 @@ def fixture():
             "exact_backend_signature_and_provenance_argument_to_vehicle_address"
         ),
         title_provenance_requested="true",
+        object_scan_enabled="false",
         object_scan_word_count="128",
         object_scan_cache_capacity="16384",
         object_correlation_capacity="2048",
@@ -116,8 +128,19 @@ def fixture():
         classification="vehicle_instance_semantic_seed",
         player_priority_admitted="false",
         owner_vtable_method_count="32",
-        owner_method_candidates="82BCC368:14,82BD2DE0:20,82BC8410:22",
-        owner_method_exit_hooks="82BCCD30,82BD35B0,82BC86F0",
+        owner_method_candidates=(
+            "82BD2BD0:0,82BD2B58:3,82BCFDD8:7,82BCFE18:8,"
+            "82BCFE58:9,82BC1D90:12,82BBDD38:13,82BCC368:14,"
+            "82BCD780:15,82BCD9B0:16,82BD0548:17,82BD05D8:18,"
+            "82BD0648:19,82BD2DE0:20,82BBA9C0:21,82BC8410:22,"
+            "82BB94D8:23,82BBC1B0:25,82BD0918:27"
+        ),
+        owner_method_exit_hooks=(
+            "82BD2C20,82BD2BC0,82BCFE10,82BCFE50,82BCFE70,"
+            "82BC1DC0,82BBDE40,82BCCD30,82BCD9A8,82BCDA90,"
+            "82BD05D0,82BD0640,82BD06B0,82BD35B0,82BBAB28,"
+            "82BC86F0,82BB9568,82BBC2C8,82BD0968"
+        ),
         owner_method_stack_faults="0",
         owner_indirect_observations="0",
         owner_indirect_valid_observations="0",
@@ -139,11 +162,12 @@ def fixture():
         identity_addresses="3",
         identity_address_capacity="512",
         identity_address_overflow="0",
-        object_scan_requests="2",
-        object_scans="1",
-        object_scan_words="128",
+        object_scan_enabled="false",
+        object_scan_requests="0",
+        object_scans="0",
+        object_scan_words="0",
         object_scan_word_count="128",
-        object_scan_cache_entries="1",
+        object_scan_cache_entries="0",
         object_scan_cache_capacity="16384",
         object_scan_cache_overflow="0",
         object_argument_matches="0",
@@ -151,10 +175,10 @@ def fixture():
         object_correlation_capacity="2048",
         render_context_callee_profile_capacity="32",
         object_correlation_overflow="0",
-        targeted_render_context_r7_scan_requests="2",
-        targeted_render_context_r7_scans="1",
-        targeted_render_context_r8_scan_requests="2",
-        targeted_render_context_r8_scans="1",
+        targeted_render_context_r7_scan_requests="0",
+        targeted_render_context_r7_scans="0",
+        targeted_render_context_r8_scan_requests="0",
+        targeted_render_context_r8_scans="0",
         render_context_callee_observations="3",
         render_context_callee_eligible_observations="2",
         render_context_callee_ineligible_observations="1",
@@ -554,6 +578,15 @@ class VehiclePoseSummaryTests(unittest.TestCase):
         self.assertEqual(1, analysis.count("address = 0x8240EC18"))
         self.assertEqual(1, analysis.count("address = 0x8240EB5C"))
         self.assertEqual(1, analysis.count("address = 0x8243646C"))
+        for method, (_, exit_address) in MODULE.OWNER_METHOD_CANDIDATES.items():
+            self.assertEqual(1, analysis.count(f"address = 0x{method}"))
+            self.assertEqual(1, analysis.count(f"address = 0x{exit_address}"))
+            self.assertEqual(
+                1,
+                hooks.count(
+                    f"PINYON_SHIFT_VEHICLE_OWNER_METHOD_HOOKS({method})"
+                ),
+            )
         for address in (
             "82BC8468",
             "82BC84A4",
@@ -837,7 +870,7 @@ class VehiclePoseSummaryTests(unittest.TestCase):
             "vehicle draw correlation table overflowed", document["failures"]
         )
 
-    def test_qualifies_one_hop_object_match_as_candidate_only(self):
+    def test_rejects_evidence_from_retired_one_hop_object_scan(self):
         events = fixture()
         events[1]["object_argument_matches"] = "2"
         events[1]["object_correlations"] = "1"
@@ -869,9 +902,13 @@ class VehiclePoseSummaryTests(unittest.TestCase):
             )
         )
         document = MODULE.build(events)
-        self.assertEqual("complete", document["status"])
+        self.assertEqual("incomplete", document["status"])
         self.assertEqual(1, len(document["draw_object_correlations"]))
-        self.assertTrue(
+        self.assertIn(
+            "retired vehicle object scan emitted evidence",
+            document["failures"],
+        )
+        self.assertFalse(
             document["qualification"][
                 "vehicle_draw_object_candidate_proved"
             ]


### PR DESCRIPTION
## Summary\n\n- instrument all 19 nontrivial methods on the qualified vehicle-owner vtable\n- require balanced exact-owner correlation across the full method sweep\n- retire the saturated one-hop object scanner and fail qualification if it emits evidence\n- keep Xenos authoritative with native vehicle publication and suppression closed\n\n## Validation\n\n- python -m unittest discover -s tools/tests (419 passed)\n- .\\tools\\build-preview.ps1 -Parallel 16\n- AppData session 20260830T121257Z-p33888 (complete)\n- 42,086 calls / 42,086 exits, all 19 methods exercised\n- zero retired scans, draw matches, stack faults, or presentation deadline misses\n- 31.378 median FPS, 29.533 Hz simulation, 59.625 Hz presentation