### PR TITLE
feat(renderer): align comparison with native prototype

### DIFF
--- a/docs/native-renderer/DUAL_PATH_COMPARISON.md
+++ b/docs/native-renderer/DUAL_PATH_COMPARISON.md
@@ -3,6 +3,8 @@
 NR-04C adds restart-gated `comparison_native` and `comparison_xenos` output
 modes. Both modes preserve the complete Xenos frame and build the exact-frame
 retained native display target in the command processor's existing submission.
+Since Phase B5, they use the same 512x288 logical scene, RGBA16F linear
+intermediate, title gamma, and title upscale path as the native prototype.
 Only the selected path becomes display authority:
 
 - `comparison_native` copies the completed private native display target into
@@ -42,16 +44,15 @@ $stateRoot = Join-Path $env:LOCALAPPDATA `
 .\tools\capture-native-renderer-output-comparison.ps1 `
   -StateRoot $stateRoot `
   -RenderDocRoot '.local\tools\renderdoc-1.45\RenderDoc_1.45_64' `
-  -IsolatedDrawSignature 1D253A52B55C9FB3 `
-  -PassAnchorSignature 747837906D0BF484 `
-  -IsolatedDrawDir '.local\qualification\nr04c-isolated-pass' `
   -CaptureDir '.local\qualification\nr04c-capture' `
   -SelectedOutput native
 ```
 
 Load the requested scene, press F12 after the retained native output is visible,
 then close the game. The wrapper changes only the renderer selector and restores
-its original value after the capture process exits.
+its original value after the capture process exits. Prototype comparison modes
+self-arm their world and shadow observation; legacy isolated-draw and pass-anchor
+arguments must not be supplied.
 
 Export the first complete same-frame pair with:
 

--- a/docs/native-renderer/NATIVE_PROTOTYPE_COMPARISON.md
+++ b/docs/native-renderer/NATIVE_PROTOTYPE_COMPARISON.md
@@ -1,0 +1,86 @@
+# Native prototype comparison
+
+Phase B5 makes the existing restart-gated comparison controls representative
+of the current prototype rather than the earlier retained-pass diagnostic.
+Xenos remains the default renderer and no comparison mode suppresses a guest
+draw, resolve, query, fence, memexport, or other side effect.
+
+## Renderer selections
+
+- `xenos` leaves the complete Xenos frame authoritative and does no native
+  output work.
+- `native_prototype` presents the continuous native world workset through the
+  logical 512x288 scene, RGBA16F linear intermediate, title gamma conversion,
+  and title upscale path.
+- `hybrid_prototype` admits a native pixel only when it agrees with completed
+  Xenos output and otherwise retains the Xenos pixel.
+- `comparison_native` builds the same native-prototype output privately, then
+  selects it after the completed Xenos frame.
+- `comparison_xenos` builds the same private native-prototype output but leaves
+  the completed Xenos frame authoritative.
+
+Both comparison selections self-arm the prototype world workset and exact
+80-draw shadow observer. Shadow publication remains current-frame and
+fail-closed; an unavailable exact consumer reports Xenos fallback without
+rejecting the rest of the prototype frame.
+
+The diagnostics contract reports renderer mode, composition, presentation,
+selected output, authority, world fallback, shadow state, preserved Xenos
+draws, and disabled suppression. All selectors require a restart.
+
+## Same-build paired export
+
+The strict paired export uses `comparison_native`. Its selection copy provides
+one deterministic same-frame boundary: the destination contains completed
+Xenos output immediately before the copy, the source contains the private
+native output, and the destination contains selected native output immediately
+after the copy. This produces the pair without comparing different gameplay
+runs.
+
+At the batched B6 qualification checkpoint, use the installed AppData save and
+the signed local RenderDoc build:
+
+```powershell
+$stateRoot = Join-Path $env:LOCALAPPDATA `
+    'PinyonShift\source\0.1.0\.local\preview'
+.\tools\capture-native-renderer-output-comparison.ps1 `
+  -StateRoot $stateRoot `
+  -RenderDocRoot '.local\tools\renderdoc-1.45\RenderDoc_1.45_64' `
+  -CaptureDir '.local\qualification\native-prototype-comparison' `
+  -SelectedOutput native
+```
+
+Load the requested scene, press F12 after the world is stable, and close the
+game. The wrapper restores the original renderer selection in a `finally`
+block. It no longer supplies legacy isolated-draw or pass-anchor signatures;
+the prototype comparison path owns its exact automatic configuration.
+
+Export a capture containing both comparison markers:
+
+```powershell
+.\tools\export-native-renderer-output-comparison.ps1 `
+  -Capture `
+    '.local\qualification\native-prototype-comparison\reference_frame1.rdc' `
+  -RenderDocRoot '.local\tools\renderdoc-1.45\RenderDoc_1.45_64' `
+  -OutputDir '.local\qualification\native-prototype-comparison-export'
+```
+
+The exporter writes `xenos-output.png`, `native-private.png`,
+`native-selected.png`, and `native-output-comparison.json`. It fails closed if
+the resources alias, dimensions differ, the private and selected native hashes
+differ, required markers are missing, or GPU timing is unavailable.
+
+Use a separate `comparison_xenos` gameplay run to qualify visual fallback and
+Xenos authority. That mode intentionally has no native selection-copy marker,
+so it is not the paired-image export source.
+
+## B5 safety boundary
+
+- Xenos stays default and remains complete before native selection.
+- Comparison uses the same presentation math and source extent as the actual
+  prototype.
+- Native failure or stale retained state yields to Xenos.
+- Comparison does not enable suppression.
+- Captures and game-derived images remain below `.local` and are not committed.
+- Full build, AppData gameplay, performance, relaunch, fallback, and screenshot
+  qualification are deliberately batched into B6.

--- a/docs/native-renderer/REPRIORITIZED_PLAN.md
+++ b/docs/native-renderer/REPRIORITIZED_PLAN.md
@@ -160,6 +160,12 @@ handoff without enabling suppression.
 - Export a paired native/Xenos screenshot and machine-readable comparison from
   the same clean build.
 
+Implementation checkpoint: the restart-gated comparison selectors now run the
+same logical-scene, linear-intermediate, title-gamma presentation pipeline as
+the prototype and self-arm its world and shadow observations. The paired export
+contract and B6 capture procedure are defined in
+[`NATIVE_PROTOTYPE_COMPARISON.md`](NATIVE_PROTOTYPE_COMPARISON.md).
+
 ### B6. Batched prototype qualification
 
 Run focused automated checks during B1-B5, then one full validation batch:

--- a/patches/rexglue/0097-d3d12-native-prototype-comparison.patch
+++ b/patches/rexglue/0097-d3d12-native-prototype-comparison.patch
@@ -1,0 +1,54 @@
+diff --git a/include/rex/system/interfaces/graphics.h b/include/rex/system/interfaces/graphics.h
+index b7fcd7f..812e5ae 100644
+--- a/include/rex/system/interfaces/graphics.h
++++ b/include/rex/system/interfaces/graphics.h
+@@ -54,6 +54,8 @@ enum class NativeGuestOutputRetainedPassMode : uint32_t {
+   kCompareXenos = 2,
+   kPrototypeNative = 3,
+   kPrototypeHybrid = 4,
++  kPrototypeCompareNative = 5,
++  kPrototypeCompareXenos = 6,
+ };
+ 
+ struct NativeGuestOutputRenderContext {
+diff --git a/src/graphics/d3d12/command_processor.cpp b/src/graphics/d3d12/command_processor.cpp
+index 51a9022..dedce73 100644
+--- a/src/graphics/d3d12/command_processor.cpp
++++ b/src/graphics/d3d12/command_processor.cpp
+@@ -2215,12 +2215,22 @@ bool D3D12CommandProcessor::DrawNativeGuestOutputRetainedPass(
+   }
+   const bool comparison =
+       mode == system::NativeGuestOutputRetainedPassMode::kCompareNative ||
+-      mode == system::NativeGuestOutputRetainedPassMode::kCompareXenos;
++      mode == system::NativeGuestOutputRetainedPassMode::kCompareXenos ||
++      mode ==
++          system::NativeGuestOutputRetainedPassMode::kPrototypeCompareNative ||
++      mode ==
++          system::NativeGuestOutputRetainedPassMode::kPrototypeCompareXenos;
+   const bool present_native =
+-      mode != system::NativeGuestOutputRetainedPassMode::kCompareXenos;
++      mode != system::NativeGuestOutputRetainedPassMode::kCompareXenos &&
++      mode !=
++          system::NativeGuestOutputRetainedPassMode::kPrototypeCompareXenos;
+   const bool prototype =
+       mode == system::NativeGuestOutputRetainedPassMode::kPrototypeNative ||
+-      mode == system::NativeGuestOutputRetainedPassMode::kPrototypeHybrid;
++      mode == system::NativeGuestOutputRetainedPassMode::kPrototypeHybrid ||
++      mode ==
++          system::NativeGuestOutputRetainedPassMode::kPrototypeCompareNative ||
++      mode ==
++          system::NativeGuestOutputRetainedPassMode::kPrototypeCompareXenos;
+   const bool hybrid =
+       mode == system::NativeGuestOutputRetainedPassMode::kPrototypeHybrid;
+ 
+@@ -2501,9 +2511,7 @@ bool D3D12CommandProcessor::DrawNativeGuestOutputRetainedPass(
+                  : std::min(preview_source.width, uint32_t(512)),
+        prototype ? kLogicalSceneHeight
+                  : std::min(preview_source.height, uint32_t(512))},
+-      mode == system::NativeGuestOutputRetainedPassMode::kPrototypeNative
+-          ? 1u
+-          : 0u,
++      prototype ? 1u : 0u,
+       0u};
+   PushTransitionBarrier(native_guest_output_display_target_.Get(),
+                         native_guest_output_display_target_state_,

--- a/src/native_renderer/graphics_hooks.cpp
+++ b/src/native_renderer/graphics_hooks.cpp
@@ -56,7 +56,8 @@ constexpr size_t kSignatureCapacity = 4096;
 
 bool NativePrototypeSelected() {
   const std::string mode = REXCVAR_GET(pinyon_shift_native_renderer);
-  return mode == "native_prototype" || mode == "hybrid_prototype";
+  return mode == "native_prototype" || mode == "hybrid_prototype" ||
+         mode == "comparison_native" || mode == "comparison_xenos";
 }
 
 constexpr size_t kSummaryLimit = 16;

--- a/src/native_renderer/guest_output_renderer.cpp
+++ b/src/native_renderer/guest_output_renderer.cpp
@@ -114,10 +114,12 @@ bool RenderDiagnosticOutput(
           rex::system::NativeGuestOutputRetainedPassMode::kPresentNative;
       if (mode == DiagnosticMode::kComparisonNative) {
         retained_mode =
-            rex::system::NativeGuestOutputRetainedPassMode::kCompareNative;
+            rex::system::NativeGuestOutputRetainedPassMode::
+                kPrototypeCompareNative;
       } else if (mode == DiagnosticMode::kComparisonXenos) {
         retained_mode =
-            rex::system::NativeGuestOutputRetainedPassMode::kCompareXenos;
+            rex::system::NativeGuestOutputRetainedPassMode::
+                kPrototypeCompareXenos;
       } else if (mode == DiagnosticMode::kNativePrototype) {
         retained_mode =
             rex::system::NativeGuestOutputRetainedPassMode::kPrototypeNative;
@@ -181,14 +183,18 @@ bool RenderDiagnosticOutput(
          {"mode", DiagnosticModeName(mode)},
          {"composition", mode == DiagnosticMode::kHybridPrototype
                              ? "conservative_pixel_agreement_hybrid"
-                             : (mode == DiagnosticMode::kNativePrototype
+                             : (mode == DiagnosticMode::kNativePrototype ||
+                                        mode == DiagnosticMode::kComparisonNative ||
+                                        mode == DiagnosticMode::kComparisonXenos
                                     ? "continuous_world_passthrough"
-                             : (UsesRetainedPass(mode)
-                                    ? "private_display_target"
-                                    : "direct_guest_output"))},
+                                    : (UsesRetainedPass(mode)
+                                           ? "private_display_target"
+                                           : "direct_guest_output"))},
          {"presentation",
           mode == DiagnosticMode::kNativePrototype ||
-                  mode == DiagnosticMode::kHybridPrototype
+                  mode == DiagnosticMode::kHybridPrototype ||
+                  mode == DiagnosticMode::kComparisonNative ||
+                  mode == DiagnosticMode::kComparisonXenos
               ? "logical_scene_scale_then_title_gamma_then_title_upscale"
               : "legacy_diagnostic"},
          {"selected_output", mode == DiagnosticMode::kComparisonXenos

--- a/tools/capture-native-renderer-output-comparison.ps1
+++ b/tools/capture-native-renderer-output-comparison.ps1
@@ -5,14 +5,6 @@ param(
     [Parameter(Mandatory)]
     [string]$RenderDocRoot,
     [Parameter(Mandatory)]
-    [ValidatePattern('^[0-9A-Fa-f]{16}$')]
-    [string]$IsolatedDrawSignature,
-    [Parameter(Mandatory)]
-    [ValidatePattern('^[0-9A-Fa-f]{16}$')]
-    [string]$PassAnchorSignature,
-    [Parameter(Mandatory)]
-    [string]$IsolatedDrawDir,
-    [Parameter(Mandatory)]
     [string]$CaptureDir,
     [ValidateSet('native', 'xenos')]
     [string]$SelectedOutput = 'native',
@@ -39,10 +31,7 @@ try {
     [void](& $settingsTool -Action SetRenderer -StateRoot $StateRoot `
         -NativeRenderer $comparisonRenderer -Json)
     & $captureTool -StateRoot $StateRoot -RenderDocRoot $RenderDocRoot `
-        -IsolatedDrawSignature $IsolatedDrawSignature `
-        -PassAnchorSignature $PassAnchorSignature `
-        -IsolatedDrawDir $IsolatedDrawDir -CaptureDir $CaptureDir `
-        -Scene $Scene
+        -CaptureDir $CaptureDir -Scene $Scene
 }
 finally {
     [void](& $settingsTool -Action SetRenderer -StateRoot $StateRoot `

--- a/tools/capture-native-renderer-renderdoc.ps1
+++ b/tools/capture-native-renderer-renderdoc.ps1
@@ -4,7 +4,6 @@ param(
     [string]$StateRoot,
     [Parameter(Mandatory)]
     [string]$RenderDocRoot,
-    [Parameter(Mandatory)]
     [ValidatePattern('^[0-9A-Fa-f]{16}$')]
     [string]$IsolatedDrawSignature,
     [ValidatePattern('^[0-9A-Fa-f]{16}$')]
@@ -118,7 +117,11 @@ try {
     $env:REX_PINYON_SHIFT_NATIVE_RENDERER_CENSUS = 'true'
     $env:PINYON_SHIFT_NATIVE_RENDERER_SCENE = $Scene
     $env:PINYON_SHIFT_NATIVE_RENDERER_ISOLATED_DRAW_SIGNATURE =
-        $IsolatedDrawSignature.ToUpperInvariant()
+        if ($IsolatedDrawSignature) {
+            $IsolatedDrawSignature.ToUpperInvariant()
+        } else {
+            $null
+        }
     $env:PINYON_SHIFT_NATIVE_RENDERER_ISOLATED_DRAW_DIR = $IsolatedDrawDir
     $env:PINYON_SHIFT_NATIVE_RENDERER_PASS_ANCHOR_SIGNATURE =
         if ($PassAnchorSignature) {

--- a/tools/tests/test_native_renderer_prototype_comparison.py
+++ b/tools/tests/test_native_renderer_prototype_comparison.py
@@ -1,0 +1,58 @@
+import pathlib
+import unittest
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+
+
+class NativeRendererPrototypeComparisonTests(unittest.TestCase):
+    def test_comparison_modes_use_prototype_presentation(self):
+        patch = (
+            ROOT
+            / "patches/rexglue/0097-d3d12-native-prototype-comparison.patch"
+        ).read_text(encoding="utf-8")
+        output = (ROOT / "src/native_renderer/guest_output_renderer.cpp").read_text(
+            encoding="utf-8"
+        )
+        for mode in ("kPrototypeCompareNative", "kPrototypeCompareXenos"):
+            self.assertIn(mode, patch)
+            self.assertIn(mode, output)
+        self.assertIn("prototype ? 1u : 0u", patch)
+        self.assertNotIn("SetDrawSuppression", patch)
+
+    def test_comparison_self_arms_world_and_shadow_observation(self):
+        hooks = (ROOT / "src/native_renderer/graphics_hooks.cpp").read_text(
+            encoding="utf-8"
+        )
+        prototype_selector = hooks.split("bool NativePrototypeSelected()", 1)[1]
+        prototype_selector = prototype_selector.split("}", 1)[0]
+        for mode in (
+            'mode == "native_prototype"',
+            'mode == "hybrid_prototype"',
+            'mode == "comparison_native"',
+            'mode == "comparison_xenos"',
+        ):
+            self.assertIn(mode, prototype_selector)
+
+    def test_capture_does_not_inject_legacy_isolated_draw_configuration(self):
+        capture = (
+            ROOT / "tools/capture-native-renderer-output-comparison.ps1"
+        ).read_text(encoding="utf-8")
+        self.assertNotIn("IsolatedDrawSignature", capture)
+        self.assertNotIn("PassAnchorSignature", capture)
+        self.assertNotIn("IsolatedDrawDir", capture)
+        self.assertIn("-CaptureDir $CaptureDir -Scene $Scene", capture)
+        self.assertIn("finally", capture)
+
+    def test_checkpoint_defers_expensive_qualification_to_b6(self):
+        document = (
+            ROOT / "docs/native-renderer/NATIVE_PROTOTYPE_COMPARISON.md"
+        ).read_text(encoding="utf-8")
+        self.assertIn("same-frame boundary", document)
+        self.assertIn("native-output-comparison.json", document)
+        self.assertIn("batched into B6", document)
+        self.assertIn("Xenos stays default", document)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/tests/test_release_contract.py
+++ b/tools/tests/test_release_contract.py
@@ -43,10 +43,10 @@ class ReleaseContractTests(unittest.TestCase):
 
     def test_rexglue_patches_have_stable_order_and_no_binary_payload(self):
         patches = sorted((ROOT / "patches/rexglue").glob("*.patch"))
-        self.assertEqual(len(patches), 96)
+        self.assertEqual(len(patches), 97)
         self.assertEqual(
             patches[-1].name,
-            "0096-d3d12-conservative-hybrid-composition.patch",
+            "0097-d3d12-native-prototype-comparison.patch",
         )
         self.assertEqual(len(patches), len({path.name[:4] for path in patches}))
         for path in patches:


### PR DESCRIPTION
## Summary
- route comparison_native and comparison_xenos through the playable prototype presentation path
- self-arm prototype world and shadow observation in comparison modes
- remove legacy isolated-draw capture inputs and document the same-frame B6 export contract

## Validation
- 76 focused Python contract tests
- ReXGlue Release rexgpu-xenos build
- root Release pinyon_shift build

Full AppData gameplay and screenshot qualification is intentionally batched into Phase B6.