### PR TITLE
feat(renderer): replay proven shadow depth privately

### DIFF
--- a/docs/native-renderer/SHADOW_DEPTH_ISOLATED_REPLAY.md
+++ b/docs/native-renderer/SHADOW_DEPTH_ISOLATED_REPLAY.md
@@ -1,0 +1,71 @@
+# Isolated native shadow-depth replay
+
+This NR-05F checkpoint turns the first capture-proven shadow producer into one
+native D3D12 replay without changing the game-visible render graph. The replay
+writes a private depth/stencil target, the original Xenos draw always executes,
+and no private result is published or used to suppress guest work.
+
+## Exact admission contract
+
+The runtime does not select a prepared-signature hash because streamed vertex
+and index buffer addresses make that hash vary. Instead it requires the full
+stable contract observed for the dominant 2048-square producer:
+
+- vertex shader `4E1DA281CC3D7EDB`, no pixel shader, and zero specialization;
+- indexed DMA triangle-list draw with 881 indices and three vertex bindings;
+- no texture, query, memexport, overflow, or resolved-input dependency;
+- Xenos surface/depth state `10000410` / `000002D0`;
+- scissor `00000000:04000400`, zero color mask, depth state `00700736`,
+  raster state `00219800`, and vertex state `00000004`;
+- exactly one D24S8 depth attachment and no color attachment; and
+- a fully prepared host pipeline with rasterization enabled.
+
+Any mismatch yields without requesting native work. It does not fall through
+to a broader shader-only or depth-only heuristic.
+
+## Private backend path
+
+ReXGlue's isolated replay request now has an explicit depth-only mode. In that
+mode the D3D12 target cache rejects any bound guest color target, clones and
+seeds only the current depth/stencil resource plane-by-plane, binds only the
+private depth target, records the duplicate draw, and restores the prepared
+guest state before the authoritative draw. The one-shot native and Xenos depth
+readbacks remain local diagnostics.
+
+The completion gate accepts the evidence as the intended checkpoint only when
+the private replay records successfully after the exact 2048 by 2048 logical
+draw contract above has matched. The logical dimensions come from the captured
+zero-origin `04000400` scissor after the configured 2x draw-resolution scale.
+ReXGlue's host depth resource is an EDRAM allocation rather than a tightly
+cropped shadow texture, so its diagnostic allocation dimensions are larger
+(`2080x5056` in the qualifying run). The result records both logical and
+allocation dimensions and never treats the padded allocation as the logical
+shadow-map extent.
+
+## Qualification
+
+Launch the installed AppData preview with a new local artifact directory:
+
+```powershell
+.\tools\capture-native-renderer-census.ps1 `
+  -StateRoot "$env:LOCALAPPDATA\PinyonShift\source\0.1.0\.local\preview" `
+  -Scene open_world_day `
+  -ShadowDepthIsolated `
+  -IsolatedDrawDir .local\qualification\nr05f-shadow-depth-isolated
+```
+
+Required evidence is one
+`native_renderer.shadow_depth_isolated.result` with
+`status=recorded_exact_target`, native and Xenos depth artifacts, and a summary
+with one private replay. Every event must retain `native_publication=false`,
+`xenos_draw=preserved`, `output_authority=xenos`, and
+`suppression_eligible=false`.
+
+The first live qualification recorded the exact draw at frame 8731 / draw 3059
+with a `2080x5056` D24S8 allocation. Native and Xenos depth/stencil readbacks
+were byte-identical (56,950,304 bytes, hash `02FE4C1D52BD6FC8`), while the
+game-visible output remained on Xenos.
+
+This checkpoint is not a native shadow atlas. Atlas ownership, tile/cascade
+semantics, multi-draw accumulation, consumer binding, reflections,
+publication, and suppression remain closed.

--- a/docs/native-renderer/SHADOW_REFLECTION_PASS_CENSUS.md
+++ b/docs/native-renderer/SHADOW_REFLECTION_PASS_CENSUS.md
@@ -145,3 +145,10 @@ families; the other 1,502 draws in 270 families remain
 layout, cascade model, native renderer, or suppression boundary. Native
 coverage and suppression remain false, Xenos stays authoritative, and
 reflection remains unidentified.
+
+The first executable follow-up is documented in
+`SHADOW_DEPTH_ISOLATED_REPLAY.md`. It admits only the dominant
+`4E1DA281CC3D7EDB` producer through its complete stable draw and attachment
+contract, duplicates one draw into a private depth-only target, and preserves
+the authoritative Xenos draw. It does not yet allocate or publish a native
+atlas.

--- a/patches/rexglue/0089-d3d12-depth-only-isolated-replay.patch
+++ b/patches/rexglue/0089-d3d12-depth-only-isolated-replay.patch
@@ -1,0 +1,208 @@
+diff --git a/include/rex/graphics/d3d12/render_target_cache.h b/include/rex/graphics/d3d12/render_target_cache.h
+index 7c6bd1f..c3ec6fc 100644
+--- a/include/rex/graphics/d3d12/render_target_cache.h
++++ b/include/rex/graphics/d3d12/render_target_cache.h
+@@ -100,7 +100,8 @@ class D3D12RenderTargetCache final : public RenderTargetCache {
+   // EndIsolatedReplayTarget restores the guest bindings without changing the
+   // guest attachments or ownership.
+   bool BeginIsolatedReplayTarget(uint32_t& width_out, uint32_t& height_out,
+-                                 bool stencil_seed_probe_requested);
++                                 bool stencil_seed_probe_requested,
++                                 bool depth_only_target = false);
+   bool ResumeIsolatedReplayTarget(uint32_t& width_out, uint32_t& height_out);
+   system::GraphicsIsolatedDrawReadbackStatus QueueIsolatedReplayReadback(
+       system::GraphicsIsolatedDrawReadbackCompletion completion,
+diff --git a/include/rex/system/interfaces/graphics.h b/include/rex/system/interfaces/graphics.h
+index 38843bd..bae213c 100644
+--- a/include/rex/system/interfaces/graphics.h
++++ b/include/rex/system/interfaces/graphics.h
+@@ -474,6 +474,9 @@ using GraphicsIsolatedDrawPublicationCompletion = void (*)(
+ 
+ struct GraphicsIsolatedDrawRequest {
+   bool requested = false;
++  // Duplicate a draw that has only a depth/stencil attachment. The backend
++  // must reject this mode if any guest color target is bound.
++  bool depth_only_target = false;
+   bool readback_requested = false;
+   // Capture the authoritative guest color target after the original draw.
+   // This is independent of the private replay readback and never suppresses
+diff --git a/src/graphics/d3d12/command_processor.cpp b/src/graphics/d3d12/command_processor.cpp
+index 37e31cc..01de5d0 100644
+--- a/src/graphics/d3d12/command_processor.cpp
++++ b/src/graphics/d3d12/command_processor.cpp
+@@ -3458,7 +3458,8 @@ bool D3D12CommandProcessor::IssueDraw(xenos::PrimitiveType primitive_type, uint3
+                   render_target_cache_->BeginIsolatedReplayTarget(
+                       isolated_result.target_width,
+                       isolated_result.target_height,
+-                      isolated_draw_request.stencil_seed_probe_requested)) ||
++                      isolated_draw_request.stencil_seed_probe_requested,
++                      isolated_draw_request.depth_only_target)) ||
+                  (isolated_draw_request.reuse_target &&
+                   render_target_cache_->ResumeIsolatedReplayTarget(
+                       isolated_result.target_width,
+@@ -3691,7 +3692,8 @@ bool D3D12CommandProcessor::IssueDraw(xenos::PrimitiveType primitive_type, uint3
+                   render_target_cache_->BeginIsolatedReplayTarget(
+                       isolated_result.target_width,
+                       isolated_result.target_height,
+-                      isolated_draw_request.stencil_seed_probe_requested)) ||
++                      isolated_draw_request.stencil_seed_probe_requested,
++                      isolated_draw_request.depth_only_target)) ||
+                  (isolated_draw_request.reuse_target &&
+                   render_target_cache_->ResumeIsolatedReplayTarget(
+                       isolated_result.target_width,
+diff --git a/src/graphics/d3d12/render_target_cache.cpp b/src/graphics/d3d12/render_target_cache.cpp
+index 32f5a16..f77cdde 100644
+--- a/src/graphics/d3d12/render_target_cache.cpp
++++ b/src/graphics/d3d12/render_target_cache.cpp
+@@ -1772,7 +1772,7 @@ RenderTargetCache::RenderTarget* D3D12RenderTargetCache::CreateRenderTarget(Rend
+ 
+ bool D3D12RenderTargetCache::BeginIsolatedReplayTarget(
+     uint32_t& width_out, uint32_t& height_out,
+-    bool stencil_seed_probe_requested) {
++    bool stencil_seed_probe_requested, bool depth_only_target) {
+   width_out = 0;
+   height_out = 0;
+   if (GetPath() != Path::kHostRenderTargets) {
+@@ -1780,26 +1780,32 @@ bool D3D12RenderTargetCache::BeginIsolatedReplayTarget(
+   }
+   RenderTarget* const* guest_targets =
+       last_update_accumulated_render_targets();
+-  if (!guest_targets[0] || !guest_targets[1]) {
++  if (!guest_targets[0] || (!depth_only_target && !guest_targets[1])) {
+     return false;
+   }
+-  for (uint32_t i = 2; i <= xenos::kMaxColorRenderTargets; ++i) {
++  for (uint32_t i = depth_only_target ? 1 : 2;
++       i <= xenos::kMaxColorRenderTargets; ++i) {
+     if (guest_targets[i]) {
+       return false;
+     }
+   }
+ 
+   const RenderTargetKey depth_key = guest_targets[0]->key();
+-  const RenderTargetKey color_key = guest_targets[1]->key();
+   if (!isolated_replay_depth_target_ ||
+       isolated_replay_depth_target_->key() != depth_key) {
+     isolated_replay_depth_target_.reset(CreateRenderTarget(depth_key));
+   }
+-  if (!isolated_replay_color_target_ ||
+-      isolated_replay_color_target_->key() != color_key) {
+-    isolated_replay_color_target_.reset(CreateRenderTarget(color_key));
++  if (depth_only_target) {
++    isolated_replay_color_target_.reset();
++  } else {
++    const RenderTargetKey color_key = guest_targets[1]->key();
++    if (!isolated_replay_color_target_ ||
++        isolated_replay_color_target_->key() != color_key) {
++      isolated_replay_color_target_.reset(CreateRenderTarget(color_key));
++    }
+   }
+-  if (!isolated_replay_depth_target_ || !isolated_replay_color_target_) {
++  if (!isolated_replay_depth_target_ ||
++      (!depth_only_target && !isolated_replay_color_target_)) {
+     isolated_replay_depth_target_.reset();
+     isolated_replay_color_target_.reset();
+     return false;
+@@ -1807,13 +1813,20 @@ bool D3D12RenderTargetCache::BeginIsolatedReplayTarget(
+ 
+   auto* isolated_depth = static_cast<D3D12RenderTarget*>(
+       isolated_replay_depth_target_.get());
+-  auto* isolated_color = static_cast<D3D12RenderTarget*>(
+-      isolated_replay_color_target_.get());
+   auto* guest_depth = static_cast<D3D12RenderTarget*>(guest_targets[0]);
+-  auto* guest_color = static_cast<D3D12RenderTarget*>(guest_targets[1]);
+-  const D3D12_RESOURCE_DESC color_desc = isolated_color->resource()->GetDesc();
+-  width_out = uint32_t(color_desc.Width);
+-  height_out = color_desc.Height;
++  auto* isolated_color = depth_only_target
++                             ? nullptr
++                             : static_cast<D3D12RenderTarget*>(
++                                   isolated_replay_color_target_.get());
++  auto* guest_color = depth_only_target
++                          ? nullptr
++                          : static_cast<D3D12RenderTarget*>(guest_targets[1]);
++  const D3D12_RESOURCE_DESC target_desc =
++      (depth_only_target ? isolated_depth : isolated_color)
++          ->resource()
++          ->GetDesc();
++  width_out = uint32_t(target_desc.Width);
++  height_out = target_desc.Height;
+ 
+   if (stencil_seed_probe_requested) {
+     constexpr uint8_t kStencilSeedProbeValue = 0xA5;
+@@ -1831,23 +1844,30 @@ bool D3D12RenderTargetCache::BeginIsolatedReplayTarget(
+   const D3D12_RESOURCE_STATES guest_depth_state =
+       guest_depth->SetResourceState(D3D12_RESOURCE_STATE_COPY_SOURCE);
+   const D3D12_RESOURCE_STATES guest_color_state =
+-      guest_color->SetResourceState(D3D12_RESOURCE_STATE_COPY_SOURCE);
++      guest_color ? guest_color->SetResourceState(D3D12_RESOURCE_STATE_COPY_SOURCE)
++                  : D3D12_RESOURCE_STATE_COMMON;
+   const D3D12_RESOURCE_STATES isolated_depth_state =
+       isolated_depth->SetResourceState(D3D12_RESOURCE_STATE_COPY_DEST);
+   const D3D12_RESOURCE_STATES isolated_color_state =
+-      isolated_color->SetResourceState(D3D12_RESOURCE_STATE_COPY_DEST);
++      isolated_color
++          ? isolated_color->SetResourceState(D3D12_RESOURCE_STATE_COPY_DEST)
++          : D3D12_RESOURCE_STATE_COMMON;
+   command_processor_.PushTransitionBarrier(
+       guest_depth->resource(), guest_depth_state,
+       D3D12_RESOURCE_STATE_COPY_SOURCE);
+-  command_processor_.PushTransitionBarrier(
+-      guest_color->resource(), guest_color_state,
+-      D3D12_RESOURCE_STATE_COPY_SOURCE);
++  if (guest_color) {
++    command_processor_.PushTransitionBarrier(
++        guest_color->resource(), guest_color_state,
++        D3D12_RESOURCE_STATE_COPY_SOURCE);
++  }
+   command_processor_.PushTransitionBarrier(
+       isolated_depth->resource(), isolated_depth_state,
+       D3D12_RESOURCE_STATE_COPY_DEST);
+-  command_processor_.PushTransitionBarrier(
+-      isolated_color->resource(), isolated_color_state,
+-      D3D12_RESOURCE_STATE_COPY_DEST);
++  if (isolated_color) {
++    command_processor_.PushTransitionBarrier(
++        isolated_color->resource(), isolated_color_state,
++        D3D12_RESOURCE_STATE_COPY_DEST);
++  }
+   command_processor_.SubmitBarriers();
+ 
+   DeferredCommandList& command_list =
+@@ -1880,21 +1900,29 @@ bool D3D12RenderTargetCache::BeginIsolatedReplayTarget(
+     command_list.D3DCopyTextureRegion(&destination, 0, 0, 0, &source,
+                                        nullptr);
+   }
+-  command_list.D3DCopyResource(isolated_color->resource(),
+-                               guest_color->resource());
++  if (isolated_color) {
++    command_list.D3DCopyResource(isolated_color->resource(),
++                                 guest_color->resource());
++  }
+ 
+   guest_depth->SetResourceState(guest_depth_state);
+-  guest_color->SetResourceState(guest_color_state);
++  if (guest_color) {
++    guest_color->SetResourceState(guest_color_state);
++  }
+   command_processor_.PushTransitionBarrier(
+       guest_depth->resource(), D3D12_RESOURCE_STATE_COPY_SOURCE,
+       guest_depth_state);
+-  command_processor_.PushTransitionBarrier(
+-      guest_color->resource(), D3D12_RESOURCE_STATE_COPY_SOURCE,
+-      guest_color_state);
++  if (guest_color) {
++    command_processor_.PushTransitionBarrier(
++        guest_color->resource(), D3D12_RESOURCE_STATE_COPY_SOURCE,
++        guest_color_state);
++  }
+ 
+   RenderTarget* isolated_targets[1 + xenos::kMaxColorRenderTargets] = {};
+   isolated_targets[0] = isolated_depth;
+-  isolated_targets[1] = isolated_color;
++  if (isolated_color) {
++    isolated_targets[1] = isolated_color;
++  }
+   SetCommandListRenderTargets(isolated_targets);
+   command_processor_.SubmitBarriers();
+ 

--- a/src/native_renderer/graphics_hooks.cpp
+++ b/src/native_renderer/graphics_hooks.cpp
@@ -151,6 +151,9 @@ constexpr uint64_t kSemanticSubmissionMaximumPayloadBytes = 64;
 constexpr uint32_t kResourceBindingKeyCacheAddress = 0x834AD4CC;
 constexpr uint64_t kSkyHorizonAnchorSignature = UINT64_C(0x747837906D0BF484);
 constexpr uint64_t kSkyHorizonFollowerSignature = UINT64_C(0x1D253A52B55C9FB3);
+constexpr uint64_t kShadowDepthVertexShader = UINT64_C(0x4E1DA281CC3D7EDB);
+constexpr uint32_t kShadowDepthLogicalWidth = 2048;
+constexpr uint32_t kShadowDepthLogicalHeight = 2048;
 std::atomic<uint64_t> g_frame_sequence{};
 
 enum class DispatchWrapper : uint32_t {
@@ -5701,6 +5704,9 @@ struct IsolatedDrawState {
   bool require_title_lod_candidate = false;
   bool auto_select_fresh_visibility_candidate = false;
   bool stencil_seed_probe_requested = false;
+  bool shadow_depth_mode = false;
+  uint64_t shadow_depth_contract_matches = 0;
+  uint64_t shadow_depth_contract_rejections = 0;
   bool visibility_wait_reported = false;
   bool title_lod_wait_reported = false;
   bool awaiting_pass_follower = false;
@@ -6163,6 +6169,25 @@ void ConfigureIsolatedDraw() {
   size_t length = 0;
   if (_dupenv_s(
           &value, &length,
+          "PINYON_SHIFT_NATIVE_RENDERER_SHADOW_DEPTH_ISOLATED") == 0 &&
+      value && length > 1) {
+    const std::string setting(value);
+    g_isolated_draw.shadow_depth_mode = setting == "true";
+    if (setting != "true" && setting != "false") {
+      g_isolated_draw.valid = false;
+    }
+  }
+  std::free(value);
+  if (g_isolated_draw.shadow_depth_mode) {
+    g_isolated_draw.requested = true;
+    if (signature_requested) {
+      g_isolated_draw.valid = false;
+    }
+  }
+  value = nullptr;
+  length = 0;
+  if (_dupenv_s(
+          &value, &length,
           "PINYON_SHIFT_NATIVE_RENDERER_AUTO_SELECT_FRESH_VISIBILITY_CANDIDATE") ==
           0 &&
       value && length > 1) {
@@ -6176,7 +6201,8 @@ void ConfigureIsolatedDraw() {
   if (g_isolated_draw.auto_select_fresh_visibility_candidate) {
     g_isolated_draw.requested = true;
     g_isolated_draw.require_fresh_visibility_candidate = true;
-    if (signature_requested || g_sky_horizon_suppression.requested) {
+    if (signature_requested || g_isolated_draw.shadow_depth_mode ||
+        g_sky_horizon_suppression.requested) {
       g_isolated_draw.valid = false;
     }
   }
@@ -6236,6 +6262,12 @@ void ConfigureIsolatedDraw() {
   }
   if (g_isolated_draw.stencil_seed_probe_requested &&
       !g_isolated_draw.readback_requested) {
+    g_isolated_draw.valid = false;
+  }
+  if (g_isolated_draw.shadow_depth_mode &&
+      (g_isolated_draw.stencil_seed_probe_requested ||
+       g_isolated_draw.require_fresh_visibility_candidate ||
+       g_isolated_draw.require_title_lod_candidate)) {
     g_isolated_draw.valid = false;
   }
   value = nullptr;
@@ -11776,6 +11808,46 @@ bool IsIsolatedDrawEligible(
       observation, samples_resolved_target, prepared);
 }
 
+bool IsExactShadowDepthIsolatedDraw(
+    const rex::system::GraphicsDrawObservation &observation,
+    bool samples_resolved_target,
+    const rex::system::GraphicsPreparedDrawObservation &prepared) {
+  const bool query_draw = observation.viz_query_condition ||
+                          (observation.pa_sc_viz_query & 1);
+  return !samples_resolved_target && !query_draw &&
+         !observation.vertex_memexport && observation.indexed &&
+         observation.source_select ==
+             uint32_t(rex::graphics::xenos::SourceSelect::kDMA) &&
+         observation.primitive_type == 6 && observation.index_count == 881 &&
+         observation.index_format == 0 && observation.index_endianness == 1 &&
+         observation.vertex_binding_count == 3 &&
+         !observation.vertex_binding_overflow &&
+         !observation.vertex_attribute_overflow &&
+         !observation.vertex_float_constant_overflow &&
+         !observation.pixel_float_constant_overflow &&
+         observation.texture_fetch_mask == 0 &&
+         observation.texture_state_count == 0 &&
+         !observation.texture_state_overflow &&
+         observation.surface_info == 0x10000410 &&
+         observation.depth_info == 0x000002D0 &&
+         observation.window_scissor_tl == 0 &&
+         observation.window_scissor_br == 0x04000400 &&
+         observation.rb_color_mask == 0 &&
+         observation.rb_depthcontrol == 0x00700736 &&
+         observation.pa_su_sc_mode_cntl == 0x00219800 &&
+         observation.pa_su_vtx_cntl == 4 &&
+         prepared.vertex_shader_hash == kShadowDepthVertexShader &&
+         prepared.pixel_shader_hash == 0 &&
+         prepared.vertex_specialization_mask == 0 &&
+         prepared.pixel_specialization_mask == 0 &&
+         prepared.guest_primitive_type == 6 &&
+         prepared.index_buffer_type == 1 &&
+         prepared.normalized_color_mask == 0 &&
+         prepared.bound_render_target_bits == 1 &&
+         prepared.bound_render_target_formats[0] == 0 &&
+         (prepared.flags & 3) == 3;
+}
+
 const char *SemanticBatchRejectionName(SemanticBatchRejection rejection) {
   switch (rejection) {
   case SemanticBatchRejection::kNone:
@@ -14198,8 +14270,21 @@ void ObservePreparedDraw(
     g_isolated_draw.frame = sample.frame_sequence;
     g_isolated_draw.draw = sample.draw_sequence;
     g_isolated_draw.prepared_sample = sample;
-    g_isolated_draw.prepared_candidate_eligible = IsIsolatedDrawEligible(
-        sample, g_pending_candidate.samples_resolved_target, observation);
+    g_isolated_draw.prepared_candidate_eligible =
+        g_isolated_draw.shadow_depth_mode
+            ? IsExactShadowDepthIsolatedDraw(
+                  sample, g_pending_candidate.samples_resolved_target,
+                  observation)
+            : IsIsolatedDrawEligible(
+                  sample, g_pending_candidate.samples_resolved_target,
+                  observation);
+    if (g_isolated_draw.shadow_depth_mode) {
+      if (g_isolated_draw.prepared_candidate_eligible) {
+        ++g_isolated_draw.shadow_depth_contract_matches;
+      } else if (observation.vertex_shader_hash == kShadowDepthVertexShader) {
+        ++g_isolated_draw.shadow_depth_contract_rejections;
+      }
+    }
     g_isolated_draw.prepared_visibility_candidate_fresh =
         visibility_admission.fresh;
     g_isolated_draw.prepared_title_lod_valid =
@@ -15251,6 +15336,29 @@ void CompleteIsolatedDraw(
        {"suppression_eligible", "false"}});
 }
 
+void CompleteIsolatedShadowDepth(
+    const rex::system::GraphicsIsolatedDrawResult &result) {
+  CompleteIsolatedDraw(result);
+  const bool exact_target =
+      result.status == rex::system::GraphicsIsolatedDrawStatus::kRecorded;
+  pinyon_shift::diagnostics::RecordEvent(
+      "native_renderer.shadow_depth_isolated.result",
+      {{"status", exact_target ? "recorded_exact_target"
+                                : "failed_closed"},
+       {"vertex_shader", fmt::format("{:016X}", kShadowDepthVertexShader)},
+       {"frame", std::to_string(g_isolated_draw.captured_frame)},
+       {"draw", std::to_string(g_isolated_draw.captured_draw)},
+       {"logical_width", std::to_string(kShadowDepthLogicalWidth)},
+       {"logical_height", std::to_string(kShadowDepthLogicalHeight)},
+       {"allocation_width", std::to_string(result.target_width)},
+       {"allocation_height", std::to_string(result.target_height)},
+       {"private_depth_target", exact_target ? "recorded" : "unqualified"},
+       {"native_publication", "false"},
+       {"xenos_draw", "preserved"},
+       {"output_authority", "xenos"},
+       {"suppression_eligible", "false"}});
+}
+
 void CompleteIsolatedShadowReplay(
     const rex::system::GraphicsIsolatedDrawResult &result) {
   if (result.status == rex::system::GraphicsIsolatedDrawStatus::kRecorded) {
@@ -15670,6 +15778,32 @@ void RequestIsolatedDraw(
   }
   if (!g_isolated_draw.requested || !g_isolated_draw.valid ||
       !g_isolated_draw.prepared_candidate_valid) {
+    return;
+  }
+  if (g_isolated_draw.shadow_depth_mode) {
+    if (g_isolated_draw.completed ||
+        !g_isolated_draw.prepared_candidate_eligible) {
+      return;
+    }
+    g_isolated_draw.completed = true;
+    g_isolated_draw.captured_signature = g_isolated_draw.prepared_signature;
+    g_isolated_draw.captured_frame = g_isolated_draw.frame;
+    g_isolated_draw.captured_draw = g_isolated_draw.draw;
+    request.requested = true;
+    request.depth_only_target = true;
+    request.frame_sequence = g_isolated_draw.frame;
+    request.depth_readback_requested = g_isolated_draw.readback_requested;
+    request.reference_depth_readback_requested =
+        g_isolated_draw.readback_requested;
+    request.reference_marker_requested = true;
+    request.completion = &CompleteIsolatedShadowDepth;
+    request.depth_readback_completion = g_isolated_draw.readback_requested
+                                            ? &CompleteIsolatedDepthReadback
+                                            : nullptr;
+    request.reference_depth_readback_completion =
+        g_isolated_draw.readback_requested
+            ? &CompleteIsolatedReferenceDepthReadback
+            : nullptr;
     return;
   }
   const bool pass_mode = g_pass_follower.requested &&
@@ -18198,22 +18332,31 @@ void InstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system,
                                     : "armed")
                                                : "invalid_configuration")},
        {"signature",
-        g_isolated_draw.valid && g_isolated_draw.requested
-            ? fmt::format("{:016X}", g_isolated_draw.target_signature)
+         g_isolated_draw.valid && g_isolated_draw.requested &&
+                 !g_isolated_draw.shadow_depth_mode
+             ? fmt::format("{:016X}", g_isolated_draw.target_signature)
+             : ""},
+       {"shadow_depth_vertex_shader",
+        g_isolated_draw.valid && g_isolated_draw.shadow_depth_mode
+            ? fmt::format("{:016X}", kShadowDepthVertexShader)
             : ""},
        {"anchor_signature",
         g_isolated_draw.valid && g_isolated_draw.requested &&
                 g_pass_follower.valid && g_pass_follower.requested
             ? fmt::format("{:016X}", g_pass_follower.target_signature)
             : ""},
-       {"mode", g_pass_follower.valid && g_pass_follower.requested
-                    ? "retained_pass"
-                    : "single_draw"},
+       {"mode", g_isolated_draw.shadow_depth_mode
+                    ? "exact_shadow_depth_single_draw"
+                    : (g_pass_follower.valid && g_pass_follower.requested
+                           ? "retained_pass"
+                           : "single_draw")},
        {"native_draw", "isolated_only"},
        {"continuous_shadow_replay",
-        g_pass_follower.valid && g_pass_follower.requested
-            ? "retained_pass_contract"
-            : "enabled_after_one_shot"},
+         g_isolated_draw.shadow_depth_mode
+             ? "disabled"
+             : (g_pass_follower.valid && g_pass_follower.requested
+             ? "retained_pass_contract"
+                : "enabled_after_one_shot")},
        {"readback", g_isolated_draw.readback_requested ? "asynchronous"
                                                         : "disabled"},
        {"stencil_seed_probe",
@@ -18226,13 +18369,17 @@ void InstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system,
             ? "private_target_before_guest_copy"
             : ""},
        {"stencil_seed_probe_guest_target", "untouched"},
-       {"reference_marker", "exact_signature"},
+       {"reference_marker", g_isolated_draw.shadow_depth_mode
+                                ? "exact_shadow_depth_contract"
+                                : "exact_signature"},
        {"selection",
-        g_isolated_draw.auto_select_fresh_visibility_candidate
-            ? (g_isolated_draw.require_title_lod_candidate
-                   ? "first_fresh_mechanically_eligible_title_lod_candidate"
-                   : "first_fresh_mechanically_eligible_candidate")
-            : "exact_signature"},
+         g_isolated_draw.shadow_depth_mode
+             ? "capture_bound_shader_state_and_depth_target"
+             : (g_isolated_draw.auto_select_fresh_visibility_candidate
+             ? (g_isolated_draw.require_title_lod_candidate
+                    ? "first_fresh_mechanically_eligible_title_lod_candidate"
+                    : "first_fresh_mechanically_eligible_candidate")
+                : "exact_signature")},
        {"visibility_gate",
         g_isolated_draw.require_fresh_visibility_candidate
             ? "fresh_selected_semantic_candidate"
@@ -18763,6 +18910,7 @@ void UninstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system) {
       !g_pass_follower.requested || !g_pass_follower.valid ||
       g_pass_follower.target_signature == g_isolated_draw.target_signature;
   if (g_isolated_draw.requested && g_isolated_draw.valid &&
+      !g_isolated_draw.shadow_depth_mode &&
       g_isolated_draw.completed && isolated_single_draw_mode) {
     const uint64_t shadow_replay_outcomes =
         g_isolated_draw.shadow_replay_recorded +
@@ -18788,6 +18936,25 @@ void UninstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system) {
               : "false"},
          {"readback", "one_shot_only"},
          {"native_draw", "private_shadow_replay"},
+         {"xenos_draw", "preserved"},
+         {"output_authority", "xenos"},
+         {"draw_suppression", "false"},
+         {"suppression_eligible", "false"}});
+  }
+  if (g_isolated_draw.shadow_depth_mode) {
+    diagnostics::RecordEvent(
+        "native_renderer.shadow_depth_isolated.summary",
+        {{"status", g_isolated_draw.completed ? "observed" : "not_observed"},
+         {"vertex_shader", fmt::format("{:016X}", kShadowDepthVertexShader)},
+         {"contract_matches",
+          std::to_string(g_isolated_draw.shadow_depth_contract_matches)},
+         {"contract_rejections",
+          std::to_string(g_isolated_draw.shadow_depth_contract_rejections)},
+         {"private_replays", g_isolated_draw.completed ? "1" : "0"},
+         {"readback", g_isolated_draw.readback_requested
+                          ? "native_and_xenos_depth_only"
+                          : "disabled"},
+         {"native_publication", "false"},
          {"xenos_draw", "preserved"},
          {"output_authority", "xenos"},
          {"draw_suppression", "false"},

--- a/tools/capture-native-renderer-census.ps1
+++ b/tools/capture-native-renderer-census.ps1
@@ -16,6 +16,7 @@ param(
     [ValidatePattern('^[0-9A-Fa-f]{16}$')]
     [string]$IsolatedDrawSignature,
     [string]$IsolatedDrawDir,
+    [switch]$ShadowDepthIsolated,
     [switch]$StencilSeedProbe,
     [switch]$RequireFreshVisibilityCandidate,
     [switch]$AutoSelectFreshVisibilityCandidate,
@@ -76,6 +77,16 @@ if ($AutoSelectFreshVisibilityCandidate -and -not $IsolatedDrawDir) {
 if ($AutoSelectFreshVisibilityCandidate -and $PassAnchorSignature) {
     throw 'AutoSelectFreshVisibilityCandidate does not support PassAnchorSignature.'
 }
+if ($ShadowDepthIsolated -and
+    ($IsolatedDrawSignature -or $AutoSelectFreshVisibilityCandidate -or
+        $StencilSeedProbe -or $RequireFreshVisibilityCandidate -or
+        $RequireTitleLodCandidate -or $PassAnchorSignature -or
+        $PublishRetainedPass -or $VisibilityShadowReplay)) {
+    throw 'ShadowDepthIsolated is mutually exclusive with other isolated/pass replay options.'
+}
+if ($ShadowDepthIsolated -and -not $IsolatedDrawDir) {
+    throw 'ShadowDepthIsolated requires IsolatedDrawDir.'
+}
 if ($StencilSeedProbe -and -not $IsolatedDrawDir) {
     throw 'StencilSeedProbe requires IsolatedDrawDir.'
 }
@@ -116,8 +127,9 @@ if ($ReplaySnapshotDir) {
 }
 
 if ($IsolatedDrawDir) {
-    if (-not $IsolatedDrawSignature -and -not $AutoSelectFreshVisibilityCandidate) {
-        throw 'IsolatedDrawDir requires IsolatedDrawSignature or AutoSelectFreshVisibilityCandidate'
+    if (-not $IsolatedDrawSignature -and -not $AutoSelectFreshVisibilityCandidate -and
+        -not $ShadowDepthIsolated) {
+        throw 'IsolatedDrawDir requires IsolatedDrawSignature, AutoSelectFreshVisibilityCandidate, or ShadowDepthIsolated'
     }
     $repositoryRoot = Split-Path $PSScriptRoot -Parent
     $localRoot = [IO.Path]::GetFullPath((Join-Path $repositoryRoot '.local'))
@@ -172,6 +184,7 @@ $savedReplaySnapshot = $env:PINYON_SHIFT_NATIVE_RENDERER_SNAPSHOT_SIGNATURE
 $savedReplaySnapshotDir = $env:PINYON_SHIFT_NATIVE_RENDERER_SNAPSHOT_DIR
 $savedIsolatedDraw = $env:PINYON_SHIFT_NATIVE_RENDERER_ISOLATED_DRAW_SIGNATURE
 $savedIsolatedDrawDir = $env:PINYON_SHIFT_NATIVE_RENDERER_ISOLATED_DRAW_DIR
+$savedShadowDepthIsolated = $env:PINYON_SHIFT_NATIVE_RENDERER_SHADOW_DEPTH_ISOLATED
 $savedStencilSeedProbe = $env:PINYON_SHIFT_NATIVE_RENDERER_STENCIL_SEED_PROBE
 $savedVisibilityGate = $env:PINYON_SHIFT_NATIVE_RENDERER_REQUIRE_FRESH_VISIBILITY_CANDIDATE
 $savedAutoVisibilityCandidate =
@@ -198,6 +211,8 @@ try {
     $env:PINYON_SHIFT_NATIVE_RENDERER_SNAPSHOT_DIR = $ReplaySnapshotDir
     $env:PINYON_SHIFT_NATIVE_RENDERER_ISOLATED_DRAW_SIGNATURE = $IsolatedDrawSignature
     $env:PINYON_SHIFT_NATIVE_RENDERER_ISOLATED_DRAW_DIR = $IsolatedDrawDir
+    $env:PINYON_SHIFT_NATIVE_RENDERER_SHADOW_DEPTH_ISOLATED =
+        if ($ShadowDepthIsolated) { 'true' } else { $null }
     $env:PINYON_SHIFT_NATIVE_RENDERER_STENCIL_SEED_PROBE =
         if ($StencilSeedProbe) { 'true' } else { $null }
     $env:PINYON_SHIFT_NATIVE_RENDERER_REQUIRE_FRESH_VISIBILITY_CANDIDATE =
@@ -231,6 +246,8 @@ finally {
     $env:PINYON_SHIFT_NATIVE_RENDERER_SNAPSHOT_DIR = $savedReplaySnapshotDir
     $env:PINYON_SHIFT_NATIVE_RENDERER_ISOLATED_DRAW_SIGNATURE = $savedIsolatedDraw
     $env:PINYON_SHIFT_NATIVE_RENDERER_ISOLATED_DRAW_DIR = $savedIsolatedDrawDir
+    $env:PINYON_SHIFT_NATIVE_RENDERER_SHADOW_DEPTH_ISOLATED =
+        $savedShadowDepthIsolated
     $env:PINYON_SHIFT_NATIVE_RENDERER_STENCIL_SEED_PROBE = $savedStencilSeedProbe
     $env:PINYON_SHIFT_NATIVE_RENDERER_REQUIRE_FRESH_VISIBILITY_CANDIDATE =
         $savedVisibilityGate

--- a/tools/tests/test_native_renderer_contract.py
+++ b/tools/tests/test_native_renderer_contract.py
@@ -1932,6 +1932,38 @@ class NativeRendererContractTests(unittest.TestCase):
         self.assertIn('"suppression_allowed": False', draw_state_planner)
         self.assertIn('"xenos_authority": True', draw_state_planner)
 
+    def test_shadow_depth_replay_is_exact_private_and_fail_closed(self):
+        scanner = (ROOT / "src/native_renderer/graphics_hooks.cpp").read_text(
+            encoding="utf-8"
+        )
+        self.assertIn("PINYON_SHIFT_NATIVE_RENDERER_SHADOW_DEPTH_ISOLATED", scanner)
+        self.assertIn("kShadowDepthVertexShader", scanner)
+        self.assertIn("IsExactShadowDepthIsolatedDraw", scanner)
+        self.assertIn("prepared.bound_render_target_bits == 1", scanner)
+        self.assertIn("request.depth_only_target = true", scanner)
+        self.assertIn("kShadowDepthLogicalWidth = 2048", scanner)
+        self.assertIn('"logical_width"', scanner)
+        self.assertIn('"allocation_width"', scanner)
+        self.assertIn('"native_renderer.shadow_depth_isolated.result"', scanner)
+        self.assertIn('"native_publication", "false"', scanner)
+        self.assertIn('"xenos_draw", "preserved"', scanner)
+        self.assertIn('"suppression_eligible", "false"', scanner)
+
+        patch = (
+            ROOT / "patches/rexglue/0089-d3d12-depth-only-isolated-replay.patch"
+        ).read_text(encoding="utf-8")
+        self.assertIn("depth_only_target", patch)
+        self.assertIn("depth_only_target ? 1 : 2", patch)
+        self.assertIn("isolated_targets[0] = isolated_depth", patch)
+        self.assertNotIn("SetDrawSuppression", patch)
+
+        capture = (
+            ROOT / "tools/capture-native-renderer-census.ps1"
+        ).read_text(encoding="utf-8")
+        self.assertIn("[switch]$ShadowDepthIsolated", capture)
+        self.assertIn("ShadowDepthIsolated requires IsolatedDrawDir", capture)
+        self.assertIn("PINYON_SHIFT_NATIVE_RENDERER_SHADOW_DEPTH_ISOLATED", capture)
+
     def test_census_ledger_tracks_exact_starting_baseline(self):
         ledger = (ROOT / "docs/native-renderer/RENDER_PASS_CENSUS.md").read_text(
             encoding="utf-8"

--- a/tools/tests/test_release_contract.py
+++ b/tools/tests/test_release_contract.py
@@ -43,10 +43,10 @@ class ReleaseContractTests(unittest.TestCase):
 
     def test_rexglue_patches_have_stable_order_and_no_binary_payload(self):
         patches = sorted((ROOT / "patches/rexglue").glob("*.patch"))
-        self.assertEqual(len(patches), 88)
+        self.assertEqual(len(patches), 89)
         self.assertEqual(
             patches[-1].name,
-            "0088-d3d12-copy-isolated-depth-stencil-planes.patch",
+            "0089-d3d12-depth-only-isolated-replay.patch",
         )
         self.assertEqual(len(patches), len({path.name[:4] for path in patches}))
         for path in patches:


### PR DESCRIPTION
## Summary
- admit only the capture-proven dominant shadow-depth draw contract
- replay it into a private D3D12 depth/stencil target with no color attachment
- preserve the authoritative Xenos draw, publication, consumers, and fallback
- add fail-closed diagnostics, AppData capture support, tests, and evidence docs

## Runtime evidence
- AppData `open_world_day` save reached live gameplay normally
- exact contract matched and one private replay recorded
- native and Xenos D24S8 readbacks were byte-identical
- each artifact was 56,950,304 bytes with SHA-256 `DB1CBAADAD1814FB24BA6A5B5A0CDBFBA8674172DBD8F1BCE5DA168589885D88`
- Xenos remained visible and authoritative; no guest draw was suppressed

## Validation
- `python -m unittest discover -s tools/tests -p 'test_*.py'` (434 passed)
- `tools/build-preview.ps1 -Parallel 12 -JsonEvents`
- fresh 89-patch ReXGlue replay
- AppData open-world qualification, normal exit