### PR TITLE
feat(native-renderer): control track far distance

### DIFF
--- a/config/rexglue/analysis/main-xex.toml
+++ b/config/rexglue/analysis/main-xex.toml
@@ -269,6 +269,11 @@ name = "PinyonShiftObserveProceduralModelDestructorExit"
 # into runtime render state rooted at r31. Hooks observe registers after each
 # source load/transform and before the original destination store.
 [[midasm_hook]]
+address = 0x824F7DC0
+name = "PinyonShiftObserveTrackFarDistanceConfiguration"
+registers = ["f0"]
+
+[[midasm_hook]]
 address = 0x8259C834
 name = "PinyonShiftObserveFastTrackRenderConfiguration"
 registers = ["r11", "r30", "r31"]

--- a/docs/native-renderer/REPRIORITIZED_PLAN.md
+++ b/docs/native-renderer/REPRIORITIZED_PLAN.md
@@ -212,9 +212,11 @@ qualification.
 - Cover representative daytime, nighttime, race, and high-speed streaming
   scenes.
 
-Active checkpoint: the title-owned `fasttrackrender` differential, independent
-`trackfardistance`, road-detail, and track-command-buffer controls are proven
-from retail RTTI and exact AOT instructions. The paired census path in
+Active checkpoint: the title-owned `fasttrackrender`, road-detail, and
+track-command-buffer controls are proven from retail RTTI and exact AOT
+instructions. The `trackfardistance` live option default and store are also
+proved: baseline holds the retail `55.0`, while an isolated mode deterministically
+forces `5.0`. Its downstream renderer consumer is deliberately still open. The paired census path in
 [`TERRAIN_ROAD_RENDER_PATH.md`](TERRAIN_ROAD_RENDER_PATH.md) now proves the
 runtime differential against matched AppData-backed open-world sessions and
 records the bounded exact-family candidate set without promoting frequency or
@@ -226,9 +228,10 @@ The first fast-track-only isolated candidate failed the color replay contract
 on its render-target layout. A subsequently matched baseline,
 `noroaddetailblur`, and `notrackcommandbuffers` matrix proved both additional
 title switches affect submitted work, but zero material delta joined to a
-mechanically color-replay-eligible semantic candidate. C1 therefore moves to
-the independent `trackfardistance` runtime consumer and then, if needed, the
-semantic world-section/mesh ingress instead of collecting more broad
+mechanically color-replay-eligible semantic candidate. C1 therefore runs one
+matched `trackfardistance` `55.0`/`5.0` qualification pair to establish its
+consumer-visible delta and then, if needed, moves to the semantic
+world-section/mesh ingress instead of collecting more broad
 frequency deltas. This is a lead change, not a scope reduction: terrain/road
 ownership, continuous hybrid output, and race/streaming qualification remain
 required.

--- a/docs/native-renderer/TERRAIN_ROAD_RENDER_PATH.md
+++ b/docs/native-renderer/TERRAIN_ROAD_RENDER_PATH.md
@@ -18,16 +18,22 @@ identity drifts. The relevant title fields are:
 | Option | Command-line field | Runtime field | Role |
 | --- | ---: | ---: | --- |
 | `fasttrackrender` | 4204 | 6297 | isolated title track-family switch |
-| `trackfardistance` | 4176 | not yet proved | floating distance control |
+| `trackfardistance` | 4176 | live option store proved; downstream consumer open | floating distance control |
 | `renderroaddetailblur` | 4181 | 6035 | road-detail effect switch |
 | `notrackcommandbuffers` | 2732 | 6230/6232 | inverted command-buffer control |
 
-The runtime copy occurs in `sub_8259C7D8` after the title retrieves the live
+The `trackfardistance` default load and live-object store occur in
+`sub_824F7898` at `0x824F7DB8` and `0x824F7DC0`. The source image value is
+exactly `55.0`; the isolated mode replaces only that store with `5.0` and
+records both values. This proves deterministic ownership of the title option,
+but not yet the downstream renderer consumer.
+
+The boolean runtime copy occurs in `sub_8259C7D8` after the title retrieves the live
 command-line parameter object. The retail startup path does not consume
 ReXGlue's `ExLoadedCommandLine` bridge for this object. The census therefore
-uses opt-in hooks at the exact `fasttrackrender`, `renderroaddetailblur`, and
+uses opt-in hooks at the exact `trackfardistance`, `fasttrackrender`, `renderroaddetailblur`, and
 transformed `notrackcommandbuffers` destination stores (`0x8259C834`,
-`0x8259C89C`, and `0x8259C8DC`). It forces a deterministic one-switch mode and
+`0x8259C89C`, and `0x8259C8DC`, plus `0x824F7DC0`). It forces a deterministic one-switch mode and
 records every original value. This proves a bounded title configuration path;
 it does not yet prove which prepared signatures are terrain, road surface,
 track props, or an exceptional dependent family.
@@ -43,16 +49,17 @@ python tools/discover-native-renderer-track-config.py `
 
 ## Paired runtime census
 
-The census wrapper accepts four deterministic modes. Each mode forces all
-three proved booleans at their exact runtime-copy instruction so only one
-value differs from the baseline:
+The census wrapper accepts five deterministic modes. Each mode forces the
+proved floating option and all three booleans at their exact stores so only
+one value differs from the baseline:
 
-| Mode | Fast track | Road-detail blur | Track command buffers |
-| --- | --- | --- | --- |
-| `baseline` | off | on | on |
-| `fasttrackrender` | on | on | on |
-| `noroaddetailblur` | off | off | on |
-| `notrackcommandbuffers` | off | on | off |
+| Mode | Track far distance | Fast track | Road-detail blur | Track command buffers |
+| --- | ---: | --- | --- | --- |
+| `baseline` | 55.0 | off | on | on |
+| `trackfardistance` | 5.0 | off | on | on |
+| `fasttrackrender` | 55.0 | on | on | on |
+| `noroaddetailblur` | 55.0 | off | off | on |
+| `notrackcommandbuffers` | 55.0 | off | on | off |
 
 These controls do not enable the broader `perfmode` group. Explicitly
 supplying a mode also arms the exact prepared-draw provenance required by the
@@ -147,10 +154,11 @@ found zero changed families with mechanical rejection mask `00000000`.
 Consequently neither discriminator currently identifies a safe visible color
 replay. Xenos remains authoritative and native admission remains disabled.
 
-The next bounded lead is the independent floating `trackfardistance` control.
-Its command-line field is known, but its exact runtime consumer still needs to
-be proved before another paired capture. If that control also resolves only
-dependent work, C1 returns to the semantic world-section/mesh ingress rather
-than spending more captures on title-wide frequency deltas. The runtime now
-emits the exact rejection mask on rejected isolated draws, so either path can
-discard unsafe candidates without an extra decoding run.
+The independent floating `trackfardistance` control is now ready for one
+matched `55.0` versus `5.0` capture pair. Its exact live option store is
+proved; its downstream renderer consumer and observable workset delta are not.
+If that pair also resolves only dependent work, C1 returns to the semantic
+world-section/mesh ingress rather than spending more captures on title-wide
+frequency deltas. The runtime emits the exact rejection mask on rejected
+isolated draws, so either path can discard unsafe candidates without an extra
+decoding run.

--- a/src/native_renderer/graphics_hooks.cpp
+++ b/src/native_renderer/graphics_hooks.cpp
@@ -187,6 +187,8 @@ constexpr const char *kMixedShadowCasterAtlasRegion = "1024,0,1024,1024";
 std::atomic<uint64_t> g_frame_sequence{};
 
 struct TrackRenderConfigurationState {
+  std::atomic<float> track_far_distance{};
+  std::atomic<float> source_track_far_distance{};
   std::atomic<uint32_t> fast_track_render{};
   std::atomic<uint32_t> source_fast_track_render{};
   std::atomic<uint32_t> road_detail_blur{};
@@ -210,7 +212,8 @@ std::string TrackRenderModeMarker() {
   }
   std::string marker(value);
   std::free(value);
-  if (marker != "baseline" && marker != "fasttrackrender" &&
+  if (marker != "baseline" && marker != "trackfardistance" &&
+      marker != "fasttrackrender" &&
       marker != "noroaddetailblur" && marker != "notrackcommandbuffers") {
     return "invalid";
   }
@@ -219,6 +222,7 @@ std::string TrackRenderModeMarker() {
 
 struct TrackRenderExpectedValues {
   bool valid = false;
+  float track_far_distance = 55.0f;
   uint32_t fast_track_render = 0;
   uint32_t road_detail_blur = 1;
   uint32_t track_command_buffers = 1;
@@ -231,6 +235,9 @@ TrackRenderExpectedValues ExpectedTrackRenderValues(const std::string &mode) {
   if (mode == "fasttrackrender") {
     return {.valid = true, .fast_track_render = 1};
   }
+  if (mode == "trackfardistance") {
+    return {.valid = true, .track_far_distance = 5.0f};
+  }
   if (mode == "noroaddetailblur") {
     return {.valid = true, .road_detail_blur = 0};
   }
@@ -238,6 +245,16 @@ TrackRenderExpectedValues ExpectedTrackRenderValues(const std::string &mode) {
     return {.valid = true, .track_command_buffers = 0};
   }
   return {};
+}
+
+void ObserveTrackFarDistanceConfiguration(float value, float source_value) {
+  if (TrackRenderModeMarker() == "unmarked") {
+    return;
+  }
+  g_track_render_configuration.track_far_distance.store(
+      value, std::memory_order_relaxed);
+  g_track_render_configuration.source_track_far_distance.store(
+      source_value, std::memory_order_relaxed);
 }
 
 void ObserveFastTrackRenderConfiguration(uint32_t value,
@@ -293,6 +310,9 @@ void ObserveTrackCommandBufferConfiguration(uint32_t enabled,
       g_track_render_configuration.road_detail_blur.load(
           std::memory_order_relaxed) != 0;
   const bool track_command_buffers = (enabled & 0xFF) != 0;
+  const float track_far_distance =
+      g_track_render_configuration.track_far_distance.load(
+          std::memory_order_relaxed);
   const TrackRenderExpectedValues expected = ExpectedTrackRenderValues(mode);
   const uint32_t observed_command_line_address =
       g_track_render_configuration.command_line_address.load(
@@ -306,12 +326,18 @@ void ObserveTrackCommandBufferConfiguration(uint32_t enabled,
   pinyon_shift::diagnostics::RecordEvent(
       "native_renderer.discovery.track_render_config",
       {{"status", expected.valid && address_consistent &&
+                          track_far_distance == expected.track_far_distance &&
                           fast_track_render == expected.fast_track_render &&
                           road_detail_blur == expected.road_detail_blur &&
                           track_command_buffers == expected.track_command_buffers
                       ? "complete"
                       : "mismatch_fail_closed"},
        {"mode", mode},
+       {"track_far_distance", fmt::format("{:.3f}", track_far_distance)},
+       {"source_track_far_distance",
+        fmt::format("{:.3f}",
+                    g_track_render_configuration.source_track_far_distance.load(
+                        std::memory_order_relaxed))},
        {"fast_track_render", fast_track_render ? "true" : "false"},
        {"source_fast_track_render",
         g_track_render_configuration.source_fast_track_render.load(
@@ -335,7 +361,8 @@ void ObserveTrackCommandBufferConfiguration(uint32_t enabled,
        {"command_line_address",
         fmt::format("{:08X}", command_line_address)},
        {"runtime_state_address", fmt::format("{:08X}", runtime_state_address)},
-       {"control", "exact_runtime_copy_overrides_8259C834_8259C89C_8259C8DC"},
+       {"control",
+        "exact_option_and_runtime_overrides_824F7DC0_8259C834_8259C89C_8259C8DC"},
        {"classification", "title_track_render_differential_control"},
        {"xenos_authority", "true"},
        {"native_draw", "false"},
@@ -19676,6 +19703,10 @@ void InstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system,
   if (!graphics_system || !memory) {
     return;
   }
+  g_track_render_configuration.track_far_distance.store(
+      0.0f, std::memory_order_relaxed);
+  g_track_render_configuration.source_track_far_distance.store(
+      0.0f, std::memory_order_relaxed);
   g_track_render_configuration.fast_track_render.store(
       0, std::memory_order_relaxed);
   g_track_render_configuration.source_fast_track_render.store(
@@ -21310,6 +21341,17 @@ void PinyonShiftObserveFastTrackRenderConfiguration(
   }
   ObserveFastTrackRenderConfiguration(r11.u32, source_value, r30.u32,
                                       r31.u32);
+}
+
+void PinyonShiftObserveTrackFarDistanceConfiguration(PPCRegister &f0) {
+  const float source_value = static_cast<float>(f0.f64);
+  const TrackRenderExpectedValues expected =
+      ExpectedTrackRenderValues(TrackRenderModeMarker());
+  if (expected.valid) {
+    f0.f64 = expected.track_far_distance;
+  }
+  ObserveTrackFarDistanceConfiguration(static_cast<float>(f0.f64),
+                                       source_value);
 }
 
 void PinyonShiftObserveRoadDetailBlurConfiguration(

--- a/tools/capture-native-renderer-census.ps1
+++ b/tools/capture-native-renderer-census.ps1
@@ -32,6 +32,7 @@ param(
     [switch]$ShadowCasterProvenance,
     [ValidateSet(
         'baseline',
+        'trackfardistance',
         'fasttrackrender',
         'noroaddetailblur',
         'notrackcommandbuffers'

--- a/tools/discover-native-renderer-track-config.py
+++ b/tools/discover-native-renderer-track-config.py
@@ -9,7 +9,7 @@ import re
 import sys
 
 
-SCHEMA = "pinyon-shift.native-renderer-track-config.v2"
+SCHEMA = "pinyon-shift.native-renderer-track-config.v3"
 IMAGE_BASE = 0x82000000
 FUNCTION_RE = re.compile(r"^DEFINE_REX_FUNC\(sub_([0-9A-F]{8})\) \{")
 LABEL_RE = re.compile(r"^loc_([0-9A-F]{8}):")
@@ -19,6 +19,9 @@ COMMAND_LINE_FUNCTION = 0x824F8150
 RUNTIME_COPY_FUNCTION = 0x8259C7D8
 COMMAND_LINE_VTABLE = 0x8200E724
 COMMAND_LINE_TYPE = ".?AVCForzaCommandLineParameters@@"
+TRACK_FAR_DEFAULT_FUNCTION = 0x824F7898
+TRACK_FAR_DEFAULT_VALUE = 55.0
+TRACK_FAR_DEFAULT_BITS = 0x425C0000
 
 OPTIONS = {
     "perfmode": {
@@ -146,7 +149,8 @@ def require(function: dict[int, str], address: int, text: str, label: str) -> No
 def build(functions: dict[int, dict[int, str]], image: bytes) -> dict:
     command_line = functions.get(COMMAND_LINE_FUNCTION)
     runtime_copy = functions.get(RUNTIME_COPY_FUNCTION)
-    if command_line is None or runtime_copy is None:
+    track_far_default = functions.get(TRACK_FAR_DEFAULT_FUNCTION)
+    if command_line is None or runtime_copy is None or track_far_default is None:
         raise ValueError("track configuration function set is incomplete")
 
     locator = image_u32(image, COMMAND_LINE_VTABLE - 4)
@@ -176,6 +180,21 @@ def build(functions: dict[int, dict[int, str]], image: bytes) -> dict:
 
     for address, text in PERFMODE_FANOUT.items():
         require(command_line, address, text, "perfmode fanout")
+
+    require(
+        track_far_default,
+        0x824F7DB8,
+        "lfs f0,-3056(r11)",
+        "trackfardistance default source",
+    )
+    require(
+        track_far_default,
+        0x824F7DC0,
+        "stfs f0,4176(r31)",
+        "trackfardistance live option store",
+    )
+    if image_u32(image, 0x8200F410) != TRACK_FAR_DEFAULT_BITS:
+        raise ValueError("trackfardistance default value drifted")
 
     require(runtime_copy, 0x8259C7E8, "bl 0x82479e88", "parameter lookup")
     require(runtime_copy, 0x8259C7EC, "mr r30,r3", "parameter receiver")
@@ -215,29 +234,47 @@ def build(functions: dict[int, dict[int, str]], image: bytes) -> dict:
             "baseline_arguments": [],
             "track_arguments": [],
             "runtime_control": (
-                "exact_runtime_copy_overrides_"
-                "8259C834_8259C89C_8259C8DC"
+                "exact_option_and_runtime_overrides_"
+                "824F7DC0_8259C834_8259C89C_8259C8DC"
             ),
+            "track_far_distance_control": {
+                "command_line_field_offset": 4176,
+                "default_source_address": "8200F410",
+                "default_store_address": "824F7DC0",
+                "baseline_value": TRACK_FAR_DEFAULT_VALUE,
+                "isolated_value": 5.0,
+                "downstream_consumer_proved": False,
+            },
             "modes": {
                 "baseline": {
+                    "track_far_distance": TRACK_FAR_DEFAULT_VALUE,
                     "fast_track_render": False,
                     "road_detail_blur": True,
                     "track_command_buffers": True,
                 },
                 "fasttrackrender": {
+                    "track_far_distance": TRACK_FAR_DEFAULT_VALUE,
                     "fast_track_render": True,
                     "road_detail_blur": True,
                     "track_command_buffers": True,
                 },
                 "noroaddetailblur": {
+                    "track_far_distance": TRACK_FAR_DEFAULT_VALUE,
                     "fast_track_render": False,
                     "road_detail_blur": False,
                     "track_command_buffers": True,
                 },
                 "notrackcommandbuffers": {
+                    "track_far_distance": TRACK_FAR_DEFAULT_VALUE,
                     "fast_track_render": False,
                     "road_detail_blur": True,
                     "track_command_buffers": False,
+                },
+                "trackfardistance": {
+                    "track_far_distance": 5.0,
+                    "fast_track_render": False,
+                    "road_detail_blur": True,
+                    "track_command_buffers": True,
                 },
             },
             "scene_must_match": True,

--- a/tools/summarize-native-renderer-track-differential.py
+++ b/tools/summarize-native-renderer-track-differential.py
@@ -18,10 +18,11 @@ DRAW_WINDOW = "native_renderer.census.draw_window"
 PROVENANCE = "native_renderer.discovery.title_provenance_entry"
 INSTALLED = "native_renderer.census.installed"
 MODE_VALUES = {
-    "baseline": (False, True, True),
-    "fasttrackrender": (True, True, True),
-    "noroaddetailblur": (False, False, True),
-    "notrackcommandbuffers": (False, True, False),
+    "baseline": (False, True, True, 55.0),
+    "trackfardistance": (False, True, True, 5.0),
+    "fasttrackrender": (True, True, True, 55.0),
+    "noroaddetailblur": (False, False, True, 55.0),
+    "notrackcommandbuffers": (False, True, False, 55.0),
 }
 
 
@@ -88,7 +89,7 @@ def summarize_side(events, expected_mode, requested_session=None):
     failures = []
     if config.get("status") != "complete" or config.get("mode") != expected_mode:
         failures.append("title did not confirm the requested track mode")
-    expected_fast, expected_road_blur, expected_command_buffers = MODE_VALUES[
+    expected_fast, expected_road_blur, expected_command_buffers, expected_far = MODE_VALUES[
         expected_mode
     ]
     for field, expected, label in (
@@ -100,6 +101,12 @@ def summarize_side(events, expected_mode, requested_session=None):
             failures.append(
                 f"{label} runtime value does not match the requested mode"
             )
+    try:
+        track_far_distance = float(config.get("track_far_distance", "nan"))
+    except (TypeError, ValueError):
+        track_far_distance = float("nan")
+    if track_far_distance != expected_far:
+        failures.append("track far distance does not match the requested mode")
     if not boolean(config, "address_consistent"):
         failures.append("command-line/runtime render-state identity drifted")
     if (

--- a/tools/tests/test_native_renderer_track_config.py
+++ b/tools/tests/test_native_renderer_track_config.py
@@ -26,6 +26,7 @@ def image_fixture():
     u32(MODULE.COMMAND_LINE_VTABLE - 4, locator)
     u32(locator + 12, type_descriptor)
     u32(MODULE.COMMAND_LINE_VTABLE + 16, MODULE.COMMAND_LINE_FUNCTION)
+    u32(0x8200F410, MODULE.TRACK_FAR_DEFAULT_BITS)
     encoded = MODULE.COMMAND_LINE_TYPE.encode() + b"\0"
     offset = type_descriptor + 8 - MODULE.IMAGE_BASE
     image[offset : offset + len(encoded)] = encoded
@@ -52,6 +53,10 @@ def function_fixture():
     return {
         MODULE.COMMAND_LINE_FUNCTION: command_line,
         MODULE.RUNTIME_COPY_FUNCTION: runtime_copy,
+        MODULE.TRACK_FAR_DEFAULT_FUNCTION: {
+            0x824F7DB8: "lfs f0,-3056(r11)",
+            0x824F7DC0: "stfs f0,4176(r31)",
+        },
     }
 
 
@@ -68,11 +73,12 @@ class NativeRendererTrackConfigTests(unittest.TestCase):
             document["capture_contract"]["track_arguments"],
         )
         self.assertEqual(
-            "exact_runtime_copy_overrides_8259C834_8259C89C_8259C8DC",
+            "exact_option_and_runtime_overrides_824F7DC0_8259C834_8259C89C_8259C8DC",
             document["capture_contract"]["runtime_control"],
         )
         self.assertEqual(
             {
+                "track_far_distance": 55.0,
                 "fast_track_render": False,
                 "road_detail_blur": False,
                 "track_command_buffers": True,
@@ -102,6 +108,7 @@ class NativeRendererTrackConfigTests(unittest.TestCase):
         launch = (ROOT / "tools/launch-preview.ps1").read_text(encoding="utf-8")
         for mode in (
             "baseline",
+            "trackfardistance",
             "fasttrackrender",
             "noroaddetailblur",
             "notrackcommandbuffers",
@@ -128,6 +135,7 @@ class NativeRendererTrackConfigTests(unittest.TestCase):
             encoding="utf-8"
         )
         for address, name in (
+            ("0x824F7DC0", "PinyonShiftObserveTrackFarDistanceConfiguration"),
             ("0x8259C834", "PinyonShiftObserveFastTrackRenderConfiguration"),
             ("0x8259C89C", "PinyonShiftObserveRoadDetailBlurConfiguration"),
             ("0x8259C8DC", "PinyonShiftObserveTrackCommandBufferConfiguration"),
@@ -137,9 +145,10 @@ class NativeRendererTrackConfigTests(unittest.TestCase):
             self.assertIn(f"void {name}", hooks)
         self.assertIn('"native_renderer.discovery.track_render_config"', hooks)
         self.assertIn(
-            '"exact_runtime_copy_overrides_8259C834_8259C89C_8259C8DC"',
+            '"exact_option_and_runtime_overrides_824F7DC0_8259C834_8259C89C_8259C8DC"',
             hooks,
         )
+        self.assertIn("f0.f64 = expected.track_far_distance;", hooks)
         self.assertIn("ExpectedTrackRenderValues(TrackRenderModeMarker())", hooks)
         self.assertIn("r11.u32 = expected.road_detail_blur;", hooks)
         self.assertIn("r11.u32 = expected.track_command_buffers;", hooks)

--- a/tools/tests/test_native_renderer_track_differential.py
+++ b/tools/tests/test_native_renderer_track_differential.py
@@ -18,7 +18,7 @@ def events(session, mode, calls):
     expected = MODULE.MODE_VALUES[mode]
     return [
         {"event": "process.start", **common, "executable_sha256": "EXE", "rexglue_patch_set_sha256": "PATCH", "rexglue_patch_count": "102"},
-        {"event": MODULE.CONFIG, **common, "status": "complete", "mode": mode, "fast_track_render": "true" if expected[0] else "false", "road_detail_blur": "true" if expected[1] else "false", "track_command_buffers": "true" if expected[2] else "false", "address_consistent": "true", "xenos_authority": "true", "native_draw": "false", "suppression_allowed": "false"},
+        {"event": MODULE.CONFIG, **common, "status": "complete", "mode": mode, "fast_track_render": "true" if expected[0] else "false", "road_detail_blur": "true" if expected[1] else "false", "track_command_buffers": "true" if expected[2] else "false", "track_far_distance": str(expected[3]), "address_consistent": "true", "xenos_authority": "true", "native_draw": "false", "suppression_allowed": "false"},
         {"event": MODULE.INSTALLED, **common, "scene": "open_world_day"},
         {"event": MODULE.DRAW_WINDOW, **common, "first_frame": "1", "last_frame": "600", "draws": "1200", "overflow_draws": "0"},
         {"event": MODULE.PROVENANCE, **common, "outcome": "prepared", "semantic_identity": "procedural_model_submission", "prepared_signature": "AABBCCDDEEFF0011", "calls": str(calls), "semantic_vertex_shader": "1111111111111111", "semantic_pixel_shader": "2222222222222222", "semantic_template_key": "3333333333333333", "semantic_receiver_address": "AAAABBBB", "semantic_receiver_generation": "1", "semantic_record_index": "7", "xenos_draw": "preserved", "suppression_eligible": "false"},
@@ -67,6 +67,17 @@ class NativeRendererTrackDifferentialTests(unittest.TestCase):
         )
         self.assertEqual(
             120, document["changed_families"][0]["noroaddetailblur_calls"]
+        )
+
+    def test_qualifies_track_far_distance_as_an_isolated_variant(self):
+        document = MODULE.build(
+            events("baseline-session", "baseline", 60),
+            events("far-session", "trackfardistance", 120),
+            track_mode="trackfardistance",
+        )
+        self.assertEqual("complete", document["status"])
+        self.assertEqual(
+            "trackfardistance", document["qualification"]["isolated_mode"]
         )
 
     def test_qualifies_disabled_track_command_buffers_as_an_isolated_variant(self):


### PR DESCRIPTION
## Summary
- prove the retail 55.0 track-far-distance default load and live option store
- add a deterministic isolated 5.0 census mode while leaving every other title track control at baseline
- validate the control in static discovery and paired differential reports
- record that the downstream renderer consumer remains unproved and Xenos stays authoritative

## Validation
- 495 repository unit tests passed
- win-amd64-release build linked successfully
- payload-free v3 static report generated from the retail image