### PR TITLE
feat(renderer): classify shadow caster ownership

### DIFF
--- a/config/native-renderer/effect-pass-classifier.json
+++ b/config/native-renderer/effect-pass-classifier.json
@@ -2,6 +2,13 @@
   "evidence_capture_sha256": "ef4064929005d08432488fd4649e845630860044a6cdc49e463fa7b3883667da",
   "rules": [
     {
+      "atlas_region": {
+        "height": 2048,
+        "width": 2048,
+        "x": 0,
+        "y": 0
+      },
+      "caster_class": "dynamic_vehicle",
       "confidence": "high",
       "evidence": "Reviewed local depth image after event 1417 shows an isolated top-down vehicle caster silhouette in the exact 2048-square producer epoch.",
       "id": "shadow-depth-vehicle-rigid",
@@ -20,6 +27,13 @@
       "visual_sha256": "3CAE4CEFD2F93B5E6645653D81440C9FED47CA22557A16B2CA3B90FCA828DF9A"
     },
     {
+      "atlas_region": {
+        "height": 2048,
+        "width": 2048,
+        "x": 0,
+        "y": 0
+      },
+      "caster_class": "dynamic_vehicle",
       "confidence": "high",
       "evidence": "Reviewed local depth image after event 1417 shows an isolated top-down vehicle caster silhouette in the exact 2048-square producer epoch.",
       "id": "shadow-depth-vehicle-secondary",
@@ -38,6 +52,13 @@
       "visual_sha256": "3CAE4CEFD2F93B5E6645653D81440C9FED47CA22557A16B2CA3B90FCA828DF9A"
     },
     {
+      "atlas_region": {
+        "height": 2048,
+        "width": 2048,
+        "x": 0,
+        "y": 0
+      },
+      "caster_class": "dynamic_vehicle",
       "confidence": "high",
       "evidence": "Reviewed local depth image after event 1417 shows an isolated top-down vehicle caster silhouette in the exact 2048-square producer epoch.",
       "id": "shadow-depth-vehicle-detail",
@@ -56,5 +77,5 @@
       "visual_sha256": "3CAE4CEFD2F93B5E6645653D81440C9FED47CA22557A16B2CA3B90FCA828DF9A"
     }
   ],
-  "schema": "pinyon-shift.native-renderer-effect-pass-classifier.v1"
+  "schema": "pinyon-shift.native-renderer-effect-pass-classifier.v2"
 }

--- a/docs/native-renderer/SHADOW_DEPTH_BATCH_REPLAY.md
+++ b/docs/native-renderer/SHADOW_DEPTH_BATCH_REPLAY.md
@@ -30,6 +30,11 @@ target through the same 2048-square viewport and scissor. Their exact order is
 - exactly 80 admitted draws; and
 - at most one completed batch in the process lifetime.
 
+The capture-bound semantic classifier identifies this complete epoch as the
+`dynamic_vehicle` caster class in atlas region `0,0,2048,2048`. Runtime result,
+publication, and summary events repeat both fields so a later static/dynamic
+policy cannot silently widen this contract to the mixed 1024-square region.
+
 A nonmatching draw, frame transition, sequence gap, target mismatch, or backend
 failure abandons the private batch. The next exact draw may begin a newly seeded
 batch, but no incomplete result is read back or published. After one batch

--- a/docs/native-renderer/SHADOW_REFLECTION_PASS_CENSUS.md
+++ b/docs/native-renderer/SHADOW_REFLECTION_PASS_CENSUS.md
@@ -104,13 +104,17 @@ payload-free export:
 python .\tools\build-native-renderer-effect-resource-lineage.py `
   .local\qualification\depth-resource-usage.json `
   .local\qualification\effect-pass-trace.json `
+  --effect-census .local\qualification\effect-pass-census.json `
   --output .local\qualification\depth-resource-lineage.json
 ```
 
 The exporter requires one exact resource-name match, records action metadata
-only, and exports no resource payload. The joiner requires both reports to
-name the same capture hash and rejects pixel reads without authoritative draw
-metadata.
+only, and exports no resource payload. The joiner requires all reports to name
+the same capture hash, rejects pixel reads without authoritative draw metadata,
+and maps each depth write through the census's exact event inventory. Every
+epoch reports its producer families, caster classes, classified shadow writes,
+and unclassified writes. `caster_class_complete` remains false if even one
+write lacks a capture-bound caster class.
 
 The 1xMSAA D24S8 candidate has six clear/write epochs, 207 unique depth-target
 writes, 36 pixel-shader reads, and two unique compute-read events. Every epoch
@@ -136,7 +140,8 @@ isolated top-down vehicle silhouette in the 2048-square epoch; its SHA-256 is
 The payload images remain local and are not tracked or distributed.
 
 `config/native-renderer/effect-pass-classifier.json` promotes only the three
-exact 2048-square producer families enclosed by that inspected epoch:
+exact 2048-square producer families enclosed by that inspected epoch. Each is
+also classified as `dynamic_vehicle` in atlas region `0,0,2048,2048`:
 
 | Pipeline label | Vertex shader label | Draws | Role |
 | --- | --- | ---: | --- |
@@ -148,11 +153,30 @@ The match also requires the exact D24S8 target label, 2048 by 2048 viewport,
 depth-only output class, and absent pixel shader. Each rule is bound to the
 qualified capture hash and reviewed image hash, and must match exactly one
 family. The classified report contains 80 `shadow_depth` draws in three
-families; the other 1,502 draws in 270 families remain
+`dynamic_vehicle` families; the other 1,502 draws in 270 families remain
 `unknown_unclassified`. This proves a shadow-depth producer seed, not an atlas
 layout, cascade model, native renderer, or suppression boundary. Native
 coverage and suppression remain false, Xenos stays authoritative, and
 reflection remains unidentified.
+
+The inspected 1024-square atlas region is deliberately not labeled static.
+Its event-803 image (SHA-256
+`A87E3AF9A36023E29D1F294F1E7155F7973FC78CB9B9CB75207E7B6CF866C675`)
+contains an orthographic mixed world view with both environment and vehicle
+silhouettes across ten exact families and 33 draws. Calling that region
+`static_world` would therefore erase a real dynamic-caster dependency. A later
+classifier may promote individual 1024-square families only after per-family
+contribution or title provenance distinguishes their caster class.
+
+The exact event-inventory join makes that incompleteness machine-checkable.
+Across the selected resource's six clear/write epochs, no epoch is yet
+caster-complete. The epoch from clear event 947 through event 1446 contains all
+80 classified `dynamic_vehicle` writes plus nine additional unclassified depth
+writes. The 1024-square world-view epoch from clear event 514 through event 832
+contains 42 total depth writes, all still unclassified by caster. The report
+therefore records `caster_complete_epochs=0`; the 80-draw native subepoch stays
+usable, but neither a whole-resource vehicle classification nor a static-cache
+policy is admitted.
 
 The first executable follow-up is documented in
 `SHADOW_DEPTH_ISOLATED_REPLAY.md`. It admits only the dominant

--- a/src/native_renderer/graphics_hooks.cpp
+++ b/src/native_renderer/graphics_hooks.cpp
@@ -164,6 +164,8 @@ constexpr uint32_t kShadowDepthTertiaryDrawCount = 4;
 constexpr uint32_t kShadowDepthBatchDrawCount =
     kShadowDepthPrimaryDrawCount + kShadowDepthSecondaryDrawCount +
     kShadowDepthTertiaryDrawCount;
+constexpr const char *kShadowDepthCasterClass = "dynamic_vehicle";
+constexpr const char *kShadowDepthAtlasRegion = "0,0,2048,2048";
 std::atomic<uint64_t> g_frame_sequence{};
 
 enum class ShadowDepthBatchFamily : uint32_t {
@@ -15774,6 +15776,8 @@ void CompleteIsolatedShadowDepthBatch(
         std::to_string(kShadowDepthSecondaryDrawCount)},
        {"tertiary_draw_count",
         std::to_string(kShadowDepthTertiaryDrawCount)},
+       {"caster_class", kShadowDepthCasterClass},
+       {"atlas_region", kShadowDepthAtlasRegion},
        {"logical_width", std::to_string(kShadowDepthLogicalWidth)},
        {"logical_height", std::to_string(kShadowDepthLogicalHeight)},
        {"allocation_width", std::to_string(result.target_width)},
@@ -15848,6 +15852,8 @@ void CompleteIsolatedShadowDepthPublication(
        {"depth_stencil",
         result.depth_stencil_published ? "published" : "preserved_xenos"},
        {"consumer_handoff", "xenos_rt_dump_retained"},
+       {"caster_class", kShadowDepthCasterClass},
+       {"atlas_region", kShadowDepthAtlasRegion},
        {"ownership_mode", g_isolated_draw.shadow_depth_continuous_mode
                               ? "multi_epoch_fail_closed"
                               : "one_shot_qualification"},
@@ -19635,6 +19641,8 @@ void UninstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system) {
          {"vertex_shader", fmt::format("{:016X}", kShadowDepthVertexShader)},
          {"expected_draws_per_batch",
           std::to_string(kShadowDepthBatchDrawCount)},
+         {"caster_class", kShadowDepthCasterClass},
+         {"atlas_region", kShadowDepthAtlasRegion},
          {"expected_primary_draws",
           std::to_string(kShadowDepthPrimaryDrawCount)},
          {"expected_secondary_draws",

--- a/tools/build-native-renderer-effect-pass-census.py
+++ b/tools/build-native-renderer-effect-pass-census.py
@@ -9,9 +9,10 @@ import sys
 
 TRACE_SCHEMA = "pinyon-shift.native-renderer-renderdoc-pass-trace.v1"
 SCHEMA = "pinyon-shift.native-renderer-effect-pass-census.v1"
-CLASSIFIER_SCHEMA = "pinyon-shift.native-renderer-effect-pass-classifier.v1"
+CLASSIFIER_SCHEMA = "pinyon-shift.native-renderer-effect-pass-classifier.v2"
 SEMANTIC_ROLES = {"shadow_depth", "reflection_capture", "retained_unknown"}
 CONFIDENCE_LEVELS = {"medium", "high"}
+CASTER_CLASSES = {"dynamic_vehicle", "static_world", "mixed_world"}
 MATCH_FIELDS = {
     "output_class",
     "depth_target_name",
@@ -121,12 +122,48 @@ def normalize_classifier(document, capture_sha256):
                 f"effect-pass classifier rule {identifier} match fields drifted"
             )
         role = rule.get("semantic_role")
+        caster_class = rule.get("caster_class")
+        atlas_region = rule.get("atlas_region")
         confidence = rule.get("confidence")
         evidence = str(rule.get("evidence", "")).strip()
         visual_sha256 = str(rule.get("visual_sha256", "")).upper()
         if role not in SEMANTIC_ROLES:
             raise ValueError(
                 f"effect-pass classifier rule {identifier} has invalid role"
+            )
+        if role == "shadow_depth":
+            if caster_class not in CASTER_CLASSES:
+                raise ValueError(
+                    f"effect-pass classifier rule {identifier} has invalid caster class"
+                )
+            if not isinstance(atlas_region, dict) or set(atlas_region) != {
+                "x",
+                "y",
+                "width",
+                "height",
+            }:
+                raise ValueError(
+                    f"effect-pass classifier rule {identifier} has invalid atlas region"
+                )
+            if any(
+                type(atlas_region[field]) is not int
+                or atlas_region[field] < 0
+                for field in ("x", "y", "width", "height")
+            ) or atlas_region["width"] == 0 or atlas_region["height"] == 0:
+                raise ValueError(
+                    f"effect-pass classifier rule {identifier} has invalid atlas region"
+                )
+            if (
+                atlas_region["width"] != match["viewport_width"]
+                or atlas_region["height"] != match["viewport_height"]
+            ):
+                raise ValueError(
+                    f"effect-pass classifier rule {identifier} atlas region and viewport differ"
+                )
+        elif caster_class is not None or atlas_region is not None:
+            raise ValueError(
+                "effect-pass classifier rule {} assigns shadow metadata "
+                "to a non-shadow role".format(identifier)
             )
         if confidence not in CONFIDENCE_LEVELS:
             raise ValueError(
@@ -145,7 +182,8 @@ def normalize_classifier(document, capture_sha256):
             )
         if rule.get("native_coverage") is not False:
             raise ValueError(
-                f"effect-pass classifier rule {identifier} must keep native coverage false"
+                "effect-pass classifier rule {} must keep native coverage "
+                "false".format(identifier)
             )
         if rule.get("suppression_eligible") is not False:
             raise ValueError(
@@ -156,6 +194,8 @@ def normalize_classifier(document, capture_sha256):
                 "id": identifier,
                 "match": match,
                 "semantic_role": role,
+                "caster_class": caster_class,
+                "atlas_region": atlas_region,
                 "semantic_confidence": confidence,
                 "semantic_evidence": evidence,
                 "visual_sha256": visual_sha256,
@@ -186,6 +226,8 @@ def apply_classifier(families, rules):
             {
                 "classifier_rule": rule["id"],
                 "semantic_role": rule["semantic_role"],
+                "caster_class": rule["caster_class"],
+                "atlas_region": rule["atlas_region"],
                 "semantic_confidence": rule["semantic_confidence"],
                 "semantic_evidence": rule["semantic_evidence"],
                 "visual_sha256": rule["visual_sha256"],
@@ -244,6 +286,7 @@ def build_census(trace, classifier=None):
                 "draw_count": 0,
                 "instance_count": 0,
                 "index_count": 0,
+                "event_ids": [],
                 "first_event": event_id,
                 "last_event": event_id,
                 "semantic_role": "unknown_unclassified",
@@ -254,6 +297,7 @@ def build_census(trace, classifier=None):
         family["draw_count"] += 1
         family["instance_count"] += int(event.get("instance_count", 0))
         family["index_count"] += int(event.get("index_count", 0))
+        family["event_ids"].append(event_id)
         family["last_event"] = event_id
 
     ordered = sorted(
@@ -270,12 +314,20 @@ def build_census(trace, classifier=None):
         matched = apply_classifier(ordered, classifier_rules)
     semantic_counts = {}
     semantic_draws = {}
+    caster_counts = {}
+    caster_draws = {}
     for family in ordered:
         key = family["signature"]["output_class"]
         counts[key] = counts.get(key, 0) + family["draw_count"]
         role = family["semantic_role"]
         semantic_counts[role] = semantic_counts.get(role, 0) + 1
         semantic_draws[role] = semantic_draws.get(role, 0) + family["draw_count"]
+        caster_class = family.get("caster_class")
+        if caster_class is not None:
+            caster_counts[caster_class] = caster_counts.get(caster_class, 0) + 1
+            caster_draws[caster_class] = (
+                caster_draws.get(caster_class, 0) + family["draw_count"]
+            )
     shadow_identified = semantic_counts.get("shadow_depth", 0) > 0
     reflection_identified = semantic_counts.get("reflection_capture", 0) > 0
     return {
@@ -288,6 +340,8 @@ def build_census(trace, classifier=None):
             "draws_by_output_class": dict(sorted(counts.items())),
             "families_by_semantic_role": dict(sorted(semantic_counts.items())),
             "draws_by_semantic_role": dict(sorted(semantic_draws.items())),
+            "families_by_caster_class": dict(sorted(caster_counts.items())),
+            "draws_by_caster_class": dict(sorted(caster_draws.items())),
         },
         "families": ordered,
         "classification": {
@@ -300,6 +354,12 @@ def build_census(trace, classifier=None):
             "pipeline_metadata_census_complete": True,
             "shadow_pass_identified": shadow_identified,
             "reflection_pass_identified": reflection_identified,
+            "shadow_caster_classes_identified": sorted(caster_counts),
+            "static_dynamic_caster_classes_observed": (
+                "dynamic_vehicle" in caster_counts
+                and "static_world" in caster_counts
+            ),
+            "static_dynamic_caster_separation_ready": False,
             "native_shadow_renderer_ready": False,
             "semantic_promotion_requires_external_evidence": True,
         },

--- a/tools/build-native-renderer-effect-resource-lineage.py
+++ b/tools/build-native-renderer-effect-resource-lineage.py
@@ -9,6 +9,7 @@ import sys
 
 USAGE_SCHEMA = "pinyon-shift.native-renderer-renderdoc-resource-usage.v1"
 PASS_SCHEMA = "pinyon-shift.native-renderer-renderdoc-pass-trace.v1"
+EFFECT_CENSUS_SCHEMA = "pinyon-shift.native-renderer-effect-pass-census.v1"
 SCHEMA = "pinyon-shift.native-renderer-effect-resource-lineage.v1"
 READ_USAGES = {"PS_Resource", "CS_Resource"}
 
@@ -40,7 +41,7 @@ def consumer_signature(draw):
     }
 
 
-def build_lineage(usage_trace, pass_trace):
+def build_lineage(usage_trace, pass_trace, effect_census=None):
     if usage_trace.get("schema") != USAGE_SCHEMA:
         raise ValueError("unsupported resource-usage schema")
     if pass_trace.get("schema") != PASS_SCHEMA:
@@ -57,6 +58,40 @@ def build_lineage(usage_trace, pass_trace):
     pass_capture = pass_trace.get("capture", {})
     if usage_capture.get("sha256") != pass_capture.get("sha256"):
         raise ValueError("resource usage and pass trace captures differ")
+    producer_by_event = {}
+    if effect_census is not None:
+        if effect_census.get("schema") != EFFECT_CENSUS_SCHEMA:
+            raise ValueError("unsupported effect-pass census schema")
+        if effect_census.get("capture", {}).get("sha256") != usage_capture.get(
+            "sha256"
+        ):
+            raise ValueError("effect-pass census capture differs")
+        census_safety = effect_census.get("safety", {})
+        if census_safety.get("metadata_only") is not True or census_safety.get(
+            "suppression_allowed"
+        ) is not False:
+            raise ValueError("effect-pass census does not preserve the safety boundary")
+        census_families = effect_census.get("families")
+        if not isinstance(census_families, list):
+            raise ValueError("effect-pass census has no family inventory")
+        for family in census_families:
+            family_sha256 = family.get("sha256")
+            if not isinstance(family_sha256, str) or not family_sha256:
+                raise ValueError("effect-pass family has no stable identity")
+            event_ids = family.get("event_ids")
+            if not isinstance(event_ids, list):
+                raise ValueError("effect-pass family has no exact event inventory")
+            for event_id in event_ids:
+                if not isinstance(event_id, int) or event_id in producer_by_event:
+                    raise ValueError("effect-pass event inventory is invalid")
+                producer_by_event[event_id] = {
+                    "family_sha256": family_sha256,
+                    "semantic_role": family.get(
+                        "semantic_role", "unknown_unclassified"
+                    ),
+                    "caster_class": family.get("caster_class"),
+                    "atlas_region": family.get("atlas_region"),
+                }
     usages = usage_trace.get("usages")
     events = pass_trace.get("events")
     if not isinstance(usages, list) or not isinstance(events, list):
@@ -145,6 +180,37 @@ def build_lineage(usage_trace, pass_trace):
             and min(epoch["pixel_read_events"] + epoch["compute_read_events"])
             > min(epoch["depth_write_events"])
         )
+        producer_families = {
+            producer_by_event[event_id]["family_sha256"]: producer_by_event[
+                event_id
+            ]
+            for event_id in epoch["depth_write_events"]
+            if event_id in producer_by_event
+        }
+        classified_shadow_events = [
+            event_id
+            for event_id in epoch["depth_write_events"]
+            if event_id in producer_by_event
+            and producer_by_event[event_id]["semantic_role"] == "shadow_depth"
+        ]
+        epoch["producer_families"] = sorted(
+            producer_families.values(),
+            key=lambda family: str(family["family_sha256"]),
+        )
+        epoch["classified_shadow_write_count"] = len(classified_shadow_events)
+        epoch["unclassified_write_count"] = (
+            epoch["depth_write_count"] - len(classified_shadow_events)
+        )
+        epoch["caster_classes"] = sorted(
+            {
+                producer_by_event[event_id]["caster_class"]
+                for event_id in classified_shadow_events
+                if producer_by_event[event_id]["caster_class"] is not None
+            }
+        )
+        epoch["caster_class_complete"] = bool(epoch["depth_write_count"]) and (
+            epoch["unclassified_write_count"] == 0
+        )
     ordered_families = sorted(
         consumer_families.values(),
         key=lambda family: (-len(family["read_events"]), family["sha256"]),
@@ -152,6 +218,27 @@ def build_lineage(usage_trace, pass_trace):
     for family in ordered_families:
         family["read_count"] = len(family["read_events"])
     sampled_epochs = sum(epoch["sampled_after_write"] for epoch in epochs)
+    classified_shadow_writes = sum(
+        epoch["classified_shadow_write_count"] for epoch in epochs
+    )
+    classified_reflection_writes = sum(
+        1
+        for epoch in epochs
+        for event_id in epoch["depth_write_events"]
+        if event_id in producer_by_event
+        and producer_by_event[event_id]["semantic_role"]
+        == "reflection_capture"
+    )
+    caster_classes = sorted(
+        {
+            caster_class
+            for epoch in epochs
+            for caster_class in epoch["caster_classes"]
+        }
+    )
+    caster_complete_epochs = sum(
+        epoch["caster_class_complete"] for epoch in epochs
+    )
     return {
         "schema": SCHEMA,
         "capture": usage_capture,
@@ -164,6 +251,8 @@ def build_lineage(usage_trace, pass_trace):
             },
             "clear_epochs": len(epochs),
             "sampled_epochs": sampled_epochs,
+            "classified_shadow_writes": classified_shadow_writes,
+            "classified_reflection_writes": classified_reflection_writes,
             "consumer_families": len(ordered_families),
             "pixel_consumer_events": len(pixel_consumer_events),
             "pixel_consumers_depth_only": len(pixel_consumers_depth_only),
@@ -184,8 +273,18 @@ def build_lineage(usage_trace, pass_trace):
             and not pixel_consumers_with_color
             and not pixel_consumers_without_output,
             "direct_color_sampling_observed": bool(pixel_consumers_with_color),
-            "shadow_semantic_proved": False,
-            "reflection_semantic_proved": False,
+            "producer_caster_inventory_joined": effect_census is not None,
+            "caster_classes_identified": caster_classes,
+            "caster_complete_epochs": caster_complete_epochs,
+            "static_dynamic_caster_separation_ready": (
+                bool(epochs)
+                and caster_complete_epochs == len(epochs)
+                and "dynamic_vehicle" in caster_classes
+                and "static_world" in caster_classes
+                and "mixed_world" not in caster_classes
+            ),
+            "shadow_semantic_proved": classified_shadow_writes > 0,
+            "reflection_semantic_proved": classified_reflection_writes > 0,
             "semantic_promotion_requires_external_evidence": True,
         },
         "safety": {
@@ -202,14 +301,28 @@ def main(argv=None):
     parser = argparse.ArgumentParser()
     parser.add_argument("usage_trace", type=pathlib.Path)
     parser.add_argument("pass_trace", type=pathlib.Path)
+    parser.add_argument("--effect-census", type=pathlib.Path)
     parser.add_argument("--output", required=True, type=pathlib.Path)
     args = parser.parse_args(argv)
     try:
         usage_bytes = args.usage_trace.read_bytes()
         pass_bytes = args.pass_trace.read_bytes()
-        lineage = build_lineage(json.loads(usage_bytes), json.loads(pass_bytes))
+        effect_bytes = (
+            args.effect_census.read_bytes()
+            if args.effect_census is not None
+            else None
+        )
+        lineage = build_lineage(
+            json.loads(usage_bytes),
+            json.loads(pass_bytes),
+            json.loads(effect_bytes) if effect_bytes is not None else None,
+        )
         lineage["usage_trace_sha256"] = hashlib.sha256(usage_bytes).hexdigest().upper()
         lineage["pass_trace_sha256"] = hashlib.sha256(pass_bytes).hexdigest().upper()
+        if effect_bytes is not None:
+            lineage["effect_census_sha256"] = hashlib.sha256(
+                effect_bytes
+            ).hexdigest().upper()
         args.output.parent.mkdir(parents=True, exist_ok=True)
         args.output.write_text(
             json.dumps(lineage, indent=2, sort_keys=True) + "\n",

--- a/tools/tests/test_native_renderer_effect_pass_census.py
+++ b/tools/tests/test_native_renderer_effect_pass_census.py
@@ -71,6 +71,8 @@ def classifier(**rule_updates):
             "viewport_height": 1024.0,
         },
         "semantic_role": "shadow_depth",
+        "caster_class": "dynamic_vehicle",
+        "atlas_region": {"x": 0, "y": 0, "width": 1024, "height": 1024},
         "confidence": "high",
         "evidence": "reviewed fixture depth image",
         "visual_sha256": "B" * 64,
@@ -98,6 +100,13 @@ class EffectPassCensusTests(unittest.TestCase):
                 "depth_only_write_candidate"
             ],
         )
+        depth_family = next(
+            item
+            for item in census["families"]
+            if item["signature"]["output_class"]
+            == "depth_only_write_candidate"
+        )
+        self.assertEqual([1, 2], depth_family["event_ids"])
         self.assertTrue(
             all(
                 item["semantic_role"] == "unknown_unclassified"
@@ -109,6 +118,15 @@ class EffectPassCensusTests(unittest.TestCase):
         self.assertFalse(census["qualification"]["shadow_pass_identified"])
         self.assertFalse(
             census["qualification"]["reflection_pass_identified"]
+        )
+        self.assertEqual(
+            [], census["qualification"]["shadow_caster_classes_identified"]
+        )
+        self.assertFalse(
+            census["qualification"]["static_dynamic_caster_separation_ready"]
+        )
+        self.assertFalse(
+            census["qualification"]["static_dynamic_caster_classes_observed"]
         )
 
     def test_ignores_native_draws_and_sorts_deterministically(self):
@@ -143,9 +161,24 @@ class EffectPassCensusTests(unittest.TestCase):
             if item["semantic_role"] == "shadow_depth"
         )
         self.assertEqual("high", family["semantic_confidence"])
+        self.assertEqual("dynamic_vehicle", family["caster_class"])
+        self.assertEqual(
+            {"x": 0, "y": 0, "width": 1024, "height": 1024},
+            family["atlas_region"],
+        )
         self.assertEqual("B" * 64, family["visual_sha256"])
         self.assertFalse(family["native_coverage"])
         self.assertFalse(family["suppression_eligible"])
+        self.assertEqual(
+            ["dynamic_vehicle"],
+            census["qualification"]["shadow_caster_classes_identified"],
+        )
+        self.assertFalse(
+            census["qualification"]["static_dynamic_caster_separation_ready"]
+        )
+        self.assertFalse(
+            census["qualification"]["static_dynamic_caster_classes_observed"]
+        )
 
     def test_rejects_unsafe_or_ambiguous_classifier(self):
         with self.assertRaisesRegex(ValueError, "native coverage false"):
@@ -159,6 +192,16 @@ class EffectPassCensusTests(unittest.TestCase):
             MODULE.build_census(trace([draw(1, colors=False)]), document)
         with self.assertRaisesRegex(ValueError, "matched 0 families"):
             MODULE.build_census(trace([draw(1)]), classifier())
+        with self.assertRaisesRegex(ValueError, "invalid caster class"):
+            MODULE.build_census(
+                trace([draw(1, colors=False)]),
+                classifier(caster_class="unknown"),
+            )
+        with self.assertRaisesRegex(ValueError, "invalid atlas region"):
+            MODULE.build_census(
+                trace([draw(1, colors=False)]),
+                classifier(atlas_region={"x": 0, "y": 0, "width": 0, "height": 1}),
+            )
 
     def test_rejects_unsafe_or_unenriched_trace(self):
         with self.assertRaisesRegex(ValueError, "payload-free"):
@@ -179,6 +222,15 @@ class EffectPassCensusTests(unittest.TestCase):
         self.assertEqual(3, len(rules))
         self.assertTrue(
             all(rule["semantic_role"] == "shadow_depth" for rule in rules)
+        )
+        self.assertTrue(
+            all(rule["caster_class"] == "dynamic_vehicle" for rule in rules)
+        )
+        self.assertEqual(
+            {"dynamic_vehicle": 1},
+            MODULE.build_census(
+                trace([draw(1, colors=False)]), classifier()
+            )["totals"]["families_by_caster_class"],
         )
         self.assertTrue(
             all(

--- a/tools/tests/test_native_renderer_effect_resource_lineage.py
+++ b/tools/tests/test_native_renderer_effect_resource_lineage.py
@@ -56,6 +56,15 @@ def pass_trace(events, sha="A" * 64):
     }
 
 
+def effect_census(families, sha="A" * 64):
+    return {
+        "schema": MODULE.EFFECT_CENSUS_SCHEMA,
+        "capture": {"path": "fixture.rdc", "sha256": sha},
+        "families": families,
+        "safety": {"metadata_only": True, "suppression_allowed": False},
+    }
+
+
 class EffectResourceLineageTests(unittest.TestCase):
     def test_proves_fully_sampled_depth_epochs_but_not_semantics(self):
         usages = [
@@ -104,6 +113,57 @@ class EffectResourceLineageTests(unittest.TestCase):
             ]
         )
 
+    def test_joins_exact_shadow_caster_families_into_epochs(self):
+        usages = [
+            {"event_id": 1, "usage": "Clear"},
+            {"event_id": 2, "usage": "DepthStencilTarget"},
+            {"event_id": 3, "usage": "DepthStencilTarget"},
+            {"event_id": 4, "usage": "CS_Resource"},
+        ]
+        census = effect_census(
+            [
+                {
+                    "sha256": "B" * 64,
+                    "event_ids": [2, 3],
+                    "semantic_role": "shadow_depth",
+                    "caster_class": "dynamic_vehicle",
+                    "atlas_region": {
+                        "x": 0,
+                        "y": 0,
+                        "width": 2048,
+                        "height": 2048,
+                    },
+                }
+            ]
+        )
+        report = MODULE.build_lineage(
+            usage_trace(usages), pass_trace([]), census
+        )
+        epoch = report["epochs"][0]
+        self.assertEqual(2, epoch["classified_shadow_write_count"])
+        self.assertEqual(2, report["totals"]["classified_shadow_writes"])
+        self.assertEqual(0, epoch["unclassified_write_count"])
+        self.assertEqual(["dynamic_vehicle"], epoch["caster_classes"])
+        self.assertTrue(epoch["caster_class_complete"])
+        self.assertEqual(1, len(epoch["producer_families"]))
+        self.assertEqual(
+            1, report["qualification"]["caster_complete_epochs"]
+        )
+        self.assertEqual(
+            ["dynamic_vehicle"],
+            report["qualification"]["caster_classes_identified"],
+        )
+        self.assertFalse(
+            report["qualification"]["static_dynamic_caster_separation_ready"]
+        )
+        self.assertTrue(
+            report["qualification"]["producer_caster_inventory_joined"]
+        )
+        self.assertTrue(report["qualification"]["shadow_semantic_proved"])
+        self.assertFalse(
+            report["qualification"]["reflection_semantic_proved"]
+        )
+
     def test_reports_color_sampling_without_promoting_semantics(self):
         usages = [
             {"event_id": 1, "usage": "Clear"},
@@ -124,6 +184,40 @@ class EffectResourceLineageTests(unittest.TestCase):
         )
         self.assertFalse(report["qualification"]["shadow_semantic_proved"])
 
+    def test_requires_complete_dynamic_and_static_epochs_for_separation(self):
+        usages = [
+            {"event_id": 1, "usage": "Clear"},
+            {"event_id": 2, "usage": "DepthStencilTarget"},
+            {"event_id": 3, "usage": "CS_Resource"},
+            {"event_id": 4, "usage": "Clear"},
+            {"event_id": 5, "usage": "DepthStencilTarget"},
+            {"event_id": 6, "usage": "CS_Resource"},
+        ]
+        census = effect_census(
+            [
+                {
+                    "sha256": "B" * 64,
+                    "event_ids": [2],
+                    "semantic_role": "shadow_depth",
+                    "caster_class": "dynamic_vehicle",
+                    "atlas_region": {"x": 0, "y": 0, "width": 2, "height": 2},
+                },
+                {
+                    "sha256": "C" * 64,
+                    "event_ids": [5],
+                    "semantic_role": "shadow_depth",
+                    "caster_class": "static_world",
+                    "atlas_region": {"x": 0, "y": 0, "width": 1, "height": 1},
+                },
+            ]
+        )
+        report = MODULE.build_lineage(
+            usage_trace(usages), pass_trace([]), census
+        )
+        self.assertTrue(
+            report["qualification"]["static_dynamic_caster_separation_ready"]
+        )
+
     def test_rejects_missing_consumer_metadata_and_capture_drift(self):
         usages = [
             {"event_id": 1, "usage": "Clear"},
@@ -135,6 +229,12 @@ class EffectResourceLineageTests(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "captures differ"):
             MODULE.build_lineage(
                 usage_trace(usages), pass_trace([draw(3)], sha="B" * 64)
+            )
+        with self.assertRaisesRegex(ValueError, "census capture differs"):
+            MODULE.build_lineage(
+                usage_trace(usages),
+                pass_trace([draw(3)]),
+                effect_census([], sha="B" * 64),
             )
 
     def test_rejects_unsafe_or_unordered_usage(self):

--- a/tools/tests/test_native_renderer_shadow_depth_publication.py
+++ b/tools/tests/test_native_renderer_shadow_depth_publication.py
@@ -43,6 +43,18 @@ class ShadowDepthPublicationContractTests(unittest.TestCase):
         self.assertIn("CompleteIsolatedShadowDepthPublication", hooks)
         self.assertIn("request.suppress_guest_draw_if_published = false", hooks)
         self.assertIn('"consumer_handoff", "xenos_rt_dump_retained"', hooks)
+        self.assertIn(
+            'kShadowDepthCasterClass = "dynamic_vehicle"', hooks
+        )
+        self.assertIn(
+            'kShadowDepthAtlasRegion = "0,0,2048,2048"', hooks
+        )
+        self.assertGreaterEqual(
+            hooks.count('{"caster_class", kShadowDepthCasterClass}'), 3
+        )
+        self.assertGreaterEqual(
+            hooks.count('{"atlas_region", kShadowDepthAtlasRegion}'), 3
+        )
         self.assertIn("bool depth_only_target = false", patch)
         self.assertIn("!result.color_published", hooks)
         self.assertNotIn("SetDrawSuppression", hooks + patch)


### PR DESCRIPTION
Bind the qualified vehicle-shadow subepoch to an exact caster class and atlas region. Join per-family event inventories into resource epochs so mixed and incomplete caster ownership stays fail closed.

Tests: python -m unittest discover -s tools/tests (440 passed); focused caster tests (19 passed); build-preview.ps1 -Parallel 16
