### PR TITLE
docs(renderer): resolve presentation upscale ingress

### DIFF
--- a/docs/native-renderer/POST_PROCESSING_CENSUS.md
+++ b/docs/native-renderer/POST_PROCESSING_CENSUS.md
@@ -56,21 +56,58 @@ The open-world frame produced the following metadata inventory:
 The sink is event `11363`, a four-index, full-output draw to
 `Swapchain Image 309`, followed by the present boundary at event `11372`.
 It is a mechanically full-screen candidate only and remains
-`operator_review_required`. Its ingress does not appear in the tracked texture
-target lineage, so `presentation_ingress_resolved`, effect semantics, the
-full-resolution UI boundary, and native implementation readiness are all
-false. This is consistent with the final ReXGlue compositor crossing a
-buffer-backed or otherwise unbound-to-color-target handoff.
+`operator_review_required`. The initial target-lineage census could not see its
+ingress, so it kept effect semantics, the full-resolution UI boundary, and
+native implementation readiness false and required the bounded binding
+follow-up below.
 
 The deterministic local target-usage report SHA-256 is
 `2CC702B5259B2A302414650DC1C39E1BC103A1C3C19E325A70AA11F0F5C40A35`;
 the derived census SHA-256 is
 `A1BC0BFB2503C3AF2BD5C07EBE19A11C2F84C03FCA986F44798938C6C9A07C7F`.
 
+## Presentation ingress checkpoint
+
+A bounded follow-up inspects only event `11363` and verifies its later present
+boundary. It exports one active pixel-stage image binding and no resource
+payload:
+
+```powershell
+.\tools\export-native-renderer-presentation-bindings.ps1 `
+  -Capture '.local\qualification\native-renderer-renderdoc-seeded\reference_frame8134.rdc' `
+  -RenderDocRoot '.local\tools\renderdoc-1.45\RenderDoc_1.45_64' `
+  -EventId 11363 `
+  -Output '.local\qualification\nr05g-presentation-bindings.json'
+
+python .\tools\build-native-renderer-presentation-ingress.py `
+  .local\qualification\nr05g-presentation-bindings.json `
+  .local\qualification\nr05g-post-chain-census.json `
+  --output .local\qualification\nr05g-presentation-ingress.json
+```
+
+The binding is `ResourceId::2404`, a `2560×1440`
+`R10G10B10A2_UNORM` texture at pixel descriptor zero. Event `11363` writes the
+single `3840×2160 B8G8R8A8_UNORM` swapchain target. Both axes therefore have
+the exact uniform ratio `3/2`, proving the mechanical presentation-upscale
+boundary. The capture records only the event-11363 pixel read for this input;
+it has no capture-local color, copy, resolve, or unordered-write producer.
+The input is consequently classified as external or pre-capture, not joined
+to the guest post-process graph.
+
+This closes `presentation_ingress_resolved` and
+`presentation_upscale_boundary_proven`, but deliberately leaves the upscale
+algorithm, guest post-chain join, effect semantics, UI-composite boundary, and
+native implementation readiness false. The local binding report SHA-256 is
+`FA7E0D5CC476DD3554D21204B47EB157DB1C7CC817A1F474179A1AD2E406EDB5`;
+the derived ingress report SHA-256 is
+`2AFB97FB0982F46C7EEB39296593D9B450886E67F9BAF2B6B31E36C9A4C87C20`.
+
 ## Next boundary
 
-The next capture-only change must add a bounded inventory of the final
-compositor's read-only bindings or the excluded buffer transfer chain. It must
-join that ingress back to the guest color-target/resolve graph before any
-effect family is named. Only after the presentation ingress and UI boundary
-are exact should an isolated native tone-map or upscale implementation begin.
+The next capture-only change must locate the creation/update/import boundary
+for `ResourceId::2404`, or add equivalent ReXGlue diagnostics for the Xenos
+presentation surface before event `11363`. It must join that surface back to
+the guest color-target/resolve graph before any guest effect family is named.
+The already proven 3:2 presentation boundary may support an isolated native
+upscale experiment, but its algorithm and UI ordering must remain independently
+gated until exact shader or visual evidence is captured.

--- a/tools/build-native-renderer-presentation-ingress.py
+++ b/tools/build-native-renderer-presentation-ingress.py
@@ -1,0 +1,185 @@
+"""Join one presentation binding report to the fail-closed post-chain census."""
+
+import argparse
+from fractions import Fraction
+import hashlib
+import json
+import pathlib
+import sys
+
+
+BINDING_SCHEMA = "pinyon-shift.native-renderer-presentation-bindings.v1"
+POST_SCHEMA = "pinyon-shift.native-renderer-post-chain-census.v1"
+SCHEMA = "pinyon-shift.native-renderer-presentation-ingress.v1"
+WRITE_USAGES = {
+    "ColorTarget",
+    "CopyDst",
+    "ResolveDst",
+    "CS_RWResource",
+    "PS_RWResource",
+}
+
+
+def ratio(output_size, input_size):
+    if type(output_size) is not int or type(input_size) is not int:
+        raise ValueError("presentation dimensions must be integers")
+    if output_size <= 0 or input_size <= 0:
+        raise ValueError("presentation dimensions must be positive")
+    value = Fraction(output_size, input_size)
+    return {"numerator": value.numerator, "denominator": value.denominator}
+
+
+def build_ingress(bindings, post_census):
+    if bindings.get("schema") != BINDING_SCHEMA:
+        raise ValueError("unsupported presentation-binding schema")
+    if post_census.get("schema") != POST_SCHEMA:
+        raise ValueError("unsupported post-chain census schema")
+    binding_safety = bindings.get("safety", {})
+    census_safety = post_census.get("safety", {})
+    if binding_safety.get("resource_payload_exported") is not False:
+        raise ValueError("binding report does not prove its payload-free boundary")
+    if binding_safety.get("action_metadata_only") is not True:
+        raise ValueError("binding report is not action-metadata-only")
+    if census_safety.get("metadata_only") is not True:
+        raise ValueError("post-chain census is not metadata-only")
+    for safety in (binding_safety, census_safety):
+        if safety.get("xenos_authority") is not True:
+            raise ValueError("Xenos authority changed")
+        if safety.get("suppression_allowed") is not False:
+            raise ValueError("suppression was allowed")
+    if bindings.get("capture", {}).get("sha256") != post_census.get(
+        "capture", {}
+    ).get("sha256"):
+        raise ValueError("presentation bindings and post census captures differ")
+
+    presentation = bindings.get("presentation")
+    binding_items = bindings.get("bindings")
+    sinks = post_census.get("presentation_sinks")
+    if not isinstance(presentation, dict) or not isinstance(binding_items, list):
+        raise ValueError("presentation binding report is incomplete")
+    if not isinstance(sinks, list) or len(sinks) != 1:
+        raise ValueError("post census must contain one presentation sink")
+    sink = sinks[0]
+    if (
+        sink.get("producer_event") != presentation.get("draw_event")
+        or sink.get("present_event") != presentation.get("present_event")
+        or sink.get("resource_id") != presentation.get("output_resource_id")
+    ):
+        raise ValueError("presentation sink identity drifted")
+    if len(binding_items) != 1:
+        raise ValueError("presentation draw must have one bounded ingress")
+    binding = binding_items[0]
+    if binding.get("stage") != "ShaderStage.Pixel":
+        raise ValueError("presentation ingress is not a pixel binding")
+    if binding.get("descriptor_type") != "DescriptorType.Image":
+        raise ValueError("presentation ingress is not an image")
+    if binding.get("statically_unused") is not False:
+        raise ValueError("presentation ingress is statically unused")
+    if binding.get("resource_kind") != "texture":
+        raise ValueError("presentation ingress is not a texture")
+    usages = binding.get("usages")
+    if not isinstance(usages, list):
+        raise ValueError("presentation ingress has no usage inventory")
+    draw_event = presentation.get("draw_event")
+    matching_reads = [
+        usage
+        for usage in usages
+        if usage.get("event_id") == draw_event
+        and usage.get("usage") == "PS_Resource"
+    ]
+    if len(matching_reads) != 1:
+        raise ValueError("presentation ingress read identity drifted")
+    prior_writes = [
+        usage
+        for usage in usages
+        if isinstance(usage.get("event_id"), int)
+        and usage["event_id"] < draw_event
+        and usage.get("usage") in WRITE_USAGES
+    ]
+
+    output = presentation.get("output")
+    if not isinstance(output, dict) or output.get("resource_kind") != "texture":
+        raise ValueError("presentation output texture is missing")
+    width_ratio = ratio(output.get("width"), binding.get("width"))
+    height_ratio = ratio(output.get("height"), binding.get("height"))
+    uniform_scale = width_ratio == height_ratio
+    upscale = uniform_scale and width_ratio["numerator"] > width_ratio["denominator"]
+    capture_local_producer = bool(prior_writes)
+    return {
+        "schema": SCHEMA,
+        "capture": bindings.get("capture"),
+        "presentation": {
+            "draw_event": draw_event,
+            "present_event": presentation.get("present_event"),
+            "input": {
+                key: binding.get(key)
+                for key in (
+                    "resource_id",
+                    "resource_name",
+                    "resource_kind",
+                    "width",
+                    "height",
+                    "format",
+                    "view_format",
+                    "stage",
+                    "descriptor_type",
+                    "index",
+                    "array_element",
+                )
+            },
+            "output": output,
+            "width_scale": width_ratio,
+            "height_scale": height_ratio,
+            "uniform_scale": uniform_scale,
+            "upscale": upscale,
+        },
+        "lineage": {
+            "capture_local_producer_observed": capture_local_producer,
+            "prior_write_usages": prior_writes,
+            "external_or_pre_capture_ingress": not capture_local_producer,
+            "guest_post_chain_joined": capture_local_producer,
+        },
+        "qualification": {
+            "presentation_ingress_resolved": True,
+            "presentation_upscale_boundary_proven": upscale,
+            "upscale_algorithm_proven": False,
+            "guest_post_chain_joined": capture_local_producer,
+            "effect_semantics_proven": False,
+            "ui_composite_boundary_proven": False,
+            "native_implementation_ready": False,
+        },
+        "safety": {
+            "metadata_only": True,
+            "resource_payload_exported": False,
+            "xenos_authority": True,
+            "native_coverage": False,
+            "suppression_allowed": False,
+        },
+    }
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser()
+    parser.add_argument("bindings", type=pathlib.Path)
+    parser.add_argument("post_census", type=pathlib.Path)
+    parser.add_argument("--output", required=True, type=pathlib.Path)
+    args = parser.parse_args(argv)
+    try:
+        binding_bytes = args.bindings.read_bytes()
+        census_bytes = args.post_census.read_bytes()
+        result = build_ingress(json.loads(binding_bytes), json.loads(census_bytes))
+        result["bindings_sha256"] = hashlib.sha256(binding_bytes).hexdigest().upper()
+        result["post_census_sha256"] = hashlib.sha256(census_bytes).hexdigest().upper()
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(
+            json.dumps(result, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+        )
+        print(json.dumps(result["qualification"], sort_keys=True))
+        return 0
+    except (OSError, ValueError, KeyError, TypeError, json.JSONDecodeError) as error:
+        print("native renderer presentation ingress failed: {}".format(error), file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/export-native-renderer-presentation-bindings.ps1
+++ b/tools/export-native-renderer-presentation-bindings.ps1
@@ -1,0 +1,69 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)]
+    [string]$Capture,
+    [Parameter(Mandatory)]
+    [string]$RenderDocRoot,
+    [Parameter(Mandatory)]
+    [ValidateRange(1, [int]::MaxValue)]
+    [int]$EventId,
+    [Parameter(Mandatory)]
+    [string]$Output
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
+$localRoot = [IO.Path]::GetFullPath((Join-Path $repoRoot '.local'))
+$localPrefix = $localRoot.TrimEnd([IO.Path]::DirectorySeparatorChar) +
+    [IO.Path]::DirectorySeparatorChar
+$resolvedCapture = (Resolve-Path -LiteralPath $Capture).Path
+$resolvedOutput = [IO.Path]::GetFullPath($Output)
+foreach ($item in @(
+        @{ Name = 'Capture'; Value = $resolvedCapture },
+        @{ Name = 'Output'; Value = $resolvedOutput }
+    )) {
+    if (-not $item.Value.StartsWith(
+            $localPrefix, [StringComparison]::OrdinalIgnoreCase)) {
+        throw "$($item.Name) must be below $localRoot"
+    }
+}
+if (Test-Path -LiteralPath $resolvedOutput) {
+    throw "Output already exists: $resolvedOutput"
+}
+
+$qrenderdoc = Join-Path ([IO.Path]::GetFullPath($RenderDocRoot)) 'qrenderdoc.exe'
+if (-not (Test-Path -LiteralPath $qrenderdoc -PathType Leaf)) {
+    throw "qrenderdoc.exe was not found below RenderDocRoot: $RenderDocRoot"
+}
+$signature = Get-AuthenticodeSignature -LiteralPath $qrenderdoc
+if ([string]$signature.Status -ne 'Valid') {
+    throw 'qrenderdoc.exe does not have a valid Authenticode signature'
+}
+
+$script = Join-Path $PSScriptRoot 'export-native-renderer-presentation-bindings.py'
+$parent = Split-Path $resolvedOutput -Parent
+[void](New-Item -ItemType Directory -Path $parent -Force)
+$savedCapture = $env:PINYON_SHIFT_RENDERDOC_CAPTURE
+$savedEvent = $env:PINYON_SHIFT_RENDERDOC_PRESENTATION_EVENT
+$savedOutput = $env:PINYON_SHIFT_RENDERDOC_PRESENTATION_BINDINGS
+try {
+    $env:PINYON_SHIFT_RENDERDOC_CAPTURE = $resolvedCapture
+    $env:PINYON_SHIFT_RENDERDOC_PRESENTATION_EVENT = [string]$EventId
+    $env:PINYON_SHIFT_RENDERDOC_PRESENTATION_BINDINGS = $resolvedOutput
+    $process = Start-Process -FilePath $qrenderdoc `
+        -ArgumentList @('--python', $script) -PassThru -Wait
+    if ($process.ExitCode) {
+        throw "qrenderdoc presentation binding export exited with code $($process.ExitCode)"
+    }
+}
+finally {
+    $env:PINYON_SHIFT_RENDERDOC_CAPTURE = $savedCapture
+    $env:PINYON_SHIFT_RENDERDOC_PRESENTATION_EVENT = $savedEvent
+    $env:PINYON_SHIFT_RENDERDOC_PRESENTATION_BINDINGS = $savedOutput
+}
+if (-not (Test-Path -LiteralPath $resolvedOutput -PathType Leaf)) {
+    throw 'qrenderdoc exited without producing the presentation binding report.'
+}
+Get-Content -LiteralPath $resolvedOutput -Raw | ConvertFrom-Json

--- a/tools/export-native-renderer-presentation-bindings.py
+++ b/tools/export-native-renderer-presentation-bindings.py
@@ -1,0 +1,230 @@
+"""Export bounded read-only bindings for one verified presentation draw."""
+
+import hashlib
+import json
+import os
+import sys
+
+import renderdoc as rd
+
+
+SCHEMA = "pinyon-shift.native-renderer-presentation-bindings.v1"
+
+
+def flatten(actions):
+    result = []
+    for action in actions:
+        result.append(action)
+        result.extend(flatten(action.children))
+    return result
+
+
+def sha256(path):
+    digest = hashlib.sha256()
+    with open(path, "rb") as source:
+        for block in iter(lambda: source.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def format_name(value):
+    name = getattr(value, "Name", None)
+    return name() if callable(name) else str(value)
+
+
+def resource_description(identifier, resource_names, textures, buffers):
+    result = {
+        "resource_id": identifier,
+        "resource_name": resource_names.get(identifier, ""),
+        "resource_kind": "unknown",
+    }
+    texture = textures.get(identifier)
+    if texture is not None:
+        result.update(
+            {
+                "resource_kind": "texture",
+                "width": texture.width,
+                "height": texture.height,
+                "format": texture.format.Name(),
+                "mips": texture.mips,
+                "arraysize": texture.arraysize,
+                "ms_samp": texture.msSamp,
+            }
+        )
+    buffer = buffers.get(identifier)
+    if buffer is not None:
+        result.update(
+            {
+                "resource_kind": "buffer",
+                "length": buffer.length,
+            }
+        )
+    return result
+
+
+def main():
+    capture_path = os.environ["PINYON_SHIFT_RENDERDOC_CAPTURE"]
+    report_path = os.environ["PINYON_SHIFT_RENDERDOC_PRESENTATION_BINDINGS"]
+    event_id = int(os.environ["PINYON_SHIFT_RENDERDOC_PRESENTATION_EVENT"])
+    if event_id <= 0:
+        raise RuntimeError("presentation event must be positive")
+    capture = rd.OpenCaptureFile()
+    controller = None
+    try:
+        result = capture.OpenFile(capture_path, "", None)
+        if result != rd.ResultCode.Succeeded:
+            raise RuntimeError("could not open capture: {}".format(result))
+        if not capture.LocalReplaySupport():
+            raise RuntimeError("capture does not support local replay")
+        result, controller = capture.OpenCapture(rd.ReplayOptions(), None)
+        if result != rd.ResultCode.Succeeded:
+            raise RuntimeError("could not initialise replay: {}".format(result))
+
+        actions = flatten(controller.GetRootActions())
+        matches = [action for action in actions if action.eventId == event_id]
+        if len(matches) != 1 or not matches[0].flags & rd.ActionFlags.Drawcall:
+            raise RuntimeError("presentation event is not one exact draw")
+        present_flag = getattr(rd.ActionFlags, "Present", None)
+        later_present = next(
+            (
+                action.eventId
+                for action in actions
+                if action.eventId > event_id
+                and present_flag is not None
+                and action.flags & present_flag
+            ),
+            None,
+        )
+        if later_present is None:
+            raise RuntimeError("presentation draw has no later present boundary")
+
+        resources = controller.GetResources()
+        resource_names = {
+            str(resource.resourceId): resource.name for resource in resources
+        }
+        textures = {
+            str(texture.resourceId): texture for texture in controller.GetTextures()
+        }
+        buffers = {
+            str(buffer.resourceId): buffer for buffer in controller.GetBuffers()
+        }
+        resource_ids = {
+            str(resource.resourceId): resource.resourceId for resource in resources
+        }
+        controller.SetFrameEvent(event_id, True)
+        pipeline = controller.GetPipelineState()
+        outputs = [
+            target
+            for target in pipeline.GetOutputTargets()
+            if target.resource != rd.ResourceId.Null()
+        ]
+        if len(outputs) != 1:
+            raise RuntimeError("presentation draw must bind one color target")
+        output_id = str(outputs[0].resource)
+        output_name = resource_names.get(output_id, "")
+        if not output_name.startswith("Swapchain Image "):
+            raise RuntimeError("presentation draw does not target the swapchain")
+
+        bindings = []
+        seen = set()
+        for used in pipeline.GetReadOnlyResources(rd.ShaderStage.Pixel):
+            descriptor = used.descriptor
+            access = used.access
+            identifier = str(descriptor.resource)
+            if identifier == str(rd.ResourceId.Null()):
+                continue
+            key = (
+                identifier,
+                int(access.index),
+                int(access.arrayElement),
+            )
+            if key in seen:
+                raise RuntimeError("duplicate presentation binding")
+            seen.add(key)
+            resource = resource_ids.get(identifier)
+            if resource is None:
+                raise RuntimeError("bound presentation resource is unknown")
+            bindings.append(
+                {
+                    **resource_description(
+                        identifier, resource_names, textures, buffers
+                    ),
+                    "stage": str(access.stage),
+                    "descriptor_type": str(access.type),
+                    "index": int(access.index),
+                    "array_element": int(access.arrayElement),
+                    "statically_unused": bool(access.staticallyUnused),
+                    "byte_offset": int(descriptor.byteOffset),
+                    "byte_size": int(descriptor.byteSize),
+                    "first_mip": int(descriptor.firstMip),
+                    "num_mips": int(descriptor.numMips),
+                    "first_slice": int(descriptor.firstSlice),
+                    "num_slices": int(descriptor.numSlices),
+                    "view_format": format_name(descriptor.format),
+                    "texture_type": str(descriptor.textureType),
+                    "usages": [
+                        {
+                            "event_id": usage.eventId,
+                            "usage": usage.usage.name,
+                        }
+                        for usage in controller.GetUsage(resource)
+                    ],
+                }
+            )
+        bindings.sort(
+            key=lambda binding: (
+                binding["index"],
+                binding["array_element"],
+                binding["resource_id"],
+            )
+        )
+        if not bindings:
+            raise RuntimeError("presentation draw has no pixel read-only binding")
+        report = {
+            "schema": SCHEMA,
+            "capture": {
+                "path": os.path.basename(capture_path),
+                "sha256": sha256(capture_path),
+            },
+            "presentation": {
+                "draw_event": event_id,
+                "present_event": later_present,
+                "output_resource_id": output_id,
+                "output_resource_name": output_name,
+                "output": resource_description(
+                    output_id, resource_names, textures, buffers
+                ),
+            },
+            "bindings": bindings,
+            "totals": {
+                "bindings": len(bindings),
+                "statically_unused": sum(
+                    binding["statically_unused"] for binding in bindings
+                ),
+            },
+            "safety": {
+                "resource_payload_exported": False,
+                "action_metadata_only": True,
+                "xenos_authority": True,
+                "native_coverage": False,
+                "suppression_allowed": False,
+            },
+        }
+        with open(report_path, "w") as output:
+            json.dump(report, output, indent=2, sort_keys=True)
+            output.write("\n")
+        print(report_path)
+        return 0
+    finally:
+        if controller is not None:
+            controller.Shutdown()
+        capture.Shutdown()
+
+
+try:
+    sys.exit(main())
+except Exception as error:
+    sys.stderr.write(
+        "native renderer presentation binding export failed: {}\n".format(error)
+    )
+    sys.exit(1)

--- a/tools/tests/test_native_renderer_presentation_ingress.py
+++ b/tools/tests/test_native_renderer_presentation_ingress.py
@@ -1,0 +1,132 @@
+import importlib.util
+import sys
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+TOOL = ROOT / "tools/build-native-renderer-presentation-ingress.py"
+SPEC = importlib.util.spec_from_file_location("native_presentation_ingress", TOOL)
+assert SPEC and SPEC.loader
+MODULE = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = MODULE
+SPEC.loader.exec_module(MODULE)
+
+
+def bindings(usages=None, capture="A" * 64):
+    return {
+        "schema": MODULE.BINDING_SCHEMA,
+        "capture": {"path": "capture.rdc", "sha256": capture},
+        "presentation": {
+            "draw_event": 30,
+            "present_event": 40,
+            "output_resource_id": "swap",
+            "output_resource_name": "Swapchain Image 1",
+            "output": {
+                "resource_id": "swap",
+                "resource_name": "Swapchain Image 1",
+                "resource_kind": "texture",
+                "width": 3840,
+                "height": 2160,
+                "format": "B8G8R8A8_UNORM",
+            },
+        },
+        "bindings": [{
+            "resource_id": "input",
+            "resource_name": "2D Texture 1",
+            "resource_kind": "texture",
+            "width": 2560,
+            "height": 1440,
+            "format": "R10G10B10A2_UNORM",
+            "view_format": "R10G10B10A2_UNORM",
+            "stage": "ShaderStage.Pixel",
+            "descriptor_type": "DescriptorType.Image",
+            "index": 0,
+            "array_element": 0,
+            "statically_unused": False,
+            "usages": (
+                [{"event_id": 30, "usage": "PS_Resource"}]
+                if usages is None
+                else usages
+            ),
+        }],
+        "safety": {
+            "resource_payload_exported": False,
+            "action_metadata_only": True,
+            "xenos_authority": True,
+            "suppression_allowed": False,
+        },
+    }
+
+
+def census(capture="A" * 64):
+    return {
+        "schema": MODULE.POST_SCHEMA,
+        "capture": {"path": "capture.rdc", "sha256": capture},
+        "presentation_sinks": [{
+            "resource_id": "swap",
+            "producer_event": 30,
+            "present_event": 40,
+        }],
+        "safety": {
+            "metadata_only": True,
+            "xenos_authority": True,
+            "suppression_allowed": False,
+        },
+    }
+
+
+class NativeRendererPresentationIngressTests(unittest.TestCase):
+    def test_proves_uniform_upscale_but_keeps_guest_lineage_closed(self):
+        result = MODULE.build_ingress(bindings(), census())
+        self.assertEqual(
+            result["presentation"]["width_scale"],
+            {"numerator": 3, "denominator": 2},
+        )
+        self.assertEqual(
+            result["presentation"]["height_scale"],
+            {"numerator": 3, "denominator": 2},
+        )
+        self.assertTrue(result["presentation"]["upscale"])
+        self.assertTrue(
+            result["qualification"]["presentation_upscale_boundary_proven"]
+        )
+        self.assertTrue(result["lineage"]["external_or_pre_capture_ingress"])
+        self.assertFalse(result["qualification"]["guest_post_chain_joined"])
+        self.assertFalse(result["qualification"]["upscale_algorithm_proven"])
+        self.assertFalse(result["qualification"]["native_implementation_ready"])
+        self.assertFalse(result["safety"]["suppression_allowed"])
+
+    def test_records_capture_local_input_without_promoting_readiness(self):
+        document = bindings([
+            {"event_id": 20, "usage": "CopyDst"},
+            {"event_id": 30, "usage": "PS_Resource"},
+        ])
+        result = MODULE.build_ingress(document, census())
+        self.assertTrue(result["lineage"]["capture_local_producer_observed"])
+        self.assertTrue(result["qualification"]["guest_post_chain_joined"])
+        self.assertFalse(result["qualification"]["native_implementation_ready"])
+
+    def test_rejects_sink_or_capture_drift(self):
+        wrong_sink = census()
+        wrong_sink["presentation_sinks"][0]["producer_event"] = 31
+        with self.assertRaisesRegex(ValueError, "identity drifted"):
+            MODULE.build_ingress(bindings(), wrong_sink)
+        with self.assertRaisesRegex(ValueError, "captures differ"):
+            MODULE.build_ingress(
+                bindings(capture="A" * 64), census("B" * 64)
+            )
+
+    def test_rejects_unsafe_or_ambiguous_binding_reports(self):
+        unsafe = bindings()
+        unsafe["safety"]["suppression_allowed"] = True
+        with self.assertRaisesRegex(ValueError, "suppression"):
+            MODULE.build_ingress(unsafe, census())
+        ambiguous = bindings()
+        ambiguous["bindings"].append(dict(ambiguous["bindings"][0]))
+        with self.assertRaisesRegex(ValueError, "one bounded ingress"):
+            MODULE.build_ingress(ambiguous, census())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- export the exact read-only binding for the verified presentation draw
- join the binding to the post-processing topology census with deterministic safety checks
- prove the mechanical 2560x1440 to 3840x2160 uniform 3:2 upscale boundary
- classify the source as external/pre-capture because it has no capture-local producer
- keep upscale algorithm, guest post-chain semantics, UI ordering, native readiness, and suppression closed

## Validation
- python -m unittest discover -s tools/tests — 458 passed
- bounded RenderDoc event 11363 binding export — passed
- deterministic presentation-ingress join — passed

## Safety
Metadata only. No resource payload is exported, Xenos remains authoritative, and native coverage/suppression remain disabled.