### PR TITLE
feat(native-renderer): prove track render differential

### DIFF
--- a/docs/native-renderer/REPRIORITIZED_PLAN.md
+++ b/docs/native-renderer/REPRIORITIZED_PLAN.md
@@ -215,10 +215,12 @@ qualification.
 Active checkpoint: the title-owned `fasttrackrender` differential, independent
 `trackfardistance`, road-detail, and track-command-buffer controls are proven
 from retail RTTI and exact AOT instructions. The paired census path in
-[`TERRAIN_ROAD_RENDER_PATH.md`](TERRAIN_ROAD_RENDER_PATH.md) will identify the
-changed prepared families without promoting frequency or shader resemblance to
-semantic evidence. Native admission remains off until that runtime delta and
-visual identity are qualified.
+[`TERRAIN_ROAD_RENDER_PATH.md`](TERRAIN_ROAD_RENDER_PATH.md) now proves the
+runtime differential against matched AppData-backed open-world sessions and
+records the bounded exact-family candidate set without promoting frequency or
+shader resemblance to semantic evidence. Native admission remains off until
+representative candidates receive visual identity, isolated replay, and race
+coverage.
 
 ### C2. Static world buildings and props
 

--- a/docs/native-renderer/TERRAIN_ROAD_RENDER_PATH.md
+++ b/docs/native-renderer/TERRAIN_ROAD_RENDER_PATH.md
@@ -23,9 +23,14 @@ identity drifts. The relevant title fields are:
 | `notrackcommandbuffers` | 2732 | 6230/6232 | inverted command-buffer control |
 
 The runtime copy occurs in `sub_8259C7D8` after the title retrieves the live
-command-line parameter object. This proves a bounded title configuration path.
-It does not yet prove which prepared signatures are terrain, road surface,
-track props, or an exceptional dependent family.
+command-line parameter object. The retail startup path does not consume
+ReXGlue's `ExLoadedCommandLine` bridge for this object. The census therefore
+uses an opt-in hook at the exact `fasttrackrender` copy instruction
+(`0x8259C834`) to write `false` for the baseline and `true` for the paired
+fast-track session. It changes only that title runtime byte and records its
+original value. This proves a bounded title configuration path; it does not
+yet prove which prepared signatures are terrain, road surface, track props, or
+an exceptional dependent family.
 
 Generate the payload-free static report with:
 
@@ -39,8 +44,10 @@ python tools/discover-native-renderer-track-config.py `
 ## Paired runtime census
 
 The census wrapper accepts `-TrackRenderMode baseline` or
-`-TrackRenderMode fasttrackrender`. The latter passes only the title argument
-`-fasttrackrender`; it does not enable the broader `perfmode` group. Run the
+`-TrackRenderMode fasttrackrender`. The exact runtime-copy hook forces only the
+isolated `fasttrackrender` byte; it does not enable the broader `perfmode`
+group. Explicitly supplying either mode also arms the exact prepared-draw
+provenance required by the paired report. Run the
 same AppData save and marked scene for both modes, then compare exact prepared
 signatures and semantic submission lineage from the two logs.
 
@@ -78,3 +85,24 @@ frames and retains shader, template, receiver-generation, and record identity
 for each changed family. A complete report proves a title-owned track delta;
 it deliberately leaves terrain/road semantic identity, native admission, and
 suppression false.
+
+## Qualified open-world differential
+
+The AppData-backed `open_world_day` pair completed on the same local build:
+
+- baseline session `20260830T233745Z-p15720`: 4,388 frames and 6,325,239
+  draws;
+- `fasttrackrender` session `20260830T234026Z-p31828`: 4,817 frames and
+  7,471,561 draws;
+- both runtime controls completed with the original title value `false`, the
+  requested runtime value applied exactly, normal shutdown, and Xenos
+  authority preserved; and
+- the normalized report found 331 material exact-family deltas after removing
+  504 low-rate jitter rows.
+
+The paired evidence proves the title-owned track-render differential and gives
+the next C1 slice a bounded candidate set. It does not identify all 331 rows as
+terrain or roads: menu/loading variance and dependent families are still
+present in the session-wide aggregates. Native admission therefore remains
+disabled until representative candidates receive visual identification,
+isolated replay, and open-world/race stability evidence.

--- a/src/native_renderer/graphics_hooks.cpp
+++ b/src/native_renderer/graphics_hooks.cpp
@@ -188,6 +188,7 @@ std::atomic<uint64_t> g_frame_sequence{};
 
 struct TrackRenderConfigurationState {
   std::atomic<uint32_t> fast_track_render{};
+  std::atomic<uint32_t> source_fast_track_render{};
   std::atomic<uint32_t> road_detail_blur{};
   std::atomic<uint32_t> command_line_address{};
   std::atomic<uint32_t> runtime_state_address{};
@@ -213,6 +214,7 @@ std::string TrackRenderModeMarker() {
 }
 
 void ObserveFastTrackRenderConfiguration(uint32_t value,
+                                         uint32_t source_value,
                                          uint32_t command_line_address,
                                          uint32_t runtime_state_address) {
   if (TrackRenderModeMarker() == "unmarked") {
@@ -220,6 +222,8 @@ void ObserveFastTrackRenderConfiguration(uint32_t value,
   }
   g_track_render_configuration.fast_track_render.store(
       value & 0xFF, std::memory_order_relaxed);
+  g_track_render_configuration.source_fast_track_render.store(
+      source_value & 0xFF, std::memory_order_relaxed);
   g_track_render_configuration.command_line_address.store(
       command_line_address, std::memory_order_relaxed);
   g_track_render_configuration.runtime_state_address.store(
@@ -268,6 +272,11 @@ void ObserveTrackCommandBufferConfiguration(uint32_t enabled,
                       : "mismatch_fail_closed"},
        {"mode", mode},
        {"fast_track_render", fast_track_render ? "true" : "false"},
+       {"source_fast_track_render",
+        g_track_render_configuration.source_fast_track_render.load(
+            std::memory_order_relaxed)
+            ? "true"
+            : "false"},
        {"road_detail_blur",
         g_track_render_configuration.road_detail_blur.load(
             std::memory_order_relaxed)
@@ -278,6 +287,7 @@ void ObserveTrackCommandBufferConfiguration(uint32_t enabled,
        {"command_line_address",
         fmt::format("{:08X}", command_line_address)},
        {"runtime_state_address", fmt::format("{:08X}", runtime_state_address)},
+       {"control", "exact_runtime_copy_override_8259C834"},
        {"classification", "title_track_render_differential_control"},
        {"xenos_authority", "true"},
        {"native_draw", "false"},
@@ -19610,6 +19620,16 @@ void InstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system,
   if (!graphics_system || !memory) {
     return;
   }
+  g_track_render_configuration.fast_track_render.store(
+      0, std::memory_order_relaxed);
+  g_track_render_configuration.source_fast_track_render.store(
+      0, std::memory_order_relaxed);
+  g_track_render_configuration.road_detail_blur.store(
+      0, std::memory_order_relaxed);
+  g_track_render_configuration.command_line_address.store(
+      0, std::memory_order_relaxed);
+  g_track_render_configuration.runtime_state_address.store(
+      0, std::memory_order_relaxed);
   ConfigureDispatchDiscovery();
   g_sky_horizon_suppression = {};
   g_sky_horizon_suppression.requested =
@@ -21220,7 +21240,13 @@ void PinyonShiftObserveProceduralModelConstructorEntry(PPCRegister &r3) {
 
 void PinyonShiftObserveFastTrackRenderConfiguration(
     PPCRegister &r11, PPCRegister &r30, PPCRegister &r31) {
-  ObserveFastTrackRenderConfiguration(r11.u32, r30.u32, r31.u32);
+  const uint32_t source_value = r11.u32 & 0xFF;
+  const std::string mode = TrackRenderModeMarker();
+  if (mode == "baseline" || mode == "fasttrackrender") {
+    r11.u32 = mode == "fasttrackrender" ? 1 : 0;
+  }
+  ObserveFastTrackRenderConfiguration(r11.u32, source_value, r30.u32,
+                                      r31.u32);
 }
 
 void PinyonShiftObserveRoadDetailBlurConfiguration(

--- a/tools/capture-native-renderer-census.ps1
+++ b/tools/capture-native-renderer-census.ps1
@@ -240,12 +240,13 @@ $savedPassPublication = $env:PINYON_SHIFT_NATIVE_RENDERER_PUBLISH_RETAINED_PASS
 $savedConsumerFamily = $env:PINYON_SHIFT_NATIVE_RENDERER_CONSUMER_FAMILY
 $savedConsumerReadbackDir = $env:PINYON_SHIFT_NATIVE_RENDERER_CONSUMER_READBACK_DIR
 $savedConsumerReadbackSamples = $env:PINYON_SHIFT_NATIVE_RENDERER_CONSUMER_READBACK_SAMPLES
+$trackDifferentialRequested = $PSBoundParameters.ContainsKey('TrackRenderMode')
 try {
     $env:REX_PINYON_SHIFT_NATIVE_RENDERER_CENSUS = 'true'
     $env:REX_PINYON_SHIFT_NATIVE_RENDERER_DISPATCH_DISCOVERY =
         if ($VisibilityShadowReplay -or $ContinuousWorldWorkset -or
             $VehicleDrawCorrelation -or
-            $ShadowCasterProvenance) {
+            $ShadowCasterProvenance -or $trackDifferentialRequested) {
             'true'
         } else { $savedDiscovery }
     $env:PINYON_SHIFT_NATIVE_RENDERER_SCENE = $Scene
@@ -291,12 +292,8 @@ try {
     $env:PINYON_SHIFT_NATIVE_RENDERER_CONSUMER_READBACK_DIR = $ConsumerReadbackDir
     $env:PINYON_SHIFT_NATIVE_RENDERER_CONSUMER_READBACK_SAMPLES =
         if ($ConsumerReadbackDir) { [string]$ConsumerReadbackSamples } else { $null }
-    $gameArguments = if ($TrackRenderMode -eq 'fasttrackrender') {
-        @('-fasttrackrender')
-    } else { @() }
     & (Join-Path $PSScriptRoot 'launch-preview.ps1') `
         -StateRoot $resolvedStateRoot -ShaderCaptureDir $ShaderCaptureDir `
-        -GameArguments $gameArguments `
         -Json:$Json
 }
 finally {

--- a/tools/discover-native-renderer-track-config.py
+++ b/tools/discover-native-renderer-track-config.py
@@ -213,7 +213,8 @@ def build(functions: dict[int, dict[int, str]], image: bytes) -> dict:
         },
         "capture_contract": {
             "baseline_arguments": [],
-            "track_arguments": ["-fasttrackrender"],
+            "track_arguments": [],
+            "runtime_control": "exact_runtime_copy_override_8259C834",
             "scene_must_match": True,
             "compare_exact_prepared_signatures": True,
             "semantic_identity": "candidate_until_runtime_delta_and_visual_evidence",

--- a/tools/launch-preview.ps1
+++ b/tools/launch-preview.ps1
@@ -67,8 +67,9 @@ try {
         WorkingDirectory = (Split-Path $executable -Parent)
         PassThru = $true
     }
-    if ($GameArguments.Count -ne 0) {
-        $start.ArgumentList = $GameArguments
+    $normalizedGameArguments = @($GameArguments)
+    if ($normalizedGameArguments.Count -ne 0) {
+        $start.ArgumentList = $normalizedGameArguments
     }
     $process = Start-Process @start
     $process.WaitForExit()

--- a/tools/summarize-native-renderer-track-differential.py
+++ b/tools/summarize-native-renderer-track-differential.py
@@ -10,6 +10,9 @@ import sys
 
 
 SCHEMA = "pinyon-shift.native-renderer-track-differential.v1"
+MINIMUM_MATERIAL_DELTA_PER_1000_FRAMES = 5.0
+MINIMUM_MATERIAL_RELATIVE_DELTA = 0.05
+MAXIMUM_CHANGED_FAMILY_DETAILS = 128
 CONFIG = "native_renderer.discovery.track_render_config"
 DRAW_WINDOW = "native_renderer.census.draw_window"
 PROVENANCE = "native_renderer.discovery.title_provenance_entry"
@@ -217,9 +220,29 @@ def build(baseline_events, track_events, baseline_session=None, track_session=No
             row["prepared_signature"],
         )
     )
-    changed = [row for row in rows if row["delta_calls_per_1000_frames"] != 0]
+    observed_changed = [
+        row for row in rows if row["delta_calls_per_1000_frames"] != 0
+    ]
+    changed = []
+    for row in observed_changed:
+        delta = abs(row["delta_calls_per_1000_frames"])
+        peak = max(
+            row["baseline_calls_per_1000_frames"],
+            row["fasttrackrender_calls_per_1000_frames"],
+        )
+        relative_delta = delta / peak if peak else 0.0
+        appeared_or_disappeared = (
+            row["baseline_calls"] == 0 or row["fasttrackrender_calls"] == 0
+        )
+        if delta >= MINIMUM_MATERIAL_DELTA_PER_1000_FRAMES and (
+            appeared_or_disappeared
+            or relative_delta >= MINIMUM_MATERIAL_RELATIVE_DELTA
+        ):
+            changed.append(row)
     if not changed:
-        failures.append("no prepared semantic family changed between modes")
+        failures.append("no prepared semantic family materially changed between modes")
+
+    detailed_changed = changed[:MAXIMUM_CHANGED_FAMILY_DETAILS]
 
     return {
         "schema": SCHEMA,
@@ -240,7 +263,15 @@ def build(baseline_events, track_events, baseline_session=None, track_session=No
             },
         },
         "changed_family_count": len(changed),
-        "changed_families": changed,
+        "changed_family_detail_count": len(detailed_changed),
+        "changed_family_details_truncated": len(changed) > len(detailed_changed),
+        "changed_families": detailed_changed,
+        "rate_noise_family_count": len(observed_changed) - len(changed),
+        "material_delta_threshold": {
+            "minimum_absolute_calls_per_1000_frames": MINIMUM_MATERIAL_DELTA_PER_1000_FRAMES,
+            "minimum_relative_delta": MINIMUM_MATERIAL_RELATIVE_DELTA,
+            "appearance_or_disappearance_bypasses_relative_threshold": True,
+        },
         "qualification": {
             "title_track_render_delta_proved": not failures,
             "terrain_road_semantic_identity_proved": False,

--- a/tools/tests/test_native_renderer_track_config.py
+++ b/tools/tests/test_native_renderer_track_config.py
@@ -63,7 +63,14 @@ class NativeRendererTrackConfigTests(unittest.TestCase):
             "title_track_render_differential_control_proved",
             document["classification"],
         )
-        self.assertEqual(["-fasttrackrender"], document["capture_contract"]["track_arguments"])
+        self.assertEqual(
+            [],
+            document["capture_contract"]["track_arguments"],
+        )
+        self.assertEqual(
+            "exact_runtime_copy_override_8259C834",
+            document["capture_contract"]["runtime_control"],
+        )
         self.assertEqual(
             6297,
             next(
@@ -80,20 +87,24 @@ class NativeRendererTrackConfigTests(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "fasttrackrender name_instruction"):
             MODULE.build(functions, image_fixture())
 
-    def test_capture_wrapper_passes_only_the_explicit_title_argument(self):
+    def test_capture_wrapper_uses_only_the_explicit_runtime_control(self):
         capture = (ROOT / "tools/capture-native-renderer-census.ps1").read_text(
             encoding="utf-8"
         )
         launch = (ROOT / "tools/launch-preview.ps1").read_text(encoding="utf-8")
         self.assertIn("[ValidateSet('baseline', 'fasttrackrender')]", capture)
-        self.assertIn("@('-fasttrackrender')", capture)
-        self.assertIn("-GameArguments $gameArguments", capture)
+        self.assertNotIn("--cl=", capture)
+        self.assertIn(
+            "$PSBoundParameters.ContainsKey('TrackRenderMode')", capture
+        )
+        self.assertIn("$trackDifferentialRequested", capture)
         self.assertIn(
             "$env:PINYON_SHIFT_NATIVE_RENDERER_TRACK_RENDER_MODE = $TrackRenderMode",
             capture,
         )
         self.assertIn("[string[]]$GameArguments = @()", launch)
-        self.assertIn("$start.ArgumentList = $GameArguments", launch)
+        self.assertIn("$normalizedGameArguments = @($GameArguments)", launch)
+        self.assertIn("$start.ArgumentList = $normalizedGameArguments", launch)
 
     def test_runtime_hook_reports_title_acceptance_without_native_admission(self):
         analysis = (ROOT / "config/rexglue/analysis/main-xex.toml").read_text(
@@ -111,6 +122,8 @@ class NativeRendererTrackConfigTests(unittest.TestCase):
             self.assertIn(f'name = "{name}"', analysis)
             self.assertIn(f"void {name}", hooks)
         self.assertIn('"native_renderer.discovery.track_render_config"', hooks)
+        self.assertIn('"exact_runtime_copy_override_8259C834"', hooks)
+        self.assertIn('r11.u32 = mode == "fasttrackrender" ? 1 : 0;', hooks)
         self.assertIn('{"xenos_authority", "true"}', hooks)
         self.assertIn('{"native_draw", "false"}', hooks)
         self.assertIn('{"suppression_allowed", "false"}', hooks)

--- a/tools/tests/test_native_renderer_track_differential.py
+++ b/tools/tests/test_native_renderer_track_differential.py
@@ -54,6 +54,15 @@ class NativeRendererTrackDifferentialTests(unittest.TestCase):
         document = MODULE.build(events("baseline-session", "baseline", 60), track)
         self.assertIn("paired sessions do not use one build identity", document["failures"])
 
+    def test_ignores_small_normalized_rate_jitter(self):
+        document = MODULE.build(
+            events("baseline-session", "baseline", 60),
+            events("track-session", "fasttrackrender", 61),
+        )
+        self.assertEqual("incomplete", document["status"])
+        self.assertEqual(0, document["changed_family_count"])
+        self.assertEqual(1, document["rate_noise_family_count"])
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- add an exact opt-in runtime-copy control for the title's isolated fasttrackrender byte
- arm exact prepared-family provenance for matched baseline/fast-track census sessions
- filter low-rate normalized jitter while keeping candidate details bounded
- record the qualified AppData open-world differential and keep native admission fail-closed

## Validation
- tools/build-preview.ps1 -Parallel 16
- python -m unittest discover -s tools/tests (494 passed)
- matched AppData-backed open_world_day sessions: 4,388 baseline frames / 4,817 fast-track frames, normal exit
- strict differential: complete, 331 material exact-family deltas, Xenos authoritative, native admission and suppression disabled