### PR TITLE
feat(native-renderer): join track texture ingress

### DIFF
--- a/docs/native-renderer/REPRIORITIZED_PLAN.md
+++ b/docs/native-renderer/REPRIORITIZED_PLAN.md
@@ -245,6 +245,13 @@ graph. The next batched slice is the passive exact-identity runtime join from
 those title-owned lifetimes to the existing procedural-model prepared-record
 boundary; this checkpoint does not enable native admission or suppression.
 
+Runtime identity checkpoint: the existing matched AppData evidence joins all
+867 aggregated procedural-model submission entries (397,142 calls) to the
+exact `Presentation_Unified::CTrackTexture_Unified` provider vtable and its
+four proved resource-provider methods. This proves track-owned texture ingress
+at the prepared-record boundary without a new capture. Track model/mesh or
+world-section identity is still required before terrain/road visual admission.
+
 ### C2. Static world buildings and props
 
 - Expand opaque-world material and geometry coverage.

--- a/docs/native-renderer/TERRAIN_ROAD_RENDER_PATH.md
+++ b/docs/native-renderer/TERRAIN_ROAD_RENDER_PATH.md
@@ -210,3 +210,25 @@ slice may observe only the reviewed title lifecycle boundaries and must join an
 exact shared object or resource identity to
 `proceduralGeometry::CProceduralModels`. Xenos remains authoritative; native
 admission and suppression remain disabled.
+
+## Exact track-texture provider join
+
+The previously captured AppData session `20260831T004400Z-p35676` already
+contains the first exact title-to-prepared-record identity join. Its complete
+semantic-submission report contains 867 aggregated entries and 397,142 live
+submission calls. Every entry resolves its primary resource through vtable
+`82001708`. Retail RTTI identifies that vtable as
+`Presentation_Unified::CTrackTexture_Unified`, and all four observed provider
+methods match its exact slots 6, 9, 10, and 11 (vtable byte offsets 24, 36, 40,
+and 44).
+
+`tools/summarize-native-renderer-track-world-join.py` validates that join from
+the payload-free static-ingress and semantic-submission reports. It records
+the track provider coverage without re-reading captured payloads or requiring
+another game run.
+
+This closes track-owned texture-provider identity at the procedural-model
+prepared-record boundary. It does not yet prove that any joined geometry is a
+terrain or road mesh: the next join must carry track model, mesh, submodel, or
+world-section resource identity to the same records. Native admission and
+suppression therefore remain disabled and every call still replays on Xenos.

--- a/tools/discover-native-renderer-track-ingress.py
+++ b/tools/discover-native-renderer-track-ingress.py
@@ -57,6 +57,20 @@ CLASSES = {
         "destructor": 0x82DEA6B8,
         "role": "active_unified_track_render_instance",
     },
+    "track_texture": {
+        "decorated_name": ".?AVCTrackTexture@@",
+        "vtable": 0x822433D8,
+        "slots": 14,
+        "destructor": 0x82DEA608,
+        "role": "legacy_track_texture_provider_baseline",
+    },
+    "track_texture_unified": {
+        "decorated_name": ".?AVCTrackTexture_Unified@Presentation_Unified@@",
+        "vtable": 0x82001708,
+        "slots": 14,
+        "destructor": 0x82DF13C8,
+        "role": "active_unified_track_texture_provider",
+    },
     "track_model": {
         "decorated_name": ".?AVCTrackModel@@",
         "vtable": 0x820016B4,
@@ -112,6 +126,7 @@ RELATIONSHIPS = (
     ("track_presentation_unified", "track_presentation", "unified_presentation_overrides"),
     ("track_render_model_unified", "track_render_model", "unified_render_model_overrides"),
     ("track_render_model_instance_unified", "track_render_model_instance", "unified_render_instance_overrides"),
+    ("track_texture_unified", "track_texture", "unified_track_texture_overrides"),
     ("track_procedural_geometry_resource", "track_pvs_zone_resource", "geometry_vs_visibility_resource_specialization"),
 )
 
@@ -132,6 +147,12 @@ KEY_SLOTS = {
         6: 0x82DEB7B0, 8: 0x8243BC80, 9: 0x824416A0,
         10: 0x82463710, 11: 0x824416C8, 12: 0x824416B0,
         13: 0x82DEB7D8, 14: 0x82DEB7F0,
+    },
+    "track_texture_unified": {
+        6: 0x824107C8,
+        9: 0x824108D0,
+        10: 0x82DF1300,
+        11: 0x82DF0B40,
     },
     "track_procedural_geometry_resource": {
         15: 0x82C22E60, 16: 0x82C22EE8, 19: 0x82C22BE0,

--- a/tools/summarize-native-renderer-track-world-join.py
+++ b/tools/summarize-native-renderer-track-world-join.py
@@ -1,0 +1,181 @@
+"""Join track RTTI identity to procedural-model semantic submissions."""
+
+from __future__ import annotations
+
+import argparse
+import collections
+import json
+import pathlib
+import sys
+
+
+SCHEMA = "pinyon-shift.native-renderer-track-world-join.v1"
+INGRESS_SCHEMA = "pinyon-shift.native-renderer-track-ingress.v1"
+SUBMISSION_SCHEMA = "pinyon-shift.native-renderer-semantic-submissions.v4"
+TRACK_TEXTURE_CLASS = "track_texture_unified"
+PROVIDER_METHOD_SLOTS = (6, 9, 10, 11)
+
+
+def _validate_input(ingress: dict, submissions: dict) -> tuple[str, tuple[str, ...]]:
+    if ingress.get("schema") != INGRESS_SCHEMA or ingress.get("status") != "complete":
+        raise ValueError("track-ingress static proof is incomplete or unsupported")
+    if (
+        ingress.get("classification")
+        != "title_track_world_ingress_statically_proved"
+    ):
+        raise ValueError("track-ingress classification drifted")
+    ingress_safety = ingress.get("safety", {})
+    if (
+        ingress_safety.get("runtime_hook_enabled") is not False
+        or ingress_safety.get("native_admission") is not False
+        or ingress_safety.get("suppression_allowed") is not False
+        or ingress_safety.get("xenos_authority_required") is not True
+    ):
+        raise ValueError("track-ingress safety boundary drifted")
+
+    if (
+        submissions.get("schema") != SUBMISSION_SCHEMA
+        or submissions.get("status") != "complete"
+    ):
+        raise ValueError("semantic-submission report is incomplete or unsupported")
+    submission_safety = submissions.get("safety", {})
+    if (
+        submission_safety.get("native_draw") is not False
+        or submission_safety.get("suppression_allowed") is not False
+        or submission_safety.get("xenos_authority") is not True
+    ):
+        raise ValueError("semantic-submission safety boundary drifted")
+
+    texture = ingress.get("classes", {}).get(TRACK_TEXTURE_CLASS, {})
+    vtable = str(texture.get("vtable_address", ""))
+    if (
+        texture.get("decorated_name")
+        != ".?AVCTrackTexture_Unified@Presentation_Unified@@"
+        or vtable != "82001708"
+        or texture.get("vtable_slot_count") != 14
+    ):
+        raise ValueError("unified track-texture RTTI identity drifted")
+    candidates = ingress.get("passive_observation_candidates", {}).get(
+        TRACK_TEXTURE_CLASS, []
+    )
+    by_slot = {int(row.get("slot", -1)): str(row.get("target", "")) for row in candidates}
+    methods = tuple(by_slot.get(slot, "") for slot in PROVIDER_METHOD_SLOTS)
+    if methods != ("824107C8", "824108D0", "82DF1300", "82DF0B40"):
+        raise ValueError("unified track-texture provider methods drifted")
+    return vtable, methods
+
+
+def build(ingress: dict, submissions: dict) -> dict:
+    track_vtable, expected_methods = _validate_input(ingress, submissions)
+    matched = []
+    matched_calls = 0
+    unmatched_calls = 0
+    method_mismatch_calls = 0
+    resource_keys: collections.Counter[str] = collections.Counter()
+    provider_selections: collections.Counter[str] = collections.Counter()
+    object_sources: collections.Counter[str] = collections.Counter()
+    first_frame = None
+    last_frame = None
+
+    for entry in submissions.get("entries", []):
+        calls = int(entry.get("calls", 0))
+        resources = entry.get("resources", {})
+        provider = resources.get("primary_provider", {})
+        if str(provider.get("vtable", "")) != track_vtable:
+            unmatched_calls += calls
+            continue
+        methods = tuple(
+            str(provider.get(key, ""))
+            for key in (
+                "predicate_24_method",
+                "primary_36_method",
+                "fallback_40_method",
+                "predicate_44_method",
+            )
+        )
+        if methods != expected_methods:
+            method_mismatch_calls += calls
+            continue
+        frames = entry.get("frames", [])
+        if len(frames) != 2:
+            raise ValueError("semantic-submission frame range is malformed")
+        matched.append(str(entry.get("key", "")))
+        matched_calls += calls
+        first_frame = frames[0] if first_frame is None else min(first_frame, frames[0])
+        last_frame = frames[1] if last_frame is None else max(last_frame, frames[1])
+        resource_keys[str(resources.get("primary_key", ""))] += calls
+        provider_selections[str(provider.get("selection", ""))] += calls
+        object_sources[str(provider.get("object_source", ""))] += calls
+
+    failures = []
+    if not matched:
+        failures.append("no procedural-model submission joins the track texture provider")
+    if method_mismatch_calls:
+        failures.append("track texture provider method tuple drifted at runtime")
+
+    return {
+        "schema": SCHEMA,
+        "session": submissions.get("session"),
+        "status": "complete" if not failures else "incomplete",
+        "failures": failures,
+        "classification": "exact_track_texture_provider_to_prepared_record_join",
+        "track_provider": {
+            "class": "Presentation_Unified::CTrackTexture_Unified",
+            "decorated_name": ".?AVCTrackTexture_Unified@Presentation_Unified@@",
+            "vtable": track_vtable,
+            "provider_method_vtable_offsets": [24, 36, 40, 44],
+            "provider_methods": list(expected_methods),
+        },
+        "coverage": {
+            "matched_submission_entries": len(matched),
+            "matched_submission_calls": matched_calls,
+            "unmatched_submission_calls": unmatched_calls,
+            "method_mismatch_calls": method_mismatch_calls,
+            "first_frame": first_frame,
+            "last_frame": last_frame,
+            "resource_keys_by_calls": dict(sorted(resource_keys.items())),
+            "provider_selections_by_calls": dict(sorted(provider_selections.items())),
+            "object_sources_by_calls": dict(sorted(object_sources.items())),
+        },
+        "remaining_identity_gap": {
+            "track_texture_ownership_proved": bool(matched),
+            "track_model_or_mesh_ownership_proved": False,
+            "terrain_or_road_visual_identity_proved": False,
+            "next_join": "track_model_mesh_or_world_section_to_same_prepared_records",
+        },
+        "safety": {
+            "payload_free_report": True,
+            "runtime_hook_added": False,
+            "guest_state_changed": False,
+            "native_admission": False,
+            "suppression_allowed": False,
+            "xenos_authority": True,
+        },
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--ingress", required=True, type=pathlib.Path)
+    parser.add_argument("--submissions", required=True, type=pathlib.Path)
+    parser.add_argument("--output", type=pathlib.Path)
+    args = parser.parse_args(argv)
+    try:
+        report = build(
+            json.loads(args.ingress.read_text(encoding="utf-8")),
+            json.loads(args.submissions.read_text(encoding="utf-8")),
+        )
+    except (OSError, ValueError, json.JSONDecodeError) as error:
+        print(f"error: {error}", file=sys.stderr)
+        return 2
+    payload = json.dumps(report, indent=2, sort_keys=True) + "\n"
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(payload, encoding="utf-8")
+    else:
+        print(payload, end="")
+    return 0 if report["status"] == "complete" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/tests/test_native_renderer_track_world_join.py
+++ b/tools/tests/test_native_renderer_track_world_join.py
@@ -1,0 +1,120 @@
+import copy
+import importlib.util
+import sys
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+TOOL = ROOT / "tools" / "summarize-native-renderer-track-world-join.py"
+SPEC = importlib.util.spec_from_file_location("native_track_world_join", TOOL)
+assert SPEC and SPEC.loader
+MODULE = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = MODULE
+SPEC.loader.exec_module(MODULE)
+
+
+def ingress():
+    return {
+        "schema": "pinyon-shift.native-renderer-track-ingress.v1",
+        "status": "complete",
+        "classification": "title_track_world_ingress_statically_proved",
+        "classes": {
+            "track_texture_unified": {
+                "decorated_name": ".?AVCTrackTexture_Unified@Presentation_Unified@@",
+                "vtable_address": "82001708",
+                "vtable_slot_count": 14,
+            }
+        },
+        "passive_observation_candidates": {
+            "track_texture_unified": [
+                {"slot": 6, "target": "824107C8"},
+                {"slot": 9, "target": "824108D0"},
+                {"slot": 10, "target": "82DF1300"},
+                {"slot": 11, "target": "82DF0B40"},
+            ]
+        },
+        "safety": {
+            "runtime_hook_enabled": False,
+            "native_admission": False,
+            "suppression_allowed": False,
+            "xenos_authority_required": True,
+        },
+    }
+
+
+def submissions():
+    return {
+        "schema": "pinyon-shift.native-renderer-semantic-submissions.v4",
+        "session": "track-session",
+        "status": "complete",
+        "entries": [
+            {
+                "key": "0123456789ABCDEF",
+                "calls": 12,
+                "frames": [10, 30],
+                "resources": {
+                    "primary_key": "00004C8A",
+                    "primary_provider": {
+                        "vtable": "82001708",
+                        "predicate_24_method": "824107C8",
+                        "primary_36_method": "824108D0",
+                        "fallback_40_method": "82DF1300",
+                        "predicate_44_method": "82DF0B40",
+                        "selection": "primary_method_36",
+                        "object_source": "provider_method",
+                    },
+                },
+            },
+            {
+                "key": "1111111111111111",
+                "calls": 3,
+                "frames": [12, 14],
+                "resources": {
+                    "primary_key": "00000001",
+                    "primary_provider": {"vtable": "8200AAAA"},
+                },
+            },
+        ],
+        "safety": {
+            "native_draw": False,
+            "suppression_allowed": False,
+            "xenos_authority": True,
+        },
+    }
+
+
+class NativeRendererTrackWorldJoinTests(unittest.TestCase):
+    def test_joins_exact_track_provider_without_native_admission(self):
+        report = MODULE.build(ingress(), submissions())
+        self.assertEqual("complete", report["status"])
+        self.assertEqual(1, report["coverage"]["matched_submission_entries"])
+        self.assertEqual(12, report["coverage"]["matched_submission_calls"])
+        self.assertEqual(3, report["coverage"]["unmatched_submission_calls"])
+        self.assertTrue(
+            report["remaining_identity_gap"]["track_texture_ownership_proved"]
+        )
+        self.assertFalse(
+            report["remaining_identity_gap"]["track_model_or_mesh_ownership_proved"]
+        )
+        self.assertFalse(report["safety"]["native_admission"])
+        self.assertFalse(report["safety"]["suppression_allowed"])
+
+    def test_rejects_runtime_provider_method_drift(self):
+        sample = submissions()
+        sample["entries"][0]["resources"]["primary_provider"][
+            "primary_36_method"
+        ] = "824108D4"
+        report = MODULE.build(ingress(), sample)
+        self.assertEqual("incomplete", report["status"])
+        self.assertEqual(12, report["coverage"]["method_mismatch_calls"])
+
+    def test_rejects_native_submission_report(self):
+        sample = copy.deepcopy(submissions())
+        sample["safety"]["native_draw"] = True
+        with self.assertRaisesRegex(ValueError, "safety boundary drifted"):
+            MODULE.build(ingress(), sample)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- extend the exact RTTI census to the legacy and unified track texture providers
- join the unified provider vtable and four resource methods to the existing procedural-model submission report
- record 867 matched entries / 397,142 calls with zero unmatched calls while keeping model/mesh identity and native admission fail-closed

## Validation
- python -m unittest discover -s tools/tests -p test_*.py (502 passed)
- retail static-ingress report generated successfully
- AppData session 20260831T004400Z-p35676 semantic report re-summarized successfully; no new game run
- git diff --check