### PR TITLE
feat(native-renderer): trace title track render families

### DIFF
--- a/config/rexglue/analysis/main-xex.toml
+++ b/config/rexglue/analysis/main-xex.toml
@@ -264,6 +264,25 @@ registers = ["r3"]
 address = 0x82E1CBD0
 name = "PinyonShiftObserveProceduralModelDestructorExit"
 
+# Phase C1 title-owned track-render differential. sub_8259C7D8 retrieves the
+# live CForzaCommandLineParameters object in r30 and copies exact option fields
+# into runtime render state rooted at r31. Hooks observe registers after each
+# source load/transform and before the original destination store.
+[[midasm_hook]]
+address = 0x8259C834
+name = "PinyonShiftObserveFastTrackRenderConfiguration"
+registers = ["r11", "r30", "r31"]
+
+[[midasm_hook]]
+address = 0x8259C89C
+name = "PinyonShiftObserveRoadDetailBlurConfiguration"
+registers = ["r11", "r30", "r31"]
+
+[[midasm_hook]]
+address = 0x8259C8DC
+name = "PinyonShiftObserveTrackCommandBufferConfiguration"
+registers = ["r11", "r30", "r31"]
+
 # Vtable slots 14 and 40 bracket optional visibility and render-state history.
 # These hooks record only the live receiver generation and balanced invocation
 # order; the stages are not universal slot-41 prerequisites.

--- a/docs/native-renderer/REPRIORITIZED_PLAN.md
+++ b/docs/native-renderer/REPRIORITIZED_PLAN.md
@@ -212,6 +212,14 @@ qualification.
 - Cover representative daytime, nighttime, race, and high-speed streaming
   scenes.
 
+Active checkpoint: the title-owned `fasttrackrender` differential, independent
+`trackfardistance`, road-detail, and track-command-buffer controls are proven
+from retail RTTI and exact AOT instructions. The paired census path in
+[`TERRAIN_ROAD_RENDER_PATH.md`](TERRAIN_ROAD_RENDER_PATH.md) will identify the
+changed prepared families without promoting frequency or shader resemblance to
+semantic evidence. Native admission remains off until that runtime delta and
+visual identity are qualified.
+
 ### C2. Static world buildings and props
 
 - Expand opaque-world material and geometry coverage.

--- a/docs/native-renderer/TERRAIN_ROAD_RENDER_PATH.md
+++ b/docs/native-renderer/TERRAIN_ROAD_RENDER_PATH.md
@@ -1,0 +1,80 @@
+# Terrain and road render-path differential
+
+Phase C1 starts from a title-owned control rather than assigning a semantic
+name to a shader or draw-frequency cluster. Static analysis proves that the
+retail executable registers `fasttrackrender`, `trackfardistance`,
+`renderroaddetailblur`, and `notrackcommandbuffers` on the exact
+`CForzaCommandLineParameters` object. The `perfmode` master option fans out to
+`fasttrackrender` and eight neighboring fast-family flags, so it is not an
+isolated terrain/road experiment.
+
+## Exact configuration bridge
+
+`tools/discover-native-renderer-track-config.py` validates the option strings,
+RTTI, registration vtable slot, parser calls, field offsets, and the known
+command-line-to-runtime copies. It fails closed if any instruction or image
+identity drifts. The relevant title fields are:
+
+| Option | Command-line field | Runtime field | Role |
+| --- | ---: | ---: | --- |
+| `fasttrackrender` | 4204 | 6297 | isolated title track-family switch |
+| `trackfardistance` | 4176 | not yet proved | floating distance control |
+| `renderroaddetailblur` | 4181 | 6035 | road-detail effect switch |
+| `notrackcommandbuffers` | 2732 | 6230/6232 | inverted command-buffer control |
+
+The runtime copy occurs in `sub_8259C7D8` after the title retrieves the live
+command-line parameter object. This proves a bounded title configuration path.
+It does not yet prove which prepared signatures are terrain, road surface,
+track props, or an exceptional dependent family.
+
+Generate the payload-free static report with:
+
+```powershell
+python tools/discover-native-renderer-track-config.py `
+  .local/generated/default `
+  --image .local/analysis/default-image.bin `
+  --output .local/qualification/native-renderer-track-config.json
+```
+
+## Paired runtime census
+
+The census wrapper accepts `-TrackRenderMode baseline` or
+`-TrackRenderMode fasttrackrender`. The latter passes only the title argument
+`-fasttrackrender`; it does not enable the broader `perfmode` group. Run the
+same AppData save and marked scene for both modes, then compare exact prepared
+signatures and semantic submission lineage from the two logs.
+
+```powershell
+$stateRoot = Join-Path $env:LOCALAPPDATA `
+  'PinyonShift\source\0.1.0\.local\preview'
+.\tools\capture-native-renderer-census.ps1 `
+  -StateRoot $stateRoot -Scene open_world_day -TrackRenderMode baseline
+.\tools\capture-native-renderer-census.ps1 `
+  -StateRoot $stateRoot -Scene open_world_day `
+  -TrackRenderMode fasttrackrender
+```
+
+The delta is candidate evidence only. A family becomes a Phase C1 rendering
+input only after the changed signature has exact semantic PM4 lineage,
+mechanically valid replay, representative visual identification, and stable
+coverage across open world and race scenes. Xenos remains authoritative, no
+native draw or suppression is enabled by this checkpoint, and the capture
+does not require any save-file operation.
+
+After both sessions exit, build the strict normalized delta report:
+
+```powershell
+python tools/summarize-native-renderer-track-differential.py `
+  --baseline <baseline-jsonl> `
+  --fasttrackrender <fasttrackrender-jsonl> `
+  --output .local/qualification/native-renderer-track-differential.json
+```
+
+The report requires distinct sessions from the same executable and patch set,
+one shared marked scene, at least 600 frames per side, zero signature overflow,
+normal shutdown, and runtime confirmation that the title accepted the requested
+mode. It compares exact prepared procedural-model provenance in calls per 1,000
+frames and retains shader, template, receiver-generation, and record identity
+for each changed family. A complete report proves a title-owned track delta;
+it deliberately leaves terrain/road semantic identity, native admission, and
+suppression false.

--- a/src/native_renderer/graphics_hooks.cpp
+++ b/src/native_renderer/graphics_hooks.cpp
@@ -186,6 +186,104 @@ constexpr const char *kMixedShadowCasterFamilySha256 =
 constexpr const char *kMixedShadowCasterAtlasRegion = "1024,0,1024,1024";
 std::atomic<uint64_t> g_frame_sequence{};
 
+struct TrackRenderConfigurationState {
+  std::atomic<uint32_t> fast_track_render{};
+  std::atomic<uint32_t> road_detail_blur{};
+  std::atomic<uint32_t> command_line_address{};
+  std::atomic<uint32_t> runtime_state_address{};
+};
+
+TrackRenderConfigurationState g_track_render_configuration;
+
+std::string TrackRenderModeMarker() {
+  char *value = nullptr;
+  size_t length = 0;
+  if (_dupenv_s(&value, &length,
+                "PINYON_SHIFT_NATIVE_RENDERER_TRACK_RENDER_MODE") != 0 ||
+      !value || length <= 1) {
+    std::free(value);
+    return "unmarked";
+  }
+  std::string marker(value);
+  std::free(value);
+  if (marker != "baseline" && marker != "fasttrackrender") {
+    return "invalid";
+  }
+  return marker;
+}
+
+void ObserveFastTrackRenderConfiguration(uint32_t value,
+                                         uint32_t command_line_address,
+                                         uint32_t runtime_state_address) {
+  if (TrackRenderModeMarker() == "unmarked") {
+    return;
+  }
+  g_track_render_configuration.fast_track_render.store(
+      value & 0xFF, std::memory_order_relaxed);
+  g_track_render_configuration.command_line_address.store(
+      command_line_address, std::memory_order_relaxed);
+  g_track_render_configuration.runtime_state_address.store(
+      runtime_state_address, std::memory_order_relaxed);
+}
+
+void ObserveRoadDetailBlurConfiguration(uint32_t value,
+                                        uint32_t command_line_address,
+                                        uint32_t runtime_state_address) {
+  if (TrackRenderModeMarker() == "unmarked") {
+    return;
+  }
+  g_track_render_configuration.road_detail_blur.store(
+      value & 0xFF, std::memory_order_relaxed);
+  g_track_render_configuration.command_line_address.store(
+      command_line_address, std::memory_order_relaxed);
+  g_track_render_configuration.runtime_state_address.store(
+      runtime_state_address, std::memory_order_relaxed);
+}
+
+void ObserveTrackCommandBufferConfiguration(uint32_t enabled,
+                                            uint32_t command_line_address,
+                                            uint32_t runtime_state_address) {
+  const std::string mode = TrackRenderModeMarker();
+  if (mode == "unmarked") {
+    return;
+  }
+  const bool fast_track_render =
+      g_track_render_configuration.fast_track_render.load(
+          std::memory_order_relaxed) != 0;
+  const bool expected_fast_track_render = mode == "fasttrackrender";
+  const uint32_t observed_command_line_address =
+      g_track_render_configuration.command_line_address.load(
+          std::memory_order_relaxed);
+  const uint32_t observed_runtime_state_address =
+      g_track_render_configuration.runtime_state_address.load(
+          std::memory_order_relaxed);
+  const bool address_consistent =
+      observed_command_line_address == command_line_address &&
+      observed_runtime_state_address == runtime_state_address;
+  pinyon_shift::diagnostics::RecordEvent(
+      "native_renderer.discovery.track_render_config",
+      {{"status", mode != "invalid" && address_consistent &&
+                          fast_track_render == expected_fast_track_render
+                      ? "complete"
+                      : "mismatch_fail_closed"},
+       {"mode", mode},
+       {"fast_track_render", fast_track_render ? "true" : "false"},
+       {"road_detail_blur",
+        g_track_render_configuration.road_detail_blur.load(
+            std::memory_order_relaxed)
+            ? "true"
+            : "false"},
+       {"track_command_buffers", (enabled & 0xFF) ? "true" : "false"},
+       {"address_consistent", address_consistent ? "true" : "false"},
+       {"command_line_address",
+        fmt::format("{:08X}", command_line_address)},
+       {"runtime_state_address", fmt::format("{:08X}", runtime_state_address)},
+       {"classification", "title_track_render_differential_control"},
+       {"xenos_authority", "true"},
+       {"native_draw", "false"},
+       {"suppression_allowed", "false"}});
+}
+
 enum class ShadowDepthBatchFamily : uint32_t {
   kNone = 0,
   kPrimary = 1,
@@ -21118,6 +21216,21 @@ PINYON_SHIFT_INDIRECT_CONTEXT_HOOKS(829F6620)
 
 void PinyonShiftObserveProceduralModelConstructorEntry(PPCRegister &r3) {
   BeginSemanticReceiverConstruction(r3.u32);
+}
+
+void PinyonShiftObserveFastTrackRenderConfiguration(
+    PPCRegister &r11, PPCRegister &r30, PPCRegister &r31) {
+  ObserveFastTrackRenderConfiguration(r11.u32, r30.u32, r31.u32);
+}
+
+void PinyonShiftObserveRoadDetailBlurConfiguration(
+    PPCRegister &r11, PPCRegister &r30, PPCRegister &r31) {
+  ObserveRoadDetailBlurConfiguration(r11.u32, r30.u32, r31.u32);
+}
+
+void PinyonShiftObserveTrackCommandBufferConfiguration(
+    PPCRegister &r11, PPCRegister &r30, PPCRegister &r31) {
+  ObserveTrackCommandBufferConfiguration(r11.u32, r30.u32, r31.u32);
 }
 
 void PinyonShiftObserveProceduralModelConstructorExit() {

--- a/tools/capture-native-renderer-census.ps1
+++ b/tools/capture-native-renderer-census.ps1
@@ -30,6 +30,8 @@ param(
     [switch]$ContinuousWorldWorkset,
     [switch]$VehicleDrawCorrelation,
     [switch]$ShadowCasterProvenance,
+    [ValidateSet('baseline', 'fasttrackrender')]
+    [string]$TrackRenderMode = 'baseline',
     [ValidatePattern('^[0-9A-Fa-f]{16}$')]
     [string]$PassAnchorSignature,
     [switch]$PublishRetainedPass,
@@ -232,6 +234,7 @@ $savedContinuousWorldWorkset =
     $env:PINYON_SHIFT_NATIVE_RENDERER_CONTINUOUS_WORLD_WORKSET
 $savedShadowCasterProvenance =
     $env:PINYON_SHIFT_NATIVE_RENDERER_SHADOW_CASTER_PROVENANCE
+$savedTrackRenderMode = $env:PINYON_SHIFT_NATIVE_RENDERER_TRACK_RENDER_MODE
 $savedPassAnchor = $env:PINYON_SHIFT_NATIVE_RENDERER_PASS_ANCHOR_SIGNATURE
 $savedPassPublication = $env:PINYON_SHIFT_NATIVE_RENDERER_PUBLISH_RETAINED_PASS
 $savedConsumerFamily = $env:PINYON_SHIFT_NATIVE_RENDERER_CONSUMER_FAMILY
@@ -280,6 +283,7 @@ try {
         if ($ContinuousWorldWorkset) { 'true' } else { $null }
     $env:PINYON_SHIFT_NATIVE_RENDERER_SHADOW_CASTER_PROVENANCE =
         if ($ShadowCasterProvenance) { 'true' } else { $null }
+    $env:PINYON_SHIFT_NATIVE_RENDERER_TRACK_RENDER_MODE = $TrackRenderMode
     $env:PINYON_SHIFT_NATIVE_RENDERER_PASS_ANCHOR_SIGNATURE = $PassAnchorSignature
     $env:PINYON_SHIFT_NATIVE_RENDERER_PUBLISH_RETAINED_PASS =
         if ($PublishRetainedPass) { 'true' } else { $null }
@@ -287,8 +291,12 @@ try {
     $env:PINYON_SHIFT_NATIVE_RENDERER_CONSUMER_READBACK_DIR = $ConsumerReadbackDir
     $env:PINYON_SHIFT_NATIVE_RENDERER_CONSUMER_READBACK_SAMPLES =
         if ($ConsumerReadbackDir) { [string]$ConsumerReadbackSamples } else { $null }
+    $gameArguments = if ($TrackRenderMode -eq 'fasttrackrender') {
+        @('-fasttrackrender')
+    } else { @() }
     & (Join-Path $PSScriptRoot 'launch-preview.ps1') `
         -StateRoot $resolvedStateRoot -ShaderCaptureDir $ShaderCaptureDir `
+        -GameArguments $gameArguments `
         -Json:$Json
 }
 finally {
@@ -324,6 +332,7 @@ finally {
         $savedContinuousWorldWorkset
     $env:PINYON_SHIFT_NATIVE_RENDERER_SHADOW_CASTER_PROVENANCE =
         $savedShadowCasterProvenance
+    $env:PINYON_SHIFT_NATIVE_RENDERER_TRACK_RENDER_MODE = $savedTrackRenderMode
     $env:PINYON_SHIFT_NATIVE_RENDERER_PASS_ANCHOR_SIGNATURE = $savedPassAnchor
     $env:PINYON_SHIFT_NATIVE_RENDERER_PUBLISH_RETAINED_PASS = $savedPassPublication
     $env:PINYON_SHIFT_NATIVE_RENDERER_CONSUMER_FAMILY = $savedConsumerFamily

--- a/tools/discover-native-renderer-track-config.py
+++ b/tools/discover-native-renderer-track-config.py
@@ -1,0 +1,255 @@
+"""Prove the title-owned track-render differential controls from AOT code."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import pathlib
+import re
+import sys
+
+
+SCHEMA = "pinyon-shift.native-renderer-track-config.v1"
+IMAGE_BASE = 0x82000000
+FUNCTION_RE = re.compile(r"^DEFINE_REX_FUNC\(sub_([0-9A-F]{8})\) \{")
+LABEL_RE = re.compile(r"^loc_([0-9A-F]{8}):")
+COMMENT_RE = re.compile(r"^\s*//\s+(.+?)\s*$")
+
+COMMAND_LINE_FUNCTION = 0x824F8150
+RUNTIME_COPY_FUNCTION = 0x8259C7D8
+COMMAND_LINE_VTABLE = 0x8200E724
+COMMAND_LINE_TYPE = ".?AVCForzaCommandLineParameters@@"
+
+OPTIONS = {
+    "perfmode": {
+        "string": 0x8200FF44,
+        "field": 4200,
+        "field_instruction": (0x824F9544, "addi r29,r31,4200"),
+        "name_instruction": (0x824F9548, "addi r4,r11,-188"),
+        "parse_instruction": (0x824F9554, "bl 0x82c096e0"),
+        "kind": "boolean_master",
+    },
+    "fasttrackrender": {
+        "string": 0x8200FEB8,
+        "field": 4204,
+        "field_instruction": (0x824F965C, "addi r25,r31,4204"),
+        "name_instruction": (0x824F9660, "addi r4,r11,-328"),
+        "parse_instruction": (0x824F966C, "bl 0x82c096e0"),
+        "kind": "boolean_family",
+    },
+    "trackfardistance": {
+        "string": 0x8200FF30,
+        "field": 4176,
+        "field_instruction": (0x824F95AC, "addi r5,r31,4176"),
+        "name_instruction": (0x824F95B0, "addi r4,r11,-208"),
+        "parse_instruction": (0x824F95B8, "bl 0x82c09648"),
+        "kind": "floating_distance",
+    },
+    "renderroaddetailblur": {
+        "string": 0x82010004,
+        "field": 4181,
+        "field_instruction": (0x824F9448, "addi r5,r31,4181"),
+        "name_instruction": (0x824F944C, "addi r4,r11,4"),
+        "parse_instruction": (0x824F9454, "bl 0x82c096e0"),
+        "kind": "boolean_effect",
+    },
+    "notrackcommandbuffers": {
+        "string": 0x82010A88,
+        "field": 2732,
+        "field_instruction": (0x824F85AC, "addi r5,r31,2732"),
+        "name_instruction": (0x824F85B0, "addi r4,r11,2696"),
+        "parse_instruction": (0x824F85BC, "bl 0x82c096e0"),
+        "kind": "boolean_command_buffer_control",
+    },
+}
+
+RUNTIME_COPIES = {
+    "fasttrackrender": {
+        "source": (0x8259C830, "lbz r11,4204(r30)"),
+        "destination": (0x8259C834, "stb r11,6297(r31)"),
+        "runtime_offset": 6297,
+        "transform": "identity",
+    },
+    "renderroaddetailblur": {
+        "source": (0x8259C898, "lbz r11,4181(r30)"),
+        "destination": (0x8259C89C, "stb r11,6035(r31)"),
+        "runtime_offset": 6035,
+        "transform": "identity",
+    },
+    "notrackcommandbuffers": {
+        "source": (0x8259C8D0, "lbz r11,2732(r30)"),
+        "destination": (0x8259C8DC, "stb r11,6232(r31)"),
+        "runtime_offset": 6232,
+        "transform": "boolean_inverted_before_store",
+    },
+}
+
+PERFMODE_FANOUT = {
+    0x824F956C: "stb r11,4201(r31)",
+    0x824F9570: "stb r11,4202(r31)",
+    0x824F9574: "stb r11,4203(r31)",
+    0x824F9578: "stb r11,4204(r31)",
+    0x824F957C: "stb r11,4205(r31)",
+    0x824F9580: "stb r11,4206(r31)",
+    0x824F9584: "stb r11,4207(r31)",
+    0x824F9588: "stb r11,4208(r31)",
+    0x824F958C: "stb r11,4209(r31)",
+}
+
+
+def parse_functions(paths: list[pathlib.Path]) -> dict[int, dict[int, str]]:
+    functions: dict[int, dict[int, str]] = {}
+    current: dict[int, str] | None = None
+    address: int | None = None
+    for path in sorted(paths, key=lambda item: item.as_posix()):
+        for line in path.read_text(encoding="utf-8").splitlines():
+            match = FUNCTION_RE.match(line)
+            if match:
+                function_address = int(match.group(1), 16)
+                current = {}
+                functions[function_address] = current
+                address = function_address
+                continue
+            label = LABEL_RE.match(line)
+            if current is not None and label:
+                address = int(label.group(1), 16)
+                continue
+            comment = COMMENT_RE.match(line)
+            if current is not None and comment and address is not None:
+                current[address] = comment.group(1)
+                address += 4
+    return functions
+
+
+def image_u32(image: bytes, address: int) -> int:
+    offset = address - IMAGE_BASE
+    if offset < 0 or offset + 4 > len(image):
+        raise ValueError(f"image address is out of range: {address:08X}")
+    return int.from_bytes(image[offset : offset + 4], "big")
+
+
+def image_string(image: bytes, address: int) -> str:
+    offset = address - IMAGE_BASE
+    if offset < 0 or offset >= len(image):
+        raise ValueError(f"image string is out of range: {address:08X}")
+    end = image.find(b"\0", offset, min(offset + 128, len(image)))
+    if end < 0:
+        raise ValueError(f"image string is unterminated: {address:08X}")
+    return image[offset:end].decode("ascii")
+
+
+def require(function: dict[int, str], address: int, text: str, label: str) -> None:
+    if function.get(address) != text:
+        raise ValueError(f"{label} evidence drifted at {address:08X}")
+
+
+def build(functions: dict[int, dict[int, str]], image: bytes) -> dict:
+    command_line = functions.get(COMMAND_LINE_FUNCTION)
+    runtime_copy = functions.get(RUNTIME_COPY_FUNCTION)
+    if command_line is None or runtime_copy is None:
+        raise ValueError("track configuration function set is incomplete")
+
+    locator = image_u32(image, COMMAND_LINE_VTABLE - 4)
+    type_descriptor = image_u32(image, locator + 12)
+    decorated_name = image_string(image, type_descriptor + 8)
+    slot_target = image_u32(image, COMMAND_LINE_VTABLE + 4 * 4)
+    if decorated_name != COMMAND_LINE_TYPE or slot_target != COMMAND_LINE_FUNCTION:
+        raise ValueError("command-line parameter RTTI/vtable evidence drifted")
+
+    require(command_line, 0x824F815C, "mr r31,r3", "command-line receiver")
+    option_rows = []
+    for name, option in OPTIONS.items():
+        if image_string(image, option["string"]) != name:
+            raise ValueError(f"{name} string evidence drifted")
+        for key in ("field_instruction", "name_instruction", "parse_instruction"):
+            address, text = option[key]
+            require(command_line, address, text, f"{name} {key}")
+        option_rows.append(
+            {
+                "name": name,
+                "string_address": f"{option['string']:08X}",
+                "command_line_field_offset": option["field"],
+                "registration_address": f"{option['name_instruction'][0]:08X}",
+                "parser_kind": option["kind"],
+            }
+        )
+
+    for address, text in PERFMODE_FANOUT.items():
+        require(command_line, address, text, "perfmode fanout")
+
+    require(runtime_copy, 0x8259C7E8, "bl 0x82479e88", "parameter lookup")
+    require(runtime_copy, 0x8259C7EC, "mr r30,r3", "parameter receiver")
+    copy_rows = []
+    for name, copy in RUNTIME_COPIES.items():
+        require(runtime_copy, *copy["source"], f"{name} runtime source")
+        require(runtime_copy, *copy["destination"], f"{name} runtime destination")
+        copy_rows.append(
+            {
+                "name": name,
+                "command_line_field_offset": OPTIONS[name]["field"],
+                "runtime_field_offset": copy["runtime_offset"],
+                "transform": copy["transform"],
+                "copy_address": f"{copy['source'][0]:08X}",
+            }
+        )
+
+    return {
+        "schema": SCHEMA,
+        "status": "complete",
+        "classification": "title_track_render_differential_control_proved",
+        "command_line_parameters": {
+            "class": "CForzaCommandLineParameters",
+            "decorated_name": decorated_name,
+            "vtable_address": f"{COMMAND_LINE_VTABLE:08X}",
+            "registration_function": f"{COMMAND_LINE_FUNCTION:08X}",
+            "registration_vtable_slot": 4,
+        },
+        "options": option_rows,
+        "runtime_copies": copy_rows,
+        "perfmode": {
+            "fanout_fields": len(PERFMODE_FANOUT),
+            "includes_fasttrackrender": True,
+            "isolated_track_differential": False,
+        },
+        "capture_contract": {
+            "baseline_arguments": [],
+            "track_arguments": ["-fasttrackrender"],
+            "scene_must_match": True,
+            "compare_exact_prepared_signatures": True,
+            "semantic_identity": "candidate_until_runtime_delta_and_visual_evidence",
+        },
+        "safety": {
+            "static_analysis_reads_guest_payload": False,
+            "runtime_capture_changes_title_render_configuration": True,
+            "xenos_authority_required": True,
+            "native_draw": False,
+            "suppression_allowed": False,
+            "save_mutation_required": False,
+        },
+    }
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("generated_root", type=pathlib.Path)
+    parser.add_argument("--image", required=True, type=pathlib.Path)
+    parser.add_argument("--output", required=True, type=pathlib.Path)
+    args = parser.parse_args(argv)
+    try:
+        paths = list(args.generated_root.glob("pinyon_shift_recomp.*.cpp"))
+        if not paths:
+            raise ValueError("no generated AOT C++ files found")
+        document = build(parse_functions(paths), args.image.read_bytes())
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(
+            json.dumps(document, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        return 0
+    except (OSError, UnicodeDecodeError, ValueError) as error:
+        print(f"native renderer track-config discovery failed: {error}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/launch-preview.ps1
+++ b/tools/launch-preview.ps1
@@ -5,6 +5,7 @@ param(
     [string]$GameRoot,
     [string]$StateRoot,
     [string]$ShaderCaptureDir,
+    [string[]]$GameArguments = @(),
     [switch]$Json,
     [switch]$CrashSelfTest
 )
@@ -61,8 +62,15 @@ try {
     } else {
         $null
     }
-    $process = Start-Process -FilePath $executable `
-        -WorkingDirectory (Split-Path $executable -Parent) -PassThru
+    $start = @{
+        FilePath = $executable
+        WorkingDirectory = (Split-Path $executable -Parent)
+        PassThru = $true
+    }
+    if ($GameArguments.Count -ne 0) {
+        $start.ArgumentList = $GameArguments
+    }
+    $process = Start-Process @start
     $process.WaitForExit()
     $process.Refresh()
 }

--- a/tools/summarize-native-renderer-track-differential.py
+++ b/tools/summarize-native-renderer-track-differential.py
@@ -1,0 +1,285 @@
+"""Compare exact prepared title families across baseline/fast-track sessions."""
+
+from __future__ import annotations
+
+import argparse
+import collections
+import json
+import pathlib
+import sys
+
+
+SCHEMA = "pinyon-shift.native-renderer-track-differential.v1"
+CONFIG = "native_renderer.discovery.track_render_config"
+DRAW_WINDOW = "native_renderer.census.draw_window"
+PROVENANCE = "native_renderer.discovery.title_provenance_entry"
+INSTALLED = "native_renderer.census.installed"
+
+
+def read_events(paths):
+    events = []
+    for path in paths:
+        with path.open(encoding="utf-8") as stream:
+            for line_number, line in enumerate(stream, 1):
+                try:
+                    event = json.loads(line)
+                except json.JSONDecodeError as error:
+                    raise ValueError(f"invalid JSON at {path}:{line_number}: {error}")
+                if isinstance(event, dict):
+                    events.append(event)
+    return events
+
+
+def integer(event, key):
+    try:
+        return int(event[key])
+    except (KeyError, TypeError, ValueError) as error:
+        raise ValueError(f"invalid {key} in {event.get('event', 'event')}") from error
+
+
+def boolean(event, key):
+    value = event.get(key)
+    if value not in ("true", "false"):
+        raise ValueError(f"invalid {key} in {event.get('event', 'event')}")
+    return value == "true"
+
+
+def session_events(events, requested_session=None):
+    sessions = {
+        str(event.get("session"))
+        for event in events
+        if event.get("event") == CONFIG and event.get("session")
+    }
+    if requested_session:
+        if requested_session not in sessions:
+            raise ValueError(f"track configuration missing for {requested_session}")
+        session = requested_session
+    elif len(sessions) == 1:
+        session = next(iter(sessions))
+    else:
+        raise ValueError("input must contain exactly one track-config session")
+    return session, [event for event in events if event.get("session") == session]
+
+
+def summarize_side(events, expected_mode, requested_session=None):
+    session, selected = session_events(events, requested_session)
+    configs = [event for event in selected if event.get("event") == CONFIG]
+    starts = [event for event in selected if event.get("event") == "process.start"]
+    shutdowns = [event for event in selected if event.get("event") == "process.shutdown"]
+    installed = [event for event in selected if event.get("event") == INSTALLED]
+    windows = [event for event in selected if event.get("event") == DRAW_WINDOW]
+    if len(configs) != 1 or len(starts) != 1 or len(shutdowns) != 1:
+        raise ValueError("session lifecycle or track configuration is incomplete")
+    if len(installed) != 1 or not windows:
+        raise ValueError("census installation or draw windows are missing")
+
+    config = configs[0]
+    failures = []
+    if config.get("status") != "complete" or config.get("mode") != expected_mode:
+        failures.append("title did not confirm the requested track mode")
+    if boolean(config, "fast_track_render") != (expected_mode == "fasttrackrender"):
+        failures.append("fast-track runtime value does not match the requested mode")
+    if not boolean(config, "address_consistent"):
+        failures.append("command-line/runtime render-state identity drifted")
+    if (
+        not boolean(config, "xenos_authority")
+        or boolean(config, "native_draw")
+        or boolean(config, "suppression_allowed")
+    ):
+        failures.append("track differential violated the observation-only boundary")
+
+    frame_count = 0
+    draw_count = 0
+    for window in windows:
+        first = integer(window, "first_frame")
+        last = integer(window, "last_frame")
+        if last < first:
+            failures.append("draw-window frame bounds are invalid")
+            continue
+        frame_count += last - first + 1
+        draw_count += integer(window, "draws")
+        if integer(window, "overflow_draws"):
+            failures.append("draw-signature table overflowed")
+    if frame_count < 600:
+        failures.append("fewer than 600 census frames were observed")
+
+    signatures = collections.defaultdict(
+        lambda: {
+            "calls": 0,
+            "vertex_shaders": set(),
+            "pixel_shaders": set(),
+            "template_keys": set(),
+            "receiver_generations": set(),
+        }
+    )
+    for event in selected:
+        if (
+            event.get("event") != PROVENANCE
+            or event.get("outcome") != "prepared"
+            or event.get("semantic_identity") != "procedural_model_submission"
+        ):
+            continue
+        signature = str(event.get("prepared_signature", "")).upper()
+        if len(signature) != 16:
+            failures.append("prepared semantic signature is invalid")
+            continue
+        entry = signatures[signature]
+        entry["calls"] += integer(event, "calls")
+        for source, destination in (
+            ("semantic_vertex_shader", "vertex_shaders"),
+            ("semantic_pixel_shader", "pixel_shaders"),
+            ("semantic_template_key", "template_keys"),
+        ):
+            value = str(event.get(source, "")).upper()
+            if value:
+                entry[destination].add(value)
+        receiver = (
+            str(event.get("semantic_receiver_address", "")).upper(),
+            str(event.get("semantic_receiver_generation", "")),
+            str(event.get("semantic_record_index", "")),
+        )
+        entry["receiver_generations"].add(receiver)
+        if (
+            event.get("xenos_draw") != "preserved"
+            or event.get("suppression_eligible") != "false"
+        ):
+            failures.append("semantic provenance violated Xenos safety")
+    if not signatures:
+        failures.append("no exact semantic prepared families were observed")
+
+    return {
+        "session": session,
+        "mode": expected_mode,
+        "status": "complete" if not failures else "incomplete",
+        "failures": sorted(set(failures)),
+        "scene": installed[0].get("scene"),
+        "identity": {
+            "executable_sha256": starts[0].get("executable_sha256"),
+            "patch_set_sha256": starts[0].get("rexglue_patch_set_sha256"),
+            "patch_count": starts[0].get("rexglue_patch_count"),
+        },
+        "frames": frame_count,
+        "draws": draw_count,
+        "signatures": signatures,
+    }
+
+
+def build(baseline_events, track_events, baseline_session=None, track_session=None):
+    baseline = summarize_side(baseline_events, "baseline", baseline_session)
+    track = summarize_side(track_events, "fasttrackrender", track_session)
+    failures = [
+        *(f"baseline: {failure}" for failure in baseline["failures"]),
+        *(f"fasttrackrender: {failure}" for failure in track["failures"]),
+    ]
+    if baseline["session"] == track["session"]:
+        failures.append("baseline and fast-track sessions are identical")
+    if baseline["scene"] != track["scene"] or baseline["scene"] in (None, "unmarked"):
+        failures.append("paired sessions do not share one marked scene")
+    if baseline["identity"] != track["identity"]:
+        failures.append("paired sessions do not use one build identity")
+
+    rows = []
+    signatures = set(baseline["signatures"]) | set(track["signatures"])
+    for signature in signatures:
+        left = baseline["signatures"].get(signature)
+        right = track["signatures"].get(signature)
+        left_calls = left["calls"] if left else 0
+        right_calls = right["calls"] if right else 0
+        left_rate = left_calls * 1000.0 / max(1, baseline["frames"])
+        right_rate = right_calls * 1000.0 / max(1, track["frames"])
+        metadata = right or left
+        rows.append(
+            {
+                "prepared_signature": signature,
+                "baseline_calls": left_calls,
+                "fasttrackrender_calls": right_calls,
+                "baseline_calls_per_1000_frames": round(left_rate, 3),
+                "fasttrackrender_calls_per_1000_frames": round(right_rate, 3),
+                "delta_calls_per_1000_frames": round(right_rate - left_rate, 3),
+                "vertex_shaders": sorted(metadata["vertex_shaders"]),
+                "pixel_shaders": sorted(metadata["pixel_shaders"]),
+                "template_keys": sorted(metadata["template_keys"]),
+                "receiver_generations": [
+                    {
+                        "address": address,
+                        "generation": generation,
+                        "record_index": record_index,
+                    }
+                    for address, generation, record_index in sorted(
+                        metadata["receiver_generations"]
+                    )
+                ],
+            }
+        )
+    rows.sort(
+        key=lambda row: (
+            -abs(row["delta_calls_per_1000_frames"]),
+            row["prepared_signature"],
+        )
+    )
+    changed = [row for row in rows if row["delta_calls_per_1000_frames"] != 0]
+    if not changed:
+        failures.append("no prepared semantic family changed between modes")
+
+    return {
+        "schema": SCHEMA,
+        "status": "complete" if not failures else "incomplete",
+        "failures": failures,
+        "scene": baseline["scene"],
+        "build_identity": baseline["identity"],
+        "sessions": {
+            "baseline": {
+                "session": baseline["session"],
+                "frames": baseline["frames"],
+                "draws": baseline["draws"],
+            },
+            "fasttrackrender": {
+                "session": track["session"],
+                "frames": track["frames"],
+                "draws": track["draws"],
+            },
+        },
+        "changed_family_count": len(changed),
+        "changed_families": changed,
+        "qualification": {
+            "title_track_render_delta_proved": not failures,
+            "terrain_road_semantic_identity_proved": False,
+            "native_admission_allowed": False,
+            "suppression_allowed": False,
+        },
+        "safety": {
+            "xenos_authority": True,
+            "native_draw": False,
+            "save_mutation_required": False,
+        },
+    }
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--baseline", required=True, type=pathlib.Path, nargs="+")
+    parser.add_argument("--fasttrackrender", required=True, type=pathlib.Path, nargs="+")
+    parser.add_argument("--baseline-session")
+    parser.add_argument("--fasttrackrender-session")
+    parser.add_argument("--output", required=True, type=pathlib.Path)
+    args = parser.parse_args(argv)
+    try:
+        document = build(
+            read_events(args.baseline),
+            read_events(args.fasttrackrender),
+            args.baseline_session,
+            args.fasttrackrender_session,
+        )
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(
+            json.dumps(document, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        return 0 if document["status"] == "complete" else 1
+    except (OSError, ValueError) as error:
+        print(f"native renderer track differential failed: {error}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/tests/test_native_renderer_track_config.py
+++ b/tools/tests/test_native_renderer_track_config.py
@@ -1,0 +1,120 @@
+import importlib.util
+import sys
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+TOOL = ROOT / "tools" / "discover-native-renderer-track-config.py"
+SPEC = importlib.util.spec_from_file_location("native_track_config", TOOL)
+assert SPEC and SPEC.loader
+MODULE = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = MODULE
+SPEC.loader.exec_module(MODULE)
+
+
+def image_fixture():
+    size = 0x8322322C + 8 + len(MODULE.COMMAND_LINE_TYPE) + 1 - MODULE.IMAGE_BASE
+    image = bytearray(size)
+
+    def u32(address, value):
+        offset = address - MODULE.IMAGE_BASE
+        image[offset : offset + 4] = value.to_bytes(4, "big")
+
+    locator = 0x822E2FBC
+    type_descriptor = 0x8322322C
+    u32(MODULE.COMMAND_LINE_VTABLE - 4, locator)
+    u32(locator + 12, type_descriptor)
+    u32(MODULE.COMMAND_LINE_VTABLE + 16, MODULE.COMMAND_LINE_FUNCTION)
+    encoded = MODULE.COMMAND_LINE_TYPE.encode() + b"\0"
+    offset = type_descriptor + 8 - MODULE.IMAGE_BASE
+    image[offset : offset + len(encoded)] = encoded
+    for name, option in MODULE.OPTIONS.items():
+        encoded = name.encode() + b"\0"
+        offset = option["string"] - MODULE.IMAGE_BASE
+        image[offset : offset + len(encoded)] = encoded
+    return bytes(image)
+
+
+def function_fixture():
+    command_line = {0x824F815C: "mr r31,r3", **MODULE.PERFMODE_FANOUT}
+    for option in MODULE.OPTIONS.values():
+        for key in ("field_instruction", "name_instruction", "parse_instruction"):
+            address, text = option[key]
+            command_line[address] = text
+    runtime_copy = {
+        0x8259C7E8: "bl 0x82479e88",
+        0x8259C7EC: "mr r30,r3",
+    }
+    for copy in MODULE.RUNTIME_COPIES.values():
+        runtime_copy[copy["source"][0]] = copy["source"][1]
+        runtime_copy[copy["destination"][0]] = copy["destination"][1]
+    return {
+        MODULE.COMMAND_LINE_FUNCTION: command_line,
+        MODULE.RUNTIME_COPY_FUNCTION: runtime_copy,
+    }
+
+
+class NativeRendererTrackConfigTests(unittest.TestCase):
+    def test_proves_isolated_title_track_differential(self):
+        document = MODULE.build(function_fixture(), image_fixture())
+        self.assertEqual("complete", document["status"])
+        self.assertEqual(
+            "title_track_render_differential_control_proved",
+            document["classification"],
+        )
+        self.assertEqual(["-fasttrackrender"], document["capture_contract"]["track_arguments"])
+        self.assertEqual(
+            6297,
+            next(
+                row["runtime_field_offset"]
+                for row in document["runtime_copies"]
+                if row["name"] == "fasttrackrender"
+            ),
+        )
+        self.assertFalse(document["safety"]["suppression_allowed"])
+
+    def test_rejects_registration_drift(self):
+        functions = function_fixture()
+        functions[MODULE.COMMAND_LINE_FUNCTION][0x824F9660] = "addi r4,r11,-327"
+        with self.assertRaisesRegex(ValueError, "fasttrackrender name_instruction"):
+            MODULE.build(functions, image_fixture())
+
+    def test_capture_wrapper_passes_only_the_explicit_title_argument(self):
+        capture = (ROOT / "tools/capture-native-renderer-census.ps1").read_text(
+            encoding="utf-8"
+        )
+        launch = (ROOT / "tools/launch-preview.ps1").read_text(encoding="utf-8")
+        self.assertIn("[ValidateSet('baseline', 'fasttrackrender')]", capture)
+        self.assertIn("@('-fasttrackrender')", capture)
+        self.assertIn("-GameArguments $gameArguments", capture)
+        self.assertIn(
+            "$env:PINYON_SHIFT_NATIVE_RENDERER_TRACK_RENDER_MODE = $TrackRenderMode",
+            capture,
+        )
+        self.assertIn("[string[]]$GameArguments = @()", launch)
+        self.assertIn("$start.ArgumentList = $GameArguments", launch)
+
+    def test_runtime_hook_reports_title_acceptance_without_native_admission(self):
+        analysis = (ROOT / "config/rexglue/analysis/main-xex.toml").read_text(
+            encoding="utf-8"
+        )
+        hooks = (ROOT / "src/native_renderer/graphics_hooks.cpp").read_text(
+            encoding="utf-8"
+        )
+        for address, name in (
+            ("0x8259C834", "PinyonShiftObserveFastTrackRenderConfiguration"),
+            ("0x8259C89C", "PinyonShiftObserveRoadDetailBlurConfiguration"),
+            ("0x8259C8DC", "PinyonShiftObserveTrackCommandBufferConfiguration"),
+        ):
+            self.assertIn(f"address = {address}", analysis)
+            self.assertIn(f'name = "{name}"', analysis)
+            self.assertIn(f"void {name}", hooks)
+        self.assertIn('"native_renderer.discovery.track_render_config"', hooks)
+        self.assertIn('{"xenos_authority", "true"}', hooks)
+        self.assertIn('{"native_draw", "false"}', hooks)
+        self.assertIn('{"suppression_allowed", "false"}', hooks)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/tests/test_native_renderer_track_differential.py
+++ b/tools/tests/test_native_renderer_track_differential.py
@@ -1,0 +1,59 @@
+import importlib.util
+import sys
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+TOOL = ROOT / "tools" / "summarize-native-renderer-track-differential.py"
+SPEC = importlib.util.spec_from_file_location("native_track_differential", TOOL)
+assert SPEC and SPEC.loader
+MODULE = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = MODULE
+SPEC.loader.exec_module(MODULE)
+
+
+def events(session, mode, calls):
+    common = {"schema": 1, "session": session}
+    return [
+        {"event": "process.start", **common, "executable_sha256": "EXE", "rexglue_patch_set_sha256": "PATCH", "rexglue_patch_count": "102"},
+        {"event": MODULE.CONFIG, **common, "status": "complete", "mode": mode, "fast_track_render": "true" if mode == "fasttrackrender" else "false", "road_detail_blur": "false", "track_command_buffers": "true", "address_consistent": "true", "xenos_authority": "true", "native_draw": "false", "suppression_allowed": "false"},
+        {"event": MODULE.INSTALLED, **common, "scene": "open_world_day"},
+        {"event": MODULE.DRAW_WINDOW, **common, "first_frame": "1", "last_frame": "600", "draws": "1200", "overflow_draws": "0"},
+        {"event": MODULE.PROVENANCE, **common, "outcome": "prepared", "semantic_identity": "procedural_model_submission", "prepared_signature": "AABBCCDDEEFF0011", "calls": str(calls), "semantic_vertex_shader": "1111111111111111", "semantic_pixel_shader": "2222222222222222", "semantic_template_key": "3333333333333333", "semantic_receiver_address": "AAAABBBB", "semantic_receiver_generation": "1", "semantic_record_index": "7", "xenos_draw": "preserved", "suppression_eligible": "false"},
+        {"event": "process.shutdown", **common},
+    ]
+
+
+class NativeRendererTrackDifferentialTests(unittest.TestCase):
+    def test_qualifies_exact_title_track_delta_without_semantic_promotion(self):
+        document = MODULE.build(
+            events("baseline-session", "baseline", 60),
+            events("track-session", "fasttrackrender", 120),
+        )
+        self.assertEqual("complete", document["status"])
+        self.assertEqual(1, document["changed_family_count"])
+        self.assertEqual(100.0, document["changed_families"][0]["delta_calls_per_1000_frames"])
+        self.assertTrue(document["qualification"]["title_track_render_delta_proved"])
+        self.assertFalse(document["qualification"]["terrain_road_semantic_identity_proved"])
+        self.assertFalse(document["qualification"]["native_admission_allowed"])
+
+    def test_rejects_unconfirmed_title_argument(self):
+        track = events("track-session", "fasttrackrender", 120)
+        track[1]["fast_track_render"] = "false"
+        document = MODULE.build(events("baseline-session", "baseline", 60), track)
+        self.assertEqual("incomplete", document["status"])
+        self.assertIn(
+            "fasttrackrender: fast-track runtime value does not match the requested mode",
+            document["failures"],
+        )
+
+    def test_rejects_build_identity_drift(self):
+        track = events("track-session", "fasttrackrender", 120)
+        track[0]["executable_sha256"] = "OTHER"
+        document = MODULE.build(events("baseline-session", "baseline", 60), track)
+        self.assertIn("paired sessions do not use one build identity", document["failures"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary\n- prove the retail title-owned track rendering controls from RTTI and exact AOT instructions\n- capture the accepted runtime track configuration without changing draw ownership\n- add paired baseline/fast-track census tooling and strict differential reporting\n\n## Safety\n- Xenos remains authoritative\n- native draw admission and suppression remain disabled\n- user-local launcher, troubleshooting, setup, and release-test changes are excluded\n\n## Validation\n- python -m unittest discover -s tools/tests -p 'test_*.py' (493 passed)\n- .\\tools\\build-preview.ps1 (codegen and Release link passed)\n- generated hook declarations and callsites verified exactly once