### PR TITLE
feat(renderer): trace exact shadow caster contributions

### DIFF
--- a/docs/native-renderer/SHADOW_REFLECTION_PASS_CENSUS.md
+++ b/docs/native-renderer/SHADOW_REFLECTION_PASS_CENSUS.md
@@ -178,6 +178,56 @@ therefore records `caster_complete_epochs=0`; the 80-draw native subepoch stays
 usable, but neither a whole-resource vehicle classification nor a static-cache
 policy is admitted.
 
+## Per-draw caster contribution export
+
+The mixed 1024-square epoch requires stronger evidence than its combined final
+image. The local-only contribution exporter takes an exact lineage epoch,
+replays the capture before and after every depth write, and saves paired PNGs
+below `.local`. It verifies the capture hash, selected resource name, ordered
+event inventory, qrenderdoc signature, and output confinement before replay:
+
+```powershell
+.\tools\export-native-renderer-shadow-caster-contributions.ps1 `
+  -Capture '.local\qualification\native-renderer-renderdoc-seeded\reference_frame8134.rdc' `
+  -RenderDocRoot '.local\tools\renderdoc\RenderDoc_64' `
+  -Lineage '.local\qualification\nr05f-caster-class-lineage.json' `
+  -EpochOrdinal 2 `
+  -OutputDir '.local\qualification\nr05f-shadow-caster-contributions'
+
+python .\tools\analyze-native-renderer-shadow-caster-contributions.py `
+  --export '.local\qualification\nr05f-shadow-caster-contributions\shadow-caster-contributions.json' `
+  --effect-census '.local\qualification\nr05f-caster-class-census.json' `
+  --output-dir '.local\qualification\nr05f-shadow-caster-contribution-analysis'
+```
+
+The analyzer decodes and CRC-validates each 8-bit RGBA PNG, measures exact
+changed pixels and bounding boxes, emits cropped local delta images, and joins
+every event to its capture-bound family. Pixel activity alone never assigns a
+caster class: the report keeps
+`caster_classification_allowed_without_review=false` until the generated delta
+images receive local visual review or matching title provenance. No payload is
+tracked, rendering is unchanged, Xenos stays authoritative, and suppression
+remains unavailable.
+
+The qualified epoch-2 export contains 42 exact depth writes. Nineteen writes
+changed the saved target, spanning seven families and 1,221,021 changed pixels;
+the other 23 writes were depth-tested away or otherwise made no observable
+change in this capture. The deterministic contribution report has SHA-256
+`5F9DA2B2168EE4DB41093DE7922EAAFE7D91B257F261683B59C1295D957E0AC1`.
+The largest delta, event 521, is not a caster: its
+known `Shader {c700dc5c}` / `Shader {23c57222}` depth-propagation family writes
+an 800 by 1024 rectangle and accounts for 819,200 changed pixels.
+
+The remaining deltas disprove family-level static/dynamic separation for the
+dominant 1024-square family
+`A61D2C09B06090140F77963167B6F739CF7D1508A7D71C578550C2EC2B235481`.
+Its six visible contributions include a clear vehicle silhouette at event 787
+as well as festival structures and world geometry at events 703, 710, 768, and
+791. One exact pipeline family therefore contains both static and dynamic
+casters. The correct next boundary is event- or title-instance provenance;
+promoting this whole family to either `static_world` or `dynamic_vehicle` would
+be incorrect, so the separation gate remains closed.
+
 The first executable follow-up is documented in
 `SHADOW_DEPTH_ISOLATED_REPLAY.md`. It admits only the dominant
 `4E1DA281CC3D7EDB` producer through its complete stable draw and attachment

--- a/tools/analyze-native-renderer-shadow-caster-contributions.py
+++ b/tools/analyze-native-renderer-shadow-caster-contributions.py
@@ -1,0 +1,403 @@
+"""Measure exact local-only shadow depth deltas by capture-bound family."""
+
+import argparse
+import binascii
+import hashlib
+import json
+import shutil
+import struct
+import subprocess
+import sys
+import zlib
+from pathlib import Path
+
+
+EXPORT_SCHEMA = "pinyon-shift.native-renderer-shadow-caster-contributions.v1"
+CENSUS_SCHEMA = "pinyon-shift.native-renderer-effect-pass-census.v1"
+SCHEMA = "pinyon-shift.native-renderer-shadow-caster-contribution-report.v1"
+PNG_SIGNATURE = b"\x89PNG\r\n\x1a\n"
+
+
+def require(condition, message):
+    if not condition:
+        raise ValueError(message)
+
+
+def sha256(path):
+    digest = hashlib.sha256()
+    with path.open("rb") as source:
+        for block in iter(lambda: source.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest().upper()
+
+
+def paeth(left, up, upper_left):
+    estimate = left + up - upper_left
+    left_distance = abs(estimate - left)
+    up_distance = abs(estimate - up)
+    upper_left_distance = abs(estimate - upper_left)
+    if left_distance <= up_distance and left_distance <= upper_left_distance:
+        return left
+    if up_distance <= upper_left_distance:
+        return up
+    return upper_left
+
+
+def decode_rgba_png(path):
+    data = path.read_bytes()
+    require(data.startswith(PNG_SIGNATURE), f"{path}: invalid PNG signature")
+    position = len(PNG_SIGNATURE)
+    width = height = None
+    compressed = bytearray()
+    while position < len(data):
+        require(position + 12 <= len(data), f"{path}: truncated PNG chunk")
+        length = struct.unpack(">I", data[position : position + 4])[0]
+        chunk_type = data[position + 4 : position + 8]
+        chunk_start = position + 8
+        chunk_end = chunk_start + length
+        require(chunk_end + 4 <= len(data), f"{path}: truncated PNG payload")
+        payload = data[chunk_start:chunk_end]
+        expected_crc = struct.unpack(">I", data[chunk_end : chunk_end + 4])[0]
+        actual_crc = binascii.crc32(chunk_type + payload) & 0xFFFFFFFF
+        require(expected_crc == actual_crc, f"{path}: PNG CRC mismatch")
+        position = chunk_end + 4
+        if chunk_type == b"IHDR":
+            require(len(payload) == 13, f"{path}: invalid IHDR")
+            (
+                width,
+                height,
+                bit_depth,
+                color_type,
+                compression,
+                filter_method,
+                interlace,
+            ) = struct.unpack(">IIBBBBB", payload)
+            require(
+                bit_depth == 8 and color_type == 6,
+                f"{path}: expected an 8-bit RGBA PNG",
+            )
+            require(
+                compression == 0 and filter_method == 0 and interlace == 0,
+                f"{path}: unsupported PNG encoding",
+            )
+        elif chunk_type == b"IDAT":
+            compressed.extend(payload)
+        elif chunk_type == b"IEND":
+            break
+    require(width and height and compressed, f"{path}: incomplete PNG")
+    ffmpeg = shutil.which("ffmpeg")
+    if ffmpeg:
+        result = subprocess.run(
+            [
+                ffmpeg,
+                "-v",
+                "error",
+                "-i",
+                str(path),
+                "-f",
+                "rawvideo",
+                "-pix_fmt",
+                "rgba",
+                "-",
+            ],
+            check=False,
+            capture_output=True,
+        )
+        require(result.returncode == 0, f"{path}: ffmpeg PNG decode failed")
+        require(
+            len(result.stdout) == width * height * 4,
+            f"{path}: unexpected ffmpeg RGBA size",
+        )
+        return width, height, result.stdout
+    stride = width * 4
+    raw = zlib.decompress(bytes(compressed))
+    require(
+        len(raw) == height * (stride + 1),
+        f"{path}: unexpected decompressed PNG size",
+    )
+    pixels = bytearray(width * height * 4)
+    previous = bytearray(stride)
+    raw_offset = 0
+    output_offset = 0
+    for _ in range(height):
+        filter_type = raw[raw_offset]
+        row = bytearray(raw[raw_offset + 1 : raw_offset + 1 + stride])
+        require(filter_type <= 4, f"{path}: unsupported PNG filter")
+        for index in range(stride):
+            left = row[index - 4] if index >= 4 else 0
+            up = previous[index]
+            upper_left = previous[index - 4] if index >= 4 else 0
+            predictor = 0
+            if filter_type == 1:
+                predictor = left
+            elif filter_type == 2:
+                predictor = up
+            elif filter_type == 3:
+                predictor = (left + up) // 2
+            elif filter_type == 4:
+                predictor = paeth(left, up, upper_left)
+            row[index] = (row[index] + predictor) & 0xFF
+        pixels[output_offset : output_offset + stride] = row
+        output_offset += stride
+        raw_offset += stride + 1
+        previous = row
+    return width, height, bytes(pixels)
+
+
+def png_chunk(chunk_type, payload):
+    checksum = binascii.crc32(chunk_type + payload) & 0xFFFFFFFF
+    return (
+        struct.pack(">I", len(payload))
+        + chunk_type
+        + payload
+        + struct.pack(">I", checksum)
+    )
+
+
+def write_rgba_png(path, width, height, pixels):
+    require(len(pixels) == width * height * 4, "invalid RGBA payload size")
+    stride = width * 4
+    rows = b"".join(
+        b"\x00" + pixels[offset : offset + stride]
+        for offset in range(0, len(pixels), stride)
+    )
+    ihdr = struct.pack(">IIBBBBB", width, height, 8, 6, 0, 0, 0)
+    path.write_bytes(
+        PNG_SIGNATURE
+        + png_chunk(b"IHDR", ihdr)
+        + png_chunk(b"IDAT", zlib.compress(rows, 9))
+        + png_chunk(b"IEND", b"")
+    )
+
+
+def local_image(root, item):
+    name = item.get("path")
+    require(isinstance(name, str) and Path(name).name == name, "unsafe image path")
+    path = root / name
+    require(path.is_file(), f"missing contribution image: {name}")
+    require(sha256(path) == item.get("sha256"), f"image hash drifted: {name}")
+    return path
+
+
+def family_inventory(census):
+    inventory = {}
+    for family in census.get("families", []):
+        signature = family.get("signature", {})
+        signature_summary = {
+            key: signature.get(key)
+            for key in (
+                "pipeline_name",
+                "vertex_shader_name",
+                "pixel_shader_name",
+                "viewport",
+                "scissor",
+            )
+        }
+        for event_id in family.get("event_ids", []):
+            require(event_id not in inventory, "duplicate census event id")
+            inventory[event_id] = {
+                "family_sha256": family.get("sha256"),
+                "classifier_rule": family.get("classifier_rule"),
+                "semantic_role": family.get(
+                    "semantic_role", "unknown_unclassified"
+                ),
+                "caster_class": family.get("caster_class"),
+                "atlas_region": family.get("atlas_region"),
+                "signature": signature_summary,
+            }
+    return inventory
+
+
+def compare_event(before_path, after_path, output_path):
+    before_width, before_height, before = decode_rgba_png(before_path)
+    after_width, after_height, after = decode_rgba_png(after_path)
+    require(
+        (before_width, before_height) == (after_width, after_height),
+        "before/after dimensions differ",
+    )
+    before_words = memoryview(before).cast("I")
+    after_words = memoryview(after).cast("I")
+    changed_pixels = 0
+    min_x = before_width
+    min_y = before_height
+    max_x = max_y = -1
+    for pixel, (before_pixel, after_pixel) in enumerate(
+        zip(before_words, after_words)
+    ):
+        if before_pixel == after_pixel:
+            continue
+        x = pixel % before_width
+        y = pixel // before_width
+        changed_pixels += 1
+        min_x = min(min_x, x)
+        min_y = min(min_y, y)
+        max_x = max(max_x, x)
+        max_y = max(max_y, y)
+    if not changed_pixels:
+        return {
+            "changed_pixels": 0,
+            "changed_fraction": 0.0,
+            "bounding_box": None,
+            "delta_image": None,
+        }
+    width = max_x - min_x + 1
+    height = max_y - min_y + 1
+    delta = bytearray(width * height * 4)
+    for y in range(min_y, max_y + 1):
+        source_row = y * before_width
+        target_row = (y - min_y) * width
+        for x in range(min_x, max_x + 1):
+            pixel = source_row + x
+            if before_words[pixel] == after_words[pixel]:
+                continue
+            source_offset = pixel * 4
+            target_offset = (target_row + x - min_x) * 4
+            delta[target_offset : target_offset + 3] = after[
+                source_offset : source_offset + 3
+            ]
+            delta[target_offset + 3] = 255
+    write_rgba_png(output_path, width, height, bytes(delta))
+    return {
+        "changed_pixels": changed_pixels,
+        "changed_fraction": changed_pixels / (before_width * before_height),
+        "bounding_box": {
+            "x": min_x,
+            "y": min_y,
+            "width": width,
+            "height": height,
+        },
+        "delta_image": output_path.name,
+    }
+
+
+def analyze(export_path, census_path, output_dir):
+    export = json.loads(export_path.read_text(encoding="utf-8"))
+    census = json.loads(census_path.read_text(encoding="utf-8"))
+    require(export.get("schema") == EXPORT_SCHEMA, "unsupported export schema")
+    require(census.get("schema") == CENSUS_SCHEMA, "unsupported census schema")
+    require(
+        str(export.get("capture", {}).get("sha256", "")).upper()
+        == str(census.get("capture", {}).get("sha256", "")).upper(),
+        "export and census captures differ",
+    )
+    census_safety = census.get("safety", {})
+    require(
+        census_safety.get("metadata_only") is True
+        and census_safety.get("resource_payload_exported") is False
+        and census_safety.get("xenos_authority") is True
+        and census_safety.get("suppression_allowed") is False,
+        "census safety boundary is incomplete",
+    )
+    safety = export.get("safety", {})
+    require(
+        safety.get("local_resource_payload_exported") is True
+        and safety.get("tracked_payload_allowed") is False
+        and safety.get("xenos_authority") is True
+        and safety.get("native_rendering_changed") is False
+        and safety.get("suppression_allowed") is False,
+        "export safety boundary is incomplete",
+    )
+    output_dir.mkdir(parents=True, exist_ok=False)
+    inventory = family_inventory(census)
+    events = []
+    aggregates = {}
+    previous_event = 0
+    for item in export.get("events", []):
+        event_id = item.get("event_id")
+        require(
+            isinstance(event_id, int) and event_id > previous_event,
+            "export events are not ordered",
+        )
+        previous_event = event_id
+        before_path = local_image(export_path.parent, item.get("before", {}))
+        after_path = local_image(export_path.parent, item.get("after", {}))
+        delta_path = output_dir / f"event-{event_id:04d}-delta.png"
+        contribution = compare_event(before_path, after_path, delta_path)
+        family = inventory.get(
+            event_id,
+            {
+                "family_sha256": None,
+                "classifier_rule": None,
+                "semantic_role": "unknown_unclassified",
+                "caster_class": None,
+                "atlas_region": None,
+                "signature": None,
+            },
+        )
+        record = {"event_id": event_id, **family, **contribution}
+        events.append(record)
+        key = family["family_sha256"] or "unclassified"
+        aggregate = aggregates.setdefault(
+            key,
+            {
+                **family,
+                "events": [],
+                "draws": 0,
+                "draws_with_delta": 0,
+                "changed_pixels": 0,
+            },
+        )
+        aggregate["events"].append(event_id)
+        aggregate["draws"] += 1
+        aggregate["draws_with_delta"] += contribution["changed_pixels"] > 0
+        aggregate["changed_pixels"] += contribution["changed_pixels"]
+    ordered_aggregates = sorted(
+        aggregates.values(),
+        key=lambda item: (
+            item["family_sha256"] is None,
+            str(item["family_sha256"]),
+        ),
+    )
+    report = {
+        "schema": SCHEMA,
+        "capture": export.get("capture"),
+        "resource": export.get("resource"),
+        "events": events,
+        "families": ordered_aggregates,
+        "totals": {
+            "events": len(events),
+            "events_with_delta": sum(item["changed_pixels"] > 0 for item in events),
+            "families": len(ordered_aggregates),
+            "families_with_delta": sum(
+                item["draws_with_delta"] > 0 for item in ordered_aggregates
+            ),
+            "changed_pixels": sum(item["changed_pixels"] for item in events),
+        },
+        "qualification": {
+            "exact_event_inventory_joined": True,
+            "visual_review_required": True,
+            "caster_classification_allowed_without_review": False,
+        },
+        "safety": {
+            "payloads_local_only": True,
+            "tracked_payload_allowed": False,
+            "xenos_authority": True,
+            "native_rendering_changed": False,
+            "suppression_allowed": False,
+        },
+    }
+    report_path = output_dir / "shadow-caster-contribution-report.json"
+    report_path.write_text(
+        json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    return report_path, report
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--export", required=True, type=Path)
+    parser.add_argument("--effect-census", required=True, type=Path)
+    parser.add_argument("--output-dir", required=True, type=Path)
+    arguments = parser.parse_args()
+    report_path, _ = analyze(
+        arguments.export, arguments.effect_census, arguments.output_dir
+    )
+    print(report_path)
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except (OSError, ValueError, KeyError, TypeError, json.JSONDecodeError) as error:
+        print(f"shadow caster contribution analysis failed: {error}", file=sys.stderr)
+        sys.exit(1)

--- a/tools/export-native-renderer-shadow-caster-contributions.ps1
+++ b/tools/export-native-renderer-shadow-caster-contributions.ps1
@@ -1,0 +1,109 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)]
+    [string]$Capture,
+    [Parameter(Mandatory)]
+    [string]$RenderDocRoot,
+    [Parameter(Mandatory)]
+    [string]$Lineage,
+    [Parameter(Mandatory)]
+    [ValidateRange(1, 1024)]
+    [int]$EpochOrdinal,
+    [Parameter(Mandatory)]
+    [string]$OutputDir
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
+$localRoot = [IO.Path]::GetFullPath((Join-Path $repoRoot '.local'))
+$localPrefix = $localRoot.TrimEnd([IO.Path]::DirectorySeparatorChar) +
+    [IO.Path]::DirectorySeparatorChar
+$resolvedCapture = (Resolve-Path -LiteralPath $Capture).Path
+$resolvedLineage = (Resolve-Path -LiteralPath $Lineage).Path
+$resolvedOutputDir = [IO.Path]::GetFullPath($OutputDir)
+foreach ($item in @(
+        @{ Name = 'Capture'; Value = $resolvedCapture },
+        @{ Name = 'Lineage'; Value = $resolvedLineage },
+        @{ Name = 'OutputDir'; Value = $resolvedOutputDir }
+    )) {
+    if (-not $item.Value.StartsWith(
+            $localPrefix, [StringComparison]::OrdinalIgnoreCase)) {
+        throw "$($item.Name) must be below $localRoot"
+    }
+}
+if (Test-Path -LiteralPath $resolvedOutputDir) {
+    throw "OutputDir already exists: $resolvedOutputDir"
+}
+
+$lineageDocument = Get-Content -LiteralPath $resolvedLineage -Raw |
+    ConvertFrom-Json
+if ([string]$lineageDocument.schema -ne
+    'pinyon-shift.native-renderer-effect-resource-lineage.v1') {
+    throw 'Lineage has an unsupported schema.'
+}
+$captureHash = (Get-FileHash -Algorithm SHA256 -LiteralPath $resolvedCapture).Hash
+if ([string]$lineageDocument.capture.sha256 -ne $captureHash) {
+    throw 'Capture and lineage hashes differ.'
+}
+$epoch = @($lineageDocument.epochs) |
+    Where-Object { [int]$_.ordinal -eq $EpochOrdinal }
+if ($epoch.Count -ne 1) {
+    throw "EpochOrdinal matched $($epoch.Count) lineage epochs."
+}
+$eventIds = @($epoch[0].depth_write_events)
+if (-not $eventIds.Count -or $eventIds.Count -gt 128) {
+    throw 'Selected epoch must contain 1 through 128 depth writes.'
+}
+for ($index = 0; $index -lt $eventIds.Count; $index++) {
+    $eventId = [int]$eventIds[$index]
+    if ($eventId -le 0 -or
+        ($index -and $eventId -le [int]$eventIds[$index - 1])) {
+        throw 'Selected epoch depth writes must be positive and ordered.'
+    }
+}
+$resourceName = [string]$lineageDocument.resource.resource_name
+if (-not $resourceName.Trim()) {
+    throw 'Lineage resource name is empty.'
+}
+
+$qrenderdoc = Join-Path ([IO.Path]::GetFullPath($RenderDocRoot)) 'qrenderdoc.exe'
+if (-not (Test-Path -LiteralPath $qrenderdoc -PathType Leaf)) {
+    throw "qrenderdoc.exe was not found below RenderDocRoot: $RenderDocRoot"
+}
+$signature = Get-AuthenticodeSignature -LiteralPath $qrenderdoc
+if ([string]$signature.Status -ne 'Valid') {
+    throw 'qrenderdoc.exe does not have a valid Authenticode signature'
+}
+
+$script = Join-Path $PSScriptRoot `
+    'export-native-renderer-shadow-caster-contributions.py'
+[void](New-Item -ItemType Directory -Path $resolvedOutputDir)
+$savedCapture = $env:PINYON_SHIFT_RENDERDOC_CAPTURE
+$savedOutput = $env:PINYON_SHIFT_RENDERDOC_EXPORT_DIR
+$savedResourceName = $env:PINYON_SHIFT_RENDERDOC_RESOURCE_NAME
+$savedEventIds = $env:PINYON_SHIFT_RENDERDOC_EVENT_IDS
+try {
+    $env:PINYON_SHIFT_RENDERDOC_CAPTURE = $resolvedCapture
+    $env:PINYON_SHIFT_RENDERDOC_EXPORT_DIR = $resolvedOutputDir
+    $env:PINYON_SHIFT_RENDERDOC_RESOURCE_NAME = $resourceName
+    $env:PINYON_SHIFT_RENDERDOC_EVENT_IDS = $eventIds -join ','
+    $process = Start-Process -FilePath $qrenderdoc `
+        -ArgumentList @('--python', $script) -PassThru -Wait
+    if ($process.ExitCode) {
+        throw "qrenderdoc contribution export exited with code $($process.ExitCode)"
+    }
+}
+finally {
+    $env:PINYON_SHIFT_RENDERDOC_CAPTURE = $savedCapture
+    $env:PINYON_SHIFT_RENDERDOC_EXPORT_DIR = $savedOutput
+    $env:PINYON_SHIFT_RENDERDOC_RESOURCE_NAME = $savedResourceName
+    $env:PINYON_SHIFT_RENDERDOC_EVENT_IDS = $savedEventIds
+}
+
+$report = Join-Path $resolvedOutputDir 'shadow-caster-contributions.json'
+if (-not (Test-Path -LiteralPath $report -PathType Leaf)) {
+    throw 'qrenderdoc exited without producing the contribution report.'
+}
+Get-Content -LiteralPath $report -Raw | ConvertFrom-Json

--- a/tools/export-native-renderer-shadow-caster-contributions.py
+++ b/tools/export-native-renderer-shadow-caster-contributions.py
@@ -1,0 +1,181 @@
+"""Export local-only before/after depth images for exact caster writes."""
+
+import hashlib
+import json
+import os
+import sys
+import traceback
+
+import renderdoc as rd
+
+
+SCHEMA = "pinyon-shift.native-renderer-shadow-caster-contributions.v1"
+
+
+def flatten(actions):
+    result = []
+    for action in actions:
+        result.append(action)
+        result.extend(flatten(action.children))
+    return result
+
+
+def sha256(path):
+    digest = hashlib.sha256()
+    with open(path, "rb") as source:
+        for block in iter(lambda: source.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest().upper()
+
+
+def parse_event_ids(value):
+    try:
+        event_ids = [int(item) for item in value.split(",") if item]
+    except ValueError as error:
+        raise RuntimeError("event ids must be decimal integers") from error
+    if not event_ids or len(event_ids) > 128:
+        raise RuntimeError("event inventory must contain 1 through 128 events")
+    if event_ids != sorted(set(event_ids)) or event_ids[0] <= 0:
+        raise RuntimeError("event ids must be positive, unique, and ordered")
+    return event_ids
+
+
+def save_texture(controller, resource_id, output_path):
+    save = rd.TextureSave()
+    save.resourceId = resource_id
+    save.destType = rd.FileType.PNG
+    save.alpha = rd.AlphaMapping.Preserve
+    result = controller.SaveTexture(save, output_path)
+    if hasattr(result, "code") and result.code != rd.ResultCode.Succeeded:
+        raise RuntimeError(
+            "RenderDoc failed to save '{}': {}".format(output_path, result)
+        )
+    if not os.path.isfile(output_path):
+        raise RuntimeError("RenderDoc did not create '{}'".format(output_path))
+    return {
+        "path": os.path.basename(output_path),
+        "bytes": os.path.getsize(output_path),
+        "sha256": sha256(output_path),
+    }
+
+
+def main():
+    capture_path = os.environ["PINYON_SHIFT_RENDERDOC_CAPTURE"]
+    output_dir = os.environ["PINYON_SHIFT_RENDERDOC_EXPORT_DIR"]
+    resource_name = os.environ["PINYON_SHIFT_RENDERDOC_RESOURCE_NAME"]
+    event_ids = parse_event_ids(os.environ["PINYON_SHIFT_RENDERDOC_EVENT_IDS"])
+    report_path = os.path.join(output_dir, "shadow-caster-contributions.json")
+    os.makedirs(output_dir, exist_ok=True)
+
+    capture = rd.OpenCaptureFile()
+    controller = None
+    try:
+        result = capture.OpenFile(capture_path, "", None)
+        if result != rd.ResultCode.Succeeded:
+            raise RuntimeError("could not open capture: {}".format(result))
+        if not capture.LocalReplaySupport():
+            raise RuntimeError("capture does not support local replay")
+        result, controller = capture.OpenCapture(rd.ReplayOptions(), None)
+        if result != rd.ResultCode.Succeeded:
+            raise RuntimeError("could not initialise replay: {}".format(result))
+
+        resources = [
+            resource
+            for resource in controller.GetResources()
+            if resource.name == resource_name
+        ]
+        if len(resources) != 1:
+            raise RuntimeError(
+                "resource name matched {} resources: {}".format(
+                    len(resources), resource_name
+                )
+            )
+        resource = resources[0]
+        textures = {
+            texture.resourceId: texture for texture in controller.GetTextures()
+        }
+        texture = textures.get(resource.resourceId)
+        if texture is None:
+            raise RuntimeError("selected resource is not a texture")
+        actions = {
+            action.eventId: action
+            for action in flatten(controller.GetRootActions())
+        }
+        exports = []
+        for event_id in event_ids:
+            action = actions.get(event_id)
+            if action is None or not action.flags & rd.ActionFlags.Drawcall:
+                raise RuntimeError(
+                    "event {} is not an exact draw action".format(event_id)
+                )
+            before_path = os.path.join(
+                output_dir, "event-{:04d}-before.png".format(event_id)
+            )
+            after_path = os.path.join(
+                output_dir, "event-{:04d}-after.png".format(event_id)
+            )
+            controller.SetFrameEvent(event_id - 1, True)
+            before = save_texture(controller, resource.resourceId, before_path)
+            controller.SetFrameEvent(event_id, True)
+            after = save_texture(controller, resource.resourceId, after_path)
+            exports.append(
+                {
+                    "event_id": event_id,
+                    "action_name": action.customName,
+                    "before": before,
+                    "after": after,
+                }
+            )
+
+        report = {
+            "schema": SCHEMA,
+            "capture": {
+                "path": os.path.basename(capture_path),
+                "sha256": sha256(capture_path),
+            },
+            "resource": {
+                "resource_id": str(resource.resourceId),
+                "resource_name": resource.name,
+                "width": texture.width,
+                "height": texture.height,
+                "format": texture.format.Name(),
+                "mips": texture.mips,
+                "arraysize": texture.arraysize,
+                "ms_samp": texture.msSamp,
+            },
+            "events": exports,
+            "safety": {
+                "local_resource_payload_exported": True,
+                "tracked_payload_allowed": False,
+                "xenos_authority": True,
+                "native_rendering_changed": False,
+                "suppression_allowed": False,
+            },
+        }
+        with open(report_path, "w") as output:
+            json.dump(report, output, indent=2, sort_keys=True)
+            output.write("\n")
+        print(report_path)
+        return 0
+    finally:
+        if controller is not None:
+            controller.Shutdown()
+        capture.Shutdown()
+
+
+try:
+    sys.exit(main())
+except Exception as error:
+    message = "shadow caster contribution export failed: {}\n{}".format(
+        error, traceback.format_exc()
+    )
+    output_dir = os.environ.get("PINYON_SHIFT_RENDERDOC_EXPORT_DIR")
+    if output_dir:
+        os.makedirs(output_dir, exist_ok=True)
+        with open(
+            os.path.join(output_dir, "shadow-caster-contributions-error.txt"),
+            "w",
+        ) as output:
+            output.write(message)
+    sys.stderr.write(message)
+    sys.exit(1)

--- a/tools/tests/test_native_renderer_shadow_caster_contributions.py
+++ b/tools/tests/test_native_renderer_shadow_caster_contributions.py
@@ -1,0 +1,167 @@
+import importlib.util
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+TOOL = ROOT / "tools/analyze-native-renderer-shadow-caster-contributions.py"
+SPEC = importlib.util.spec_from_file_location("shadow_caster_contributions", TOOL)
+assert SPEC and SPEC.loader
+MODULE = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = MODULE
+SPEC.loader.exec_module(MODULE)
+
+
+class ShadowCasterContributionTests(unittest.TestCase):
+    def test_measures_exact_png_delta_and_joins_family(self):
+        with tempfile.TemporaryDirectory(prefix="pinyon-caster-delta-") as root:
+            root = Path(root)
+            before = root / "before.png"
+            after = root / "after.png"
+            before_pixels = bytes([0, 0, 0, 255] * 4)
+            after_pixels = bytearray(before_pixels)
+            after_pixels[4:8] = bytes([64, 64, 64, 255])
+            MODULE.write_rgba_png(before, 2, 2, before_pixels)
+            MODULE.write_rgba_png(after, 2, 2, bytes(after_pixels))
+            capture = {"path": "fixture.rdc", "sha256": "A" * 64}
+            export = {
+                "schema": MODULE.EXPORT_SCHEMA,
+                "capture": capture,
+                "resource": {"resource_name": "depth", "width": 2, "height": 2},
+                "events": [
+                    {
+                        "event_id": 10,
+                        "before": {
+                            "path": before.name,
+                            "sha256": MODULE.sha256(before),
+                        },
+                        "after": {
+                            "path": after.name,
+                            "sha256": MODULE.sha256(after),
+                        },
+                    }
+                ],
+                "safety": {
+                    "local_resource_payload_exported": True,
+                    "tracked_payload_allowed": False,
+                    "xenos_authority": True,
+                    "native_rendering_changed": False,
+                    "suppression_allowed": False,
+                },
+            }
+            census = {
+                "schema": MODULE.CENSUS_SCHEMA,
+                "capture": capture,
+                "families": [
+                    {
+                        "sha256": "B" * 64,
+                        "event_ids": [10],
+                        "semantic_role": "unknown_unclassified",
+                        "signature": {
+                            "pipeline_name": "fixture pipeline",
+                            "vertex_shader_name": "fixture vertex",
+                            "pixel_shader_name": None,
+                            "viewport": {"width": 2, "height": 2},
+                            "scissor": {"width": 2, "height": 2},
+                        },
+                    }
+                ],
+                "safety": {
+                    "metadata_only": True,
+                    "resource_payload_exported": False,
+                    "xenos_authority": True,
+                    "suppression_allowed": False,
+                },
+            }
+            export_path = root / "export.json"
+            census_path = root / "census.json"
+            export_path.write_text(json.dumps(export), encoding="utf-8")
+            census_path.write_text(json.dumps(census), encoding="utf-8")
+            report_path, report = MODULE.analyze(
+                export_path, census_path, root / "analysis"
+            )
+            self.assertTrue(report_path.is_file())
+            self.assertEqual(1, report["totals"]["events_with_delta"])
+            self.assertEqual(1, report["totals"]["changed_pixels"])
+            event = report["events"][0]
+            self.assertEqual(
+                {"x": 1, "y": 0, "width": 1, "height": 1},
+                event["bounding_box"],
+            )
+            self.assertEqual(
+                "fixture pipeline", event["signature"]["pipeline_name"]
+            )
+            delta_path = report_path.parent / event["delta_image"]
+            self.assertEqual((1, 1), MODULE.decode_rgba_png(delta_path)[:2])
+            self.assertFalse(
+                report["qualification"][
+                    "caster_classification_allowed_without_review"
+                ]
+            )
+
+    def test_rejects_hash_drift_and_unsafe_export(self):
+        with tempfile.TemporaryDirectory(prefix="pinyon-caster-unsafe-") as root:
+            root = Path(root)
+            image = root / "image.png"
+            MODULE.write_rgba_png(image, 1, 1, bytes([0, 0, 0, 255]))
+            capture = {"path": "fixture.rdc", "sha256": "A" * 64}
+            export = {
+                "schema": MODULE.EXPORT_SCHEMA,
+                "capture": capture,
+                "events": [
+                    {
+                        "event_id": 1,
+                        "before": {"path": image.name, "sha256": "B" * 64},
+                        "after": {"path": image.name, "sha256": "B" * 64},
+                    }
+                ],
+                "safety": {
+                    "local_resource_payload_exported": True,
+                    "tracked_payload_allowed": False,
+                    "xenos_authority": True,
+                    "native_rendering_changed": False,
+                    "suppression_allowed": False,
+                },
+            }
+            census = {
+                "schema": MODULE.CENSUS_SCHEMA,
+                "capture": capture,
+                "families": [],
+                "safety": {
+                    "metadata_only": True,
+                    "resource_payload_exported": False,
+                    "xenos_authority": True,
+                    "suppression_allowed": False,
+                },
+            }
+            export_path = root / "export.json"
+            census_path = root / "census.json"
+            export_path.write_text(json.dumps(export), encoding="utf-8")
+            census_path.write_text(json.dumps(census), encoding="utf-8")
+            with self.assertRaisesRegex(ValueError, "image hash drifted"):
+                MODULE.analyze(export_path, census_path, root / "analysis")
+
+    def test_export_contract_is_local_only_and_xenos_preserving(self):
+        exporter = (
+            ROOT / "tools/export-native-renderer-shadow-caster-contributions.py"
+        ).read_text(encoding="utf-8")
+        wrapper = (
+            ROOT / "tools/export-native-renderer-shadow-caster-contributions.ps1"
+        ).read_text(encoding="utf-8")
+        self.assertIn("controller.SetFrameEvent(event_id - 1, True)", exporter)
+        self.assertIn("controller.SetFrameEvent(event_id, True)", exporter)
+        self.assertIn("controller.SaveTexture", exporter)
+        self.assertIn('"tracked_payload_allowed": False', exporter)
+        self.assertIn('"xenos_authority": True', exporter)
+        self.assertIn('"native_rendering_changed": False', exporter)
+        self.assertIn('"suppression_allowed": False', exporter)
+        self.assertIn("must be below $localRoot", wrapper)
+        self.assertIn("Get-AuthenticodeSignature", wrapper)
+        self.assertIn("depth_write_events", wrapper)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Export local-only before/after depth images for capture-bound resource epochs and measure exact per-draw deltas. Keep caster promotion review-gated after proving one 1024-square family mixes vehicle and world geometry.

Tests: python -m unittest discover -s tools/tests (444 passed); qrenderdoc 42-write export; deterministic contribution report
