### PR TITLE
feat(native-renderer): prove track world ingress

### DIFF
--- a/docs/native-renderer/REPRIORITIZED_PLAN.md
+++ b/docs/native-renderer/REPRIORITIZED_PLAN.md
@@ -238,6 +238,13 @@ collecting more broad frequency deltas. This is a lead change, not a scope
 reduction: terrain/road ownership, continuous hybrid output, and
 race/streaming qualification remain required.
 
+Static ingress checkpoint: retail RTTI, complete-object locators, and full
+AOT-backed vtables now prove the unified track presentation/model/instance
+surfaces and the track model, mesh, procedural-geometry, and PVS-zone resource
+graph. The next batched slice is the passive exact-identity runtime join from
+those title-owned lifetimes to the existing procedural-model prepared-record
+boundary; this checkpoint does not enable native admission or suppression.
+
 ### C2. Static world buildings and props
 
 - Expand opaque-world material and geometry coverage.

--- a/docs/native-renderer/TERRAIN_ROAD_RENDER_PATH.md
+++ b/docs/native-renderer/TERRAIN_ROAD_RENDER_PATH.md
@@ -180,3 +180,33 @@ is allowed.
 The independent title switches are now exhausted as useful C1 discriminators.
 The next lead is semantic world-section/mesh ingress, with the exact
 visibility-to-prepared lineage retained as its fail-closed replay gate.
+
+## Track world-ingress static proof
+
+`tools/discover-native-renderer-track-ingress.py` now makes that lead exact.
+It validates the retail RTTI complete-object locators, full AOT-backed vtables,
+and reviewed specialization slots for the unified track presentation, render
+model, render-model instance, track model/mesh/submodel, procedural-geometry
+object/resource, and PVS-zone object/resource classes.
+
+The proof separates three layers that broad draw deltas could not distinguish:
+
+- the 135-slot unified title presentation surface and its exact overrides;
+- the unified render-model and render-instance surfaces; and
+- the track model, mesh, procedural-geometry, and visibility-zone resource
+  graph that owns world-section identity before prepared draw submission.
+
+Generate the payload-free report with:
+
+```powershell
+python tools/discover-native-renderer-track-ingress.py `
+  .local/generated/default `
+  --image ..\horizon1-recomp\.local\analysis\default-image.bin `
+  --output .local/qualification/native-renderer-track-ingress.json
+```
+
+This is a static ownership proof, not yet the runtime semantic join. The next
+slice may observe only the reviewed title lifecycle boundaries and must join an
+exact shared object or resource identity to
+`proceduralGeometry::CProceduralModels`. Xenos remains authoritative; native
+admission and suppression remain disabled.

--- a/tools/discover-native-renderer-track-ingress.py
+++ b/tools/discover-native-renderer-track-ingress.py
@@ -1,0 +1,274 @@
+"""Prove title-owned track presentation and world-resource ingress types."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import pathlib
+import re
+import sys
+
+
+SCHEMA = "pinyon-shift.native-renderer-track-ingress.v1"
+IMAGE_BASE = 0x82000000
+FUNCTION_RE = re.compile(r"^DEFINE_REX_FUNC\(sub_([0-9A-F]{8})\) \{")
+
+
+CLASSES = {
+    "track_presentation": {
+        "decorated_name": ".?AVCTrackPresentation@@",
+        "vtable": 0x82239AB4,
+        "slots": 135,
+        "destructor": 0x82D6AC10,
+        "role": "legacy_track_presentation_baseline",
+    },
+    "track_presentation_unified": {
+        "decorated_name": ".?AVCTrackPresentation@Presentation_Unified@@",
+        "vtable": 0x82243774,
+        "slots": 135,
+        "destructor": 0x82DF3C80,
+        "role": "active_unified_track_presentation",
+    },
+    "track_render_model": {
+        "decorated_name": ".?AVCTrackRenderModel@@",
+        "vtable": 0x82243414,
+        "slots": 18,
+        "destructor": 0x82DEA670,
+        "role": "legacy_track_render_model_baseline",
+    },
+    "track_render_model_unified": {
+        "decorated_name": ".?AVCTrackRenderModel_Unified@Presentation_Unified@@",
+        "vtable": 0x82001D74,
+        "slots": 18,
+        "destructor": 0x82DF1D98,
+        "role": "active_unified_track_render_model",
+    },
+    "track_render_model_instance": {
+        "decorated_name": ".?AVCTrackRenderModelInstance@@",
+        "vtable": 0x82243464,
+        "slots": 15,
+        "destructor": 0x82DEA6B8,
+        "role": "legacy_track_render_instance_baseline",
+    },
+    "track_render_model_instance_unified": {
+        "decorated_name": ".?AVCTrackRenderModelInstance_Unified@Presentation_Unified@@",
+        "vtable": 0x820019CC,
+        "slots": 15,
+        "destructor": 0x82DEA6B8,
+        "role": "active_unified_track_render_instance",
+    },
+    "track_model": {
+        "decorated_name": ".?AVCTrackModel@@",
+        "vtable": 0x820016B4,
+        "slots": 20,
+        "destructor": 0x82C26B40,
+        "role": "track_model_resource_graph",
+    },
+    "track_mesh": {
+        "decorated_name": ".?AVCTrackMesh@@",
+        "vtable": 0x8200143C,
+        "slots": 6,
+        "destructor": 0x82C25CE8,
+        "role": "track_mesh_resource",
+    },
+    "track_sub_model": {
+        "decorated_name": ".?AVCTrackSubModel@@",
+        "vtable": 0x82001474,
+        "slots": 7,
+        "destructor": 0x82C26940,
+        "role": "track_submodel_resource",
+    },
+    "track_procedural_geometry_object": {
+        "decorated_name": ".?AVCTrackProceduralGeometryObject@@",
+        "vtable": 0x82144CF8,
+        "slots": 7,
+        "destructor": 0x82C22A78,
+        "role": "world_section_procedural_geometry_object",
+    },
+    "track_procedural_geometry_resource": {
+        "decorated_name": ".?AVCTrackProceduralGeometryResource@@",
+        "vtable": 0x82144D7C,
+        "slots": 23,
+        "destructor": 0x82C23190,
+        "role": "world_section_procedural_geometry_resource",
+    },
+    "track_pvs_zone_object": {
+        "decorated_name": ".?AVCTrackPVSZoneObject@@",
+        "vtable": 0x82144DE0,
+        "slots": 7,
+        "destructor": 0x82C23668,
+        "role": "world_section_visibility_zone_object",
+    },
+    "track_pvs_zone_resource": {
+        "decorated_name": ".?AVCTrackPVSZoneResource@@",
+        "vtable": 0x82144E64,
+        "slots": 23,
+        "destructor": 0x82C23CE0,
+        "role": "world_section_visibility_zone_resource",
+    },
+}
+
+RELATIONSHIPS = (
+    ("track_presentation_unified", "track_presentation", "unified_presentation_overrides"),
+    ("track_render_model_unified", "track_render_model", "unified_render_model_overrides"),
+    ("track_render_model_instance_unified", "track_render_model_instance", "unified_render_instance_overrides"),
+    ("track_procedural_geometry_resource", "track_pvs_zone_resource", "geometry_vs_visibility_resource_specialization"),
+)
+
+KEY_SLOTS = {
+    "track_presentation_unified": {
+        38: 0x82DF2D40, 52: 0x82DEC6F0, 53: 0x82DEEAE0,
+        68: 0x82DF2528, 77: 0x82DF3AC0, 97: 0x82DF1A98,
+        98: 0x82DF1FD0, 99: 0x82DF2068, 100: 0x82DF2100,
+        101: 0x82DF16B8, 102: 0x82DF16F0, 103: 0x82DEE690,
+        121: 0x82DEB800, 127: 0x82DEC800, 131: 0x82DE6CE0,
+        132: 0x82DF3F00, 133: 0x82DF3CD0,
+    },
+    "track_render_model_unified": {
+        8: 0x82DF2420, 13: 0x82413228, 16: 0x82DF14B8,
+    },
+    "track_render_model_instance_unified": {
+        2: 0x82DEBDF8, 3: 0x82DEBD58, 5: 0x8243BCF8,
+        6: 0x82DEB7B0, 8: 0x8243BC80, 9: 0x824416A0,
+        10: 0x82463710, 11: 0x824416C8, 12: 0x824416B0,
+        13: 0x82DEB7D8, 14: 0x82DEB7F0,
+    },
+    "track_procedural_geometry_resource": {
+        15: 0x82C22E60, 16: 0x82C22EE8, 19: 0x82C22BE0,
+        22: 0x82C222C8,
+    },
+}
+
+
+def parse_function_addresses(paths: list[pathlib.Path]) -> set[int]:
+    functions = set()
+    for path in sorted(paths, key=lambda item: item.as_posix()):
+        for line in path.read_text(encoding="utf-8").splitlines():
+            match = FUNCTION_RE.match(line)
+            if match:
+                functions.add(int(match.group(1), 16))
+    return functions
+
+
+def image_u32(image: bytes, address: int) -> int:
+    offset = address - IMAGE_BASE
+    if offset < 0 or offset + 4 > len(image):
+        raise ValueError(f"image address is out of range: {address:08X}")
+    return int.from_bytes(image[offset : offset + 4], "big")
+
+
+def image_string(image: bytes, address: int) -> str:
+    offset = address - IMAGE_BASE
+    if offset < 0 or offset >= len(image):
+        raise ValueError(f"image string is out of range: {address:08X}")
+    end = image.find(b"\0", offset, min(offset + 160, len(image)))
+    if end < 0:
+        raise ValueError(f"image string is unterminated: {address:08X}")
+    return image[offset:end].decode("ascii")
+
+
+def build(functions: set[int], image: bytes) -> dict:
+    rows = {}
+    slot_tables = {}
+    for name, spec in CLASSES.items():
+        vtable = spec["vtable"]
+        locator = image_u32(image, vtable - 4)
+        type_descriptor = image_u32(image, locator + 12)
+        decorated_name = image_string(image, type_descriptor + 8)
+        if decorated_name != spec["decorated_name"]:
+            raise ValueError(f"{name} RTTI evidence drifted")
+        slots = [image_u32(image, vtable + index * 4) for index in range(spec["slots"])]
+        if slots[0] != spec["destructor"]:
+            raise ValueError(f"{name} deleting destructor drifted")
+        if any(target not in functions for target in slots):
+            raise ValueError(f"{name} vtable contains a non-AOT target")
+        for index, target in KEY_SLOTS.get(name, {}).items():
+            if slots[index] != target:
+                raise ValueError(f"{name} key slot {index} drifted")
+        slot_tables[name] = slots
+        rows[name] = {
+            "decorated_name": decorated_name,
+            "complete_object_locator": f"{locator:08X}",
+            "type_descriptor": f"{type_descriptor:08X}",
+            "vtable_address": f"{vtable:08X}",
+            "vtable_slot_count": len(slots),
+            "deleting_destructor": f"{slots[0]:08X}",
+            "role": spec["role"],
+        }
+
+    comparisons = []
+    for derived, baseline, label in RELATIONSHIPS:
+        derived_slots = slot_tables[derived]
+        baseline_slots = slot_tables[baseline]
+        if len(derived_slots) != len(baseline_slots):
+            raise ValueError(f"{label} vtable length mismatch")
+        changed = [
+            {
+                "slot": index,
+                "derived_target": f"{target:08X}",
+                "baseline_target": f"{baseline_slots[index]:08X}",
+            }
+            for index, target in enumerate(derived_slots)
+            if target != baseline_slots[index]
+        ]
+        if not changed:
+            raise ValueError(f"{label} has no specialized slots")
+        comparisons.append({
+            "classification": label,
+            "derived_class": derived,
+            "baseline_class": baseline,
+            "changed_slot_count": len(changed),
+            "changed_slots": changed,
+        })
+
+    return {
+        "schema": SCHEMA,
+        "status": "complete",
+        "classification": "title_track_world_ingress_statically_proved",
+        "classes": rows,
+        "specialization_comparisons": comparisons,
+        "passive_observation_candidates": {
+            name: [
+                {"slot": index, "target": f"{target:08X}"}
+                for index, target in sorted(slots.items())
+            ]
+            for name, slots in KEY_SLOTS.items()
+        },
+        "next_runtime_join": {
+            "source": "title_track_presentation_model_and_world_resource_lifetimes",
+            "destination": "proceduralGeometry_CProceduralModels_prepared_record_identity",
+            "proved": False,
+            "required_evidence": "exact_shared_object_or_resource_identity_at_both_boundaries",
+        },
+        "safety": {
+            "static_analysis_only": True,
+            "guest_payload_exported": False,
+            "runtime_hook_enabled": False,
+            "native_admission": False,
+            "suppression_allowed": False,
+            "xenos_authority_required": True,
+        },
+    }
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("generated_root", type=pathlib.Path)
+    parser.add_argument("--image", required=True, type=pathlib.Path)
+    parser.add_argument("--output", required=True, type=pathlib.Path)
+    args = parser.parse_args(argv)
+    try:
+        paths = list(args.generated_root.glob("pinyon_shift_recomp.*.cpp"))
+        if not paths:
+            raise ValueError("no generated AOT C++ files found")
+        document = build(parse_function_addresses(paths), args.image.read_bytes())
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(json.dumps(document, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+        return 0
+    except (OSError, UnicodeDecodeError, ValueError) as error:
+        print(f"native renderer track-ingress discovery failed: {error}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/tests/test_native_renderer_track_ingress.py
+++ b/tools/tests/test_native_renderer_track_ingress.py
@@ -1,0 +1,105 @@
+import importlib.util
+import sys
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+TOOL = ROOT / "tools" / "discover-native-renderer-track-ingress.py"
+SPEC = importlib.util.spec_from_file_location("native_track_ingress", TOOL)
+assert SPEC and SPEC.loader
+MODULE = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = MODULE
+SPEC.loader.exec_module(MODULE)
+
+
+def fixture():
+    next_locator = 0x82370000
+    next_type = 0x832C0000
+    highest = next_type + len(MODULE.CLASSES) * 0x100 + 0x200
+    image = bytearray(highest - MODULE.IMAGE_BASE)
+    functions = set()
+
+    def u32(address, value):
+        offset = address - MODULE.IMAGE_BASE
+        image[offset : offset + 4] = value.to_bytes(4, "big")
+
+    tables = {}
+    for class_index, (name, spec) in enumerate(MODULE.CLASSES.items()):
+        slots = [
+            0x82800000 + class_index * 0x1000 + index * 4
+            for index in range(spec["slots"])
+        ]
+        slots[0] = spec["destructor"]
+        for index, target in MODULE.KEY_SLOTS.get(name, {}).items():
+            slots[index] = target
+        tables[name] = slots
+
+    for derived, baseline, _ in MODULE.RELATIONSHIPS:
+        if tables[derived] == tables[baseline]:
+            tables[derived][1] += 4
+
+    for class_index, (name, spec) in enumerate(MODULE.CLASSES.items()):
+        locator = next_locator + class_index * 0x20
+        type_descriptor = next_type + class_index * 0x100
+        u32(spec["vtable"] - 4, locator)
+        u32(locator + 12, type_descriptor)
+        encoded = spec["decorated_name"].encode() + b"\0"
+        offset = type_descriptor + 8 - MODULE.IMAGE_BASE
+        image[offset : offset + len(encoded)] = encoded
+        for index, target in enumerate(tables[name]):
+            u32(spec["vtable"] + index * 4, target)
+            functions.add(target)
+    return functions, bytes(image)
+
+
+class NativeRendererTrackIngressTests(unittest.TestCase):
+    def test_proves_title_track_world_ingress_without_admission(self):
+        functions, image = fixture()
+        document = MODULE.build(functions, image)
+        self.assertEqual("complete", document["status"])
+        self.assertEqual(
+            "title_track_world_ingress_statically_proved",
+            document["classification"],
+        )
+        self.assertEqual(
+            135,
+            document["classes"]["track_presentation_unified"]["vtable_slot_count"],
+        )
+        self.assertEqual(
+            "82DF3F00",
+            next(
+                row["target"]
+                for row in document["passive_observation_candidates"][
+                    "track_presentation_unified"
+                ]
+                if row["slot"] == 132
+            ),
+        )
+        self.assertFalse(document["next_runtime_join"]["proved"])
+        self.assertFalse(document["safety"]["runtime_hook_enabled"])
+        self.assertFalse(document["safety"]["suppression_allowed"])
+
+    def test_rejects_rtti_drift(self):
+        functions, image = fixture()
+        corrupted = bytearray(image)
+        spec = MODULE.CLASSES["track_mesh"]
+        locator = MODULE.image_u32(image, spec["vtable"] - 4)
+        type_descriptor = MODULE.image_u32(image, locator + 12)
+        corrupted[type_descriptor + 8 - MODULE.IMAGE_BASE] = ord("!")
+        with self.assertRaisesRegex(ValueError, "track_mesh RTTI evidence drifted"):
+            MODULE.build(functions, bytes(corrupted))
+
+    def test_rejects_key_slot_drift(self):
+        functions, image = fixture()
+        corrupted = bytearray(image)
+        spec = MODULE.CLASSES["track_presentation_unified"]
+        offset = spec["vtable"] + 132 * 4 - MODULE.IMAGE_BASE
+        corrupted[offset : offset + 4] = (0x82DF3F04).to_bytes(4, "big")
+        functions.add(0x82DF3F04)
+        with self.assertRaisesRegex(ValueError, "key slot 132 drifted"):
+            MODULE.build(functions, bytes(corrupted))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- prove exact retail RTTI and complete AOT-backed vtables for 13 track presentation, model, mesh, procedural-geometry, and PVS resource classes
- enumerate unified specialization slots and reviewed passive observation candidates
- document the next exact-identity runtime join while keeping Xenos authoritative

## Validation
- python -m unittest discover -s tools/tests -p test_*.py (499 passed)
- retail-image discovery report generated successfully
- git diff --check