### PR TITLE
feat(native-renderer): qualify track far distance

### DIFF
--- a/docs/native-renderer/REPRIORITIZED_PLAN.md
+++ b/docs/native-renderer/REPRIORITIZED_PLAN.md
@@ -215,8 +215,8 @@ qualification.
 Active checkpoint: the title-owned `fasttrackrender`, road-detail, and
 track-command-buffer controls are proven from retail RTTI and exact AOT
 instructions. The `trackfardistance` live option default and store are also
-proved: baseline holds the retail `55.0`, while an isolated mode deterministically
-forces `5.0`. Its downstream renderer consumer is deliberately still open. The paired census path in
+proved: baseline holds the retail `55.0`, while an isolated mode
+deterministically forces `5.0`. The paired census path in
 [`TERRAIN_ROAD_RENDER_PATH.md`](TERRAIN_ROAD_RENDER_PATH.md) now proves the
 runtime differential against matched AppData-backed open-world sessions and
 records the bounded exact-family candidate set without promoting frequency or
@@ -228,13 +228,15 @@ The first fast-track-only isolated candidate failed the color replay contract
 on its render-target layout. A subsequently matched baseline,
 `noroaddetailblur`, and `notrackcommandbuffers` matrix proved both additional
 title switches affect submitted work, but zero material delta joined to a
-mechanically color-replay-eligible semantic candidate. C1 therefore runs one
-matched `trackfardistance` `55.0`/`5.0` qualification pair to establish its
-consumer-visible delta and then, if needed, moves to the semantic
-world-section/mesh ingress instead of collecting more broad
-frequency deltas. This is a lead change, not a scope reduction: terrain/road
-ownership, continuous hybrid output, and race/streaming qualification remain
-required.
+mechanically color-replay-eligible semantic candidate. The matched
+`trackfardistance` `55.0`/`5.0` pair then proved a 77-family submitted-work
+delta. Only one changed signature passed the mechanical color gate, and its 17
+eligible draws occurred solely during the transition into the save rather than
+a representative gameplay window. The title-switch leads are therefore
+exhausted. C1 now moves to semantic world-section/mesh ingress instead of
+collecting more broad frequency deltas. This is a lead change, not a scope
+reduction: terrain/road ownership, continuous hybrid output, and
+race/streaming qualification remain required.
 
 ### C2. Static world buildings and props
 

--- a/docs/native-renderer/TERRAIN_ROAD_RENDER_PATH.md
+++ b/docs/native-renderer/TERRAIN_ROAD_RENDER_PATH.md
@@ -93,18 +93,20 @@ python tools/summarize-native-renderer-track-differential.py `
   --output .local/qualification/native-renderer-track-differential.json
 ```
 
-For either additional discriminator, replace `--fasttrackrender` with
-`--variant <jsonl>` and pass `--variant-mode noroaddetailblur` or
-`--variant-mode notrackcommandbuffers`.
+For another discriminator, replace `--fasttrackrender` with `--variant
+<jsonl>` and pass `--variant-mode trackfardistance`, `noroaddetailblur`, or
+`notrackcommandbuffers`.
 
-The report requires distinct sessions from the same executable and patch set,
+The v3 report requires distinct sessions from the same executable and patch set,
 one shared marked scene, at least 600 frames per side, zero signature overflow,
 normal shutdown, and runtime confirmation that the title accepted the requested
 mode. It compares exact prepared procedural-model provenance in calls per 1,000
 frames and retains shader, template, receiver-generation, and record identity
-for each changed family. A complete report proves a title-owned track delta;
-it deliberately leaves terrain/road semantic identity, native admission, and
-suppression false.
+for each changed family. It also joins materially changed signatures to exact
+prepared semantic-visibility candidates and reports their mechanical rejection
+masks. A complete report proves a title-owned track delta; it deliberately
+leaves representative terrain/road identity, native admission, and suppression
+false.
 
 ## Qualified open-world differential
 
@@ -154,11 +156,27 @@ found zero changed families with mechanical rejection mask `00000000`.
 Consequently neither discriminator currently identifies a safe visible color
 replay. Xenos remains authoritative and native admission remains disabled.
 
-The independent floating `trackfardistance` control is now ready for one
-matched `55.0` versus `5.0` capture pair. Its exact live option store is
-proved; its downstream renderer consumer and observable workset delta are not.
-If that pair also resolves only dependent work, C1 returns to the semantic
-world-section/mesh ingress rather than spending more captures on title-wide
-frequency deltas. The runtime emits the exact rejection mask on rejected
-isolated draws, so either path can discard unsafe candidates without an extra
-decoding run.
+## Track-far-distance qualification checkpoint
+
+The matched AppData-backed `55.0` versus `5.0` pair used one clean executable
+and the same stationary festival scene:
+
+- baseline `20260831T004121Z-p23820`: 4,146 frames and 4,344,201 draws;
+- `trackfardistance` `20260831T004400Z-p35676`: 4,480 frames and 4,860,836
+  draws; and
+- 77 material families changed after 756 normalized rate-noise families were
+  rejected.
+
+This proves that the live floating option reaches submitted renderer work.
+Four changed signatures joined to ten exact semantic-visibility candidate
+entries. Six entries rejected on mask `00004000`, two on `00000001`, and two
+entries for one signature (`BE5FF23CA0389E54`) were mechanically eligible.
+That signature had 132 baseline calls and zero variant calls, but its eligible
+candidate rows comprised only 17 draws at baseline frames 3,083 and
+3,095-3,097 during the transition into the save. Representative gameplay
+identity is therefore not proved, and neither native admission nor suppression
+is allowed.
+
+The independent title switches are now exhausted as useful C1 discriminators.
+The next lead is semantic world-section/mesh ingress, with the exact
+visibility-to-prepared lineage retained as its fail-closed replay gate.

--- a/tools/summarize-native-renderer-track-differential.py
+++ b/tools/summarize-native-renderer-track-differential.py
@@ -9,13 +9,16 @@ import pathlib
 import sys
 
 
-SCHEMA = "pinyon-shift.native-renderer-track-differential.v2"
+SCHEMA = "pinyon-shift.native-renderer-track-differential.v3"
 MINIMUM_MATERIAL_DELTA_PER_1000_FRAMES = 5.0
 MINIMUM_MATERIAL_RELATIVE_DELTA = 0.05
 MAXIMUM_CHANGED_FAMILY_DETAILS = 128
 CONFIG = "native_renderer.discovery.track_render_config"
 DRAW_WINDOW = "native_renderer.census.draw_window"
 PROVENANCE = "native_renderer.discovery.title_provenance_entry"
+PREPARED_CANDIDATE = (
+    "native_renderer.discovery.semantic_visibility_prepared_candidate_entry"
+)
 INSTALLED = "native_renderer.census.installed"
 MODE_VALUES = {
     "baseline": (False, True, True, 55.0),
@@ -52,6 +55,15 @@ def boolean(event, key):
     if value not in ("true", "false"):
         raise ValueError(f"invalid {key} in {event.get('event', 'event')}")
     return value == "true"
+
+
+def hexadecimal(event, key, width):
+    value = str(event.get(key, "")).upper()
+    if len(value) != width or any(
+        character not in "0123456789ABCDEF" for character in value
+    ):
+        raise ValueError(f"invalid {key} in {event.get('event', 'event')}")
+    return value
 
 
 def session_events(events, requested_session=None):
@@ -175,6 +187,41 @@ def summarize_side(events, expected_mode, requested_session=None):
     if not signatures:
         failures.append("no exact semantic prepared families were observed")
 
+    prepared_candidates = collections.defaultdict(list)
+    for event in selected:
+        if event.get("event") != PREPARED_CANDIDATE:
+            continue
+        signature = hexadecimal(event, "prepared_signature", 16)
+        rejection_mask = hexadecimal(event, "mechanical_rejection_mask", 8)
+        mechanically_eligible = boolean(event, "mechanically_eligible")
+        if mechanically_eligible != (rejection_mask == "00000000"):
+            failures.append("prepared candidate eligibility disagrees with its mask")
+        if (
+            boolean(event, "guest_state_changed")
+            or boolean(event, "control_flow_changed")
+            or boolean(event, "native_upload")
+            or boolean(event, "native_draw")
+            or event.get("xenos_draw") != "preserved"
+            or boolean(event, "suppression_allowed")
+        ):
+            failures.append("prepared candidate violated Xenos safety")
+        first_frame = integer(event, "first_frame")
+        last_frame = integer(event, "last_frame")
+        if last_frame < first_frame:
+            failures.append("prepared candidate frame bounds are invalid")
+        prepared_candidates[signature].append(
+            {
+                "candidate_key": hexadecimal(event, "candidate_key", 16),
+                "draws": integer(event, "draws"),
+                "first_frame": first_frame,
+                "last_frame": last_frame,
+                "mechanically_eligible": mechanically_eligible,
+                "mechanical_rejection_mask": rejection_mask,
+                "visibility_category": str(event.get("visibility_category", "")),
+                "visibility_result_mask": str(event.get("visibility_result_mask", "")),
+            }
+        )
+
     return {
         "session": session,
         "mode": expected_mode,
@@ -189,6 +236,7 @@ def summarize_side(events, expected_mode, requested_session=None):
         "frames": frame_count,
         "draws": draw_count,
         "signatures": signatures,
+        "prepared_candidates": prepared_candidates,
     }
 
 
@@ -274,6 +322,37 @@ def build(
         failures.append("no prepared semantic family materially changed between modes")
 
     detailed_changed = changed[:MAXIMUM_CHANGED_FAMILY_DETAILS]
+    changed_signatures = {row["prepared_signature"] for row in changed}
+    candidate_rows = []
+    for side_name, side in (("baseline", baseline), (track_mode, track)):
+        for signature, entries in side["prepared_candidates"].items():
+            if signature not in changed_signatures:
+                continue
+            for entry in entries:
+                candidate_rows.append(
+                    {
+                        "session_mode": side_name,
+                        "prepared_signature": signature,
+                        **entry,
+                    }
+                )
+    candidate_rows.sort(
+        key=lambda row: (
+            row["prepared_signature"],
+            row["session_mode"],
+            row["first_frame"],
+            row["candidate_key"],
+        )
+    )
+    joined_signatures = {row["prepared_signature"] for row in candidate_rows}
+    eligible_signatures = {
+        row["prepared_signature"]
+        for row in candidate_rows
+        if row["mechanically_eligible"]
+    }
+    rejection_mask_counts = collections.Counter(
+        row["mechanical_rejection_mask"] for row in candidate_rows
+    )
 
     return {
         "schema": SCHEMA,
@@ -302,6 +381,22 @@ def build(
             "minimum_absolute_calls_per_1000_frames": MINIMUM_MATERIAL_DELTA_PER_1000_FRAMES,
             "minimum_relative_delta": MINIMUM_MATERIAL_RELATIVE_DELTA,
             "appearance_or_disappearance_bypasses_relative_threshold": True,
+        },
+        "semantic_visibility_join": {
+            "changed_signature_count_with_candidate_lineage": len(joined_signatures),
+            "candidate_entry_count": len(candidate_rows),
+            "mechanically_eligible_changed_signature_count": len(
+                eligible_signatures
+            ),
+            "mechanically_eligible_changed_signatures": sorted(
+                eligible_signatures
+            ),
+            "rejection_mask_entry_counts": dict(
+                sorted(rejection_mask_counts.items())
+            ),
+            "candidate_entries": candidate_rows,
+            "representative_gameplay_identity_proved": False,
+            "native_admission_allowed": False,
         },
         "qualification": {
             "title_track_render_delta_proved": not failures,

--- a/tools/tests/test_native_renderer_track_differential.py
+++ b/tools/tests/test_native_renderer_track_differential.py
@@ -26,6 +26,31 @@ def events(session, mode, calls):
     ]
 
 
+def candidate(session, rejection_mask="00000000"):
+    return {
+        "event": MODULE.PREPARED_CANDIDATE,
+        "schema": 1,
+        "session": session,
+        "candidate_key": "1234567890ABCDEF",
+        "prepared_signature": "AABBCCDDEEFF0011",
+        "draws": "12",
+        "first_frame": "500",
+        "last_frame": "511",
+        "mechanically_eligible": (
+            "true" if rejection_mask == "00000000" else "false"
+        ),
+        "mechanical_rejection_mask": rejection_mask,
+        "visibility_category": "11",
+        "visibility_result_mask": "7",
+        "guest_state_changed": "false",
+        "control_flow_changed": "false",
+        "native_upload": "false",
+        "native_draw": "false",
+        "xenos_draw": "preserved",
+        "suppression_allowed": "false",
+    }
+
+
 class NativeRendererTrackDifferentialTests(unittest.TestCase):
     def test_qualifies_exact_title_track_delta_without_semantic_promotion(self):
         document = MODULE.build(
@@ -70,14 +95,41 @@ class NativeRendererTrackDifferentialTests(unittest.TestCase):
         )
 
     def test_qualifies_track_far_distance_as_an_isolated_variant(self):
+        baseline = events("baseline-session", "baseline", 60)
+        baseline.insert(-1, candidate("baseline-session"))
         document = MODULE.build(
-            events("baseline-session", "baseline", 60),
+            baseline,
             events("far-session", "trackfardistance", 120),
             track_mode="trackfardistance",
         )
         self.assertEqual("complete", document["status"])
         self.assertEqual(
             "trackfardistance", document["qualification"]["isolated_mode"]
+        )
+        join = document["semantic_visibility_join"]
+        self.assertEqual(1, join["changed_signature_count_with_candidate_lineage"])
+        self.assertEqual(1, join["mechanically_eligible_changed_signature_count"])
+        self.assertEqual(
+            ["AABBCCDDEEFF0011"],
+            join["mechanically_eligible_changed_signatures"],
+        )
+        self.assertFalse(join["representative_gameplay_identity_proved"])
+        self.assertFalse(join["native_admission_allowed"])
+
+    def test_rejects_candidate_mask_eligibility_disagreement(self):
+        baseline = events("baseline-session", "baseline", 60)
+        entry = candidate("baseline-session", "00000001")
+        entry["mechanically_eligible"] = "true"
+        baseline.insert(-1, entry)
+        document = MODULE.build(
+            baseline,
+            events("far-session", "trackfardistance", 120),
+            track_mode="trackfardistance",
+        )
+        self.assertEqual("incomplete", document["status"])
+        self.assertIn(
+            "baseline: prepared candidate eligibility disagrees with its mask",
+            document["failures"],
         )
 
     def test_qualifies_disabled_track_command_buffers_as_an_isolated_variant(self):


### PR DESCRIPTION
## Summary
- qualify the retail 55.0 baseline against the isolated 5.0 track-far-distance mode using the AppData save
- extend the v3 report with an exact material-to-semantic-visibility join and mechanical rejection masks
- record the 77-family differential and the single transition-only mechanically eligible signature
- keep Xenos authoritative and pivot C1 to semantic world-section/mesh ingress

## Evidence
- baseline: 4,146 frames / 4,344,201 draws / normal exit
- variant: 4,480 frames / 4,860,836 draws / normal exit
- 77 material deltas after 756 normalized rate-noise families
- 496 repository unit tests passed