### PR TITLE
feat(native-renderer): refine terrain road differentials

### DIFF
--- a/docs/native-renderer/REPRIORITIZED_PLAN.md
+++ b/docs/native-renderer/REPRIORITIZED_PLAN.md
@@ -222,6 +222,17 @@ shader resemblance to semantic evidence. Native admission remains off until
 representative candidates receive visual identity, isolated replay, and race
 coverage.
 
+The first fast-track-only isolated candidate failed the color replay contract
+on its render-target layout. A subsequently matched baseline,
+`noroaddetailblur`, and `notrackcommandbuffers` matrix proved both additional
+title switches affect submitted work, but zero material delta joined to a
+mechanically color-replay-eligible semantic candidate. C1 therefore moves to
+the independent `trackfardistance` runtime consumer and then, if needed, the
+semantic world-section/mesh ingress instead of collecting more broad
+frequency deltas. This is a lead change, not a scope reduction: terrain/road
+ownership, continuous hybrid output, and race/streaming qualification remain
+required.
+
 ### C2. Static world buildings and props
 
 - Expand opaque-world material and geometry coverage.

--- a/docs/native-renderer/TERRAIN_ROAD_RENDER_PATH.md
+++ b/docs/native-renderer/TERRAIN_ROAD_RENDER_PATH.md
@@ -25,12 +25,12 @@ identity drifts. The relevant title fields are:
 The runtime copy occurs in `sub_8259C7D8` after the title retrieves the live
 command-line parameter object. The retail startup path does not consume
 ReXGlue's `ExLoadedCommandLine` bridge for this object. The census therefore
-uses an opt-in hook at the exact `fasttrackrender` copy instruction
-(`0x8259C834`) to write `false` for the baseline and `true` for the paired
-fast-track session. It changes only that title runtime byte and records its
-original value. This proves a bounded title configuration path; it does not
-yet prove which prepared signatures are terrain, road surface, track props, or
-an exceptional dependent family.
+uses opt-in hooks at the exact `fasttrackrender`, `renderroaddetailblur`, and
+transformed `notrackcommandbuffers` destination stores (`0x8259C834`,
+`0x8259C89C`, and `0x8259C8DC`). It forces a deterministic one-switch mode and
+records every original value. This proves a bounded title configuration path;
+it does not yet prove which prepared signatures are terrain, road surface,
+track props, or an exceptional dependent family.
 
 Generate the payload-free static report with:
 
@@ -43,13 +43,22 @@ python tools/discover-native-renderer-track-config.py `
 
 ## Paired runtime census
 
-The census wrapper accepts `-TrackRenderMode baseline` or
-`-TrackRenderMode fasttrackrender`. The exact runtime-copy hook forces only the
-isolated `fasttrackrender` byte; it does not enable the broader `perfmode`
-group. Explicitly supplying either mode also arms the exact prepared-draw
-provenance required by the paired report. Run the
-same AppData save and marked scene for both modes, then compare exact prepared
-signatures and semantic submission lineage from the two logs.
+The census wrapper accepts four deterministic modes. Each mode forces all
+three proved booleans at their exact runtime-copy instruction so only one
+value differs from the baseline:
+
+| Mode | Fast track | Road-detail blur | Track command buffers |
+| --- | --- | --- | --- |
+| `baseline` | off | on | on |
+| `fasttrackrender` | on | on | on |
+| `noroaddetailblur` | off | off | on |
+| `notrackcommandbuffers` | off | on | off |
+
+These controls do not enable the broader `perfmode` group. Explicitly
+supplying a mode also arms the exact prepared-draw provenance required by the
+paired report. Run the same AppData save and marked scene for the baseline and
+one variant, then compare exact prepared signatures and semantic submission
+lineage from the two logs.
 
 ```powershell
 $stateRoot = Join-Path $env:LOCALAPPDATA `
@@ -76,6 +85,10 @@ python tools/summarize-native-renderer-track-differential.py `
   --fasttrackrender <fasttrackrender-jsonl> `
   --output .local/qualification/native-renderer-track-differential.json
 ```
+
+For either additional discriminator, replace `--fasttrackrender` with
+`--variant <jsonl>` and pass `--variant-mode noroaddetailblur` or
+`--variant-mode notrackcommandbuffers`.
 
 The report requires distinct sessions from the same executable and patch set,
 one shared marked scene, at least 600 frames per side, zero signature overflow,
@@ -106,3 +119,38 @@ terrain or roads: menu/loading variance and dependent families are still
 present in the session-wide aggregates. Native admission therefore remains
 disabled until representative candidates receive visual identification,
 isolated replay, and open-world/race stability evidence.
+
+## Candidate reduction checkpoint
+
+The first exact `fasttrackrender`-only probe used prepared signature
+`044DA8CCB07E4236` in the same stationary festival scene. The title lineage
+was repeatable, but isolated admission failed closed with mechanical rejection
+mask `00004000` (`render_targets`). The paired visibility census likewise found
+no materially changed `fasttrackrender` family that satisfied the current
+color replay contract. This shows that the strongest fast-track deltas are
+render-to-texture or dependent work, not yet proof of a visible terrain/road
+color family.
+
+The matched follow-up matrix completed on executable
+`EDC2C531BD61565ACFFCA897DA1FF88DF282F383468D331E404DF701E2BB8B7B`:
+
+- baseline `20260831T000126Z-p16032`: 6,265 frames and 9,313,318 draws;
+- `noroaddetailblur` `20260831T000504Z-p27532`: 6,890 frames and
+  11,685,250 draws, with 317 material deltas after 491 jitter rows; and
+- `notrackcommandbuffers` `20260831T000916Z-p8992`: 5,885 frames and
+  8,040,263 draws, with 314 material deltas after 280 jitter rows.
+
+All three controls applied their exact expected values and exited normally.
+Both isolated reports prove that the title switches affect submitted work,
+but joining every material delta to the semantic-visibility candidate census
+found zero changed families with mechanical rejection mask `00000000`.
+Consequently neither discriminator currently identifies a safe visible color
+replay. Xenos remains authoritative and native admission remains disabled.
+
+The next bounded lead is the independent floating `trackfardistance` control.
+Its command-line field is known, but its exact runtime consumer still needs to
+be proved before another paired capture. If that control also resolves only
+dependent work, C1 returns to the semantic world-section/mesh ingress rather
+than spending more captures on title-wide frequency deltas. The runtime now
+emits the exact rejection mask on rejected isolated draws, so either path can
+discard unsafe candidates without an extra decoding run.

--- a/src/native_renderer/graphics_hooks.cpp
+++ b/src/native_renderer/graphics_hooks.cpp
@@ -190,6 +190,9 @@ struct TrackRenderConfigurationState {
   std::atomic<uint32_t> fast_track_render{};
   std::atomic<uint32_t> source_fast_track_render{};
   std::atomic<uint32_t> road_detail_blur{};
+  std::atomic<uint32_t> source_road_detail_blur{};
+  std::atomic<uint32_t> track_command_buffers{};
+  std::atomic<uint32_t> source_track_command_buffers{};
   std::atomic<uint32_t> command_line_address{};
   std::atomic<uint32_t> runtime_state_address{};
 };
@@ -207,10 +210,34 @@ std::string TrackRenderModeMarker() {
   }
   std::string marker(value);
   std::free(value);
-  if (marker != "baseline" && marker != "fasttrackrender") {
+  if (marker != "baseline" && marker != "fasttrackrender" &&
+      marker != "noroaddetailblur" && marker != "notrackcommandbuffers") {
     return "invalid";
   }
   return marker;
+}
+
+struct TrackRenderExpectedValues {
+  bool valid = false;
+  uint32_t fast_track_render = 0;
+  uint32_t road_detail_blur = 1;
+  uint32_t track_command_buffers = 1;
+};
+
+TrackRenderExpectedValues ExpectedTrackRenderValues(const std::string &mode) {
+  if (mode == "baseline") {
+    return {.valid = true};
+  }
+  if (mode == "fasttrackrender") {
+    return {.valid = true, .fast_track_render = 1};
+  }
+  if (mode == "noroaddetailblur") {
+    return {.valid = true, .road_detail_blur = 0};
+  }
+  if (mode == "notrackcommandbuffers") {
+    return {.valid = true, .track_command_buffers = 0};
+  }
+  return {};
 }
 
 void ObserveFastTrackRenderConfiguration(uint32_t value,
@@ -231,6 +258,7 @@ void ObserveFastTrackRenderConfiguration(uint32_t value,
 }
 
 void ObserveRoadDetailBlurConfiguration(uint32_t value,
+                                        uint32_t source_value,
                                         uint32_t command_line_address,
                                         uint32_t runtime_state_address) {
   if (TrackRenderModeMarker() == "unmarked") {
@@ -238,6 +266,8 @@ void ObserveRoadDetailBlurConfiguration(uint32_t value,
   }
   g_track_render_configuration.road_detail_blur.store(
       value & 0xFF, std::memory_order_relaxed);
+  g_track_render_configuration.source_road_detail_blur.store(
+      source_value & 0xFF, std::memory_order_relaxed);
   g_track_render_configuration.command_line_address.store(
       command_line_address, std::memory_order_relaxed);
   g_track_render_configuration.runtime_state_address.store(
@@ -245,16 +275,25 @@ void ObserveRoadDetailBlurConfiguration(uint32_t value,
 }
 
 void ObserveTrackCommandBufferConfiguration(uint32_t enabled,
+                                            uint32_t source_enabled,
                                             uint32_t command_line_address,
                                             uint32_t runtime_state_address) {
   const std::string mode = TrackRenderModeMarker();
   if (mode == "unmarked") {
     return;
   }
+  g_track_render_configuration.track_command_buffers.store(
+      enabled & 0xFF, std::memory_order_relaxed);
+  g_track_render_configuration.source_track_command_buffers.store(
+      source_enabled & 0xFF, std::memory_order_relaxed);
   const bool fast_track_render =
       g_track_render_configuration.fast_track_render.load(
           std::memory_order_relaxed) != 0;
-  const bool expected_fast_track_render = mode == "fasttrackrender";
+  const bool road_detail_blur =
+      g_track_render_configuration.road_detail_blur.load(
+          std::memory_order_relaxed) != 0;
+  const bool track_command_buffers = (enabled & 0xFF) != 0;
+  const TrackRenderExpectedValues expected = ExpectedTrackRenderValues(mode);
   const uint32_t observed_command_line_address =
       g_track_render_configuration.command_line_address.load(
           std::memory_order_relaxed);
@@ -266,8 +305,10 @@ void ObserveTrackCommandBufferConfiguration(uint32_t enabled,
       observed_runtime_state_address == runtime_state_address;
   pinyon_shift::diagnostics::RecordEvent(
       "native_renderer.discovery.track_render_config",
-      {{"status", mode != "invalid" && address_consistent &&
-                          fast_track_render == expected_fast_track_render
+      {{"status", expected.valid && address_consistent &&
+                          fast_track_render == expected.fast_track_render &&
+                          road_detail_blur == expected.road_detail_blur &&
+                          track_command_buffers == expected.track_command_buffers
                       ? "complete"
                       : "mismatch_fail_closed"},
        {"mode", mode},
@@ -278,16 +319,23 @@ void ObserveTrackCommandBufferConfiguration(uint32_t enabled,
             ? "true"
             : "false"},
        {"road_detail_blur",
-        g_track_render_configuration.road_detail_blur.load(
+        road_detail_blur ? "true" : "false"},
+       {"source_road_detail_blur",
+        g_track_render_configuration.source_road_detail_blur.load(
             std::memory_order_relaxed)
             ? "true"
             : "false"},
-       {"track_command_buffers", (enabled & 0xFF) ? "true" : "false"},
+       {"track_command_buffers", track_command_buffers ? "true" : "false"},
+       {"source_track_command_buffers",
+        g_track_render_configuration.source_track_command_buffers.load(
+            std::memory_order_relaxed)
+            ? "true"
+            : "false"},
        {"address_consistent", address_consistent ? "true" : "false"},
        {"command_line_address",
         fmt::format("{:08X}", command_line_address)},
        {"runtime_state_address", fmt::format("{:08X}", runtime_state_address)},
-       {"control", "exact_runtime_copy_override_8259C834"},
+       {"control", "exact_runtime_copy_overrides_8259C834_8259C89C_8259C8DC"},
        {"classification", "title_track_render_differential_control"},
        {"xenos_authority", "true"},
        {"native_draw", "false"},
@@ -5976,6 +6024,7 @@ struct IsolatedDrawState {
   bool valid = true;
   bool prepared_candidate_valid = false;
   bool prepared_candidate_eligible = false;
+  uint32_t prepared_candidate_rejection_mask = 0;
   bool prepared_shadow_depth_seed_eligible = false;
   bool prepared_shadow_depth_batch_member = false;
   ShadowDepthBatchFamily prepared_shadow_depth_batch_family =
@@ -15495,12 +15544,16 @@ void ObservePreparedDraw(
         (g_isolated_draw.shadow_depth_mode ||
          g_isolated_draw.shadow_depth_batch_mode) &&
         !g_isolated_draw.shadow_depth_prototype_mode;
+    g_isolated_draw.prepared_candidate_rejection_mask =
+        dedicated_shadow_mode
+            ? 0
+            : IsolatedDrawMechanicalRejectionMask(
+                  sample, g_pending_candidate.samples_resolved_target,
+                  observation);
     g_isolated_draw.prepared_candidate_eligible =
         dedicated_shadow_mode
             ? g_isolated_draw.prepared_shadow_depth_seed_eligible
-            : IsIsolatedDrawEligible(
-                  sample, g_pending_candidate.samples_resolved_target,
-                  observation);
+            : !g_isolated_draw.prepared_candidate_rejection_mask;
     if (g_isolated_draw.shadow_depth_batch_mode) {
       g_isolated_draw.prepared_shadow_depth_batch_family =
           ClassifyShadowDepthBatchMemberDraw(
@@ -17811,6 +17864,9 @@ void RequestIsolatedDraw(
          {"native_draw", "false"},
          {"mechanically_eligible",
           g_isolated_draw.prepared_candidate_eligible ? "true" : "false"},
+         {"mechanical_rejection_mask",
+          fmt::format("{:08X}",
+                      g_isolated_draw.prepared_candidate_rejection_mask)},
          {"fresh_visibility_candidate",
           g_isolated_draw.prepared_visibility_candidate_fresh ? "true"
                                                               : "false"},
@@ -19626,6 +19682,12 @@ void InstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system,
       0, std::memory_order_relaxed);
   g_track_render_configuration.road_detail_blur.store(
       0, std::memory_order_relaxed);
+  g_track_render_configuration.source_road_detail_blur.store(
+      0, std::memory_order_relaxed);
+  g_track_render_configuration.track_command_buffers.store(
+      0, std::memory_order_relaxed);
+  g_track_render_configuration.source_track_command_buffers.store(
+      0, std::memory_order_relaxed);
   g_track_render_configuration.command_line_address.store(
       0, std::memory_order_relaxed);
   g_track_render_configuration.runtime_state_address.store(
@@ -21242,8 +21304,9 @@ void PinyonShiftObserveFastTrackRenderConfiguration(
     PPCRegister &r11, PPCRegister &r30, PPCRegister &r31) {
   const uint32_t source_value = r11.u32 & 0xFF;
   const std::string mode = TrackRenderModeMarker();
-  if (mode == "baseline" || mode == "fasttrackrender") {
-    r11.u32 = mode == "fasttrackrender" ? 1 : 0;
+  const TrackRenderExpectedValues expected = ExpectedTrackRenderValues(mode);
+  if (expected.valid) {
+    r11.u32 = expected.fast_track_render;
   }
   ObserveFastTrackRenderConfiguration(r11.u32, source_value, r30.u32,
                                       r31.u32);
@@ -21251,12 +21314,26 @@ void PinyonShiftObserveFastTrackRenderConfiguration(
 
 void PinyonShiftObserveRoadDetailBlurConfiguration(
     PPCRegister &r11, PPCRegister &r30, PPCRegister &r31) {
-  ObserveRoadDetailBlurConfiguration(r11.u32, r30.u32, r31.u32);
+  const uint32_t source_value = r11.u32 & 0xFF;
+  const TrackRenderExpectedValues expected =
+      ExpectedTrackRenderValues(TrackRenderModeMarker());
+  if (expected.valid) {
+    r11.u32 = expected.road_detail_blur;
+  }
+  ObserveRoadDetailBlurConfiguration(r11.u32, source_value, r30.u32,
+                                     r31.u32);
 }
 
 void PinyonShiftObserveTrackCommandBufferConfiguration(
     PPCRegister &r11, PPCRegister &r30, PPCRegister &r31) {
-  ObserveTrackCommandBufferConfiguration(r11.u32, r30.u32, r31.u32);
+  const uint32_t source_value = r11.u32 & 0xFF;
+  const TrackRenderExpectedValues expected =
+      ExpectedTrackRenderValues(TrackRenderModeMarker());
+  if (expected.valid) {
+    r11.u32 = expected.track_command_buffers;
+  }
+  ObserveTrackCommandBufferConfiguration(r11.u32, source_value, r30.u32,
+                                         r31.u32);
 }
 
 void PinyonShiftObserveProceduralModelConstructorExit() {

--- a/tools/capture-native-renderer-census.ps1
+++ b/tools/capture-native-renderer-census.ps1
@@ -30,7 +30,12 @@ param(
     [switch]$ContinuousWorldWorkset,
     [switch]$VehicleDrawCorrelation,
     [switch]$ShadowCasterProvenance,
-    [ValidateSet('baseline', 'fasttrackrender')]
+    [ValidateSet(
+        'baseline',
+        'fasttrackrender',
+        'noroaddetailblur',
+        'notrackcommandbuffers'
+    )]
     [string]$TrackRenderMode = 'baseline',
     [ValidatePattern('^[0-9A-Fa-f]{16}$')]
     [string]$PassAnchorSignature,

--- a/tools/discover-native-renderer-track-config.py
+++ b/tools/discover-native-renderer-track-config.py
@@ -9,7 +9,7 @@ import re
 import sys
 
 
-SCHEMA = "pinyon-shift.native-renderer-track-config.v1"
+SCHEMA = "pinyon-shift.native-renderer-track-config.v2"
 IMAGE_BASE = 0x82000000
 FUNCTION_RE = re.compile(r"^DEFINE_REX_FUNC\(sub_([0-9A-F]{8})\) \{")
 LABEL_RE = re.compile(r"^loc_([0-9A-F]{8}):")
@@ -214,7 +214,32 @@ def build(functions: dict[int, dict[int, str]], image: bytes) -> dict:
         "capture_contract": {
             "baseline_arguments": [],
             "track_arguments": [],
-            "runtime_control": "exact_runtime_copy_override_8259C834",
+            "runtime_control": (
+                "exact_runtime_copy_overrides_"
+                "8259C834_8259C89C_8259C8DC"
+            ),
+            "modes": {
+                "baseline": {
+                    "fast_track_render": False,
+                    "road_detail_blur": True,
+                    "track_command_buffers": True,
+                },
+                "fasttrackrender": {
+                    "fast_track_render": True,
+                    "road_detail_blur": True,
+                    "track_command_buffers": True,
+                },
+                "noroaddetailblur": {
+                    "fast_track_render": False,
+                    "road_detail_blur": False,
+                    "track_command_buffers": True,
+                },
+                "notrackcommandbuffers": {
+                    "fast_track_render": False,
+                    "road_detail_blur": True,
+                    "track_command_buffers": False,
+                },
+            },
             "scene_must_match": True,
             "compare_exact_prepared_signatures": True,
             "semantic_identity": "candidate_until_runtime_delta_and_visual_evidence",

--- a/tools/summarize-native-renderer-track-differential.py
+++ b/tools/summarize-native-renderer-track-differential.py
@@ -1,4 +1,4 @@
-"""Compare exact prepared title families across baseline/fast-track sessions."""
+"""Compare exact prepared title families across isolated track modes."""
 
 from __future__ import annotations
 
@@ -9,7 +9,7 @@ import pathlib
 import sys
 
 
-SCHEMA = "pinyon-shift.native-renderer-track-differential.v1"
+SCHEMA = "pinyon-shift.native-renderer-track-differential.v2"
 MINIMUM_MATERIAL_DELTA_PER_1000_FRAMES = 5.0
 MINIMUM_MATERIAL_RELATIVE_DELTA = 0.05
 MAXIMUM_CHANGED_FAMILY_DETAILS = 128
@@ -17,6 +17,12 @@ CONFIG = "native_renderer.discovery.track_render_config"
 DRAW_WINDOW = "native_renderer.census.draw_window"
 PROVENANCE = "native_renderer.discovery.title_provenance_entry"
 INSTALLED = "native_renderer.census.installed"
+MODE_VALUES = {
+    "baseline": (False, True, True),
+    "fasttrackrender": (True, True, True),
+    "noroaddetailblur": (False, False, True),
+    "notrackcommandbuffers": (False, True, False),
+}
 
 
 def read_events(paths):
@@ -65,6 +71,8 @@ def session_events(events, requested_session=None):
 
 
 def summarize_side(events, expected_mode, requested_session=None):
+    if expected_mode not in MODE_VALUES:
+        raise ValueError(f"unsupported track mode: {expected_mode}")
     session, selected = session_events(events, requested_session)
     configs = [event for event in selected if event.get("event") == CONFIG]
     starts = [event for event in selected if event.get("event") == "process.start"]
@@ -80,8 +88,18 @@ def summarize_side(events, expected_mode, requested_session=None):
     failures = []
     if config.get("status") != "complete" or config.get("mode") != expected_mode:
         failures.append("title did not confirm the requested track mode")
-    if boolean(config, "fast_track_render") != (expected_mode == "fasttrackrender"):
-        failures.append("fast-track runtime value does not match the requested mode")
+    expected_fast, expected_road_blur, expected_command_buffers = MODE_VALUES[
+        expected_mode
+    ]
+    for field, expected, label in (
+        ("fast_track_render", expected_fast, "fast-track"),
+        ("road_detail_blur", expected_road_blur, "road-detail blur"),
+        ("track_command_buffers", expected_command_buffers, "track command-buffer"),
+    ):
+        if boolean(config, field) != expected:
+            failures.append(
+                f"{label} runtime value does not match the requested mode"
+            )
     if not boolean(config, "address_consistent"):
         failures.append("command-line/runtime render-state identity drifted")
     if (
@@ -167,12 +185,18 @@ def summarize_side(events, expected_mode, requested_session=None):
     }
 
 
-def build(baseline_events, track_events, baseline_session=None, track_session=None):
+def build(
+    baseline_events,
+    track_events,
+    baseline_session=None,
+    track_session=None,
+    track_mode="fasttrackrender",
+):
     baseline = summarize_side(baseline_events, "baseline", baseline_session)
-    track = summarize_side(track_events, "fasttrackrender", track_session)
+    track = summarize_side(track_events, track_mode, track_session)
     failures = [
         *(f"baseline: {failure}" for failure in baseline["failures"]),
-        *(f"fasttrackrender: {failure}" for failure in track["failures"]),
+        *(f"{track_mode}: {failure}" for failure in track["failures"]),
     ]
     if baseline["session"] == track["session"]:
         failures.append("baseline and fast-track sessions are identical")
@@ -195,9 +219,9 @@ def build(baseline_events, track_events, baseline_session=None, track_session=No
             {
                 "prepared_signature": signature,
                 "baseline_calls": left_calls,
-                "fasttrackrender_calls": right_calls,
+                f"{track_mode}_calls": right_calls,
                 "baseline_calls_per_1000_frames": round(left_rate, 3),
-                "fasttrackrender_calls_per_1000_frames": round(right_rate, 3),
+                f"{track_mode}_calls_per_1000_frames": round(right_rate, 3),
                 "delta_calls_per_1000_frames": round(right_rate - left_rate, 3),
                 "vertex_shaders": sorted(metadata["vertex_shaders"]),
                 "pixel_shaders": sorted(metadata["pixel_shaders"]),
@@ -228,11 +252,11 @@ def build(baseline_events, track_events, baseline_session=None, track_session=No
         delta = abs(row["delta_calls_per_1000_frames"])
         peak = max(
             row["baseline_calls_per_1000_frames"],
-            row["fasttrackrender_calls_per_1000_frames"],
+            row[f"{track_mode}_calls_per_1000_frames"],
         )
         relative_delta = delta / peak if peak else 0.0
         appeared_or_disappeared = (
-            row["baseline_calls"] == 0 or row["fasttrackrender_calls"] == 0
+            row["baseline_calls"] == 0 or row[f"{track_mode}_calls"] == 0
         )
         if delta >= MINIMUM_MATERIAL_DELTA_PER_1000_FRAMES and (
             appeared_or_disappeared
@@ -256,7 +280,7 @@ def build(baseline_events, track_events, baseline_session=None, track_session=No
                 "frames": baseline["frames"],
                 "draws": baseline["draws"],
             },
-            "fasttrackrender": {
+            track_mode: {
                 "session": track["session"],
                 "frames": track["frames"],
                 "draws": track["draws"],
@@ -274,6 +298,7 @@ def build(baseline_events, track_events, baseline_session=None, track_session=No
         },
         "qualification": {
             "title_track_render_delta_proved": not failures,
+            "isolated_mode": track_mode,
             "terrain_road_semantic_identity_proved": False,
             "native_admission_allowed": False,
             "suppression_allowed": False,
@@ -289,17 +314,32 @@ def build(baseline_events, track_events, baseline_session=None, track_session=No
 def main(argv=None):
     parser = argparse.ArgumentParser()
     parser.add_argument("--baseline", required=True, type=pathlib.Path, nargs="+")
-    parser.add_argument("--fasttrackrender", required=True, type=pathlib.Path, nargs="+")
+    variant = parser.add_mutually_exclusive_group(required=True)
+    variant.add_argument("--fasttrackrender", type=pathlib.Path, nargs="+")
+    variant.add_argument("--variant", type=pathlib.Path, nargs="+")
+    parser.add_argument(
+        "--variant-mode",
+        choices=tuple(mode for mode in MODE_VALUES if mode != "baseline"),
+    )
     parser.add_argument("--baseline-session")
     parser.add_argument("--fasttrackrender-session")
     parser.add_argument("--output", required=True, type=pathlib.Path)
     args = parser.parse_args(argv)
     try:
+        if args.fasttrackrender:
+            variant_paths = args.fasttrackrender
+            variant_mode = "fasttrackrender"
+        else:
+            variant_paths = args.variant
+            if not args.variant_mode:
+                raise ValueError("--variant-mode is required with --variant")
+            variant_mode = args.variant_mode
         document = build(
             read_events(args.baseline),
-            read_events(args.fasttrackrender),
+            read_events(variant_paths),
             args.baseline_session,
             args.fasttrackrender_session,
+            variant_mode,
         )
         args.output.parent.mkdir(parents=True, exist_ok=True)
         args.output.write_text(

--- a/tools/tests/test_native_renderer_track_config.py
+++ b/tools/tests/test_native_renderer_track_config.py
@@ -68,8 +68,16 @@ class NativeRendererTrackConfigTests(unittest.TestCase):
             document["capture_contract"]["track_arguments"],
         )
         self.assertEqual(
-            "exact_runtime_copy_override_8259C834",
+            "exact_runtime_copy_overrides_8259C834_8259C89C_8259C8DC",
             document["capture_contract"]["runtime_control"],
+        )
+        self.assertEqual(
+            {
+                "fast_track_render": False,
+                "road_detail_blur": False,
+                "track_command_buffers": True,
+            },
+            document["capture_contract"]["modes"]["noroaddetailblur"],
         )
         self.assertEqual(
             6297,
@@ -92,7 +100,13 @@ class NativeRendererTrackConfigTests(unittest.TestCase):
             encoding="utf-8"
         )
         launch = (ROOT / "tools/launch-preview.ps1").read_text(encoding="utf-8")
-        self.assertIn("[ValidateSet('baseline', 'fasttrackrender')]", capture)
+        for mode in (
+            "baseline",
+            "fasttrackrender",
+            "noroaddetailblur",
+            "notrackcommandbuffers",
+        ):
+            self.assertIn(f"'{mode}'", capture)
         self.assertNotIn("--cl=", capture)
         self.assertIn(
             "$PSBoundParameters.ContainsKey('TrackRenderMode')", capture
@@ -122,8 +136,15 @@ class NativeRendererTrackConfigTests(unittest.TestCase):
             self.assertIn(f'name = "{name}"', analysis)
             self.assertIn(f"void {name}", hooks)
         self.assertIn('"native_renderer.discovery.track_render_config"', hooks)
-        self.assertIn('"exact_runtime_copy_override_8259C834"', hooks)
-        self.assertIn('r11.u32 = mode == "fasttrackrender" ? 1 : 0;', hooks)
+        self.assertIn(
+            '"exact_runtime_copy_overrides_8259C834_8259C89C_8259C8DC"',
+            hooks,
+        )
+        self.assertIn("ExpectedTrackRenderValues(TrackRenderModeMarker())", hooks)
+        self.assertIn("r11.u32 = expected.road_detail_blur;", hooks)
+        self.assertIn("r11.u32 = expected.track_command_buffers;", hooks)
+        self.assertIn("prepared_candidate_rejection_mask", hooks)
+        self.assertIn('{"mechanical_rejection_mask",', hooks)
         self.assertIn('{"xenos_authority", "true"}', hooks)
         self.assertIn('{"native_draw", "false"}', hooks)
         self.assertIn('{"suppression_allowed", "false"}', hooks)

--- a/tools/tests/test_native_renderer_track_differential.py
+++ b/tools/tests/test_native_renderer_track_differential.py
@@ -15,9 +15,10 @@ SPEC.loader.exec_module(MODULE)
 
 def events(session, mode, calls):
     common = {"schema": 1, "session": session}
+    expected = MODULE.MODE_VALUES[mode]
     return [
         {"event": "process.start", **common, "executable_sha256": "EXE", "rexglue_patch_set_sha256": "PATCH", "rexglue_patch_count": "102"},
-        {"event": MODULE.CONFIG, **common, "status": "complete", "mode": mode, "fast_track_render": "true" if mode == "fasttrackrender" else "false", "road_detail_blur": "false", "track_command_buffers": "true", "address_consistent": "true", "xenos_authority": "true", "native_draw": "false", "suppression_allowed": "false"},
+        {"event": MODULE.CONFIG, **common, "status": "complete", "mode": mode, "fast_track_render": "true" if expected[0] else "false", "road_detail_blur": "true" if expected[1] else "false", "track_command_buffers": "true" if expected[2] else "false", "address_consistent": "true", "xenos_authority": "true", "native_draw": "false", "suppression_allowed": "false"},
         {"event": MODULE.INSTALLED, **common, "scene": "open_world_day"},
         {"event": MODULE.DRAW_WINDOW, **common, "first_frame": "1", "last_frame": "600", "draws": "1200", "overflow_draws": "0"},
         {"event": MODULE.PROVENANCE, **common, "outcome": "prepared", "semantic_identity": "procedural_model_submission", "prepared_signature": "AABBCCDDEEFF0011", "calls": str(calls), "semantic_vertex_shader": "1111111111111111", "semantic_pixel_shader": "2222222222222222", "semantic_template_key": "3333333333333333", "semantic_receiver_address": "AAAABBBB", "semantic_receiver_generation": "1", "semantic_record_index": "7", "xenos_draw": "preserved", "suppression_eligible": "false"},
@@ -53,6 +54,32 @@ class NativeRendererTrackDifferentialTests(unittest.TestCase):
         track[0]["executable_sha256"] = "OTHER"
         document = MODULE.build(events("baseline-session", "baseline", 60), track)
         self.assertIn("paired sessions do not use one build identity", document["failures"])
+
+    def test_qualifies_road_detail_blur_as_an_isolated_variant(self):
+        document = MODULE.build(
+            events("baseline-session", "baseline", 60),
+            events("road-session", "noroaddetailblur", 120),
+            track_mode="noroaddetailblur",
+        )
+        self.assertEqual("complete", document["status"])
+        self.assertEqual(
+            "noroaddetailblur", document["qualification"]["isolated_mode"]
+        )
+        self.assertEqual(
+            120, document["changed_families"][0]["noroaddetailblur_calls"]
+        )
+
+    def test_qualifies_disabled_track_command_buffers_as_an_isolated_variant(self):
+        document = MODULE.build(
+            events("baseline-session", "baseline", 60),
+            events("command-session", "notrackcommandbuffers", 120),
+            track_mode="notrackcommandbuffers",
+        )
+        self.assertEqual("complete", document["status"])
+        self.assertEqual(
+            "notrackcommandbuffers",
+            document["qualification"]["isolated_mode"],
+        )
 
     def test_ignores_small_normalized_rate_jitter(self):
         document = MODULE.build(


### PR DESCRIPTION
## Summary
- add exact isolated runtime modes for road-detail blur and track command buffers
- emit the mechanical rejection mask for failed isolated candidates
- generalize the paired differential report and record the matched AppData evidence
- redirect C1 to the bounded track-distance/semantic-ingress leads

## Validation
- python -m unittest discover -s tools/tests (496 passed)
- tools/build-preview.ps1 (passed)
- matched baseline, noroaddetailblur, and notrackcommandbuffers AppData captures (normal exits)

Xenos remains authoritative; native admission and suppression remain disabled.