### PR TITLE
feat(renderer): census shadow and reflection candidates

### DIFF
--- a/docs/native-renderer/SHADOW_REFLECTION_PASS_CENSUS.md
+++ b/docs/native-renderer/SHADOW_REFLECTION_PASS_CENSUS.md
@@ -1,0 +1,81 @@
+# Shadow and reflection pass census
+
+This is the first capture-and-documentation boundary for NR-05F. It enriches
+the existing payload-free RenderDoc pass trace with exact graphics-pipeline,
+shader identifiers and labels, viewport, scissor, depth, raster, and target
+metadata. It does not export images, buffers, textures, shaders, or other game
+payloads.
+
+## Safety boundary
+
+The effect-pass census groups exact pipeline metadata into deterministic
+families. Target topology produces only mechanical candidate classes:
+
+- `depth_only_write_candidate`;
+- `depth_only_read_candidate`;
+- `color_depth_candidate`;
+- `color_only_candidate`; and
+- `no_output_candidate`.
+
+These names do not assign a semantic role. Every family remains
+`unknown_unclassified`, reports no native coverage, is suppression-ineligible,
+and leaves Xenos authoritative. A depth-only pass is not automatically a
+shadow map, and a repeated square color target is not automatically a
+reflection or cubemap.
+
+## Workflow
+
+```powershell
+.\tools\export-native-renderer-pass-trace.ps1 `
+  -Capture '.local\qualification\reference.rdc' `
+  -RenderDocRoot '.local\tools\renderdoc\RenderDoc_64' `
+  -Output '.local\qualification\effect-pass-trace.json'
+
+python .\tools\build-native-renderer-effect-pass-census.py `
+  .local\qualification\effect-pass-trace.json `
+  --output .local\qualification\effect-pass-census.json
+```
+
+The trace must explicitly prove that it exported no resource payload and that
+its added fields are pipeline metadata only. The census rejects legacy traces
+without the enriched contract instead of silently producing weak candidates.
+
+## Promotion evidence
+
+A candidate may receive a `shadow` or `reflection` role only after at least one
+stronger source agrees with its exact signature, such as:
+
+- a high-level title hook enclosing the complete pass;
+- a controlled light, caster, or reflection-probe perturbation;
+- a bounded resource-consumer chain proving later shadow/reflection sampling;
+- shader reflection or disassembly proving the expected transform and output;
+- or a reviewed RenderDoc image/resource inspection performed locally.
+
+Promotion must retain per-item replay fallback, an independent feature gate,
+and guest-visible side effects. Native drawing, atlas allocation, reflection
+publication, and Xenos suppression remain out of scope for this census.
+
+## Initial open-world census
+
+The qualified `open_world_day` capture `reference_frame8134.rdc` (SHA-256
+`EF4064929005D08432488FD4649E845630860044A6CDC49E463FA7B3883667DA`)
+contains 1,582 authoritative Xenos draws and six ignored diagnostic native
+draws. The enriched census groups the authoritative work into 273 exact
+pipeline families:
+
+| Mechanical output class | Draws |
+| --- | ---: |
+| Depth-only write candidate | 922 |
+| Depth-only read candidate | 241 |
+| Color + depth candidate | 357 |
+| Color-only candidate | 62 |
+
+One bounded target is the strongest next shadow candidate without yet being a
+semantic match. Resource `RT @ 720t, <13t>, 1xMSAA, kD24S8` receives 33
+depth-only draws through 1024 by 1024 viewports and 80 through 2048 by 2048
+viewports. The 2048 group has no pixel shader and is dominated by vertex shader
+labels `Shader {b1ccceb6}` (64 draws), `Shader {d18760b6}` (12), and
+`Shader {23c9cd31}` (4). This exact target/view/shader boundary is suitable for
+a bounded producer-consumer or controlled-light probe. It is not sufficient to
+identify a shadow atlas, cascade split, caster class, or quality tier, so the
+report keeps both shadow and reflection qualification false.

--- a/tools/build-native-renderer-effect-pass-census.py
+++ b/tools/build-native-renderer-effect-pass-census.py
@@ -1,0 +1,188 @@
+"""Build a fail-closed effect-pass census from an enriched RenderDoc trace."""
+
+import argparse
+import hashlib
+import json
+import pathlib
+import sys
+
+
+TRACE_SCHEMA = "pinyon-shift.native-renderer-renderdoc-pass-trace.v1"
+SCHEMA = "pinyon-shift.native-renderer-effect-pass-census.v1"
+
+
+def canonical_sha256(value):
+    return hashlib.sha256(
+        json.dumps(value, sort_keys=True, separators=(",", ":")).encode(
+            "utf-8"
+        )
+    ).hexdigest().upper()
+
+
+def target_shape(target):
+    if target is None:
+        return None
+    return {
+        key: target.get(key)
+        for key in ("width", "height", "mip", "slice", "format")
+    }
+
+
+def output_class(draw):
+    colors = draw.get("color_targets", [])
+    depth = draw.get("depth_target")
+    depth_state = draw.get("depth_state", {})
+    if not colors and depth is not None:
+        if depth_state.get("writes") is True:
+            return "depth_only_write_candidate"
+        return "depth_only_read_candidate"
+    if colors and depth is not None:
+        return "color_depth_candidate"
+    if colors:
+        return "color_only_candidate"
+    return "no_output_candidate"
+
+
+def signature(draw):
+    return {
+        "output_class": output_class(draw),
+        "color_target_shapes": [
+            target_shape(target) for target in draw.get("color_targets", [])
+        ],
+        "depth_target_shape": target_shape(draw.get("depth_target")),
+        "pipeline": draw.get("pipeline"),
+        "pipeline_name": draw.get("pipeline_name"),
+        "vertex_shader": draw.get("vertex_shader"),
+        "vertex_shader_name": draw.get("vertex_shader_name"),
+        "pixel_shader": draw.get("pixel_shader"),
+        "pixel_shader_name": draw.get("pixel_shader_name"),
+        "primitive_topology": draw.get("primitive_topology"),
+        "viewport": draw.get("viewport"),
+        "scissor": draw.get("scissor"),
+        "depth_state": draw.get("depth_state"),
+        "raster_state": draw.get("raster_state"),
+    }
+
+
+def build_census(trace):
+    if trace.get("schema") != TRACE_SCHEMA:
+        raise ValueError("unsupported pass trace schema")
+    safety = trace.get("safety", {})
+    if safety.get("resource_payload_exported") is not False:
+        raise ValueError("pass trace does not prove its payload-free boundary")
+    if safety.get("pipeline_metadata_only") is not True:
+        raise ValueError("pass trace has no enriched pipeline metadata")
+    events = trace.get("events")
+    if not isinstance(events, list):
+        raise ValueError("pass trace events must be a list")
+
+    families = {}
+    ignored_native_draws = 0
+    last_event = -1
+    for event in events:
+        event_id = event.get("event_id")
+        if not isinstance(event_id, int) or event_id < last_event:
+            raise ValueError("pass trace events are not monotonically ordered")
+        last_event = event_id
+        kind = event.get("kind")
+        if kind == "boundary":
+            continue
+        if kind != "draw":
+            raise ValueError("pass trace contains an unknown event kind")
+        if event.get("isolated_native") is True:
+            ignored_native_draws += 1
+            continue
+        required = (
+            "pipeline",
+            "vertex_shader",
+            "pixel_shader",
+            "primitive_topology",
+            "viewport",
+            "scissor",
+            "depth_state",
+            "raster_state",
+        )
+        if any(key not in event for key in required):
+            raise ValueError("draw is missing enriched pipeline metadata")
+        value = signature(event)
+        key = canonical_sha256(value)
+        family = families.setdefault(
+            key,
+            {
+                "sha256": key,
+                "signature": value,
+                "draw_count": 0,
+                "instance_count": 0,
+                "index_count": 0,
+                "first_event": event_id,
+                "last_event": event_id,
+                "semantic_role": "unknown_unclassified",
+                "native_coverage": False,
+                "suppression_eligible": False,
+            },
+        )
+        family["draw_count"] += 1
+        family["instance_count"] += int(event.get("instance_count", 0))
+        family["index_count"] += int(event.get("index_count", 0))
+        family["last_event"] = event_id
+
+    ordered = sorted(
+        families.values(),
+        key=lambda item: (-item["draw_count"], item["sha256"]),
+    )
+    counts = {}
+    for family in ordered:
+        key = family["signature"]["output_class"]
+        counts[key] = counts.get(key, 0) + family["draw_count"]
+    return {
+        "schema": SCHEMA,
+        "capture": trace.get("capture"),
+        "totals": {
+            "draws": sum(item["draw_count"] for item in ordered),
+            "families": len(ordered),
+            "isolated_native_draws_ignored": ignored_native_draws,
+            "draws_by_output_class": dict(sorted(counts.items())),
+        },
+        "families": ordered,
+        "qualification": {
+            "pipeline_metadata_census_complete": True,
+            "shadow_pass_identified": False,
+            "reflection_pass_identified": False,
+            "semantic_promotion_requires_external_evidence": True,
+        },
+        "safety": {
+            "metadata_only": True,
+            "resource_payload_exported": False,
+            "xenos_authority": True,
+            "native_coverage": False,
+            "suppression_allowed": False,
+        },
+    }
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser()
+    parser.add_argument("trace", type=pathlib.Path)
+    parser.add_argument("--output", required=True, type=pathlib.Path)
+    args = parser.parse_args(argv)
+    try:
+        trace_bytes = args.trace.read_bytes()
+        trace = json.loads(trace_bytes)
+        census = build_census(trace)
+        census["trace_sha256"] = hashlib.sha256(trace_bytes).hexdigest().upper()
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(
+            json.dumps(census, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        return 0
+    except (OSError, ValueError, KeyError, TypeError, json.JSONDecodeError) as error:
+        print(
+            "native renderer effect-pass census failed: {}".format(error),
+            file=sys.stderr,
+        )
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/build-native-renderer-pass-inventory.py
+++ b/tools/build-native-renderer-pass-inventory.py
@@ -23,6 +23,26 @@ def target_key(draw):
     return colors, depth_key
 
 
+def pipeline_signature(draw):
+    return {
+        key: draw.get(key)
+        for key in (
+            "pipeline",
+            "pipeline_name",
+            "vertex_shader",
+            "vertex_shader_name",
+            "pixel_shader",
+            "pixel_shader_name",
+            "primitive_topology",
+            "viewport",
+            "scissor",
+            "depth_state",
+            "raster_state",
+        )
+        if key in draw
+    }
+
+
 def build_inventory(trace):
     if trace.get("schema") != TRACE_SCHEMA:
         raise ValueError("unsupported pass trace schema")
@@ -67,6 +87,7 @@ def build_inventory(trace):
                 "boundary_before": sorted(set(pending_boundaries)),
                 "color_targets": event.get("color_targets", []),
                 "depth_target": event.get("depth_target"),
+                "pipeline_signatures": {},
                 "_key": key,
             }
             phases.append(current)
@@ -76,10 +97,26 @@ def build_inventory(trace):
         if event.get("authoritative_candidate") is True:
             current["candidate_draw_count"] += 1
             authoritative_candidates += 1
+        signature = pipeline_signature(event)
+        if signature:
+            signature_key = hashlib.sha256(
+                json.dumps(
+                    signature, sort_keys=True, separators=(",", ":")
+                ).encode("utf-8")
+            ).hexdigest().upper()
+            entry = current["pipeline_signatures"].setdefault(
+                signature_key,
+                {"signature": signature, "draw_count": 0},
+            )
+            entry["draw_count"] += 1
         pending_boundaries = []
 
     for phase in phases:
         phase.pop("_key")
+        phase["pipeline_signatures"] = [
+            {"sha256": key, **value}
+            for key, value in sorted(phase["pipeline_signatures"].items())
+        ]
         phase["qualification"] = (
             "candidate_phase"
             if phase["candidate_draw_count"]

--- a/tools/export-native-renderer-pass-trace.py
+++ b/tools/export-native-renderer-pass-trace.py
@@ -46,7 +46,14 @@ def texture_map(controller):
     return {str(texture.resourceId): texture for texture in controller.GetTextures()}
 
 
-def target_description(target, textures):
+def resource_name_map(controller):
+    return {
+        str(resource.resourceId): resource.name
+        for resource in controller.GetResources()
+    }
+
+
+def target_description(target, textures, resource_names):
     if target.resource == rd.ResourceId.Null():
         return None
     resource_id = str(target.resource)
@@ -55,11 +62,66 @@ def target_description(target, textures):
         raise RuntimeError("target texture description was not found: " + resource_id)
     return {
         "resource_id": resource_id,
+        "resource_name": resource_names.get(resource_id, ""),
         "width": texture.width,
         "height": texture.height,
         "mip": getattr(target, "firstMip", 0),
         "slice": getattr(target, "firstSlice", 0),
         "format": texture.format.Name(),
+    }
+
+
+def resource_id(value):
+    if value == rd.ResourceId.Null():
+        return None
+    return str(value)
+
+
+def resource_name(value, resource_names):
+    identifier = resource_id(value)
+    if identifier is None:
+        return None
+    return resource_names.get(identifier, "")
+
+
+def viewport_description(viewport):
+    return {
+        "enabled": viewport.enabled,
+        "x": viewport.x,
+        "y": viewport.y,
+        "width": viewport.width,
+        "height": viewport.height,
+        "min_depth": viewport.minDepth,
+        "max_depth": viewport.maxDepth,
+    }
+
+
+def scissor_description(scissor):
+    return {
+        "enabled": scissor.enabled,
+        "x": scissor.x,
+        "y": scissor.y,
+        "width": scissor.width,
+        "height": scissor.height,
+    }
+
+
+def depth_state_description(state):
+    return {
+        "enabled": state.depthEnable,
+        "writes": state.depthWrites,
+        "function": str(state.depthFunction),
+        "bounds": state.depthBounds,
+        "min_bounds": state.minDepthBounds,
+        "max_bounds": state.maxDepthBounds,
+    }
+
+
+def raster_state_description(state):
+    return {
+        "front_ccw": state.frontCCW,
+        "fill_mode": str(state.fillMode),
+        "cull_mode": str(state.cullMode),
     }
 
 
@@ -97,6 +159,7 @@ def main():
                 authoritative_events.update(child.eventId for child in descendants(action))
 
         textures = texture_map(controller)
+        resource_names = resource_name_map(controller)
         events = []
         for action in actions:
             kinds = boundary_kinds(action)
@@ -110,19 +173,47 @@ def main():
                 continue
             controller.SetFrameEvent(action.eventId, True)
             pipeline = controller.GetPipelineState()
+            viewport = pipeline.GetViewport(0)
+            scissor = pipeline.GetScissor(0)
             colors = [
-                target_description(target, textures)
+                target_description(target, textures, resource_names)
                 for target in pipeline.GetOutputTargets()
                 if target.resource != rd.ResourceId.Null()
             ]
             events.append({
                 "event_id": action.eventId,
                 "kind": "draw",
+                "action_name": action.customName,
                 "index_count": action.numIndices,
                 "instance_count": action.numInstances,
+                "pipeline": resource_id(pipeline.GetGraphicsPipelineObject()),
+                "pipeline_name": resource_name(
+                    pipeline.GetGraphicsPipelineObject(), resource_names
+                ),
+                "vertex_shader": resource_id(
+                    pipeline.GetShader(rd.ShaderStage.Vertex)
+                ),
+                "vertex_shader_name": resource_name(
+                    pipeline.GetShader(rd.ShaderStage.Vertex), resource_names
+                ),
+                "pixel_shader": resource_id(
+                    pipeline.GetShader(rd.ShaderStage.Pixel)
+                ),
+                "pixel_shader_name": resource_name(
+                    pipeline.GetShader(rd.ShaderStage.Pixel), resource_names
+                ),
+                "primitive_topology": str(pipeline.GetPrimitiveTopology()),
+                "viewport": viewport_description(viewport),
+                "scissor": scissor_description(scissor),
+                "depth_state": depth_state_description(
+                    pipeline.GetDepthTestState()
+                ),
+                "raster_state": raster_state_description(
+                    pipeline.GetRasterState()
+                ),
                 "color_targets": colors,
                 "depth_target": target_description(
-                    pipeline.GetDepthTarget(), textures
+                    pipeline.GetDepthTarget(), textures, resource_names
                 ),
                 "isolated_native": action.eventId in isolated_events,
                 "authoritative_candidate": action.eventId in authoritative_events,
@@ -138,6 +229,7 @@ def main():
             "events": events,
             "safety": {
                 "resource_payload_exported": False,
+                "pipeline_metadata_only": True,
                 "xenos_authority": True,
                 "suppression_allowed": False,
             },

--- a/tools/tests/test_native_renderer_effect_pass_census.py
+++ b/tools/tests/test_native_renderer_effect_pass_census.py
@@ -1,0 +1,120 @@
+import importlib.util
+import sys
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+TOOL = ROOT / "tools" / "build-native-renderer-effect-pass-census.py"
+SPEC = importlib.util.spec_from_file_location("effect_pass_census", TOOL)
+assert SPEC and SPEC.loader
+MODULE = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = MODULE
+SPEC.loader.exec_module(MODULE)
+
+
+def draw(event_id, colors=True, depth=True, writes=True, isolated=False):
+    target = {
+        "resource_id": "ResourceId::1",
+        "resource_name": "target",
+        "width": 1024,
+        "height": 1024,
+        "mip": 0,
+        "slice": 0,
+        "format": "D32_FLOAT",
+    }
+    return {
+        "event_id": event_id,
+        "kind": "draw",
+        "index_count": 3,
+        "instance_count": 1,
+        "pipeline": "ResourceId::10",
+        "pipeline_name": "Pipeline 10",
+        "vertex_shader": "ResourceId::11",
+        "vertex_shader_name": "Shader {11111111}",
+        "pixel_shader": None,
+        "pixel_shader_name": None,
+        "primitive_topology": "TriangleList",
+        "viewport": {"width": 1024.0, "height": 1024.0},
+        "scissor": {"width": 1024, "height": 1024},
+        "depth_state": {"enabled": True, "writes": writes},
+        "raster_state": {"cull_mode": "Back"},
+        "color_targets": [target] if colors else [],
+        "depth_target": target if depth else None,
+        "isolated_native": isolated,
+    }
+
+
+def trace(events, metadata=True, payload=False):
+    return {
+        "schema": MODULE.TRACE_SCHEMA,
+        "capture": {"path": "fixture.rdc", "sha256": "A" * 64},
+        "events": events,
+        "safety": {
+            "resource_payload_exported": payload,
+            "pipeline_metadata_only": metadata,
+        },
+    }
+
+
+class EffectPassCensusTests(unittest.TestCase):
+    def test_groups_exact_metadata_and_keeps_semantics_closed(self):
+        census = MODULE.build_census(
+            trace([draw(1, colors=False), draw(2, colors=False), draw(3)])
+        )
+        self.assertEqual(3, census["totals"]["draws"])
+        self.assertEqual(2, census["totals"]["families"])
+        self.assertEqual(
+            2,
+            census["totals"]["draws_by_output_class"][
+                "depth_only_write_candidate"
+            ],
+        )
+        self.assertTrue(
+            all(
+                item["semantic_role"] == "unknown_unclassified"
+                and not item["native_coverage"]
+                and not item["suppression_eligible"]
+                for item in census["families"]
+            )
+        )
+        self.assertFalse(census["qualification"]["shadow_pass_identified"])
+        self.assertFalse(
+            census["qualification"]["reflection_pass_identified"]
+        )
+
+    def test_ignores_native_draws_and_sorts_deterministically(self):
+        census = MODULE.build_census(
+            trace([draw(1), draw(2, colors=False), draw(3, isolated=True)])
+        )
+        self.assertEqual(2, census["totals"]["draws"])
+        self.assertEqual(1, census["totals"]["isolated_native_draws_ignored"])
+        self.assertEqual(
+            sorted(
+                census["families"],
+                key=lambda item: (-item["draw_count"], item["sha256"]),
+            ),
+            census["families"],
+        )
+
+    def test_rejects_unsafe_or_unenriched_trace(self):
+        with self.assertRaisesRegex(ValueError, "payload-free"):
+            MODULE.build_census(trace([], payload=True))
+        with self.assertRaisesRegex(ValueError, "enriched"):
+            MODULE.build_census(trace([], metadata=False))
+        event = draw(1)
+        event.pop("viewport")
+        with self.assertRaisesRegex(ValueError, "missing enriched"):
+            MODULE.build_census(trace([event]))
+
+    def test_rejects_unknown_or_unordered_events(self):
+        with self.assertRaisesRegex(ValueError, "unknown event"):
+            MODULE.build_census(
+                trace([{"event_id": 1, "kind": "mystery"}])
+            )
+        with self.assertRaisesRegex(ValueError, "monotonically"):
+            MODULE.build_census(trace([draw(2), draw(1)]))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/tests/test_native_renderer_pass_inventory.py
+++ b/tools/tests/test_native_renderer_pass_inventory.py
@@ -74,6 +74,31 @@ class NativeRendererPassInventoryTests(unittest.TestCase):
         self.assertEqual(inventory["phases"][1]["boundary_before"], ["clear"])
         self.assertEqual(inventory["phases"][2]["boundary_before"], [])
 
+    def test_preserves_exact_enriched_pipeline_signatures(self):
+        event = draw(
+            1,
+            pipeline="ResourceId::10",
+            pipeline_name="Pipeline 10",
+            vertex_shader="ResourceId::11",
+            vertex_shader_name="Shader {11111111}",
+            pixel_shader=None,
+            pixel_shader_name=None,
+            primitive_topology="TriangleList",
+            viewport={"width": 1024.0, "height": 1024.0},
+            scissor={"width": 1024, "height": 1024},
+            depth_state={"enabled": True, "writes": True},
+            raster_state={"cull_mode": "Back"},
+        )
+        inventory = MODULE.build_inventory(trace([event, dict(event, event_id=2)]))
+        signatures = inventory["phases"][0]["pipeline_signatures"]
+        self.assertEqual(1, len(signatures))
+        self.assertEqual(2, signatures[0]["draw_count"])
+        self.assertEqual("ResourceId::10", signatures[0]["signature"]["pipeline"])
+        self.assertEqual(
+            "Shader {11111111}",
+            signatures[0]["signature"]["vertex_shader_name"],
+        )
+
     def test_rejects_payload_export_and_unordered_events(self):
         with self.assertRaisesRegex(ValueError, "payload-free"):
             MODULE.build_inventory(trace([], payload_exported=True))


### PR DESCRIPTION
## Summary

- enrich payload-free RenderDoc traces with exact pipeline, shader, viewport, depth, raster, and target metadata
- group deterministic effect-pass candidates without assigning unsupported shadow/reflection semantics
- preserve enriched signatures in the existing pass inventory
- document the first qualified open-world census and its bounded depth-target candidate
- keep Xenos authoritative with native coverage and suppression closed

## Evidence

- qualified capture: reference_frame8134.rdc
- 1,582 authoritative Xenos draws and six ignored diagnostic native draws
- 273 exact pipeline families
- 922 depth-only writers, 241 depth-only readers, 357 color+depth, 62 color-only
- bounded D24S8 candidate: 33 draws at 1024 square and 80 at 2048 square

## Validation

- python -m unittest discover -s tools/tests (423 passed)
- enriched effect-pass census completed successfully
- Python syntax checks and git diff --check