### PR TITLE
feat(renderer): accumulate continuous native world worksets

### DIFF
--- a/docs/native-renderer/CONTINUOUS_WORLD_WORKSET.md
+++ b/docs/native-renderer/CONTINUOUS_WORLD_WORKSET.md
@@ -1,0 +1,73 @@
+# Continuous native world workset
+
+Phase B1 promotes the qualified visibility-selected private replay from one
+draw per frame to a bounded multi-draw target that can participate in the
+existing continuous native composition path.
+
+This checkpoint is default-off and does not suppress any Xenos work. It proves
+the accumulation and freshness contract before expanding material-family
+coverage or claiming a coherent native scene.
+
+## Selection
+
+Set `PINYON_SHIFT_NATIVE_RENDERER_CONTINUOUS_WORLD_WORKSET=true` through the
+capture wrapper's `-ContinuousWorldWorkset` switch. The mode requires renderer
+census and semantic dispatch discovery so every admitted draw has:
+
+- a mechanically replayable prepared-draw contract;
+- a current, selected semantic visibility decision; and
+- exact title-to-backend lineage.
+
+The mode accepts at most 64 draws in one guest frame. The first accepted draw
+seeds a private color/depth pair from the authoritative guest attachments.
+Later accepted draws in the same frame resume that private pair without another
+seed copy. Target incompatibility, unsupported state, or a replay failure marks
+the frame failed and rejects every later candidate in that frame.
+
+## Swap-committed freshness
+
+ReXGlue patch `0094-d3d12-deferred-replay-preview-publication.patch` separates
+recording a private replay from declaring it display-fresh:
+
+1. each accepted draw records into the retained private target;
+2. successful draws leave a pending frame sequence rather than publishing it;
+3. any failed selected draw cancels that pending sequence; and
+4. the matching swap commits the sequence immediately before the existing
+   guest-output callback checks retained-frame freshness.
+
+The callback can therefore select only a complete accumulated target from the
+current frame. A partial or stale workset cannot satisfy the existing exact
+frame comparison and the complete Xenos output remains authoritative.
+
+## Diagnostics
+
+The runtime emits:
+
+- `native_renderer.continuous_world_workset.config`; and
+- `native_renderer.continuous_world_workset.summary`.
+
+The summary reconciles prepared observations, selection outcomes, replay
+outcomes, target reuse, complete frames, failed frames, and the 64-draw bound.
+Build a payload-free qualification report with:
+
+```powershell
+python .\tools\summarize-native-renderer-continuous-world-workset.py `
+  .local\preview\logs\events.jsonl `
+  --output .local\qualification\continuous-world-workset.json
+```
+
+Qualification requires at least one complete frame with multiple accumulated
+draws, zero replay or frame failures, exact accounting, preserved Xenos draws,
+and disabled suppression.
+
+## Safety boundary
+
+- Xenos draws, resolves, queries, fences, memexport, and guest-visible side
+  effects remain enabled.
+- Output selection remains controlled by the existing renderer selector.
+- The mode performs no readback and no guest-target publication.
+- Missing semantic lineage, incompatible replay experiments, stale visibility,
+  capacity exhaustion, or replay failure yields without weakening freshness.
+- This checkpoint does not yet prove recognizable world coverage; that requires
+  a clean build, an AppData run, and visual inspection after the broader Phase B
+  implementation batch is ready.

--- a/docs/native-renderer/REPRIORITIZED_PLAN.md
+++ b/docs/native-renderer/REPRIORITIZED_PLAN.md
@@ -103,6 +103,11 @@ for missing content while proving continuous native gameplay rendering.
 - Publish only a complete current-frame target.
 - Yield to Xenos when freshness or coverage gates fail.
 
+Implementation checkpoint: bounded multi-draw target reuse and swap-committed
+freshness are defined in
+[`CONTINUOUS_WORLD_WORKSET.md`](CONTINUOUS_WORLD_WORKSET.md). Runtime visual
+qualification remains part of the Phase B batch.
+
 ### B2. Minimal presentation path
 
 - Use the proven presentation ingress and output dimensions.

--- a/patches/rexglue/0094-d3d12-deferred-replay-preview-publication.patch
+++ b/patches/rexglue/0094-d3d12-deferred-replay-preview-publication.patch
@@ -1,0 +1,210 @@
+diff --git a/include/rex/graphics/d3d12/render_target_cache.h b/include/rex/graphics/d3d12/render_target_cache.h
+index f0e0030..4e025db 100644
+--- a/include/rex/graphics/d3d12/render_target_cache.h
++++ b/include/rex/graphics/d3d12/render_target_cache.h
+@@ -131,7 +131,11 @@ class D3D12RenderTargetCache final : public RenderTargetCache {
+   system::GraphicsIsolatedDrawReadbackStatus QueueGuestDepthReadback(
+       system::GraphicsIsolatedDrawReadbackCompletion completion,
+       uint32_t* failure_detail_out);
+-  void EndIsolatedReplayTarget(uint64_t frame_sequence);
++  void EndIsolatedReplayTarget(
++      uint64_t frame_sequence,
++      bool defer_preview_publication_until_swap = false);
++  void CommitDeferredIsolatedReplayPreview(uint64_t frame_sequence);
++  void CancelDeferredIsolatedReplayPreview(uint64_t frame_sequence);
+   system::GraphicsIsolatedDrawPublicationResult PublishIsolatedReplayTarget(
+       bool depth_only_target = false);
+ 
+@@ -729,6 +733,7 @@ class D3D12RenderTargetCache final : public RenderTargetCache {
+   D3D12_RESOURCE_STATES isolated_replay_preview_resolved_target_state_ =
+       D3D12_RESOURCE_STATE_RESOLVE_DEST;
+   uint64_t isolated_replay_preview_frame_sequence_ = 0;
++  uint64_t isolated_replay_deferred_preview_frame_sequence_ = 0;
+   struct IsolatedReplayReadback {
+     Microsoft::WRL::ComPtr<ID3D12Resource> buffer;
+     Microsoft::WRL::ComPtr<ID3D12Resource> resolved_target;
+diff --git a/include/rex/system/interfaces/graphics.h b/include/rex/system/interfaces/graphics.h
+index 4b61d8e..49fcdfc 100644
+--- a/include/rex/system/interfaces/graphics.h
++++ b/include/rex/system/interfaces/graphics.h
+@@ -518,6 +518,11 @@ struct GraphicsIsolatedDrawRequest {
+   // Rebind the retained private target without copying the guest target. This
+   // is valid only for the immediately following draw of an isolated pass.
+   bool reuse_target = false;
++  // Accumulate this draw into the private target, but do not make that target
++  // visible to the guest-output callback until the matching swap commits the
++  // complete frame. Any failed draw in the accumulation cancels the pending
++  // preview and leaves the previous Xenos frame authoritative.
++  bool defer_preview_publication_until_swap = false;
+   // After the original authoritative guest draw, publish the completed private
+   // pass into the same guest color and depth/stencil resources. The backend
+   // must validate the entire pair before recording either copy. This never
+diff --git a/src/graphics/d3d12/command_processor.cpp b/src/graphics/d3d12/command_processor.cpp
+index 53e2842..c0b9071 100644
+--- a/src/graphics/d3d12/command_processor.cpp
++++ b/src/graphics/d3d12/command_processor.cpp
+@@ -2599,6 +2599,11 @@ void D3D12CommandProcessor::IssueSwap(uint32_t frontbuffer_ptr, uint32_t frontbu
+   uint32_t display_width = std::max(uint32_t(1), uint32_t(video_mode.display_width));
+   uint32_t display_height = std::max(uint32_t(1), uint32_t(video_mode.display_height));
+ 
++  // A multi-draw private replay becomes display-fresh only at the swap
++  // boundary, after every admitted draw in this guest frame has completed.
++  render_target_cache_->CommitDeferredIsolatedReplayPreview(
++      observation_frame_sequence_);
++
+   presenter->RefreshGuestOutput(
+       guest_output_width, guest_output_height, display_width, display_height,
+       [this, &swap_texture_srv_desc, frontbuffer_format, swap_texture_resource, guest_output_width,
+@@ -2918,8 +2923,14 @@ bool D3D12CommandProcessor::IssueDraw(xenos::PrimitiveType primitive_type, uint3
+   const RegisterFile& regs = *register_file_;
+   auto draw_outcome_observer = graphics_system_->draw_outcome_observer();
+   bool draw_prepared = false;
++  system::GraphicsIsolatedDrawRequest isolated_draw_request;
+   const auto observe_draw_outcome =
+       [&](system::GraphicsDrawOutcomeStatus status, bool succeeded) {
++        if (!succeeded &&
++            isolated_draw_request.defer_preview_publication_until_swap) {
++          render_target_cache_->CancelDeferredIsolatedReplayPreview(
++              isolated_draw_request.frame_sequence);
++        }
+         if (draw_outcome_observer) {
+           system::GraphicsDrawOutcomeObservation observation;
+           observation.status = status;
+@@ -3076,7 +3087,6 @@ bool D3D12CommandProcessor::IssueDraw(xenos::PrimitiveType primitive_type, uint3
+   auto isolated_draw_request_observer =
+       graphics_system_->isolated_draw_request_observer();
+   system::GraphicsPreparedDrawObservation prepared_observation;
+-  system::GraphicsIsolatedDrawRequest isolated_draw_request;
+   if (prepared_draw_observer || isolated_draw_request_observer) {
+     prepared_observation.vertex_shader_hash = vertex_shader->ucode_data_hash();
+     prepared_observation.pixel_shader_hash =
+@@ -3500,7 +3510,12 @@ bool D3D12CommandProcessor::IssueDraw(xenos::PrimitiveType primitive_type, uint3
+         }
+         if (!restore_prepared_guest_graphics_state()) {
+           render_target_cache_->EndIsolatedReplayTarget(
+-              isolated_draw_request.frame_sequence);
++              isolated_draw_request.frame_sequence,
++              isolated_draw_request.defer_preview_publication_until_swap);
++          if (isolated_draw_request.defer_preview_publication_until_swap) {
++            render_target_cache_->CancelDeferredIsolatedReplayPreview(
++                isolated_draw_request.frame_sequence);
++          }
+           isolated_result.status =
+               system::GraphicsIsolatedDrawStatus::kUnsupportedState;
+           if (isolated_draw_request.completion) {
+@@ -3547,7 +3562,8 @@ bool D3D12CommandProcessor::IssueDraw(xenos::PrimitiveType primitive_type, uint3
+           }
+         }
+         render_target_cache_->EndIsolatedReplayTarget(
+-            isolated_draw_request.frame_sequence);
++            isolated_draw_request.frame_sequence,
++            isolated_draw_request.defer_preview_publication_until_swap);
+         isolated_replay_recorded = true;
+         isolated_result.status =
+             system::GraphicsIsolatedDrawStatus::kRecorded;
+@@ -3555,6 +3571,12 @@ bool D3D12CommandProcessor::IssueDraw(xenos::PrimitiveType primitive_type, uint3
+         isolated_result.status =
+             system::GraphicsIsolatedDrawStatus::kTargetCreationFailed;
+       }
++      if (isolated_draw_request.defer_preview_publication_until_swap &&
++          isolated_result.status !=
++              system::GraphicsIsolatedDrawStatus::kRecorded) {
++        render_target_cache_->CancelDeferredIsolatedReplayPreview(
++            isolated_draw_request.frame_sequence);
++      }
+       if (isolated_draw_request.completion) {
+         isolated_draw_request.completion(isolated_result);
+       }
+@@ -3738,7 +3760,12 @@ bool D3D12CommandProcessor::IssueDraw(xenos::PrimitiveType primitive_type, uint3
+         }
+         if (!restore_prepared_guest_graphics_state()) {
+           render_target_cache_->EndIsolatedReplayTarget(
+-              isolated_draw_request.frame_sequence);
++              isolated_draw_request.frame_sequence,
++              isolated_draw_request.defer_preview_publication_until_swap);
++          if (isolated_draw_request.defer_preview_publication_until_swap) {
++            render_target_cache_->CancelDeferredIsolatedReplayPreview(
++                isolated_draw_request.frame_sequence);
++          }
+           isolated_result.status =
+               system::GraphicsIsolatedDrawStatus::kUnsupportedState;
+           if (isolated_draw_request.completion) {
+@@ -3785,7 +3812,8 @@ bool D3D12CommandProcessor::IssueDraw(xenos::PrimitiveType primitive_type, uint3
+           }
+         }
+         render_target_cache_->EndIsolatedReplayTarget(
+-            isolated_draw_request.frame_sequence);
++            isolated_draw_request.frame_sequence,
++            isolated_draw_request.defer_preview_publication_until_swap);
+         isolated_replay_recorded = true;
+         isolated_result.status =
+             system::GraphicsIsolatedDrawStatus::kRecorded;
+@@ -3793,6 +3821,12 @@ bool D3D12CommandProcessor::IssueDraw(xenos::PrimitiveType primitive_type, uint3
+         isolated_result.status =
+             system::GraphicsIsolatedDrawStatus::kTargetCreationFailed;
+       }
++      if (isolated_draw_request.defer_preview_publication_until_swap &&
++          isolated_result.status !=
++              system::GraphicsIsolatedDrawStatus::kRecorded) {
++        render_target_cache_->CancelDeferredIsolatedReplayPreview(
++            isolated_draw_request.frame_sequence);
++      }
+       if (isolated_draw_request.completion) {
+         isolated_draw_request.completion(isolated_result);
+       }
+diff --git a/src/graphics/d3d12/render_target_cache.cpp b/src/graphics/d3d12/render_target_cache.cpp
+index 195b54c..a83214d 100644
+--- a/src/graphics/d3d12/render_target_cache.cpp
++++ b/src/graphics/d3d12/render_target_cache.cpp
+@@ -1045,6 +1045,7 @@ void D3D12RenderTargetCache::Shutdown(bool from_destructor) {
+   isolated_replay_preview_resolved_target_state_ =
+       D3D12_RESOURCE_STATE_RESOLVE_DEST;
+   isolated_replay_preview_frame_sequence_ = 0;
++  isolated_replay_deferred_preview_frame_sequence_ = 0;
+   isolated_replay_depth_target_.reset();
+   isolated_replay_color_target_.reset();
+   null_rtv_descriptor_ms_.Free();
+@@ -1775,6 +1776,7 @@ bool D3D12RenderTargetCache::BeginIsolatedReplayTarget(
+     bool stencil_seed_probe_requested, bool depth_only_target) {
+   width_out = 0;
+   height_out = 0;
++  isolated_replay_deferred_preview_frame_sequence_ = 0;
+   if (GetPath() != Path::kHostRenderTargets) {
+     return false;
+   }
+@@ -2439,13 +2441,33 @@ system::GraphicsIsolatedDrawReadbackStatus D3D12RenderTargetCache::QueueRenderTa
+ }
+ 
+ void D3D12RenderTargetCache::EndIsolatedReplayTarget(
+-    uint64_t frame_sequence) {
++    uint64_t frame_sequence, bool defer_preview_publication_until_swap) {
+   if (GetPath() != Path::kHostRenderTargets) {
+     return;
+   }
+   SetCommandListRenderTargets(last_update_accumulated_render_targets());
+   command_processor_.SubmitBarriers();
+-  isolated_replay_preview_frame_sequence_ = frame_sequence;
++  if (defer_preview_publication_until_swap) {
++    isolated_replay_deferred_preview_frame_sequence_ = frame_sequence;
++  } else {
++    isolated_replay_deferred_preview_frame_sequence_ = 0;
++    isolated_replay_preview_frame_sequence_ = frame_sequence;
++  }
++}
++
++void D3D12RenderTargetCache::CommitDeferredIsolatedReplayPreview(
++    uint64_t frame_sequence) {
++  if (isolated_replay_deferred_preview_frame_sequence_ == frame_sequence) {
++    isolated_replay_preview_frame_sequence_ = frame_sequence;
++  }
++  isolated_replay_deferred_preview_frame_sequence_ = 0;
++}
++
++void D3D12RenderTargetCache::CancelDeferredIsolatedReplayPreview(
++    uint64_t frame_sequence) {
++  if (isolated_replay_deferred_preview_frame_sequence_ == frame_sequence) {
++    isolated_replay_deferred_preview_frame_sequence_ = 0;
++  }
+ }
+ 
+ system::GraphicsIsolatedDrawPublicationResult

--- a/src/native_renderer/graphics_hooks.cpp
+++ b/src/native_renderer/graphics_hooks.cpp
@@ -101,6 +101,7 @@ constexpr uint64_t kSemanticVisibilityMaximumPolicyAgeFrames = 1;
 constexpr size_t kVisibilityShadowReplaySignatureCapacity = 256;
 constexpr size_t kVisibilityShadowReplaySignatureSummaryLimit = 16;
 constexpr uint64_t kVisibilityShadowReplayMaximumDrawsPerFrame = 1;
+constexpr uint64_t kContinuousWorldWorksetMaximumDrawsPerFrame = 64;
 constexpr size_t kVehicleIdentityCapacity = 64;
 constexpr size_t kVehicleIdentitySummaryLimit = kVehicleIdentityCapacity;
 constexpr size_t kVehicleOwnerVtableMethodCount = 32;
@@ -5951,6 +5952,30 @@ struct VisibilityShadowReplayState {
 
 VisibilityShadowReplayState g_visibility_shadow_replay;
 
+struct ContinuousWorldWorksetState {
+  uint64_t prepared_observations = 0;
+  uint64_t requests = 0;
+  uint64_t recorded = 0;
+  uint64_t target_creation_failures = 0;
+  uint64_t unsupported = 0;
+  uint64_t mechanical_rejections = 0;
+  uint64_t stale_or_unselected_rejections = 0;
+  uint64_t per_frame_quota_yields = 0;
+  uint64_t fail_closed_yields = 0;
+  uint64_t reused_target_requests = 0;
+  uint64_t frames_started = 0;
+  uint64_t frames_completed = 0;
+  uint64_t frames_failed = 0;
+  uint64_t current_frame = UINT64_MAX;
+  uint64_t current_frame_requests = 0;
+  uint64_t current_frame_recorded = 0;
+  bool current_frame_failed = false;
+  bool requested = false;
+  bool valid = true;
+};
+
+ContinuousWorldWorksetState g_continuous_world_workset;
+
 struct PassFollowerState {
   uint64_t target_signature = 0;
   uint64_t anchor_frame = 0;
@@ -6588,11 +6613,33 @@ void ConfigureVisibilityShadowReplay() {
   g_visibility_shadow_replay.valid = setting == "true";
 }
 
+void ConfigureContinuousWorldWorkset() {
+  g_continuous_world_workset = {};
+  g_continuous_world_workset.current_frame = UINT64_MAX;
+  char *value = nullptr;
+  size_t length = 0;
+  if (_dupenv_s(
+          &value, &length,
+          "PINYON_SHIFT_NATIVE_RENDERER_CONTINUOUS_WORLD_WORKSET") != 0 ||
+      !value || length <= 1) {
+    std::free(value);
+    return;
+  }
+  const std::string setting(value);
+  std::free(value);
+  if (setting == "false") {
+    return;
+  }
+  g_continuous_world_workset.requested = true;
+  g_continuous_world_workset.valid = setting == "true";
+}
+
 void ValidateAndEmitVisibilityShadowReplayConfiguration() {
   if (g_visibility_shadow_replay.requested &&
       (g_isolated_draw.requested || g_pass_follower.requested ||
        g_pass_publication.requested ||
-       g_sky_horizon_suppression.requested)) {
+       g_sky_horizon_suppression.requested ||
+       g_continuous_world_workset.requested)) {
     g_visibility_shadow_replay.valid = false;
   }
   const bool semantic_lineage_armed =
@@ -6625,6 +6672,45 @@ void ValidateAndEmitVisibilityShadowReplayConfiguration() {
                            : "false"},
        {"xenos_draw", "preserved"},
        {"output_authority", "xenos"},
+       {"draw_suppression", "false"},
+       {"suppression_eligible", "false"}});
+}
+
+void ValidateAndEmitContinuousWorldWorksetConfiguration() {
+  if (g_continuous_world_workset.requested &&
+      (g_isolated_draw.requested || g_visibility_shadow_replay.requested ||
+       g_pass_follower.requested || g_pass_publication.requested ||
+       g_sky_horizon_suppression.requested)) {
+    g_continuous_world_workset.valid = false;
+  }
+  const bool semantic_lineage_armed =
+      g_title_provenance_installed.load(std::memory_order_acquire);
+  if (g_continuous_world_workset.requested && !semantic_lineage_armed) {
+    g_continuous_world_workset.valid = false;
+  }
+  pinyon_shift::diagnostics::RecordEvent(
+      "native_renderer.continuous_world_workset.config",
+      {{"status", !g_continuous_world_workset.requested
+                      ? "disabled"
+                      : (g_continuous_world_workset.valid
+                             ? "armed_deferred_private_composition"
+                             : "blocked_invalid_configuration")},
+       {"activation", "startup_environment_only"},
+       {"default_enabled", "false"},
+       {"selection", "fresh_visibility_and_mechanical"},
+       {"maximum_draws_per_frame",
+        std::to_string(kContinuousWorldWorksetMaximumDrawsPerFrame)},
+       {"target_lifetime", "one_guest_frame"},
+       {"freshness_commit", "matching_swap_after_complete_accumulation"},
+       {"semantic_lineage",
+        semantic_lineage_armed ? "armed" : "unavailable"},
+       {"readback", "disabled"},
+       {"native_draw", g_continuous_world_workset.valid &&
+                               g_continuous_world_workset.requested
+                           ? "continuous_world_workset"
+                           : "false"},
+       {"xenos_draw", "preserved"},
+       {"output_authority", "renderer_selector"},
        {"draw_suppression", "false"},
        {"suppression_eligible", "false"}});
 }
@@ -16720,6 +16806,111 @@ void CompleteVisibilityShadowReplay(
   }
 }
 
+void FinalizeContinuousWorldWorksetFrame() {
+  if (g_continuous_world_workset.current_frame == UINT64_MAX ||
+      !g_continuous_world_workset.current_frame_requests) {
+    return;
+  }
+  if (!g_continuous_world_workset.current_frame_failed &&
+      g_continuous_world_workset.current_frame_recorded ==
+          g_continuous_world_workset.current_frame_requests) {
+    ++g_continuous_world_workset.frames_completed;
+  } else {
+    ++g_continuous_world_workset.frames_failed;
+  }
+}
+
+void BeginContinuousWorldWorksetFrame(uint64_t frame) {
+  if (g_continuous_world_workset.current_frame == frame) {
+    return;
+  }
+  FinalizeContinuousWorldWorksetFrame();
+  g_continuous_world_workset.current_frame = frame;
+  g_continuous_world_workset.current_frame_requests = 0;
+  g_continuous_world_workset.current_frame_recorded = 0;
+  g_continuous_world_workset.current_frame_failed = false;
+}
+
+void CompleteContinuousWorldWorksetReplay(
+    const rex::system::GraphicsIsolatedDrawResult &result) {
+  if (result.status == rex::system::GraphicsIsolatedDrawStatus::kRecorded) {
+    ++g_continuous_world_workset.recorded;
+    ++g_continuous_world_workset.current_frame_recorded;
+    return;
+  }
+  g_continuous_world_workset.current_frame_failed = true;
+  if (result.status == rex::system::
+                           GraphicsIsolatedDrawStatus::kTargetCreationFailed) {
+    ++g_continuous_world_workset.target_creation_failures;
+  } else {
+    ++g_continuous_world_workset.unsupported;
+  }
+}
+
+void EmitContinuousWorldWorksetSummary() {
+  if (!g_continuous_world_workset.requested) {
+    return;
+  }
+  FinalizeContinuousWorldWorksetFrame();
+  const uint64_t outcomes = g_continuous_world_workset.recorded +
+                            g_continuous_world_workset.target_creation_failures +
+                            g_continuous_world_workset.unsupported;
+  const uint64_t selections =
+      g_continuous_world_workset.requests +
+      g_continuous_world_workset.mechanical_rejections +
+      g_continuous_world_workset.stale_or_unselected_rejections +
+      g_continuous_world_workset.per_frame_quota_yields +
+      g_continuous_world_workset.fail_closed_yields;
+  pinyon_shift::diagnostics::RecordEvent(
+      "native_renderer.continuous_world_workset.summary",
+      {{"status", !g_continuous_world_workset.valid
+                      ? "invalid_configuration"
+                      : (g_continuous_world_workset.frames_failed
+                             ? "fallback_observed"
+                             : (g_continuous_world_workset.frames_completed
+                                    ? "complete"
+                                    : "not_observed"))},
+       {"prepared_observations",
+        std::to_string(g_continuous_world_workset.prepared_observations)},
+       {"requests", std::to_string(g_continuous_world_workset.requests)},
+       {"recorded", std::to_string(g_continuous_world_workset.recorded)},
+       {"target_creation_failures",
+        std::to_string(g_continuous_world_workset.target_creation_failures)},
+       {"unsupported", std::to_string(g_continuous_world_workset.unsupported)},
+       {"mechanical_rejections",
+        std::to_string(g_continuous_world_workset.mechanical_rejections)},
+       {"stale_or_unselected_rejections",
+        std::to_string(
+            g_continuous_world_workset.stale_or_unselected_rejections)},
+       {"per_frame_quota_yields",
+        std::to_string(g_continuous_world_workset.per_frame_quota_yields)},
+       {"fail_closed_yields",
+        std::to_string(g_continuous_world_workset.fail_closed_yields)},
+       {"reused_target_requests",
+        std::to_string(g_continuous_world_workset.reused_target_requests)},
+       {"frames_started",
+        std::to_string(g_continuous_world_workset.frames_started)},
+       {"frames_completed",
+        std::to_string(g_continuous_world_workset.frames_completed)},
+       {"frames_failed",
+        std::to_string(g_continuous_world_workset.frames_failed)},
+       {"accounting_complete",
+        outcomes == g_continuous_world_workset.requests ? "true" : "false"},
+       {"selection_accounting_complete",
+        selections == g_continuous_world_workset.prepared_observations
+            ? "true"
+            : "false"},
+       {"maximum_draws_per_frame",
+        std::to_string(kContinuousWorldWorksetMaximumDrawsPerFrame)},
+       {"freshness_commit", "matching_swap_after_complete_accumulation"},
+       {"readback", "disabled"},
+       {"native_draw", "continuous_world_workset"},
+       {"xenos_draw", "preserved"},
+       {"output_authority", "renderer_selector"},
+       {"draw_suppression", "false"},
+       {"suppression_eligible", "false"}});
+}
+
 void EmitVisibilityShadowReplaySummary() {
   if (!g_visibility_shadow_replay.requested) {
     return;
@@ -17034,6 +17225,46 @@ void RequestIsolatedDraw(
       request.consumer_reference_after_depth_readback_completion =
           &CompleteConsumerFamilyAfterDepthReadback;
     }
+  }
+  if (g_continuous_world_workset.requested &&
+      g_continuous_world_workset.valid &&
+      g_isolated_draw.prepared_candidate_valid) {
+    BeginContinuousWorldWorksetFrame(g_isolated_draw.frame);
+    ++g_continuous_world_workset.prepared_observations;
+    if (!g_isolated_draw.prepared_candidate_eligible) {
+      ++g_continuous_world_workset.mechanical_rejections;
+      return;
+    }
+    if (!g_isolated_draw.prepared_visibility_candidate_fresh) {
+      ++g_continuous_world_workset.stale_or_unselected_rejections;
+      return;
+    }
+    if (g_continuous_world_workset.current_frame_failed) {
+      ++g_continuous_world_workset.fail_closed_yields;
+      return;
+    }
+    if (g_continuous_world_workset.current_frame_requests >=
+        kContinuousWorldWorksetMaximumDrawsPerFrame) {
+      ++g_continuous_world_workset.per_frame_quota_yields;
+      return;
+    }
+    const bool reuse_target =
+        g_continuous_world_workset.current_frame_requests != 0;
+    if (!g_continuous_world_workset.current_frame_requests) {
+      ++g_continuous_world_workset.frames_started;
+    } else {
+      ++g_continuous_world_workset.reused_target_requests;
+    }
+    ++g_continuous_world_workset.current_frame_requests;
+    ++g_continuous_world_workset.requests;
+    request.requested = true;
+    request.retain_target = true;
+    request.reuse_target = reuse_target;
+    request.defer_preview_publication_until_swap = true;
+    request.frame_sequence = g_isolated_draw.frame;
+    request.reference_marker_requested = true;
+    request.completion = &CompleteContinuousWorldWorksetReplay;
+    return;
   }
   if (g_visibility_shadow_replay.requested &&
       g_visibility_shadow_replay.valid &&
@@ -19228,6 +19459,7 @@ void InstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system,
   ConfigureReplaySnapshot();
   ConfigureIsolatedDraw();
   ConfigureVisibilityShadowReplay();
+  ConfigureContinuousWorldWorkset();
   ConfigurePassFollower();
   if (g_isolated_draw.stencil_seed_probe_requested &&
       g_pass_follower.requested) {
@@ -19235,6 +19467,7 @@ void InstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system,
   }
   ConfigurePassPublication();
   ValidateAndEmitVisibilityShadowReplayConfiguration();
+  ValidateAndEmitContinuousWorldWorksetConfiguration();
   ArmSkyHorizonSuppression();
   EmitSkyHorizonSuppressionControl();
   ConfigureConsumerFamilyMarker();
@@ -20335,6 +20568,7 @@ void UninstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system) {
          {"suppression_eligible", "false"}});
   }
   EmitVisibilityShadowReplaySummary();
+  EmitContinuousWorldWorksetSummary();
   const bool isolated_single_draw_mode =
       !g_pass_follower.requested || !g_pass_follower.valid ||
       g_pass_follower.target_signature == g_isolated_draw.target_signature;

--- a/tools/capture-native-renderer-census.ps1
+++ b/tools/capture-native-renderer-census.ps1
@@ -27,6 +27,7 @@ param(
     [switch]$AutoSelectFreshVisibilityCandidate,
     [switch]$RequireTitleLodCandidate,
     [switch]$VisibilityShadowReplay,
+    [switch]$ContinuousWorldWorkset,
     [switch]$VehicleDrawCorrelation,
     [switch]$ShadowCasterProvenance,
     [ValidatePattern('^[0-9A-Fa-f]{16}$')]
@@ -90,7 +91,8 @@ if (($ShadowDepthIsolated -or $ShadowDepthBatch) -and
     ($IsolatedDrawSignature -or $AutoSelectFreshVisibilityCandidate -or
         $StencilSeedProbe -or $RequireFreshVisibilityCandidate -or
         $RequireTitleLodCandidate -or $PassAnchorSignature -or
-        $PublishRetainedPass -or $VisibilityShadowReplay)) {
+        $PublishRetainedPass -or $VisibilityShadowReplay -or
+        $ContinuousWorldWorkset)) {
     throw 'Shadow-depth modes are mutually exclusive with other isolated/pass replay options.'
 }
 if ($ShadowDepthIsolated -and -not $IsolatedDrawDir) {
@@ -118,8 +120,16 @@ if ($VisibilityShadowReplay -and
     ($IsolatedDrawSignature -or $IsolatedDrawDir -or $StencilSeedProbe -or
         $RequireFreshVisibilityCandidate -or
         $AutoSelectFreshVisibilityCandidate -or $RequireTitleLodCandidate -or
-        $PassAnchorSignature -or $PublishRetainedPass)) {
+        $PassAnchorSignature -or $PublishRetainedPass -or
+        $ContinuousWorldWorkset)) {
     throw 'VisibilityShadowReplay is mutually exclusive with isolated/pass replay options.'
+}
+if ($ContinuousWorldWorkset -and
+    ($IsolatedDrawSignature -or $IsolatedDrawDir -or $StencilSeedProbe -or
+        $RequireFreshVisibilityCandidate -or
+        $AutoSelectFreshVisibilityCandidate -or $RequireTitleLodCandidate -or
+        $PassAnchorSignature -or $PublishRetainedPass)) {
+    throw 'ContinuousWorldWorkset is mutually exclusive with isolated/pass replay options.'
 }
 if ($PublishRetainedPass -and
     (-not $IsolatedDrawSignature -or -not $PassAnchorSignature)) {
@@ -218,6 +228,8 @@ $savedTitleLodCandidate =
     $env:PINYON_SHIFT_NATIVE_RENDERER_REQUIRE_TITLE_LOD_CANDIDATE
 $savedVisibilityShadowReplay =
     $env:PINYON_SHIFT_NATIVE_RENDERER_VISIBILITY_SHADOW_REPLAY
+$savedContinuousWorldWorkset =
+    $env:PINYON_SHIFT_NATIVE_RENDERER_CONTINUOUS_WORLD_WORKSET
 $savedShadowCasterProvenance =
     $env:PINYON_SHIFT_NATIVE_RENDERER_SHADOW_CASTER_PROVENANCE
 $savedPassAnchor = $env:PINYON_SHIFT_NATIVE_RENDERER_PASS_ANCHOR_SIGNATURE
@@ -228,7 +240,8 @@ $savedConsumerReadbackSamples = $env:PINYON_SHIFT_NATIVE_RENDERER_CONSUMER_READB
 try {
     $env:REX_PINYON_SHIFT_NATIVE_RENDERER_CENSUS = 'true'
     $env:REX_PINYON_SHIFT_NATIVE_RENDERER_DISPATCH_DISCOVERY =
-        if ($VisibilityShadowReplay -or $VehicleDrawCorrelation -or
+        if ($VisibilityShadowReplay -or $ContinuousWorldWorkset -or
+            $VehicleDrawCorrelation -or
             $ShadowCasterProvenance) {
             'true'
         } else { $savedDiscovery }
@@ -263,6 +276,8 @@ try {
         if ($RequireTitleLodCandidate) { 'true' } else { $null }
     $env:PINYON_SHIFT_NATIVE_RENDERER_VISIBILITY_SHADOW_REPLAY =
         if ($VisibilityShadowReplay) { 'true' } else { $null }
+    $env:PINYON_SHIFT_NATIVE_RENDERER_CONTINUOUS_WORLD_WORKSET =
+        if ($ContinuousWorldWorkset) { 'true' } else { $null }
     $env:PINYON_SHIFT_NATIVE_RENDERER_SHADOW_CASTER_PROVENANCE =
         if ($ShadowCasterProvenance) { 'true' } else { $null }
     $env:PINYON_SHIFT_NATIVE_RENDERER_PASS_ANCHOR_SIGNATURE = $PassAnchorSignature
@@ -305,6 +320,8 @@ finally {
         $savedTitleLodCandidate
     $env:PINYON_SHIFT_NATIVE_RENDERER_VISIBILITY_SHADOW_REPLAY =
         $savedVisibilityShadowReplay
+    $env:PINYON_SHIFT_NATIVE_RENDERER_CONTINUOUS_WORLD_WORKSET =
+        $savedContinuousWorldWorkset
     $env:PINYON_SHIFT_NATIVE_RENDERER_SHADOW_CASTER_PROVENANCE =
         $savedShadowCasterProvenance
     $env:PINYON_SHIFT_NATIVE_RENDERER_PASS_ANCHOR_SIGNATURE = $savedPassAnchor

--- a/tools/summarize-native-renderer-continuous-world-workset.py
+++ b/tools/summarize-native-renderer-continuous-world-workset.py
@@ -1,0 +1,199 @@
+#!/usr/bin/env python3
+"""Qualify continuous multi-draw native world-workset accumulation."""
+
+import argparse
+import json
+import pathlib
+import sys
+
+
+SCHEMA = "pinyon-shift.native-renderer-continuous-world-workset.v1"
+CONFIG = "native_renderer.continuous_world_workset.config"
+SUMMARY = "native_renderer.continuous_world_workset.summary"
+
+
+def read_events(paths):
+    events = []
+    for path in paths:
+        for line in path.read_text(encoding="utf-8").splitlines():
+            if line.strip():
+                events.append(json.loads(line))
+    return events
+
+
+def integer(mapping, key):
+    try:
+        value = int(mapping[key])
+    except (KeyError, TypeError, ValueError) as error:
+        raise ValueError(f"invalid {key}") from error
+    if value < 0:
+        raise ValueError(f"negative {key}")
+    return value
+
+
+def exact_event(events, name):
+    matches = [event for event in events if event.get("event") == name]
+    if len(matches) != 1:
+        raise ValueError(f"expected exactly one {name} event")
+    return matches[0]
+
+
+def select_session(events, requested):
+    sessions = {
+        event.get("session") for event in events if event.get("event") == CONFIG
+    }
+    sessions.discard(None)
+    if requested:
+        if requested not in sessions:
+            raise ValueError("requested session has no workset config")
+        return requested
+    if len(sessions) != 1:
+        raise ValueError("workset input contains multiple sessions")
+    return next(iter(sessions))
+
+
+def require_safety(event):
+    expected = {
+        "readback": "disabled",
+        "native_draw": "continuous_world_workset",
+        "xenos_draw": "preserved",
+        "output_authority": "renderer_selector",
+        "draw_suppression": "false",
+        "suppression_eligible": "false",
+    }
+    if any(event.get(key) != value for key, value in expected.items()):
+        raise ValueError("workset evidence violates safety boundary")
+
+
+def build(events, requested_session=None):
+    session = select_session(events, requested_session)
+    selected = [event for event in events if event.get("session") == session]
+    config = exact_event(selected, CONFIG)
+    summary = exact_event(selected, SUMMARY)
+    expected_config = {
+        "status": "armed_deferred_private_composition",
+        "activation": "startup_environment_only",
+        "default_enabled": "false",
+        "selection": "fresh_visibility_and_mechanical",
+        "maximum_draws_per_frame": "64",
+        "target_lifetime": "one_guest_frame",
+        "freshness_commit": "matching_swap_after_complete_accumulation",
+        "semantic_lineage": "armed",
+        "readback": "disabled",
+        "native_draw": "continuous_world_workset",
+        "xenos_draw": "preserved",
+        "output_authority": "renderer_selector",
+        "draw_suppression": "false",
+        "suppression_eligible": "false",
+    }
+    if any(config.get(key) != value for key, value in expected_config.items()):
+        raise ValueError("workset runtime configuration drifted")
+    require_safety(summary)
+    if (
+        summary.get("accounting_complete") != "true"
+        or summary.get("selection_accounting_complete") != "true"
+        or summary.get("freshness_commit")
+        != "matching_swap_after_complete_accumulation"
+        or summary.get("maximum_draws_per_frame") != "64"
+    ):
+        raise ValueError("workset summary is incomplete")
+
+    keys = (
+        "prepared_observations",
+        "requests",
+        "recorded",
+        "target_creation_failures",
+        "unsupported",
+        "mechanical_rejections",
+        "stale_or_unselected_rejections",
+        "per_frame_quota_yields",
+        "fail_closed_yields",
+        "reused_target_requests",
+        "frames_started",
+        "frames_completed",
+        "frames_failed",
+        "maximum_draws_per_frame",
+    )
+    totals = {key: integer(summary, key) for key in keys}
+    failures = []
+    selections = (
+        totals["requests"]
+        + totals["mechanical_rejections"]
+        + totals["stale_or_unselected_rejections"]
+        + totals["per_frame_quota_yields"]
+        + totals["fail_closed_yields"]
+    )
+    outcomes = (
+        totals["recorded"]
+        + totals["target_creation_failures"]
+        + totals["unsupported"]
+    )
+    if selections != totals["prepared_observations"]:
+        failures.append("prepared selection accounting drifted")
+    if outcomes != totals["requests"]:
+        failures.append("replay outcome accounting drifted")
+    if totals["frames_started"] != (
+        totals["frames_completed"] + totals["frames_failed"]
+    ):
+        failures.append("frame accounting drifted")
+    if not totals["frames_completed"]:
+        failures.append("no complete continuous workset frame was recorded")
+    if totals["frames_failed"]:
+        failures.append("one or more workset frames failed closed")
+    if totals["fail_closed_yields"]:
+        failures.append("workset requests yielded after a frame failure")
+    if totals["target_creation_failures"] or totals["unsupported"]:
+        failures.append("one or more private replays failed")
+    if not totals["reused_target_requests"]:
+        failures.append("no frame accumulated multiple native draws")
+    if totals["maximum_draws_per_frame"] != 64:
+        failures.append("per-frame workset bound drifted")
+    if summary.get("status") != "complete":
+        failures.append("runtime did not report complete worksets")
+
+    return {
+        "schema": SCHEMA,
+        "session": session,
+        "status": "complete" if not failures else "incomplete",
+        "failures": failures,
+        "totals": totals,
+        "qualification": {
+            "continuous_multi_draw_workset_proved": not failures,
+            "swap_committed_freshness_proved": not failures,
+            "suppression_allowed": False,
+        },
+        "safety": {
+            "readback": False,
+            "xenos_draw_preserved": True,
+            "output_authority": "renderer_selector",
+            "suppression_allowed": False,
+        },
+    }
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser()
+    parser.add_argument("events", nargs="+", type=pathlib.Path)
+    parser.add_argument("--session")
+    parser.add_argument("--output", required=True, type=pathlib.Path)
+    args = parser.parse_args(argv)
+    try:
+        document = build(read_events(args.events), args.session)
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(
+            json.dumps(document, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        if document["status"] != "complete":
+            raise ValueError("; ".join(document["failures"]))
+        return 0
+    except (OSError, ValueError, json.JSONDecodeError) as error:
+        print(
+            f"native renderer continuous workset summary failed: {error}",
+            file=sys.stderr,
+        )
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/tests/test_native_renderer_continuous_world_workset.py
+++ b/tools/tests/test_native_renderer_continuous_world_workset.py
@@ -1,0 +1,139 @@
+import copy
+import importlib.util
+import pathlib
+import unittest
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+TOOL = ROOT / "tools/summarize-native-renderer-continuous-world-workset.py"
+SPEC = importlib.util.spec_from_file_location(
+    "summarize_native_renderer_continuous_world_workset", TOOL
+)
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+def event(name, **values):
+    return {"event": name, "session": "session-1", **values}
+
+
+def fixture():
+    config = event(
+        MODULE.CONFIG,
+        status="armed_deferred_private_composition",
+        activation="startup_environment_only",
+        default_enabled="false",
+        selection="fresh_visibility_and_mechanical",
+        maximum_draws_per_frame="64",
+        target_lifetime="one_guest_frame",
+        freshness_commit="matching_swap_after_complete_accumulation",
+        semantic_lineage="armed",
+        readback="disabled",
+        native_draw="continuous_world_workset",
+        xenos_draw="preserved",
+        output_authority="renderer_selector",
+        draw_suppression="false",
+        suppression_eligible="false",
+    )
+    summary = event(
+        MODULE.SUMMARY,
+        status="complete",
+        prepared_observations="17",
+        requests="8",
+        recorded="8",
+        target_creation_failures="0",
+        unsupported="0",
+        mechanical_rejections="4",
+        stale_or_unselected_rejections="3",
+        per_frame_quota_yields="2",
+        fail_closed_yields="0",
+        reused_target_requests="6",
+        frames_started="2",
+        frames_completed="2",
+        frames_failed="0",
+        accounting_complete="true",
+        selection_accounting_complete="true",
+        maximum_draws_per_frame="64",
+        freshness_commit="matching_swap_after_complete_accumulation",
+        readback="disabled",
+        native_draw="continuous_world_workset",
+        xenos_draw="preserved",
+        output_authority="renderer_selector",
+        draw_suppression="false",
+        suppression_eligible="false",
+    )
+    return [config, summary]
+
+
+class ContinuousWorldWorksetTests(unittest.TestCase):
+    def test_runtime_contract_is_swap_committed_and_fail_closed(self):
+        source = (ROOT / "src/native_renderer/graphics_hooks.cpp").read_text(
+            encoding="utf-8"
+        )
+        self.assertIn(
+            "PINYON_SHIFT_NATIVE_RENDERER_CONTINUOUS_WORLD_WORKSET", source
+        )
+        self.assertIn("kContinuousWorldWorksetMaximumDrawsPerFrame = 64", source)
+        self.assertIn("request.reuse_target = reuse_target", source)
+        self.assertIn("request.defer_preview_publication_until_swap = true", source)
+        self.assertIn('"native_renderer.continuous_world_workset.summary"', source)
+        self.assertIn('{"xenos_draw", "preserved"}', source)
+        self.assertIn('{"draw_suppression", "false"}', source)
+
+        patch = (
+            ROOT
+            / "patches/rexglue/0094-d3d12-deferred-replay-preview-publication.patch"
+        ).read_text(encoding="utf-8")
+        self.assertIn("CommitDeferredIsolatedReplayPreview", patch)
+        self.assertIn("CancelDeferredIsolatedReplayPreview", patch)
+        self.assertIn("defer_preview_publication_until_swap", patch)
+        self.assertIn("observation_frame_sequence_", patch)
+        self.assertNotIn("suppress_guest_draw_if_published = true", patch)
+
+        capture = (ROOT / "tools/capture-native-renderer-census.ps1").read_text(
+            encoding="utf-8"
+        )
+        self.assertIn("[switch]$ContinuousWorldWorkset", capture)
+        self.assertIn(
+            "PINYON_SHIFT_NATIVE_RENDERER_CONTINUOUS_WORLD_WORKSET", capture
+        )
+
+    def test_qualifies_complete_multi_draw_worksets(self):
+        document = MODULE.build(fixture())
+        self.assertEqual("complete", document["status"])
+        self.assertTrue(
+            document["qualification"]["continuous_multi_draw_workset_proved"]
+        )
+        self.assertFalse(document["qualification"]["suppression_allowed"])
+
+    def test_rejects_single_draw_frames(self):
+        events = fixture()
+        events[1]["reused_target_requests"] = "0"
+        document = MODULE.build(events)
+        self.assertEqual("incomplete", document["status"])
+        self.assertIn(
+            "no frame accumulated multiple native draws", document["failures"]
+        )
+
+    def test_rejects_failed_frame(self):
+        events = fixture()
+        events[1].update(
+            status="fallback_observed",
+            recorded="7",
+            unsupported="1",
+            frames_completed="1",
+            frames_failed="1",
+        )
+        document = MODULE.build(events)
+        self.assertEqual("incomplete", document["status"])
+        self.assertIn("one or more workset frames failed closed", document["failures"])
+
+    def test_rejects_safety_drift(self):
+        events = copy.deepcopy(fixture())
+        events[1]["draw_suppression"] = "true"
+        with self.assertRaisesRegex(ValueError, "safety boundary"):
+            MODULE.build(events)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/tests/test_release_contract.py
+++ b/tools/tests/test_release_contract.py
@@ -43,10 +43,10 @@ class ReleaseContractTests(unittest.TestCase):
 
     def test_rexglue_patches_have_stable_order_and_no_binary_payload(self):
         patches = sorted((ROOT / "patches/rexglue").glob("*.patch"))
-        self.assertEqual(len(patches), 93)
+        self.assertEqual(len(patches), 94)
         self.assertEqual(
             patches[-1].name,
-            "0093-graphics-draw-viewport-observer.patch",
+            "0094-d3d12-deferred-replay-preview-publication.patch",
         )
         self.assertEqual(len(patches), len({path.name[:4] for path in patches}))
         for path in patches:


### PR DESCRIPTION
## Summary

- Accumulate up to 64 mechanically eligible, visibility-selected native replay draws into one private target per guest frame.
- Defer exact-frame preview freshness until the matching swap and cancel it on any replay failure.
- Add startup-only capture controls, diagnostics, documentation, and focused contract tests.

Xenos remains authoritative, all original draws are preserved, and the experiment is disabled by default.

## Validation

- `python -m unittest discover -s tools/tests -p 'test_*.py'` (463 tests)
- ReXGlue Release build: `rexglue` and `rexgpu-xenos`
- Pinyon Shift Release build

The expensive AppData gameplay run is intentionally batched with the later visible hybrid-composition checkpoint.
