### PR TITLE
feat(renderer): classify proven shadow depth producers

### DIFF
--- a/config/native-renderer/effect-pass-classifier.json
+++ b/config/native-renderer/effect-pass-classifier.json
@@ -1,0 +1,60 @@
+{
+  "evidence_capture_sha256": "ef4064929005d08432488fd4649e845630860044a6cdc49e463fa7b3883667da",
+  "rules": [
+    {
+      "confidence": "high",
+      "evidence": "Reviewed local depth image after event 1417 shows an isolated top-down vehicle caster silhouette in the exact 2048-square producer epoch.",
+      "id": "shadow-depth-vehicle-rigid",
+      "match": {
+        "depth_target_name": "RT @ 720t, <13t>, 1xMSAA, kD24S8",
+        "output_class": "depth_only_write_candidate",
+        "pipeline_name": "VS 4E1DA281CC3D7EDB",
+        "pixel_shader_name": null,
+        "vertex_shader_name": "Shader {b1ccceb6}",
+        "viewport_height": 2048.0,
+        "viewport_width": 2048.0
+      },
+      "native_coverage": false,
+      "semantic_role": "shadow_depth",
+      "suppression_eligible": false,
+      "visual_sha256": "3CAE4CEFD2F93B5E6645653D81440C9FED47CA22557A16B2CA3B90FCA828DF9A"
+    },
+    {
+      "confidence": "high",
+      "evidence": "Reviewed local depth image after event 1417 shows an isolated top-down vehicle caster silhouette in the exact 2048-square producer epoch.",
+      "id": "shadow-depth-vehicle-secondary",
+      "match": {
+        "depth_target_name": "RT @ 720t, <13t>, 1xMSAA, kD24S8",
+        "output_class": "depth_only_write_candidate",
+        "pipeline_name": "VS CDDB454589126317",
+        "pixel_shader_name": null,
+        "vertex_shader_name": "Shader {d18760b6}",
+        "viewport_height": 2048.0,
+        "viewport_width": 2048.0
+      },
+      "native_coverage": false,
+      "semantic_role": "shadow_depth",
+      "suppression_eligible": false,
+      "visual_sha256": "3CAE4CEFD2F93B5E6645653D81440C9FED47CA22557A16B2CA3B90FCA828DF9A"
+    },
+    {
+      "confidence": "high",
+      "evidence": "Reviewed local depth image after event 1417 shows an isolated top-down vehicle caster silhouette in the exact 2048-square producer epoch.",
+      "id": "shadow-depth-vehicle-detail",
+      "match": {
+        "depth_target_name": "RT @ 720t, <13t>, 1xMSAA, kD24S8",
+        "output_class": "depth_only_write_candidate",
+        "pipeline_name": "VS 68DF329C66481843",
+        "pixel_shader_name": null,
+        "vertex_shader_name": "Shader {23c9cd31}",
+        "viewport_height": 2048.0,
+        "viewport_width": 2048.0
+      },
+      "native_coverage": false,
+      "semantic_role": "shadow_depth",
+      "suppression_eligible": false,
+      "visual_sha256": "3CAE4CEFD2F93B5E6645653D81440C9FED47CA22557A16B2CA3B90FCA828DF9A"
+    }
+  ],
+  "schema": "pinyon-shift.native-renderer-effect-pass-classifier.v1"
+}

--- a/docs/native-renderer/SHADOW_REFLECTION_PASS_CENSUS.md
+++ b/docs/native-renderer/SHADOW_REFLECTION_PASS_CENSUS.md
@@ -33,6 +33,7 @@ reflection or cubemap.
 
 python .\tools\build-native-renderer-effect-pass-census.py `
   .local\qualification\effect-pass-trace.json `
+  --classifier config\native-renderer\effect-pass-classifier.json `
   --output .local\qualification\effect-pass-census.json
 ```
 
@@ -113,8 +114,34 @@ destination is `RT @ 720t, <13t>, 4xMSAA, kD24S8`.
 Following that destination proves the same mechanical pattern: four complete
 clear/write epochs, 40 unique depth-target writes, 59 pixel reads, and two
 unique compute-read events. Every pixel consumer again writes depth only, with
-zero color outputs. The square-view candidate is therefore a qualified
-depth-to-depth propagation chain, not a direct scene-color shadow sampler.
-This rejects it as the next shadow semantic seed while leaving the broader
-possibility of shadow data elsewhere open. Native coverage and suppression
-remain false.
+zero color outputs. The square-view target is therefore a qualified
+depth-to-depth propagation chain and not a direct scene-color shadow sampler.
+That mechanical result does not identify the source contents by itself.
+
+## Exact shadow-depth promotion
+
+Reviewed local depth exports supply the stronger semantic evidence required by
+the promotion contract. The image after event 803 shows an orthographic world
+caster view in the 1024-square epoch. The image after event 1417 shows an
+isolated top-down vehicle silhouette in the 2048-square epoch; its SHA-256 is
+`3CAE4CEFD2F93B5E6645653D81440C9FED47CA22557A16B2CA3B90FCA828DF9A`.
+The payload images remain local and are not tracked or distributed.
+
+`config/native-renderer/effect-pass-classifier.json` promotes only the three
+exact 2048-square producer families enclosed by that inspected epoch:
+
+| Pipeline label | Vertex shader label | Draws | Role |
+| --- | --- | ---: | --- |
+| `VS 4E1DA281CC3D7EDB` | `Shader {b1ccceb6}` | 64 | `shadow_depth` |
+| `VS CDDB454589126317` | `Shader {d18760b6}` | 12 | `shadow_depth` |
+| `VS 68DF329C66481843` | `Shader {23c9cd31}` | 4 | `shadow_depth` |
+
+The match also requires the exact D24S8 target label, 2048 by 2048 viewport,
+depth-only output class, and absent pixel shader. Each rule is bound to the
+qualified capture hash and reviewed image hash, and must match exactly one
+family. The classified report contains 80 `shadow_depth` draws in three
+families; the other 1,502 draws in 270 families remain
+`unknown_unclassified`. This proves a shadow-depth producer seed, not an atlas
+layout, cascade model, native renderer, or suppression boundary. Native
+coverage and suppression remain false, Xenos stays authoritative, and
+reflection remains unidentified.

--- a/tools/build-native-renderer-effect-pass-census.py
+++ b/tools/build-native-renderer-effect-pass-census.py
@@ -9,6 +9,18 @@ import sys
 
 TRACE_SCHEMA = "pinyon-shift.native-renderer-renderdoc-pass-trace.v1"
 SCHEMA = "pinyon-shift.native-renderer-effect-pass-census.v1"
+CLASSIFIER_SCHEMA = "pinyon-shift.native-renderer-effect-pass-classifier.v1"
+SEMANTIC_ROLES = {"shadow_depth", "reflection_capture", "retained_unknown"}
+CONFIDENCE_LEVELS = {"medium", "high"}
+MATCH_FIELDS = {
+    "output_class",
+    "depth_target_name",
+    "pipeline_name",
+    "vertex_shader_name",
+    "pixel_shader_name",
+    "viewport_width",
+    "viewport_height",
+}
 
 
 def canonical_sha256(value):
@@ -46,9 +58,18 @@ def output_class(draw):
 def signature(draw):
     return {
         "output_class": output_class(draw),
+        "color_target_names": [
+            target.get("resource_name")
+            for target in draw.get("color_targets", [])
+        ],
         "color_target_shapes": [
             target_shape(target) for target in draw.get("color_targets", [])
         ],
+        "depth_target_name": (
+            None
+            if draw.get("depth_target") is None
+            else draw["depth_target"].get("resource_name")
+        ),
         "depth_target_shape": target_shape(draw.get("depth_target")),
         "pipeline": draw.get("pipeline"),
         "pipeline_name": draw.get("pipeline_name"),
@@ -64,7 +85,116 @@ def signature(draw):
     }
 
 
-def build_census(trace):
+def match_projection(value):
+    viewport = value.get("viewport") or {}
+    return {
+        "output_class": value.get("output_class"),
+        "depth_target_name": value.get("depth_target_name"),
+        "pipeline_name": value.get("pipeline_name"),
+        "vertex_shader_name": value.get("vertex_shader_name"),
+        "pixel_shader_name": value.get("pixel_shader_name"),
+        "viewport_width": viewport.get("width"),
+        "viewport_height": viewport.get("height"),
+    }
+
+
+def normalize_classifier(document, capture_sha256):
+    if document.get("schema") != CLASSIFIER_SCHEMA:
+        raise ValueError("unsupported effect-pass classifier schema")
+    if document.get("evidence_capture_sha256") != capture_sha256:
+        raise ValueError("effect-pass classifier capture evidence drifted")
+    rules = document.get("rules")
+    if not isinstance(rules, list) or not rules:
+        raise ValueError("effect-pass classifier rules must be a nonempty array")
+    normalized = []
+    seen = set()
+    for index, rule in enumerate(rules):
+        if not isinstance(rule, dict):
+            raise ValueError(f"effect-pass classifier rule {index} must be an object")
+        identifier = str(rule.get("id", "")).strip()
+        if not identifier or identifier in seen:
+            raise ValueError("effect-pass classifier rule ids must be unique")
+        seen.add(identifier)
+        match = rule.get("match")
+        if not isinstance(match, dict) or set(match) != MATCH_FIELDS:
+            raise ValueError(
+                f"effect-pass classifier rule {identifier} match fields drifted"
+            )
+        role = rule.get("semantic_role")
+        confidence = rule.get("confidence")
+        evidence = str(rule.get("evidence", "")).strip()
+        visual_sha256 = str(rule.get("visual_sha256", "")).upper()
+        if role not in SEMANTIC_ROLES:
+            raise ValueError(
+                f"effect-pass classifier rule {identifier} has invalid role"
+            )
+        if confidence not in CONFIDENCE_LEVELS:
+            raise ValueError(
+                f"effect-pass classifier rule {identifier} has invalid confidence"
+            )
+        if not evidence:
+            raise ValueError(
+                f"effect-pass classifier rule {identifier} requires evidence"
+            )
+        if len(visual_sha256) != 64 or any(
+            character not in "0123456789ABCDEF"
+            for character in visual_sha256
+        ):
+            raise ValueError(
+                f"effect-pass classifier rule {identifier} has invalid visual hash"
+            )
+        if rule.get("native_coverage") is not False:
+            raise ValueError(
+                f"effect-pass classifier rule {identifier} must keep native coverage false"
+            )
+        if rule.get("suppression_eligible") is not False:
+            raise ValueError(
+                f"effect-pass classifier rule {identifier} must forbid suppression"
+            )
+        normalized.append(
+            {
+                "id": identifier,
+                "match": match,
+                "semantic_role": role,
+                "semantic_confidence": confidence,
+                "semantic_evidence": evidence,
+                "visual_sha256": visual_sha256,
+            }
+        )
+    return normalized
+
+
+def apply_classifier(families, rules):
+    matched = set()
+    for rule in rules:
+        candidates = [
+            family
+            for family in families
+            if match_projection(family["signature"]) == rule["match"]
+        ]
+        if len(candidates) != 1:
+            raise ValueError(
+                "effect-pass classifier rule {} matched {} families".format(
+                    rule["id"], len(candidates)
+                )
+            )
+        family = candidates[0]
+        if family["sha256"] in matched:
+            raise ValueError("multiple effect-pass rules matched one family")
+        matched.add(family["sha256"])
+        family.update(
+            {
+                "classifier_rule": rule["id"],
+                "semantic_role": rule["semantic_role"],
+                "semantic_confidence": rule["semantic_confidence"],
+                "semantic_evidence": rule["semantic_evidence"],
+                "visual_sha256": rule["visual_sha256"],
+            }
+        )
+    return matched
+
+
+def build_census(trace, classifier=None):
     if trace.get("schema") != TRACE_SCHEMA:
         raise ValueError("unsupported pass trace schema")
     safety = trace.get("safety", {})
@@ -131,9 +261,23 @@ def build_census(trace):
         key=lambda item: (-item["draw_count"], item["sha256"]),
     )
     counts = {}
+    classifier_rules = []
+    matched = set()
+    if classifier is not None:
+        classifier_rules = normalize_classifier(
+            classifier, str(trace.get("capture", {}).get("sha256", ""))
+        )
+        matched = apply_classifier(ordered, classifier_rules)
+    semantic_counts = {}
+    semantic_draws = {}
     for family in ordered:
         key = family["signature"]["output_class"]
         counts[key] = counts.get(key, 0) + family["draw_count"]
+        role = family["semantic_role"]
+        semantic_counts[role] = semantic_counts.get(role, 0) + 1
+        semantic_draws[role] = semantic_draws.get(role, 0) + family["draw_count"]
+    shadow_identified = semantic_counts.get("shadow_depth", 0) > 0
+    reflection_identified = semantic_counts.get("reflection_capture", 0) > 0
     return {
         "schema": SCHEMA,
         "capture": trace.get("capture"),
@@ -142,12 +286,21 @@ def build_census(trace):
             "families": len(ordered),
             "isolated_native_draws_ignored": ignored_native_draws,
             "draws_by_output_class": dict(sorted(counts.items())),
+            "families_by_semantic_role": dict(sorted(semantic_counts.items())),
+            "draws_by_semantic_role": dict(sorted(semantic_draws.items())),
         },
         "families": ordered,
+        "classification": {
+            "configured": classifier is not None,
+            "rules": len(classifier_rules),
+            "matched_families": len(matched),
+            "unclassified_families": len(ordered) - len(matched),
+        },
         "qualification": {
             "pipeline_metadata_census_complete": True,
-            "shadow_pass_identified": False,
-            "reflection_pass_identified": False,
+            "shadow_pass_identified": shadow_identified,
+            "reflection_pass_identified": reflection_identified,
+            "native_shadow_renderer_ready": False,
             "semantic_promotion_requires_external_evidence": True,
         },
         "safety": {
@@ -163,12 +316,16 @@ def build_census(trace):
 def main(argv=None):
     parser = argparse.ArgumentParser()
     parser.add_argument("trace", type=pathlib.Path)
+    parser.add_argument("--classifier", type=pathlib.Path)
     parser.add_argument("--output", required=True, type=pathlib.Path)
     args = parser.parse_args(argv)
     try:
         trace_bytes = args.trace.read_bytes()
         trace = json.loads(trace_bytes)
-        census = build_census(trace)
+        classifier = None
+        if args.classifier is not None:
+            classifier = json.loads(args.classifier.read_text(encoding="utf-8"))
+        census = build_census(trace, classifier)
         census["trace_sha256"] = hashlib.sha256(trace_bytes).hexdigest().upper()
         args.output.parent.mkdir(parents=True, exist_ok=True)
         args.output.write_text(

--- a/tools/tests/test_native_renderer_effect_pass_census.py
+++ b/tools/tests/test_native_renderer_effect_pass_census.py
@@ -1,4 +1,5 @@
 import importlib.util
+import json
 import sys
 import unittest
 from pathlib import Path
@@ -57,6 +58,33 @@ def trace(events, metadata=True, payload=False):
     }
 
 
+def classifier(**rule_updates):
+    rule = {
+        "id": "shadow-fixture",
+        "match": {
+            "output_class": "depth_only_write_candidate",
+            "depth_target_name": "target",
+            "pipeline_name": "Pipeline 10",
+            "vertex_shader_name": "Shader {11111111}",
+            "pixel_shader_name": None,
+            "viewport_width": 1024.0,
+            "viewport_height": 1024.0,
+        },
+        "semantic_role": "shadow_depth",
+        "confidence": "high",
+        "evidence": "reviewed fixture depth image",
+        "visual_sha256": "B" * 64,
+        "native_coverage": False,
+        "suppression_eligible": False,
+    }
+    rule.update(rule_updates)
+    return {
+        "schema": MODULE.CLASSIFIER_SCHEMA,
+        "evidence_capture_sha256": "A" * 64,
+        "rules": [rule],
+    }
+
+
 class EffectPassCensusTests(unittest.TestCase):
     def test_groups_exact_metadata_and_keeps_semantics_closed(self):
         census = MODULE.build_census(
@@ -97,6 +125,41 @@ class EffectPassCensusTests(unittest.TestCase):
             census["families"],
         )
 
+    def test_promotes_one_exact_visual_rule_without_native_coverage(self):
+        census = MODULE.build_census(
+            trace([draw(1, colors=False), draw(2)]), classifier()
+        )
+        self.assertTrue(census["qualification"]["shadow_pass_identified"])
+        self.assertFalse(
+            census["qualification"]["native_shadow_renderer_ready"]
+        )
+        self.assertEqual(1, census["classification"]["matched_families"])
+        self.assertEqual(
+            1, census["totals"]["families_by_semantic_role"]["shadow_depth"]
+        )
+        family = next(
+            item
+            for item in census["families"]
+            if item["semantic_role"] == "shadow_depth"
+        )
+        self.assertEqual("high", family["semantic_confidence"])
+        self.assertEqual("B" * 64, family["visual_sha256"])
+        self.assertFalse(family["native_coverage"])
+        self.assertFalse(family["suppression_eligible"])
+
+    def test_rejects_unsafe_or_ambiguous_classifier(self):
+        with self.assertRaisesRegex(ValueError, "native coverage false"):
+            MODULE.build_census(
+                trace([draw(1, colors=False)]),
+                classifier(native_coverage=True),
+            )
+        document = classifier()
+        document["evidence_capture_sha256"] = "C" * 64
+        with self.assertRaisesRegex(ValueError, "capture evidence drifted"):
+            MODULE.build_census(trace([draw(1, colors=False)]), document)
+        with self.assertRaisesRegex(ValueError, "matched 0 families"):
+            MODULE.build_census(trace([draw(1)]), classifier())
+
     def test_rejects_unsafe_or_unenriched_trace(self):
         with self.assertRaisesRegex(ValueError, "payload-free"):
             MODULE.build_census(trace([], payload=True))
@@ -106,6 +169,24 @@ class EffectPassCensusTests(unittest.TestCase):
         event.pop("viewport")
         with self.assertRaisesRegex(ValueError, "missing enriched"):
             MODULE.build_census(trace([event]))
+
+    def test_tracked_classifier_is_safe_and_capture_bound(self):
+        path = ROOT / "config/native-renderer/effect-pass-classifier.json"
+        document = json.loads(path.read_text(encoding="utf-8"))
+        rules = MODULE.normalize_classifier(
+            document, document["evidence_capture_sha256"]
+        )
+        self.assertEqual(3, len(rules))
+        self.assertTrue(
+            all(rule["semantic_role"] == "shadow_depth" for rule in rules)
+        )
+        self.assertTrue(
+            all(
+                rule["native_coverage"] is False
+                and rule["suppression_eligible"] is False
+                for rule in document["rules"]
+            )
+        )
 
     def test_rejects_unknown_or_unordered_events(self):
         with self.assertRaisesRegex(ValueError, "unknown event"):


### PR DESCRIPTION
## Summary

- add a capture-bound effect-pass classifier with strict stable-label matching
- promote only three visually reviewed 2048-square producer families to shadow_depth
- require exact target, pipeline, shader, viewport, and output-class matches
- bind every rule to the qualified capture and local visual evidence hashes
- retain 270 other families as unknown and keep native coverage, reflection, and suppression closed

## Evidence

- reviewed event 1417 depth image: isolated top-down vehicle caster silhouette
- visual SHA-256: 3CAE4CEFD2F93B5E6645653D81440C9FED47CA22557A16B2CA3B90FCA828DF9A
- 3 matched families / 80 shadow-depth draws
- 270 unclassified families / 1,502 retained draws

## Validation

- python -m unittest discover -s tools/tests (433 passed)
- labeled open-world effect census completed with one-rule/one-family matching
- Python syntax checks and git diff --check