### PR TITLE
feat(renderer): batch proven shadow depth privately

### DIFF
--- a/docs/native-renderer/SHADOW_DEPTH_BATCH_REPLAY.md
+++ b/docs/native-renderer/SHADOW_DEPTH_BATCH_REPLAY.md
@@ -1,0 +1,88 @@
+# Bounded native shadow-depth batch replay
+
+This NR-05F checkpoint extends the exact private shadow-depth draw into one
+bounded producer batch. It does not publish a native atlas or alter the
+game-visible render graph. Every original Xenos draw still executes and remains
+authoritative.
+
+## Capture-proven boundary
+
+The qualified `reference_frame8134.rdc` capture contains 64 draws for the
+dominant `4E1DA281CC3D7EDB` shadow-depth family. They share pipeline
+`ResourceId::1865`, have no pixel shader or color attachment, write the same
+`ResourceId::19359` depth target, and are the only authoritative draws from
+event 1004 through event 1340. The runtime therefore requires:
+
+- the complete exact 881-index draw from `SHADOW_DEPTH_ISOLATED_REPLAY.md` as
+  the batch seed;
+- 63 followers that retain the capture-proven shader family, depth-target,
+  scissor, depth/raster, indexed-DMA, attachment, and overflow contracts while
+  allowing each follower's title-selected geometry count and prepared shader
+  specialization;
+- one frame and strictly adjacent draw sequence numbers;
+- exactly 64 admitted draws; and
+- at most one completed batch in the process lifetime.
+
+A nonmatching draw, frame transition, sequence gap, target mismatch, or backend
+failure abandons the private batch. The next exact draw may begin a newly seeded
+batch, but no incomplete result is read back or published. After one batch
+completes, all later draws remain solely on the authoritative Xenos path; the
+qualification mode does not repeat the private replay every frame.
+
+## Private accumulation
+
+The first draw clones the authoritative D24S8 allocation into a private
+depth-only target. The following 63 draws rebind that same private target
+without reseeding it. ReXGlue's resume path revalidates the depth attachment key
+and rejects every guest color attachment before each duplicate draw.
+
+The first completed batch queues asynchronous native and Xenos depth/stencil
+readbacks. Artifacts use `.depth.batch` and `.depth.batch.xenos` suffixes. The
+runtime reports draw, batch, interruption, backend-failure, and per-frame quota
+accounting at shutdown.
+
+## Qualification
+
+```powershell
+.\tools\capture-native-renderer-census.ps1 `
+  -StateRoot "$env:LOCALAPPDATA\PinyonShift\source\0.1.0\.local\preview" `
+  -Scene open_world_day `
+  -ShadowDepthBatch `
+  -IsolatedDrawDir .local\qualification\nr05f-shadow-depth-batch
+```
+
+Required evidence is a
+`native_renderer.shadow_depth_batch.result` event with
+`status=recorded_seed_plus_63_draw_batch`, byte-identical native and Xenos batch
+artifacts, and complete request and batch accounting. Every event must retain
+`native_publication=false`, `xenos_draw=preserved`,
+`output_authority=xenos`, and `suppression_eligible=false`.
+
+The remaining two capture-proven shadow families, complete atlas ownership,
+consumer binding, publication, and suppression remain closed.
+
+The first AppData qualification attempt (`20260830T140611Z-p3944`) proved why
+the seed and follower contracts must be separate: 8,252 exact seeds were
+recorded successfully, every one was interrupted by the next family draw, and
+the run exited normally with zero backend failures. This fail-closed evidence
+prevented broadening the one-shot seed contract; only the capture-proven
+followers are admitted after a seed and before the 64-draw boundary.
+
+The corrected AppData qualification (`20260830T141806Z-p28280`) completed
+3,481 consecutive batches with zero interruptions or backend failures before
+the process exited normally. Its first asynchronous native and Xenos D24S8
+artifacts were both 56,950,304 bytes and byte-identical at SHA-256
+`0A526FD009A52BD41DE92C63CF20252A1A214F0AC89965F6B746D8D2534D25B9`.
+That run also exposed avoidable qualification overhead: completed batches kept
+replaying every frame after the evidence was captured. The final contract is
+therefore process-one-shot while retaining retry-after-failure behavior.
+
+Final Release/AppData qualification (`20260830T142402Z-p16956`) exercised the
+process-one-shot contract in live festival gameplay. Exactly one batch started
+and completed, all 64 requests were recorded, and the run reported zero
+interruptions, target failures, unsupported draws, or backend failures. The
+result count remained one while gameplay continued. Native and Xenos artifacts
+were both 56,950,304 bytes and byte-identical at SHA-256
+`A6AA07AC55B4A4851D4636F18D5148C1A52EDD8F2D44FB00CE34DC4F48284DCD`.
+Request and batch accounting were complete, Xenos remained authoritative with
+suppression disabled, and the process exited normally.

--- a/docs/native-renderer/SHADOW_REFLECTION_PASS_CENSUS.md
+++ b/docs/native-renderer/SHADOW_REFLECTION_PASS_CENSUS.md
@@ -152,3 +152,10 @@ The first executable follow-up is documented in
 contract, duplicates one draw into a private depth-only target, and preserves
 the authoritative Xenos draw. It does not yet allocate or publish a native
 atlas.
+
+The next bounded follow-up is documented in
+`SHADOW_DEPTH_BATCH_REPLAY.md`. The capture proves that all 64 draws in the
+dominant family are consecutive with no intervening authoritative draw, so the
+private path may seed once and reuse its depth-only target for exactly that
+run. Gaps, frame changes, target mismatches, and backend failures remain
+fail-closed; Xenos stays authoritative.

--- a/patches/rexglue/0090-d3d12-reuse-depth-only-isolated-target.patch
+++ b/patches/rexglue/0090-d3d12-reuse-depth-only-isolated-target.patch
@@ -1,0 +1,102 @@
+diff --git a/include/rex/graphics/d3d12/render_target_cache.h b/include/rex/graphics/d3d12/render_target_cache.h
+index c3ec6fc..7c96335 100644
+--- a/include/rex/graphics/d3d12/render_target_cache.h
++++ b/include/rex/graphics/d3d12/render_target_cache.h
+@@ -102,7 +102,8 @@ class D3D12RenderTargetCache final : public RenderTargetCache {
+   bool BeginIsolatedReplayTarget(uint32_t& width_out, uint32_t& height_out,
+                                  bool stencil_seed_probe_requested,
+                                  bool depth_only_target = false);
+-  bool ResumeIsolatedReplayTarget(uint32_t& width_out, uint32_t& height_out);
++  bool ResumeIsolatedReplayTarget(uint32_t& width_out, uint32_t& height_out,
++                                  bool depth_only_target = false);
+   system::GraphicsIsolatedDrawReadbackStatus QueueIsolatedReplayReadback(
+       system::GraphicsIsolatedDrawReadbackCompletion completion,
+       uint32_t* failure_detail_out);
+diff --git a/src/graphics/d3d12/command_processor.cpp b/src/graphics/d3d12/command_processor.cpp
+index 01de5d0..fe6d269 100644
+--- a/src/graphics/d3d12/command_processor.cpp
++++ b/src/graphics/d3d12/command_processor.cpp
+@@ -3463,7 +3463,8 @@ bool D3D12CommandProcessor::IssueDraw(xenos::PrimitiveType primitive_type, uint3
+                  (isolated_draw_request.reuse_target &&
+                   render_target_cache_->ResumeIsolatedReplayTarget(
+                       isolated_result.target_width,
+-                      isolated_result.target_height))) {
++                      isolated_result.target_height,
++                      isolated_draw_request.depth_only_target))) {
+         if (isolated_draw_request.reference_seed_depth_readback_requested &&
+             isolated_draw_request.reference_seed_depth_readback_completion) {
+           uint32_t readback_detail = 0;
+@@ -3697,7 +3698,8 @@ bool D3D12CommandProcessor::IssueDraw(xenos::PrimitiveType primitive_type, uint3
+                  (isolated_draw_request.reuse_target &&
+                   render_target_cache_->ResumeIsolatedReplayTarget(
+                       isolated_result.target_width,
+-                      isolated_result.target_height))) {
++                      isolated_result.target_height,
++                      isolated_draw_request.depth_only_target))) {
+         if (isolated_draw_request.reference_seed_depth_readback_requested &&
+             isolated_draw_request.reference_seed_depth_readback_completion) {
+           uint32_t readback_detail = 0;
+diff --git a/src/graphics/d3d12/render_target_cache.cpp b/src/graphics/d3d12/render_target_cache.cpp
+index f77cdde..803f716 100644
+--- a/src/graphics/d3d12/render_target_cache.cpp
++++ b/src/graphics/d3d12/render_target_cache.cpp
+@@ -1930,21 +1930,26 @@ bool D3D12RenderTargetCache::BeginIsolatedReplayTarget(
+ }
+ 
+ bool D3D12RenderTargetCache::ResumeIsolatedReplayTarget(
+-    uint32_t& width_out, uint32_t& height_out) {
++    uint32_t& width_out, uint32_t& height_out, bool depth_only_target) {
+   width_out = 0;
+   height_out = 0;
+   if (GetPath() != Path::kHostRenderTargets ||
+-      !isolated_replay_depth_target_ || !isolated_replay_color_target_) {
++      !isolated_replay_depth_target_ ||
++      (!depth_only_target && !isolated_replay_color_target_)) {
+     return false;
+   }
+   RenderTarget* const* guest_targets =
+       last_update_accumulated_render_targets();
+-  if (!guest_targets[0] || !guest_targets[1] ||
+-      guest_targets[0]->key() != isolated_replay_depth_target_->key() ||
++  if (!guest_targets[0] || (!depth_only_target && !guest_targets[1]) ||
++      guest_targets[0]->key() != isolated_replay_depth_target_->key()) {
++    return false;
++  }
++  if (!depth_only_target &&
+       guest_targets[1]->key() != isolated_replay_color_target_->key()) {
+     return false;
+   }
+-  for (uint32_t i = 2; i <= xenos::kMaxColorRenderTargets; ++i) {
++  for (uint32_t i = depth_only_target ? 1 : 2;
++       i <= xenos::kMaxColorRenderTargets; ++i) {
+     if (guest_targets[i]) {
+       return false;
+     }
+@@ -1952,14 +1957,21 @@ bool D3D12RenderTargetCache::ResumeIsolatedReplayTarget(
+ 
+   auto* isolated_depth = static_cast<D3D12RenderTarget*>(
+       isolated_replay_depth_target_.get());
+-  auto* isolated_color = static_cast<D3D12RenderTarget*>(
+-      isolated_replay_color_target_.get());
+-  const D3D12_RESOURCE_DESC color_desc = isolated_color->resource()->GetDesc();
+-  width_out = uint32_t(color_desc.Width);
+-  height_out = color_desc.Height;
++  auto* isolated_color = depth_only_target
++                             ? nullptr
++                             : static_cast<D3D12RenderTarget*>(
++                                   isolated_replay_color_target_.get());
++  const D3D12_RESOURCE_DESC target_desc =
++      (depth_only_target ? isolated_depth : isolated_color)
++          ->resource()
++          ->GetDesc();
++  width_out = uint32_t(target_desc.Width);
++  height_out = target_desc.Height;
+   RenderTarget* isolated_targets[1 + xenos::kMaxColorRenderTargets] = {};
+   isolated_targets[0] = isolated_depth;
+-  isolated_targets[1] = isolated_color;
++  if (isolated_color) {
++    isolated_targets[1] = isolated_color;
++  }
+   SetCommandListRenderTargets(isolated_targets);
+   command_processor_.SubmitBarriers();
+   return true;

--- a/src/native_renderer/graphics_hooks.cpp
+++ b/src/native_renderer/graphics_hooks.cpp
@@ -154,6 +154,7 @@ constexpr uint64_t kSkyHorizonFollowerSignature = UINT64_C(0x1D253A52B55C9FB3);
 constexpr uint64_t kShadowDepthVertexShader = UINT64_C(0x4E1DA281CC3D7EDB);
 constexpr uint32_t kShadowDepthLogicalWidth = 2048;
 constexpr uint32_t kShadowDepthLogicalHeight = 2048;
+constexpr uint32_t kShadowDepthBatchDrawCount = 64;
 std::atomic<uint64_t> g_frame_sequence{};
 
 enum class DispatchWrapper : uint32_t {
@@ -5698,6 +5699,7 @@ struct IsolatedDrawState {
   bool valid = true;
   bool prepared_candidate_valid = false;
   bool prepared_candidate_eligible = false;
+  bool prepared_shadow_depth_batch_member = false;
   bool prepared_visibility_candidate_fresh = false;
   bool prepared_title_lod_valid = false;
   bool require_fresh_visibility_candidate = false;
@@ -5705,8 +5707,26 @@ struct IsolatedDrawState {
   bool auto_select_fresh_visibility_candidate = false;
   bool stencil_seed_probe_requested = false;
   bool shadow_depth_mode = false;
+  bool shadow_depth_batch_mode = false;
   uint64_t shadow_depth_contract_matches = 0;
   uint64_t shadow_depth_contract_rejections = 0;
+  uint64_t shadow_depth_batch_member_matches = 0;
+  uint64_t shadow_depth_batch_member_rejections = 0;
+  uint64_t shadow_depth_batch_frame = UINT64_MAX;
+  uint64_t shadow_depth_batch_last_draw = 0;
+  uint64_t shadow_depth_batch_last_completed_frame = UINT64_MAX;
+  uint64_t shadow_depth_batches_started = 0;
+  uint64_t shadow_depth_batches_completed = 0;
+  uint64_t shadow_depth_batches_interrupted = 0;
+  uint64_t shadow_depth_batch_requests = 0;
+  uint64_t shadow_depth_batch_recorded = 0;
+  uint64_t shadow_depth_batch_target_failures = 0;
+  uint64_t shadow_depth_batch_unsupported = 0;
+  uint64_t shadow_depth_batch_frame_quota_yields = 0;
+  uint32_t shadow_depth_batch_draws = 0;
+  bool shadow_depth_batch_active = false;
+  bool shadow_depth_batch_backend_ready = false;
+  bool shadow_depth_batch_capture_completed = false;
   bool visibility_wait_reported = false;
   bool title_lod_wait_reported = false;
   bool awaiting_pass_follower = false;
@@ -6178,7 +6198,26 @@ void ConfigureIsolatedDraw() {
     }
   }
   std::free(value);
+  value = nullptr;
+  length = 0;
+  if (_dupenv_s(
+          &value, &length,
+          "PINYON_SHIFT_NATIVE_RENDERER_SHADOW_DEPTH_BATCH") == 0 &&
+      value && length > 1) {
+    const std::string setting(value);
+    g_isolated_draw.shadow_depth_batch_mode = setting == "true";
+    if (setting != "true" && setting != "false") {
+      g_isolated_draw.valid = false;
+    }
+  }
+  std::free(value);
   if (g_isolated_draw.shadow_depth_mode) {
+    g_isolated_draw.requested = true;
+    if (signature_requested || g_isolated_draw.shadow_depth_batch_mode) {
+      g_isolated_draw.valid = false;
+    }
+  }
+  if (g_isolated_draw.shadow_depth_batch_mode) {
     g_isolated_draw.requested = true;
     if (signature_requested) {
       g_isolated_draw.valid = false;
@@ -6202,6 +6241,7 @@ void ConfigureIsolatedDraw() {
     g_isolated_draw.requested = true;
     g_isolated_draw.require_fresh_visibility_candidate = true;
     if (signature_requested || g_isolated_draw.shadow_depth_mode ||
+        g_isolated_draw.shadow_depth_batch_mode ||
         g_sky_horizon_suppression.requested) {
       g_isolated_draw.valid = false;
     }
@@ -6247,7 +6287,8 @@ void ConfigureIsolatedDraw() {
       !value || length <= 1) {
     std::free(value);
     if (g_isolated_draw.auto_select_fresh_visibility_candidate ||
-        g_isolated_draw.stencil_seed_probe_requested) {
+        g_isolated_draw.stencil_seed_probe_requested ||
+        g_isolated_draw.shadow_depth_batch_mode) {
       g_isolated_draw.valid = false;
     }
     return;
@@ -6264,7 +6305,8 @@ void ConfigureIsolatedDraw() {
       !g_isolated_draw.readback_requested) {
     g_isolated_draw.valid = false;
   }
-  if (g_isolated_draw.shadow_depth_mode &&
+  if ((g_isolated_draw.shadow_depth_mode ||
+       g_isolated_draw.shadow_depth_batch_mode) &&
       (g_isolated_draw.stencil_seed_probe_requested ||
        g_isolated_draw.require_fresh_visibility_candidate ||
        g_isolated_draw.require_title_lod_candidate)) {
@@ -11808,7 +11850,7 @@ bool IsIsolatedDrawEligible(
       observation, samples_resolved_target, prepared);
 }
 
-bool IsExactShadowDepthIsolatedDraw(
+bool IsShadowDepthBatchMemberDraw(
     const rex::system::GraphicsDrawObservation &observation,
     bool samples_resolved_target,
     const rex::system::GraphicsPreparedDrawObservation &prepared) {
@@ -11818,7 +11860,7 @@ bool IsExactShadowDepthIsolatedDraw(
          !observation.vertex_memexport && observation.indexed &&
          observation.source_select ==
              uint32_t(rex::graphics::xenos::SourceSelect::kDMA) &&
-         observation.primitive_type == 6 && observation.index_count == 881 &&
+         observation.primitive_type == 6 && observation.index_count != 0 &&
          observation.index_format == 0 && observation.index_endianness == 1 &&
          observation.vertex_binding_count == 3 &&
          !observation.vertex_binding_overflow &&
@@ -11836,16 +11878,26 @@ bool IsExactShadowDepthIsolatedDraw(
          observation.rb_depthcontrol == 0x00700736 &&
          observation.pa_su_sc_mode_cntl == 0x00219800 &&
          observation.pa_su_vtx_cntl == 4 &&
-         prepared.vertex_shader_hash == kShadowDepthVertexShader &&
-         prepared.pixel_shader_hash == 0 &&
-         prepared.vertex_specialization_mask == 0 &&
-         prepared.pixel_specialization_mask == 0 &&
+         observation.vertex_shader_hash == kShadowDepthVertexShader &&
          prepared.guest_primitive_type == 6 &&
          prepared.index_buffer_type == 1 &&
          prepared.normalized_color_mask == 0 &&
          prepared.bound_render_target_bits == 1 &&
          prepared.bound_render_target_formats[0] == 0 &&
          (prepared.flags & 3) == 3;
+}
+
+bool IsExactShadowDepthIsolatedDraw(
+    const rex::system::GraphicsDrawObservation &observation,
+    bool samples_resolved_target,
+    const rex::system::GraphicsPreparedDrawObservation &prepared) {
+  return IsShadowDepthBatchMemberDraw(observation, samples_resolved_target,
+                                      prepared) &&
+         observation.index_count == 881 &&
+         prepared.vertex_shader_hash == kShadowDepthVertexShader &&
+         prepared.pixel_shader_hash == 0 &&
+         prepared.vertex_specialization_mask == 0 &&
+         prepared.pixel_specialization_mask == 0;
 }
 
 const char *SemanticBatchRejectionName(SemanticBatchRejection rejection) {
@@ -14248,6 +14300,7 @@ void CommitPassConsumer(
 void ObservePreparedDraw(
     const rex::system::GraphicsPreparedDrawObservation &observation) {
   g_isolated_draw.prepared_candidate_valid = false;
+  g_isolated_draw.prepared_shadow_depth_batch_member = false;
   g_consumer_family_marker.current_match = false;
   if (!g_pending_candidate.valid) {
     ++g_candidate_prepared_without_observation_count;
@@ -14271,14 +14324,27 @@ void ObservePreparedDraw(
     g_isolated_draw.draw = sample.draw_sequence;
     g_isolated_draw.prepared_sample = sample;
     g_isolated_draw.prepared_candidate_eligible =
-        g_isolated_draw.shadow_depth_mode
+        (g_isolated_draw.shadow_depth_mode ||
+         g_isolated_draw.shadow_depth_batch_mode)
             ? IsExactShadowDepthIsolatedDraw(
                   sample, g_pending_candidate.samples_resolved_target,
                   observation)
             : IsIsolatedDrawEligible(
                   sample, g_pending_candidate.samples_resolved_target,
                   observation);
-    if (g_isolated_draw.shadow_depth_mode) {
+    if (g_isolated_draw.shadow_depth_batch_mode) {
+      g_isolated_draw.prepared_shadow_depth_batch_member =
+          IsShadowDepthBatchMemberDraw(
+              sample, g_pending_candidate.samples_resolved_target,
+              observation);
+      if (g_isolated_draw.prepared_shadow_depth_batch_member) {
+        ++g_isolated_draw.shadow_depth_batch_member_matches;
+      } else if (observation.vertex_shader_hash == kShadowDepthVertexShader) {
+        ++g_isolated_draw.shadow_depth_batch_member_rejections;
+      }
+    }
+    if (g_isolated_draw.shadow_depth_mode ||
+        g_isolated_draw.shadow_depth_batch_mode) {
       if (g_isolated_draw.prepared_candidate_eligible) {
         ++g_isolated_draw.shadow_depth_contract_matches;
       } else if (observation.vertex_shader_hash == kShadowDepthVertexShader) {
@@ -15308,6 +15374,24 @@ void CompleteIsolatedReferenceDepthReadback(
       g_isolated_draw.reference_depth_artifact_writer);
 }
 
+void CompleteIsolatedShadowBatchDepthReadback(
+    const rex::system::GraphicsIsolatedDrawReadback &readback) {
+  std::filesystem::path depth_root = g_isolated_draw.output_root;
+  depth_root += L".depth.batch";
+  CompleteIsolatedDepthReadbackArtifact(
+      readback, "native_batch", depth_root,
+      g_isolated_draw.depth_artifact_writer);
+}
+
+void CompleteIsolatedReferenceShadowBatchDepthReadback(
+    const rex::system::GraphicsIsolatedDrawReadback &readback) {
+  std::filesystem::path depth_root = g_isolated_draw.output_root;
+  depth_root += L".depth.batch.xenos";
+  CompleteIsolatedDepthReadbackArtifact(
+      readback, "xenos_batch", depth_root,
+      g_isolated_draw.reference_depth_artifact_writer);
+}
+
 void CompleteIsolatedDraw(
     const rex::system::GraphicsIsolatedDrawResult &result) {
   const char *status = "unsupported_state";
@@ -15353,6 +15437,58 @@ void CompleteIsolatedShadowDepth(
        {"allocation_width", std::to_string(result.target_width)},
        {"allocation_height", std::to_string(result.target_height)},
        {"private_depth_target", exact_target ? "recorded" : "unqualified"},
+       {"native_publication", "false"},
+       {"xenos_draw", "preserved"},
+       {"output_authority", "xenos"},
+       {"suppression_eligible", "false"}});
+}
+
+void CompleteIsolatedShadowDepthBatch(
+    const rex::system::GraphicsIsolatedDrawResult &result) {
+  const bool recorded =
+      result.status == rex::system::GraphicsIsolatedDrawStatus::kRecorded;
+  if (recorded) {
+    ++g_isolated_draw.shadow_depth_batch_recorded;
+    g_isolated_draw.shadow_depth_batch_backend_ready = true;
+  } else if (result.status == rex::system::
+                                  GraphicsIsolatedDrawStatus::
+                                      kTargetCreationFailed) {
+    ++g_isolated_draw.shadow_depth_batch_target_failures;
+  } else {
+    ++g_isolated_draw.shadow_depth_batch_unsupported;
+  }
+  if (!recorded) {
+    g_isolated_draw.shadow_depth_batch_active = false;
+    g_isolated_draw.shadow_depth_batch_backend_ready = false;
+  }
+  if (g_isolated_draw.shadow_depth_batch_draws !=
+      kShadowDepthBatchDrawCount) {
+    return;
+  }
+  if (recorded) {
+    ++g_isolated_draw.shadow_depth_batches_completed;
+    g_isolated_draw.shadow_depth_batch_last_completed_frame =
+        g_isolated_draw.shadow_depth_batch_frame;
+    g_isolated_draw.shadow_depth_batch_capture_completed = true;
+  }
+  g_isolated_draw.shadow_depth_batch_active = false;
+  pinyon_shift::diagnostics::RecordEvent(
+      "native_renderer.shadow_depth_batch.result",
+      {{"status", recorded ? "recorded_seed_plus_63_draw_batch"
+                             : "failed_closed"},
+       {"vertex_shader", fmt::format("{:016X}", kShadowDepthVertexShader)},
+       {"frame", std::to_string(g_isolated_draw.shadow_depth_batch_frame)},
+       {"first_draw",
+        std::to_string(g_isolated_draw.shadow_depth_batch_last_draw -
+                       (kShadowDepthBatchDrawCount - 1))},
+       {"last_draw",
+        std::to_string(g_isolated_draw.shadow_depth_batch_last_draw)},
+       {"draw_count", std::to_string(kShadowDepthBatchDrawCount)},
+       {"logical_width", std::to_string(kShadowDepthLogicalWidth)},
+       {"logical_height", std::to_string(kShadowDepthLogicalHeight)},
+       {"allocation_width", std::to_string(result.target_width)},
+       {"allocation_height", std::to_string(result.target_height)},
+       {"private_depth_target", recorded ? "accumulated" : "unqualified"},
        {"native_publication", "false"},
        {"xenos_draw", "preserved"},
        {"output_authority", "xenos"},
@@ -15778,6 +15914,79 @@ void RequestIsolatedDraw(
   }
   if (!g_isolated_draw.requested || !g_isolated_draw.valid ||
       !g_isolated_draw.prepared_candidate_valid) {
+    return;
+  }
+  if (g_isolated_draw.shadow_depth_batch_mode) {
+    // Qualification mode is intentionally one-shot. Once one complete private
+    // batch has been recorded, keep every later title draw on the authoritative
+    // Xenos path without paying the duplicate replay or diagnostic cost again.
+    if (g_isolated_draw.shadow_depth_batch_capture_completed) {
+      return;
+    }
+    const bool exact_seed = g_isolated_draw.prepared_candidate_eligible;
+    const bool batch_member =
+        g_isolated_draw.prepared_shadow_depth_batch_member;
+    if (g_isolated_draw.shadow_depth_batch_active) {
+      const bool contiguous =
+          batch_member && g_isolated_draw.frame ==
+                              g_isolated_draw.shadow_depth_batch_frame &&
+          g_isolated_draw.draw ==
+              g_isolated_draw.shadow_depth_batch_last_draw + 1 &&
+          g_isolated_draw.shadow_depth_batch_backend_ready;
+      if (!contiguous) {
+        ++g_isolated_draw.shadow_depth_batches_interrupted;
+        g_isolated_draw.shadow_depth_batch_active = false;
+        g_isolated_draw.shadow_depth_batch_backend_ready = false;
+        g_isolated_draw.shadow_depth_batch_draws = 0;
+      }
+    }
+    if (!g_isolated_draw.shadow_depth_batch_active && !exact_seed) {
+      return;
+    }
+    if (!batch_member) {
+      return;
+    }
+    if (g_isolated_draw.shadow_depth_batch_last_completed_frame ==
+        g_isolated_draw.frame) {
+      ++g_isolated_draw.shadow_depth_batch_frame_quota_yields;
+      return;
+    }
+    if (!g_isolated_draw.shadow_depth_batch_active) {
+      g_isolated_draw.shadow_depth_batch_active = true;
+      g_isolated_draw.shadow_depth_batch_backend_ready = false;
+      g_isolated_draw.shadow_depth_batch_frame = g_isolated_draw.frame;
+      g_isolated_draw.shadow_depth_batch_draws = 0;
+      ++g_isolated_draw.shadow_depth_batches_started;
+    }
+    ++g_isolated_draw.shadow_depth_batch_draws;
+    ++g_isolated_draw.shadow_depth_batch_requests;
+    g_isolated_draw.shadow_depth_batch_last_draw = g_isolated_draw.draw;
+    const bool completing_batch =
+        g_isolated_draw.shadow_depth_batch_draws ==
+        kShadowDepthBatchDrawCount;
+    if (completing_batch) {
+      g_isolated_draw.captured_signature =
+          g_isolated_draw.prepared_signature;
+      g_isolated_draw.captured_frame = g_isolated_draw.frame;
+      g_isolated_draw.captured_draw = g_isolated_draw.draw;
+    }
+    request.requested = true;
+    request.depth_only_target = true;
+    request.frame_sequence = g_isolated_draw.frame;
+    request.retain_target = !completing_batch;
+    request.reuse_target = g_isolated_draw.shadow_depth_batch_draws > 1;
+    request.reference_marker_requested = true;
+    request.completion = &CompleteIsolatedShadowDepthBatch;
+    const bool capture_batch =
+        completing_batch && g_isolated_draw.readback_requested &&
+        !g_isolated_draw.shadow_depth_batch_capture_completed;
+    request.depth_readback_requested = capture_batch;
+    request.reference_depth_readback_requested = capture_batch;
+    request.depth_readback_completion =
+        capture_batch ? &CompleteIsolatedShadowBatchDepthReadback : nullptr;
+    request.reference_depth_readback_completion =
+        capture_batch ? &CompleteIsolatedReferenceShadowBatchDepthReadback
+                      : nullptr;
     return;
   }
   if (g_isolated_draw.shadow_depth_mode) {
@@ -18333,11 +18542,14 @@ void InstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system,
                                                : "invalid_configuration")},
        {"signature",
          g_isolated_draw.valid && g_isolated_draw.requested &&
-                 !g_isolated_draw.shadow_depth_mode
+                 !g_isolated_draw.shadow_depth_mode &&
+                 !g_isolated_draw.shadow_depth_batch_mode
              ? fmt::format("{:016X}", g_isolated_draw.target_signature)
              : ""},
        {"shadow_depth_vertex_shader",
-        g_isolated_draw.valid && g_isolated_draw.shadow_depth_mode
+        g_isolated_draw.valid &&
+                (g_isolated_draw.shadow_depth_mode ||
+                 g_isolated_draw.shadow_depth_batch_mode)
             ? fmt::format("{:016X}", kShadowDepthVertexShader)
             : ""},
        {"anchor_signature",
@@ -18345,18 +18557,26 @@ void InstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system,
                 g_pass_follower.valid && g_pass_follower.requested
             ? fmt::format("{:016X}", g_pass_follower.target_signature)
             : ""},
-       {"mode", g_isolated_draw.shadow_depth_mode
-                    ? "exact_shadow_depth_single_draw"
-                    : (g_pass_follower.valid && g_pass_follower.requested
+       {"mode", g_isolated_draw.shadow_depth_batch_mode
+                    ? "exact_shadow_depth_64_draw_batch"
+                    : (g_isolated_draw.shadow_depth_mode
+                           ? "exact_shadow_depth_single_draw"
+                           : (g_pass_follower.valid && g_pass_follower.requested
                            ? "retained_pass"
-                           : "single_draw")},
+                           : "single_draw"))},
        {"native_draw", "isolated_only"},
        {"continuous_shadow_replay",
-         g_isolated_draw.shadow_depth_mode
+         g_isolated_draw.shadow_depth_batch_mode
+             ? "one_shot_seed_plus_63_draw_batch"
+             : (g_isolated_draw.shadow_depth_mode
              ? "disabled"
              : (g_pass_follower.valid && g_pass_follower.requested
              ? "retained_pass_contract"
-                : "enabled_after_one_shot")},
+                : "enabled_after_one_shot"))},
+       {"maximum_batch_draws",
+        g_isolated_draw.shadow_depth_batch_mode
+            ? std::to_string(kShadowDepthBatchDrawCount)
+            : ""},
        {"readback", g_isolated_draw.readback_requested ? "asynchronous"
                                                         : "disabled"},
        {"stencil_seed_probe",
@@ -18369,11 +18589,14 @@ void InstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system,
             ? "private_target_before_guest_copy"
             : ""},
        {"stencil_seed_probe_guest_target", "untouched"},
-       {"reference_marker", g_isolated_draw.shadow_depth_mode
-                                ? "exact_shadow_depth_contract"
-                                : "exact_signature"},
+       {"reference_marker",
+        (g_isolated_draw.shadow_depth_mode ||
+         g_isolated_draw.shadow_depth_batch_mode)
+            ? "exact_shadow_depth_contract"
+            : "exact_signature"},
        {"selection",
-         g_isolated_draw.shadow_depth_mode
+         (g_isolated_draw.shadow_depth_mode ||
+          g_isolated_draw.shadow_depth_batch_mode)
              ? "capture_bound_shader_state_and_depth_target"
              : (g_isolated_draw.auto_select_fresh_visibility_candidate
              ? (g_isolated_draw.require_title_lod_candidate
@@ -18911,6 +19134,7 @@ void UninstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system) {
       g_pass_follower.target_signature == g_isolated_draw.target_signature;
   if (g_isolated_draw.requested && g_isolated_draw.valid &&
       !g_isolated_draw.shadow_depth_mode &&
+      !g_isolated_draw.shadow_depth_batch_mode &&
       g_isolated_draw.completed && isolated_single_draw_mode) {
     const uint64_t shadow_replay_outcomes =
         g_isolated_draw.shadow_replay_recorded +
@@ -18950,10 +19174,80 @@ void UninstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system) {
           std::to_string(g_isolated_draw.shadow_depth_contract_matches)},
          {"contract_rejections",
           std::to_string(g_isolated_draw.shadow_depth_contract_rejections)},
+         {"batch_member_matches",
+          std::to_string(
+              g_isolated_draw.shadow_depth_batch_member_matches)},
+         {"batch_member_rejections",
+          std::to_string(
+              g_isolated_draw.shadow_depth_batch_member_rejections)},
          {"private_replays", g_isolated_draw.completed ? "1" : "0"},
          {"readback", g_isolated_draw.readback_requested
                           ? "native_and_xenos_depth_only"
                           : "disabled"},
+         {"native_publication", "false"},
+         {"xenos_draw", "preserved"},
+         {"output_authority", "xenos"},
+         {"draw_suppression", "false"},
+       {"suppression_eligible", "false"}});
+  }
+  if (g_isolated_draw.shadow_depth_batch_mode) {
+    const uint64_t request_outcomes =
+        g_isolated_draw.shadow_depth_batch_recorded +
+        g_isolated_draw.shadow_depth_batch_target_failures +
+        g_isolated_draw.shadow_depth_batch_unsupported;
+    const uint64_t failed_batches =
+        g_isolated_draw.shadow_depth_batch_target_failures +
+        g_isolated_draw.shadow_depth_batch_unsupported;
+    const uint64_t batch_outcomes =
+        g_isolated_draw.shadow_depth_batches_completed +
+        g_isolated_draw.shadow_depth_batches_interrupted + failed_batches +
+        (g_isolated_draw.shadow_depth_batch_active ? 1 : 0);
+    diagnostics::RecordEvent(
+        "native_renderer.shadow_depth_batch.summary",
+        {{"status",
+          g_isolated_draw.shadow_depth_batches_completed
+              ? "observed_complete_batch"
+              : "no_complete_batch"},
+         {"vertex_shader", fmt::format("{:016X}", kShadowDepthVertexShader)},
+         {"expected_draws_per_batch",
+          std::to_string(kShadowDepthBatchDrawCount)},
+         {"contract_matches",
+          std::to_string(g_isolated_draw.shadow_depth_contract_matches)},
+         {"contract_rejections",
+          std::to_string(g_isolated_draw.shadow_depth_contract_rejections)},
+         {"batches_started",
+          std::to_string(g_isolated_draw.shadow_depth_batches_started)},
+         {"batches_completed",
+          std::to_string(g_isolated_draw.shadow_depth_batches_completed)},
+         {"batches_interrupted",
+          std::to_string(g_isolated_draw.shadow_depth_batches_interrupted)},
+         {"backend_failed_batches", std::to_string(failed_batches)},
+         {"active_incomplete_batch",
+          g_isolated_draw.shadow_depth_batch_active ? "true" : "false"},
+         {"requests",
+          std::to_string(g_isolated_draw.shadow_depth_batch_requests)},
+         {"recorded",
+          std::to_string(g_isolated_draw.shadow_depth_batch_recorded)},
+         {"target_creation_failures",
+          std::to_string(
+              g_isolated_draw.shadow_depth_batch_target_failures)},
+         {"unsupported",
+          std::to_string(g_isolated_draw.shadow_depth_batch_unsupported)},
+         {"per_frame_quota_yields",
+          std::to_string(
+              g_isolated_draw.shadow_depth_batch_frame_quota_yields)},
+         {"request_accounting_complete",
+          request_outcomes == g_isolated_draw.shadow_depth_batch_requests
+              ? "true"
+              : "false"},
+         {"batch_accounting_complete",
+          batch_outcomes == g_isolated_draw.shadow_depth_batches_started
+              ? "true"
+              : "false"},
+         {"readback",
+          g_isolated_draw.shadow_depth_batch_capture_completed
+              ? "native_and_xenos_completed_batch"
+              : "not_captured"},
          {"native_publication", "false"},
          {"xenos_draw", "preserved"},
          {"output_authority", "xenos"},

--- a/tools/capture-native-renderer-census.ps1
+++ b/tools/capture-native-renderer-census.ps1
@@ -17,6 +17,7 @@ param(
     [string]$IsolatedDrawSignature,
     [string]$IsolatedDrawDir,
     [switch]$ShadowDepthIsolated,
+    [switch]$ShadowDepthBatch,
     [switch]$StencilSeedProbe,
     [switch]$RequireFreshVisibilityCandidate,
     [switch]$AutoSelectFreshVisibilityCandidate,
@@ -77,15 +78,21 @@ if ($AutoSelectFreshVisibilityCandidate -and -not $IsolatedDrawDir) {
 if ($AutoSelectFreshVisibilityCandidate -and $PassAnchorSignature) {
     throw 'AutoSelectFreshVisibilityCandidate does not support PassAnchorSignature.'
 }
-if ($ShadowDepthIsolated -and
+if ($ShadowDepthIsolated -and $ShadowDepthBatch) {
+    throw 'ShadowDepthIsolated and ShadowDepthBatch are mutually exclusive.'
+}
+if (($ShadowDepthIsolated -or $ShadowDepthBatch) -and
     ($IsolatedDrawSignature -or $AutoSelectFreshVisibilityCandidate -or
         $StencilSeedProbe -or $RequireFreshVisibilityCandidate -or
         $RequireTitleLodCandidate -or $PassAnchorSignature -or
         $PublishRetainedPass -or $VisibilityShadowReplay)) {
-    throw 'ShadowDepthIsolated is mutually exclusive with other isolated/pass replay options.'
+    throw 'Shadow-depth modes are mutually exclusive with other isolated/pass replay options.'
 }
 if ($ShadowDepthIsolated -and -not $IsolatedDrawDir) {
     throw 'ShadowDepthIsolated requires IsolatedDrawDir.'
+}
+if ($ShadowDepthBatch -and -not $IsolatedDrawDir) {
+    throw 'ShadowDepthBatch requires IsolatedDrawDir.'
 }
 if ($StencilSeedProbe -and -not $IsolatedDrawDir) {
     throw 'StencilSeedProbe requires IsolatedDrawDir.'
@@ -128,8 +135,8 @@ if ($ReplaySnapshotDir) {
 
 if ($IsolatedDrawDir) {
     if (-not $IsolatedDrawSignature -and -not $AutoSelectFreshVisibilityCandidate -and
-        -not $ShadowDepthIsolated) {
-        throw 'IsolatedDrawDir requires IsolatedDrawSignature, AutoSelectFreshVisibilityCandidate, or ShadowDepthIsolated'
+        -not $ShadowDepthIsolated -and -not $ShadowDepthBatch) {
+        throw 'IsolatedDrawDir requires an isolated draw or shadow-depth mode'
     }
     $repositoryRoot = Split-Path $PSScriptRoot -Parent
     $localRoot = [IO.Path]::GetFullPath((Join-Path $repositoryRoot '.local'))
@@ -185,6 +192,7 @@ $savedReplaySnapshotDir = $env:PINYON_SHIFT_NATIVE_RENDERER_SNAPSHOT_DIR
 $savedIsolatedDraw = $env:PINYON_SHIFT_NATIVE_RENDERER_ISOLATED_DRAW_SIGNATURE
 $savedIsolatedDrawDir = $env:PINYON_SHIFT_NATIVE_RENDERER_ISOLATED_DRAW_DIR
 $savedShadowDepthIsolated = $env:PINYON_SHIFT_NATIVE_RENDERER_SHADOW_DEPTH_ISOLATED
+$savedShadowDepthBatch = $env:PINYON_SHIFT_NATIVE_RENDERER_SHADOW_DEPTH_BATCH
 $savedStencilSeedProbe = $env:PINYON_SHIFT_NATIVE_RENDERER_STENCIL_SEED_PROBE
 $savedVisibilityGate = $env:PINYON_SHIFT_NATIVE_RENDERER_REQUIRE_FRESH_VISIBILITY_CANDIDATE
 $savedAutoVisibilityCandidate =
@@ -213,6 +221,8 @@ try {
     $env:PINYON_SHIFT_NATIVE_RENDERER_ISOLATED_DRAW_DIR = $IsolatedDrawDir
     $env:PINYON_SHIFT_NATIVE_RENDERER_SHADOW_DEPTH_ISOLATED =
         if ($ShadowDepthIsolated) { 'true' } else { $null }
+    $env:PINYON_SHIFT_NATIVE_RENDERER_SHADOW_DEPTH_BATCH =
+        if ($ShadowDepthBatch) { 'true' } else { $null }
     $env:PINYON_SHIFT_NATIVE_RENDERER_STENCIL_SEED_PROBE =
         if ($StencilSeedProbe) { 'true' } else { $null }
     $env:PINYON_SHIFT_NATIVE_RENDERER_REQUIRE_FRESH_VISIBILITY_CANDIDATE =
@@ -248,6 +258,8 @@ finally {
     $env:PINYON_SHIFT_NATIVE_RENDERER_ISOLATED_DRAW_DIR = $savedIsolatedDrawDir
     $env:PINYON_SHIFT_NATIVE_RENDERER_SHADOW_DEPTH_ISOLATED =
         $savedShadowDepthIsolated
+    $env:PINYON_SHIFT_NATIVE_RENDERER_SHADOW_DEPTH_BATCH =
+        $savedShadowDepthBatch
     $env:PINYON_SHIFT_NATIVE_RENDERER_STENCIL_SEED_PROBE = $savedStencilSeedProbe
     $env:PINYON_SHIFT_NATIVE_RENDERER_REQUIRE_FRESH_VISIBILITY_CANDIDATE =
         $savedVisibilityGate

--- a/tools/tests/test_native_renderer_contract.py
+++ b/tools/tests/test_native_renderer_contract.py
@@ -1964,6 +1964,43 @@ class NativeRendererContractTests(unittest.TestCase):
         self.assertIn("ShadowDepthIsolated requires IsolatedDrawDir", capture)
         self.assertIn("PINYON_SHIFT_NATIVE_RENDERER_SHADOW_DEPTH_ISOLATED", capture)
 
+    def test_shadow_depth_batch_is_bounded_contiguous_and_private(self):
+        scanner = (ROOT / "src/native_renderer/graphics_hooks.cpp").read_text(
+            encoding="utf-8"
+        )
+        self.assertIn("PINYON_SHIFT_NATIVE_RENDERER_SHADOW_DEPTH_BATCH", scanner)
+        self.assertIn("kShadowDepthBatchDrawCount = 64", scanner)
+        self.assertIn("IsShadowDepthBatchMemberDraw", scanner)
+        self.assertIn("prepared_shadow_depth_batch_member", scanner)
+        self.assertIn(
+            "if (g_isolated_draw.shadow_depth_batch_capture_completed)", scanner
+        )
+        self.assertIn('"one_shot_seed_plus_63_draw_batch"', scanner)
+        self.assertIn("!exact_seed", scanner)
+        self.assertIn("shadow_depth_batch_last_draw + 1", scanner)
+        self.assertIn("request.reuse_target =", scanner)
+        self.assertIn('"native_renderer.shadow_depth_batch.result"', scanner)
+        self.assertIn('"recorded_seed_plus_63_draw_batch"', scanner)
+        self.assertIn('"native_publication", "false"', scanner)
+        self.assertIn('"xenos_draw", "preserved"', scanner)
+        self.assertIn('"suppression_eligible", "false"', scanner)
+
+        patch = (
+            ROOT
+            / "patches/rexglue/0090-d3d12-reuse-depth-only-isolated-target.patch"
+        ).read_text(encoding="utf-8")
+        self.assertIn("ResumeIsolatedReplayTarget", patch)
+        self.assertIn("bool depth_only_target", patch)
+        self.assertIn("depth_only_target ? 1 : 2", patch)
+        self.assertNotIn("SetDrawSuppression", patch)
+
+        capture = (
+            ROOT / "tools/capture-native-renderer-census.ps1"
+        ).read_text(encoding="utf-8")
+        self.assertIn("[switch]$ShadowDepthBatch", capture)
+        self.assertIn("ShadowDepthBatch requires IsolatedDrawDir", capture)
+        self.assertIn("PINYON_SHIFT_NATIVE_RENDERER_SHADOW_DEPTH_BATCH", capture)
+
     def test_census_ledger_tracks_exact_starting_baseline(self):
         ledger = (ROOT / "docs/native-renderer/RENDER_PASS_CENSUS.md").read_text(
             encoding="utf-8"

--- a/tools/tests/test_release_contract.py
+++ b/tools/tests/test_release_contract.py
@@ -43,10 +43,10 @@ class ReleaseContractTests(unittest.TestCase):
 
     def test_rexglue_patches_have_stable_order_and_no_binary_payload(self):
         patches = sorted((ROOT / "patches/rexglue").glob("*.patch"))
-        self.assertEqual(len(patches), 89)
+        self.assertEqual(len(patches), 90)
         self.assertEqual(
             patches[-1].name,
-            "0089-d3d12-depth-only-isolated-replay.patch",
+            "0090-d3d12-reuse-depth-only-isolated-target.patch",
         )
         self.assertEqual(len(patches), len({path.name[:4] for path in patches}))
         for path in patches:


### PR DESCRIPTION
## Summary
- accumulate the capture-proven 64-draw shadow-depth family in one retained private D24S8 target
- separate the exact seed from capture-proven follower membership and fail closed on gaps, frame changes, target mismatches, or backend errors
- preserve every Xenos draw, native non-publication, and suppression ineligibility
- stop qualification replay after the first completed batch while retaining retry-after-failure
- add capture tooling, contract tests, ReXGlue target reuse, and qualification documentation

## Validation
- 435 unit tests passed
- Windows release build passed; executable SHA-256 1BF92EEE194E9B595B1080619D22F2476331DED33B4CF60BAB974163BDD6CFF4
- AppData gameplay session 20260830T142402Z-p16956 exited normally
- one batch started and completed; 64/64 requests recorded; zero interruptions and backend failures
- native and Xenos D24S8 outputs were byte-identical: 56,950,304 bytes, SHA-256 A6AA07AC55B4A4851D4636F18D5148C1A52EDD8F2D44FB00CE34DC4F48284DCD