### PR TITLE
feat(renderer): accumulate full shadow atlas epoch

### DIFF
--- a/docs/native-renderer/SHADOW_DEPTH_BATCH_REPLAY.md
+++ b/docs/native-renderer/SHADOW_DEPTH_BATCH_REPLAY.md
@@ -1,17 +1,20 @@
-# Bounded native shadow-depth batch replay
+# Bounded native shadow-atlas epoch replay
 
 This NR-05F checkpoint extends the exact private shadow-depth draw into one
-bounded producer batch. It does not publish a native atlas or alter the
+bounded, capture-proven 80-draw producer epoch. It does not publish a native
+atlas or alter the
 game-visible render graph. Every original Xenos draw still executes and remains
 authoritative.
 
 ## Capture-proven boundary
 
-The qualified `reference_frame8134.rdc` capture contains 64 draws for the
-dominant `4E1DA281CC3D7EDB` shadow-depth family. They share pipeline
-`ResourceId::1865`, have no pixel shader or color attachment, write the same
-`ResourceId::19359` depth target, and are the only authoritative draws from
-event 1004 through event 1340. The runtime therefore requires:
+The qualified `reference_frame8134.rdc` capture contains exactly 80 draws and
+no other authoritative draw from event 1004 through event 1417. All 80 have no
+pixel shader or color attachment and write the same `ResourceId::19359` D24S8
+target through the same 2048-square viewport and scissor. Their exact order is
+64 draws from `4E1DA281CC3D7EDB`, followed by four repetitions of
+`CDDB454589126317` index counts `1474, 506, 3223` and one
+`68DF329C66481843` draw with index count `703`. The runtime therefore requires:
 
 - the complete exact 881-index draw from `SHADOW_DEPTH_ISOLATED_REPLAY.md` as
   the batch seed;
@@ -19,8 +22,12 @@ event 1004 through event 1340. The runtime therefore requires:
   scissor, depth/raster, indexed-DMA, attachment, and overflow contracts while
   allowing each follower's title-selected geometry count and prepared shader
   specialization;
+- the exact 16-draw tail pattern: three zero-specialization
+  `CDDB454589126317` draws with index counts `1474, 506, 3223`, then one
+  zero-specialization `68DF329C66481843` draw with index count `703`, repeated
+  four times;
 - one frame and strictly adjacent draw sequence numbers;
-- exactly 64 admitted draws; and
+- exactly 80 admitted draws; and
 - at most one completed batch in the process lifetime.
 
 A nonmatching draw, frame transition, sequence gap, target mismatch, or backend
@@ -32,9 +39,11 @@ qualification mode does not repeat the private replay every frame.
 ## Private accumulation
 
 The first draw clones the authoritative D24S8 allocation into a private
-depth-only target. The following 63 draws rebind that same private target
-without reseeding it. ReXGlue's resume path revalidates the depth attachment key
-and rejects every guest color attachment before each duplicate draw.
+depth-only target. The following 79 draws rebind that same private target
+without reseeding it. ReXGlue's resume path revalidates the depth attachment
+key and rejects every guest color attachment before each duplicate draw. The
+16-draw tail reuses the normal draw path's already converted host index buffer;
+private replay admits only guest-DMA and host-converted indexed draws.
 
 The first completed batch queues asynchronous native and Xenos depth/stencil
 readbacks. Artifacts use `.depth.batch` and `.depth.batch.xenos` suffixes. The
@@ -53,13 +62,13 @@ accounting at shutdown.
 
 Required evidence is a
 `native_renderer.shadow_depth_batch.result` event with
-`status=recorded_seed_plus_63_draw_batch`, byte-identical native and Xenos batch
+`status=recorded_full_80_draw_atlas_epoch`, byte-identical native and Xenos batch
 artifacts, and complete request and batch accounting. Every event must retain
 `native_publication=false`, `xenos_draw=preserved`,
 `output_authority=xenos`, and `suppression_eligible=false`.
 
-The remaining two capture-proven shadow families, complete atlas ownership,
-consumer binding, publication, and suppression remain closed.
+Complete atlas ownership, consumer binding, publication, and suppression remain
+closed.
 
 The first AppData qualification attempt (`20260830T140611Z-p3944`) proved why
 the seed and follower contracts must be separate: 8,252 exact seeds were
@@ -77,12 +86,22 @@ That run also exposed avoidable qualification overhead: completed batches kept
 replaying every frame after the evidence was captured. The final contract is
 therefore process-one-shot while retaining retry-after-failure behavior.
 
-Final Release/AppData qualification (`20260830T142402Z-p16956`) exercised the
-process-one-shot contract in live festival gameplay. Exactly one batch started
-and completed, all 64 requests were recorded, and the run reported zero
+The 64-draw Release/AppData qualification (`20260830T142402Z-p16956`) exercised
+the process-one-shot contract in live festival gameplay. Exactly one batch
+started and completed, all 64 requests were recorded, and the run reported zero
 interruptions, target failures, unsupported draws, or backend failures. The
 result count remained one while gameplay continued. Native and Xenos artifacts
 were both 56,950,304 bytes and byte-identical at SHA-256
 `A6AA07AC55B4A4851D4636F18D5148C1A52EDD8F2D44FB00CE34DC4F48284DCD`.
 Request and batch accounting were complete, Xenos remained authoritative with
 suppression disabled, and the process exited normally.
+
+The full-epoch Release/AppData qualification
+(`20260830T145725Z-p34560`) reached live festival gameplay and recorded one
+complete 80-draw epoch: 64 primary, 12 secondary, and four tertiary draws. All
+80 requests were recorded with zero interruptions, unsupported draws, target
+creation failures, or backend-failed batches. Native and Xenos D24S8 artifacts
+were both 56,950,304 bytes and byte-identical at SHA-256
+`B612D06B2599FC84441256DFC08552AFEF2865AD6A58A81AF2A3916E6FE9D128`.
+Request and batch accounting were complete, the process exited normally, Xenos
+remained authoritative, and native publication and suppression stayed closed.

--- a/docs/native-renderer/SHADOW_REFLECTION_PASS_CENSUS.md
+++ b/docs/native-renderer/SHADOW_REFLECTION_PASS_CENSUS.md
@@ -154,8 +154,10 @@ the authoritative Xenos draw. It does not yet allocate or publish a native
 atlas.
 
 The next bounded follow-up is documented in
-`SHADOW_DEPTH_BATCH_REPLAY.md`. The capture proves that all 64 draws in the
-dominant family are consecutive with no intervening authoritative draw, so the
-private path may seed once and reuse its depth-only target for exactly that
-run. Gaps, frame changes, target mismatches, and backend failures remain
-fail-closed; Xenos stays authoritative.
+`SHADOW_DEPTH_BATCH_REPLAY.md`. The capture proves that all 80 promoted draws
+form one uninterrupted producer epoch: 64 dominant-family draws followed by an
+exact four-times repetition of three secondary-family draws and one
+tertiary-family draw. The private path may seed once and reuse its depth-only
+target for exactly that epoch. Gaps, frame changes, family/count reordering,
+target mismatches, and backend failures remain fail-closed; Xenos stays
+authoritative.

--- a/patches/rexglue/0091-d3d12-isolated-host-converted-index-buffer.patch
+++ b/patches/rexglue/0091-d3d12-isolated-host-converted-index-buffer.patch
@@ -1,0 +1,21 @@
+diff --git a/src/graphics/d3d12/command_processor.cpp b/src/graphics/d3d12/command_processor.cpp
+index fe6d269..b3449b8 100644
+--- a/src/graphics/d3d12/command_processor.cpp
++++ b/src/graphics/d3d12/command_processor.cpp
+@@ -3682,10 +3682,13 @@ bool D3D12CommandProcessor::IssueDraw(xenos::PrimitiveType primitive_type, uint3
+     SubmitBarriers();
+     if (isolated_draw_request.requested) {
+       system::GraphicsIsolatedDrawResult isolated_result;
++      const bool isolated_index_buffer_supported =
++          primitive_processing_result.index_buffer_type ==
++              PrimitiveProcessor::ProcessedIndexBufferType::kGuestDMA ||
++          primitive_processing_result.index_buffer_type ==
++              PrimitiveProcessor::ProcessedIndexBufferType::kHostConverted;
+       if (memexport_used || !host_render_targets_used ||
+-          !is_rasterization_done ||
+-          primitive_processing_result.index_buffer_type !=
+-              PrimitiveProcessor::ProcessedIndexBufferType::kGuestDMA) {
++          !is_rasterization_done || !isolated_index_buffer_supported) {
+         isolated_result.status =
+             system::GraphicsIsolatedDrawStatus::kUnsupportedState;
+       } else if ((!isolated_draw_request.reuse_target &&

--- a/src/native_renderer/graphics_hooks.cpp
+++ b/src/native_renderer/graphics_hooks.cpp
@@ -152,10 +152,26 @@ constexpr uint32_t kResourceBindingKeyCacheAddress = 0x834AD4CC;
 constexpr uint64_t kSkyHorizonAnchorSignature = UINT64_C(0x747837906D0BF484);
 constexpr uint64_t kSkyHorizonFollowerSignature = UINT64_C(0x1D253A52B55C9FB3);
 constexpr uint64_t kShadowDepthVertexShader = UINT64_C(0x4E1DA281CC3D7EDB);
+constexpr uint64_t kShadowDepthSecondaryVertexShader =
+    UINT64_C(0xCDDB454589126317);
+constexpr uint64_t kShadowDepthTertiaryVertexShader =
+    UINT64_C(0x68DF329C66481843);
 constexpr uint32_t kShadowDepthLogicalWidth = 2048;
 constexpr uint32_t kShadowDepthLogicalHeight = 2048;
-constexpr uint32_t kShadowDepthBatchDrawCount = 64;
+constexpr uint32_t kShadowDepthPrimaryDrawCount = 64;
+constexpr uint32_t kShadowDepthSecondaryDrawCount = 12;
+constexpr uint32_t kShadowDepthTertiaryDrawCount = 4;
+constexpr uint32_t kShadowDepthBatchDrawCount =
+    kShadowDepthPrimaryDrawCount + kShadowDepthSecondaryDrawCount +
+    kShadowDepthTertiaryDrawCount;
 std::atomic<uint64_t> g_frame_sequence{};
+
+enum class ShadowDepthBatchFamily : uint32_t {
+  kNone = 0,
+  kPrimary = 1,
+  kSecondary = 2,
+  kTertiary = 3,
+};
 
 enum class DispatchWrapper : uint32_t {
   kDrawIndexed = 1,
@@ -5700,6 +5716,8 @@ struct IsolatedDrawState {
   bool prepared_candidate_valid = false;
   bool prepared_candidate_eligible = false;
   bool prepared_shadow_depth_batch_member = false;
+  ShadowDepthBatchFamily prepared_shadow_depth_batch_family =
+      ShadowDepthBatchFamily::kNone;
   bool prepared_visibility_candidate_fresh = false;
   bool prepared_title_lod_valid = false;
   bool require_fresh_visibility_candidate = false;
@@ -5712,6 +5730,9 @@ struct IsolatedDrawState {
   uint64_t shadow_depth_contract_rejections = 0;
   uint64_t shadow_depth_batch_member_matches = 0;
   uint64_t shadow_depth_batch_member_rejections = 0;
+  uint64_t shadow_depth_batch_primary_matches = 0;
+  uint64_t shadow_depth_batch_secondary_matches = 0;
+  uint64_t shadow_depth_batch_tertiary_matches = 0;
   uint64_t shadow_depth_batch_frame = UINT64_MAX;
   uint64_t shadow_depth_batch_last_draw = 0;
   uint64_t shadow_depth_batch_last_completed_frame = UINT64_MAX;
@@ -5727,6 +5748,8 @@ struct IsolatedDrawState {
   bool shadow_depth_batch_active = false;
   bool shadow_depth_batch_backend_ready = false;
   bool shadow_depth_batch_capture_completed = false;
+  bool shadow_depth_secondary_rejection_reported = false;
+  bool shadow_depth_tertiary_rejection_reported = false;
   bool visibility_wait_reported = false;
   bool title_lod_wait_reported = false;
   bool awaiting_pass_follower = false;
@@ -11850,7 +11873,7 @@ bool IsIsolatedDrawEligible(
       observation, samples_resolved_target, prepared);
 }
 
-bool IsShadowDepthBatchMemberDraw(
+bool IsShadowDepthBatchMechanicalDraw(
     const rex::system::GraphicsDrawObservation &observation,
     bool samples_resolved_target,
     const rex::system::GraphicsPreparedDrawObservation &prepared) {
@@ -11861,8 +11884,6 @@ bool IsShadowDepthBatchMemberDraw(
          observation.source_select ==
              uint32_t(rex::graphics::xenos::SourceSelect::kDMA) &&
          observation.primitive_type == 6 && observation.index_count != 0 &&
-         observation.index_format == 0 && observation.index_endianness == 1 &&
-         observation.vertex_binding_count == 3 &&
          !observation.vertex_binding_overflow &&
          !observation.vertex_attribute_overflow &&
          !observation.vertex_float_constant_overflow &&
@@ -11878,21 +11899,86 @@ bool IsShadowDepthBatchMemberDraw(
          observation.rb_depthcontrol == 0x00700736 &&
          observation.pa_su_sc_mode_cntl == 0x00219800 &&
          observation.pa_su_vtx_cntl == 4 &&
-         observation.vertex_shader_hash == kShadowDepthVertexShader &&
          prepared.guest_primitive_type == 6 &&
-         prepared.index_buffer_type == 1 &&
          prepared.normalized_color_mask == 0 &&
          prepared.bound_render_target_bits == 1 &&
          prepared.bound_render_target_formats[0] == 0 &&
          (prepared.flags & 3) == 3;
 }
 
+ShadowDepthBatchFamily ClassifyShadowDepthBatchMemberDraw(
+    const rex::system::GraphicsDrawObservation &observation,
+    bool samples_resolved_target,
+    const rex::system::GraphicsPreparedDrawObservation &prepared) {
+  if (!IsShadowDepthBatchMechanicalDraw(observation, samples_resolved_target,
+                                        prepared)) {
+    return ShadowDepthBatchFamily::kNone;
+  }
+  const bool primary_index_layout =
+      observation.index_format == 0 && observation.index_endianness == 1 &&
+      observation.vertex_binding_count == 3 &&
+      prepared.index_buffer_type == 1;
+  if (observation.vertex_shader_hash == kShadowDepthVertexShader &&
+      primary_index_layout) {
+    return ShadowDepthBatchFamily::kPrimary;
+  }
+  const bool tail_index_layout =
+      observation.index_format == 1 && observation.index_endianness == 2 &&
+      observation.vertex_binding_count == 1 &&
+      prepared.index_buffer_type == 2;
+  const bool exact_prepared_shader =
+      prepared.vertex_shader_hash == observation.vertex_shader_hash &&
+      prepared.pixel_shader_hash == 0 &&
+      prepared.vertex_specialization_mask == 0 &&
+      prepared.pixel_specialization_mask == 0;
+  if (!tail_index_layout || !exact_prepared_shader) {
+    return ShadowDepthBatchFamily::kNone;
+  }
+  if (observation.vertex_shader_hash == kShadowDepthSecondaryVertexShader &&
+      (observation.index_count == 1474 || observation.index_count == 506 ||
+       observation.index_count == 3223)) {
+    return ShadowDepthBatchFamily::kSecondary;
+  }
+  if (observation.vertex_shader_hash == kShadowDepthTertiaryVertexShader &&
+      observation.index_count == 703) {
+    return ShadowDepthBatchFamily::kTertiary;
+  }
+  return ShadowDepthBatchFamily::kNone;
+}
+
+bool IsExpectedShadowDepthBatchMember(ShadowDepthBatchFamily family,
+                                      uint32_t index_count,
+                                      uint32_t draw_offset) {
+  if (draw_offset < kShadowDepthPrimaryDrawCount) {
+    return family == ShadowDepthBatchFamily::kPrimary;
+  }
+  if (draw_offset >= kShadowDepthBatchDrawCount) {
+    return false;
+  }
+  switch ((draw_offset - kShadowDepthPrimaryDrawCount) % 4) {
+  case 0:
+    return family == ShadowDepthBatchFamily::kSecondary &&
+           index_count == 1474;
+  case 1:
+    return family == ShadowDepthBatchFamily::kSecondary &&
+           index_count == 506;
+  case 2:
+    return family == ShadowDepthBatchFamily::kSecondary &&
+           index_count == 3223;
+  case 3:
+    return family == ShadowDepthBatchFamily::kTertiary && index_count == 703;
+  default:
+    return false;
+  }
+}
+
 bool IsExactShadowDepthIsolatedDraw(
     const rex::system::GraphicsDrawObservation &observation,
     bool samples_resolved_target,
     const rex::system::GraphicsPreparedDrawObservation &prepared) {
-  return IsShadowDepthBatchMemberDraw(observation, samples_resolved_target,
-                                      prepared) &&
+  return ClassifyShadowDepthBatchMemberDraw(
+             observation, samples_resolved_target, prepared) ==
+             ShadowDepthBatchFamily::kPrimary &&
          observation.index_count == 881 &&
          prepared.vertex_shader_hash == kShadowDepthVertexShader &&
          prepared.pixel_shader_hash == 0 &&
@@ -14301,6 +14387,8 @@ void ObservePreparedDraw(
     const rex::system::GraphicsPreparedDrawObservation &observation) {
   g_isolated_draw.prepared_candidate_valid = false;
   g_isolated_draw.prepared_shadow_depth_batch_member = false;
+  g_isolated_draw.prepared_shadow_depth_batch_family =
+      ShadowDepthBatchFamily::kNone;
   g_consumer_family_marker.current_match = false;
   if (!g_pending_candidate.valid) {
     ++g_candidate_prepared_without_observation_count;
@@ -14333,14 +14421,117 @@ void ObservePreparedDraw(
                   sample, g_pending_candidate.samples_resolved_target,
                   observation);
     if (g_isolated_draw.shadow_depth_batch_mode) {
-      g_isolated_draw.prepared_shadow_depth_batch_member =
-          IsShadowDepthBatchMemberDraw(
+      g_isolated_draw.prepared_shadow_depth_batch_family =
+          ClassifyShadowDepthBatchMemberDraw(
               sample, g_pending_candidate.samples_resolved_target,
               observation);
+      g_isolated_draw.prepared_shadow_depth_batch_member =
+          g_isolated_draw.prepared_shadow_depth_batch_family !=
+          ShadowDepthBatchFamily::kNone;
       if (g_isolated_draw.prepared_shadow_depth_batch_member) {
         ++g_isolated_draw.shadow_depth_batch_member_matches;
-      } else if (observation.vertex_shader_hash == kShadowDepthVertexShader) {
+        switch (g_isolated_draw.prepared_shadow_depth_batch_family) {
+        case ShadowDepthBatchFamily::kPrimary:
+          ++g_isolated_draw.shadow_depth_batch_primary_matches;
+          break;
+        case ShadowDepthBatchFamily::kSecondary:
+          ++g_isolated_draw.shadow_depth_batch_secondary_matches;
+          break;
+        case ShadowDepthBatchFamily::kTertiary:
+          ++g_isolated_draw.shadow_depth_batch_tertiary_matches;
+          break;
+        case ShadowDepthBatchFamily::kNone:
+          break;
+        }
+      } else if (observation.vertex_shader_hash == kShadowDepthVertexShader ||
+                 observation.vertex_shader_hash ==
+                     kShadowDepthSecondaryVertexShader ||
+                 observation.vertex_shader_hash ==
+                     kShadowDepthTertiaryVertexShader) {
         ++g_isolated_draw.shadow_depth_batch_member_rejections;
+        bool *rejection_reported = nullptr;
+        const char *family = "primary";
+        if (observation.vertex_shader_hash ==
+            kShadowDepthSecondaryVertexShader) {
+          rejection_reported =
+              &g_isolated_draw.shadow_depth_secondary_rejection_reported;
+          family = "secondary";
+        } else if (observation.vertex_shader_hash ==
+                   kShadowDepthTertiaryVertexShader) {
+          rejection_reported =
+              &g_isolated_draw.shadow_depth_tertiary_rejection_reported;
+          family = "tertiary";
+        }
+        if (rejection_reported && !*rejection_reported) {
+          *rejection_reported = true;
+          pinyon_shift::diagnostics::RecordEvent(
+              "native_renderer.shadow_depth_batch.member_rejection",
+              {{"family", family},
+               {"vertex_shader",
+                fmt::format("{:016X}", observation.vertex_shader_hash)},
+               {"samples_resolved_target",
+                g_pending_candidate.samples_resolved_target ? "true"
+                                                            : "false"},
+               {"indexed", sample.indexed ? "true" : "false"},
+               {"source_select", std::to_string(sample.source_select)},
+               {"primitive_type", std::to_string(sample.primitive_type)},
+               {"index_count", std::to_string(sample.index_count)},
+               {"index_format", std::to_string(sample.index_format)},
+               {"index_endianness",
+                std::to_string(sample.index_endianness)},
+               {"vertex_binding_count",
+                std::to_string(sample.vertex_binding_count)},
+               {"vertex_binding_overflow",
+                sample.vertex_binding_overflow ? "true" : "false"},
+               {"vertex_attribute_overflow",
+                sample.vertex_attribute_overflow ? "true" : "false"},
+               {"vertex_float_constant_overflow",
+                sample.vertex_float_constant_overflow ? "true" : "false"},
+               {"pixel_float_constant_overflow",
+                sample.pixel_float_constant_overflow ? "true" : "false"},
+               {"texture_fetch_mask",
+                fmt::format("{:08X}", sample.texture_fetch_mask)},
+               {"texture_state_count",
+                std::to_string(sample.texture_state_count)},
+               {"surface_info", fmt::format("{:08X}", sample.surface_info)},
+               {"depth_info", fmt::format("{:08X}", sample.depth_info)},
+               {"window_scissor_tl",
+                fmt::format("{:08X}", sample.window_scissor_tl)},
+               {"window_scissor_br",
+                fmt::format("{:08X}", sample.window_scissor_br)},
+               {"rb_color_mask",
+                fmt::format("{:08X}", sample.rb_color_mask)},
+               {"rb_depthcontrol",
+                fmt::format("{:08X}", sample.rb_depthcontrol)},
+               {"pa_su_sc_mode_cntl",
+                fmt::format("{:08X}", sample.pa_su_sc_mode_cntl)},
+               {"pa_su_vtx_cntl",
+                fmt::format("{:08X}", sample.pa_su_vtx_cntl)},
+               {"prepared_vertex_shader",
+                fmt::format("{:016X}", observation.vertex_shader_hash)},
+               {"prepared_pixel_shader",
+                fmt::format("{:016X}", observation.pixel_shader_hash)},
+               {"vertex_specialization_mask",
+                fmt::format("{:016X}",
+                            observation.vertex_specialization_mask)},
+               {"pixel_specialization_mask",
+                fmt::format("{:016X}",
+                            observation.pixel_specialization_mask)},
+               {"guest_primitive_type",
+                std::to_string(observation.guest_primitive_type)},
+               {"index_buffer_type",
+                std::to_string(observation.index_buffer_type)},
+               {"normalized_color_mask",
+                fmt::format("{:08X}", observation.normalized_color_mask)},
+               {"bound_render_target_bits",
+                fmt::format("{:08X}", observation.bound_render_target_bits)},
+               {"depth_format",
+                std::to_string(observation.bound_render_target_formats[0])},
+               {"prepared_flags", fmt::format("{:08X}", observation.flags)},
+               {"native_publication", "false"},
+               {"xenos_draw", "preserved"},
+               {"suppression_eligible", "false"}});
+        }
       }
     }
     if (g_isolated_draw.shadow_depth_mode ||
@@ -15474,9 +15665,14 @@ void CompleteIsolatedShadowDepthBatch(
   g_isolated_draw.shadow_depth_batch_active = false;
   pinyon_shift::diagnostics::RecordEvent(
       "native_renderer.shadow_depth_batch.result",
-      {{"status", recorded ? "recorded_seed_plus_63_draw_batch"
+      {{"status", recorded ? "recorded_full_80_draw_atlas_epoch"
                              : "failed_closed"},
-       {"vertex_shader", fmt::format("{:016X}", kShadowDepthVertexShader)},
+       {"primary_vertex_shader",
+        fmt::format("{:016X}", kShadowDepthVertexShader)},
+       {"secondary_vertex_shader",
+        fmt::format("{:016X}", kShadowDepthSecondaryVertexShader)},
+       {"tertiary_vertex_shader",
+        fmt::format("{:016X}", kShadowDepthTertiaryVertexShader)},
        {"frame", std::to_string(g_isolated_draw.shadow_depth_batch_frame)},
        {"first_draw",
         std::to_string(g_isolated_draw.shadow_depth_batch_last_draw -
@@ -15484,6 +15680,12 @@ void CompleteIsolatedShadowDepthBatch(
        {"last_draw",
         std::to_string(g_isolated_draw.shadow_depth_batch_last_draw)},
        {"draw_count", std::to_string(kShadowDepthBatchDrawCount)},
+       {"primary_draw_count",
+        std::to_string(kShadowDepthPrimaryDrawCount)},
+       {"secondary_draw_count",
+        std::to_string(kShadowDepthSecondaryDrawCount)},
+       {"tertiary_draw_count",
+        std::to_string(kShadowDepthTertiaryDrawCount)},
        {"logical_width", std::to_string(kShadowDepthLogicalWidth)},
        {"logical_height", std::to_string(kShadowDepthLogicalHeight)},
        {"allocation_width", std::to_string(result.target_width)},
@@ -15926,10 +16128,19 @@ void RequestIsolatedDraw(
     const bool exact_seed = g_isolated_draw.prepared_candidate_eligible;
     const bool batch_member =
         g_isolated_draw.prepared_shadow_depth_batch_member;
+    const ShadowDepthBatchFamily batch_family =
+        g_isolated_draw.prepared_shadow_depth_batch_family;
+    bool expected_member =
+        batch_member && IsExpectedShadowDepthBatchMember(
+                            batch_family,
+                            g_isolated_draw.prepared_sample.index_count,
+                            g_isolated_draw.shadow_depth_batch_active
+                                ? g_isolated_draw.shadow_depth_batch_draws
+                                : 0);
     if (g_isolated_draw.shadow_depth_batch_active) {
       const bool contiguous =
-          batch_member && g_isolated_draw.frame ==
-                              g_isolated_draw.shadow_depth_batch_frame &&
+          expected_member && g_isolated_draw.frame ==
+                                 g_isolated_draw.shadow_depth_batch_frame &&
           g_isolated_draw.draw ==
               g_isolated_draw.shadow_depth_batch_last_draw + 1 &&
           g_isolated_draw.shadow_depth_batch_backend_ready;
@@ -15943,7 +16154,13 @@ void RequestIsolatedDraw(
     if (!g_isolated_draw.shadow_depth_batch_active && !exact_seed) {
       return;
     }
-    if (!batch_member) {
+    if (!g_isolated_draw.shadow_depth_batch_active) {
+      expected_member =
+          batch_member && IsExpectedShadowDepthBatchMember(
+                              batch_family,
+                              g_isolated_draw.prepared_sample.index_count, 0);
+    }
+    if (!expected_member) {
       return;
     }
     if (g_isolated_draw.shadow_depth_batch_last_completed_frame ==
@@ -18558,7 +18775,7 @@ void InstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system,
             ? fmt::format("{:016X}", g_pass_follower.target_signature)
             : ""},
        {"mode", g_isolated_draw.shadow_depth_batch_mode
-                    ? "exact_shadow_depth_64_draw_batch"
+                    ? "exact_shadow_depth_80_draw_atlas_epoch"
                     : (g_isolated_draw.shadow_depth_mode
                            ? "exact_shadow_depth_single_draw"
                            : (g_pass_follower.valid && g_pass_follower.requested
@@ -18567,7 +18784,7 @@ void InstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system,
        {"native_draw", "isolated_only"},
        {"continuous_shadow_replay",
          g_isolated_draw.shadow_depth_batch_mode
-             ? "one_shot_seed_plus_63_draw_batch"
+             ? "one_shot_full_80_draw_atlas_epoch"
              : (g_isolated_draw.shadow_depth_mode
              ? "disabled"
              : (g_pass_follower.valid && g_pass_follower.requested
@@ -19211,10 +19428,24 @@ void UninstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system) {
          {"vertex_shader", fmt::format("{:016X}", kShadowDepthVertexShader)},
          {"expected_draws_per_batch",
           std::to_string(kShadowDepthBatchDrawCount)},
+         {"expected_primary_draws",
+          std::to_string(kShadowDepthPrimaryDrawCount)},
+         {"expected_secondary_draws",
+          std::to_string(kShadowDepthSecondaryDrawCount)},
+         {"expected_tertiary_draws",
+          std::to_string(kShadowDepthTertiaryDrawCount)},
          {"contract_matches",
           std::to_string(g_isolated_draw.shadow_depth_contract_matches)},
          {"contract_rejections",
           std::to_string(g_isolated_draw.shadow_depth_contract_rejections)},
+         {"primary_member_matches",
+          std::to_string(g_isolated_draw.shadow_depth_batch_primary_matches)},
+         {"secondary_member_matches",
+          std::to_string(
+              g_isolated_draw.shadow_depth_batch_secondary_matches)},
+         {"tertiary_member_matches",
+          std::to_string(
+              g_isolated_draw.shadow_depth_batch_tertiary_matches)},
          {"batches_started",
           std::to_string(g_isolated_draw.shadow_depth_batches_started)},
          {"batches_completed",

--- a/tools/tests/test_native_renderer_contract.py
+++ b/tools/tests/test_native_renderer_contract.py
@@ -1568,6 +1568,13 @@ class NativeRendererContractTests(unittest.TestCase):
         self.assertIn('"native_upload", "false"', scanner)
         self.assertIn('"native_draw", "false"', scanner)
         self.assertIn('"suppression_eligible", "false"', scanner)
+        replay_patch = (
+            ROOT
+            / "patches/rexglue/0091-d3d12-isolated-host-converted-index-buffer.patch"
+        ).read_text(encoding="utf-8")
+        self.assertIn("isolated_index_buffer_supported", replay_patch)
+        self.assertIn("ProcessedIndexBufferType::kGuestDMA", replay_patch)
+        self.assertIn("ProcessedIndexBufferType::kHostConverted", replay_patch)
         self.assertNotIn("SetDrawSuppression", scanner)
         self.assertIn("PINYON_SHIFT_NATIVE_RENDERER_PASS_ANCHOR_SIGNATURE", scanner)
         self.assertIn('"native_renderer.census.pass_follower"', scanner)
@@ -1969,18 +1976,30 @@ class NativeRendererContractTests(unittest.TestCase):
             encoding="utf-8"
         )
         self.assertIn("PINYON_SHIFT_NATIVE_RENDERER_SHADOW_DEPTH_BATCH", scanner)
-        self.assertIn("kShadowDepthBatchDrawCount = 64", scanner)
-        self.assertIn("IsShadowDepthBatchMemberDraw", scanner)
+        self.assertIn("kShadowDepthPrimaryDrawCount = 64", scanner)
+        self.assertIn("kShadowDepthSecondaryDrawCount = 12", scanner)
+        self.assertIn("kShadowDepthTertiaryDrawCount = 4", scanner)
+        self.assertIn("ClassifyShadowDepthBatchMemberDraw", scanner)
+        self.assertIn("IsExpectedShadowDepthBatchMember", scanner)
+        self.assertIn("kShadowDepthSecondaryVertexShader", scanner)
+        self.assertIn("kShadowDepthTertiaryVertexShader", scanner)
+        self.assertIn("observation.index_count == 1474", scanner)
+        self.assertIn("observation.index_count == 506", scanner)
+        self.assertIn("observation.index_count == 3223", scanner)
+        self.assertIn("observation.index_count == 703", scanner)
         self.assertIn("prepared_shadow_depth_batch_member", scanner)
         self.assertIn(
             "if (g_isolated_draw.shadow_depth_batch_capture_completed)", scanner
         )
-        self.assertIn('"one_shot_seed_plus_63_draw_batch"', scanner)
+        self.assertIn('"one_shot_full_80_draw_atlas_epoch"', scanner)
         self.assertIn("!exact_seed", scanner)
         self.assertIn("shadow_depth_batch_last_draw + 1", scanner)
         self.assertIn("request.reuse_target =", scanner)
         self.assertIn('"native_renderer.shadow_depth_batch.result"', scanner)
-        self.assertIn('"recorded_seed_plus_63_draw_batch"', scanner)
+        self.assertIn('"recorded_full_80_draw_atlas_epoch"', scanner)
+        self.assertIn(
+            '"native_renderer.shadow_depth_batch.member_rejection"', scanner
+        )
         self.assertIn('"native_publication", "false"', scanner)
         self.assertIn('"xenos_draw", "preserved"', scanner)
         self.assertIn('"suppression_eligible", "false"', scanner)

--- a/tools/tests/test_release_contract.py
+++ b/tools/tests/test_release_contract.py
@@ -43,10 +43,10 @@ class ReleaseContractTests(unittest.TestCase):
 
     def test_rexglue_patches_have_stable_order_and_no_binary_payload(self):
         patches = sorted((ROOT / "patches/rexglue").glob("*.patch"))
-        self.assertEqual(len(patches), 90)
+        self.assertEqual(len(patches), 91)
         self.assertEqual(
             patches[-1].name,
-            "0090-d3d12-reuse-depth-only-isolated-target.patch",
+            "0091-d3d12-isolated-host-converted-index-buffer.patch",
         )
         self.assertEqual(len(patches), len({path.name[:4] for path in patches}))
         for path in patches:


### PR DESCRIPTION
## Summary
- extend the private shadow replay from the 64-draw dominant family to the exact capture-proven 80-draw atlas epoch
- enforce the ordered 64/12/4 family contract with family-specific indexed layouts and bounded rejection diagnostics
- admit the tail's existing host-converted index buffer in isolated ReXGlue replay while keeping Xenos authoritative and publication/suppression disabled

## Validation
- python -m unittest discover -s tools/tests -p test_*.py (435 passed)
- Release build succeeded
- AppData runtime session 20260830T145725Z-p34560 exited normally
- one complete batch, 80/80 requests recorded, exact 64/12/4 family counts
- zero interruptions, unsupported draws, target failures, or backend-failed batches
- native/Xenos D24S8 readbacks both 56,950,304 bytes with SHA-256 B612D06B2599FC84441256DFC08552AFEF2865AD6A58A81AF2A3916E6FE9D128
- native publication false; Xenos draws preserved; suppression ineligible