### PR TITLE
feat(renderer): trace effect resource lineage

### DIFF
--- a/docs/native-renderer/SHADOW_REFLECTION_PASS_CENSUS.md
+++ b/docs/native-renderer/SHADOW_REFLECTION_PASS_CENSUS.md
@@ -79,3 +79,42 @@ labels `Shader {b1ccceb6}` (64 draws), `Shader {d18760b6}` (12), and
 a bounded producer-consumer or controlled-light probe. It is not sufficient to
 identify a shadow atlas, cascade split, caster class, or quality tier, so the
 report keeps both shadow and reflection qualification false.
+
+## Bounded resource lineage
+
+The candidate target is joined to exact pass metadata with a second
+payload-free export:
+
+```powershell
+.\tools\export-native-renderer-resource-usage.ps1 `
+  -Capture '.local\qualification\reference_frame8134.rdc' `
+  -RenderDocRoot '.local\tools\renderdoc\RenderDoc_64' `
+  -ResourceName 'RT @ 720t, <13t>, 1xMSAA, kD24S8' `
+  -Output '.local\qualification\depth-resource-usage.json'
+
+python .\tools\build-native-renderer-effect-resource-lineage.py `
+  .local\qualification\depth-resource-usage.json `
+  .local\qualification\effect-pass-trace.json `
+  --output .local\qualification\depth-resource-lineage.json
+```
+
+The exporter requires one exact resource-name match, records action metadata
+only, and exports no resource payload. The joiner requires both reports to
+name the same capture hash and rejects pixel reads without authoritative draw
+metadata.
+
+The 1xMSAA D24S8 candidate has six clear/write epochs, 207 unique depth-target
+writes, 36 pixel-shader reads, and two unique compute-read events. Every epoch
+is sampled after a write. All 36 pixel consumers write another depth target;
+none writes color. Their fixed vertex shader is `Shader {c700dc5c}`, and the
+pixel shaders are `Shader {1007aa27}` and `Shader {ea1021af}`. The immediate
+destination is `RT @ 720t, <13t>, 4xMSAA, kD24S8`.
+
+Following that destination proves the same mechanical pattern: four complete
+clear/write epochs, 40 unique depth-target writes, 59 pixel reads, and two
+unique compute-read events. Every pixel consumer again writes depth only, with
+zero color outputs. The square-view candidate is therefore a qualified
+depth-to-depth propagation chain, not a direct scene-color shadow sampler.
+This rejects it as the next shadow semantic seed while leaving the broader
+possibility of shadow data elsewhere open. Native coverage and suppression
+remain false.

--- a/tools/build-native-renderer-effect-resource-lineage.py
+++ b/tools/build-native-renderer-effect-resource-lineage.py
@@ -1,0 +1,228 @@
+"""Join a RenderDoc resource-usage trace to exact effect-pass metadata."""
+
+import argparse
+import hashlib
+import json
+import pathlib
+import sys
+
+
+USAGE_SCHEMA = "pinyon-shift.native-renderer-renderdoc-resource-usage.v1"
+PASS_SCHEMA = "pinyon-shift.native-renderer-renderdoc-pass-trace.v1"
+SCHEMA = "pinyon-shift.native-renderer-effect-resource-lineage.v1"
+READ_USAGES = {"PS_Resource", "CS_Resource"}
+
+
+def canonical_sha256(value):
+    return hashlib.sha256(
+        json.dumps(value, sort_keys=True, separators=(",", ":")).encode(
+            "utf-8"
+        )
+    ).hexdigest().upper()
+
+
+def consumer_signature(draw):
+    return {
+        key: draw.get(key)
+        for key in (
+            "pipeline",
+            "pipeline_name",
+            "vertex_shader",
+            "vertex_shader_name",
+            "pixel_shader",
+            "pixel_shader_name",
+            "primitive_topology",
+            "viewport",
+            "color_targets",
+            "depth_target",
+        )
+        if key in draw
+    }
+
+
+def build_lineage(usage_trace, pass_trace):
+    if usage_trace.get("schema") != USAGE_SCHEMA:
+        raise ValueError("unsupported resource-usage schema")
+    if pass_trace.get("schema") != PASS_SCHEMA:
+        raise ValueError("unsupported pass-trace schema")
+    usage_safety = usage_trace.get("safety", {})
+    pass_safety = pass_trace.get("safety", {})
+    if usage_safety.get("resource_payload_exported") is not False:
+        raise ValueError("resource usage does not prove its payload-free boundary")
+    if usage_safety.get("action_metadata_only") is not True:
+        raise ValueError("resource usage is not action-metadata-only")
+    if pass_safety.get("resource_payload_exported") is not False:
+        raise ValueError("pass trace does not prove its payload-free boundary")
+    usage_capture = usage_trace.get("capture", {})
+    pass_capture = pass_trace.get("capture", {})
+    if usage_capture.get("sha256") != pass_capture.get("sha256"):
+        raise ValueError("resource usage and pass trace captures differ")
+    usages = usage_trace.get("usages")
+    events = pass_trace.get("events")
+    if not isinstance(usages, list) or not isinstance(events, list):
+        raise ValueError("lineage inputs must contain event arrays")
+
+    draw_events = {
+        event["event_id"]: event
+        for event in events
+        if event.get("kind") == "draw" and event.get("isolated_native") is not True
+    }
+    epochs = []
+    current = None
+    usage_counts = {}
+    unique_events = {}
+    consumer_families = {}
+    pixel_consumer_events = set()
+    pixel_consumers_depth_only = set()
+    pixel_consumers_with_color = set()
+    pixel_consumers_without_output = set()
+    last_event = -1
+    for item in usages:
+        event_id = item.get("event_id")
+        usage = item.get("usage")
+        if not isinstance(event_id, int) or event_id < last_event:
+            raise ValueError("resource usages are not monotonically ordered")
+        if not isinstance(usage, str) or not usage:
+            raise ValueError("resource usage kind is invalid")
+        last_event = event_id
+        usage_counts[usage] = usage_counts.get(usage, 0) + 1
+        unique_events.setdefault(usage, set()).add(event_id)
+        if usage == "Clear":
+            current = {
+                "ordinal": len(epochs) + 1,
+                "clear_event": event_id,
+                "last_event": event_id,
+                "depth_write_events": [],
+                "pixel_read_events": [],
+                "compute_read_events": [],
+            }
+            epochs.append(current)
+            continue
+        if current is not None:
+            current["last_event"] = event_id
+            key = {
+                "DepthStencilTarget": "depth_write_events",
+                "PS_Resource": "pixel_read_events",
+                "CS_Resource": "compute_read_events",
+            }.get(usage)
+            if key is not None and event_id not in current[key]:
+                current[key].append(event_id)
+        if usage != "PS_Resource":
+            continue
+        draw = draw_events.get(event_id)
+        if draw is None:
+            raise ValueError("pixel consumer has no authoritative draw metadata")
+        pixel_consumer_events.add(event_id)
+        if draw.get("color_targets"):
+            pixel_consumers_with_color.add(event_id)
+        elif draw.get("depth_target") is not None:
+            pixel_consumers_depth_only.add(event_id)
+        else:
+            pixel_consumers_without_output.add(event_id)
+        value = consumer_signature(draw)
+        key = canonical_sha256(value)
+        family = consumer_families.setdefault(
+            key,
+            {
+                "sha256": key,
+                "signature": value,
+                "read_events": [],
+                "semantic_role": "unknown_unclassified",
+                "native_coverage": False,
+                "suppression_eligible": False,
+            },
+        )
+        if event_id not in family["read_events"]:
+            family["read_events"].append(event_id)
+
+    for epoch in epochs:
+        epoch["depth_write_count"] = len(epoch["depth_write_events"])
+        epoch["pixel_read_count"] = len(epoch["pixel_read_events"])
+        epoch["compute_read_count"] = len(epoch["compute_read_events"])
+        epoch["sampled_after_write"] = bool(
+            epoch["depth_write_events"]
+            and (epoch["pixel_read_events"] or epoch["compute_read_events"])
+            and min(epoch["pixel_read_events"] + epoch["compute_read_events"])
+            > min(epoch["depth_write_events"])
+        )
+    ordered_families = sorted(
+        consumer_families.values(),
+        key=lambda family: (-len(family["read_events"]), family["sha256"]),
+    )
+    for family in ordered_families:
+        family["read_count"] = len(family["read_events"])
+    sampled_epochs = sum(epoch["sampled_after_write"] for epoch in epochs)
+    return {
+        "schema": SCHEMA,
+        "capture": usage_capture,
+        "resource": usage_trace.get("resource"),
+        "totals": {
+            "usage_references": len(usages),
+            "usage_references_by_kind": dict(sorted(usage_counts.items())),
+            "unique_events_by_kind": {
+                key: len(value) for key, value in sorted(unique_events.items())
+            },
+            "clear_epochs": len(epochs),
+            "sampled_epochs": sampled_epochs,
+            "consumer_families": len(ordered_families),
+            "pixel_consumer_events": len(pixel_consumer_events),
+            "pixel_consumers_depth_only": len(pixel_consumers_depth_only),
+            "pixel_consumers_with_color": len(pixel_consumers_with_color),
+            "pixel_consumers_without_output": len(
+                pixel_consumers_without_output
+            ),
+        },
+        "epochs": epochs,
+        "consumer_families": ordered_families,
+        "qualification": {
+            "depth_producer_consumer_chain_proved": bool(epochs)
+            and sampled_epochs == len(epochs),
+            "depth_to_depth_propagation_chain_proved": bool(
+                pixel_consumer_events
+            )
+            and len(pixel_consumers_depth_only) == len(pixel_consumer_events)
+            and not pixel_consumers_with_color
+            and not pixel_consumers_without_output,
+            "direct_color_sampling_observed": bool(pixel_consumers_with_color),
+            "shadow_semantic_proved": False,
+            "reflection_semantic_proved": False,
+            "semantic_promotion_requires_external_evidence": True,
+        },
+        "safety": {
+            "metadata_only": True,
+            "resource_payload_exported": False,
+            "xenos_authority": True,
+            "native_coverage": False,
+            "suppression_allowed": False,
+        },
+    }
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser()
+    parser.add_argument("usage_trace", type=pathlib.Path)
+    parser.add_argument("pass_trace", type=pathlib.Path)
+    parser.add_argument("--output", required=True, type=pathlib.Path)
+    args = parser.parse_args(argv)
+    try:
+        usage_bytes = args.usage_trace.read_bytes()
+        pass_bytes = args.pass_trace.read_bytes()
+        lineage = build_lineage(json.loads(usage_bytes), json.loads(pass_bytes))
+        lineage["usage_trace_sha256"] = hashlib.sha256(usage_bytes).hexdigest().upper()
+        lineage["pass_trace_sha256"] = hashlib.sha256(pass_bytes).hexdigest().upper()
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(
+            json.dumps(lineage, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        return 0
+    except (OSError, ValueError, KeyError, TypeError, json.JSONDecodeError) as error:
+        print(
+            "native renderer effect resource lineage failed: {}".format(error),
+            file=sys.stderr,
+        )
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/export-native-renderer-resource-usage.ps1
+++ b/tools/export-native-renderer-resource-usage.ps1
@@ -1,0 +1,71 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)]
+    [string]$Capture,
+    [Parameter(Mandatory)]
+    [string]$RenderDocRoot,
+    [Parameter(Mandatory)]
+    [string]$ResourceName,
+    [Parameter(Mandatory)]
+    [string]$Output
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
+$localRoot = [IO.Path]::GetFullPath((Join-Path $repoRoot '.local'))
+$localPrefix = $localRoot.TrimEnd([IO.Path]::DirectorySeparatorChar) +
+    [IO.Path]::DirectorySeparatorChar
+$resolvedCapture = (Resolve-Path -LiteralPath $Capture).Path
+$resolvedOutput = [IO.Path]::GetFullPath($Output)
+foreach ($item in @(
+        @{ Name = 'Capture'; Value = $resolvedCapture },
+        @{ Name = 'Output'; Value = $resolvedOutput }
+    )) {
+    if (-not $item.Value.StartsWith(
+            $localPrefix, [StringComparison]::OrdinalIgnoreCase)) {
+        throw "$($item.Name) must be below $localRoot"
+    }
+}
+if (-not $ResourceName.Trim()) {
+    throw 'ResourceName must not be empty.'
+}
+if (Test-Path -LiteralPath $resolvedOutput) {
+    throw "Output already exists: $resolvedOutput"
+}
+
+$qrenderdoc = Join-Path ([IO.Path]::GetFullPath($RenderDocRoot)) 'qrenderdoc.exe'
+if (-not (Test-Path -LiteralPath $qrenderdoc -PathType Leaf)) {
+    throw "qrenderdoc.exe was not found below RenderDocRoot: $RenderDocRoot"
+}
+$signature = Get-AuthenticodeSignature -LiteralPath $qrenderdoc
+if ([string]$signature.Status -ne 'Valid') {
+    throw 'qrenderdoc.exe does not have a valid Authenticode signature'
+}
+
+$script = Join-Path $PSScriptRoot 'export-native-renderer-resource-usage.py'
+$parent = Split-Path $resolvedOutput -Parent
+[void](New-Item -ItemType Directory -Path $parent -Force)
+$savedCapture = $env:PINYON_SHIFT_RENDERDOC_CAPTURE
+$savedResourceName = $env:PINYON_SHIFT_RENDERDOC_RESOURCE_NAME
+$savedOutput = $env:PINYON_SHIFT_RENDERDOC_RESOURCE_USAGE
+try {
+    $env:PINYON_SHIFT_RENDERDOC_CAPTURE = $resolvedCapture
+    $env:PINYON_SHIFT_RENDERDOC_RESOURCE_NAME = $ResourceName
+    $env:PINYON_SHIFT_RENDERDOC_RESOURCE_USAGE = $resolvedOutput
+    $process = Start-Process -FilePath $qrenderdoc `
+        -ArgumentList @('--python', $script) -PassThru -Wait
+    if ($process.ExitCode) {
+        throw "qrenderdoc resource usage exited with code $($process.ExitCode)"
+    }
+}
+finally {
+    $env:PINYON_SHIFT_RENDERDOC_CAPTURE = $savedCapture
+    $env:PINYON_SHIFT_RENDERDOC_RESOURCE_NAME = $savedResourceName
+    $env:PINYON_SHIFT_RENDERDOC_RESOURCE_USAGE = $savedOutput
+}
+if (-not (Test-Path -LiteralPath $resolvedOutput -PathType Leaf)) {
+    throw 'qrenderdoc exited without producing the resource usage report.'
+}
+Get-Content -LiteralPath $resolvedOutput -Raw | ConvertFrom-Json

--- a/tools/export-native-renderer-resource-usage.py
+++ b/tools/export-native-renderer-resource-usage.py
@@ -1,0 +1,125 @@
+"""Export payload-free RenderDoc resource-usage metadata through qrenderdoc."""
+
+import hashlib
+import json
+import os
+import sys
+
+import renderdoc as rd
+
+
+SCHEMA = "pinyon-shift.native-renderer-renderdoc-resource-usage.v1"
+
+
+def flatten(actions):
+    result = []
+    for action in actions:
+        result.append(action)
+        result.extend(flatten(action.children))
+    return result
+
+
+def sha256(path):
+    digest = hashlib.sha256()
+    with open(path, "rb") as source:
+        for block in iter(lambda: source.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def main():
+    capture_path = os.environ["PINYON_SHIFT_RENDERDOC_CAPTURE"]
+    resource_name = os.environ["PINYON_SHIFT_RENDERDOC_RESOURCE_NAME"]
+    report_path = os.environ["PINYON_SHIFT_RENDERDOC_RESOURCE_USAGE"]
+    capture = rd.OpenCaptureFile()
+    controller = None
+    try:
+        result = capture.OpenFile(capture_path, "", None)
+        if result != rd.ResultCode.Succeeded:
+            raise RuntimeError("could not open capture: {}".format(result))
+        if not capture.LocalReplaySupport():
+            raise RuntimeError("capture does not support local replay")
+        result, controller = capture.OpenCapture(rd.ReplayOptions(), None)
+        if result != rd.ResultCode.Succeeded:
+            raise RuntimeError("could not initialise replay: {}".format(result))
+
+        matches = [
+            resource
+            for resource in controller.GetResources()
+            if resource.name == resource_name
+        ]
+        if len(matches) != 1:
+            raise RuntimeError(
+                "resource name matched {} resources: {}".format(
+                    len(matches), resource_name
+                )
+            )
+        resource = matches[0]
+        textures = {
+            str(texture.resourceId): texture
+            for texture in controller.GetTextures()
+        }
+        texture = textures.get(str(resource.resourceId))
+        actions = {
+            action.eventId: action
+            for action in flatten(controller.GetRootActions())
+        }
+        usages = []
+        for usage in controller.GetUsage(resource.resourceId):
+            action = actions.get(usage.eventId)
+            usages.append(
+                {
+                    "event_id": usage.eventId,
+                    "usage": usage.usage.name,
+                    "action_name": None if action is None else action.customName,
+                    "action_flags": None if action is None else str(action.flags),
+                }
+            )
+        target = {
+            "resource_id": str(resource.resourceId),
+            "resource_name": resource.name,
+        }
+        if texture is not None:
+            target.update(
+                {
+                    "width": texture.width,
+                    "height": texture.height,
+                    "format": texture.format.Name(),
+                    "mips": texture.mips,
+                    "arraysize": texture.arraysize,
+                    "ms_samp": texture.msSamp,
+                }
+            )
+        report = {
+            "schema": SCHEMA,
+            "capture": {
+                "path": os.path.basename(capture_path),
+                "sha256": sha256(capture_path),
+            },
+            "resource": target,
+            "usages": usages,
+            "safety": {
+                "resource_payload_exported": False,
+                "action_metadata_only": True,
+                "xenos_authority": True,
+                "suppression_allowed": False,
+            },
+        }
+        with open(report_path, "w") as output:
+            json.dump(report, output, indent=2, sort_keys=True)
+            output.write("\n")
+        print(report_path)
+        return 0
+    finally:
+        if controller is not None:
+            controller.Shutdown()
+        capture.Shutdown()
+
+
+try:
+    sys.exit(main())
+except Exception as error:
+    sys.stderr.write(
+        "native renderer resource usage export failed: {}\n".format(error)
+    )
+    sys.exit(1)

--- a/tools/tests/test_native_renderer_effect_resource_lineage.py
+++ b/tools/tests/test_native_renderer_effect_resource_lineage.py
@@ -1,0 +1,175 @@
+import importlib.util
+import sys
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+TOOL = ROOT / "tools" / "build-native-renderer-effect-resource-lineage.py"
+SPEC = importlib.util.spec_from_file_location("effect_resource_lineage", TOOL)
+assert SPEC and SPEC.loader
+MODULE = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = MODULE
+SPEC.loader.exec_module(MODULE)
+
+
+CAPTURE = {"path": "fixture.rdc", "sha256": "A" * 64}
+
+
+def usage_trace(usages, *, payload=False, metadata=True):
+    return {
+        "schema": MODULE.USAGE_SCHEMA,
+        "capture": CAPTURE,
+        "resource": {"resource_name": "depth"},
+        "usages": usages,
+        "safety": {
+            "resource_payload_exported": payload,
+            "action_metadata_only": metadata,
+        },
+    }
+
+
+def draw(event_id, pixel="Shader {pixel}"):
+    return {
+        "event_id": event_id,
+        "kind": "draw",
+        "isolated_native": False,
+        "pipeline": "ResourceId::1",
+        "pipeline_name": "pipeline",
+        "vertex_shader": "ResourceId::2",
+        "vertex_shader_name": "Shader {vertex}",
+        "pixel_shader": "ResourceId::3",
+        "pixel_shader_name": pixel,
+        "primitive_topology": "TriangleList",
+        "viewport": {"width": 1024, "height": 1024},
+        "color_targets": [],
+        "depth_target": {"resource_name": "consumer-depth"},
+    }
+
+
+def pass_trace(events, sha="A" * 64):
+    return {
+        "schema": MODULE.PASS_SCHEMA,
+        "capture": {"path": "fixture.rdc", "sha256": sha},
+        "events": events,
+        "safety": {"resource_payload_exported": False},
+    }
+
+
+class EffectResourceLineageTests(unittest.TestCase):
+    def test_proves_fully_sampled_depth_epochs_but_not_semantics(self):
+        usages = [
+            {"event_id": 1, "usage": "Clear"},
+            {"event_id": 2, "usage": "DepthStencilTarget"},
+            {"event_id": 3, "usage": "PS_Resource"},
+            {"event_id": 4, "usage": "Clear"},
+            {"event_id": 5, "usage": "DepthStencilTarget"},
+            {"event_id": 6, "usage": "CS_Resource"},
+            {"event_id": 6, "usage": "CS_Resource"},
+        ]
+        report = MODULE.build_lineage(usage_trace(usages), pass_trace([draw(3)]))
+        self.assertEqual(2, report["totals"]["clear_epochs"])
+        self.assertEqual(2, report["totals"]["sampled_epochs"])
+        self.assertEqual(1, report["totals"]["consumer_families"])
+        self.assertTrue(
+            report["qualification"]["depth_producer_consumer_chain_proved"]
+        )
+        self.assertTrue(
+            report["qualification"][
+                "depth_to_depth_propagation_chain_proved"
+            ]
+        )
+        self.assertFalse(
+            report["qualification"]["direct_color_sampling_observed"]
+        )
+        self.assertEqual(1, report["totals"]["pixel_consumers_depth_only"])
+        self.assertEqual(0, report["totals"]["pixel_consumers_with_color"])
+        self.assertFalse(report["qualification"]["shadow_semantic_proved"])
+        self.assertFalse(report["qualification"]["reflection_semantic_proved"])
+        self.assertFalse(report["consumer_families"][0]["native_coverage"])
+        self.assertFalse(report["consumer_families"][0]["suppression_eligible"])
+
+    def test_keeps_incomplete_epoch_unqualified(self):
+        usages = [
+            {"event_id": 1, "usage": "Clear"},
+            {"event_id": 2, "usage": "DepthStencilTarget"},
+        ]
+        report = MODULE.build_lineage(usage_trace(usages), pass_trace([]))
+        self.assertFalse(
+            report["qualification"]["depth_producer_consumer_chain_proved"]
+        )
+        self.assertFalse(
+            report["qualification"][
+                "depth_to_depth_propagation_chain_proved"
+            ]
+        )
+
+    def test_reports_color_sampling_without_promoting_semantics(self):
+        usages = [
+            {"event_id": 1, "usage": "Clear"},
+            {"event_id": 2, "usage": "DepthStencilTarget"},
+            {"event_id": 3, "usage": "PS_Resource"},
+        ]
+        event = draw(3)
+        event["color_targets"] = [{"resource_name": "scene-color"}]
+        event["depth_target"] = None
+        report = MODULE.build_lineage(usage_trace(usages), pass_trace([event]))
+        self.assertTrue(
+            report["qualification"]["direct_color_sampling_observed"]
+        )
+        self.assertFalse(
+            report["qualification"][
+                "depth_to_depth_propagation_chain_proved"
+            ]
+        )
+        self.assertFalse(report["qualification"]["shadow_semantic_proved"])
+
+    def test_rejects_missing_consumer_metadata_and_capture_drift(self):
+        usages = [
+            {"event_id": 1, "usage": "Clear"},
+            {"event_id": 2, "usage": "DepthStencilTarget"},
+            {"event_id": 3, "usage": "PS_Resource"},
+        ]
+        with self.assertRaisesRegex(ValueError, "no authoritative draw"):
+            MODULE.build_lineage(usage_trace(usages), pass_trace([]))
+        with self.assertRaisesRegex(ValueError, "captures differ"):
+            MODULE.build_lineage(
+                usage_trace(usages), pass_trace([draw(3)], sha="B" * 64)
+            )
+
+    def test_rejects_unsafe_or_unordered_usage(self):
+        with self.assertRaisesRegex(ValueError, "payload-free"):
+            MODULE.build_lineage(usage_trace([], payload=True), pass_trace([]))
+        with self.assertRaisesRegex(ValueError, "action-metadata-only"):
+            MODULE.build_lineage(
+                usage_trace([], metadata=False), pass_trace([])
+            )
+        with self.assertRaisesRegex(ValueError, "monotonically"):
+            MODULE.build_lineage(
+                usage_trace(
+                    [
+                        {"event_id": 2, "usage": "Clear"},
+                        {"event_id": 1, "usage": "Clear"},
+                    ]
+                ),
+                pass_trace([]),
+            )
+
+    def test_export_contract_is_payload_free_and_local_only(self):
+        exporter = (
+            ROOT / "tools/export-native-renderer-resource-usage.py"
+        ).read_text(encoding="utf-8")
+        wrapper = (
+            ROOT / "tools/export-native-renderer-resource-usage.ps1"
+        ).read_text(encoding="utf-8")
+        self.assertIn("controller.GetUsage(resource.resourceId)", exporter)
+        self.assertIn('"resource_payload_exported": False', exporter)
+        self.assertIn('"action_metadata_only": True', exporter)
+        self.assertIn("if len(matches) != 1", exporter)
+        self.assertIn("Get-AuthenticodeSignature", wrapper)
+        self.assertIn("must be below $localRoot", wrapper)
+        self.assertIn("ResourceName must not be empty", wrapper)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- export exact RenderDoc resource usage as payload-free action metadata
- join resource usage to authoritative effect-pass pipeline metadata
- qualify complete clear/write/sample epochs and exact pixel-consumer families
- prove the selected 1xMSAA and 4xMSAA D24S8 targets are depth-to-depth propagation chains
- reject the square-view target as the next direct shadow semantic seed
- keep Xenos authoritative with native coverage and suppression closed

## Evidence

- 1xMSAA target: 6/6 sampled epochs, 207 depth writes, 36 pixel reads, 2 unique compute reads, 0 color consumers
- 4xMSAA target: 4/4 sampled epochs, 40 depth writes, 59 pixel reads, 2 unique compute reads, 0 color consumers
- every pixel consumer writes another depth target

## Validation

- python -m unittest discover -s tools/tests (430 passed)
- qualified 1xMSAA and 4xMSAA lineage reports
- Python syntax checks and git diff --check