### PR TITLE
feat(native-renderer): filter track workset lineage

### DIFF
--- a/docs/native-renderer/CONTINUOUS_WORLD_WORKSET.md
+++ b/docs/native-renderer/CONTINUOUS_WORLD_WORKSET.md
@@ -15,7 +15,8 @@ capture wrapper's `-ContinuousWorldWorkset` switch. The mode requires renderer
 census and semantic dispatch discovery so every admitted draw has:
 
 - a mechanically replayable prepared-draw contract;
-- either a current, selected semantic visibility decision or the exact,
+- either a current, selected semantic visibility decision carrying the exact
+  unified track-texture provider vtable and four-method tuple, or the exact
   previously qualified sky/horizon follower signature; and
 - exact title-to-backend lineage.
 
@@ -58,7 +59,8 @@ requires at least three strictly increasing output markers with exact matching
 frame and retained-frame identifiers; every waiting marker must retain Xenos
 authority with suppression disabled.
 It reports the exact-family seed count separately as
-`qualified_retained_family_requests`.
+`qualified_retained_family_requests`, and reports fresh visibility candidates
+excluded by the track-provider gate as `non_track_provider_rejections`.
 Build a payload-free qualification report with:
 
 ```powershell
@@ -67,9 +69,9 @@ python .\tools\summarize-native-renderer-continuous-world-workset.py `
   --output .local\qualification\continuous-world-workset.json
 ```
 
-Qualification requires at least one complete frame with multiple accumulated
-draws, zero replay or frame failures, exact accounting, preserved Xenos draws,
-and disabled suppression.
+Qualification requires at least one exact track-provider visibility request,
+one complete frame with multiple accumulated draws, zero replay or frame
+failures, exact accounting, preserved Xenos draws, and disabled suppression.
 
 ## Safety boundary
 
@@ -78,7 +80,11 @@ and disabled suppression.
 - Output selection remains controlled by the existing renderer selector.
 - The mode performs no readback and no guest-target publication.
 - Missing semantic lineage, incompatible replay experiments, stale visibility,
-  capacity exhaustion, or replay failure yields without weakening freshness.
+  non-track provider identity, capacity exhaustion, or replay failure yields
+  without weakening freshness.
+- Track-texture ownership is a precision filter for the existing prototype
+  workset. It is not a terrain/road mesh ownership claim and does not satisfy
+  the C1 semantic-family admission gate by itself.
 - This checkpoint does not yet prove recognizable world coverage; that requires
   a clean build, an AppData run, and visual inspection after the broader Phase B
   implementation batch is ready.

--- a/docs/native-renderer/REPRIORITIZED_PLAN.md
+++ b/docs/native-renderer/REPRIORITIZED_PLAN.md
@@ -252,6 +252,14 @@ four proved resource-provider methods. This proves track-owned texture ingress
 at the prepared-record boundary without a new capture. Track model/mesh or
 world-section identity is still required before terrain/road visual admission.
 
+Implementation checkpoint: the exact track-texture provider tuple is carried
+through semantic draw identity into the fresh visibility-prepared records. The
+default-off continuous prototype workset now admits ordinary fresh candidates
+only with that tuple and accounts all non-track exclusions; its independently
+qualified sky/horizon seed remains available. Runtime qualification is deferred
+to the next batched build/AppData checkpoint. This precision filter is not yet
+a terrain/road mesh identity or C1 family-admission claim.
+
 ### C2. Static world buildings and props
 
 - Expand opaque-world material and geometry coverage.

--- a/docs/native-renderer/TERRAIN_ROAD_RENDER_PATH.md
+++ b/docs/native-renderer/TERRAIN_ROAD_RENDER_PATH.md
@@ -232,3 +232,17 @@ prepared-record boundary. It does not yet prove that any joined geometry is a
 terrain or road mesh: the next join must carry track model, mesh, submodel, or
 world-section resource identity to the same records. Native admission and
 suppression therefore remain disabled and every call still replays on Xenos.
+
+## Prepared-workset provider filter
+
+The runtime now carries that exact primary-provider tuple through the semantic
+draw identity and fresh visibility-prepared candidate record. The existing
+default-off continuous prototype workset rejects fresh visibility candidates
+without it, while retaining the separately qualified sky/horizon seed. Its
+summary accounts `non_track_provider_rejections`, and the payload-free
+prepared-candidate report partitions exact provider entries and draws.
+
+This is an implementation checkpoint pending the next batched preview build
+and AppData-backed run. It narrows the prototype's existing private native
+replay; it does not identify terrain/road geometry, enable C1 family admission,
+enable suppression, or change Xenos authority.

--- a/src/native_renderer/graphics_hooks.cpp
+++ b/src/native_renderer/graphics_hooks.cpp
@@ -160,6 +160,11 @@ constexpr size_t kSemanticTransformWordCount = 192 / sizeof(uint32_t);
 constexpr uint64_t kSemanticObservationPayloadBytes = 380;
 constexpr uint64_t kSemanticSubmissionMaximumPayloadBytes = 64;
 constexpr uint32_t kResourceBindingKeyCacheAddress = 0x834AD4CC;
+constexpr uint32_t kTrackTextureUnifiedVtable = 0x82001708;
+constexpr uint32_t kTrackTexturePredicate24Method = 0x824107C8;
+constexpr uint32_t kTrackTexturePrimary36Method = 0x824108D0;
+constexpr uint32_t kTrackTextureFallback40Method = 0x82DF1300;
+constexpr uint32_t kTrackTexturePredicate44Method = 0x82DF0B40;
 constexpr uint64_t kSkyHorizonAnchorSignature = UINT64_C(0x747837906D0BF484);
 constexpr uint64_t kSkyHorizonFollowerSignature = UINT64_C(0x1D253A52B55C9FB3);
 constexpr uint64_t kShadowDepthVertexShader = UINT64_C(0x4E1DA281CC3D7EDB);
@@ -435,6 +440,7 @@ struct SemanticDrawIdentity {
       SemanticVisibilityWorksetJoin::kMissing;
   bool secondary_resource_present = false;
   bool title_lod_valid = false;
+  bool track_texture_provider = false;
   bool valid = false;
 };
 
@@ -561,6 +567,7 @@ struct SemanticVisibilityPreparedCandidateEntry {
   uint32_t mechanical_rejection_mask = 0;
   bool mechanically_eligible = false;
   bool title_lod_valid = false;
+  bool track_texture_provider = false;
 };
 
 struct SemanticBatchRun {
@@ -6058,6 +6065,7 @@ struct IsolatedDrawState {
       ShadowDepthBatchFamily::kNone;
   bool prepared_visibility_candidate_fresh = false;
   bool prepared_title_lod_valid = false;
+  bool prepared_track_texture_provider = false;
   bool require_fresh_visibility_candidate = false;
   bool require_title_lod_candidate = false;
   bool auto_select_fresh_visibility_candidate = false;
@@ -6155,6 +6163,7 @@ struct ContinuousWorldWorksetState {
   uint64_t unsupported = 0;
   uint64_t mechanical_rejections = 0;
   uint64_t stale_or_unselected_rejections = 0;
+  uint64_t non_track_provider_rejections = 0;
   uint64_t per_frame_quota_yields = 0;
   uint64_t fail_closed_yields = 0;
   uint64_t qualified_retained_family_requests = 0;
@@ -6911,7 +6920,7 @@ void ValidateAndEmitContinuousWorldWorksetConfiguration() {
        {"activation", "startup_environment_only"},
        {"default_enabled", "false"},
        {"selection",
-        "fresh_visibility_or_qualified_sky_horizon_and_mechanical"},
+        "fresh_track_texture_provider_visibility_or_qualified_sky_horizon_and_mechanical"},
        {"maximum_draws_per_frame",
         std::to_string(kContinuousWorldWorksetMaximumDrawsPerFrame)},
        {"target_lifetime", "one_guest_frame"},
@@ -7876,6 +7885,15 @@ bool IsResolvedSemanticResourceProviderProvenance(
          selected_provider_path && produced_object;
 }
 
+bool IsUnifiedTrackTextureProvider(
+    const SemanticResourceProviderProvenance &provider) {
+  return provider.provider_vtable == kTrackTextureUnifiedVtable &&
+         provider.predicate_24_method == kTrackTexturePredicate24Method &&
+         provider.primary_36_method == kTrackTexturePrimary36Method &&
+         provider.fallback_40_method == kTrackTextureFallback40Method &&
+         provider.predicate_44_method == kTrackTexturePredicate44Method;
+}
+
 void PublishProceduralModelResourceBinding(
     uint32_t binding_slot, uint32_t bound_resource_object,
     const SemanticResourceProviderProvenance &provider) {
@@ -8453,7 +8471,8 @@ void JoinProceduralModelSemanticDraw(uint64_t submission_key,
                                      uint32_t helper_state,
                                      uint32_t primary_resource_key,
                                      uint32_t secondary_resource_key,
-                                     bool secondary_resource_present) {
+                                     bool secondary_resource_present,
+                                     bool track_texture_provider) {
   if (!g_semantic_render_item_stack_depth) {
     g_semantic_draw_scope_mismatches.fetch_add(1,
                                                 std::memory_order_relaxed);
@@ -8477,6 +8496,7 @@ void JoinProceduralModelSemanticDraw(uint64_t submission_key,
   semantic_draw.primary_resource_key = primary_resource_key;
   semantic_draw.secondary_resource_key = secondary_resource_key;
   semantic_draw.secondary_resource_present = secondary_resource_present;
+  semantic_draw.track_texture_provider = track_texture_provider;
   semantic_draw.valid = true;
   g_semantic_draw_scope_joins.fetch_add(1, std::memory_order_relaxed);
 }
@@ -8696,11 +8716,13 @@ void RecordProceduralModelGeometrySubmission(
     key = HashCombine(key, value);
   }
   key = key ? key : 1;
+  const bool track_texture_provider =
+      IsUnifiedTrackTextureProvider(pending.primary_provider);
   JoinProceduralModelSemanticDraw(
       key, receiver_address, receiver_generation, record_index,
       descriptor_address, runtime_address, descriptor_kind, helper_state,
       primary_resource_key, secondary_resource_key,
-      secondary_resource_present);
+      secondary_resource_present, track_texture_provider);
 
   size_t index = size_t(key % kSemanticSubmissionCapacity);
   for (size_t probe = 0; probe < kSemanticSubmissionCapacity; ++probe) {
@@ -13645,6 +13667,7 @@ bool RecordSemanticVisibilityPreparedCandidate(
         uint64_t(identity.visibility_result_mask),
         uint64_t(identity.title_lod_valid),
         uint64_t(identity.title_lod_index),
+        uint64_t(identity.track_texture_provider),
         uint64_t(mechanical_rejection_mask)}) {
     key = HashCombine(key, value);
   }
@@ -13680,6 +13703,7 @@ bool RecordSemanticVisibilityPreparedCandidate(
           .mechanical_rejection_mask = mechanical_rejection_mask,
           .mechanically_eligible = !mechanical_rejection_mask,
           .title_lod_valid = identity.title_lod_valid,
+          .track_texture_provider = identity.track_texture_provider,
       };
       ++g_semantic_visibility_prepared_candidate_count;
       return true;
@@ -13702,7 +13726,8 @@ bool RecordSemanticVisibilityPreparedCandidate(
         entry.visibility_category == identity.visibility_category &&
         entry.visibility_result_mask == identity.visibility_result_mask &&
         entry.title_lod_index == identity.title_lod_index &&
-        entry.title_lod_valid == identity.title_lod_valid) {
+        entry.title_lod_valid == identity.title_lod_valid &&
+        entry.track_texture_provider == identity.track_texture_provider) {
       ++entry.draws;
       entry.last_frame = observation.frame_sequence;
       entry.maximum_policy_age_frames =
@@ -13719,6 +13744,7 @@ bool RecordSemanticVisibilityPreparedCandidate(
 struct SemanticVisibilityPreparedAdmission {
   bool fresh = false;
   bool title_lod_valid = false;
+  bool track_texture_provider = false;
   uint32_t title_lod_index = 0;
 };
 
@@ -13743,6 +13769,8 @@ SemanticVisibilityPreparedAdmission RecordSemanticBatchOpportunity(
   const SemanticVisibilityPreparedAdmission visibility_admission = {
       .fresh = fresh_visibility_candidate,
       .title_lod_valid = fresh_visibility_candidate && identity.title_lod_valid,
+      .track_texture_provider =
+          fresh_visibility_candidate && identity.track_texture_provider,
       .title_lod_index = identity.title_lod_index,
   };
   const SemanticBatchRejection rejection =
@@ -15198,6 +15226,8 @@ void EmitSemanticVisibilityPreparedCandidates() {
   uint64_t mechanically_ineligible_entries = 0;
   uint64_t title_lod_draws = 0;
   uint64_t title_lod_entries = 0;
+  uint64_t track_texture_provider_draws = 0;
+  uint64_t track_texture_provider_entries = 0;
   for (const SemanticVisibilityPreparedCandidateEntry &entry :
        g_semantic_visibility_prepared_candidates) {
     if (!entry.key) {
@@ -15215,6 +15245,10 @@ void EmitSemanticVisibilityPreparedCandidates() {
     if (entry.title_lod_valid) {
       title_lod_draws += entry.draws;
       ++title_lod_entries;
+    }
+    if (entry.track_texture_provider) {
+      track_texture_provider_draws += entry.draws;
+      ++track_texture_provider_entries;
     }
     pinyon_shift::diagnostics::RecordEvent(
         "native_renderer.discovery.semantic_visibility_prepared_candidate_entry",
@@ -15246,6 +15280,10 @@ void EmitSemanticVisibilityPreparedCandidates() {
          {"title_lod_index", std::to_string(entry.title_lod_index)},
          {"title_lod_valid", entry.title_lod_valid ? "true" : "false"},
          {"title_lod_lineage", "exact_visibility_identity_to_prepared_draw"},
+         {"track_texture_provider",
+          entry.track_texture_provider ? "true" : "false"},
+         {"track_texture_provider_lineage",
+          "exact_primary_provider_vtable_and_four_methods"},
          {"draws", std::to_string(entry.draws)},
          {"first_frame", std::to_string(entry.first_frame)},
          {"last_frame", std::to_string(entry.last_frame)},
@@ -15283,7 +15321,9 @@ void EmitSemanticVisibilityPreparedCandidates() {
           entry_draws &&
       mechanically_eligible_entries + mechanically_ineligible_entries ==
           entry_count &&
-      title_lod_draws <= entry_draws && title_lod_entries <= entry_count;
+      title_lod_draws <= entry_draws && title_lod_entries <= entry_count &&
+      track_texture_provider_draws <= entry_draws &&
+      track_texture_provider_entries <= entry_count;
   pinyon_shift::diagnostics::RecordEvent(
       "native_renderer.discovery.semantic_visibility_prepared_candidate_summary",
       {{"status", !g_semantic_visibility_prepared_observations
@@ -15317,6 +15357,10 @@ void EmitSemanticVisibilityPreparedCandidates() {
        {"mechanical_admission_contract", "isolated_draw_v1"},
        {"title_lod_entries", std::to_string(title_lod_entries)},
        {"title_lod_draws", std::to_string(title_lod_draws)},
+       {"track_texture_provider_entries",
+        std::to_string(track_texture_provider_entries)},
+       {"track_texture_provider_draws",
+        std::to_string(track_texture_provider_draws)},
        {"capacity",
         std::to_string(kSemanticVisibilityPreparedCandidateCapacity)},
        {"overflow",
@@ -15328,6 +15372,8 @@ void EmitSemanticVisibilityPreparedCandidates() {
        {"prepared_lineage", "exact_semantic_pm4_prepared_draw"},
        {"selection", "independent_visibility_selected_and_fresh"},
        {"title_lod_lineage", "exact_visibility_identity_to_prepared_draw"},
+       {"track_texture_provider_lineage",
+        "exact_primary_provider_vtable_and_four_methods"},
        {"guest_state_changed", "false"},
        {"control_flow_changed", "false"},
        {"native_upload", "false"},
@@ -15707,6 +15753,8 @@ void ObservePreparedDraw(
         visibility_admission.fresh;
     g_isolated_draw.prepared_title_lod_valid =
         visibility_admission.title_lod_valid;
+    g_isolated_draw.prepared_track_texture_provider =
+        visibility_admission.track_texture_provider;
     g_isolated_draw.prepared_title_lod_index =
         visibility_admission.title_lod_index;
     g_isolated_draw.prepared_candidate_valid = true;
@@ -17097,6 +17145,7 @@ void EmitContinuousWorldWorksetSummary() {
       g_continuous_world_workset.requests +
       g_continuous_world_workset.mechanical_rejections +
       g_continuous_world_workset.stale_or_unselected_rejections +
+      g_continuous_world_workset.non_track_provider_rejections +
       g_continuous_world_workset.per_frame_quota_yields +
       g_continuous_world_workset.fail_closed_yields;
   pinyon_shift::diagnostics::RecordEvent(
@@ -17120,6 +17169,9 @@ void EmitContinuousWorldWorksetSummary() {
        {"stale_or_unselected_rejections",
         std::to_string(
             g_continuous_world_workset.stale_or_unselected_rejections)},
+       {"non_track_provider_rejections",
+        std::to_string(
+            g_continuous_world_workset.non_track_provider_rejections)},
        {"per_frame_quota_yields",
         std::to_string(g_continuous_world_workset.per_frame_quota_yields)},
        {"fail_closed_yields",
@@ -17143,6 +17195,8 @@ void EmitContinuousWorldWorksetSummary() {
             : "false"},
        {"maximum_draws_per_frame",
         std::to_string(kContinuousWorldWorksetMaximumDrawsPerFrame)},
+       {"selection",
+        "fresh_track_texture_provider_visibility_or_qualified_sky_horizon_and_mechanical"},
        {"freshness_commit", "matching_swap_after_complete_accumulation"},
        {"readback", "disabled"},
        {"native_draw", "continuous_world_workset"},
@@ -17483,6 +17537,11 @@ void RequestIsolatedDraw(
     if (!g_isolated_draw.prepared_visibility_candidate_fresh &&
         !qualified_retained_family) {
       ++g_continuous_world_workset.stale_or_unselected_rejections;
+      return;
+    }
+    if (!qualified_retained_family &&
+        !g_isolated_draw.prepared_track_texture_provider) {
+      ++g_continuous_world_workset.non_track_provider_rejections;
       return;
     }
     if (g_continuous_world_workset.current_frame_failed) {

--- a/tools/summarize-native-renderer-continuous-world-workset.py
+++ b/tools/summarize-native-renderer-continuous-world-workset.py
@@ -7,7 +7,11 @@ import pathlib
 import sys
 
 
-SCHEMA = "pinyon-shift.native-renderer-continuous-world-workset.v2"
+SCHEMA = "pinyon-shift.native-renderer-continuous-world-workset.v3"
+SELECTION = (
+    "fresh_track_texture_provider_visibility_or_qualified_"
+    "sky_horizon_and_mechanical"
+)
 CONFIG = "native_renderer.continuous_world_workset.config"
 SUMMARY = "native_renderer.continuous_world_workset.summary"
 OUTPUT_FRAME = "native_renderer.output.frame"
@@ -76,7 +80,7 @@ def build(events, requested_session=None):
         "status": "armed_deferred_private_composition",
         "activation": "startup_environment_only",
         "default_enabled": "false",
-        "selection": "fresh_visibility_or_qualified_sky_horizon_and_mechanical",
+        "selection": SELECTION,
         "maximum_draws_per_frame": "64",
         "target_lifetime": "one_guest_frame",
         "freshness_commit": "matching_swap_after_complete_accumulation",
@@ -97,6 +101,7 @@ def build(events, requested_session=None):
         or summary.get("freshness_commit")
         != "matching_swap_after_complete_accumulation"
         or summary.get("maximum_draws_per_frame") != "64"
+        or summary.get("selection") != SELECTION
     ):
         raise ValueError("workset summary is incomplete")
 
@@ -108,6 +113,7 @@ def build(events, requested_session=None):
         "unsupported",
         "mechanical_rejections",
         "stale_or_unselected_rejections",
+        "non_track_provider_rejections",
         "per_frame_quota_yields",
         "fail_closed_yields",
         "qualified_retained_family_requests",
@@ -129,6 +135,7 @@ def build(events, requested_session=None):
         totals["requests"]
         + totals["mechanical_rejections"]
         + totals["stale_or_unselected_rejections"]
+        + totals["non_track_provider_rejections"]
         + totals["per_frame_quota_yields"]
         + totals["fail_closed_yields"]
     )
@@ -153,6 +160,8 @@ def build(events, requested_session=None):
         failures.append("failed frames do not reconcile with replay fallbacks")
     if not totals["qualified_retained_family_requests"]:
         failures.append("qualified retained-family seed was not observed")
+    if totals["requests"] <= totals["qualified_retained_family_requests"]:
+        failures.append("no track-provider visibility request was observed")
     if not totals["reused_target_requests"]:
         failures.append("no frame accumulated multiple native draws")
     if totals["maximum_draws_per_frame"] != 64:
@@ -232,6 +241,18 @@ def build(events, requested_session=None):
             "native output callbacks are not strictly increasing",
         )
     )
+    track_provider_selection_proved = (
+        not any(
+            message
+            in failures
+            for message in (
+                "prepared selection accounting drifted",
+                "runtime workset status does not match its outcomes",
+                "no track-provider visibility request was observed",
+            )
+        )
+        and totals["requests"] > totals["qualified_retained_family_requests"]
+    )
 
     return {
         "schema": SCHEMA,
@@ -243,6 +264,7 @@ def build(events, requested_session=None):
             "continuous_multi_draw_workset_proved": accumulation_proved,
             "swap_committed_freshness_proved": freshness_proved,
             "clean_xenos_fallback_proved": clean_fallback_proved,
+            "track_provider_selection_proved": track_provider_selection_proved,
             "native_output_markers": len(exact_output_frames),
             "xenos_fallback_markers": len(output_waiting),
             "suppression_allowed": False,

--- a/tools/summarize-native-renderer-visibility-prepared-candidates.py
+++ b/tools/summarize-native-renderer-visibility-prepared-candidates.py
@@ -7,7 +7,7 @@ import pathlib
 import sys
 
 
-SCHEMA = "pinyon-shift.native-renderer-visibility-prepared-candidates.v4"
+SCHEMA = "pinyon-shift.native-renderer-visibility-prepared-candidates.v5"
 STATIC_SCHEMA = "pinyon-shift.native-renderer-dispatch-static.v3"
 CONFIG = (
     "native_renderer.discovery."
@@ -178,6 +178,8 @@ def build(events, static, requested_session=None):
         != "independent_visibility_selected_and_fresh"
         or summary.get("title_lod_lineage")
         != "exact_visibility_identity_to_prepared_draw"
+        or summary.get("track_texture_provider_lineage")
+        != "exact_primary_provider_vtable_and_four_methods"
         or summary.get("mechanical_admission_contract") != "isolated_draw_v1"
     ):
         raise ValueError("prepared-candidate summary is incomplete")
@@ -198,6 +200,8 @@ def build(events, static, requested_session=None):
         "mechanically_ineligible_draws",
         "title_lod_entries",
         "title_lod_draws",
+        "track_texture_provider_entries",
+        "track_texture_provider_draws",
         "capacity",
         "overflow",
         "policy_age_limit_frames",
@@ -238,6 +242,9 @@ def build(events, static, requested_session=None):
             "visibility_result_mask": integer(event, "visibility_result_mask"),
             "title_lod_index": integer(event, "title_lod_index"),
             "title_lod_valid": event.get("title_lod_valid") == "true",
+            "track_texture_provider": (
+                event.get("track_texture_provider") == "true"
+            ),
             "draws": integer(event, "draws"),
             "first_frame": integer(event, "first_frame"),
             "last_frame": integer(event, "last_frame"),
@@ -270,6 +277,9 @@ def build(events, static, requested_session=None):
             or event.get("title_lod_valid") not in ("true", "false")
             or event.get("title_lod_lineage")
             != "exact_visibility_identity_to_prepared_draw"
+            or event.get("track_texture_provider") not in ("true", "false")
+            or event.get("track_texture_provider_lineage")
+            != "exact_primary_provider_vtable_and_four_methods"
             or (item["title_lod_valid"] and item["title_lod_index"] >= 32)
             or integer(event, "policy_age_limit_frames")
             != totals["policy_age_limit_frames"]
@@ -332,6 +342,15 @@ def build(events, static, requested_session=None):
         != sum(entry["draws"] for entry in lod_entries)
     ):
         failures.append("title LOD candidate totals drifted")
+    track_provider_entries = [
+        entry for entry in entries if entry["track_texture_provider"]
+    ]
+    if (
+        totals["track_texture_provider_entries"] != len(track_provider_entries)
+        or totals["track_texture_provider_draws"]
+        != sum(entry["draws"] for entry in track_provider_entries)
+    ):
+        failures.append("track texture provider candidate totals drifted")
     if totals["capacity"] != 4096 or totals["policy_age_limit_frames"] != 1:
         failures.append("prepared-candidate bounds drifted")
     if totals["selected_joins"] > integer(workset, "selected_joins"):
@@ -355,6 +374,9 @@ def build(events, static, requested_session=None):
             "isolated_native_candidate_proved": not failures
             and bool(eligible_entries),
             "title_lod_lineage_proved": not failures and bool(lod_entries),
+            "track_texture_provider_lineage_proved": (
+                not failures and bool(track_provider_entries)
+            ),
             "native_draw_enabled": False,
             "suppression_allowed": False,
         },

--- a/tools/tests/test_native_renderer_continuous_world_workset.py
+++ b/tools/tests/test_native_renderer_continuous_world_workset.py
@@ -23,7 +23,7 @@ def fixture():
         status="armed_deferred_private_composition",
         activation="startup_environment_only",
         default_enabled="false",
-        selection="fresh_visibility_or_qualified_sky_horizon_and_mechanical",
+        selection=MODULE.SELECTION,
         maximum_draws_per_frame="64",
         target_lifetime="one_guest_frame",
         freshness_commit="matching_swap_after_complete_accumulation",
@@ -38,13 +38,14 @@ def fixture():
     summary = event(
         MODULE.SUMMARY,
         status="complete",
-        prepared_observations="17",
+        prepared_observations="19",
         requests="8",
         recorded="8",
         target_creation_failures="0",
         unsupported="0",
         mechanical_rejections="4",
         stale_or_unselected_rejections="3",
+        non_track_provider_rejections="2",
         per_frame_quota_yields="2",
         fail_closed_yields="0",
         qualified_retained_family_requests="2",
@@ -54,6 +55,7 @@ def fixture():
         frames_failed="0",
         accounting_complete="true",
         selection_accounting_complete="true",
+        selection=MODULE.SELECTION,
         maximum_draws_per_frame="64",
         freshness_commit="matching_swap_after_complete_accumulation",
         readback="disabled",
@@ -97,6 +99,9 @@ class ContinuousWorldWorksetTests(unittest.TestCase):
         self.assertIn("request.reuse_target = reuse_target", source)
         self.assertIn("request.defer_preview_publication_until_swap = true", source)
         self.assertIn("qualified_retained_family_requests", source)
+        self.assertIn("prepared_track_texture_provider", source)
+        self.assertIn("kTrackTextureUnifiedVtable = 0x82001708", source)
+        self.assertIn("non_track_provider_rejections", source)
         self.assertIn('"native_renderer.continuous_world_workset.summary"', source)
         self.assertIn('{"xenos_draw", "preserved"}', source)
         self.assertIn('{"draw_suppression", "false"}', source)
@@ -125,6 +130,9 @@ class ContinuousWorldWorksetTests(unittest.TestCase):
         self.assertTrue(
             document["qualification"]["continuous_multi_draw_workset_proved"]
         )
+        self.assertTrue(
+            document["qualification"]["track_provider_selection_proved"]
+        )
         self.assertFalse(document["qualification"]["suppression_allowed"])
 
     def test_rejects_single_draw_frames(self):
@@ -134,6 +142,20 @@ class ContinuousWorldWorksetTests(unittest.TestCase):
         self.assertEqual("incomplete", document["status"])
         self.assertIn(
             "no frame accumulated multiple native draws", document["failures"]
+        )
+
+    def test_rejects_seed_only_workset(self):
+        events = fixture()
+        summary = events[-1]
+        summary["prepared_observations"] = "13"
+        summary["requests"] = "2"
+        summary["recorded"] = "2"
+        summary["qualified_retained_family_requests"] = "2"
+        document = MODULE.build(events)
+        self.assertEqual("incomplete", document["status"])
+        self.assertIn(
+            "no track-provider visibility request was observed",
+            document["failures"],
         )
 
     def test_qualifies_an_accounted_fail_closed_frame(self):

--- a/tools/tests/test_native_renderer_prototype_comparison.py
+++ b/tools/tests/test_native_renderer_prototype_comparison.py
@@ -115,7 +115,8 @@ class NativeRendererPrototypeComparisonTests(unittest.TestCase):
         )
         self.assertIn("qualified_retained_family_requests", hooks)
         self.assertIn(
-            "fresh_visibility_or_qualified_sky_horizon_and_mechanical", hooks
+            "fresh_track_texture_provider_visibility_or_qualified_sky_horizon_and_mechanical",
+            hooks,
         )
         self.assertIn("!g_isolated_draw.prepared_candidate_eligible", hooks)
 

--- a/tools/tests/test_native_renderer_visibility_prepared_candidates.py
+++ b/tools/tests/test_native_renderer_visibility_prepared_candidates.py
@@ -85,6 +85,10 @@ class VisibilityPreparedCandidateReportTests(unittest.TestCase):
             "title_lod_index": "2",
             "title_lod_valid": "true",
             "title_lod_lineage": "exact_visibility_identity_to_prepared_draw",
+            "track_texture_provider": "true",
+            "track_texture_provider_lineage": (
+                "exact_primary_provider_vtable_and_four_methods"
+            ),
             "draws": "7",
             "first_frame": "10",
             "last_frame": "12",
@@ -116,6 +120,8 @@ class VisibilityPreparedCandidateReportTests(unittest.TestCase):
             "mechanical_admission_contract": "isolated_draw_v1",
             "title_lod_entries": "1",
             "title_lod_draws": "7",
+            "track_texture_provider_entries": "1",
+            "track_texture_provider_draws": "7",
             "capacity": "4096",
             "overflow": "0",
             "policy_age_limit_frames": "1",
@@ -124,6 +130,9 @@ class VisibilityPreparedCandidateReportTests(unittest.TestCase):
             "prepared_lineage": "exact_semantic_pm4_prepared_draw",
             "selection": "independent_visibility_selected_and_fresh",
             "title_lod_lineage": "exact_visibility_identity_to_prepared_draw",
+            "track_texture_provider_lineage": (
+                "exact_primary_provider_vtable_and_four_methods"
+            ),
             **self.safety(),
         }
         workset = {
@@ -146,6 +155,11 @@ class VisibilityPreparedCandidateReportTests(unittest.TestCase):
             document["qualification"]["isolated_native_candidate_proved"]
         )
         self.assertTrue(document["qualification"]["title_lod_lineage_proved"])
+        self.assertTrue(
+            document["qualification"][
+                "track_texture_provider_lineage_proved"
+            ]
+        )
 
     def test_build_accepts_candidate_without_title_lod(self):
         events = copy.deepcopy(self.events())
@@ -178,6 +192,21 @@ class VisibilityPreparedCandidateReportTests(unittest.TestCase):
         self.assertEqual(
             7,
             document["mechanical_rejection_draw_counts"]["prepared_pipeline"],
+        )
+
+    def test_build_accepts_non_track_provider_partition(self):
+        events = copy.deepcopy(self.events())
+        entry = next(event for event in events if event["event"] == MODULE.ENTRY)
+        entry["track_texture_provider"] = "false"
+        summary = next(event for event in events if event["event"] == MODULE.SUMMARY)
+        summary["track_texture_provider_entries"] = "0"
+        summary["track_texture_provider_draws"] = "0"
+        document = MODULE.build(events, self.static())
+        self.assertEqual("complete", document["status"])
+        self.assertFalse(
+            document["qualification"][
+                "track_texture_provider_lineage_proved"
+            ]
         )
 
     def test_build_rejects_eligibility_mask_drift(self):


### PR DESCRIPTION
## Summary
- carry the exact unified track-texture provider tuple into semantic prepared candidates
- require exact track-provider lineage for ordinary continuous native world-workset draws
- preserve the qualified sky/horizon seed, Xenos authority, and fail-closed accounting
- update payload-free qualifiers, tests, and the reprioritized roadmap

## Validation
- `python -m unittest discover -s tools/tests -p test_*.py` (504 tests)
- `.\tools\build-preview.ps1 -Parallel 16` (102-patch clean build and final link)