### PR TITLE
feat(native-renderer): join track model dispatch

### DIFF
--- a/config/rexglue/analysis/main-xex.toml
+++ b/config/rexglue/analysis/main-xex.toml
@@ -210,6 +210,21 @@ address = 0x8240EC18
 name = "PinyonShiftObserveVehicleTypedRenderItem"
 registers = ["r11", "r31"]
 
+# Phase C1 exact track-render-model scope. At 0x8240EC80 every title predicate
+# has accepted r31, whose RTTI-proved unified instance owns the unified render
+# model at +4 and its live descriptor through child +48 then +128. The balanced
+# return hook runs immediately after the nested 0x82436468 dispatch. Runtime
+# joins only procedural-model submissions made synchronously inside this exact
+# dynamic-type scope; it changes no registers, guest state, or control flow.
+[[midasm_hook]]
+address = 0x8240EC80
+name = "PinyonShiftObserveTrackRenderModelDispatchEntry"
+registers = ["r31"]
+
+[[midasm_hook]]
+address = 0x8240ECAC
+name = "PinyonShiftObserveTrackRenderModelDispatchExit"
+
 # Immediately before 8240E7B0 submits its 64-byte matrix payload to 82435E78,
 # r22 still owns the original r7 object/reference matrix and r5 points at the
 # fully composed stack payload. Compare both exact live matrices with admitted

--- a/docs/native-renderer/REPRIORITIZED_PLAN.md
+++ b/docs/native-renderer/REPRIORITIZED_PLAN.md
@@ -260,6 +260,14 @@ qualified sky/horizon seed remains available. Runtime qualification is deferred
 to the next batched build/AppData checkpoint. This precision filter is not yet
 a terrain/road mesh identity or C1 family-admission claim.
 
+Next runtime checkpoint: the old typed-render-item evidence is now correctly
+classified by RTTI as the unified track render-model instance/model pair. A
+balanced passive scope at its accepted nested dispatch (`8240EC80`-`8240ECAC`)
+joins exact dynamic-type ownership and explicit shared-identity relations to
+procedural-model submissions and prepared records. The implementation and
+payload-free qualifier are ready; runtime proof is deferred to the next batched
+AppData session. No C1 admission or suppression is enabled by this probe.
+
 ### C2. Static world buildings and props
 
 - Expand opaque-world material and geometry coverage.

--- a/docs/native-renderer/TERRAIN_ROAD_RENDER_PATH.md
+++ b/docs/native-renderer/TERRAIN_ROAD_RENDER_PATH.md
@@ -246,3 +246,26 @@ This is an implementation checkpoint pending the next batched preview build
 and AppData-backed run. It narrows the prototype's existing private native
 replay; it does not identify terrain/road geometry, enable C1 family admission,
 enable suppression, or change Xenos authority.
+
+## Exact track render-model submission scope
+
+The earlier typed-render-item diagnostic at `8240EC18` was originally pursued
+as a vehicle lead. Its qualified runtime profile was actually unambiguous track
+RTTI: root vtable `820019CC` is
+`Presentation_Unified::CTrackRenderModelInstance_Unified`, and child vtable
+`82001D74` is `Presentation_Unified::CTrackRenderModel_Unified`. Static title
+flow shows that `8240EC80` is reached only after the instance, its child, and
+the child-owned 248-byte type-21 descriptor pass the title predicates. The
+nested render dispatch returns at `8240ECAC`.
+
+A balanced passive runtime scope now brackets those two addresses. It joins
+only procedural-model semantic submissions made synchronously inside the exact
+dynamic-type scope, carries the result to prepared candidates, and separately
+tests exact equality between the title descriptor/root/child identity and the
+procedural receiver, runtime object, bound resource, and provider identities.
+The payload-free qualifier distinguishes exact nested ownership from the
+stronger shared-object/resource proof rather than conflating them.
+
+This instrumentation awaits the next batched AppData-backed run. Until then it
+does not prove the runtime join, terrain/road visual identity, or C1 admission.
+It changes no guest state, draw, output authority, or suppression decision.

--- a/docs/native-renderer/VEHICLE_INSTANCE_SEMANTIC_SEED.md
+++ b/docs/native-renderer/VEHICLE_INSTANCE_SEMANTIC_SEED.md
@@ -311,6 +311,13 @@ vehicle identity bridge. Continue at the explicit `8240E7B0` matrix composition
 that writes the 64-byte payload passed to `82435E78`; do not widen heuristic
 object scans. Native vehicle drawing and suppression remain closed.
 
+Phase C1 follow-up RTTI work reclassifies this one dynamic profile more
+precisely: `820019CC` is the unified track render-model instance and `82001D74`
+is the unified track render model. That strengthens the original rejection as
+a vehicle identity bridge and makes the same exact-lifetime edge useful for the
+terrain/road ownership investigation. It does not retroactively establish a
+vehicle or terrain draw by itself.
+
 ## Object/reference composed matrix
 
 Static instruction flow now closes the next transform boundary inside

--- a/src/native_renderer/graphics_hooks.cpp
+++ b/src/native_renderer/graphics_hooks.cpp
@@ -165,6 +165,11 @@ constexpr uint32_t kTrackTexturePredicate24Method = 0x824107C8;
 constexpr uint32_t kTrackTexturePrimary36Method = 0x824108D0;
 constexpr uint32_t kTrackTextureFallback40Method = 0x82DF1300;
 constexpr uint32_t kTrackTexturePredicate44Method = 0x82DF0B40;
+constexpr uint32_t kTrackRenderModelInstanceUnifiedVtable = 0x820019CC;
+constexpr uint32_t kTrackRenderModelUnifiedVtable = 0x82001D74;
+constexpr uint32_t kTrackRenderModelDescriptorType = 21;
+constexpr uint32_t kTrackRenderModelDescriptorFlag = 1;
+constexpr uint32_t kTrackRenderModelDescriptorBytes = 248;
 constexpr uint64_t kSkyHorizonAnchorSignature = UINT64_C(0x747837906D0BF484);
 constexpr uint64_t kSkyHorizonFollowerSignature = UINT64_C(0x1D253A52B55C9FB3);
 constexpr uint64_t kShadowDepthVertexShader = UINT64_C(0x4E1DA281CC3D7EDB);
@@ -441,6 +446,8 @@ struct SemanticDrawIdentity {
   bool secondary_resource_present = false;
   bool title_lod_valid = false;
   bool track_texture_provider = false;
+  bool track_render_model_scope = false;
+  uint32_t track_render_shared_identity_mask = 0;
   bool valid = false;
 };
 
@@ -568,6 +575,8 @@ struct SemanticVisibilityPreparedCandidateEntry {
   bool mechanically_eligible = false;
   bool title_lod_valid = false;
   bool track_texture_provider = false;
+  bool track_render_model_scope = false;
+  uint32_t track_render_shared_identity_mask = 0;
 };
 
 struct SemanticBatchRun {
@@ -1788,6 +1797,28 @@ struct PendingSemanticResourceResolution {
   bool secondary_resolution_result_seen = false;
 };
 
+enum TrackRenderSharedIdentity : uint32_t {
+  kTrackRenderSharedDescriptor = 1u << 0,
+  kTrackRenderSharedDescriptorPayloadBoundResource = 1u << 1,
+  kTrackRenderSharedDescriptorPayloadProvider = 1u << 2,
+  kTrackRenderSharedDescriptorPayloadRuntimeObject = 1u << 3,
+  kTrackRenderSharedRootReceiver = 1u << 4,
+  kTrackRenderSharedChildReceiver = 1u << 5,
+  kTrackRenderSharedRootRuntimeObject = 1u << 6,
+  kTrackRenderSharedChildRuntimeObject = 1u << 7,
+};
+
+struct TrackRenderModelDispatchScope {
+  uint64_t submission_joins = 0;
+  uint32_t root_address = 0;
+  uint32_t child_address = 0;
+  uint32_t descriptor_address = 0;
+  uint32_t descriptor_payload = 0;
+  uint32_t shared_identity_mask = 0;
+  bool active = false;
+  bool exact = false;
+};
+
 std::array<SemanticSubmissionEntry, kSemanticSubmissionCapacity>
     g_semantic_submissions{};
 std::mutex g_semantic_submission_mutex;
@@ -1845,6 +1876,21 @@ std::atomic<uint64_t> g_semantic_draw_packets_recorded{};
 std::atomic<uint64_t> g_semantic_draw_packet_matches{};
 std::atomic<uint64_t> g_semantic_draw_prepared_matches{};
 std::atomic<uint64_t> g_semantic_draw_unprepared_matches{};
+std::atomic<uint64_t> g_track_render_model_scope_entries{};
+std::atomic<uint64_t> g_track_render_model_scope_exits{};
+std::atomic<uint64_t> g_track_render_model_scope_overlaps{};
+std::atomic<uint64_t> g_track_render_model_scope_exit_without_entry{};
+std::atomic<uint64_t> g_track_render_model_scope_exact{};
+std::atomic<uint64_t> g_track_render_model_scope_invalid_root{};
+std::atomic<uint64_t> g_track_render_model_scope_invalid_child{};
+std::atomic<uint64_t> g_track_render_model_scope_invalid_descriptor{};
+std::atomic<uint64_t> g_track_render_model_scope_contract_mismatches{};
+std::atomic<uint64_t> g_track_render_model_scope_joined{};
+std::atomic<uint64_t> g_track_render_model_scope_unjoined{};
+std::atomic<uint64_t> g_track_render_model_submission_joins{};
+std::atomic<uint64_t> g_track_render_model_shared_identity_joins{};
+std::array<std::atomic<uint64_t>, 8>
+    g_track_render_model_shared_identity_relations{};
 std::array<SemanticBindingCacheSlot, 5> g_semantic_binding_cache_slots{};
 std::array<SemanticResolverCacheSlot, 5> g_semantic_resolver_cache_slots{};
 thread_local PendingSemanticResourceBindings g_pending_semantic_bindings{};
@@ -1855,6 +1901,7 @@ thread_local std::array<SemanticDrawIdentity,
     g_semantic_render_item_stack{};
 thread_local size_t g_semantic_render_item_stack_depth = 0;
 thread_local size_t g_semantic_render_item_stack_overflow_depth = 0;
+thread_local TrackRenderModelDispatchScope g_track_render_model_scope{};
 thread_local TitleDrawOrigin g_pending_adapter_origin;
 thread_local std::array<TitleDrawOrigin, kTitleOriginStackCapacity>
     g_title_origin_stack;
@@ -2319,6 +2366,82 @@ bool IsReadableVehicleGuestRange(rex::memory::Memory *memory,
   return heap &&
          heap->QueryRangeAccess(address, address + length - 1) !=
              rex::memory::PageAccess::kNoAccess;
+}
+
+void BeginTrackRenderModelDispatch(uint32_t root_address) {
+  ++g_track_render_model_scope_entries;
+  if (g_track_render_model_scope.active) {
+    ++g_track_render_model_scope_overlaps;
+    g_track_render_model_scope = {};
+  }
+  g_track_render_model_scope.active = true;
+  rex::memory::Memory *memory =
+      g_command_buffer_lineage_memory.load(std::memory_order_acquire);
+  if (!g_command_buffer_lineage_installed.load(std::memory_order_acquire) ||
+      !IsReadableVehicleGuestRange(memory, root_address, 8)) {
+    ++g_track_render_model_scope_invalid_root;
+    return;
+  }
+  std::array<uint32_t, 2> root_words{};
+  LoadSemanticGuestWords(memory, root_address, root_words);
+  if (root_words[0] != kTrackRenderModelInstanceUnifiedVtable) {
+    ++g_track_render_model_scope_invalid_root;
+    return;
+  }
+  const uint32_t child_address = root_words[1];
+  if (!IsReadableVehicleGuestRange(memory, child_address, 52)) {
+    ++g_track_render_model_scope_invalid_child;
+    return;
+  }
+  std::array<uint32_t, 13> child_words{};
+  LoadSemanticGuestWords(memory, child_address, child_words);
+  if (child_words[0] != kTrackRenderModelUnifiedVtable) {
+    ++g_track_render_model_scope_invalid_child;
+    return;
+  }
+  const uint32_t descriptor_base = child_words[12];
+  if (!descriptor_base || descriptor_base > UINT32_MAX - 128) {
+    ++g_track_render_model_scope_invalid_descriptor;
+    return;
+  }
+  const uint32_t descriptor_address = descriptor_base + 128;
+  if (!IsReadableVehicleGuestRange(memory, descriptor_address,
+                                   kTrackRenderModelDescriptorBytes)) {
+    ++g_track_render_model_scope_invalid_descriptor;
+    return;
+  }
+  std::array<uint32_t, kTrackRenderModelDescriptorBytes / sizeof(uint32_t)>
+      descriptor_words{};
+  LoadSemanticGuestWords(memory, descriptor_address, descriptor_words);
+  const uint32_t descriptor_type = descriptor_words[8] >> 16;
+  const uint32_t descriptor_flag = descriptor_words[61] >> 24;
+  if (descriptor_type != kTrackRenderModelDescriptorType ||
+      descriptor_flag != kTrackRenderModelDescriptorFlag) {
+    ++g_track_render_model_scope_contract_mismatches;
+    return;
+  }
+  g_track_render_model_scope.root_address = root_address;
+  g_track_render_model_scope.child_address = child_address;
+  g_track_render_model_scope.descriptor_address = descriptor_address;
+  g_track_render_model_scope.descriptor_payload = descriptor_words[10];
+  g_track_render_model_scope.exact = true;
+  ++g_track_render_model_scope_exact;
+}
+
+void EndTrackRenderModelDispatch() {
+  ++g_track_render_model_scope_exits;
+  if (!g_track_render_model_scope.active) {
+    ++g_track_render_model_scope_exit_without_entry;
+    return;
+  }
+  if (g_track_render_model_scope.exact) {
+    if (g_track_render_model_scope.submission_joins) {
+      ++g_track_render_model_scope_joined;
+    } else {
+      ++g_track_render_model_scope_unjoined;
+    }
+  }
+  g_track_render_model_scope = {};
 }
 
 const char *VehicleMatrixLayoutName(VehicleMatrixLayout layout) {
@@ -8472,7 +8595,9 @@ void JoinProceduralModelSemanticDraw(uint64_t submission_key,
                                      uint32_t primary_resource_key,
                                      uint32_t secondary_resource_key,
                                      bool secondary_resource_present,
-                                     bool track_texture_provider) {
+                                     bool track_texture_provider,
+                                     bool track_render_model_scope,
+                                     uint32_t track_render_shared_identity_mask) {
   if (!g_semantic_render_item_stack_depth) {
     g_semantic_draw_scope_mismatches.fetch_add(1,
                                                 std::memory_order_relaxed);
@@ -8497,6 +8622,9 @@ void JoinProceduralModelSemanticDraw(uint64_t submission_key,
   semantic_draw.secondary_resource_key = secondary_resource_key;
   semantic_draw.secondary_resource_present = secondary_resource_present;
   semantic_draw.track_texture_provider = track_texture_provider;
+  semantic_draw.track_render_model_scope = track_render_model_scope;
+  semantic_draw.track_render_shared_identity_mask =
+      track_render_shared_identity_mask;
   semantic_draw.valid = true;
   g_semantic_draw_scope_joins.fetch_add(1, std::memory_order_relaxed);
 }
@@ -8718,11 +8846,63 @@ void RecordProceduralModelGeometrySubmission(
   key = key ? key : 1;
   const bool track_texture_provider =
       IsUnifiedTrackTextureProvider(pending.primary_provider);
+  const bool track_render_model_scope =
+      g_track_render_model_scope.active && g_track_render_model_scope.exact;
+  uint32_t track_render_shared_identity_mask = 0;
+  if (track_render_model_scope) {
+    const TrackRenderModelDispatchScope &scope = g_track_render_model_scope;
+    track_render_shared_identity_mask |=
+        scope.descriptor_address == descriptor_address
+            ? kTrackRenderSharedDescriptor
+            : 0;
+    track_render_shared_identity_mask |=
+        scope.descriptor_payload == pending.primary_bound_resource_object
+            ? kTrackRenderSharedDescriptorPayloadBoundResource
+            : 0;
+    track_render_shared_identity_mask |=
+        scope.descriptor_payload == pending.primary_provider.provider_object
+            ? kTrackRenderSharedDescriptorPayloadProvider
+            : 0;
+    track_render_shared_identity_mask |=
+        scope.descriptor_payload == runtime_submission_object
+            ? kTrackRenderSharedDescriptorPayloadRuntimeObject
+            : 0;
+    track_render_shared_identity_mask |=
+        scope.root_address == receiver_address ? kTrackRenderSharedRootReceiver
+                                               : 0;
+    track_render_shared_identity_mask |=
+        scope.child_address == receiver_address
+            ? kTrackRenderSharedChildReceiver
+            : 0;
+    track_render_shared_identity_mask |=
+        scope.root_address == runtime_submission_object
+            ? kTrackRenderSharedRootRuntimeObject
+            : 0;
+    track_render_shared_identity_mask |=
+        scope.child_address == runtime_submission_object
+            ? kTrackRenderSharedChildRuntimeObject
+            : 0;
+    ++g_track_render_model_scope.submission_joins;
+    g_track_render_model_scope.shared_identity_mask |=
+        track_render_shared_identity_mask;
+    ++g_track_render_model_submission_joins;
+    if (track_render_shared_identity_mask) {
+      ++g_track_render_model_shared_identity_joins;
+      for (size_t bit = 0;
+           bit < g_track_render_model_shared_identity_relations.size();
+           ++bit) {
+        if (track_render_shared_identity_mask & (1u << bit)) {
+          ++g_track_render_model_shared_identity_relations[bit];
+        }
+      }
+    }
+  }
   JoinProceduralModelSemanticDraw(
       key, receiver_address, receiver_generation, record_index,
       descriptor_address, runtime_address, descriptor_kind, helper_state,
       primary_resource_key, secondary_resource_key,
-      secondary_resource_present, track_texture_provider);
+      secondary_resource_present, track_texture_provider,
+      track_render_model_scope, track_render_shared_identity_mask);
 
   size_t index = size_t(key % kSemanticSubmissionCapacity);
   for (size_t probe = 0; probe < kSemanticSubmissionCapacity; ++probe) {
@@ -9037,6 +9217,101 @@ void EmitProceduralModelSemanticSubmissions() {
         "bounded_submission_and_dispatch_fields_only"},
        {"guest_state_changed", "false"},
        {"native_upload", "false"},
+       {"native_draw", "false"},
+       {"xenos_authority", "true"},
+       {"suppression_allowed", "false"}});
+}
+
+void EmitTrackRenderModelRuntimeJoinSummary() {
+  const uint64_t entries =
+      g_track_render_model_scope_entries.load(std::memory_order_relaxed);
+  const uint64_t exits =
+      g_track_render_model_scope_exits.load(std::memory_order_relaxed);
+  const uint64_t exact =
+      g_track_render_model_scope_exact.load(std::memory_order_relaxed);
+  const uint64_t invalid_root =
+      g_track_render_model_scope_invalid_root.load(std::memory_order_relaxed);
+  const uint64_t invalid_child =
+      g_track_render_model_scope_invalid_child.load(std::memory_order_relaxed);
+  const uint64_t invalid_descriptor =
+      g_track_render_model_scope_invalid_descriptor.load(
+          std::memory_order_relaxed);
+  const uint64_t contract_mismatches =
+      g_track_render_model_scope_contract_mismatches.load(
+          std::memory_order_relaxed);
+  const uint64_t joined =
+      g_track_render_model_scope_joined.load(std::memory_order_relaxed);
+  const uint64_t unjoined =
+      g_track_render_model_scope_unjoined.load(std::memory_order_relaxed);
+  const uint64_t overlaps =
+      g_track_render_model_scope_overlaps.load(std::memory_order_relaxed);
+  const uint64_t exit_without_entry =
+      g_track_render_model_scope_exit_without_entry.load(
+          std::memory_order_relaxed);
+  const bool accounting_complete =
+      entries == exact + invalid_root + invalid_child + invalid_descriptor +
+                     contract_mismatches &&
+      exact == joined + unjoined && entries == exits && !overlaps &&
+      !exit_without_entry;
+  const bool qualification_complete =
+      accounting_complete && exact && joined &&
+      g_track_render_model_submission_joins.load(std::memory_order_relaxed) &&
+      !invalid_root && !invalid_child && !invalid_descriptor &&
+      !contract_mismatches;
+  pinyon_shift::diagnostics::RecordEvent(
+      "native_renderer.discovery.track_render_model_runtime_join_summary",
+      {{"status", !entries ? "not_observed"
+                            : (qualification_complete ? "complete"
+                                                      : "incomplete")},
+       {"scope_entries", std::to_string(entries)},
+       {"scope_exits", std::to_string(exits)},
+       {"exact_scopes", std::to_string(exact)},
+       {"invalid_root", std::to_string(invalid_root)},
+       {"invalid_child", std::to_string(invalid_child)},
+       {"invalid_descriptor", std::to_string(invalid_descriptor)},
+       {"contract_mismatches", std::to_string(contract_mismatches)},
+       {"joined_scopes", std::to_string(joined)},
+       {"unjoined_scopes", std::to_string(unjoined)},
+       {"submission_joins",
+        std::to_string(g_track_render_model_submission_joins.load(
+            std::memory_order_relaxed))},
+       {"shared_identity_joins",
+        std::to_string(g_track_render_model_shared_identity_joins.load(
+            std::memory_order_relaxed))},
+       {"shared_descriptor",
+        std::to_string(g_track_render_model_shared_identity_relations[0].load(
+            std::memory_order_relaxed))},
+       {"shared_descriptor_payload_bound_resource",
+        std::to_string(g_track_render_model_shared_identity_relations[1].load(
+            std::memory_order_relaxed))},
+       {"shared_descriptor_payload_provider",
+        std::to_string(g_track_render_model_shared_identity_relations[2].load(
+            std::memory_order_relaxed))},
+       {"shared_descriptor_payload_runtime_object",
+        std::to_string(g_track_render_model_shared_identity_relations[3].load(
+            std::memory_order_relaxed))},
+       {"shared_root_receiver",
+        std::to_string(g_track_render_model_shared_identity_relations[4].load(
+            std::memory_order_relaxed))},
+       {"shared_child_receiver",
+        std::to_string(g_track_render_model_shared_identity_relations[5].load(
+            std::memory_order_relaxed))},
+       {"shared_root_runtime_object",
+        std::to_string(g_track_render_model_shared_identity_relations[6].load(
+            std::memory_order_relaxed))},
+       {"shared_child_runtime_object",
+        std::to_string(g_track_render_model_shared_identity_relations[7].load(
+            std::memory_order_relaxed))},
+       {"scope_overlaps", std::to_string(overlaps)},
+       {"exit_without_entry", std::to_string(exit_without_entry)},
+       {"accounting_complete", accounting_complete ? "true" : "false"},
+       {"qualification_complete",
+        qualification_complete ? "true" : "false"},
+       {"classification",
+        "exact_unified_track_render_model_nested_submission_join"},
+       {"guest_state_changed", "false"},
+       {"control_flow_changed", "false"},
+       {"native_admission", "false"},
        {"native_draw", "false"},
        {"xenos_authority", "true"},
        {"suppression_allowed", "false"}});
@@ -10767,6 +11042,7 @@ void EmitCommandBufferLineageSummary() {
   EmitSemanticVisibilityWorkset();
   EmitProceduralModelSemanticInstances();
   EmitProceduralModelSemanticSubmissions();
+  EmitTrackRenderModelRuntimeJoinSummary();
   for (const CommandBufferLineageEntry &entry : g_command_buffer_lineages) {
     if (!entry.calls) {
       continue;
@@ -13668,6 +13944,8 @@ bool RecordSemanticVisibilityPreparedCandidate(
         uint64_t(identity.title_lod_valid),
         uint64_t(identity.title_lod_index),
         uint64_t(identity.track_texture_provider),
+        uint64_t(identity.track_render_model_scope),
+        uint64_t(identity.track_render_shared_identity_mask),
         uint64_t(mechanical_rejection_mask)}) {
     key = HashCombine(key, value);
   }
@@ -13704,6 +13982,9 @@ bool RecordSemanticVisibilityPreparedCandidate(
           .mechanically_eligible = !mechanical_rejection_mask,
           .title_lod_valid = identity.title_lod_valid,
           .track_texture_provider = identity.track_texture_provider,
+          .track_render_model_scope = identity.track_render_model_scope,
+          .track_render_shared_identity_mask =
+              identity.track_render_shared_identity_mask,
       };
       ++g_semantic_visibility_prepared_candidate_count;
       return true;
@@ -13727,7 +14008,10 @@ bool RecordSemanticVisibilityPreparedCandidate(
         entry.visibility_result_mask == identity.visibility_result_mask &&
         entry.title_lod_index == identity.title_lod_index &&
         entry.title_lod_valid == identity.title_lod_valid &&
-        entry.track_texture_provider == identity.track_texture_provider) {
+        entry.track_texture_provider == identity.track_texture_provider &&
+        entry.track_render_model_scope == identity.track_render_model_scope &&
+        entry.track_render_shared_identity_mask ==
+            identity.track_render_shared_identity_mask) {
       ++entry.draws;
       entry.last_frame = observation.frame_sequence;
       entry.maximum_policy_age_frames =
@@ -15228,6 +15512,10 @@ void EmitSemanticVisibilityPreparedCandidates() {
   uint64_t title_lod_entries = 0;
   uint64_t track_texture_provider_draws = 0;
   uint64_t track_texture_provider_entries = 0;
+  uint64_t track_render_model_scope_draws = 0;
+  uint64_t track_render_model_scope_entries = 0;
+  uint64_t track_render_shared_identity_draws = 0;
+  uint64_t track_render_shared_identity_entries = 0;
   for (const SemanticVisibilityPreparedCandidateEntry &entry :
        g_semantic_visibility_prepared_candidates) {
     if (!entry.key) {
@@ -15249,6 +15537,14 @@ void EmitSemanticVisibilityPreparedCandidates() {
     if (entry.track_texture_provider) {
       track_texture_provider_draws += entry.draws;
       ++track_texture_provider_entries;
+    }
+    if (entry.track_render_model_scope) {
+      track_render_model_scope_draws += entry.draws;
+      ++track_render_model_scope_entries;
+    }
+    if (entry.track_render_shared_identity_mask) {
+      track_render_shared_identity_draws += entry.draws;
+      ++track_render_shared_identity_entries;
     }
     pinyon_shift::diagnostics::RecordEvent(
         "native_renderer.discovery.semantic_visibility_prepared_candidate_entry",
@@ -15284,6 +15580,12 @@ void EmitSemanticVisibilityPreparedCandidates() {
           entry.track_texture_provider ? "true" : "false"},
          {"track_texture_provider_lineage",
           "exact_primary_provider_vtable_and_four_methods"},
+         {"track_render_model_scope",
+          entry.track_render_model_scope ? "true" : "false"},
+         {"track_render_shared_identity_mask",
+          fmt::format("{:08X}", entry.track_render_shared_identity_mask)},
+         {"track_render_model_lineage",
+          "exact_unified_instance_model_nested_dispatch_scope"},
          {"draws", std::to_string(entry.draws)},
          {"first_frame", std::to_string(entry.first_frame)},
          {"last_frame", std::to_string(entry.last_frame)},
@@ -15323,7 +15625,12 @@ void EmitSemanticVisibilityPreparedCandidates() {
           entry_count &&
       title_lod_draws <= entry_draws && title_lod_entries <= entry_count &&
       track_texture_provider_draws <= entry_draws &&
-      track_texture_provider_entries <= entry_count;
+      track_texture_provider_entries <= entry_count &&
+      track_render_model_scope_draws <= entry_draws &&
+      track_render_model_scope_entries <= entry_count &&
+      track_render_shared_identity_draws <= track_render_model_scope_draws &&
+      track_render_shared_identity_entries <=
+          track_render_model_scope_entries;
   pinyon_shift::diagnostics::RecordEvent(
       "native_renderer.discovery.semantic_visibility_prepared_candidate_summary",
       {{"status", !g_semantic_visibility_prepared_observations
@@ -15361,6 +15668,14 @@ void EmitSemanticVisibilityPreparedCandidates() {
         std::to_string(track_texture_provider_entries)},
        {"track_texture_provider_draws",
         std::to_string(track_texture_provider_draws)},
+       {"track_render_model_scope_entries",
+        std::to_string(track_render_model_scope_entries)},
+       {"track_render_model_scope_draws",
+        std::to_string(track_render_model_scope_draws)},
+       {"track_render_shared_identity_entries",
+        std::to_string(track_render_shared_identity_entries)},
+       {"track_render_shared_identity_draws",
+        std::to_string(track_render_shared_identity_draws)},
        {"capacity",
         std::to_string(kSemanticVisibilityPreparedCandidateCapacity)},
        {"overflow",
@@ -15374,6 +15689,8 @@ void EmitSemanticVisibilityPreparedCandidates() {
        {"title_lod_lineage", "exact_visibility_identity_to_prepared_draw"},
        {"track_texture_provider_lineage",
         "exact_primary_provider_vtable_and_four_methods"},
+       {"track_render_model_lineage",
+        "exact_unified_instance_model_nested_dispatch_scope"},
        {"guest_state_changed", "false"},
        {"control_flow_changed", "false"},
        {"native_upload", "false"},
@@ -20136,6 +20453,28 @@ void InstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system,
        {"xenos_draw", "preserved"},
        {"suppression_allowed", "false"}});
   diagnostics::RecordEvent(
+      "native_renderer.discovery.track_render_model_runtime_join_config",
+      {{"status", lineage_armed ? "armed" : "disabled"},
+       {"entry_hook", "8240EC80"},
+       {"exit_hook", "8240ECAC"},
+       {"nested_dispatch", "82436468"},
+       {"instance_vtable", "820019CC"},
+       {"model_vtable", "82001D74"},
+       {"instance_to_model", "root_plus_4"},
+       {"model_to_descriptor", "child_plus_48_then_plus_128"},
+       {"descriptor_type", "21"},
+       {"descriptor_flag", "1"},
+       {"join", "synchronous_scope_to_procedural_model_submission"},
+       {"shared_identity",
+        "descriptor_payload_or_object_address_exact_equality"},
+       {"guest_payload_read", "bounded_308_bytes_per_scope"},
+       {"guest_state_changed", "false"},
+       {"control_flow_changed", "false"},
+       {"native_admission", "false"},
+       {"native_draw", "false"},
+       {"xenos_authority", "true"},
+       {"suppression_allowed", "false"}});
+  diagnostics::RecordEvent(
       "native_renderer.discovery.semantic_instance_config",
       {{"status", lineage_armed ? "armed" : "disabled"},
        {"class", "proceduralGeometry::CProceduralModels"},
@@ -21343,6 +21682,14 @@ void PinyonShiftObserveVehicleMatrixCallerEntry(PPCRegister &r6,
 void PinyonShiftObserveVehicleTypedRenderItem(PPCRegister &r11,
                                               PPCRegister &r31) {
   ObserveVehicleTypedRenderItem(r31.u32, r11.u32);
+}
+
+void PinyonShiftObserveTrackRenderModelDispatchEntry(PPCRegister &r31) {
+  BeginTrackRenderModelDispatch(r31.u32);
+}
+
+void PinyonShiftObserveTrackRenderModelDispatchExit() {
+  EndTrackRenderModelDispatch();
 }
 
 void PinyonShiftObserveVehicleComposedMatrix(PPCRegister &r5,

--- a/tools/summarize-native-renderer-track-model-runtime-join.py
+++ b/tools/summarize-native-renderer-track-model-runtime-join.py
@@ -1,0 +1,224 @@
+#!/usr/bin/env python3
+"""Qualify unified track render-model scopes joined to semantic submissions."""
+
+import argparse
+import json
+import pathlib
+import sys
+
+
+SCHEMA = "pinyon-shift.native-renderer-track-model-runtime-join.v1"
+CONFIG = "native_renderer.discovery.track_render_model_runtime_join_config"
+SUMMARY = "native_renderer.discovery.track_render_model_runtime_join_summary"
+
+RELATIONS = (
+    "shared_descriptor",
+    "shared_descriptor_payload_bound_resource",
+    "shared_descriptor_payload_provider",
+    "shared_descriptor_payload_runtime_object",
+    "shared_root_receiver",
+    "shared_child_receiver",
+    "shared_root_runtime_object",
+    "shared_child_runtime_object",
+)
+
+
+def integer(mapping, key):
+    try:
+        value = int(mapping[key])
+    except (KeyError, TypeError, ValueError) as error:
+        raise ValueError(f"invalid {key}") from error
+    if value < 0:
+        raise ValueError(f"negative {key}")
+    return value
+
+
+def exact_event(events, name):
+    matches = [event for event in events if event.get("event") == name]
+    if len(matches) != 1:
+        raise ValueError(f"expected exactly one {name} event")
+    return matches[0]
+
+
+def read_events(paths):
+    events = []
+    for path in paths:
+        for line in path.read_text(encoding="utf-8").splitlines():
+            if line.strip():
+                events.append(json.loads(line))
+    return events
+
+
+def select_session(events, requested):
+    sessions = {
+        event.get("session") for event in events if event.get("event") == CONFIG
+    }
+    sessions.discard(None)
+    if requested:
+        if requested not in sessions:
+            raise ValueError("requested session has no track-model join config")
+        return requested
+    if len(sessions) != 1:
+        raise ValueError("track-model join input contains multiple sessions")
+    return next(iter(sessions))
+
+
+def require_safety(event):
+    expected = {
+        "guest_state_changed": "false",
+        "control_flow_changed": "false",
+        "native_admission": "false",
+        "native_draw": "false",
+        "xenos_authority": "true",
+        "suppression_allowed": "false",
+    }
+    if any(event.get(key) != value for key, value in expected.items()):
+        raise ValueError("track-model join violates its safety boundary")
+
+
+def build(events, requested_session=None):
+    session = select_session(events, requested_session)
+    selected = [event for event in events if event.get("session") == session]
+    config = exact_event(selected, CONFIG)
+    summary = exact_event(selected, SUMMARY)
+    expected_config = {
+        "status": "armed",
+        "entry_hook": "8240EC80",
+        "exit_hook": "8240ECAC",
+        "nested_dispatch": "82436468",
+        "instance_vtable": "820019CC",
+        "model_vtable": "82001D74",
+        "instance_to_model": "root_plus_4",
+        "model_to_descriptor": "child_plus_48_then_plus_128",
+        "descriptor_type": "21",
+        "descriptor_flag": "1",
+        "join": "synchronous_scope_to_procedural_model_submission",
+        "shared_identity": "descriptor_payload_or_object_address_exact_equality",
+        "guest_payload_read": "bounded_308_bytes_per_scope",
+    }
+    if any(config.get(key) != value for key, value in expected_config.items()):
+        raise ValueError("track-model runtime configuration drifted")
+    require_safety(config)
+    require_safety(summary)
+    if (
+        summary.get("status") not in ("complete", "incomplete", "not_observed")
+        or summary.get("classification")
+        != "exact_unified_track_render_model_nested_submission_join"
+    ):
+        raise ValueError("track-model runtime summary drifted")
+
+    keys = (
+        "scope_entries",
+        "scope_exits",
+        "exact_scopes",
+        "invalid_root",
+        "invalid_child",
+        "invalid_descriptor",
+        "contract_mismatches",
+        "joined_scopes",
+        "unjoined_scopes",
+        "submission_joins",
+        "shared_identity_joins",
+        "scope_overlaps",
+        "exit_without_entry",
+        *RELATIONS,
+    )
+    totals = {key: integer(summary, key) for key in keys}
+    failures = []
+    classified = (
+        totals["exact_scopes"]
+        + totals["invalid_root"]
+        + totals["invalid_child"]
+        + totals["invalid_descriptor"]
+        + totals["contract_mismatches"]
+    )
+    if summary.get("accounting_complete") != "true":
+        failures.append("runtime accounting is incomplete")
+    if totals["scope_entries"] != totals["scope_exits"]:
+        failures.append("track-model scope entry/exit accounting drifted")
+    if totals["scope_entries"] != classified:
+        failures.append("track-model scope classification drifted")
+    if totals["exact_scopes"] != (
+        totals["joined_scopes"] + totals["unjoined_scopes"]
+    ):
+        failures.append("exact scope outcome accounting drifted")
+    if not totals["exact_scopes"]:
+        failures.append("no exact unified track render-model scope was observed")
+    if not totals["joined_scopes"] or not totals["submission_joins"]:
+        failures.append("no exact scope joined a procedural-model submission")
+    for key in (
+        "invalid_root",
+        "invalid_child",
+        "invalid_descriptor",
+        "contract_mismatches",
+        "scope_overlaps",
+        "exit_without_entry",
+    ):
+        if totals[key]:
+            failures.append(f"{key} is nonzero")
+    if totals["shared_identity_joins"] > totals["submission_joins"]:
+        failures.append("shared identity joins exceed submission joins")
+    if totals["shared_identity_joins"] and not any(
+        totals[key] for key in RELATIONS
+    ):
+        failures.append("shared identity relation accounting is empty")
+    expected_status = "complete" if not failures else "incomplete"
+    if summary.get("status") != expected_status:
+        failures.append("runtime status does not match qualification outcome")
+    if summary.get("qualification_complete") != (
+        "true" if not failures else "false"
+    ):
+        failures.append("runtime qualification flag does not match outcome")
+
+    return {
+        "schema": SCHEMA,
+        "session": session,
+        "status": "complete" if not failures else "incomplete",
+        "failures": failures,
+        "totals": totals,
+        "shared_identity_relations": {
+            key: totals[key] for key in RELATIONS
+        },
+        "qualification": {
+            "track_render_model_scope_to_submission_proved": not failures,
+            "shared_object_or_resource_identity_proved": (
+                not failures and totals["shared_identity_joins"] > 0
+            ),
+            "terrain_or_road_visual_identity_proved": False,
+            "native_admission": False,
+            "suppression_allowed": False,
+        },
+        "safety": {
+            "guest_state_changed": False,
+            "control_flow_changed": False,
+            "native_admission": False,
+            "native_draw": False,
+            "xenos_authority": True,
+            "suppression_allowed": False,
+        },
+    }
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("events", nargs="+", type=pathlib.Path)
+    parser.add_argument("--session")
+    parser.add_argument("--output", required=True, type=pathlib.Path)
+    args = parser.parse_args(argv)
+    try:
+        document = build(read_events(args.events), args.session)
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(
+            json.dumps(document, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        if document["status"] != "complete":
+            raise ValueError("; ".join(document["failures"]))
+        return 0
+    except (OSError, ValueError, json.JSONDecodeError) as error:
+        print(f"native renderer track-model join failed: {error}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/summarize-native-renderer-visibility-prepared-candidates.py
+++ b/tools/summarize-native-renderer-visibility-prepared-candidates.py
@@ -7,7 +7,7 @@ import pathlib
 import sys
 
 
-SCHEMA = "pinyon-shift.native-renderer-visibility-prepared-candidates.v5"
+SCHEMA = "pinyon-shift.native-renderer-visibility-prepared-candidates.v6"
 STATIC_SCHEMA = "pinyon-shift.native-renderer-dispatch-static.v3"
 CONFIG = (
     "native_renderer.discovery."
@@ -180,6 +180,8 @@ def build(events, static, requested_session=None):
         != "exact_visibility_identity_to_prepared_draw"
         or summary.get("track_texture_provider_lineage")
         != "exact_primary_provider_vtable_and_four_methods"
+        or summary.get("track_render_model_lineage")
+        != "exact_unified_instance_model_nested_dispatch_scope"
         or summary.get("mechanical_admission_contract") != "isolated_draw_v1"
     ):
         raise ValueError("prepared-candidate summary is incomplete")
@@ -202,6 +204,10 @@ def build(events, static, requested_session=None):
         "title_lod_draws",
         "track_texture_provider_entries",
         "track_texture_provider_draws",
+        "track_render_model_scope_entries",
+        "track_render_model_scope_draws",
+        "track_render_shared_identity_entries",
+        "track_render_shared_identity_draws",
         "capacity",
         "overflow",
         "policy_age_limit_frames",
@@ -255,6 +261,12 @@ def build(events, static, requested_session=None):
         }
         rejection_mask = int(hexadecimal(event, "mechanical_rejection_mask", 8), 16)
         item["mechanical_rejection_mask"] = rejection_mask
+        item["track_render_model_scope"] = (
+            event.get("track_render_model_scope") == "true"
+        )
+        item["track_render_shared_identity_mask"] = int(
+            hexadecimal(event, "track_render_shared_identity_mask", 8), 16
+        )
         item["mechanical_rejections"] = [
             name
             for bit, name in MECHANICAL_REJECTIONS.items()
@@ -280,6 +292,13 @@ def build(events, static, requested_session=None):
             or event.get("track_texture_provider") not in ("true", "false")
             or event.get("track_texture_provider_lineage")
             != "exact_primary_provider_vtable_and_four_methods"
+            or event.get("track_render_model_scope") not in ("true", "false")
+            or event.get("track_render_model_lineage")
+            != "exact_unified_instance_model_nested_dispatch_scope"
+            or (
+                item["track_render_shared_identity_mask"]
+                and not item["track_render_model_scope"]
+            )
             or (item["title_lod_valid"] and item["title_lod_index"] >= 32)
             or integer(event, "policy_age_limit_frames")
             != totals["policy_age_limit_frames"]
@@ -351,6 +370,27 @@ def build(events, static, requested_session=None):
         != sum(entry["draws"] for entry in track_provider_entries)
     ):
         failures.append("track texture provider candidate totals drifted")
+    track_model_entries = [
+        entry for entry in entries if entry["track_render_model_scope"]
+    ]
+    if (
+        totals["track_render_model_scope_entries"] != len(track_model_entries)
+        or totals["track_render_model_scope_draws"]
+        != sum(entry["draws"] for entry in track_model_entries)
+    ):
+        failures.append("track render-model scope candidate totals drifted")
+    shared_identity_entries = [
+        entry
+        for entry in entries
+        if entry["track_render_shared_identity_mask"]
+    ]
+    if (
+        totals["track_render_shared_identity_entries"]
+        != len(shared_identity_entries)
+        or totals["track_render_shared_identity_draws"]
+        != sum(entry["draws"] for entry in shared_identity_entries)
+    ):
+        failures.append("track render shared-identity totals drifted")
     if totals["capacity"] != 4096 or totals["policy_age_limit_frames"] != 1:
         failures.append("prepared-candidate bounds drifted")
     if totals["selected_joins"] > integer(workset, "selected_joins"):
@@ -376,6 +416,12 @@ def build(events, static, requested_session=None):
             "title_lod_lineage_proved": not failures and bool(lod_entries),
             "track_texture_provider_lineage_proved": (
                 not failures and bool(track_provider_entries)
+            ),
+            "track_render_model_scope_lineage_proved": (
+                not failures and bool(track_model_entries)
+            ),
+            "track_render_shared_identity_proved": (
+                not failures and bool(shared_identity_entries)
             ),
             "native_draw_enabled": False,
             "suppression_allowed": False,

--- a/tools/tests/test_native_renderer_track_model_runtime_join.py
+++ b/tools/tests/test_native_renderer_track_model_runtime_join.py
@@ -1,0 +1,146 @@
+import copy
+import importlib.util
+import pathlib
+import unittest
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+TOOL = ROOT / "tools/summarize-native-renderer-track-model-runtime-join.py"
+SPEC = importlib.util.spec_from_file_location("track_model_runtime_join", TOOL)
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+def event(name, **values):
+    return {"event": name, "session": "test", **values}
+
+
+def safety():
+    return {
+        "guest_state_changed": "false",
+        "control_flow_changed": "false",
+        "native_admission": "false",
+        "native_draw": "false",
+        "xenos_authority": "true",
+        "suppression_allowed": "false",
+    }
+
+
+def fixture(shared=3):
+    config = event(
+        MODULE.CONFIG,
+        status="armed",
+        entry_hook="8240EC80",
+        exit_hook="8240ECAC",
+        nested_dispatch="82436468",
+        instance_vtable="820019CC",
+        model_vtable="82001D74",
+        instance_to_model="root_plus_4",
+        model_to_descriptor="child_plus_48_then_plus_128",
+        descriptor_type="21",
+        descriptor_flag="1",
+        join="synchronous_scope_to_procedural_model_submission",
+        shared_identity="descriptor_payload_or_object_address_exact_equality",
+        guest_payload_read="bounded_308_bytes_per_scope",
+        **safety(),
+    )
+    relations = {key: "0" for key in MODULE.RELATIONS}
+    if shared:
+        relations["shared_descriptor_payload_bound_resource"] = str(shared)
+    summary = event(
+        MODULE.SUMMARY,
+        status="complete",
+        scope_entries="10",
+        scope_exits="10",
+        exact_scopes="10",
+        invalid_root="0",
+        invalid_child="0",
+        invalid_descriptor="0",
+        contract_mismatches="0",
+        joined_scopes="8",
+        unjoined_scopes="2",
+        submission_joins="12",
+        shared_identity_joins=str(shared),
+        scope_overlaps="0",
+        exit_without_entry="0",
+        accounting_complete="true",
+        qualification_complete="true",
+        classification="exact_unified_track_render_model_nested_submission_join",
+        **relations,
+        **safety(),
+    )
+    return [config, summary]
+
+
+class TrackModelRuntimeJoinTests(unittest.TestCase):
+    def test_qualifies_scope_and_shared_identity(self):
+        document = MODULE.build(fixture())
+        self.assertEqual("complete", document["status"])
+        self.assertTrue(
+            document["qualification"][
+                "track_render_model_scope_to_submission_proved"
+            ]
+        )
+        self.assertTrue(
+            document["qualification"][
+                "shared_object_or_resource_identity_proved"
+            ]
+        )
+
+    def test_qualifies_scope_without_claiming_shared_identity(self):
+        document = MODULE.build(fixture(shared=0))
+        self.assertEqual("complete", document["status"])
+        self.assertFalse(
+            document["qualification"][
+                "shared_object_or_resource_identity_proved"
+            ]
+        )
+
+    def test_rejects_unjoined_scopes(self):
+        events = copy.deepcopy(fixture())
+        summary = events[-1]
+        summary.update(
+            status="incomplete",
+            joined_scopes="0",
+            unjoined_scopes="10",
+            submission_joins="0",
+            shared_identity_joins="0",
+            shared_descriptor_payload_bound_resource="0",
+            qualification_complete="false",
+        )
+        document = MODULE.build(events)
+        self.assertEqual("incomplete", document["status"])
+        self.assertIn(
+            "no exact scope joined a procedural-model submission",
+            document["failures"],
+        )
+
+    def test_rejects_scope_fault(self):
+        events = copy.deepcopy(fixture())
+        events[-1].update(
+            status="incomplete",
+            accounting_complete="false",
+            qualification_complete="false",
+            scope_overlaps="1",
+        )
+        document = MODULE.build(events)
+        self.assertEqual("incomplete", document["status"])
+        self.assertIn("scope_overlaps is nonzero", document["failures"])
+
+    def test_source_contract_has_exact_balanced_hooks(self):
+        hooks = (ROOT / "src/native_renderer/graphics_hooks.cpp").read_text(
+            encoding="utf-8"
+        )
+        analysis = (ROOT / "config/rexglue/analysis/main-xex.toml").read_text(
+            encoding="utf-8"
+        )
+        self.assertIn("kTrackRenderModelInstanceUnifiedVtable = 0x820019CC", hooks)
+        self.assertIn("kTrackRenderModelUnifiedVtable = 0x82001D74", hooks)
+        self.assertIn("BeginTrackRenderModelDispatch", hooks)
+        self.assertIn("EndTrackRenderModelDispatch", hooks)
+        self.assertIn("address = 0x8240EC80", analysis)
+        self.assertIn("address = 0x8240ECAC", analysis)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/tests/test_native_renderer_visibility_prepared_candidates.py
+++ b/tools/tests/test_native_renderer_visibility_prepared_candidates.py
@@ -89,6 +89,11 @@ class VisibilityPreparedCandidateReportTests(unittest.TestCase):
             "track_texture_provider_lineage": (
                 "exact_primary_provider_vtable_and_four_methods"
             ),
+            "track_render_model_scope": "true",
+            "track_render_shared_identity_mask": "00000002",
+            "track_render_model_lineage": (
+                "exact_unified_instance_model_nested_dispatch_scope"
+            ),
             "draws": "7",
             "first_frame": "10",
             "last_frame": "12",
@@ -122,6 +127,10 @@ class VisibilityPreparedCandidateReportTests(unittest.TestCase):
             "title_lod_draws": "7",
             "track_texture_provider_entries": "1",
             "track_texture_provider_draws": "7",
+            "track_render_model_scope_entries": "1",
+            "track_render_model_scope_draws": "7",
+            "track_render_shared_identity_entries": "1",
+            "track_render_shared_identity_draws": "7",
             "capacity": "4096",
             "overflow": "0",
             "policy_age_limit_frames": "1",
@@ -132,6 +141,9 @@ class VisibilityPreparedCandidateReportTests(unittest.TestCase):
             "title_lod_lineage": "exact_visibility_identity_to_prepared_draw",
             "track_texture_provider_lineage": (
                 "exact_primary_provider_vtable_and_four_methods"
+            ),
+            "track_render_model_lineage": (
+                "exact_unified_instance_model_nested_dispatch_scope"
             ),
             **self.safety(),
         }
@@ -159,6 +171,14 @@ class VisibilityPreparedCandidateReportTests(unittest.TestCase):
             document["qualification"][
                 "track_texture_provider_lineage_proved"
             ]
+        )
+        self.assertTrue(
+            document["qualification"][
+                "track_render_model_scope_lineage_proved"
+            ]
+        )
+        self.assertTrue(
+            document["qualification"]["track_render_shared_identity_proved"]
         )
 
     def test_build_accepts_candidate_without_title_lod(self):
@@ -207,6 +227,24 @@ class VisibilityPreparedCandidateReportTests(unittest.TestCase):
             document["qualification"][
                 "track_texture_provider_lineage_proved"
             ]
+        )
+
+    def test_build_accepts_track_scope_without_shared_identity(self):
+        events = copy.deepcopy(self.events())
+        entry = next(event for event in events if event["event"] == MODULE.ENTRY)
+        entry["track_render_shared_identity_mask"] = "00000000"
+        summary = next(event for event in events if event["event"] == MODULE.SUMMARY)
+        summary["track_render_shared_identity_entries"] = "0"
+        summary["track_render_shared_identity_draws"] = "0"
+        document = MODULE.build(events, self.static())
+        self.assertEqual("complete", document["status"])
+        self.assertTrue(
+            document["qualification"][
+                "track_render_model_scope_lineage_proved"
+            ]
+        )
+        self.assertFalse(
+            document["qualification"]["track_render_shared_identity_proved"]
         )
 
     def test_build_rejects_eligibility_mask_drift(self):


### PR DESCRIPTION
Carry exact unified track render-model dispatch scope into procedural
semantic submissions and prepared records. Add a payload-free runtime
qualifier for the balanced scope and shared identity relations.

Tests: python -m unittest discover -s tools/tests -p test_*.py
Tests: .\tools\build-preview.ps1 -Parallel 16
