### PR TITLE
feat(native-renderer): qualify retained prototype lifecycle

### DIFF
--- a/docs/native-renderer/CONTINUOUS_WORLD_WORKSET.md
+++ b/docs/native-renderer/CONTINUOUS_WORLD_WORKSET.md
@@ -15,11 +15,15 @@ capture wrapper's `-ContinuousWorldWorkset` switch. The mode requires renderer
 census and semantic dispatch discovery so every admitted draw has:
 
 - a mechanically replayable prepared-draw contract;
-- a current, selected semantic visibility decision; and
+- either a current, selected semantic visibility decision or the exact,
+  previously qualified sky/horizon follower signature; and
 - exact title-to-backend lineage.
 
-The mode accepts at most 64 draws in one guest frame. The first accepted draw
-seeds a private color/depth pair from the authoritative guest attachments.
+The exact retained family supplies a current-frame seed in supported gameplay
+scenes where the visibility-selected opaque set contains no mechanically
+replayable color target. It does not admit unknown signatures. The mode accepts
+at most 64 draws in one guest frame. The first accepted draw seeds a private
+color/depth pair from the authoritative guest attachments.
 Later accepted draws in the same frame resume that private pair without another
 seed copy. Target incompatibility, unsupported state, or a replay failure marks
 the frame failed and rejects every later candidate in that frame.
@@ -48,6 +52,13 @@ The runtime emits:
 
 The summary reconciles prepared observations, selection outcomes, replay
 outcomes, target reuse, complete frames, failed frames, and the 64-draw bound.
+The payload-free qualifier treats an accounted unsupported frame as a proven
+Xenos fallback, not as a native success. Continuous native qualification also
+requires at least three strictly increasing output markers with exact matching
+frame and retained-frame identifiers; every waiting marker must retain Xenos
+authority with suppression disabled.
+It reports the exact-family seed count separately as
+`qualified_retained_family_requests`.
 Build a payload-free qualification report with:
 
 ```powershell

--- a/docs/native-renderer/DUAL_PATH_COMPARISON.md
+++ b/docs/native-renderer/DUAL_PATH_COMPARISON.md
@@ -3,8 +3,10 @@
 NR-04C adds restart-gated `comparison_native` and `comparison_xenos` output
 modes. Both modes preserve the complete Xenos frame and build the exact-frame
 retained native display target in the command processor's existing submission.
-Since Phase B5, they use the same 512x288 logical scene, RGBA16F linear
-intermediate, title gamma, and title upscale path as the native prototype.
+Since Phase B5, they use the same draw-derived logical scene extent, RGBA16F
+linear intermediate, title gamma, and title upscale path as the native
+prototype. The observed logical extents are `512x288` at 2x and `256x144` at
+1x; padded backing dimensions are never used as visible crop dimensions.
 Only the selected path becomes display authority:
 
 - `comparison_native` copies the completed private native display target into

--- a/docs/native-renderer/HYBRID_PROTOTYPE_COMPOSITION.md
+++ b/docs/native-renderer/HYBRID_PROTOTYPE_COMPOSITION.md
@@ -4,7 +4,7 @@ Phase B3 adds a complete-frame `hybrid_prototype` mode without guessing a
 semantic vehicle, transparency, effects, or UI mask. It remains restart-gated,
 default-off, and independent from suppression.
 
-The backend first scales the measured `512x288` logical scene out of the padded
+The backend first scales the draw-derived logical scene extent out of the padded
 retained allocation into a private RGBA16F target, then converts it with the
 same active table or PWL gamma-ramp pipeline used for the Xenos swap source. It
 compares that private guest-format result with the already completed Xenos
@@ -44,5 +44,7 @@ Claimed hybrid frames report:
 - exact matching `frame` and `retained_frame`; and
 - preserved Xenos draws with suppression disabled.
 
-The AppData gameplay and visual comparison run is intentionally deferred to the
-batched Phase B qualification checkpoint.
+The logical extent is `512x288` in the observed 2x path and `256x144` in the
+observed 1x path; physical backing dimensions remain separate. The AppData
+gameplay and visual qualification is recorded in
+[`PROTOTYPE_BATCH_QUALIFICATION.md`](PROTOTYPE_BATCH_QUALIFICATION.md).

--- a/docs/native-renderer/NATIVE_PROTOTYPE_COMPARISON.md
+++ b/docs/native-renderer/NATIVE_PROTOTYPE_COMPARISON.md
@@ -9,9 +9,9 @@ draw, resolve, query, fence, memexport, or other side effect.
 
 - `xenos` leaves the complete Xenos frame authoritative and does no native
   output work.
-- `native_prototype` presents the continuous native world workset through the
-  logical 512x288 scene, RGBA16F linear intermediate, title gamma conversion,
-  and title upscale path.
+- `native_prototype` presents the continuous native world workset through its
+  draw-derived logical scene extent, RGBA16F linear intermediate, title gamma
+  conversion, and title upscale path.
 - `hybrid_prototype` admits a native pixel only when it agrees with completed
   Xenos output and otherwise retains the Xenos pixel.
 - `comparison_native` builds the same native-prototype output privately, then
@@ -84,3 +84,9 @@ so it is not the paired-image export source.
 - Captures and game-derived images remain below `.local` and are not committed.
 - Full build, AppData gameplay, performance, relaunch, fallback, and screenshot
   qualification are deliberately batched into B6.
+
+The B6 implementation keeps physical backing dimensions separate from the
+logical crop: `512x288` was observed at 2x and `256x144` at 1x, while the
+corresponding padded resources were `640x8192` and `320x4096`. See
+[`PROTOTYPE_BATCH_QUALIFICATION.md`](PROTOTYPE_BATCH_QUALIFICATION.md) for the
+clean-build and AppData evidence.

--- a/docs/native-renderer/NATIVE_PROTOTYPE_PRESENTATION.md
+++ b/docs/native-renderer/NATIVE_PROTOTYPE_PRESENTATION.md
@@ -6,9 +6,11 @@ restart-gated, default-off, and fail-closed. Selecting it automatically arms
 the bounded continuous world workset from Phase B1; the environment override
 remains available to capture tooling.
 
-For an exact current-frame retained target, ReXGlue maps the measured top-left
-`512x288` logical scene out of the padded `640x8192` allocation into a private
-RGBA16F output-sized target. It then uses the same title gamma-ramp pipeline
+For an exact current-frame retained target, ReXGlue maps the draw-derived
+logical scene extent out of the padded backing allocation into a private
+RGBA16F output-sized target. The extent is bounded by the active viewport and
+scissor and clamped to the physical resource dimensions. It then uses the same
+title gamma-ramp pipeline
 used by the authoritative Xenos swap source. The existing title presentation
 boundary performs the already-proven 3:2 output upscale. This removes the amber
 border and checkerboard from the supported prototype path without treating
@@ -17,13 +19,18 @@ depth-of-field, or UI semantics.
 
 The source and destination mapping is:
 
-- source: the measured `512x288` logical region of the current-frame retained
-  replay target;
+- source: the draw-derived logical region of the current-frame retained replay
+  target (`512x288` observed at 2x and `256x144` at 1x);
 - linear intermediate: output-sized RGBA16F nearest-neighbor mapping;
 - converted destination: the ordinary guest-output texture;
 - final destination: the title's established presentation surface;
 - conversion: the active table or PWL title gamma ramp; and
 - ownership: native only after an exact-frame source is available.
+
+The physical backing remains padded (`640x8192` at 2x and `320x4096` at 1x).
+Its dimensions are used for D3D resource access only; crop and upscale math use
+the retained logical extent. This distinction prevents padded storage from
+becoming visible and makes the prototype independent of the launcher scale.
 
 If the workset is absent, stale, unsupported, or failed, the callback records
 the existing waiting diagnostic and returns `false` before touching guest
@@ -49,5 +56,5 @@ addition to the safe `xenos` default. Native prototype frame markers report:
 - `xenos_draw=preserved`; and
 - `suppression=disabled`.
 
-No AppData-backed visual qualification is claimed by this implementation
-checkpoint. It is batched with the remaining Phase B composition work.
+The AppData-backed Phase B6 qualification is recorded in
+[`PROTOTYPE_BATCH_QUALIFICATION.md`](PROTOTYPE_BATCH_QUALIFICATION.md).

--- a/docs/native-renderer/PROTOTYPE_BATCH_QUALIFICATION.md
+++ b/docs/native-renderer/PROTOTYPE_BATCH_QUALIFICATION.md
@@ -1,0 +1,119 @@
+# Native prototype batched qualification
+
+Phase B6 is qualified as an early, manually testable native prototype. A clean
+build and an AppData-backed `comparison_native` run displayed a recognizable,
+stable world slice with current-frame native authority. Xenos draws remained
+enabled, suppression remained disabled, and unsupported startup or replay work
+fell back to the complete Xenos output.
+
+This checkpoint is not native scene parity. The displayed native slice includes
+sky and atmosphere, a ground or road surface, horizon structures, and integrated
+lighting and shadow behavior. It remains visibly low-resolution and does not
+yet contain the vehicle, HUD, detailed world and props, transparency, or the
+complete effects chain. Those are Phase C and D work.
+
+## Build identity
+
+The repository prepared all 102 ReXGlue patches from a clean clone and built the
+preview successfully:
+
+- patch-set SHA-256:
+  `9D3DF3A2560A4F5DF9AA00E992FA759BAD42494711324BBC90E0D57FEE38EFF5`;
+- `pinyon_shift.exe` SHA-256:
+  `33AA2B330582F0E1AD84488D332C957C4488112E47DB4C7D43E498DF4EED1C89`;
+- `rexgpu-xenos.dll` SHA-256:
+  `99E92B1D18EF838AAF005B4B0DBBA8142B268D21301194DC665AFE0DBD8E2C39`;
+  and
+- ReXGlue commit `f5337cdc947ff6d4c4196737e2c807a48f2a1fc2`.
+
+The last lifecycle change separates the D3D12 backing resource dimensions from
+the effective logical draw dimensions. The command processor derives a bounded
+logical width and height from the active viewport and scissor, carries them
+through active, deferred, and committed retained state, and uses them for the
+prototype crop. D3D resource operations continue to use the physical backing.
+The observed pairs were `512x288` logical in `640x8192` backing at 2x and
+`256x144` logical in `320x4096` backing at 1x.
+
+## AppData gameplay evidence
+
+Session `20260830T223753Z-p38480` used the installed 0.1.0 preview state root
+and its existing profile through `tools/launch-preview.ps1`. The temporary
+qualification settings selected shipping 1x, `comparison_native`, FXAA,
+16x anisotropy, and disabled blur and depth-of-field. The original graphics
+configuration was restored after normal shutdown.
+
+The process exited normally with code 0. Logs contain no runtime fatal, crash,
+device loss, device removal, D3D validation error, or unintended suppression
+signature. Nine sampled native-output markers had exact matching frame and
+retained-frame identifiers, native authority, preserved Xenos draws, and
+disabled suppression. Three waiting markers retained Xenos fallback safely.
+
+The payload-free continuous-workset report records:
+
+- 10,295,899 prepared observations and 16,892 replay requests;
+- 16,868 recorded requests, including 16,854 qualified retained-family seeds;
+- 14,083 target-reuse requests;
+- 2,785 complete frames and 24 accounted target-creation fallback frames;
+- zero unsupported outcomes and zero fail-closed yields; and
+- independently proven multi-draw accumulation, swap-committed freshness, and
+  clean Xenos fallback.
+
+The exact shadow observer recorded 2,768 complete 80-draw batches: all 221,440
+draws recorded successfully, all 2,768 publications completed, and no producer,
+backend, target, or publication failure was observed.
+
+The game naturally autosaved the active profile during the run. Its resulting
+file was 51,208 bytes with SHA-256
+`1D1932BA49679C11A5D0962B49A91505041CF9E6F6FDB1D5ACE9C393519D3B70`.
+The launcher and qualification workflow did not copy, move, reset, overwrite,
+or otherwise manipulate the save.
+
+## Observed timing
+
+The session contained 3,305 samples over 134.979 seconds. These values describe
+one prototype run and are not performance claims:
+
+- median derived FPS: 28.465;
+- one-percent-low FPS: 14.587;
+- presentation, simulation, and vblank cadence: 58.987, 29.575, and 60.002 Hz;
+- presentation deadline misses: 0;
+- mean guest-frame GPU time: 33,791.990 microseconds;
+- mean native-composition GPU time: 49.731 microseconds; and
+- mean native-selection GPU time: 8.905 microseconds.
+
+The run recorded 70 dropped and 4,727 duplicate presents. These counters and
+the low-resolution partial output remain baseline evidence for later parity and
+performance work, not a regression judgment.
+
+## Failure investigation and closure
+
+Four AppData sessions narrowed and closed the retained-frame lifecycle defect:
+
+- `p44068` exposed a crash caused by sharing the color-preview and depth-only
+  replay target lifetime;
+- `p45032` remained stable after separating those targets but exposed stale
+  retained-state reporting;
+- `p33228` isolated the remaining mismatch: a `320x4096` 1x backing resource
+  was being compared with a fixed `512x288` logical scene; and
+- `p38480` passed after logical extent became draw-derived and retained through
+  publication.
+
+The qualifier schema is now version 2. It accepts only accounted fail-closed
+fallback frames, requires at least three increasing exact native-output markers,
+and verifies that every waiting marker preserves Xenos authority with
+suppression disabled. It therefore distinguishes safe fallback from native
+success without rejecting a healthy prototype merely because startup or an
+unsupported frame yielded to Xenos.
+
+## Gate decision
+
+B6 passes the early-prototype gate: the supported gameplay scene visibly and
+continuously reaches the final displayed frame, missing work remains safe under
+Xenos fallback, and the result launches normally without capture tooling.
+
+The default remains `xenos`; all prototype selectors remain restart-gated;
+guest draws, resolves, queries, fences, memexport, and other side effects remain
+preserved; and suppression is not allowed. Phase C must now replace the partial
+retained family with semantic terrain, road, static-world, vehicle, sky,
+vegetation, transparency, and effects coverage before this can be described as
+a complete native gameplay renderer.

--- a/docs/native-renderer/REPRIORITIZED_PLAN.md
+++ b/docs/native-renderer/REPRIORITIZED_PLAN.md
@@ -63,9 +63,9 @@ Already landed or substantially qualified:
   vehicle rendering bridge yet; and
 - post-processing topology census plus the mechanical presentation ingress.
 
-The active slice is `arcanite24/native-post-processing-ingress`, following
-merged PRs #160 and #161. The largest remaining near-term gap is integration:
-turn qualified private work into a coherent continuous frame.
+Phase A and B1-B5 are merged. The active B6 slice qualifies the first coherent
+continuous frame and closes the retained-target lifecycle discovered during
+the AppData run. Phase C terrain and roads are the next visible-impact target.
 
 ---
 
@@ -186,6 +186,15 @@ Prototype exit gate:
 - missing families remain visibly correct through hybrid composition or clean
   Xenos fallback; and
 - the result is manually testable without developer capture tooling.
+
+Qualification checkpoint: the clean 102-patch build and AppData-backed 1x run
+showed a recognizable, stable native world slice with exact current-frame
+authority, continuous multi-draw accumulation, and clean Xenos fallback. The
+retained source now carries draw-derived logical dimensions independently from
+its padded resource. Evidence and remaining visual limitations are recorded in
+[`PROTOTYPE_BATCH_QUALIFICATION.md`](PROTOTYPE_BATCH_QUALIFICATION.md). This
+qualifies B6 as an early prototype; it does not enable suppression, change the
+default renderer, or satisfy any Phase C family.
 
 ---
 

--- a/patches/rexglue/0098-d3d12-preserve-color-preview-across-depth-replay.patch
+++ b/patches/rexglue/0098-d3d12-preserve-color-preview-across-depth-replay.patch
@@ -1,0 +1,103 @@
+diff --git a/include/rex/graphics/d3d12/render_target_cache.h b/include/rex/graphics/d3d12/render_target_cache.h
+--- a/include/rex/graphics/d3d12/render_target_cache.h
++++ b/include/rex/graphics/d3d12/render_target_cache.h
+@@ -132,7 +132,8 @@ class D3D12RenderTargetCache final : public RenderTargetCache {
+       uint32_t* failure_detail_out);
+   void EndIsolatedReplayTarget(
+       uint64_t frame_sequence,
+-      bool defer_preview_publication_until_swap = false);
++      bool defer_preview_publication_until_swap = false,
++      bool depth_only_target = false);
+   void CommitDeferredIsolatedReplayPreview(uint64_t frame_sequence);
+   void CancelDeferredIsolatedReplayPreview(uint64_t frame_sequence);
+   system::GraphicsIsolatedDrawPublicationResult PublishIsolatedReplayTarget(
+diff --git a/src/graphics/d3d12/command_processor.cpp b/src/graphics/d3d12/command_processor.cpp
+--- a/src/graphics/d3d12/command_processor.cpp
++++ b/src/graphics/d3d12/command_processor.cpp
+@@ -3833,7 +3833,8 @@ bool D3D12CommandProcessor::IssueDraw(xenos::PrimitiveType primitive_type, uint3
+         if (!restore_prepared_guest_graphics_state()) {
+           render_target_cache_->EndIsolatedReplayTarget(
+               isolated_draw_request.frame_sequence,
+-              isolated_draw_request.defer_preview_publication_until_swap);
++              isolated_draw_request.defer_preview_publication_until_swap,
++              isolated_draw_request.depth_only_target);
+           if (isolated_draw_request.defer_preview_publication_until_swap) {
+             render_target_cache_->CancelDeferredIsolatedReplayPreview(
+                 isolated_draw_request.frame_sequence);
+@@ -3885,7 +3886,8 @@ bool D3D12CommandProcessor::IssueDraw(xenos::PrimitiveType primitive_type, uint3
+         }
+         render_target_cache_->EndIsolatedReplayTarget(
+             isolated_draw_request.frame_sequence,
+-            isolated_draw_request.defer_preview_publication_until_swap);
++            isolated_draw_request.defer_preview_publication_until_swap,
++            isolated_draw_request.depth_only_target);
+         isolated_replay_recorded = true;
+         isolated_result.status =
+             system::GraphicsIsolatedDrawStatus::kRecorded;
+@@ -4083,7 +4085,8 @@ bool D3D12CommandProcessor::IssueDraw(xenos::PrimitiveType primitive_type, uint3
+         if (!restore_prepared_guest_graphics_state()) {
+           render_target_cache_->EndIsolatedReplayTarget(
+               isolated_draw_request.frame_sequence,
+-              isolated_draw_request.defer_preview_publication_until_swap);
++              isolated_draw_request.defer_preview_publication_until_swap,
++              isolated_draw_request.depth_only_target);
+           if (isolated_draw_request.defer_preview_publication_until_swap) {
+             render_target_cache_->CancelDeferredIsolatedReplayPreview(
+                 isolated_draw_request.frame_sequence);
+@@ -4135,7 +4138,8 @@ bool D3D12CommandProcessor::IssueDraw(xenos::PrimitiveType primitive_type, uint3
+         }
+         render_target_cache_->EndIsolatedReplayTarget(
+             isolated_draw_request.frame_sequence,
+-            isolated_draw_request.defer_preview_publication_until_swap);
++            isolated_draw_request.defer_preview_publication_until_swap,
++            isolated_draw_request.depth_only_target);
+         isolated_replay_recorded = true;
+         isolated_result.status =
+             system::GraphicsIsolatedDrawStatus::kRecorded;
+diff --git a/src/graphics/d3d12/render_target_cache.cpp b/src/graphics/d3d12/render_target_cache.cpp
+--- a/src/graphics/d3d12/render_target_cache.cpp
++++ b/src/graphics/d3d12/render_target_cache.cpp
+@@ -1776,7 +1776,9 @@ bool D3D12RenderTargetCache::BeginIsolatedReplayTarget(
+     bool stencil_seed_probe_requested, bool depth_only_target) {
+   width_out = 0;
+   height_out = 0;
+-  isolated_replay_deferred_preview_frame_sequence_ = 0;
++  if (!depth_only_target) {
++    isolated_replay_deferred_preview_frame_sequence_ = 0;
++  }
+   if (GetPath() != Path::kHostRenderTargets) {
+     return false;
+   }
+@@ -1797,9 +1799,7 @@ bool D3D12RenderTargetCache::BeginIsolatedReplayTarget(
+       isolated_replay_depth_target_->key() != depth_key) {
+     isolated_replay_depth_target_.reset(CreateRenderTarget(depth_key));
+   }
+-  if (depth_only_target) {
+-    isolated_replay_color_target_.reset();
+-  } else {
++  if (!depth_only_target) {
+     const RenderTargetKey color_key = guest_targets[1]->key();
+     if (!isolated_replay_color_target_ ||
+         isolated_replay_color_target_->key() != color_key) {
+@@ -2441,12 +2441,16 @@ system::GraphicsIsolatedDrawReadbackStatus D3D12RenderTargetCache::QueueRenderTa
+ }
+ 
+ void D3D12RenderTargetCache::EndIsolatedReplayTarget(
+-    uint64_t frame_sequence, bool defer_preview_publication_until_swap) {
++    uint64_t frame_sequence, bool defer_preview_publication_until_swap,
++    bool depth_only_target) {
+   if (GetPath() != Path::kHostRenderTargets) {
+     return;
+   }
+   SetCommandListRenderTargets(last_update_accumulated_render_targets());
+   command_processor_.SubmitBarriers();
++  if (depth_only_target) {
++    return;
++  }
+   if (defer_preview_publication_until_swap) {
+     isolated_replay_deferred_preview_frame_sequence_ = frame_sequence;
+   } else {
+     isolated_replay_deferred_preview_frame_sequence_ = 0;
+     isolated_replay_preview_frame_sequence_ = frame_sequence;
+   }
+ }

--- a/patches/rexglue/0099-d3d12-flush-device-loss-diagnostics.patch
+++ b/patches/rexglue/0099-d3d12-flush-device-loss-diagnostics.patch
@@ -1,0 +1,13 @@
+diff --git a/src/graphics/d3d12/command_processor.cpp b/src/graphics/d3d12/command_processor.cpp
+--- a/src/graphics/d3d12/command_processor.cpp
++++ b/src/graphics/d3d12/command_processor.cpp
+@@ -4859,6 +4859,9 @@ bool D3D12CommandProcessor::BeginSubmission(bool is_guest_command) {
+   if (FAILED(device_removed_reason)) {
+     device_removed_ = true;
+     LogDeviceRemovalDiagnostics(device, device_removed_reason);
++    // The GPU-loss callback terminates the process. Persist the HRESULT and
++    // any available DRED breadcrumbs before control reaches the fatal path.
++    rex::FlushLogging();
+     if (graphics_system_) {
+       graphics_system_->OnHostGpuLossFromAnyThread(device_removed_reason !=
+                                                    DXGI_ERROR_DEVICE_REMOVED);

--- a/patches/rexglue/0100-d3d12-separate-depth-only-replay-target.patch
+++ b/patches/rexglue/0100-d3d12-separate-depth-only-replay-target.patch
@@ -1,0 +1,186 @@
+diff --git a/include/rex/graphics/d3d12/render_target_cache.h b/include/rex/graphics/d3d12/render_target_cache.h
+--- a/include/rex/graphics/d3d12/render_target_cache.h
++++ b/include/rex/graphics/d3d12/render_target_cache.h
+@@ -729,6 +729,8 @@ class D3D12RenderTargetCache final : public RenderTargetCache {
+   std::shared_ptr<ui::d3d12::D3D12CpuDescriptorPool> descriptor_pool_depth_;
+   std::unique_ptr<RenderTarget> isolated_replay_color_target_;
+   std::unique_ptr<RenderTarget> isolated_replay_depth_target_;
++  std::unique_ptr<RenderTarget> isolated_replay_depth_only_target_;
++  RenderTarget* isolated_replay_active_depth_target_ = nullptr;
+   Microsoft::WRL::ComPtr<ID3D12Resource>
+       isolated_replay_preview_resolved_target_;
+   D3D12_RESOURCE_STATES isolated_replay_preview_resolved_target_state_ =
+diff --git a/src/graphics/d3d12/render_target_cache.cpp b/src/graphics/d3d12/render_target_cache.cpp
+--- a/src/graphics/d3d12/render_target_cache.cpp
++++ b/src/graphics/d3d12/render_target_cache.cpp
+@@ -1046,6 +1046,8 @@ void D3D12RenderTargetCache::Shutdown(bool from_destructor) {
+       D3D12_RESOURCE_STATE_RESOLVE_DEST;
+   isolated_replay_preview_frame_sequence_ = 0;
+   isolated_replay_deferred_preview_frame_sequence_ = 0;
++  isolated_replay_active_depth_target_ = nullptr;
++  isolated_replay_depth_only_target_.reset();
+   isolated_replay_depth_target_.reset();
+   isolated_replay_color_target_.reset();
+   null_rtv_descriptor_ms_.Free();
+@@ -1778,6 +1780,7 @@ bool D3D12RenderTargetCache::BeginIsolatedReplayTarget(
+     bool stencil_seed_probe_requested, bool depth_only_target) {
+   width_out = 0;
+   height_out = 0;
++  isolated_replay_active_depth_target_ = nullptr;
+   if (!depth_only_target) {
+     isolated_replay_deferred_preview_frame_sequence_ = 0;
+   }
+@@ -1797,10 +1800,13 @@ bool D3D12RenderTargetCache::BeginIsolatedReplayTarget(
+     }
+   }
+ 
++  auto& isolated_replay_depth_target =
++      depth_only_target ? isolated_replay_depth_only_target_
++                        : isolated_replay_depth_target_;
+   const RenderTargetKey depth_key = guest_targets[0]->key();
+-  if (!isolated_replay_depth_target_ ||
+-      isolated_replay_depth_target_->key() != depth_key) {
+-    isolated_replay_depth_target_.reset(CreateRenderTarget(depth_key));
++  if (!isolated_replay_depth_target ||
++      isolated_replay_depth_target->key() != depth_key) {
++    isolated_replay_depth_target.reset(CreateRenderTarget(depth_key));
+   }
+   if (!depth_only_target) {
+     const RenderTargetKey color_key = guest_targets[1]->key();
+@@ -1809,15 +1815,18 @@ bool D3D12RenderTargetCache::BeginIsolatedReplayTarget(
+       isolated_replay_color_target_.reset(CreateRenderTarget(color_key));
+     }
+   }
+-  if (!isolated_replay_depth_target_ ||
++  if (!isolated_replay_depth_target ||
+       (!depth_only_target && !isolated_replay_color_target_)) {
+-    isolated_replay_depth_target_.reset();
+-    isolated_replay_color_target_.reset();
++    isolated_replay_depth_target.reset();
++    if (!depth_only_target) {
++      isolated_replay_color_target_.reset();
++    }
++    isolated_replay_active_depth_target_ = nullptr;
+     return false;
+   }
+ 
+   auto* isolated_depth = static_cast<D3D12RenderTarget*>(
+-      isolated_replay_depth_target_.get());
++      isolated_replay_depth_target.get());
+   auto* guest_depth = static_cast<D3D12RenderTarget*>(guest_targets[0]);
+   auto* isolated_color = depth_only_target
+                              ? nullptr
+@@ -1929,16 +1939,22 @@ bool D3D12RenderTargetCache::BeginIsolatedReplayTarget(
+   SetCommandListRenderTargets(isolated_targets);
+   command_processor_.SubmitBarriers();
+ 
++  isolated_replay_active_depth_target_ = isolated_depth;
+   return true;
+ }
+ 
+ bool D3D12RenderTargetCache::ResumeIsolatedReplayTarget(
+     uint32_t& width_out, uint32_t& height_out, bool depth_only_target) {
+   width_out = 0;
+   height_out = 0;
++  isolated_replay_active_depth_target_ = nullptr;
++  auto& isolated_replay_depth_target =
++      depth_only_target ? isolated_replay_depth_only_target_
++                        : isolated_replay_depth_target_;
+   if (GetPath() != Path::kHostRenderTargets ||
+-      !isolated_replay_depth_target_ ||
++      !isolated_replay_depth_target ||
+       (!depth_only_target && !isolated_replay_color_target_)) {
++    isolated_replay_active_depth_target_ = nullptr;
+     return false;
+   }
+   RenderTarget* const* guest_targets =
+@@ -1946,6 +1962,7 @@ bool D3D12RenderTargetCache::ResumeIsolatedReplayTarget(
+       last_update_accumulated_render_targets();
+   if (!guest_targets[0] || (!depth_only_target && !guest_targets[1]) ||
+-      guest_targets[0]->key() != isolated_replay_depth_target_->key()) {
++      guest_targets[0]->key() != isolated_replay_depth_target->key()) {
++    isolated_replay_active_depth_target_ = nullptr;
+     return false;
+   }
+   if (!depth_only_target &&
+@@ -1958,7 +1975,7 @@ bool D3D12RenderTargetCache::ResumeIsolatedReplayTarget(
+   }
+ 
+   auto* isolated_depth = static_cast<D3D12RenderTarget*>(
+-      isolated_replay_depth_target_.get());
++      isolated_replay_depth_target.get());
+   auto* isolated_color = depth_only_target
+                              ? nullptr
+                              : static_cast<D3D12RenderTarget*>(
+@@ -1976,6 +1993,7 @@ bool D3D12RenderTargetCache::ResumeIsolatedReplayTarget(
+   }
+   SetCommandListRenderTargets(isolated_targets);
+   command_processor_.SubmitBarriers();
++  isolated_replay_active_depth_target_ = isolated_depth;
+   return true;
+ }
+ 
+@@ -2066,10 +2084,10 @@ D3D12RenderTargetCache::QueueIsolatedReplayDepthReadback(
+     system::GraphicsIsolatedDrawReadbackCompletion completion,
+     uint32_t* failure_detail_out) {
+-  if (!isolated_replay_depth_target_) {
++  if (!isolated_replay_active_depth_target_) {
+     return system::GraphicsIsolatedDrawReadbackStatus::kUnsupportedTarget;
+   }
+   return QueueRenderTargetReadback(
+-      static_cast<D3D12RenderTarget*>(isolated_replay_depth_target_.get()),
++      static_cast<D3D12RenderTarget*>(isolated_replay_active_depth_target_),
+       isolated_replay_depth_readback_, completion, failure_detail_out);
+ }
+ 
+@@ -2078,10 +2096,10 @@ D3D12RenderTargetCache::QueueIsolatedReplaySeedDepthReadback(
+     system::GraphicsIsolatedDrawReadbackCompletion completion,
+     uint32_t* failure_detail_out) {
+-  if (!isolated_replay_depth_target_) {
++  if (!isolated_replay_active_depth_target_) {
+     return system::GraphicsIsolatedDrawReadbackStatus::kUnsupportedTarget;
+   }
+   return QueueRenderTargetReadback(
+-      static_cast<D3D12RenderTarget*>(isolated_replay_depth_target_.get()),
++      static_cast<D3D12RenderTarget*>(isolated_replay_active_depth_target_),
+       isolated_replay_seed_depth_readback_, completion, failure_detail_out);
+ }
+ 
+@@ -2448,6 +2466,7 @@ void D3D12RenderTargetCache::EndIsolatedReplayTarget(
+   }
+   SetCommandListRenderTargets(last_update_accumulated_render_targets());
+   command_processor_.SubmitBarriers();
++  isolated_replay_active_depth_target_ = nullptr;
+   if (depth_only_target) {
+     return;
+   }
+@@ -2481,7 +2500,10 @@ D3D12RenderTargetCache::PublishIsolatedReplayTarget(bool depth_only_target) {
+     result.status = system::GraphicsIsolatedDrawPublicationStatus::kUnsupportedPath;
+     return result;
+   }
+-  if (!isolated_replay_depth_target_ ||
++  auto& isolated_replay_depth_target =
++      depth_only_target ? isolated_replay_depth_only_target_
++                        : isolated_replay_depth_target_;
++  if (!isolated_replay_depth_target ||
+       (!depth_only_target && !isolated_replay_color_target_)) {
+     result.status = system::GraphicsIsolatedDrawPublicationStatus::kUnavailable;
+     return result;
+@@ -2500,7 +2522,7 @@ D3D12RenderTargetCache::PublishIsolatedReplayTarget(bool depth_only_target) {
+       return result;
+     }
+   }
+-  if (guest_targets[0]->key() != isolated_replay_depth_target_->key() ||
++  if (guest_targets[0]->key() != isolated_replay_depth_target->key() ||
+       (!depth_only_target &&
+        guest_targets[1]->key() != isolated_replay_color_target_->key())) {
+     result.status = system::GraphicsIsolatedDrawPublicationStatus::kTargetMismatch;
+@@ -2512,7 +2534,7 @@ D3D12RenderTargetCache::PublishIsolatedReplayTarget(bool depth_only_target) {
+                           ? nullptr
+                           : static_cast<D3D12RenderTarget*>(guest_targets[1]);
+   auto* isolated_depth = static_cast<D3D12RenderTarget*>(
+-      isolated_replay_depth_target_.get());
++      isolated_replay_depth_target.get());
+   auto* isolated_color =
+       depth_only_target
+           ? nullptr

--- a/patches/rexglue/0101-d3d12-report-retained-preview-failures.patch
+++ b/patches/rexglue/0101-d3d12-report-retained-preview-failures.patch
@@ -1,0 +1,50 @@
+diff --git a/src/graphics/d3d12/command_processor.cpp b/src/graphics/d3d12/command_processor.cpp
+--- a/src/graphics/d3d12/command_processor.cpp
++++ b/src/graphics/d3d12/command_processor.cpp
+@@ -2402,6 +2402,14 @@ bool D3D12CommandProcessor::DrawNativeGuestOutputRetainedPass(
+           D3D12_RESOURCE_STATE_UNORDERED_ACCESS, nullptr,
+           IID_PPV_ARGS(&native_guest_output_linear_target_));
+       if (FAILED(create_result)) {
++        static bool logged_linear_target_failure = false;
++        if (!logged_linear_target_failure) {
++          logged_linear_target_failure = true;
++          REXGPU_WARN(
++              "Native guest-output linear target allocation failed: "
++              "HRESULT 0x{:08X}, {}x{}",
++              uint32_t(create_result), width, height);
++        }
+         return false;
+       }
+       native_guest_output_linear_target_->SetName(
+@@ -2448,6 +2456,15 @@ bool D3D12CommandProcessor::DrawNativeGuestOutputRetainedPass(
+   D3D12RenderTargetCache::IsolatedReplayPreviewSource preview_source;
+   if (!render_target_cache_->BeginIsolatedReplayPreview(
+           observation_frame_sequence_, preview_source)) {
++    static bool logged_retained_preview_begin_failure = false;
++    if (!logged_retained_preview_begin_failure) {
++      logged_retained_preview_begin_failure = true;
++      REXGPU_WARN(
++          "Native retained-pass preview unavailable for frame {}, retained "
++          "frame {}",
++          observation_frame_sequence_,
++          render_target_cache_->GetIsolatedReplayPreviewFrameSequence());
++    }
+     return false;
+   }
+   constexpr uint32_t kLogicalSceneWidth = 512;
+@@ -2456,6 +2473,15 @@ bool D3D12CommandProcessor::DrawNativeGuestOutputRetainedPass(
+   if (prototype &&
+       (preview_source.width < kLogicalSceneWidth ||
+        preview_source.height < kLogicalSceneHeight)) {
++    static bool logged_retained_preview_size_failure = false;
++    if (!logged_retained_preview_size_failure) {
++      logged_retained_preview_size_failure = true;
++      REXGPU_WARN(
++          "Native prototype retained-pass preview is smaller than the "
++          "logical scene: {}x{} (requires at least {}x{})",
++          preview_source.width, preview_source.height, kLogicalSceneWidth,
++          kLogicalSceneHeight);
++    }
+     render_target_cache_->EndIsolatedReplayPreview(preview_source);
+     return false;
+   }

--- a/patches/rexglue/0102-d3d12-track-retained-preview-logical-extent.patch
+++ b/patches/rexglue/0102-d3d12-track-retained-preview-logical-extent.patch
@@ -1,0 +1,263 @@
+diff --git a/include/rex/graphics/d3d12/render_target_cache.h b/include/rex/graphics/d3d12/render_target_cache.h
+index c8c6301..df7cb5b 100644
+--- a/include/rex/graphics/d3d12/render_target_cache.h
++++ b/include/rex/graphics/d3d12/render_target_cache.h
+@@ -100,9 +100,13 @@ class D3D12RenderTargetCache final : public RenderTargetCache {
+   // EndIsolatedReplayTarget restores the guest bindings without changing the
+   // guest attachments or ownership.
+   bool BeginIsolatedReplayTarget(uint32_t& width_out, uint32_t& height_out,
++                                 uint32_t logical_width,
++                                 uint32_t logical_height,
+                                  bool stencil_seed_probe_requested,
+                                  bool depth_only_target = false);
+   bool ResumeIsolatedReplayTarget(uint32_t& width_out, uint32_t& height_out,
++                                  uint32_t logical_width,
++                                  uint32_t logical_height,
+                                   bool depth_only_target = false);
+   system::GraphicsIsolatedDrawReadbackStatus QueueIsolatedReplayReadback(
+       system::GraphicsIsolatedDrawReadbackCompletion completion,
+@@ -146,6 +150,8 @@ class D3D12RenderTargetCache final : public RenderTargetCache {
+     DXGI_FORMAT format = DXGI_FORMAT_UNKNOWN;
+     uint32_t width = 0;
+     uint32_t height = 0;
++    uint32_t logical_width = 0;
++    uint32_t logical_height = 0;
+     uint64_t frame_sequence = 0;
+     bool resolved = false;
+   };
+@@ -737,6 +743,12 @@ class D3D12RenderTargetCache final : public RenderTargetCache {
+       D3D12_RESOURCE_STATE_RESOLVE_DEST;
+   uint64_t isolated_replay_preview_frame_sequence_ = 0;
+   uint64_t isolated_replay_deferred_preview_frame_sequence_ = 0;
++  uint32_t isolated_replay_active_preview_width_ = 0;
++  uint32_t isolated_replay_active_preview_height_ = 0;
++  uint32_t isolated_replay_preview_width_ = 0;
++  uint32_t isolated_replay_preview_height_ = 0;
++  uint32_t isolated_replay_deferred_preview_width_ = 0;
++  uint32_t isolated_replay_deferred_preview_height_ = 0;
+   struct IsolatedReplayReadback {
+     Microsoft::WRL::ComPtr<ID3D12Resource> buffer;
+     Microsoft::WRL::ComPtr<ID3D12Resource> resolved_target;
+diff --git a/src/graphics/d3d12/render_target_cache.cpp b/src/graphics/d3d12/render_target_cache.cpp
+index 6c3fd64..0f10307 100644
+--- a/src/graphics/d3d12/render_target_cache.cpp
++++ b/src/graphics/d3d12/render_target_cache.cpp
+@@ -1775,12 +1775,17 @@ RenderTargetCache::RenderTarget* D3D12RenderTargetCache::CreateRenderTarget(Rend
+ 
+ bool D3D12RenderTargetCache::BeginIsolatedReplayTarget(
+     uint32_t& width_out, uint32_t& height_out,
++    uint32_t logical_width, uint32_t logical_height,
+     bool stencil_seed_probe_requested, bool depth_only_target) {
+   width_out = 0;
+   height_out = 0;
+   isolated_replay_active_depth_target_ = nullptr;
+   if (!depth_only_target) {
+     isolated_replay_deferred_preview_frame_sequence_ = 0;
++    isolated_replay_deferred_preview_width_ = 0;
++    isolated_replay_deferred_preview_height_ = 0;
++    isolated_replay_active_preview_width_ = 0;
++    isolated_replay_active_preview_height_ = 0;
+   }
+   if (GetPath() != Path::kHostRenderTargets) {
+     return false;
+@@ -1838,6 +1843,16 @@ bool D3D12RenderTargetCache::BeginIsolatedReplayTarget(
+           ->GetDesc();
+   width_out = uint32_t(target_desc.Width);
+   height_out = target_desc.Height;
++  if (!depth_only_target) {
++    isolated_replay_active_preview_width_ =
++        std::min(logical_width, width_out);
++    isolated_replay_active_preview_height_ =
++        std::min(logical_height, height_out);
++    if (!isolated_replay_active_preview_width_ ||
++        !isolated_replay_active_preview_height_) {
++      return false;
++    }
++  }
+ 
+   if (stencil_seed_probe_requested) {
+     constexpr uint8_t kStencilSeedProbeValue = 0xA5;
+@@ -1942,7 +1957,8 @@ bool D3D12RenderTargetCache::BeginIsolatedReplayTarget(
+ }
+ 
+ bool D3D12RenderTargetCache::ResumeIsolatedReplayTarget(
+-    uint32_t& width_out, uint32_t& height_out, bool depth_only_target) {
++    uint32_t& width_out, uint32_t& height_out, uint32_t logical_width,
++    uint32_t logical_height, bool depth_only_target) {
+   width_out = 0;
+   height_out = 0;
+   isolated_replay_active_depth_target_ = nullptr;
+@@ -1985,6 +2001,18 @@ bool D3D12RenderTargetCache::ResumeIsolatedReplayTarget(
+           ->GetDesc();
+   width_out = uint32_t(target_desc.Width);
+   height_out = target_desc.Height;
++  if (!depth_only_target) {
++    isolated_replay_active_preview_width_ = std::max(
++        isolated_replay_active_preview_width_,
++        std::min(logical_width, width_out));
++    isolated_replay_active_preview_height_ = std::max(
++        isolated_replay_active_preview_height_,
++        std::min(logical_height, height_out));
++    if (!isolated_replay_active_preview_width_ ||
++        !isolated_replay_active_preview_height_) {
++      return false;
++    }
++  }
+   RenderTarget* isolated_targets[1 + xenos::kMaxColorRenderTargets] = {};
+   isolated_targets[0] = isolated_depth;
+   if (isolated_color) {
+@@ -2471,9 +2499,17 @@ void D3D12RenderTargetCache::EndIsolatedReplayTarget(
+   }
+   if (defer_preview_publication_until_swap) {
+     isolated_replay_deferred_preview_frame_sequence_ = frame_sequence;
++    isolated_replay_deferred_preview_width_ =
++        isolated_replay_active_preview_width_;
++    isolated_replay_deferred_preview_height_ =
++        isolated_replay_active_preview_height_;
+   } else {
+     isolated_replay_deferred_preview_frame_sequence_ = 0;
++    isolated_replay_deferred_preview_width_ = 0;
++    isolated_replay_deferred_preview_height_ = 0;
+     isolated_replay_preview_frame_sequence_ = frame_sequence;
++    isolated_replay_preview_width_ = isolated_replay_active_preview_width_;
++    isolated_replay_preview_height_ = isolated_replay_active_preview_height_;
+   }
+ }
+ 
+@@ -2481,14 +2517,20 @@ void D3D12RenderTargetCache::CommitDeferredIsolatedReplayPreview(
+     uint64_t frame_sequence) {
+   if (isolated_replay_deferred_preview_frame_sequence_ == frame_sequence) {
+     isolated_replay_preview_frame_sequence_ = frame_sequence;
++    isolated_replay_preview_width_ = isolated_replay_deferred_preview_width_;
++    isolated_replay_preview_height_ = isolated_replay_deferred_preview_height_;
+   }
+   isolated_replay_deferred_preview_frame_sequence_ = 0;
++  isolated_replay_deferred_preview_width_ = 0;
++  isolated_replay_deferred_preview_height_ = 0;
+ }
+ 
+ void D3D12RenderTargetCache::CancelDeferredIsolatedReplayPreview(
+     uint64_t frame_sequence) {
+   if (isolated_replay_deferred_preview_frame_sequence_ == frame_sequence) {
+     isolated_replay_deferred_preview_frame_sequence_ = 0;
++    isolated_replay_deferred_preview_width_ = 0;
++    isolated_replay_deferred_preview_height_ = 0;
+   }
+ }
+ 
+@@ -2687,6 +2729,19 @@ bool D3D12RenderTargetCache::BeginIsolatedReplayPreview(
+   source_out.format = resource_desc.Format;
+   source_out.width = uint32_t(resource_desc.Width);
+   source_out.height = resource_desc.Height;
++  source_out.logical_width = isolated_replay_preview_width_;
++  source_out.logical_height = isolated_replay_preview_height_;
++  if (!source_out.logical_width || !source_out.logical_height ||
++      source_out.logical_width > source_out.width ||
++      source_out.logical_height > source_out.height) {
++    REXGPU_WARN(
++        "Native retained-pass preview has invalid logical extent {}x{} "
++        "for backing resource {}x{}",
++        source_out.logical_width, source_out.logical_height, source_out.width,
++        source_out.height);
++    source_out = {};
++    return false;
++  }
+   source_out.frame_sequence = isolated_replay_preview_frame_sequence_;
+   if (resource_desc.SampleDesc.Count > 1) {
+     D3D12_RESOURCE_DESC resolved_desc = resource_desc;
+diff --git a/src/graphics/d3d12/command_processor.cpp b/src/graphics/d3d12/command_processor.cpp
+index 9e92104..98b3525 100644
+--- a/src/graphics/d3d12/command_processor.cpp
++++ b/src/graphics/d3d12/command_processor.cpp
+@@ -2467,24 +2467,6 @@ bool D3D12CommandProcessor::DrawNativeGuestOutputRetainedPass(
+     }
+     return false;
+   }
+-  constexpr uint32_t kLogicalSceneWidth = 512;
+-  constexpr uint32_t kLogicalSceneHeight = 288;
+-  if (prototype &&
+-      (preview_source.width < kLogicalSceneWidth ||
+-       preview_source.height < kLogicalSceneHeight)) {
+-    static bool logged_retained_preview_size_failure = false;
+-    if (!logged_retained_preview_size_failure) {
+-      logged_retained_preview_size_failure = true;
+-      REXGPU_WARN(
+-          "Native prototype retained-pass preview is smaller than the "
+-          "logical scene: {}x{} (requires at least {}x{})",
+-          preview_source.width, preview_source.height, kLogicalSceneWidth,
+-          kLogicalSceneHeight);
+-    }
+-    render_target_cache_->EndIsolatedReplayPreview(preview_source);
+-    return false;
+-  }
+-
+   D3D12_SHADER_RESOURCE_VIEW_DESC source_view_desc{};
+   source_view_desc.Format = preview_source.format;
+   source_view_desc.ViewDimension = D3D12_SRV_DIMENSION_TEXTURE2D;
+@@ -2533,9 +2515,9 @@ bool D3D12CommandProcessor::DrawNativeGuestOutputRetainedPass(
+   NativeGuestOutputRetainedPassConstants preview_constants{
+       {width, height},
+       {preview_source.width, preview_source.height},
+-      {prototype ? kLogicalSceneWidth
++      {prototype ? preview_source.logical_width
+                  : std::min(preview_source.width, uint32_t(512)),
+-       prototype ? kLogicalSceneHeight
++       prototype ? preview_source.logical_height
+                  : std::min(preview_source.height, uint32_t(512))},
+       prototype ? 1u : 0u,
+       0u};
+@@ -3545,6 +3527,20 @@ bool D3D12CommandProcessor::IssueDraw(xenos::PrimitiveType primitive_type, uint3
+   scissor.extent[0] *= draw_resolution_scale_x;
+   scissor.extent[1] *= draw_resolution_scale_y;
+ 
++  const auto saturated_extent_end = [](uint32_t offset,
++                                       uint32_t extent) {
++    return uint32_t(std::min(uint64_t(offset) + extent,
++                             uint64_t(UINT32_MAX)));
++  };
++  const uint32_t isolated_replay_logical_width = std::min(
++      saturated_extent_end(viewport_info.xy_offset[0],
++                           viewport_info.xy_extent[0]),
++      saturated_extent_end(scissor.offset[0], scissor.extent[0]));
++  const uint32_t isolated_replay_logical_height = std::min(
++      saturated_extent_end(viewport_info.xy_offset[1],
++                           viewport_info.xy_extent[1]),
++      saturated_extent_end(scissor.offset[1], scissor.extent[1]));
++
+   // Update viewport, scissor, blend factor and stencil reference.
+   UpdateFixedFunctionState(viewport_info, scissor, primitive_polygonal, normalized_depth_control);
+ 
+@@ -3817,12 +3813,16 @@ bool D3D12CommandProcessor::IssueDraw(xenos::PrimitiveType primitive_type, uint3
+                   render_target_cache_->BeginIsolatedReplayTarget(
+                       isolated_result.target_width,
+                       isolated_result.target_height,
++                      isolated_replay_logical_width,
++                      isolated_replay_logical_height,
+                       isolated_draw_request.stencil_seed_probe_requested,
+                       isolated_draw_request.depth_only_target)) ||
+                  (isolated_draw_request.reuse_target &&
+                   render_target_cache_->ResumeIsolatedReplayTarget(
+                       isolated_result.target_width,
+                       isolated_result.target_height,
++                      isolated_replay_logical_width,
++                      isolated_replay_logical_height,
+                       isolated_draw_request.depth_only_target))) {
+         if (isolated_draw_request.reference_seed_depth_readback_requested &&
+             isolated_draw_request.reference_seed_depth_readback_completion) {
+@@ -4069,12 +4069,16 @@ bool D3D12CommandProcessor::IssueDraw(xenos::PrimitiveType primitive_type, uint3
+                   render_target_cache_->BeginIsolatedReplayTarget(
+                       isolated_result.target_width,
+                       isolated_result.target_height,
++                      isolated_replay_logical_width,
++                      isolated_replay_logical_height,
+                       isolated_draw_request.stencil_seed_probe_requested,
+                       isolated_draw_request.depth_only_target)) ||
+                  (isolated_draw_request.reuse_target &&
+                   render_target_cache_->ResumeIsolatedReplayTarget(
+                       isolated_result.target_width,
+                       isolated_result.target_height,
++                      isolated_replay_logical_width,
++                      isolated_replay_logical_height,
+                       isolated_draw_request.depth_only_target))) {
+         if (isolated_draw_request.reference_seed_depth_readback_requested &&
+             isolated_draw_request.reference_seed_depth_readback_completion) {

--- a/src/native_renderer/graphics_hooks.cpp
+++ b/src/native_renderer/graphics_hooks.cpp
@@ -5973,6 +5973,7 @@ struct ContinuousWorldWorksetState {
   uint64_t stale_or_unselected_rejections = 0;
   uint64_t per_frame_quota_yields = 0;
   uint64_t fail_closed_yields = 0;
+  uint64_t qualified_retained_family_requests = 0;
   uint64_t reused_target_requests = 0;
   uint64_t frames_started = 0;
   uint64_t frames_completed = 0;
@@ -6725,7 +6726,8 @@ void ValidateAndEmitContinuousWorldWorksetConfiguration() {
                              : "blocked_invalid_configuration")},
        {"activation", "startup_environment_only"},
        {"default_enabled", "false"},
-       {"selection", "fresh_visibility_and_mechanical"},
+       {"selection",
+        "fresh_visibility_or_qualified_sky_horizon_and_mechanical"},
        {"maximum_draws_per_frame",
         std::to_string(kContinuousWorldWorksetMaximumDrawsPerFrame)},
        {"target_lifetime", "one_guest_frame"},
@@ -16934,6 +16936,9 @@ void EmitContinuousWorldWorksetSummary() {
         std::to_string(g_continuous_world_workset.per_frame_quota_yields)},
        {"fail_closed_yields",
         std::to_string(g_continuous_world_workset.fail_closed_yields)},
+       {"qualified_retained_family_requests",
+        std::to_string(
+            g_continuous_world_workset.qualified_retained_family_requests)},
        {"reused_target_requests",
         std::to_string(g_continuous_world_workset.reused_target_requests)},
        {"frames_started",
@@ -17285,7 +17290,10 @@ void RequestIsolatedDraw(
       ++g_continuous_world_workset.mechanical_rejections;
       return;
     }
-    if (!g_isolated_draw.prepared_visibility_candidate_fresh) {
+    const bool qualified_retained_family =
+        g_isolated_draw.prepared_signature == kSkyHorizonFollowerSignature;
+    if (!g_isolated_draw.prepared_visibility_candidate_fresh &&
+        !qualified_retained_family) {
       ++g_continuous_world_workset.stale_or_unselected_rejections;
       return;
     }
@@ -17307,6 +17315,9 @@ void RequestIsolatedDraw(
     }
     ++g_continuous_world_workset.current_frame_requests;
     ++g_continuous_world_workset.requests;
+    if (qualified_retained_family) {
+      ++g_continuous_world_workset.qualified_retained_family_requests;
+    }
     request.requested = true;
     request.retain_target = true;
     request.reuse_target = reuse_target;

--- a/src/native_renderer/guest_output_renderer.cpp
+++ b/src/native_renderer/guest_output_renderer.cpp
@@ -140,9 +140,13 @@ bool RenderDiagnosticOutput(
       if (callback == 1 || callback % 300 == 0) {
         pinyon_shift::diagnostics::RecordEvent(
             "native_renderer.output.waiting",
-            {{"reason", context.retained_pass_frame_sequence
-                            ? "retained_pass_stale"
-                            : "retained_pass_unavailable"},
+            {{"reason",
+              !context.retained_pass_frame_sequence
+                  ? "retained_pass_unavailable"
+                  : (context.retained_pass_frame_sequence !=
+                             context.frame_sequence
+                         ? "retained_pass_stale"
+                         : "retained_pass_callback_failed")},
              {"callback", std::to_string(callback)},
              {"frame", std::to_string(context.frame_sequence)},
              {"retained_frame",

--- a/tools/summarize-native-renderer-continuous-world-workset.py
+++ b/tools/summarize-native-renderer-continuous-world-workset.py
@@ -7,9 +7,11 @@ import pathlib
 import sys
 
 
-SCHEMA = "pinyon-shift.native-renderer-continuous-world-workset.v1"
+SCHEMA = "pinyon-shift.native-renderer-continuous-world-workset.v2"
 CONFIG = "native_renderer.continuous_world_workset.config"
 SUMMARY = "native_renderer.continuous_world_workset.summary"
+OUTPUT_FRAME = "native_renderer.output.frame"
+OUTPUT_WAITING = "native_renderer.output.waiting"
 
 
 def read_events(paths):
@@ -74,7 +76,7 @@ def build(events, requested_session=None):
         "status": "armed_deferred_private_composition",
         "activation": "startup_environment_only",
         "default_enabled": "false",
-        "selection": "fresh_visibility_and_mechanical",
+        "selection": "fresh_visibility_or_qualified_sky_horizon_and_mechanical",
         "maximum_draws_per_frame": "64",
         "target_lifetime": "one_guest_frame",
         "freshness_commit": "matching_swap_after_complete_accumulation",
@@ -108,6 +110,7 @@ def build(events, requested_session=None):
         "stale_or_unselected_rejections",
         "per_frame_quota_yields",
         "fail_closed_yields",
+        "qualified_retained_family_requests",
         "reused_target_requests",
         "frames_started",
         "frames_completed",
@@ -115,6 +118,12 @@ def build(events, requested_session=None):
         "maximum_draws_per_frame",
     )
     totals = {key: integer(summary, key) for key in keys}
+    output_frames = [
+        event for event in selected if event.get("event") == OUTPUT_FRAME
+    ]
+    output_waiting = [
+        event for event in selected if event.get("event") == OUTPUT_WAITING
+    ]
     failures = []
     selections = (
         totals["requests"]
@@ -138,18 +147,91 @@ def build(events, requested_session=None):
         failures.append("frame accounting drifted")
     if not totals["frames_completed"]:
         failures.append("no complete continuous workset frame was recorded")
-    if totals["frames_failed"]:
-        failures.append("one or more workset frames failed closed")
-    if totals["fail_closed_yields"]:
-        failures.append("workset requests yielded after a frame failure")
-    if totals["target_creation_failures"] or totals["unsupported"]:
-        failures.append("one or more private replays failed")
+    if totals["frames_failed"] != (
+        totals["target_creation_failures"] + totals["unsupported"]
+    ):
+        failures.append("failed frames do not reconcile with replay fallbacks")
+    if not totals["qualified_retained_family_requests"]:
+        failures.append("qualified retained-family seed was not observed")
     if not totals["reused_target_requests"]:
         failures.append("no frame accumulated multiple native draws")
     if totals["maximum_draws_per_frame"] != 64:
         failures.append("per-frame workset bound drifted")
-    if summary.get("status") != "complete":
-        failures.append("runtime did not report complete worksets")
+    expected_summary_status = (
+        "fallback_observed" if totals["frames_failed"] else "complete"
+    )
+    if summary.get("status") != expected_summary_status:
+        failures.append("runtime workset status does not match its outcomes")
+
+    exact_output_frames = []
+    for event in output_frames:
+        try:
+            exact_frame = integer(event, "frame") == integer(
+                event, "retained_frame"
+            )
+            callback = integer(event, "callback")
+        except ValueError:
+            exact_frame = False
+            callback = 0
+        safe = (
+            exact_frame
+            and event.get("selected_output") == "native"
+            and event.get("authority") == "native"
+            and event.get("xenos_draw") == "preserved"
+            and event.get("suppression") == "disabled"
+        )
+        if safe:
+            exact_output_frames.append((callback, event))
+        else:
+            failures.append("native output marker violates freshness or safety")
+            break
+    if len(exact_output_frames) < 3:
+        failures.append("fewer than three exact native output markers were observed")
+    elif any(
+        right[0] <= left[0]
+        for left, right in zip(exact_output_frames, exact_output_frames[1:])
+    ):
+        failures.append("native output callbacks are not strictly increasing")
+
+    for event in output_waiting:
+        if (
+            event.get("fallback") != "xenos"
+            or event.get("suppression") != "disabled"
+        ):
+            failures.append("waiting output marker violates fallback safety")
+            break
+
+    clean_fallback_proved = not any(
+        message
+        in failures
+        for message in (
+            "failed frames do not reconcile with replay fallbacks",
+            "runtime workset status does not match its outcomes",
+            "waiting output marker violates fallback safety",
+        )
+    )
+    accumulation_proved = not any(
+        message
+        in failures
+        for message in (
+            "prepared selection accounting drifted",
+            "replay outcome accounting drifted",
+            "frame accounting drifted",
+            "no complete continuous workset frame was recorded",
+            "qualified retained-family seed was not observed",
+            "no frame accumulated multiple native draws",
+            "per-frame workset bound drifted",
+        )
+    )
+    freshness_proved = not any(
+        message
+        in failures
+        for message in (
+            "native output marker violates freshness or safety",
+            "fewer than three exact native output markers were observed",
+            "native output callbacks are not strictly increasing",
+        )
+    )
 
     return {
         "schema": SCHEMA,
@@ -158,8 +240,11 @@ def build(events, requested_session=None):
         "failures": failures,
         "totals": totals,
         "qualification": {
-            "continuous_multi_draw_workset_proved": not failures,
-            "swap_committed_freshness_proved": not failures,
+            "continuous_multi_draw_workset_proved": accumulation_proved,
+            "swap_committed_freshness_proved": freshness_proved,
+            "clean_xenos_fallback_proved": clean_fallback_proved,
+            "native_output_markers": len(exact_output_frames),
+            "xenos_fallback_markers": len(output_waiting),
             "suppression_allowed": False,
         },
         "safety": {

--- a/tools/tests/test_native_renderer_continuous_world_workset.py
+++ b/tools/tests/test_native_renderer_continuous_world_workset.py
@@ -23,7 +23,7 @@ def fixture():
         status="armed_deferred_private_composition",
         activation="startup_environment_only",
         default_enabled="false",
-        selection="fresh_visibility_and_mechanical",
+        selection="fresh_visibility_or_qualified_sky_horizon_and_mechanical",
         maximum_draws_per_frame="64",
         target_lifetime="one_guest_frame",
         freshness_commit="matching_swap_after_complete_accumulation",
@@ -47,6 +47,7 @@ def fixture():
         stale_or_unselected_rejections="3",
         per_frame_quota_yields="2",
         fail_closed_yields="0",
+        qualified_retained_family_requests="2",
         reused_target_requests="6",
         frames_started="2",
         frames_completed="2",
@@ -62,7 +63,26 @@ def fixture():
         draw_suppression="false",
         suppression_eligible="false",
     )
-    return [config, summary]
+    output_frames = [
+        event(
+            MODULE.OUTPUT_FRAME,
+            callback=str(callback),
+            frame=str(callback),
+            retained_frame=str(callback),
+            selected_output="native",
+            authority="native",
+            xenos_draw="preserved",
+            suppression="disabled",
+        )
+        for callback in (300, 600, 900)
+    ]
+    waiting = event(
+        MODULE.OUTPUT_WAITING,
+        reason="retained_pass_unavailable",
+        fallback="xenos",
+        suppression="disabled",
+    )
+    return [config, *output_frames, waiting, summary]
 
 
 class ContinuousWorldWorksetTests(unittest.TestCase):
@@ -76,6 +96,7 @@ class ContinuousWorldWorksetTests(unittest.TestCase):
         self.assertIn("kContinuousWorldWorksetMaximumDrawsPerFrame = 64", source)
         self.assertIn("request.reuse_target = reuse_target", source)
         self.assertIn("request.defer_preview_publication_until_swap = true", source)
+        self.assertIn("qualified_retained_family_requests", source)
         self.assertIn('"native_renderer.continuous_world_workset.summary"', source)
         self.assertIn('{"xenos_draw", "preserved"}', source)
         self.assertIn('{"draw_suppression", "false"}', source)
@@ -108,16 +129,16 @@ class ContinuousWorldWorksetTests(unittest.TestCase):
 
     def test_rejects_single_draw_frames(self):
         events = fixture()
-        events[1]["reused_target_requests"] = "0"
+        events[-1]["reused_target_requests"] = "0"
         document = MODULE.build(events)
         self.assertEqual("incomplete", document["status"])
         self.assertIn(
             "no frame accumulated multiple native draws", document["failures"]
         )
 
-    def test_rejects_failed_frame(self):
+    def test_qualifies_an_accounted_fail_closed_frame(self):
         events = fixture()
-        events[1].update(
+        events[-1].update(
             status="fallback_observed",
             recorded="7",
             unsupported="1",
@@ -125,12 +146,38 @@ class ContinuousWorldWorksetTests(unittest.TestCase):
             frames_failed="1",
         )
         document = MODULE.build(events)
+        self.assertEqual("complete", document["status"])
+        self.assertTrue(
+            document["qualification"]["clean_xenos_fallback_proved"]
+        )
+
+    def test_rejects_unreconciled_failed_frame(self):
+        events = fixture()
+        events[-1].update(
+            status="fallback_observed",
+            frames_completed="1",
+            frames_failed="1",
+        )
+        document = MODULE.build(events)
         self.assertEqual("incomplete", document["status"])
-        self.assertIn("one or more workset frames failed closed", document["failures"])
+        self.assertIn(
+            "failed frames do not reconcile with replay fallbacks",
+            document["failures"],
+        )
+
+    def test_rejects_stale_native_output_claim(self):
+        events = fixture()
+        events[2]["retained_frame"] = "599"
+        document = MODULE.build(events)
+        self.assertEqual("incomplete", document["status"])
+        self.assertIn(
+            "native output marker violates freshness or safety",
+            document["failures"],
+        )
 
     def test_rejects_safety_drift(self):
         events = copy.deepcopy(fixture())
-        events[1]["draw_suppression"] = "true"
+        events[-1]["draw_suppression"] = "true"
         with self.assertRaisesRegex(ValueError, "safety boundary"):
             MODULE.build(events)
 

--- a/tools/tests/test_native_renderer_prototype_comparison.py
+++ b/tools/tests/test_native_renderer_prototype_comparison.py
@@ -34,6 +34,91 @@ class NativeRendererPrototypeComparisonTests(unittest.TestCase):
         ):
             self.assertIn(mode, prototype_selector)
 
+    def test_depth_only_replay_preserves_deferred_color_preview(self):
+        patch = (
+            ROOT
+            / "patches/rexglue/0098-d3d12-preserve-color-preview-across-depth-replay.patch"
+        ).read_text(encoding="utf-8")
+        self.assertIn("bool depth_only_target = false", patch)
+        self.assertIn("if (!depth_only_target)", patch)
+        self.assertIn("if (depth_only_target)", patch)
+        self.assertIn("-    isolated_replay_color_target_.reset();", patch)
+        self.assertIn("isolated_draw_request.depth_only_target", patch)
+        self.assertNotIn("SetDrawSuppression", patch)
+
+    def test_device_loss_diagnostics_are_flushed_before_fatal_callback(self):
+        patch = (
+            ROOT
+            / "patches/rexglue/0099-d3d12-flush-device-loss-diagnostics.patch"
+        ).read_text(encoding="utf-8")
+        diagnostic = patch.index("LogDeviceRemovalDiagnostics")
+        flush = patch.index("rex::FlushLogging()")
+        callback = patch.index("OnHostGpuLossFromAnyThread")
+        self.assertLess(diagnostic, flush)
+        self.assertLess(flush, callback)
+
+    def test_shadow_replay_uses_a_separate_depth_target_lifetime(self):
+        patch = (
+            ROOT
+            / "patches/rexglue/0100-d3d12-separate-depth-only-replay-target.patch"
+        ).read_text(encoding="utf-8")
+        self.assertIn("isolated_replay_depth_only_target_", patch)
+        self.assertIn("isolated_replay_active_depth_target_", patch)
+        self.assertIn(
+            "depth_only_target ? isolated_replay_depth_only_target_", patch
+        )
+        self.assertIn("isolated_replay_depth_target_", patch)
+        self.assertNotIn("SetDrawSuppression", patch)
+
+    def test_retained_preview_failures_are_actionable(self):
+        patch = (
+            ROOT
+            / "patches/rexglue/0101-d3d12-report-retained-preview-failures.patch"
+        ).read_text(encoding="utf-8")
+        self.assertIn("linear target allocation failed", patch)
+        self.assertIn("retained-pass preview unavailable for frame", patch)
+        self.assertIn("retained-pass preview is smaller than the", patch)
+        self.assertIn('"logical scene:', patch)
+
+        output = (ROOT / "src/native_renderer/guest_output_renderer.cpp").read_text(
+            encoding="utf-8"
+        )
+        self.assertIn('"retained_pass_callback_failed"', output)
+        self.assertIn("context.retained_pass_frame_sequence !=", output)
+
+    def test_retained_preview_separates_backing_and_logical_extents(self):
+        patch = (
+            ROOT
+            / "patches/rexglue/0102-d3d12-track-retained-preview-logical-extent.patch"
+        ).read_text(encoding="utf-8")
+        self.assertIn("source_out.width = uint32_t(resource_desc.Width)", patch)
+        self.assertIn("source_out.logical_width", patch)
+        self.assertIn("isolated_replay_active_preview_width_", patch)
+        self.assertIn("isolated_replay_deferred_preview_width_", patch)
+        self.assertIn(
+            "isolated_replay_preview_width_ = isolated_replay_deferred_preview_width_",
+            patch,
+        )
+        self.assertIn("prototype ? preview_source.logical_width", patch)
+        self.assertIn("prototype ? preview_source.logical_height", patch)
+        self.assertIn("saturated_extent_end(viewport_info.xy_offset[0]", patch)
+        self.assertIn("saturated_extent_end(scissor.offset[0]", patch)
+        self.assertNotIn("SetDrawSuppression", patch)
+
+    def test_continuous_workset_uses_only_the_qualified_retained_seed(self):
+        hooks = (ROOT / "src/native_renderer/graphics_hooks.cpp").read_text(
+            encoding="utf-8"
+        )
+        self.assertIn(
+            "g_isolated_draw.prepared_signature == kSkyHorizonFollowerSignature",
+            hooks,
+        )
+        self.assertIn("qualified_retained_family_requests", hooks)
+        self.assertIn(
+            "fresh_visibility_or_qualified_sky_horizon_and_mechanical", hooks
+        )
+        self.assertIn("!g_isolated_draw.prepared_candidate_eligible", hooks)
+
     def test_capture_does_not_inject_legacy_isolated_draw_configuration(self):
         capture = (
             ROOT / "tools/capture-native-renderer-output-comparison.ps1"

--- a/tools/tests/test_release_contract.py
+++ b/tools/tests/test_release_contract.py
@@ -43,10 +43,10 @@ class ReleaseContractTests(unittest.TestCase):
 
     def test_rexglue_patches_have_stable_order_and_no_binary_payload(self):
         patches = sorted((ROOT / "patches/rexglue").glob("*.patch"))
-        self.assertEqual(len(patches), 97)
+        self.assertEqual(len(patches), 102)
         self.assertEqual(
             patches[-1].name,
-            "0097-d3d12-native-prototype-comparison.patch",
+            "0102-d3d12-track-retained-preview-logical-extent.patch",
         )
         self.assertEqual(len(patches), len({path.name[:4] for path in patches}))
         for path in patches:


### PR DESCRIPTION
## Summary
- separate retained color-preview and depth-only replay lifetimes
- preserve device-loss diagnostics and make retained-preview failures actionable
- carry draw-derived logical extents independently from padded D3D12 backing resources
- qualify continuous native output, exact-frame freshness, and clean Xenos fallback with the AppData save
- record B6 evidence and advance the reprioritized roadmap toward Phase C

## Validation
- 486 repository tests passed
- clean ReXGlue preparation with 102 patches passed
- clean preview build passed
- AppData session 20260830T223753Z-p38480 exited normally with no fatal, crash, device-loss, validation-error, or suppression signature

## Safety
- Xenos remains default and fully preserved
- suppression remains disabled
- user-local launcher/setup/troubleshooting changes are not included
- the existing save was not copied, reset, or overwritten by the workflow; the game naturally autosaved during qualification