### PR TITLE
feat(renderer): publish bounded shadow atlas epochs

### DIFF
--- a/docs/native-renderer/SHADOW_DEPTH_BATCH_REPLAY.md
+++ b/docs/native-renderer/SHADOW_DEPTH_BATCH_REPLAY.md
@@ -115,6 +115,58 @@ event must retain `xenos_producer_draws=preserved`,
 Continuous atlas ownership and suppression remain closed. This mode qualifies
 only a one-shot native producer-to-Xenos-dump handoff.
 
+## Multi-epoch ownership experiment
+
+`-ContinuousShadowDepth` extends the admitted one-shot handoff across later
+exact 80-draw epochs. It requires both `-ShadowDepthBatch` and
+`-PublishShadowDepth`. The experiment is bounded to eight published epochs by
+default and accepts `-ContinuousShadowDepthEpochs` from 2 through 120. Only the
+first completed epoch requests native and Xenos readbacks; later epochs reuse
+the same private target path without producing additional artifacts.
+
+The experiment is fail-closed for the lifetime of the process. A non-contiguous
+epoch, backend replay failure, non-monotonic publication, or publication failure
+emits `native_renderer.shadow_depth_continuous.fail_closed` and permanently
+stops later native shadow requests. The current and every later Xenos producer,
+render-target dump, consumer, query, fence, and resolve remain active. Draw and
+resolve suppression are unavailable in this mode.
+
+```powershell
+.\tools\capture-native-renderer-census.ps1 `
+  -StateRoot "$env:LOCALAPPDATA\PinyonShift\source\0.1.0\.local\preview" `
+  -Scene open_world_day `
+  -ShadowDepthBatch `
+  -PublishShadowDepth `
+  -ContinuousShadowDepth `
+  -ContinuousShadowDepthEpochs 8 `
+  -IsolatedDrawDir .local\qualification\nr05f-shadow-depth-continuous
+```
+
+Qualification requires `status=bounded_multi_epoch_complete`, exactly the
+configured number of strictly increasing publication epochs, exact
+request/batch accounting, zero fail-closed events, and the same first-epoch
+native/Xenos byte parity as the one-shot mode. This proves hybrid multi-epoch
+ownership before any Xenos suppression; it does not yet prove an independently
+consumed native atlas.
+
+After shutdown, verify the session and paired first-epoch artifacts with:
+
+```powershell
+python .\tools\verify-native-renderer-shadow-depth-continuous.py `
+  --log <session.jsonl> `
+  --native-dir <output>.depth.batch `
+  --xenos-dir <output>.depth.batch.xenos `
+  --expected-epochs 8
+```
+
+The AppData qualification session `20260830T155030Z-p35164` completed normally
+with eight consecutive publications on frames 5268 through 5275. The verifier
+qualified all 640 requested and recorded draws, retained every Xenos stage,
+observed no fail-closed or suppression event, and proved byte-for-byte parity
+between the 56,950,304-byte native and Xenos payloads. Both payloads produced
+SHA-256
+`7F66FEA3EBAF1995C89339095185C0693A3C15F6A0BEDE0B72AFC79E6BC991E5`.
+
 The first AppData qualification attempt (`20260830T140611Z-p3944`) proved why
 the seed and follower contracts must be separate: 8,252 exact seeds were
 recorded successfully, every one was interrupted by the next family draw, and

--- a/src/native_renderer/graphics_hooks.cpp
+++ b/src/native_renderer/graphics_hooks.cpp
@@ -5727,6 +5727,9 @@ struct IsolatedDrawState {
   bool shadow_depth_mode = false;
   bool shadow_depth_batch_mode = false;
   bool shadow_depth_publication_mode = false;
+  bool shadow_depth_continuous_mode = false;
+  bool shadow_depth_continuous_failed_closed = false;
+  std::string shadow_depth_continuous_failure_reason;
   uint64_t shadow_depth_contract_matches = 0;
   uint64_t shadow_depth_contract_rejections = 0;
   uint64_t shadow_depth_batch_member_matches = 0;
@@ -5748,6 +5751,10 @@ struct IsolatedDrawState {
   uint64_t shadow_depth_publication_attempts = 0;
   uint64_t shadow_depth_publications = 0;
   uint64_t shadow_depth_publication_failures = 0;
+  uint64_t shadow_depth_continuous_last_publication_frame = UINT64_MAX;
+  uint64_t shadow_depth_continuous_publication_epochs = 0;
+  uint64_t shadow_depth_continuous_max_publication_epochs = 0;
+  uint64_t shadow_depth_continuous_epoch_limit = 0;
   uint32_t shadow_depth_batch_draws = 0;
   bool shadow_depth_batch_active = false;
   bool shadow_depth_batch_backend_ready = false;
@@ -6264,6 +6271,44 @@ void ConfigureIsolatedDraw() {
   std::free(value);
   if (g_isolated_draw.shadow_depth_publication_mode &&
       !g_isolated_draw.shadow_depth_batch_mode) {
+    g_isolated_draw.valid = false;
+  }
+  value = nullptr;
+  length = 0;
+  if (_dupenv_s(&value, &length,
+                "PINYON_SHIFT_NATIVE_RENDERER_SHADOW_DEPTH_CONTINUOUS") == 0 &&
+      value && length > 1) {
+    const std::string setting(value);
+    g_isolated_draw.shadow_depth_continuous_mode = setting == "true";
+    if (setting != "true" && setting != "false") {
+      g_isolated_draw.valid = false;
+    }
+  }
+  std::free(value);
+  if (g_isolated_draw.shadow_depth_continuous_mode &&
+      !g_isolated_draw.shadow_depth_publication_mode) {
+    g_isolated_draw.valid = false;
+  }
+  value = nullptr;
+  length = 0;
+  if (_dupenv_s(
+          &value, &length,
+          "PINYON_SHIFT_NATIVE_RENDERER_SHADOW_DEPTH_CONTINUOUS_EPOCH_LIMIT") ==
+          0 &&
+      value && length > 1) {
+    uint64_t epoch_limit = 0;
+    const char *end = value + std::strlen(value);
+    const auto parsed = std::from_chars(value, end, epoch_limit);
+    if (parsed.ec != std::errc{} || parsed.ptr != end || epoch_limit < 2 ||
+        epoch_limit > 120) {
+      g_isolated_draw.valid = false;
+    } else {
+      g_isolated_draw.shadow_depth_continuous_epoch_limit = epoch_limit;
+    }
+  }
+  std::free(value);
+  if (g_isolated_draw.shadow_depth_continuous_mode !=
+      (g_isolated_draw.shadow_depth_continuous_epoch_limit != 0)) {
     g_isolated_draw.valid = false;
   }
   value = nullptr;
@@ -15651,6 +15696,28 @@ void CompleteIsolatedShadowDepth(
        {"native_publication", "false"},
        {"xenos_draw", "preserved"},
        {"output_authority", "xenos"},
+        {"suppression_eligible", "false"}});
+}
+
+void FailClosedContinuousShadowDepth(const char *reason) {
+  if (!g_isolated_draw.shadow_depth_continuous_mode ||
+      g_isolated_draw.shadow_depth_continuous_failed_closed) {
+    return;
+  }
+  g_isolated_draw.shadow_depth_continuous_failed_closed = true;
+  g_isolated_draw.shadow_depth_continuous_failure_reason = reason;
+  pinyon_shift::diagnostics::RecordEvent(
+      "native_renderer.shadow_depth_continuous.fail_closed",
+      {{"reason", reason},
+       {"frame", std::to_string(g_isolated_draw.frame)},
+       {"draw", std::to_string(g_isolated_draw.draw)},
+       {"completed_publication_epochs",
+        std::to_string(
+            g_isolated_draw.shadow_depth_continuous_publication_epochs)},
+       {"fallback", "authoritative_xenos_content"},
+       {"xenos_draw", "preserved"},
+       {"draw_suppression", "false"},
+       {"resolve_suppression", "false"},
        {"suppression_eligible", "false"}});
 }
 
@@ -15671,6 +15738,7 @@ void CompleteIsolatedShadowDepthBatch(
   if (!recorded) {
     g_isolated_draw.shadow_depth_batch_active = false;
     g_isolated_draw.shadow_depth_batch_backend_ready = false;
+    FailClosedContinuousShadowDepth("backend_replay_failure");
   }
   if (g_isolated_draw.shadow_depth_batch_draws !=
       kShadowDepthBatchDrawCount) {
@@ -15714,6 +15782,9 @@ void CompleteIsolatedShadowDepthBatch(
        {"native_publication", g_isolated_draw.shadow_depth_publication_mode
                                   ? "pending_after_authoritative_draw"
                                   : "disabled"},
+       {"ownership_mode", g_isolated_draw.shadow_depth_continuous_mode
+                              ? "multi_epoch_fail_closed"
+                              : "one_shot_qualification"},
        {"xenos_draw", "preserved"},
        {"output_authority", "xenos"},
        {"suppression_eligible", "false"}});
@@ -15727,15 +15798,34 @@ void CompleteIsolatedShadowDepthPublication(
           rex::system::GraphicsIsolatedDrawPublicationStatus::kPublished &&
       !result.color_published && result.depth_stencil_published &&
       !result.guest_draw_suppressed;
-  if (published) {
+  const bool ordered_epoch =
+      g_isolated_draw.shadow_depth_continuous_last_publication_frame ==
+          UINT64_MAX ||
+      g_isolated_draw.shadow_depth_batch_frame >
+          g_isolated_draw.shadow_depth_continuous_last_publication_frame;
+  const bool qualified_publication = published && ordered_epoch;
+  if (qualified_publication) {
     ++g_isolated_draw.shadow_depth_publications;
+    if (g_isolated_draw.shadow_depth_continuous_mode) {
+      g_isolated_draw.shadow_depth_continuous_last_publication_frame =
+          g_isolated_draw.shadow_depth_batch_frame;
+      ++g_isolated_draw.shadow_depth_continuous_publication_epochs;
+      g_isolated_draw.shadow_depth_continuous_max_publication_epochs =
+          std::max(
+              g_isolated_draw.shadow_depth_continuous_max_publication_epochs,
+              g_isolated_draw.shadow_depth_continuous_publication_epochs);
+    }
   } else {
     ++g_isolated_draw.shadow_depth_publication_failures;
+    FailClosedContinuousShadowDepth(published ? "non_monotonic_epoch"
+                                              : "publication_failure");
   }
   const char *status = "unavailable";
   switch (result.status) {
   case rex::system::GraphicsIsolatedDrawPublicationStatus::kPublished:
-    status = published ? "published_depth_stencil" : "incomplete";
+    status = qualified_publication ? "published_depth_stencil"
+                                   : (published ? "non_monotonic_epoch"
+                                                : "incomplete");
     break;
   case rex::system::GraphicsIsolatedDrawPublicationStatus::kUnsupportedPath:
     status = "unsupported_path";
@@ -15758,10 +15848,17 @@ void CompleteIsolatedShadowDepthPublication(
        {"depth_stencil",
         result.depth_stencil_published ? "published" : "preserved_xenos"},
        {"consumer_handoff", "xenos_rt_dump_retained"},
+       {"ownership_mode", g_isolated_draw.shadow_depth_continuous_mode
+                              ? "multi_epoch_fail_closed"
+                              : "one_shot_qualification"},
+       {"publication_epoch",
+        std::to_string(
+            g_isolated_draw.shadow_depth_continuous_publication_epochs)},
        {"xenos_producer_draws", "preserved"},
        {"xenos_draw_suppression", "false"},
        {"resolve_suppression", "false"},
-       {"fallback", published ? "not_needed" : "authoritative_xenos_content"},
+       {"fallback", qualified_publication ? "not_needed"
+                                           : "authoritative_xenos_content"},
        {"suppression_eligible", "false"}});
 }
 
@@ -16187,10 +16284,15 @@ void RequestIsolatedDraw(
     return;
   }
   if (g_isolated_draw.shadow_depth_batch_mode) {
-    // Qualification mode is intentionally one-shot. Once one complete private
-    // batch has been recorded, keep every later title draw on the authoritative
-    // Xenos path without paying the duplicate replay or diagnostic cost again.
-    if (g_isolated_draw.shadow_depth_batch_capture_completed) {
+    // Qualification mode is one-shot. Continuous mode admits later exact
+    // epochs, but the first ordering, replay, or publication failure disables
+    // every later native request for the process and leaves Xenos authoritative.
+    if ((g_isolated_draw.shadow_depth_batch_capture_completed &&
+         !g_isolated_draw.shadow_depth_continuous_mode) ||
+        g_isolated_draw.shadow_depth_continuous_failed_closed ||
+        (g_isolated_draw.shadow_depth_continuous_mode &&
+         g_isolated_draw.shadow_depth_continuous_publication_epochs >=
+             g_isolated_draw.shadow_depth_continuous_epoch_limit)) {
       return;
     }
     const bool exact_seed = g_isolated_draw.prepared_candidate_eligible;
@@ -16217,6 +16319,10 @@ void RequestIsolatedDraw(
         g_isolated_draw.shadow_depth_batch_active = false;
         g_isolated_draw.shadow_depth_batch_backend_ready = false;
         g_isolated_draw.shadow_depth_batch_draws = 0;
+        FailClosedContinuousShadowDepth("non_contiguous_epoch");
+        if (g_isolated_draw.shadow_depth_continuous_failed_closed) {
+          return;
+        }
       }
     }
     if (!g_isolated_draw.shadow_depth_batch_active && !exact_seed) {
@@ -18849,26 +18955,42 @@ void InstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system,
                 g_pass_follower.valid && g_pass_follower.requested
             ? fmt::format("{:016X}", g_pass_follower.target_signature)
             : ""},
-       {"mode", g_isolated_draw.shadow_depth_batch_mode
-                    ? "exact_shadow_depth_80_draw_atlas_epoch"
-                    : (g_isolated_draw.shadow_depth_mode
-                           ? "exact_shadow_depth_single_draw"
-                           : (g_pass_follower.valid && g_pass_follower.requested
-                           ? "retained_pass"
-                           : "single_draw"))},
+       {"mode", g_isolated_draw.shadow_depth_continuous_mode
+                    ? "exact_shadow_depth_multi_epoch_publication"
+                    : (g_isolated_draw.shadow_depth_batch_mode
+                           ? "exact_shadow_depth_80_draw_atlas_epoch"
+                           : (g_isolated_draw.shadow_depth_mode
+                                  ? "exact_shadow_depth_single_draw"
+                                  : (g_pass_follower.valid &&
+                                             g_pass_follower.requested
+                                         ? "retained_pass"
+                                         : "single_draw")))},
        {"native_draw", "isolated_only"},
        {"continuous_shadow_replay",
-         g_isolated_draw.shadow_depth_batch_mode
-             ? "one_shot_full_80_draw_atlas_epoch"
-             : (g_isolated_draw.shadow_depth_mode
-             ? "disabled"
-             : (g_pass_follower.valid && g_pass_follower.requested
-             ? "retained_pass_contract"
-                : "enabled_after_one_shot"))},
+        g_isolated_draw.shadow_depth_batch_mode
+            ? (g_isolated_draw.shadow_depth_continuous_mode
+                   ? "multi_epoch_fail_closed"
+                   : "one_shot_full_80_draw_atlas_epoch")
+            : (g_isolated_draw.shadow_depth_mode
+                   ? "disabled"
+                   : (g_pass_follower.valid && g_pass_follower.requested
+                          ? "retained_pass_contract"
+                          : "enabled_after_one_shot"))},
        {"maximum_batch_draws",
         g_isolated_draw.shadow_depth_batch_mode
             ? std::to_string(kShadowDepthBatchDrawCount)
             : ""},
+       {"continuous_epoch_limit",
+        g_isolated_draw.shadow_depth_continuous_mode
+            ? std::to_string(
+                  g_isolated_draw.shadow_depth_continuous_epoch_limit)
+            : ""},
+       {"shadow_depth_publication",
+        g_isolated_draw.shadow_depth_publication_mode
+            ? (g_isolated_draw.shadow_depth_continuous_mode
+                   ? "multi_epoch_before_retained_xenos_dump"
+                   : "one_shot_before_retained_xenos_dump")
+            : "disabled"},
        {"readback", g_isolated_draw.readback_requested ? "asynchronous"
                                                         : "disabled"},
        {"stencil_seed_probe",
@@ -19494,12 +19616,22 @@ void UninstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system) {
         g_isolated_draw.shadow_depth_batches_completed +
         g_isolated_draw.shadow_depth_batches_interrupted + failed_batches +
         (g_isolated_draw.shadow_depth_batch_active ? 1 : 0);
+    const bool continuous_limit_reached =
+        g_isolated_draw.shadow_depth_continuous_mode &&
+        g_isolated_draw.shadow_depth_continuous_publication_epochs ==
+            g_isolated_draw.shadow_depth_continuous_epoch_limit;
     diagnostics::RecordEvent(
         "native_renderer.shadow_depth_batch.summary",
         {{"status",
-          g_isolated_draw.shadow_depth_batches_completed
-              ? "observed_complete_batch"
-              : "no_complete_batch"},
+          g_isolated_draw.shadow_depth_continuous_failed_closed
+              ? "continuous_fail_closed"
+              : (g_isolated_draw.shadow_depth_batches_completed
+                     ? (g_isolated_draw.shadow_depth_continuous_mode
+                            ? (continuous_limit_reached
+                                   ? "bounded_multi_epoch_complete"
+                                   : "multi_epoch_publication_active")
+                            : "observed_complete_batch")
+                     : "no_complete_batch")},
          {"vertex_shader", fmt::format("{:016X}", kShadowDepthVertexShader)},
          {"expected_draws_per_batch",
           std::to_string(kShadowDepthBatchDrawCount)},
@@ -19566,6 +19698,26 @@ void UninstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system) {
           std::to_string(g_isolated_draw.shadow_depth_publications)},
          {"publication_failures",
           std::to_string(g_isolated_draw.shadow_depth_publication_failures)},
+         {"ownership_mode", g_isolated_draw.shadow_depth_continuous_mode
+                                ? "multi_epoch_fail_closed"
+                                : "one_shot_qualification"},
+         {"continuous_failed_closed",
+          g_isolated_draw.shadow_depth_continuous_failed_closed ? "true"
+                                                                : "false"},
+         {"continuous_failure_reason",
+          g_isolated_draw.shadow_depth_continuous_failure_reason.empty()
+              ? "none"
+              : g_isolated_draw.shadow_depth_continuous_failure_reason},
+         {"continuous_publication_epochs",
+          std::to_string(
+              g_isolated_draw.shadow_depth_continuous_publication_epochs)},
+         {"continuous_max_publication_epochs",
+          std::to_string(
+              g_isolated_draw.shadow_depth_continuous_max_publication_epochs)},
+         {"continuous_epoch_limit",
+          std::to_string(g_isolated_draw.shadow_depth_continuous_epoch_limit)},
+         {"continuous_limit_reached",
+          continuous_limit_reached ? "true" : "false"},
          {"consumer_handoff", "xenos_rt_dump_retained"},
          {"xenos_draw", "preserved"},
          {"output_authority", "xenos"},

--- a/tools/capture-native-renderer-census.ps1
+++ b/tools/capture-native-renderer-census.ps1
@@ -19,6 +19,9 @@ param(
     [switch]$ShadowDepthIsolated,
     [switch]$ShadowDepthBatch,
     [switch]$PublishShadowDepth,
+    [switch]$ContinuousShadowDepth,
+    [ValidateRange(2, 120)]
+    [int]$ContinuousShadowDepthEpochs = 8,
     [switch]$StencilSeedProbe,
     [switch]$RequireFreshVisibilityCandidate,
     [switch]$AutoSelectFreshVisibilityCandidate,
@@ -97,6 +100,9 @@ if ($ShadowDepthBatch -and -not $IsolatedDrawDir) {
 }
 if ($PublishShadowDepth -and -not $ShadowDepthBatch) {
     throw 'PublishShadowDepth requires ShadowDepthBatch.'
+}
+if ($ContinuousShadowDepth -and -not $PublishShadowDepth) {
+    throw 'ContinuousShadowDepth requires PublishShadowDepth.'
 }
 if ($StencilSeedProbe -and -not $IsolatedDrawDir) {
     throw 'StencilSeedProbe requires IsolatedDrawDir.'
@@ -199,6 +205,10 @@ $savedShadowDepthIsolated = $env:PINYON_SHIFT_NATIVE_RENDERER_SHADOW_DEPTH_ISOLA
 $savedShadowDepthBatch = $env:PINYON_SHIFT_NATIVE_RENDERER_SHADOW_DEPTH_BATCH
 $savedShadowDepthPublication =
     $env:PINYON_SHIFT_NATIVE_RENDERER_SHADOW_DEPTH_PUBLICATION
+$savedShadowDepthContinuous =
+    $env:PINYON_SHIFT_NATIVE_RENDERER_SHADOW_DEPTH_CONTINUOUS
+$savedShadowDepthContinuousEpochLimit =
+    $env:PINYON_SHIFT_NATIVE_RENDERER_SHADOW_DEPTH_CONTINUOUS_EPOCH_LIMIT
 $savedStencilSeedProbe = $env:PINYON_SHIFT_NATIVE_RENDERER_STENCIL_SEED_PROBE
 $savedVisibilityGate = $env:PINYON_SHIFT_NATIVE_RENDERER_REQUIRE_FRESH_VISIBILITY_CANDIDATE
 $savedAutoVisibilityCandidate =
@@ -231,6 +241,12 @@ try {
         if ($ShadowDepthBatch) { 'true' } else { $null }
     $env:PINYON_SHIFT_NATIVE_RENDERER_SHADOW_DEPTH_PUBLICATION =
         if ($PublishShadowDepth) { 'true' } else { $null }
+    $env:PINYON_SHIFT_NATIVE_RENDERER_SHADOW_DEPTH_CONTINUOUS =
+        if ($ContinuousShadowDepth) { 'true' } else { $null }
+    $env:PINYON_SHIFT_NATIVE_RENDERER_SHADOW_DEPTH_CONTINUOUS_EPOCH_LIMIT =
+        if ($ContinuousShadowDepth) {
+            [string]$ContinuousShadowDepthEpochs
+        } else { $null }
     $env:PINYON_SHIFT_NATIVE_RENDERER_STENCIL_SEED_PROBE =
         if ($StencilSeedProbe) { 'true' } else { $null }
     $env:PINYON_SHIFT_NATIVE_RENDERER_REQUIRE_FRESH_VISIBILITY_CANDIDATE =
@@ -270,6 +286,10 @@ finally {
         $savedShadowDepthBatch
     $env:PINYON_SHIFT_NATIVE_RENDERER_SHADOW_DEPTH_PUBLICATION =
         $savedShadowDepthPublication
+    $env:PINYON_SHIFT_NATIVE_RENDERER_SHADOW_DEPTH_CONTINUOUS =
+        $savedShadowDepthContinuous
+    $env:PINYON_SHIFT_NATIVE_RENDERER_SHADOW_DEPTH_CONTINUOUS_EPOCH_LIMIT =
+        $savedShadowDepthContinuousEpochLimit
     $env:PINYON_SHIFT_NATIVE_RENDERER_STENCIL_SEED_PROBE = $savedStencilSeedProbe
     $env:PINYON_SHIFT_NATIVE_RENDERER_REQUIRE_FRESH_VISIBILITY_CANDIDATE =
         $savedVisibilityGate

--- a/tools/tests/test_native_renderer_contract.py
+++ b/tools/tests/test_native_renderer_contract.py
@@ -1989,7 +1989,13 @@ class NativeRendererContractTests(unittest.TestCase):
         self.assertIn("observation.index_count == 703", scanner)
         self.assertIn("prepared_shadow_depth_batch_member", scanner)
         self.assertIn(
-            "if (g_isolated_draw.shadow_depth_batch_capture_completed)", scanner
+            "g_isolated_draw.shadow_depth_batch_capture_completed &&", scanner
+        )
+        self.assertIn(
+            "!g_isolated_draw.shadow_depth_continuous_mode", scanner
+        )
+        self.assertIn(
+            "g_isolated_draw.shadow_depth_continuous_failed_closed", scanner
         )
         self.assertIn('"one_shot_full_80_draw_atlas_epoch"', scanner)
         self.assertIn("!exact_seed", scanner)

--- a/tools/tests/test_native_renderer_shadow_depth_publication.py
+++ b/tools/tests/test_native_renderer_shadow_depth_publication.py
@@ -1,3 +1,7 @@
+import json
+import subprocess
+import sys
+import tempfile
 import unittest
 from pathlib import Path
 
@@ -45,6 +49,147 @@ class ShadowDepthPublicationContractTests(unittest.TestCase):
         self.assertNotIn("SetCopySuppression", hooks + patch)
         self.assertIn("[switch]$PublishShadowDepth", capture)
         self.assertIn("PublishShadowDepth requires ShadowDepthBatch", capture)
+
+    def test_continuous_depth_publication_fails_closed_without_suppression(self):
+        hooks = (ROOT / "src/native_renderer/graphics_hooks.cpp").read_text(
+            encoding="utf-8"
+        )
+        capture = (
+            ROOT / "tools/capture-native-renderer-census.ps1"
+        ).read_text(encoding="utf-8")
+        self.assertIn(
+            "PINYON_SHIFT_NATIVE_RENDERER_SHADOW_DEPTH_CONTINUOUS", hooks
+        )
+        self.assertIn(
+            "PINYON_SHIFT_NATIVE_RENDERER_SHADOW_DEPTH_CONTINUOUS_EPOCH_LIMIT",
+            hooks,
+        )
+        self.assertIn("epoch_limit < 2", hooks)
+        self.assertIn("epoch_limit > 120", hooks)
+        self.assertIn('"bounded_multi_epoch_complete"', hooks)
+        self.assertIn("FailClosedContinuousShadowDepth", hooks)
+        self.assertIn('"non_contiguous_epoch"', hooks)
+        self.assertIn('"backend_replay_failure"', hooks)
+        self.assertIn('"publication_failure"', hooks)
+        self.assertIn(
+            '"native_renderer.shadow_depth_continuous.fail_closed"', hooks
+        )
+        self.assertIn('"fallback", "authoritative_xenos_content"', hooks)
+        self.assertIn('"draw_suppression", "false"', hooks)
+        self.assertIn('"resolve_suppression", "false"', hooks)
+        self.assertNotIn("SetDrawSuppression", hooks)
+        self.assertNotIn("SetCopySuppression", hooks)
+        self.assertIn("[switch]$ContinuousShadowDepth", capture)
+        self.assertIn("[int]$ContinuousShadowDepthEpochs = 8", capture)
+        self.assertIn(
+            "ContinuousShadowDepth requires PublishShadowDepth", capture
+        )
+
+    def test_continuous_qualification_verifier_accepts_exact_safe_epochs(self):
+        verifier = (
+            ROOT / "tools/verify-native-renderer-shadow-depth-continuous.py"
+        )
+        with tempfile.TemporaryDirectory(prefix="pinyon-shadow-depth-") as root:
+            root = Path(root)
+            native_dir = root / "native"
+            xenos_dir = root / "xenos"
+            native_dir.mkdir()
+            xenos_dir.mkdir()
+            payload = b"paired-depth-stencil"
+            (native_dir / "isolated.bin").write_bytes(payload)
+            (xenos_dir / "isolated.bin").write_bytes(payload)
+            source = {"bytes": len(payload), "hash": "SAME"}
+            (native_dir / "readback.json").write_text(
+                json.dumps(
+                    {
+                        "capture_role": "native_batch",
+                        "source": source,
+                        "safety": {"suppression_allowed": False},
+                    }
+                ),
+                encoding="utf-8",
+            )
+            (xenos_dir / "readback.json").write_text(
+                json.dumps(
+                    {
+                        "capture_role": "xenos_batch",
+                        "source": source,
+                        "safety": {"suppression_allowed": False},
+                    }
+                ),
+                encoding="utf-8",
+            )
+            events = []
+            for epoch, frame in enumerate((100, 101), 1):
+                events.append(
+                    {
+                        "event": "native_renderer.shadow_depth_batch.publication",
+                        "status": "published_depth_stencil",
+                        "ownership_mode": "multi_epoch_fail_closed",
+                        "publication_epoch": str(epoch),
+                        "frame": str(frame),
+                        "color": "not_bound",
+                        "consumer_handoff": "xenos_rt_dump_retained",
+                        "xenos_producer_draws": "preserved",
+                        "xenos_draw_suppression": "false",
+                        "resolve_suppression": "false",
+                        "suppression_eligible": "false",
+                    }
+                )
+            events.append(
+                {
+                    "event": "native_renderer.shadow_depth_batch.summary",
+                    "status": "bounded_multi_epoch_complete",
+                    "ownership_mode": "multi_epoch_fail_closed",
+                    "continuous_failed_closed": "false",
+                    "continuous_failure_reason": "none",
+                    "continuous_limit_reached": "true",
+                    "request_accounting_complete": "true",
+                    "batch_accounting_complete": "true",
+                    "consumer_handoff": "xenos_rt_dump_retained",
+                    "xenos_draw": "preserved",
+                    "draw_suppression": "false",
+                    "suppression_eligible": "false",
+                    "batches_started": "2",
+                    "batches_completed": "2",
+                    "publication_attempts": "2",
+                    "publications": "2",
+                    "continuous_publication_epochs": "2",
+                    "continuous_max_publication_epochs": "2",
+                    "continuous_epoch_limit": "2",
+                    "requests": "160",
+                    "recorded": "160",
+                    "batches_interrupted": "0",
+                    "backend_failed_batches": "0",
+                    "target_creation_failures": "0",
+                    "unsupported": "0",
+                    "publication_failures": "0",
+                }
+            )
+            log = root / "session.jsonl"
+            log.write_text(
+                "".join(json.dumps(event) + "\n" for event in events),
+                encoding="utf-8",
+            )
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(verifier),
+                    "--log",
+                    str(log),
+                    "--native-dir",
+                    str(native_dir),
+                    "--xenos-dir",
+                    str(xenos_dir),
+                    "--expected-epochs",
+                    "2",
+                ],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertEqual(json.loads(result.stdout)["status"], "qualified")
 
 
 if __name__ == "__main__":

--- a/tools/verify-native-renderer-shadow-depth-continuous.py
+++ b/tools/verify-native-renderer-shadow-depth-continuous.py
@@ -1,0 +1,186 @@
+"""Verify one bounded multi-epoch shadow-depth qualification."""
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+
+
+def require(condition, message):
+    if not condition:
+        raise ValueError(message)
+
+
+def load_json(path):
+    with path.open("r", encoding="utf-8") as source:
+        return json.load(source)
+
+
+def load_events(path):
+    events = []
+    with path.open("r", encoding="utf-8") as source:
+        for line_number, line in enumerate(source, 1):
+            if line.strip():
+                try:
+                    events.append(json.loads(line))
+                except json.JSONDecodeError as error:
+                    raise ValueError(
+                        f"invalid JSONL at line {line_number}: {error}"
+                    ) from error
+    return events
+
+
+def sha256(path):
+    digest = hashlib.sha256()
+    with path.open("rb") as source:
+        for block in iter(lambda: source.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest().upper()
+
+
+def integer(record, key):
+    try:
+        return int(record[key])
+    except (KeyError, TypeError, ValueError) as error:
+        raise ValueError(f"missing or invalid integer field: {key}") from error
+
+
+def verify(log_path, native_dir, xenos_dir, expected_epochs):
+    events = load_events(log_path)
+    failures = [
+        event
+        for event in events
+        if event.get("event")
+        == "native_renderer.shadow_depth_continuous.fail_closed"
+    ]
+    require(not failures, "continuous shadow depth failed closed")
+
+    publications = [
+        event
+        for event in events
+        if event.get("event")
+        == "native_renderer.shadow_depth_batch.publication"
+    ]
+    require(
+        len(publications) == expected_epochs,
+        f"expected {expected_epochs} publications, found {len(publications)}",
+    )
+    frames = []
+    for epoch, publication in enumerate(publications, 1):
+        require(
+            publication.get("status") == "published_depth_stencil",
+            f"publication {epoch} did not publish depth/stencil",
+        )
+        require(
+            publication.get("ownership_mode") == "multi_epoch_fail_closed",
+            f"publication {epoch} used an unexpected ownership mode",
+        )
+        require(
+            integer(publication, "publication_epoch") == epoch,
+            f"publication epoch {epoch} is out of sequence",
+        )
+        require(publication.get("color") == "not_bound", "color was published")
+        require(
+            publication.get("consumer_handoff") == "xenos_rt_dump_retained",
+            "Xenos render-target dump was not retained",
+        )
+        require(
+            publication.get("xenos_producer_draws") == "preserved",
+            "Xenos producer draws were not preserved",
+        )
+        require(
+            publication.get("xenos_draw_suppression") == "false"
+            and publication.get("resolve_suppression") == "false"
+            and publication.get("suppression_eligible") == "false",
+            "a suppression gate was enabled",
+        )
+        frames.append(integer(publication, "frame"))
+    require(
+        all(later > earlier for earlier, later in zip(frames, frames[1:])),
+        "publication frames are not strictly increasing",
+    )
+
+    summaries = [
+        event
+        for event in events
+        if event.get("event") == "native_renderer.shadow_depth_batch.summary"
+    ]
+    require(len(summaries) == 1, "expected exactly one shadow-depth summary")
+    summary = summaries[0]
+    expected_requests = expected_epochs * 80
+    expected = {
+        "status": "bounded_multi_epoch_complete",
+        "ownership_mode": "multi_epoch_fail_closed",
+        "continuous_failed_closed": "false",
+        "continuous_failure_reason": "none",
+        "continuous_limit_reached": "true",
+        "request_accounting_complete": "true",
+        "batch_accounting_complete": "true",
+        "consumer_handoff": "xenos_rt_dump_retained",
+        "xenos_draw": "preserved",
+        "draw_suppression": "false",
+        "suppression_eligible": "false",
+    }
+    for key, value in expected.items():
+        require(summary.get(key) == value, f"summary field {key} != {value}")
+    for key in ("batches_started", "batches_completed", "publication_attempts",
+                "publications", "continuous_publication_epochs",
+                "continuous_max_publication_epochs", "continuous_epoch_limit"):
+        require(integer(summary, key) == expected_epochs, f"summary field {key} mismatch")
+    for key in ("requests", "recorded"):
+        require(integer(summary, key) == expected_requests, f"summary field {key} mismatch")
+    for key in ("batches_interrupted", "backend_failed_batches",
+                "target_creation_failures", "unsupported",
+                "publication_failures"):
+        require(integer(summary, key) == 0, f"summary field {key} is nonzero")
+
+    native = load_json(native_dir / "readback.json")
+    xenos = load_json(xenos_dir / "readback.json")
+    require(native.get("capture_role") == "native_batch", "invalid native role")
+    require(xenos.get("capture_role") == "xenos_batch", "invalid Xenos role")
+    require(native.get("source") == xenos.get("source"), "readback metadata differs")
+    require(
+        native.get("safety", {}).get("suppression_allowed") is False
+        and xenos.get("safety", {}).get("suppression_allowed") is False,
+        "readback suppression safety differs",
+    )
+    native_payload = native_dir / "isolated.bin"
+    xenos_payload = xenos_dir / "isolated.bin"
+    require(native_payload.is_file(), "native payload is missing")
+    require(xenos_payload.is_file(), "Xenos payload is missing")
+    native_hash = sha256(native_payload)
+    xenos_hash = sha256(xenos_payload)
+    require(native_hash == xenos_hash, "native and Xenos payload hashes differ")
+    require(
+        native_payload.stat().st_size == xenos_payload.stat().st_size,
+        "native and Xenos payload sizes differ",
+    )
+    return {
+        "status": "qualified",
+        "epochs": expected_epochs,
+        "first_frame": frames[0],
+        "last_frame": frames[-1],
+        "payload_bytes": native_payload.stat().st_size,
+        "payload_sha256": native_hash,
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--log", type=Path, required=True)
+    parser.add_argument("--native-dir", type=Path, required=True)
+    parser.add_argument("--xenos-dir", type=Path, required=True)
+    parser.add_argument("--expected-epochs", type=int, default=8)
+    arguments = parser.parse_args()
+    require(2 <= arguments.expected_epochs <= 120, "expected epochs must be 2..120")
+    result = verify(
+        arguments.log,
+        arguments.native_dir,
+        arguments.xenos_dir,
+        arguments.expected_epochs,
+    )
+    print(json.dumps(result, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Extend the retained Xenos dump handoff across a bounded number of exact shadow-depth epochs. Fail closed permanently on ordering, replay, or publication errors while preserving all Xenos work and suppression gates.

Tests: python -m unittest discover -s tools/tests; build-preview.ps1 -Parallel 16; AppData 8-epoch qualification
