### PR TITLE
docs(renderer): census post-processing resource topology

### DIFF
--- a/docs/native-renderer/POST_PROCESSING_CENSUS.md
+++ b/docs/native-renderer/POST_PROCESSING_CENSUS.md
@@ -1,0 +1,76 @@
+# Native renderer post-processing census
+
+## Scope and safety boundary
+
+NR-05G starts with a payload-free topology census. It does not assign tone
+mapping, exposure, bloom, motion blur, color grading, depth-of-field, upscale,
+or UI-composite semantics from shader shape alone. It exports only RenderDoc
+action, attachment, transfer, and resource-usage metadata. Xenos remains
+authoritative; native coverage and suppression remain disabled.
+
+The target-usage exporter visits every authoritative draw, inventories its
+color targets, and follows texture copy/resolve destinations. Non-texture
+transfers are counted but excluded because this report has no bounded buffer
+description contract. The offline census then links a resource read to the
+most recent authoritative draw producer, crossing an exact copy/resolve only
+when the captured source and destination are both known. Missing, cleared,
+buffer-backed, or ambiguous lineage stays unresolved.
+
+## Reproduction
+
+```powershell
+.\tools\export-native-renderer-target-usage.ps1 `
+  -Capture '.local\qualification\native-renderer-renderdoc-seeded\reference_frame8134.rdc' `
+  -RenderDocRoot '.local\tools\renderdoc-1.45\RenderDoc_1.45_64' `
+  -Output '.local\qualification\nr05g-target-usage.json'
+
+python .\tools\build-native-renderer-post-chain-census.py `
+  .local\qualification\nr05g-target-usage.json `
+  .local\qualification\nr05f-labeled-pass-trace.json `
+  --output .local\qualification\nr05g-post-chain-census.json
+```
+
+The input capture SHA-256 is
+`EF4064929005D08432488FD4649E845630860044A6CDC49E463FA7B3883667DA`.
+The enriched pass trace SHA-256 is
+`D8D05B35B4EFAE3B4810C3639C8F9562F002F0DB686F6CE68278857797895DC7`.
+Local game-derived reports stay below `.local/qualification` and are not
+committed.
+
+## Current evidence
+
+The open-world frame produced the following metadata inventory:
+
+| Measurement | Count |
+| --- | ---: |
+| Tracked texture targets/destinations | 67 |
+| Texture copy/resolve transfers | 125 |
+| Non-texture transfers excluded and counted | 524 |
+| Authoritative color-target draw events | 419 |
+| Exact draw-to-draw resource edges | 31 |
+| Reads without an exact draw producer | 69 |
+| Presentation sinks | 1 |
+| Presentation-reachable draws | 1 |
+| Presentation source boundaries | 1 |
+
+The sink is event `11363`, a four-index, full-output draw to
+`Swapchain Image 309`, followed by the present boundary at event `11372`.
+It is a mechanically full-screen candidate only and remains
+`operator_review_required`. Its ingress does not appear in the tracked texture
+target lineage, so `presentation_ingress_resolved`, effect semantics, the
+full-resolution UI boundary, and native implementation readiness are all
+false. This is consistent with the final ReXGlue compositor crossing a
+buffer-backed or otherwise unbound-to-color-target handoff.
+
+The deterministic local target-usage report SHA-256 is
+`2CC702B5259B2A302414650DC1C39E1BC103A1C3C19E325A70AA11F0F5C40A35`;
+the derived census SHA-256 is
+`A1BC0BFB2503C3AF2BD5C07EBE19A11C2F84C03FCA986F44798938C6C9A07C7F`.
+
+## Next boundary
+
+The next capture-only change must add a bounded inventory of the final
+compositor's read-only bindings or the excluded buffer transfer chain. It must
+join that ingress back to the guest color-target/resolve graph before any
+effect family is named. Only after the presentation ingress and UI boundary
+are exact should an isolated native tone-map or upscale implementation begin.

--- a/tools/build-native-renderer-post-chain-census.py
+++ b/tools/build-native-renderer-post-chain-census.py
@@ -1,0 +1,350 @@
+"""Build a fail-closed post-chain topology from payload-free capture metadata."""
+
+import argparse
+import hashlib
+import json
+import pathlib
+import sys
+
+
+USAGE_SCHEMA = "pinyon-shift.native-renderer-renderdoc-target-usage.v1"
+PASS_SCHEMA = "pinyon-shift.native-renderer-renderdoc-pass-trace.v1"
+SCHEMA = "pinyon-shift.native-renderer-post-chain-census.v1"
+WRITE_USAGES = {"ColorTarget", "CopyDst", "ResolveDst", "Clear"}
+READ_USAGES = {"PS_Resource", "CS_Resource", "CopySrc", "ResolveSrc"}
+
+
+def canonical_sha256(value):
+    return hashlib.sha256(
+        json.dumps(value, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    ).hexdigest().upper()
+
+
+def draw_signature(draw):
+    return {
+        key: draw.get(key)
+        for key in (
+            "pipeline",
+            "pipeline_name",
+            "vertex_shader",
+            "vertex_shader_name",
+            "pixel_shader",
+            "pixel_shader_name",
+            "primitive_topology",
+            "viewport",
+            "scissor",
+            "depth_state",
+            "raster_state",
+            "color_targets",
+            "depth_target",
+        )
+    }
+
+
+def is_fullscreen_candidate(draw):
+    viewport = draw.get("viewport") or {}
+    depth_state = draw.get("depth_state") or {}
+    return (
+        0 < int(draw.get("index_count", 0)) <= 6
+        and int(draw.get("instance_count", 0)) == 1
+        and bool(draw.get("color_targets"))
+        and draw.get("pixel_shader") is not None
+        and viewport.get("enabled") is True
+        and float(viewport.get("width", 0)) > 0
+        and float(viewport.get("height", 0)) > 0
+        and depth_state.get("writes") is not True
+    )
+
+
+def build_census(target_usage, pass_trace):
+    if target_usage.get("schema") != USAGE_SCHEMA:
+        raise ValueError("unsupported target-usage schema")
+    if pass_trace.get("schema") != PASS_SCHEMA:
+        raise ValueError("unsupported pass-trace schema")
+    usage_safety = target_usage.get("safety", {})
+    pass_safety = pass_trace.get("safety", {})
+    if usage_safety.get("resource_payload_exported") is not False:
+        raise ValueError("target usage does not prove its payload-free boundary")
+    if usage_safety.get("action_metadata_only") is not True:
+        raise ValueError("target usage is not action-metadata-only")
+    if pass_safety.get("resource_payload_exported") is not False:
+        raise ValueError("pass trace does not prove its payload-free boundary")
+    if target_usage.get("capture", {}).get("sha256") != pass_trace.get(
+        "capture", {}
+    ).get("sha256"):
+        raise ValueError("target usage and pass trace captures differ")
+    resources = target_usage.get("resources")
+    transfers = target_usage.get("transfers", [])
+    events = pass_trace.get("events")
+    if (
+        not isinstance(resources, list)
+        or not isinstance(transfers, list)
+        or not isinstance(events, list)
+    ):
+        raise ValueError("census inputs must contain arrays")
+
+    draws = {
+        event["event_id"]: event
+        for event in events
+        if event.get("kind") == "draw" and event.get("isolated_native") is not True
+    }
+    present_boundaries = sorted(
+        event["event_id"]
+        for event in events
+        if event.get("kind") == "boundary"
+        and "present" in event.get("boundary_kinds", [])
+    )
+    edges = []
+    unresolved_reads = []
+    presentation_sinks = []
+    produced_events = set()
+    writes_by_resource = {}
+    transfer_by_destination_event = {}
+    for transfer in transfers:
+        event_id = transfer.get("event_id")
+        source = transfer.get("source_resource_id")
+        destination = transfer.get("destination_resource_id")
+        if (
+            not isinstance(event_id, int)
+            or not isinstance(source, str)
+            or not isinstance(destination, str)
+            or transfer.get("kind") not in {"copy", "resolve"}
+        ):
+            raise ValueError("target transfer inventory is invalid")
+        key = (destination, event_id)
+        if key in transfer_by_destination_event:
+            raise ValueError("duplicate target transfer destination")
+        transfer_by_destination_event[key] = transfer
+    for resource in resources:
+        identifier = resource.get("resource_id")
+        usages = resource.get("usages")
+        if not isinstance(identifier, str) or not isinstance(usages, list):
+            raise ValueError("target resource inventory is invalid")
+        writes_by_resource[identifier] = [
+            (usage.get("event_id"), usage.get("usage"))
+            for usage in usages
+            if usage.get("usage") in WRITE_USAGES
+        ]
+
+    def resolve_producer(identifier, before_event, visited=None):
+        visited = set() if visited is None else set(visited)
+        key = (identifier, before_event)
+        if key in visited:
+            return None
+        visited.add(key)
+        prior = [
+            item
+            for item in writes_by_resource.get(identifier, [])
+            if isinstance(item[0], int) and item[0] < before_event
+        ]
+        if not prior:
+            return None
+        event_id, kind = prior[-1]
+        if kind == "ColorTarget" and event_id in draws:
+            return event_id
+        if kind in {"CopyDst", "ResolveDst"}:
+            transfer = transfer_by_destination_event.get((identifier, event_id))
+            if transfer is not None:
+                return resolve_producer(
+                    transfer["source_resource_id"], event_id, visited
+                )
+        return None
+
+    for resource in resources:
+        identifier = resource.get("resource_id")
+        usages = resource.get("usages")
+        if not isinstance(identifier, str) or not isinstance(usages, list):
+            raise ValueError("target resource inventory is invalid")
+        last_event = -1
+        writes = []
+        resource_sinks = []
+        for usage in usages:
+            event_id = usage.get("event_id")
+            kind = usage.get("usage")
+            if not isinstance(event_id, int) or event_id < last_event:
+                raise ValueError("target usages are not monotonically ordered")
+            if not isinstance(kind, str) or not kind:
+                raise ValueError("target usage kind is invalid")
+            last_event = event_id
+            if kind in WRITE_USAGES:
+                writes.append((event_id, kind))
+                if kind == "ColorTarget" and event_id in draws:
+                    produced_events.add(event_id)
+            if kind in READ_USAGES:
+                prior = [item for item in writes if item[0] < event_id]
+                producer = prior[-1] if prior else None
+                resolved_producer = resolve_producer(identifier, event_id)
+                if resolved_producer is not None and event_id in draws:
+                    edges.append(
+                        {
+                            "resource_id": identifier,
+                            "resource_name": resource.get("resource_name", ""),
+                            "producer_event": resolved_producer,
+                            "consumer_event": event_id,
+                            "read_usage": kind,
+                        }
+                    )
+                else:
+                    unresolved_reads.append(
+                        {
+                            "resource_id": identifier,
+                            "consumer_event": event_id,
+                            "read_usage": kind,
+                            "last_write_event": None if producer is None else producer[0],
+                            "last_write_usage": None if producer is None else producer[1],
+                        }
+                    )
+            if kind == "Present":
+                prior = [item for item in writes if item[0] < event_id]
+                sink = prior[-1] if prior else None
+                if sink is not None and sink[1] == "ColorTarget" and sink[0] in draws:
+                    resource_sinks.append(
+                        {
+                            "resource_id": identifier,
+                            "present_event": event_id,
+                            "producer_event": sink[0],
+                        }
+                    )
+        if (
+            not resource_sinks
+            and str(resource.get("resource_name", "")).startswith(
+                "Swapchain Image "
+            )
+        ):
+            color_writes = [
+                item
+                for item in writes
+                if item[1] == "ColorTarget" and item[0] in draws
+            ]
+            if color_writes:
+                sink = color_writes[-1]
+                present_event = next(
+                    (
+                        event_id
+                        for event_id in present_boundaries
+                        if event_id > sink[0]
+                    ),
+                    None,
+                )
+                if present_event is not None:
+                    resource_sinks.append(
+                        {
+                            "resource_id": identifier,
+                            "present_event": present_event,
+                            "producer_event": sink[0],
+                            "present_source": "swapchain_name_and_boundary",
+                        }
+                    )
+        presentation_sinks.extend(resource_sinks)
+
+    incoming = {}
+    for edge in edges:
+        incoming.setdefault(edge["consumer_event"], []).append(edge)
+    reachable = set()
+    pending = [sink["producer_event"] for sink in presentation_sinks]
+    while pending:
+        event_id = pending.pop()
+        if event_id in reachable:
+            continue
+        reachable.add(event_id)
+        pending.extend(
+            edge["producer_event"] for edge in incoming.get(event_id, [])
+        )
+
+    candidates = []
+    for event_id in sorted(reachable):
+        draw = draws[event_id]
+        if not is_fullscreen_candidate(draw):
+            continue
+        signature = draw_signature(draw)
+        candidates.append(
+            {
+                "event_id": event_id,
+                "sha256": canonical_sha256(signature),
+                "signature": signature,
+                "index_count": int(draw.get("index_count", 0)),
+                "semantic_role": "operator_review_required",
+                "native_coverage": False,
+                "suppression_eligible": False,
+            }
+        )
+    presentation_source_boundaries = sorted(
+        sink["producer_event"]
+        for sink in presentation_sinks
+        if not incoming.get(sink["producer_event"])
+    )
+    return {
+        "schema": SCHEMA,
+        "capture": pass_trace.get("capture"),
+        "totals": {
+            "target_resources": len(resources),
+            "transfers": len(transfers),
+            "produced_draw_events": len(produced_events),
+            "resource_edges": len(edges),
+            "unresolved_reads": len(unresolved_reads),
+            "presentation_sinks": len(presentation_sinks),
+            "presentation_reachable_draws": len(reachable),
+            "fullscreen_candidates": len(candidates),
+            "presentation_source_boundaries": len(
+                presentation_source_boundaries
+            ),
+        },
+        "presentation_sinks": presentation_sinks,
+        "edges": sorted(
+            edges,
+            key=lambda edge: (
+                edge["consumer_event"],
+                edge["producer_event"],
+                edge["resource_id"],
+            ),
+        ),
+        "unresolved_reads": unresolved_reads,
+        "presentation_reachable_events": sorted(reachable),
+        "presentation_source_boundaries": presentation_source_boundaries,
+        "fullscreen_candidates": candidates,
+        "qualification": {
+            "presentation_topology_observed": bool(presentation_sinks),
+            "presentation_ingress_resolved": bool(presentation_sinks)
+            and not presentation_source_boundaries,
+            "effect_semantics_proven": False,
+            "ui_composite_boundary_proven": False,
+            "native_implementation_ready": False,
+        },
+        "safety": {
+            "metadata_only": True,
+            "resource_payload_exported": False,
+            "xenos_authority": True,
+            "native_coverage": False,
+            "suppression_allowed": False,
+        },
+    }
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser()
+    parser.add_argument("target_usage", type=pathlib.Path)
+    parser.add_argument("pass_trace", type=pathlib.Path)
+    parser.add_argument("--output", required=True, type=pathlib.Path)
+    args = parser.parse_args(argv)
+    try:
+        usage_bytes = args.target_usage.read_bytes()
+        pass_bytes = args.pass_trace.read_bytes()
+        result = build_census(json.loads(usage_bytes), json.loads(pass_bytes))
+        result["target_usage_sha256"] = hashlib.sha256(usage_bytes).hexdigest().upper()
+        result["pass_trace_sha256"] = hashlib.sha256(pass_bytes).hexdigest().upper()
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(
+            json.dumps(result, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+        )
+        print(
+            json.dumps(result["totals"], sort_keys=True),
+            file=sys.stdout,
+        )
+        return 0
+    except (OSError, ValueError, KeyError, TypeError, json.JSONDecodeError) as error:
+        print("native renderer post-chain census failed: {}".format(error), file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/export-native-renderer-target-usage.ps1
+++ b/tools/export-native-renderer-target-usage.ps1
@@ -1,0 +1,63 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)]
+    [string]$Capture,
+    [Parameter(Mandatory)]
+    [string]$RenderDocRoot,
+    [Parameter(Mandatory)]
+    [string]$Output
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
+$localRoot = [IO.Path]::GetFullPath((Join-Path $repoRoot '.local'))
+$localPrefix = $localRoot.TrimEnd([IO.Path]::DirectorySeparatorChar) +
+    [IO.Path]::DirectorySeparatorChar
+$resolvedCapture = (Resolve-Path -LiteralPath $Capture).Path
+$resolvedOutput = [IO.Path]::GetFullPath($Output)
+foreach ($item in @(
+        @{ Name = 'Capture'; Value = $resolvedCapture },
+        @{ Name = 'Output'; Value = $resolvedOutput }
+    )) {
+    if (-not $item.Value.StartsWith(
+            $localPrefix, [StringComparison]::OrdinalIgnoreCase)) {
+        throw "$($item.Name) must be below $localRoot"
+    }
+}
+if (Test-Path -LiteralPath $resolvedOutput) {
+    throw "Output already exists: $resolvedOutput"
+}
+
+$qrenderdoc = Join-Path ([IO.Path]::GetFullPath($RenderDocRoot)) 'qrenderdoc.exe'
+if (-not (Test-Path -LiteralPath $qrenderdoc -PathType Leaf)) {
+    throw "qrenderdoc.exe was not found below RenderDocRoot: $RenderDocRoot"
+}
+$signature = Get-AuthenticodeSignature -LiteralPath $qrenderdoc
+if ([string]$signature.Status -ne 'Valid') {
+    throw 'qrenderdoc.exe does not have a valid Authenticode signature'
+}
+
+$script = Join-Path $PSScriptRoot 'export-native-renderer-target-usage.py'
+$parent = Split-Path $resolvedOutput -Parent
+[void](New-Item -ItemType Directory -Path $parent -Force)
+$savedCapture = $env:PINYON_SHIFT_RENDERDOC_CAPTURE
+$savedOutput = $env:PINYON_SHIFT_RENDERDOC_TARGET_USAGE
+try {
+    $env:PINYON_SHIFT_RENDERDOC_CAPTURE = $resolvedCapture
+    $env:PINYON_SHIFT_RENDERDOC_TARGET_USAGE = $resolvedOutput
+    $process = Start-Process -FilePath $qrenderdoc `
+        -ArgumentList @('--python', $script) -PassThru -Wait
+    if ($process.ExitCode) {
+        throw "qrenderdoc target usage exited with code $($process.ExitCode)"
+    }
+}
+finally {
+    $env:PINYON_SHIFT_RENDERDOC_CAPTURE = $savedCapture
+    $env:PINYON_SHIFT_RENDERDOC_TARGET_USAGE = $savedOutput
+}
+if (-not (Test-Path -LiteralPath $resolvedOutput -PathType Leaf)) {
+    throw 'qrenderdoc exited without producing the target usage report.'
+}
+Get-Content -LiteralPath $resolvedOutput -Raw | ConvertFrom-Json

--- a/tools/export-native-renderer-target-usage.py
+++ b/tools/export-native-renderer-target-usage.py
@@ -1,0 +1,187 @@
+"""Export payload-free usage metadata for every authoritative color target."""
+
+import hashlib
+import json
+import os
+import sys
+
+import renderdoc as rd
+
+
+SCHEMA = "pinyon-shift.native-renderer-renderdoc-target-usage.v1"
+ISOLATED_MARKER = "PinyonShift NR-02E isolated native draw"
+
+
+def flatten(actions):
+    result = []
+    for action in actions:
+        result.append(action)
+        result.extend(flatten(action.children))
+    return result
+
+
+def descendants(action):
+    result = []
+    for child in action.children:
+        result.append(child)
+        result.extend(descendants(child))
+    return result
+
+
+def sha256(path):
+    digest = hashlib.sha256()
+    with open(path, "rb") as source:
+        for block in iter(lambda: source.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def texture_description(resource, texture, resource_names):
+    return {
+        "resource_id": str(resource),
+        "resource_name": resource_names.get(str(resource), ""),
+        "width": texture.width,
+        "height": texture.height,
+        "format": texture.format.Name(),
+        "mips": texture.mips,
+        "arraysize": texture.arraysize,
+        "ms_samp": texture.msSamp,
+    }
+
+
+def main():
+    capture_path = os.environ["PINYON_SHIFT_RENDERDOC_CAPTURE"]
+    report_path = os.environ["PINYON_SHIFT_RENDERDOC_TARGET_USAGE"]
+    capture = rd.OpenCaptureFile()
+    controller = None
+    try:
+        result = capture.OpenFile(capture_path, "", None)
+        if result != rd.ResultCode.Succeeded:
+            raise RuntimeError("could not open capture: {}".format(result))
+        if not capture.LocalReplaySupport():
+            raise RuntimeError("capture does not support local replay")
+        result, controller = capture.OpenCapture(rd.ReplayOptions(), None)
+        if result != rd.ResultCode.Succeeded:
+            raise RuntimeError("could not initialise replay: {}".format(result))
+
+        actions = flatten(controller.GetRootActions())
+        isolated_events = set()
+        for action in actions:
+            if action.customName == ISOLATED_MARKER:
+                isolated_events.update(child.eventId for child in descendants(action))
+        textures = {
+            str(texture.resourceId): texture for texture in controller.GetTextures()
+        }
+        resource_names = {
+            str(resource.resourceId): resource.name
+            for resource in controller.GetResources()
+        }
+        targets = {}
+        transfers = []
+        skipped_non_texture_transfers = 0
+        for action in actions:
+            if (
+                not action.flags & rd.ActionFlags.Drawcall
+                or action.eventId in isolated_events
+            ):
+                continue
+            controller.SetFrameEvent(action.eventId, True)
+            for target in controller.GetPipelineState().GetOutputTargets():
+                if target.resource == rd.ResourceId.Null():
+                    continue
+                identifier = str(target.resource)
+                texture = textures.get(identifier)
+                if texture is None:
+                    raise RuntimeError(
+                        "color target texture description was not found: "
+                        + identifier
+                    )
+                targets[identifier] = (target.resource, texture)
+
+        for action in actions:
+            transfer_kind = None
+            copy_flag = getattr(rd.ActionFlags, "Copy", None)
+            resolve_flag = getattr(rd.ActionFlags, "Resolve", None)
+            if copy_flag is not None and action.flags & copy_flag:
+                transfer_kind = "copy"
+            elif resolve_flag is not None and action.flags & resolve_flag:
+                transfer_kind = "resolve"
+            if transfer_kind is None:
+                continue
+            source = getattr(action, "copySource", rd.ResourceId.Null())
+            destination = getattr(action, "copyDestination", rd.ResourceId.Null())
+            if (
+                source == rd.ResourceId.Null()
+                or destination == rd.ResourceId.Null()
+            ):
+                continue
+            destination_id = str(destination)
+            destination_texture = textures.get(destination_id)
+            if destination_texture is None:
+                skipped_non_texture_transfers += 1
+                continue
+            targets[destination_id] = (destination, destination_texture)
+            transfers.append(
+                {
+                    "event_id": action.eventId,
+                    "kind": transfer_kind,
+                    "source_resource_id": str(source),
+                    "destination_resource_id": destination_id,
+                }
+            )
+
+        resources = []
+        for identifier in sorted(targets):
+            resource, texture = targets[identifier]
+            usages = [
+                {
+                    "event_id": usage.eventId,
+                    "usage": usage.usage.name,
+                }
+                for usage in controller.GetUsage(resource)
+            ]
+            resources.append(
+                {
+                    **texture_description(resource, texture, resource_names),
+                    "usages": usages,
+                }
+            )
+        report = {
+            "schema": SCHEMA,
+            "capture": {
+                "path": os.path.basename(capture_path),
+                "sha256": sha256(capture_path),
+            },
+            "resources": resources,
+            "transfers": transfers,
+            "totals": {
+                "color_target_resources": len(resources),
+                "transfers": len(transfers),
+                "skipped_non_texture_transfers": skipped_non_texture_transfers,
+                "usage_references": sum(
+                    len(resource["usages"]) for resource in resources
+                ),
+            },
+            "safety": {
+                "resource_payload_exported": False,
+                "action_metadata_only": True,
+                "xenos_authority": True,
+                "suppression_allowed": False,
+            },
+        }
+        with open(report_path, "w") as output:
+            json.dump(report, output, indent=2, sort_keys=True)
+            output.write("\n")
+        print(report_path)
+        return 0
+    finally:
+        if controller is not None:
+            controller.Shutdown()
+        capture.Shutdown()
+
+
+try:
+    sys.exit(main())
+except Exception as error:
+    sys.stderr.write("native renderer target usage failed: {}\n".format(error))
+    sys.exit(1)

--- a/tools/tests/test_native_renderer_post_chain_census.py
+++ b/tools/tests/test_native_renderer_post_chain_census.py
@@ -1,0 +1,200 @@
+import importlib.util
+import sys
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+TOOL = ROOT / "tools/build-native-renderer-post-chain-census.py"
+SPEC = importlib.util.spec_from_file_location("native_post_chain_census", TOOL)
+assert SPEC and SPEC.loader
+MODULE = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = MODULE
+SPEC.loader.exec_module(MODULE)
+
+
+def target(identifier):
+    return {
+        "resource_id": identifier,
+        "resource_name": identifier,
+        "width": 1280,
+        "height": 720,
+        "format": "R8G8B8A8_UNORM",
+    }
+
+
+def draw(event_id, output, index_count=3):
+    return {
+        "event_id": event_id,
+        "kind": "draw",
+        "index_count": index_count,
+        "instance_count": 1,
+        "pipeline": "pipeline-{}".format(event_id),
+        "pipeline_name": "pipeline {}".format(event_id),
+        "vertex_shader": "vs",
+        "vertex_shader_name": "vs",
+        "pixel_shader": "ps",
+        "pixel_shader_name": "ps",
+        "primitive_topology": "TriangleList",
+        "viewport": {"enabled": True, "width": 1280.0, "height": 720.0},
+        "scissor": {"enabled": True, "width": 1280, "height": 720},
+        "depth_state": {"writes": False},
+        "raster_state": {"cull_mode": "NoCull"},
+        "color_targets": [target(output)],
+        "depth_target": None,
+        "isolated_native": False,
+    }
+
+
+def pass_trace(events, capture="A" * 64):
+    return {
+        "schema": MODULE.PASS_SCHEMA,
+        "capture": {"path": "fixture.rdc", "sha256": capture},
+        "events": events,
+        "safety": {"resource_payload_exported": False},
+    }
+
+
+def resource(identifier, usages):
+    return {**target(identifier), "usages": usages}
+
+
+def target_usage(resources, capture="A" * 64, transfers=None):
+    return {
+        "schema": MODULE.USAGE_SCHEMA,
+        "capture": {"path": "fixture.rdc", "sha256": capture},
+        "resources": resources,
+        "transfers": [] if transfers is None else transfers,
+        "safety": {
+            "resource_payload_exported": False,
+            "action_metadata_only": True,
+        },
+    }
+
+
+class NativeRendererPostChainCensusTests(unittest.TestCase):
+    def test_builds_presentation_reachable_fullscreen_chain(self):
+        events = [draw(10, "scene", 100), draw(20, "post"), draw(30, "swap")]
+        resources = [
+            resource("scene", [
+                {"event_id": 10, "usage": "ColorTarget"},
+                {"event_id": 20, "usage": "PS_Resource"},
+            ]),
+            resource("post", [
+                {"event_id": 20, "usage": "ColorTarget"},
+                {"event_id": 30, "usage": "PS_Resource"},
+            ]),
+            resource("swap", [
+                {"event_id": 30, "usage": "ColorTarget"},
+                {"event_id": 40, "usage": "Present"},
+            ]),
+        ]
+        result = MODULE.build_census(target_usage(resources), pass_trace(events))
+        self.assertEqual(result["presentation_reachable_events"], [10, 20, 30])
+        self.assertEqual(
+            [item["event_id"] for item in result["fullscreen_candidates"]],
+            [20, 30],
+        )
+        self.assertEqual(result["totals"]["resource_edges"], 2)
+        self.assertTrue(result["qualification"]["presentation_topology_observed"])
+        self.assertTrue(result["qualification"]["presentation_ingress_resolved"])
+        self.assertFalse(result["qualification"]["effect_semantics_proven"])
+        self.assertFalse(result["safety"]["suppression_allowed"])
+
+    def test_uses_most_recent_draw_write_for_a_read(self):
+        events = [draw(10, "ping"), draw(11, "ping"), draw(20, "swap")]
+        resources = [
+            resource("ping", [
+                {"event_id": 10, "usage": "ColorTarget"},
+                {"event_id": 11, "usage": "ColorTarget"},
+                {"event_id": 20, "usage": "PS_Resource"},
+            ]),
+            resource("swap", [
+                {"event_id": 20, "usage": "ColorTarget"},
+                {"event_id": 30, "usage": "Present"},
+            ]),
+        ]
+        result = MODULE.build_census(target_usage(resources), pass_trace(events))
+        self.assertEqual(result["edges"][0]["producer_event"], 11)
+        self.assertNotIn(10, result["presentation_reachable_events"])
+
+    def test_correlates_swapchain_target_with_later_present_boundary(self):
+        event = draw(20, "swap")
+        event["color_targets"][0]["resource_name"] = "Swapchain Image 1"
+        boundary = {
+            "event_id": 30,
+            "kind": "boundary",
+            "boundary_kinds": ["present"],
+        }
+        swap = resource(
+            "swap", [{"event_id": 20, "usage": "ColorTarget"}]
+        )
+        swap["resource_name"] = "Swapchain Image 1"
+        result = MODULE.build_census(
+            target_usage([swap]), pass_trace([event, boundary])
+        )
+        self.assertEqual(result["presentation_reachable_events"], [20])
+        self.assertEqual(
+            result["presentation_sinks"][0]["present_source"],
+            "swapchain_name_and_boundary",
+        )
+        self.assertFalse(result["qualification"]["presentation_ingress_resolved"])
+        self.assertEqual(result["presentation_source_boundaries"], [20])
+
+    def test_records_copy_or_missing_producers_as_unresolved(self):
+        events = [draw(20, "swap")]
+        resources = [
+            resource("copied", [
+                {"event_id": 10, "usage": "CopyDst"},
+                {"event_id": 20, "usage": "PS_Resource"},
+            ]),
+            resource("swap", [
+                {"event_id": 20, "usage": "ColorTarget"},
+                {"event_id": 30, "usage": "Present"},
+            ]),
+        ]
+        result = MODULE.build_census(target_usage(resources), pass_trace(events))
+        self.assertEqual(result["totals"]["unresolved_reads"], 1)
+        self.assertEqual(result["unresolved_reads"][0]["last_write_usage"], "CopyDst")
+        self.assertFalse(result["qualification"]["native_implementation_ready"])
+
+    def test_follows_copy_destination_back_to_draw_producer(self):
+        events = [draw(10, "scene", 100), draw(20, "swap")]
+        resources = [
+            resource("scene", [
+                {"event_id": 10, "usage": "ColorTarget"},
+                {"event_id": 15, "usage": "CopySrc"},
+            ]),
+            resource("resolved", [
+                {"event_id": 15, "usage": "CopyDst"},
+                {"event_id": 20, "usage": "PS_Resource"},
+            ]),
+            resource("swap", [
+                {"event_id": 20, "usage": "ColorTarget"},
+                {"event_id": 30, "usage": "Present"},
+            ]),
+        ]
+        transfers = [{
+            "event_id": 15,
+            "kind": "copy",
+            "source_resource_id": "scene",
+            "destination_resource_id": "resolved",
+        }]
+        result = MODULE.build_census(
+            target_usage(resources, transfers=transfers), pass_trace(events)
+        )
+        self.assertEqual(result["edges"][0]["producer_event"], 10)
+        self.assertEqual(result["presentation_reachable_events"], [10, 20])
+        self.assertEqual(result["totals"]["transfers"], 1)
+
+    def test_rejects_capture_drift_and_unsafe_inputs(self):
+        with self.assertRaisesRegex(ValueError, "captures differ"):
+            MODULE.build_census(target_usage([], "A" * 64), pass_trace([], "B" * 64))
+        unsafe = target_usage([])
+        unsafe["safety"]["resource_payload_exported"] = True
+        with self.assertRaisesRegex(ValueError, "payload-free"):
+            MODULE.build_census(unsafe, pass_trace([]))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- export payload-free usage metadata for authoritative color targets and texture copy/resolve destinations
- build a deterministic presentation-reachable producer/consumer topology with fail-closed unresolved lineage
- document the retained open-world capture: 67 tracked texture targets/destinations, 125 transfers, 31 exact resource edges, and one unresolved presentation ingress
- keep effect labels, UI-boundary claims, native readiness, coverage, and suppression disabled

## Validation
- python -m unittest discover -s tools/tests — 454 passed
- RenderDoc target-usage export against eference_frame8134.rdc — passed
- deterministic post-chain census — passed

## Safety
Metadata only. No game payload is exported, Xenos remains authoritative, and no native rendering or suppression is enabled.