### PR TITLE
feat(renderer): publish shadow depth into retained dump

### DIFF
--- a/docs/native-renderer/SHADOW_DEPTH_BATCH_REPLAY.md
+++ b/docs/native-renderer/SHADOW_DEPTH_BATCH_REPLAY.md
@@ -1,10 +1,10 @@
 # Bounded native shadow-atlas epoch replay
 
 This NR-05F checkpoint extends the exact private shadow-depth draw into one
-bounded, capture-proven 80-draw producer epoch. It does not publish a native
-atlas or alter the
-game-visible render graph. Every original Xenos draw still executes and remains
-authoritative.
+bounded, capture-proven 80-draw producer epoch and an independently gated
+depth-only publication experiment. Every original Xenos producer draw, the
+following render-target dump, and all later consumers still execute. No draw or
+resolve suppression is enabled.
 
 ## Capture-proven boundary
 
@@ -50,6 +50,35 @@ readbacks. Artifacts use `.depth.batch` and `.depth.batch.xenos` suffixes. The
 runtime reports draw, batch, interruption, backend-failure, and per-frame quota
 accounting at shutdown.
 
+## Compute handoff and publication boundary
+
+The payload-free compute-handoff report for `reference_frame8134.rdc` proves
+that event 1426 is the first consumer after the exact event-1417 producer
+epoch. Pipeline `RT Dump kD24S8 1xMSAA`, compute shader `{83b6d426}`, reads the
+same D24S8 resource through two image descriptors and writes the 40 MiB
+`EDRAM Buffer` through a read/write typed-buffer descriptor. Its dispatch is
+`52x128x1`. This is a render-target dump into emulated EDRAM, not a pixel
+consumer or a final scene-color sample.
+
+`-PublishShadowDepth` requests publication only on draw 80, after its
+authoritative Xenos draw has executed. ReXGlue revalidates the exact depth
+target key and complete D3D12 resource description, transitions only the depth
+resources, copies the accumulated private D24S8 target into the authoritative
+target, and restores both states before the retained Xenos dump runs. The
+depth-only path rejects every color attachment. A failed or incomplete copy
+leaves the authoritative Xenos content in place. Suppression is structurally
+disabled for this request.
+
+The metadata-only handoff can be reproduced without launching the game:
+
+```powershell
+.\tools\export-native-renderer-compute-handoff.ps1 `
+  -Capture .local\qualification\native-renderer-renderdoc-seeded\reference_frame8134.rdc `
+  -RenderDocRoot .local\tools\renderdoc-1.45\RenderDoc_1.45_64 `
+  -ResourceName 'RT @ 720t, <13t>, 1xMSAA, kD24S8' `
+  -Output .local\qualification\nr05f-compute-handoff.json
+```
+
 ## Qualification
 
 ```powershell
@@ -57,18 +86,34 @@ accounting at shutdown.
   -StateRoot "$env:LOCALAPPDATA\PinyonShift\source\0.1.0\.local\preview" `
   -Scene open_world_day `
   -ShadowDepthBatch `
+  -PublishShadowDepth `
   -IsolatedDrawDir .local\qualification\nr05f-shadow-depth-batch
 ```
 
-Required evidence is a
+The AppData qualification session `20260830T153020Z-p2564` completed normally
+with exit code 0. At frame 5456, draw 1038, the runtime published exactly one
+2080x5056 D24S8 private target, with `color=not_bound`, into the retained Xenos
+render-target dump. The completed batch contained all 80 draws (64 primary,
+12 secondary, and 4 tertiary), with zero interruptions, backend failures,
+unsupported requests, target-creation failures, or publication failures.
+Native and Xenos readbacks were both 56,950,304 bytes and had identical SHA-256
+`B1950219B977C3BAB75715ABEA5A9E7E70881082D6884429CA0DF82334FE5D64`.
+The session reported no error-like diagnostic events.
+
+For private replay alone, required evidence is a
 `native_renderer.shadow_depth_batch.result` event with
 `status=recorded_full_80_draw_atlas_epoch`, byte-identical native and Xenos batch
-artifacts, and complete request and batch accounting. Every event must retain
-`native_publication=false`, `xenos_draw=preserved`,
-`output_authority=xenos`, and `suppression_eligible=false`.
+artifacts, and complete request and batch accounting. Publication qualification
+additionally requires exactly one
+`native_renderer.shadow_depth_batch.publication` event with
+`status=published_depth_stencil`, `color=not_bound`,
+`consumer_handoff=xenos_rt_dump_retained`, and no publication failure. Every
+event must retain `xenos_producer_draws=preserved`,
+`xenos_draw_suppression=false`, `resolve_suppression=false`, and
+`suppression_eligible=false`.
 
-Complete atlas ownership, consumer binding, publication, and suppression remain
-closed.
+Continuous atlas ownership and suppression remain closed. This mode qualifies
+only a one-shot native producer-to-Xenos-dump handoff.
 
 The first AppData qualification attempt (`20260830T140611Z-p3944`) proved why
 the seed and follower contracts must be separate: 8,252 exact seeds were

--- a/docs/native-renderer/SHADOW_REFLECTION_PASS_CENSUS.md
+++ b/docs/native-renderer/SHADOW_REFLECTION_PASS_CENSUS.md
@@ -56,6 +56,14 @@ Promotion must retain per-item replay fallback, an independent feature gate,
 and guest-visible side effects. Native drawing, atlas allocation, reflection
 publication, and Xenos suppression remain out of scope for this census.
 
+The later compute-handoff export identifies the two compute consumers that were
+previously boundary-only events. Both use pipeline `RT Dump kD24S8 1xMSAA` and
+shader `{83b6d426}`, bind the selected D24S8 texture twice as read-only images,
+and write the 40 MiB `EDRAM Buffer`. Event 1426 (`52x128x1`) immediately follows
+the inspected 80-draw vehicle-shadow epoch. This proves the next ownership
+boundary is an EDRAM dump rather than a pixel depth-copy family; it does not by
+itself authorize publication or suppression.
+
 ## Initial open-world census
 
 The qualified `open_world_day` capture `reference_frame8134.rdc` (SHA-256

--- a/patches/rexglue/0092-d3d12-depth-only-isolated-publication.patch
+++ b/patches/rexglue/0092-d3d12-depth-only-isolated-publication.patch
@@ -1,0 +1,215 @@
+diff --git a/include/rex/graphics/d3d12/render_target_cache.h b/include/rex/graphics/d3d12/render_target_cache.h
+--- a/include/rex/graphics/d3d12/render_target_cache.h
++++ b/include/rex/graphics/d3d12/render_target_cache.h
+@@ -132,7 +132,8 @@ class D3D12RenderTargetCache final : public RenderTargetCache {
+       system::GraphicsIsolatedDrawReadbackCompletion completion,
+       uint32_t* failure_detail_out);
+   void EndIsolatedReplayTarget(uint64_t frame_sequence);
+-  system::GraphicsIsolatedDrawPublicationResult PublishIsolatedReplayTarget();
++  system::GraphicsIsolatedDrawPublicationResult PublishIsolatedReplayTarget(
++      bool depth_only_target = false);
+ 
+   struct IsolatedReplayPreviewSource {
+     ID3D12Resource* resource = nullptr;
+diff --git a/src/graphics/d3d12/command_processor.cpp b/src/graphics/d3d12/command_processor.cpp
+--- a/src/graphics/d3d12/command_processor.cpp
++++ b/src/graphics/d3d12/command_processor.cpp
+@@ -3425,6 +3425,7 @@ bool D3D12CommandProcessor::IssueDraw(xenos::PrimitiveType primitive_type, uint3
+     if (isolated_replay_recorded) {
+       isolated_publication =
+-          render_target_cache_->PublishIsolatedReplayTarget();
++          render_target_cache_->PublishIsolatedReplayTarget(
++              isolated_draw_request.depth_only_target);
+     }
+     isolated_publication.guest_draw_suppressed =
+         isolated_draw_request.suppress_guest_draw_if_published &&
+diff --git a/src/graphics/d3d12/render_target_cache.cpp b/src/graphics/d3d12/render_target_cache.cpp
+--- a/src/graphics/d3d12/render_target_cache.cpp
++++ b/src/graphics/d3d12/render_target_cache.cpp
+@@ -2449,31 +2449,34 @@ void D3D12RenderTargetCache::EndIsolatedReplayTarget(
+ }
+ 
+ system::GraphicsIsolatedDrawPublicationResult
+-D3D12RenderTargetCache::PublishIsolatedReplayTarget() {
++D3D12RenderTargetCache::PublishIsolatedReplayTarget(bool depth_only_target) {
+   system::GraphicsIsolatedDrawPublicationResult result;
+   if (GetPath() != Path::kHostRenderTargets) {
+     result.status = system::GraphicsIsolatedDrawPublicationStatus::kUnsupportedPath;
+     return result;
+   }
+-  if (!isolated_replay_depth_target_ || !isolated_replay_color_target_) {
++  if (!isolated_replay_depth_target_ ||
++      (!depth_only_target && !isolated_replay_color_target_)) {
+     result.status = system::GraphicsIsolatedDrawPublicationStatus::kUnavailable;
+     return result;
+   }
+ 
+   RenderTarget* const* guest_targets =
+       last_update_accumulated_render_targets();
+-  if (!guest_targets[0] || !guest_targets[1]) {
++  if (!guest_targets[0] || (!depth_only_target && !guest_targets[1])) {
+     result.status = system::GraphicsIsolatedDrawPublicationStatus::kUnavailable;
+     return result;
+   }
+-  for (uint32_t i = 2; i <= xenos::kMaxColorRenderTargets; ++i) {
++  for (uint32_t i = depth_only_target ? 1 : 2;
++       i <= xenos::kMaxColorRenderTargets; ++i) {
+     if (guest_targets[i]) {
+       result.status = system::GraphicsIsolatedDrawPublicationStatus::kTargetMismatch;
+       return result;
+     }
+   }
+   if (guest_targets[0]->key() != isolated_replay_depth_target_->key() ||
+-      guest_targets[1]->key() != isolated_replay_color_target_->key()) {
++      (!depth_only_target &&
++       guest_targets[1]->key() != isolated_replay_color_target_->key())) {
+     result.status = system::GraphicsIsolatedDrawPublicationStatus::kTargetMismatch;
+     return result;
+   }
+@@ -2480,18 +2483,24 @@ D3D12RenderTargetCache::PublishIsolatedReplayTarget() {
+ 
+   auto* guest_depth = static_cast<D3D12RenderTarget*>(guest_targets[0]);
+-  auto* guest_color = static_cast<D3D12RenderTarget*>(guest_targets[1]);
++  auto* guest_color = depth_only_target
++                          ? nullptr
++                          : static_cast<D3D12RenderTarget*>(guest_targets[1]);
+   auto* isolated_depth = static_cast<D3D12RenderTarget*>(
+       isolated_replay_depth_target_.get());
+-  auto* isolated_color = static_cast<D3D12RenderTarget*>(
+-      isolated_replay_color_target_.get());
++  auto* isolated_color =
++      depth_only_target
++          ? nullptr
++          : static_cast<D3D12RenderTarget*>(
++                isolated_replay_color_target_.get());
+   const D3D12_RESOURCE_DESC guest_depth_desc =
+       guest_depth->resource()->GetDesc();
+   const D3D12_RESOURCE_DESC guest_color_desc =
+-      guest_color->resource()->GetDesc();
++      guest_color ? guest_color->resource()->GetDesc() : D3D12_RESOURCE_DESC{};
+   const D3D12_RESOURCE_DESC isolated_depth_desc =
+       isolated_depth->resource()->GetDesc();
+   const D3D12_RESOURCE_DESC isolated_color_desc =
+-      isolated_color->resource()->GetDesc();
++      isolated_color ? isolated_color->resource()->GetDesc()
++                     : D3D12_RESOURCE_DESC{};
+   const auto matching_desc = [](const D3D12_RESOURCE_DESC& left,
+                                 const D3D12_RESOURCE_DESC& right) {
+     return left.Dimension == right.Dimension &&
+@@ -2504,8 +2513,10 @@ D3D12RenderTargetCache::PublishIsolatedReplayTarget() {
+            left.Layout == right.Layout && left.Flags == right.Flags;
+   };
+   if (!matching_desc(guest_depth_desc, isolated_depth_desc) ||
+-      !matching_desc(guest_color_desc, isolated_color_desc) ||
+-      guest_color_desc.Width > UINT32_MAX) {
++      (!depth_only_target &&
++       !matching_desc(guest_color_desc, isolated_color_desc)) ||
++      guest_depth_desc.Width > UINT32_MAX ||
++      (!depth_only_target && guest_color_desc.Width > UINT32_MAX)) {
+     result.status = system::GraphicsIsolatedDrawPublicationStatus::kTargetMismatch;
+     return result;
+   }
+@@ -2513,23 +2524,30 @@ D3D12RenderTargetCache::PublishIsolatedReplayTarget() {
+   const D3D12_RESOURCE_STATES guest_depth_state =
+       guest_depth->SetResourceState(D3D12_RESOURCE_STATE_COPY_DEST);
+   const D3D12_RESOURCE_STATES guest_color_state =
+-      guest_color->SetResourceState(D3D12_RESOURCE_STATE_COPY_DEST);
++      guest_color ? guest_color->SetResourceState(D3D12_RESOURCE_STATE_COPY_DEST)
++                  : D3D12_RESOURCE_STATE_COMMON;
+   const D3D12_RESOURCE_STATES isolated_depth_state =
+       isolated_depth->SetResourceState(D3D12_RESOURCE_STATE_COPY_SOURCE);
+   const D3D12_RESOURCE_STATES isolated_color_state =
+-      isolated_color->SetResourceState(D3D12_RESOURCE_STATE_COPY_SOURCE);
++      isolated_color
++          ? isolated_color->SetResourceState(D3D12_RESOURCE_STATE_COPY_SOURCE)
++          : D3D12_RESOURCE_STATE_COMMON;
+   command_processor_.PushTransitionBarrier(
+       guest_depth->resource(), guest_depth_state,
+       D3D12_RESOURCE_STATE_COPY_DEST);
+-  command_processor_.PushTransitionBarrier(
+-      guest_color->resource(), guest_color_state,
+-      D3D12_RESOURCE_STATE_COPY_DEST);
++  if (guest_color) {
++    command_processor_.PushTransitionBarrier(
++        guest_color->resource(), guest_color_state,
++        D3D12_RESOURCE_STATE_COPY_DEST);
++  }
+   command_processor_.PushTransitionBarrier(
+       isolated_depth->resource(), isolated_depth_state,
+       D3D12_RESOURCE_STATE_COPY_SOURCE);
+-  command_processor_.PushTransitionBarrier(
+-      isolated_color->resource(), isolated_color_state,
+-      D3D12_RESOURCE_STATE_COPY_SOURCE);
++  if (isolated_color) {
++    command_processor_.PushTransitionBarrier(
++        isolated_color->resource(), isolated_color_state,
++        D3D12_RESOURCE_STATE_COPY_SOURCE);
++  }
+   command_processor_.SubmitBarriers();
+ 
+   DeferredCommandList& command_list =
+@@ -2536,34 +2554,48 @@ D3D12RenderTargetCache::PublishIsolatedReplayTarget() {
+-  command_list.BeginDebugMarker(
+-      "PinyonShift NR-04D native retained-pass publication");
++  command_list.BeginDebugMarker(depth_only_target
++                                    ? "PinyonShift NR-05F native shadow-depth publication"
++                                    : "PinyonShift NR-04D native retained-pass publication");
+   command_list.D3DCopyResource(guest_depth->resource(),
+                                isolated_depth->resource());
+-  command_list.D3DCopyResource(guest_color->resource(),
+-                               isolated_color->resource());
++  if (guest_color && isolated_color) {
++    command_list.D3DCopyResource(guest_color->resource(),
++                                 isolated_color->resource());
++  }
+   command_list.EndDebugMarker();
+ 
+   guest_depth->SetResourceState(guest_depth_state);
+-  guest_color->SetResourceState(guest_color_state);
++  if (guest_color) {
++    guest_color->SetResourceState(guest_color_state);
++  }
+   isolated_depth->SetResourceState(isolated_depth_state);
+-  isolated_color->SetResourceState(isolated_color_state);
++  if (isolated_color) {
++    isolated_color->SetResourceState(isolated_color_state);
++  }
+   command_processor_.PushTransitionBarrier(
+       guest_depth->resource(), D3D12_RESOURCE_STATE_COPY_DEST,
+       guest_depth_state);
+-  command_processor_.PushTransitionBarrier(
+-      guest_color->resource(), D3D12_RESOURCE_STATE_COPY_DEST,
+-      guest_color_state);
++  if (guest_color) {
++    command_processor_.PushTransitionBarrier(
++        guest_color->resource(), D3D12_RESOURCE_STATE_COPY_DEST,
++        guest_color_state);
++  }
+   command_processor_.PushTransitionBarrier(
+       isolated_depth->resource(), D3D12_RESOURCE_STATE_COPY_SOURCE,
+       isolated_depth_state);
+-  command_processor_.PushTransitionBarrier(
+-      isolated_color->resource(), D3D12_RESOURCE_STATE_COPY_SOURCE,
+-      isolated_color_state);
++  if (isolated_color) {
++    command_processor_.PushTransitionBarrier(
++        isolated_color->resource(), D3D12_RESOURCE_STATE_COPY_SOURCE,
++        isolated_color_state);
++  }
+   command_processor_.SubmitBarriers();
+ 
+   result.status = system::GraphicsIsolatedDrawPublicationStatus::kPublished;
+-  result.target_width = uint32_t(guest_color_desc.Width);
+-  result.target_height = guest_color_desc.Height;
+-  result.sample_count = guest_color_desc.SampleDesc.Count;
+-  result.color_published = true;
++  result.target_width = uint32_t(depth_only_target ? guest_depth_desc.Width
++                                                   : guest_color_desc.Width);
++  result.target_height =
++      depth_only_target ? guest_depth_desc.Height : guest_color_desc.Height;
++  result.sample_count = depth_only_target ? guest_depth_desc.SampleDesc.Count
++                                          : guest_color_desc.SampleDesc.Count;
++  result.color_published = !depth_only_target;
+   result.depth_stencil_published = true;
+   return result;
+ }

--- a/src/native_renderer/graphics_hooks.cpp
+++ b/src/native_renderer/graphics_hooks.cpp
@@ -5726,6 +5726,7 @@ struct IsolatedDrawState {
   bool stencil_seed_probe_requested = false;
   bool shadow_depth_mode = false;
   bool shadow_depth_batch_mode = false;
+  bool shadow_depth_publication_mode = false;
   uint64_t shadow_depth_contract_matches = 0;
   uint64_t shadow_depth_contract_rejections = 0;
   uint64_t shadow_depth_batch_member_matches = 0;
@@ -5744,6 +5745,9 @@ struct IsolatedDrawState {
   uint64_t shadow_depth_batch_target_failures = 0;
   uint64_t shadow_depth_batch_unsupported = 0;
   uint64_t shadow_depth_batch_frame_quota_yields = 0;
+  uint64_t shadow_depth_publication_attempts = 0;
+  uint64_t shadow_depth_publications = 0;
+  uint64_t shadow_depth_publication_failures = 0;
   uint32_t shadow_depth_batch_draws = 0;
   bool shadow_depth_batch_active = false;
   bool shadow_depth_batch_backend_ready = false;
@@ -6245,6 +6249,22 @@ void ConfigureIsolatedDraw() {
     if (signature_requested) {
       g_isolated_draw.valid = false;
     }
+  }
+  value = nullptr;
+  length = 0;
+  if (_dupenv_s(&value, &length,
+                "PINYON_SHIFT_NATIVE_RENDERER_SHADOW_DEPTH_PUBLICATION") == 0 &&
+      value && length > 1) {
+    const std::string setting(value);
+    g_isolated_draw.shadow_depth_publication_mode = setting == "true";
+    if (setting != "true" && setting != "false") {
+      g_isolated_draw.valid = false;
+    }
+  }
+  std::free(value);
+  if (g_isolated_draw.shadow_depth_publication_mode &&
+      !g_isolated_draw.shadow_depth_batch_mode) {
+    g_isolated_draw.valid = false;
   }
   value = nullptr;
   length = 0;
@@ -15691,9 +15711,57 @@ void CompleteIsolatedShadowDepthBatch(
        {"allocation_width", std::to_string(result.target_width)},
        {"allocation_height", std::to_string(result.target_height)},
        {"private_depth_target", recorded ? "accumulated" : "unqualified"},
-       {"native_publication", "false"},
+       {"native_publication", g_isolated_draw.shadow_depth_publication_mode
+                                  ? "pending_after_authoritative_draw"
+                                  : "disabled"},
        {"xenos_draw", "preserved"},
        {"output_authority", "xenos"},
+       {"suppression_eligible", "false"}});
+}
+
+void CompleteIsolatedShadowDepthPublication(
+    const rex::system::GraphicsIsolatedDrawPublicationResult &result) {
+  ++g_isolated_draw.shadow_depth_publication_attempts;
+  const bool published =
+      result.status ==
+          rex::system::GraphicsIsolatedDrawPublicationStatus::kPublished &&
+      !result.color_published && result.depth_stencil_published &&
+      !result.guest_draw_suppressed;
+  if (published) {
+    ++g_isolated_draw.shadow_depth_publications;
+  } else {
+    ++g_isolated_draw.shadow_depth_publication_failures;
+  }
+  const char *status = "unavailable";
+  switch (result.status) {
+  case rex::system::GraphicsIsolatedDrawPublicationStatus::kPublished:
+    status = published ? "published_depth_stencil" : "incomplete";
+    break;
+  case rex::system::GraphicsIsolatedDrawPublicationStatus::kUnsupportedPath:
+    status = "unsupported_path";
+    break;
+  case rex::system::GraphicsIsolatedDrawPublicationStatus::kTargetMismatch:
+    status = "target_mismatch";
+    break;
+  case rex::system::GraphicsIsolatedDrawPublicationStatus::kUnavailable:
+    break;
+  }
+  pinyon_shift::diagnostics::RecordEvent(
+      "native_renderer.shadow_depth_batch.publication",
+      {{"status", status},
+       {"frame", std::to_string(g_isolated_draw.shadow_depth_batch_frame)},
+       {"draw", std::to_string(g_isolated_draw.shadow_depth_batch_last_draw)},
+       {"target_width", std::to_string(result.target_width)},
+       {"target_height", std::to_string(result.target_height)},
+       {"sample_count", std::to_string(result.sample_count)},
+       {"color", result.color_published ? "unexpected" : "not_bound"},
+       {"depth_stencil",
+        result.depth_stencil_published ? "published" : "preserved_xenos"},
+       {"consumer_handoff", "xenos_rt_dump_retained"},
+       {"xenos_producer_draws", "preserved"},
+       {"xenos_draw_suppression", "false"},
+       {"resolve_suppression", "false"},
+       {"fallback", published ? "not_needed" : "authoritative_xenos_content"},
        {"suppression_eligible", "false"}});
 }
 
@@ -16204,6 +16272,13 @@ void RequestIsolatedDraw(
     request.reference_depth_readback_completion =
         capture_batch ? &CompleteIsolatedReferenceShadowBatchDepthReadback
                       : nullptr;
+    request.publish_to_guest_requested =
+        completing_batch && g_isolated_draw.shadow_depth_publication_mode;
+    request.suppress_guest_draw_if_published = false;
+    request.publication_completion =
+        request.publish_to_guest_requested
+            ? &CompleteIsolatedShadowDepthPublication
+            : nullptr;
     return;
   }
   if (g_isolated_draw.shadow_depth_mode) {
@@ -19479,7 +19554,19 @@ void UninstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system) {
           g_isolated_draw.shadow_depth_batch_capture_completed
               ? "native_and_xenos_completed_batch"
               : "not_captured"},
-         {"native_publication", "false"},
+         {"native_publication",
+          g_isolated_draw.shadow_depth_publication_mode
+              ? (g_isolated_draw.shadow_depth_publications
+                     ? "published_private_depth_before_xenos_rt_dump"
+                     : "requested_but_not_published")
+              : "disabled"},
+         {"publication_attempts",
+          std::to_string(g_isolated_draw.shadow_depth_publication_attempts)},
+         {"publications",
+          std::to_string(g_isolated_draw.shadow_depth_publications)},
+         {"publication_failures",
+          std::to_string(g_isolated_draw.shadow_depth_publication_failures)},
+         {"consumer_handoff", "xenos_rt_dump_retained"},
          {"xenos_draw", "preserved"},
          {"output_authority", "xenos"},
          {"draw_suppression", "false"},

--- a/tools/capture-native-renderer-census.ps1
+++ b/tools/capture-native-renderer-census.ps1
@@ -18,6 +18,7 @@ param(
     [string]$IsolatedDrawDir,
     [switch]$ShadowDepthIsolated,
     [switch]$ShadowDepthBatch,
+    [switch]$PublishShadowDepth,
     [switch]$StencilSeedProbe,
     [switch]$RequireFreshVisibilityCandidate,
     [switch]$AutoSelectFreshVisibilityCandidate,
@@ -93,6 +94,9 @@ if ($ShadowDepthIsolated -and -not $IsolatedDrawDir) {
 }
 if ($ShadowDepthBatch -and -not $IsolatedDrawDir) {
     throw 'ShadowDepthBatch requires IsolatedDrawDir.'
+}
+if ($PublishShadowDepth -and -not $ShadowDepthBatch) {
+    throw 'PublishShadowDepth requires ShadowDepthBatch.'
 }
 if ($StencilSeedProbe -and -not $IsolatedDrawDir) {
     throw 'StencilSeedProbe requires IsolatedDrawDir.'
@@ -193,6 +197,8 @@ $savedIsolatedDraw = $env:PINYON_SHIFT_NATIVE_RENDERER_ISOLATED_DRAW_SIGNATURE
 $savedIsolatedDrawDir = $env:PINYON_SHIFT_NATIVE_RENDERER_ISOLATED_DRAW_DIR
 $savedShadowDepthIsolated = $env:PINYON_SHIFT_NATIVE_RENDERER_SHADOW_DEPTH_ISOLATED
 $savedShadowDepthBatch = $env:PINYON_SHIFT_NATIVE_RENDERER_SHADOW_DEPTH_BATCH
+$savedShadowDepthPublication =
+    $env:PINYON_SHIFT_NATIVE_RENDERER_SHADOW_DEPTH_PUBLICATION
 $savedStencilSeedProbe = $env:PINYON_SHIFT_NATIVE_RENDERER_STENCIL_SEED_PROBE
 $savedVisibilityGate = $env:PINYON_SHIFT_NATIVE_RENDERER_REQUIRE_FRESH_VISIBILITY_CANDIDATE
 $savedAutoVisibilityCandidate =
@@ -223,6 +229,8 @@ try {
         if ($ShadowDepthIsolated) { 'true' } else { $null }
     $env:PINYON_SHIFT_NATIVE_RENDERER_SHADOW_DEPTH_BATCH =
         if ($ShadowDepthBatch) { 'true' } else { $null }
+    $env:PINYON_SHIFT_NATIVE_RENDERER_SHADOW_DEPTH_PUBLICATION =
+        if ($PublishShadowDepth) { 'true' } else { $null }
     $env:PINYON_SHIFT_NATIVE_RENDERER_STENCIL_SEED_PROBE =
         if ($StencilSeedProbe) { 'true' } else { $null }
     $env:PINYON_SHIFT_NATIVE_RENDERER_REQUIRE_FRESH_VISIBILITY_CANDIDATE =
@@ -260,6 +268,8 @@ finally {
         $savedShadowDepthIsolated
     $env:PINYON_SHIFT_NATIVE_RENDERER_SHADOW_DEPTH_BATCH =
         $savedShadowDepthBatch
+    $env:PINYON_SHIFT_NATIVE_RENDERER_SHADOW_DEPTH_PUBLICATION =
+        $savedShadowDepthPublication
     $env:PINYON_SHIFT_NATIVE_RENDERER_STENCIL_SEED_PROBE = $savedStencilSeedProbe
     $env:PINYON_SHIFT_NATIVE_RENDERER_REQUIRE_FRESH_VISIBILITY_CANDIDATE =
         $savedVisibilityGate

--- a/tools/export-native-renderer-compute-handoff.ps1
+++ b/tools/export-native-renderer-compute-handoff.ps1
@@ -1,0 +1,69 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)]
+    [string]$Capture,
+    [Parameter(Mandatory)]
+    [string]$RenderDocRoot,
+    [Parameter(Mandatory)]
+    [ValidateNotNullOrEmpty()]
+    [string]$ResourceName,
+    [Parameter(Mandatory)]
+    [string]$Output
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
+$localRoot = [IO.Path]::GetFullPath((Join-Path $repoRoot '.local'))
+$localPrefix = $localRoot.TrimEnd([IO.Path]::DirectorySeparatorChar) +
+    [IO.Path]::DirectorySeparatorChar
+$resolvedCapture = (Resolve-Path -LiteralPath $Capture).Path
+$resolvedOutput = [IO.Path]::GetFullPath($Output)
+foreach ($item in @(
+        @{ Name = 'Capture'; Value = $resolvedCapture },
+        @{ Name = 'Output'; Value = $resolvedOutput }
+    )) {
+    if (-not $item.Value.StartsWith(
+            $localPrefix, [StringComparison]::OrdinalIgnoreCase)) {
+        throw "$($item.Name) must be below $localRoot"
+    }
+}
+if (Test-Path -LiteralPath $resolvedOutput) {
+    throw "Output already exists: $resolvedOutput"
+}
+
+$qrenderdoc = Join-Path ([IO.Path]::GetFullPath($RenderDocRoot)) 'qrenderdoc.exe'
+if (-not (Test-Path -LiteralPath $qrenderdoc -PathType Leaf)) {
+    throw "qrenderdoc.exe was not found below RenderDocRoot: $RenderDocRoot"
+}
+$signature = Get-AuthenticodeSignature -LiteralPath $qrenderdoc
+if ([string]$signature.Status -ne 'Valid') {
+    throw 'qrenderdoc.exe does not have a valid Authenticode signature'
+}
+
+$script = Join-Path $PSScriptRoot 'export-native-renderer-compute-handoff.py'
+$parent = Split-Path $resolvedOutput -Parent
+[void](New-Item -ItemType Directory -Path $parent -Force)
+$savedCapture = $env:PINYON_SHIFT_RENDERDOC_CAPTURE
+$savedResource = $env:PINYON_SHIFT_RENDERDOC_RESOURCE_NAME
+$savedOutput = $env:PINYON_SHIFT_RENDERDOC_COMPUTE_HANDOFF
+try {
+    $env:PINYON_SHIFT_RENDERDOC_CAPTURE = $resolvedCapture
+    $env:PINYON_SHIFT_RENDERDOC_RESOURCE_NAME = $ResourceName
+    $env:PINYON_SHIFT_RENDERDOC_COMPUTE_HANDOFF = $resolvedOutput
+    $process = Start-Process -FilePath $qrenderdoc `
+        -ArgumentList @('--python', $script) -PassThru -Wait
+    if ($process.ExitCode) {
+        throw "qrenderdoc compute handoff export exited with code $($process.ExitCode)"
+    }
+}
+finally {
+    $env:PINYON_SHIFT_RENDERDOC_CAPTURE = $savedCapture
+    $env:PINYON_SHIFT_RENDERDOC_RESOURCE_NAME = $savedResource
+    $env:PINYON_SHIFT_RENDERDOC_COMPUTE_HANDOFF = $savedOutput
+}
+if (-not (Test-Path -LiteralPath $resolvedOutput -PathType Leaf)) {
+    throw 'qrenderdoc exited without producing the compute handoff report.'
+}
+Get-Content -LiteralPath $resolvedOutput -Raw | ConvertFrom-Json

--- a/tools/export-native-renderer-compute-handoff.py
+++ b/tools/export-native-renderer-compute-handoff.py
@@ -1,0 +1,250 @@
+"""Export payload-free compute handoffs for one RenderDoc resource.
+
+Executed by qrenderdoc's bundled Python runtime. The report contains only
+action, pipeline, descriptor, and resource-description metadata. It never
+exports shader bytecode or resource payloads.
+"""
+
+import hashlib
+import json
+import os
+import sys
+
+import renderdoc as rd
+
+
+SCHEMA = "pinyon-shift.native-renderer-renderdoc-compute-handoff.v1"
+
+
+def flatten(actions):
+    result = []
+    for action in actions:
+        result.append(action)
+        result.extend(flatten(action.children))
+    return result
+
+
+def sha256(path):
+    digest = hashlib.sha256()
+    with open(path, "rb") as source:
+        for block in iter(lambda: source.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest().upper()
+
+
+def resource_id(value):
+    if value is None or value == rd.ResourceId.Null():
+        return None
+    return str(value)
+
+
+def describe_resource(identifier, resources, textures, buffers):
+    if identifier is None:
+        return None
+    result = {
+        "resource_id": identifier,
+        "resource_name": resources.get(identifier, ""),
+    }
+    texture = textures.get(identifier)
+    if texture is not None:
+        result.update(
+            {
+                "kind": "texture",
+                "width": texture.width,
+                "height": texture.height,
+                "depth": texture.depth,
+                "format": texture.format.Name(),
+                "mips": texture.mips,
+                "arraysize": texture.arraysize,
+                "ms_samp": texture.msSamp,
+            }
+        )
+    buffer = buffers.get(identifier)
+    if buffer is not None:
+        result.update({"kind": "buffer", "length": buffer.length})
+    if "kind" not in result:
+        result["kind"] = "other"
+    return result
+
+
+def describe_used_descriptor(used, resources, textures, buffers):
+    descriptor = used.descriptor
+    identifier = resource_id(descriptor.resource)
+    result = {
+        "access": {
+            "stage": str(used.access.stage),
+            "type": str(used.access.type),
+            "index": used.access.index,
+            "array_element": used.access.arrayElement,
+        },
+        "descriptor_type": str(descriptor.type),
+        "byte_range": {
+            "offset": descriptor.byteOffset,
+            "size": descriptor.byteSize,
+        },
+        "resource": describe_resource(identifier, resources, textures, buffers),
+    }
+    if identifier is not None:
+        result["subresource"] = {
+            "first_mip": descriptor.firstMip,
+            "num_mips": descriptor.numMips,
+            "first_slice": descriptor.firstSlice,
+            "num_slices": descriptor.numSlices,
+        }
+    return result
+
+
+def main():
+    capture_path = os.environ["PINYON_SHIFT_RENDERDOC_CAPTURE"]
+    resource_name = os.environ["PINYON_SHIFT_RENDERDOC_RESOURCE_NAME"]
+    report_path = os.environ["PINYON_SHIFT_RENDERDOC_COMPUTE_HANDOFF"]
+    capture = rd.OpenCaptureFile()
+    controller = None
+    try:
+        result = capture.OpenFile(capture_path, "", None)
+        if result != rd.ResultCode.Succeeded:
+            raise RuntimeError("could not open capture: {}".format(result))
+        if not capture.LocalReplaySupport():
+            raise RuntimeError("capture does not support local replay")
+        result, controller = capture.OpenCapture(rd.ReplayOptions(), None)
+        if result != rd.ResultCode.Succeeded:
+            raise RuntimeError("could not initialise replay: {}".format(result))
+
+        resource_list = controller.GetResources()
+        matches = [resource for resource in resource_list if resource.name == resource_name]
+        if len(matches) != 1:
+            raise RuntimeError(
+                "resource name matched {} resources: {}".format(
+                    len(matches), resource_name
+                )
+            )
+        target_id = matches[0].resourceId
+        target_identifier = str(target_id)
+        resources = {
+            str(resource.resourceId): resource.name for resource in resource_list
+        }
+        textures = {
+            str(texture.resourceId): texture for texture in controller.GetTextures()
+        }
+        buffers = {
+            str(buffer.resourceId): buffer for buffer in controller.GetBuffers()
+        }
+        actions = {
+            action.eventId: action
+            for action in flatten(controller.GetRootActions())
+        }
+        compute_events = sorted(
+            {
+                usage.eventId
+                for usage in controller.GetUsage(target_id)
+                if usage.usage.name == "CS_Resource"
+            }
+        )
+        handoffs = []
+        for event_id in compute_events:
+            action = actions.get(event_id)
+            if action is None or not action.flags & rd.ActionFlags.Dispatch:
+                raise RuntimeError(
+                    "compute resource use is not a dispatch action: {}".format(event_id)
+                )
+            controller.SetFrameEvent(event_id, True)
+            pipeline = controller.GetPipelineState()
+            reads = [
+                describe_used_descriptor(item, resources, textures, buffers)
+                for item in pipeline.GetReadOnlyResources(rd.ShaderStage.Compute, True)
+            ]
+            writes = [
+                describe_used_descriptor(item, resources, textures, buffers)
+                for item in pipeline.GetReadWriteResources(rd.ShaderStage.Compute, True)
+            ]
+            target_reads = [
+                item
+                for item in reads
+                if item["resource"] is not None
+                and item["resource"]["resource_id"] == target_identifier
+            ]
+            if not target_reads:
+                raise RuntimeError(
+                    "dispatch does not bind the selected resource: {}".format(event_id)
+                )
+            handoffs.append(
+                {
+                    "event_id": event_id,
+                    "action_name": action.customName,
+                    "dispatch": {
+                        "x": action.dispatchDimension[0],
+                        "y": action.dispatchDimension[1],
+                        "z": action.dispatchDimension[2],
+                    },
+                    "pipeline": describe_resource(
+                        resource_id(pipeline.GetComputePipelineObject()),
+                        resources,
+                        textures,
+                        buffers,
+                    ),
+                    "compute_shader": describe_resource(
+                        resource_id(pipeline.GetShader(rd.ShaderStage.Compute)),
+                        resources,
+                        textures,
+                        buffers,
+                    ),
+                    "selected_resource_reads": target_reads,
+                    "read_only_resources": reads,
+                    "read_write_resources": writes,
+                    "classification": {
+                        "semantic_role": "unknown_unclassified",
+                        "native_coverage": False,
+                        "publication_eligible": False,
+                        "suppression_eligible": False,
+                    },
+                }
+            )
+
+        report = {
+            "schema": SCHEMA,
+            "capture": {
+                "path": os.path.basename(capture_path),
+                "sha256": sha256(capture_path),
+            },
+            "selected_resource": describe_resource(
+                target_identifier, resources, textures, buffers
+            ),
+            "compute_handoffs": handoffs,
+            "totals": {
+                "compute_handoffs": len(handoffs),
+                "read_write_bindings": sum(
+                    len(item["read_write_resources"]) for item in handoffs
+                ),
+            },
+            "qualification": {
+                "compute_consumer_identity_complete": bool(handoffs),
+                "output_resource_lineage_complete": False,
+                "atlas_ownership_proved": False,
+                "publication_allowed": False,
+            },
+            "safety": {
+                "metadata_only": True,
+                "shader_payload_exported": False,
+                "resource_payload_exported": False,
+                "xenos_authority": True,
+                "suppression_allowed": False,
+            },
+        }
+        with open(report_path, "w") as output:
+            json.dump(report, output, indent=2, sort_keys=True)
+            output.write("\n")
+        print(report_path)
+        return 0
+    finally:
+        if controller is not None:
+            controller.Shutdown()
+        capture.Shutdown()
+
+
+try:
+    sys.exit(main())
+except Exception as error:
+    sys.stderr.write(
+        "native renderer compute handoff export failed: {}\n".format(error)
+    )
+    sys.exit(1)

--- a/tools/tests/test_native_renderer_shadow_depth_publication.py
+++ b/tools/tests/test_native_renderer_shadow_depth_publication.py
@@ -1,0 +1,51 @@
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+class ShadowDepthPublicationContractTests(unittest.TestCase):
+    def test_compute_handoff_export_is_payload_free_and_exact(self):
+        exporter = (
+            ROOT / "tools/export-native-renderer-compute-handoff.py"
+        ).read_text(encoding="utf-8")
+        wrapper = (
+            ROOT / "tools/export-native-renderer-compute-handoff.ps1"
+        ).read_text(encoding="utf-8")
+        self.assertIn("GetReadOnlyResources(rd.ShaderStage.Compute, True)", exporter)
+        self.assertIn("GetReadWriteResources(rd.ShaderStage.Compute, True)", exporter)
+        self.assertIn("descriptor.byteOffset", exporter)
+        self.assertIn('"resource_payload_exported": False', exporter)
+        self.assertIn('"shader_payload_exported": False', exporter)
+        self.assertIn('"publication_allowed": False', exporter)
+        self.assertIn("Get-AuthenticodeSignature", wrapper)
+        self.assertIn("must be below $localRoot", wrapper)
+
+    def test_depth_publication_keeps_every_xenos_stage(self):
+        hooks = (ROOT / "src/native_renderer/graphics_hooks.cpp").read_text(
+            encoding="utf-8"
+        )
+        patch = (
+            ROOT
+            / "patches/rexglue/0092-d3d12-depth-only-isolated-publication.patch"
+        ).read_text(encoding="utf-8")
+        capture = (
+            ROOT / "tools/capture-native-renderer-census.ps1"
+        ).read_text(encoding="utf-8")
+        self.assertIn(
+            "PINYON_SHIFT_NATIVE_RENDERER_SHADOW_DEPTH_PUBLICATION", hooks
+        )
+        self.assertIn("CompleteIsolatedShadowDepthPublication", hooks)
+        self.assertIn("request.suppress_guest_draw_if_published = false", hooks)
+        self.assertIn('"consumer_handoff", "xenos_rt_dump_retained"', hooks)
+        self.assertIn("bool depth_only_target = false", patch)
+        self.assertIn("!result.color_published", hooks)
+        self.assertNotIn("SetDrawSuppression", hooks + patch)
+        self.assertNotIn("SetCopySuppression", hooks + patch)
+        self.assertIn("[switch]$PublishShadowDepth", capture)
+        self.assertIn("PublishShadowDepth requires ShadowDepthBatch", capture)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/tests/test_release_contract.py
+++ b/tools/tests/test_release_contract.py
@@ -43,10 +43,10 @@ class ReleaseContractTests(unittest.TestCase):
 
     def test_rexglue_patches_have_stable_order_and_no_binary_payload(self):
         patches = sorted((ROOT / "patches/rexglue").glob("*.patch"))
-        self.assertEqual(len(patches), 91)
+        self.assertEqual(len(patches), 92)
         self.assertEqual(
             patches[-1].name,
-            "0091-d3d12-isolated-host-converted-index-buffer.patch",
+            "0092-d3d12-depth-only-isolated-publication.patch",
         )
         self.assertEqual(len(patches), len({path.name[:4] for path in patches}))
         for path in patches:


### PR DESCRIPTION
## Summary
- identify the first compute consumer after the exact 80-draw shadow epoch without exporting resource or shader payloads
- publish only the completed private D24S8 target before the retained Xenos render-target dump
- keep all Xenos producer draws, the dump, later consumers, and suppression paths active
- add the one-shot qualification switch, diagnostics, documentation, and safety-contract tests

## Validation
- full Python suite: 437/437 passed
- focused publication/release contracts: 22/22 passed
- clean build with all 92 ReXGlue patches
- incremental compatibility rebuild passed
- AppData session 20260830T153020Z-p2564 exited normally
- one 80-draw batch completed with exact 64/12/4 membership and zero failures
- native and Xenos 56,950,304-byte readbacks were SHA-256 identical