### PR TITLE
feat(native-renderer): trace track resource graph

### DIFF
--- a/docs/native-renderer/REPRIORITIZED_PLAN.md
+++ b/docs/native-renderer/REPRIORITIZED_PLAN.md
@@ -268,6 +268,16 @@ procedural-model submissions and prepared records. The implementation and
 payload-free qualifier are ready; runtime proof is deferred to the next batched
 AppData session. No C1 admission or suppression is enabled by this probe.
 
+Implementation checkpoint: the exact model scope now inspects only its
+already-validated 64-byte child prefix and 248-byte type-21 descriptor for
+direct pointers to the seven RTTI-proved track model, mesh, submodel,
+procedural-geometry, and PVS-zone object/resource vtables. A 1,024-entry
+fingerprinted cache avoids repeating guest pointer validation for unchanged
+graphs. Detected identities and stronger exact address equality to procedural
+submission objects/resources are carried separately into prepared records.
+This is ready for the same deferred AppData checkpoint; it still changes no
+admission, draw, authority, or suppression decision.
+
 ### C2. Static world buildings and props
 
 - Expand opaque-world material and geometry coverage.

--- a/docs/native-renderer/TERRAIN_ROAD_RENDER_PATH.md
+++ b/docs/native-renderer/TERRAIN_ROAD_RENDER_PATH.md
@@ -269,3 +269,36 @@ stronger shared-object/resource proof rather than conflating them.
 This instrumentation awaits the next batched AppData-backed run. Until then it
 does not prove the runtime join, terrain/road visual identity, or C1 admission.
 It changes no guest state, draw, output authority, or suppression decision.
+
+## Bounded track world-resource graph identity
+
+The balanced render-model scope now extends the passive join without adding a
+new title hook. After the exact unified instance/model vtables and type-21
+descriptor contract pass, it scans the already-live 64-byte render-model child
+prefix and 248-byte descriptor for aligned direct object pointers. A pointer is
+classified only when its first word is one of the static-ingress proof's exact
+RTTI-backed vtables:
+
+- `CTrackModel`, `CTrackMesh`, or `CTrackSubModel`;
+- `CTrackProceduralGeometryObject` or
+  `CTrackProceduralGeometryResource`; and
+- `CTrackPVSZoneObject` or `CTrackPVSZoneResource`.
+
+The scope records two distinct facts. The world-resource mask means an exact
+class appeared directly in the accepted title graph. The shared-resource mask
+is stronger: that same object address also equalled the procedural receiver,
+runtime submission object, bound resource, or exact provider object for a
+synchronous submission. Neither fact is inferred from frequency, shader
+similarity, or payload contents.
+
+The scan is bounded and cached. A 1,024-entry thread-local cache is keyed by
+child/descriptor address plus a fingerprint of the already-read words; a cache
+hit performs no repeated pointer validation. Each graph retains at most 16
+unique exact-class references and fail-visible overflow accounting. The runtime
+and prepared-candidate qualifiers separately report graph presence and exact
+cross-boundary shared identity.
+
+This instrumentation is part of the next batched AppData checkpoint. A graph
+identity alone is useful track ownership evidence, while exact shared identity
+is the preferred C1 terrain/road admission gate. Until runtime qualification,
+Xenos remains authoritative and no native admission or suppression is enabled.

--- a/src/native_renderer/graphics_hooks.cpp
+++ b/src/native_renderer/graphics_hooks.cpp
@@ -170,6 +170,16 @@ constexpr uint32_t kTrackRenderModelUnifiedVtable = 0x82001D74;
 constexpr uint32_t kTrackRenderModelDescriptorType = 21;
 constexpr uint32_t kTrackRenderModelDescriptorFlag = 1;
 constexpr uint32_t kTrackRenderModelDescriptorBytes = 248;
+constexpr uint32_t kTrackRenderModelGraphBytes = 64;
+constexpr uint32_t kTrackModelVtable = 0x820016B4;
+constexpr uint32_t kTrackMeshVtable = 0x8200143C;
+constexpr uint32_t kTrackSubModelVtable = 0x82001474;
+constexpr uint32_t kTrackProceduralGeometryObjectVtable = 0x82144CF8;
+constexpr uint32_t kTrackProceduralGeometryResourceVtable = 0x82144D7C;
+constexpr uint32_t kTrackPvsZoneObjectVtable = 0x82144DE0;
+constexpr uint32_t kTrackPvsZoneResourceVtable = 0x82144E64;
+constexpr size_t kTrackWorldResourceIdentityCapacity = 16;
+constexpr size_t kTrackWorldResourceGraphCacheCapacity = 1024;
 constexpr uint64_t kSkyHorizonAnchorSignature = UINT64_C(0x747837906D0BF484);
 constexpr uint64_t kSkyHorizonFollowerSignature = UINT64_C(0x1D253A52B55C9FB3);
 constexpr uint64_t kShadowDepthVertexShader = UINT64_C(0x4E1DA281CC3D7EDB);
@@ -448,6 +458,8 @@ struct SemanticDrawIdentity {
   bool track_texture_provider = false;
   bool track_render_model_scope = false;
   uint32_t track_render_shared_identity_mask = 0;
+  uint32_t track_world_resource_identity_mask = 0;
+  uint32_t track_world_resource_shared_identity_mask = 0;
   bool valid = false;
 };
 
@@ -577,6 +589,8 @@ struct SemanticVisibilityPreparedCandidateEntry {
   bool track_texture_provider = false;
   bool track_render_model_scope = false;
   uint32_t track_render_shared_identity_mask = 0;
+  uint32_t track_world_resource_identity_mask = 0;
+  uint32_t track_world_resource_shared_identity_mask = 0;
 };
 
 struct SemanticBatchRun {
@@ -1808,6 +1822,32 @@ enum TrackRenderSharedIdentity : uint32_t {
   kTrackRenderSharedChildRuntimeObject = 1u << 7,
 };
 
+enum TrackWorldResourceIdentity : uint32_t {
+  kTrackWorldResourceTrackModel = 1u << 0,
+  kTrackWorldResourceTrackMesh = 1u << 1,
+  kTrackWorldResourceTrackSubModel = 1u << 2,
+  kTrackWorldResourceProceduralGeometryObject = 1u << 3,
+  kTrackWorldResourceProceduralGeometryResource = 1u << 4,
+  kTrackWorldResourcePvsZoneObject = 1u << 5,
+  kTrackWorldResourcePvsZoneResource = 1u << 6,
+};
+
+struct TrackWorldResourceReference {
+  uint32_t address = 0;
+  uint32_t identity = 0;
+};
+
+struct TrackWorldResourceGraphCacheEntry {
+  uint64_t fingerprint = 0;
+  uint32_t child_address = 0;
+  uint32_t descriptor_address = 0;
+  uint32_t identity_mask = 0;
+  uint32_t reference_count = 0;
+  std::array<TrackWorldResourceReference,
+             kTrackWorldResourceIdentityCapacity>
+      references{};
+};
+
 struct TrackRenderModelDispatchScope {
   uint64_t submission_joins = 0;
   uint32_t root_address = 0;
@@ -1815,6 +1855,12 @@ struct TrackRenderModelDispatchScope {
   uint32_t descriptor_address = 0;
   uint32_t descriptor_payload = 0;
   uint32_t shared_identity_mask = 0;
+  uint32_t world_resource_identity_mask = 0;
+  uint32_t world_resource_shared_identity_mask = 0;
+  uint32_t world_resource_reference_count = 0;
+  std::array<TrackWorldResourceReference,
+             kTrackWorldResourceIdentityCapacity>
+      world_resource_references{};
   bool active = false;
   bool exact = false;
 };
@@ -1891,6 +1937,15 @@ std::atomic<uint64_t> g_track_render_model_submission_joins{};
 std::atomic<uint64_t> g_track_render_model_shared_identity_joins{};
 std::array<std::atomic<uint64_t>, 8>
     g_track_render_model_shared_identity_relations{};
+std::atomic<uint64_t> g_track_world_resource_graph_cache_hits{};
+std::atomic<uint64_t> g_track_world_resource_graph_cache_misses{};
+std::atomic<uint64_t> g_track_world_resource_graph_reference_overflow{};
+std::atomic<uint64_t> g_track_world_resource_graph_scopes{};
+std::atomic<uint64_t> g_track_world_resource_shared_identity_joins{};
+std::array<std::atomic<uint64_t>, 7>
+    g_track_world_resource_identity_relations{};
+std::array<std::atomic<uint64_t>, 7>
+    g_track_world_resource_shared_identity_relations{};
 std::array<SemanticBindingCacheSlot, 5> g_semantic_binding_cache_slots{};
 std::array<SemanticResolverCacheSlot, 5> g_semantic_resolver_cache_slots{};
 thread_local PendingSemanticResourceBindings g_pending_semantic_bindings{};
@@ -1902,6 +1957,9 @@ thread_local std::array<SemanticDrawIdentity,
 thread_local size_t g_semantic_render_item_stack_depth = 0;
 thread_local size_t g_semantic_render_item_stack_overflow_depth = 0;
 thread_local TrackRenderModelDispatchScope g_track_render_model_scope{};
+thread_local std::array<TrackWorldResourceGraphCacheEntry,
+                        kTrackWorldResourceGraphCacheCapacity>
+    g_track_world_resource_graph_cache{};
 thread_local TitleDrawOrigin g_pending_adapter_origin;
 thread_local std::array<TitleDrawOrigin, kTitleOriginStackCapacity>
     g_title_origin_stack;
@@ -2229,6 +2287,8 @@ const char *DrawOutcomeName(uint32_t outcome) {
 
 std::string CensusSceneMarker();
 uint64_t HashCombine(uint64_t hash, uint64_t value);
+uint32_t LoadSemanticGuestU32(rex::memory::Memory *memory,
+                              uint32_t address);
 template <size_t N>
 void LoadSemanticGuestWords(rex::memory::Memory *memory, uint32_t address,
                             std::array<uint32_t, N> &words);
@@ -2368,6 +2428,115 @@ bool IsReadableVehicleGuestRange(rex::memory::Memory *memory,
              rex::memory::PageAccess::kNoAccess;
 }
 
+uint32_t ClassifyTrackWorldResourceVtable(uint32_t vtable) {
+  switch (vtable) {
+  case kTrackModelVtable:
+    return kTrackWorldResourceTrackModel;
+  case kTrackMeshVtable:
+    return kTrackWorldResourceTrackMesh;
+  case kTrackSubModelVtable:
+    return kTrackWorldResourceTrackSubModel;
+  case kTrackProceduralGeometryObjectVtable:
+    return kTrackWorldResourceProceduralGeometryObject;
+  case kTrackProceduralGeometryResourceVtable:
+    return kTrackWorldResourceProceduralGeometryResource;
+  case kTrackPvsZoneObjectVtable:
+    return kTrackWorldResourcePvsZoneObject;
+  case kTrackPvsZoneResourceVtable:
+    return kTrackWorldResourcePvsZoneResource;
+  default:
+    return 0;
+  }
+}
+
+void AddTrackWorldResourceReference(
+    TrackWorldResourceGraphCacheEntry &entry, uint32_t address,
+    uint32_t identity) {
+  if (!address || !identity) {
+    return;
+  }
+  entry.identity_mask |= identity;
+  for (size_t index = 0; index < entry.reference_count; ++index) {
+    if (entry.references[index].address == address) {
+      entry.references[index].identity |= identity;
+      return;
+    }
+  }
+  if (entry.reference_count >= entry.references.size()) {
+    ++g_track_world_resource_graph_reference_overflow;
+    return;
+  }
+  entry.references[entry.reference_count++] = {
+      .address = address,
+      .identity = identity,
+  };
+}
+
+template <size_t N>
+void ScanTrackWorldResourcePointers(
+    rex::memory::Memory *memory, const std::array<uint32_t, N> &words,
+    TrackWorldResourceGraphCacheEntry &entry) {
+  for (uint32_t address : words) {
+    if (!address || (address & 3) ||
+        !IsReadableVehicleGuestRange(memory, address, sizeof(uint32_t))) {
+      continue;
+    }
+    const uint32_t identity = ClassifyTrackWorldResourceVtable(
+        LoadSemanticGuestU32(memory, address));
+    AddTrackWorldResourceReference(entry, address, identity);
+  }
+}
+
+template <size_t ChildWords, size_t DescriptorWords>
+void PopulateTrackWorldResourceGraph(
+    rex::memory::Memory *memory, uint32_t child_address,
+    uint32_t descriptor_address,
+    const std::array<uint32_t, ChildWords> &child_words,
+    const std::array<uint32_t, DescriptorWords> &descriptor_words) {
+  uint64_t fingerprint = UINT64_C(0xCBF29CE484222325);
+  for (uint32_t word : child_words) {
+    fingerprint = HashCombine(fingerprint, word);
+  }
+  for (uint32_t word : descriptor_words) {
+    fingerprint = HashCombine(fingerprint, word);
+  }
+  fingerprint = fingerprint ? fingerprint : 1;
+  const size_t index =
+      size_t(((child_address >> 4) ^ (descriptor_address >> 4)) &
+             (kTrackWorldResourceGraphCacheCapacity - 1));
+  static_assert((kTrackWorldResourceGraphCacheCapacity &
+                 (kTrackWorldResourceGraphCacheCapacity - 1)) == 0);
+  TrackWorldResourceGraphCacheEntry &entry =
+      g_track_world_resource_graph_cache[index];
+  if (entry.child_address == child_address &&
+      entry.descriptor_address == descriptor_address &&
+      entry.fingerprint == fingerprint) {
+    ++g_track_world_resource_graph_cache_hits;
+  } else {
+    ++g_track_world_resource_graph_cache_misses;
+    entry = {
+        .fingerprint = fingerprint,
+        .child_address = child_address,
+        .descriptor_address = descriptor_address,
+    };
+    ScanTrackWorldResourcePointers(memory, child_words, entry);
+    ScanTrackWorldResourcePointers(memory, descriptor_words, entry);
+  }
+  TrackRenderModelDispatchScope &scope = g_track_render_model_scope;
+  scope.world_resource_identity_mask = entry.identity_mask;
+  scope.world_resource_reference_count = entry.reference_count;
+  scope.world_resource_references = entry.references;
+  if (entry.identity_mask) {
+    ++g_track_world_resource_graph_scopes;
+    for (size_t bit = 0;
+         bit < g_track_world_resource_identity_relations.size(); ++bit) {
+      if (entry.identity_mask & (1u << bit)) {
+        ++g_track_world_resource_identity_relations[bit];
+      }
+    }
+  }
+}
+
 void BeginTrackRenderModelDispatch(uint32_t root_address) {
   ++g_track_render_model_scope_entries;
   if (g_track_render_model_scope.active) {
@@ -2389,11 +2558,13 @@ void BeginTrackRenderModelDispatch(uint32_t root_address) {
     return;
   }
   const uint32_t child_address = root_words[1];
-  if (!IsReadableVehicleGuestRange(memory, child_address, 52)) {
+  if (!IsReadableVehicleGuestRange(memory, child_address,
+                                   kTrackRenderModelGraphBytes)) {
     ++g_track_render_model_scope_invalid_child;
     return;
   }
-  std::array<uint32_t, 13> child_words{};
+  std::array<uint32_t, kTrackRenderModelGraphBytes / sizeof(uint32_t)>
+      child_words{};
   LoadSemanticGuestWords(memory, child_address, child_words);
   if (child_words[0] != kTrackRenderModelUnifiedVtable) {
     ++g_track_render_model_scope_invalid_child;
@@ -2425,6 +2596,8 @@ void BeginTrackRenderModelDispatch(uint32_t root_address) {
   g_track_render_model_scope.descriptor_address = descriptor_address;
   g_track_render_model_scope.descriptor_payload = descriptor_words[10];
   g_track_render_model_scope.exact = true;
+  PopulateTrackWorldResourceGraph(memory, child_address, descriptor_address,
+                                  child_words, descriptor_words);
   ++g_track_render_model_scope_exact;
 }
 
@@ -8597,7 +8770,10 @@ void JoinProceduralModelSemanticDraw(uint64_t submission_key,
                                      bool secondary_resource_present,
                                      bool track_texture_provider,
                                      bool track_render_model_scope,
-                                     uint32_t track_render_shared_identity_mask) {
+                                     uint32_t track_render_shared_identity_mask,
+                                     uint32_t track_world_resource_identity_mask,
+                                     uint32_t
+                                         track_world_resource_shared_identity_mask) {
   if (!g_semantic_render_item_stack_depth) {
     g_semantic_draw_scope_mismatches.fetch_add(1,
                                                 std::memory_order_relaxed);
@@ -8625,6 +8801,10 @@ void JoinProceduralModelSemanticDraw(uint64_t submission_key,
   semantic_draw.track_render_model_scope = track_render_model_scope;
   semantic_draw.track_render_shared_identity_mask =
       track_render_shared_identity_mask;
+  semantic_draw.track_world_resource_identity_mask =
+      track_world_resource_identity_mask;
+  semantic_draw.track_world_resource_shared_identity_mask =
+      track_world_resource_shared_identity_mask;
   semantic_draw.valid = true;
   g_semantic_draw_scope_joins.fetch_add(1, std::memory_order_relaxed);
 }
@@ -8849,6 +9029,8 @@ void RecordProceduralModelGeometrySubmission(
   const bool track_render_model_scope =
       g_track_render_model_scope.active && g_track_render_model_scope.exact;
   uint32_t track_render_shared_identity_mask = 0;
+  uint32_t track_world_resource_identity_mask = 0;
+  uint32_t track_world_resource_shared_identity_mask = 0;
   if (track_render_model_scope) {
     const TrackRenderModelDispatchScope &scope = g_track_render_model_scope;
     track_render_shared_identity_mask |=
@@ -8882,6 +9064,23 @@ void RecordProceduralModelGeometrySubmission(
         scope.child_address == runtime_submission_object
             ? kTrackRenderSharedChildRuntimeObject
             : 0;
+    track_world_resource_identity_mask =
+        scope.world_resource_identity_mask;
+    for (size_t index = 0; index < scope.world_resource_reference_count;
+         ++index) {
+      const TrackWorldResourceReference &reference =
+          scope.world_resource_references[index];
+      if (reference.address == receiver_address ||
+          reference.address == runtime_submission_object ||
+          reference.address == pending.primary_bound_resource_object ||
+          reference.address == pending.primary_provider.provider_object ||
+          (secondary_resource_present &&
+           (reference.address == pending.secondary_bound_resource_object ||
+            reference.address ==
+                pending.secondary_provider.provider_object))) {
+        track_world_resource_shared_identity_mask |= reference.identity;
+      }
+    }
     ++g_track_render_model_scope.submission_joins;
     g_track_render_model_scope.shared_identity_mask |=
         track_render_shared_identity_mask;
@@ -8896,13 +9095,27 @@ void RecordProceduralModelGeometrySubmission(
         }
       }
     }
+    g_track_render_model_scope.world_resource_shared_identity_mask |=
+        track_world_resource_shared_identity_mask;
+    if (track_world_resource_shared_identity_mask) {
+      ++g_track_world_resource_shared_identity_joins;
+      for (size_t bit = 0;
+           bit < g_track_world_resource_shared_identity_relations.size();
+           ++bit) {
+        if (track_world_resource_shared_identity_mask & (1u << bit)) {
+          ++g_track_world_resource_shared_identity_relations[bit];
+        }
+      }
+    }
   }
   JoinProceduralModelSemanticDraw(
       key, receiver_address, receiver_generation, record_index,
       descriptor_address, runtime_address, descriptor_kind, helper_state,
       primary_resource_key, secondary_resource_key,
       secondary_resource_present, track_texture_provider,
-      track_render_model_scope, track_render_shared_identity_mask);
+      track_render_model_scope, track_render_shared_identity_mask,
+      track_world_resource_identity_mask,
+      track_world_resource_shared_identity_mask);
 
   size_t index = size_t(key % kSemanticSubmissionCapacity);
   for (size_t probe = 0; probe < kSemanticSubmissionCapacity; ++probe) {
@@ -9302,6 +9515,70 @@ void EmitTrackRenderModelRuntimeJoinSummary() {
        {"shared_child_runtime_object",
         std::to_string(g_track_render_model_shared_identity_relations[7].load(
             std::memory_order_relaxed))},
+       {"world_resource_graph_scopes",
+        std::to_string(g_track_world_resource_graph_scopes.load(
+            std::memory_order_relaxed))},
+       {"world_resource_graph_cache_hits",
+        std::to_string(g_track_world_resource_graph_cache_hits.load(
+            std::memory_order_relaxed))},
+       {"world_resource_graph_cache_misses",
+        std::to_string(g_track_world_resource_graph_cache_misses.load(
+            std::memory_order_relaxed))},
+       {"world_resource_graph_reference_overflow",
+        std::to_string(g_track_world_resource_graph_reference_overflow.load(
+            std::memory_order_relaxed))},
+       {"world_resource_shared_identity_joins",
+        std::to_string(g_track_world_resource_shared_identity_joins.load(
+            std::memory_order_relaxed))},
+       {"world_track_model",
+        std::to_string(g_track_world_resource_identity_relations[0].load(
+            std::memory_order_relaxed))},
+       {"world_track_mesh",
+        std::to_string(g_track_world_resource_identity_relations[1].load(
+            std::memory_order_relaxed))},
+       {"world_track_submodel",
+        std::to_string(g_track_world_resource_identity_relations[2].load(
+            std::memory_order_relaxed))},
+       {"world_procedural_geometry_object",
+        std::to_string(g_track_world_resource_identity_relations[3].load(
+            std::memory_order_relaxed))},
+       {"world_procedural_geometry_resource",
+        std::to_string(g_track_world_resource_identity_relations[4].load(
+            std::memory_order_relaxed))},
+       {"world_pvs_zone_object",
+        std::to_string(g_track_world_resource_identity_relations[5].load(
+            std::memory_order_relaxed))},
+       {"world_pvs_zone_resource",
+        std::to_string(g_track_world_resource_identity_relations[6].load(
+            std::memory_order_relaxed))},
+       {"shared_world_track_model",
+        std::to_string(
+            g_track_world_resource_shared_identity_relations[0].load(
+                std::memory_order_relaxed))},
+       {"shared_world_track_mesh",
+        std::to_string(
+            g_track_world_resource_shared_identity_relations[1].load(
+                std::memory_order_relaxed))},
+       {"shared_world_track_submodel",
+        std::to_string(
+            g_track_world_resource_shared_identity_relations[2].load(
+                std::memory_order_relaxed))},
+       {"shared_world_procedural_geometry_object",
+        std::to_string(
+            g_track_world_resource_shared_identity_relations[3].load(
+                std::memory_order_relaxed))},
+       {"shared_world_procedural_geometry_resource",
+        std::to_string(
+            g_track_world_resource_shared_identity_relations[4].load(
+                std::memory_order_relaxed))},
+       {"shared_world_pvs_zone_object",
+        std::to_string(
+            g_track_world_resource_shared_identity_relations[5].load(
+                std::memory_order_relaxed))},
+       {"shared_world_pvs_zone_resource",
+        std::to_string(
+            g_track_world_resource_shared_identity_relations[6].load(
+                std::memory_order_relaxed))},
        {"scope_overlaps", std::to_string(overlaps)},
        {"exit_without_entry", std::to_string(exit_without_entry)},
        {"accounting_complete", accounting_complete ? "true" : "false"},
@@ -13946,6 +14223,8 @@ bool RecordSemanticVisibilityPreparedCandidate(
         uint64_t(identity.track_texture_provider),
         uint64_t(identity.track_render_model_scope),
         uint64_t(identity.track_render_shared_identity_mask),
+        uint64_t(identity.track_world_resource_identity_mask),
+        uint64_t(identity.track_world_resource_shared_identity_mask),
         uint64_t(mechanical_rejection_mask)}) {
     key = HashCombine(key, value);
   }
@@ -13985,6 +14264,10 @@ bool RecordSemanticVisibilityPreparedCandidate(
           .track_render_model_scope = identity.track_render_model_scope,
           .track_render_shared_identity_mask =
               identity.track_render_shared_identity_mask,
+          .track_world_resource_identity_mask =
+              identity.track_world_resource_identity_mask,
+          .track_world_resource_shared_identity_mask =
+              identity.track_world_resource_shared_identity_mask,
       };
       ++g_semantic_visibility_prepared_candidate_count;
       return true;
@@ -14011,7 +14294,11 @@ bool RecordSemanticVisibilityPreparedCandidate(
         entry.track_texture_provider == identity.track_texture_provider &&
         entry.track_render_model_scope == identity.track_render_model_scope &&
         entry.track_render_shared_identity_mask ==
-            identity.track_render_shared_identity_mask) {
+            identity.track_render_shared_identity_mask &&
+        entry.track_world_resource_identity_mask ==
+            identity.track_world_resource_identity_mask &&
+        entry.track_world_resource_shared_identity_mask ==
+            identity.track_world_resource_shared_identity_mask) {
       ++entry.draws;
       entry.last_frame = observation.frame_sequence;
       entry.maximum_policy_age_frames =
@@ -15516,6 +15803,10 @@ void EmitSemanticVisibilityPreparedCandidates() {
   uint64_t track_render_model_scope_entries = 0;
   uint64_t track_render_shared_identity_draws = 0;
   uint64_t track_render_shared_identity_entries = 0;
+  uint64_t track_world_resource_identity_draws = 0;
+  uint64_t track_world_resource_identity_entries = 0;
+  uint64_t track_world_resource_shared_identity_draws = 0;
+  uint64_t track_world_resource_shared_identity_entries = 0;
   for (const SemanticVisibilityPreparedCandidateEntry &entry :
        g_semantic_visibility_prepared_candidates) {
     if (!entry.key) {
@@ -15545,6 +15836,14 @@ void EmitSemanticVisibilityPreparedCandidates() {
     if (entry.track_render_shared_identity_mask) {
       track_render_shared_identity_draws += entry.draws;
       ++track_render_shared_identity_entries;
+    }
+    if (entry.track_world_resource_identity_mask) {
+      track_world_resource_identity_draws += entry.draws;
+      ++track_world_resource_identity_entries;
+    }
+    if (entry.track_world_resource_shared_identity_mask) {
+      track_world_resource_shared_identity_draws += entry.draws;
+      ++track_world_resource_shared_identity_entries;
     }
     pinyon_shift::diagnostics::RecordEvent(
         "native_renderer.discovery.semantic_visibility_prepared_candidate_entry",
@@ -15586,6 +15885,13 @@ void EmitSemanticVisibilityPreparedCandidates() {
           fmt::format("{:08X}", entry.track_render_shared_identity_mask)},
          {"track_render_model_lineage",
           "exact_unified_instance_model_nested_dispatch_scope"},
+         {"track_world_resource_identity_mask",
+          fmt::format("{:08X}", entry.track_world_resource_identity_mask)},
+         {"track_world_resource_shared_identity_mask",
+          fmt::format("{:08X}",
+                      entry.track_world_resource_shared_identity_mask)},
+         {"track_world_resource_lineage",
+          "bounded_direct_vtable_identity_from_exact_model_graph"},
          {"draws", std::to_string(entry.draws)},
          {"first_frame", std::to_string(entry.first_frame)},
          {"last_frame", std::to_string(entry.last_frame)},
@@ -15630,7 +15936,15 @@ void EmitSemanticVisibilityPreparedCandidates() {
       track_render_model_scope_entries <= entry_count &&
       track_render_shared_identity_draws <= track_render_model_scope_draws &&
       track_render_shared_identity_entries <=
-          track_render_model_scope_entries;
+          track_render_model_scope_entries &&
+      track_world_resource_identity_draws <=
+          track_render_model_scope_draws &&
+      track_world_resource_identity_entries <=
+          track_render_model_scope_entries &&
+      track_world_resource_shared_identity_draws <=
+          track_world_resource_identity_draws &&
+      track_world_resource_shared_identity_entries <=
+          track_world_resource_identity_entries;
   pinyon_shift::diagnostics::RecordEvent(
       "native_renderer.discovery.semantic_visibility_prepared_candidate_summary",
       {{"status", !g_semantic_visibility_prepared_observations
@@ -15676,6 +15990,14 @@ void EmitSemanticVisibilityPreparedCandidates() {
         std::to_string(track_render_shared_identity_entries)},
        {"track_render_shared_identity_draws",
         std::to_string(track_render_shared_identity_draws)},
+       {"track_world_resource_identity_entries",
+        std::to_string(track_world_resource_identity_entries)},
+       {"track_world_resource_identity_draws",
+        std::to_string(track_world_resource_identity_draws)},
+       {"track_world_resource_shared_identity_entries",
+        std::to_string(track_world_resource_shared_identity_entries)},
+       {"track_world_resource_shared_identity_draws",
+        std::to_string(track_world_resource_shared_identity_draws)},
        {"capacity",
         std::to_string(kSemanticVisibilityPreparedCandidateCapacity)},
        {"overflow",
@@ -15691,6 +16013,8 @@ void EmitSemanticVisibilityPreparedCandidates() {
         "exact_primary_provider_vtable_and_four_methods"},
        {"track_render_model_lineage",
         "exact_unified_instance_model_nested_dispatch_scope"},
+       {"track_world_resource_lineage",
+        "bounded_direct_vtable_identity_from_exact_model_graph"},
        {"guest_state_changed", "false"},
        {"control_flow_changed", "false"},
        {"native_upload", "false"},
@@ -20467,7 +20791,16 @@ void InstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system,
        {"join", "synchronous_scope_to_procedural_model_submission"},
        {"shared_identity",
         "descriptor_payload_or_object_address_exact_equality"},
-       {"guest_payload_read", "bounded_308_bytes_per_scope"},
+       {"world_resource_vtables",
+        "820016B4,8200143C,82001474,82144CF8,82144D7C,82144DE0,82144E64"},
+       {"world_resource_graph",
+        "direct_child_or_descriptor_pointer_with_exact_rtti_vtable"},
+       {"world_resource_shared_identity",
+        "exact_address_equality_to_submission_objects_or_resources"},
+       {"world_resource_graph_cache_capacity", "1024"},
+       {"world_resource_reference_capacity", "16"},
+       {"guest_payload_read",
+        "bounded_320_bytes_plus_direct_vtable_words_per_cache_miss"},
        {"guest_state_changed", "false"},
        {"control_flow_changed", "false"},
        {"native_admission", "false"},

--- a/tools/discover-native-renderer-track-ingress.py
+++ b/tools/discover-native-renderer-track-ingress.py
@@ -261,6 +261,28 @@ def build(functions: set[int], image: bytes) -> dict:
             "proved": False,
             "required_evidence": "exact_shared_object_or_resource_identity_at_both_boundaries",
         },
+        "runtime_graph_probe": {
+            "source_scope": "8240EC80_8240ECAC",
+            "child_bytes": 64,
+            "descriptor_bytes": 248,
+            "direct_vtable_classes": [
+                "track_model",
+                "track_mesh",
+                "track_sub_model",
+                "track_procedural_geometry_object",
+                "track_procedural_geometry_resource",
+                "track_pvs_zone_object",
+                "track_pvs_zone_resource",
+            ],
+            "cache_capacity": 1024,
+            "reference_capacity": 16,
+            "identity_join": (
+                "exact_address_equality_to_procedural_submission_objects_or_resources"
+            ),
+            "guest_state_changed": False,
+            "native_admission": False,
+            "suppression_allowed": False,
+        },
         "safety": {
             "static_analysis_only": True,
             "guest_payload_exported": False,

--- a/tools/summarize-native-renderer-track-model-runtime-join.py
+++ b/tools/summarize-native-renderer-track-model-runtime-join.py
@@ -7,7 +7,7 @@ import pathlib
 import sys
 
 
-SCHEMA = "pinyon-shift.native-renderer-track-model-runtime-join.v1"
+SCHEMA = "pinyon-shift.native-renderer-track-model-runtime-join.v2"
 CONFIG = "native_renderer.discovery.track_render_model_runtime_join_config"
 SUMMARY = "native_renderer.discovery.track_render_model_runtime_join_summary"
 
@@ -20,6 +20,20 @@ RELATIONS = (
     "shared_child_receiver",
     "shared_root_runtime_object",
     "shared_child_runtime_object",
+)
+
+WORLD_RELATIONS = (
+    "world_track_model",
+    "world_track_mesh",
+    "world_track_submodel",
+    "world_procedural_geometry_object",
+    "world_procedural_geometry_resource",
+    "world_pvs_zone_object",
+    "world_pvs_zone_resource",
+)
+
+SHARED_WORLD_RELATIONS = tuple(
+    f"shared_{relation}" for relation in WORLD_RELATIONS
 )
 
 
@@ -94,7 +108,21 @@ def build(events, requested_session=None):
         "descriptor_flag": "1",
         "join": "synchronous_scope_to_procedural_model_submission",
         "shared_identity": "descriptor_payload_or_object_address_exact_equality",
-        "guest_payload_read": "bounded_308_bytes_per_scope",
+        "world_resource_vtables": (
+            "820016B4,8200143C,82001474,82144CF8,82144D7C,82144DE0,"
+            "82144E64"
+        ),
+        "world_resource_graph": (
+            "direct_child_or_descriptor_pointer_with_exact_rtti_vtable"
+        ),
+        "world_resource_shared_identity": (
+            "exact_address_equality_to_submission_objects_or_resources"
+        ),
+        "world_resource_graph_cache_capacity": "1024",
+        "world_resource_reference_capacity": "16",
+        "guest_payload_read": (
+            "bounded_320_bytes_plus_direct_vtable_words_per_cache_miss"
+        ),
     }
     if any(config.get(key) != value for key, value in expected_config.items()):
         raise ValueError("track-model runtime configuration drifted")
@@ -121,7 +149,14 @@ def build(events, requested_session=None):
         "shared_identity_joins",
         "scope_overlaps",
         "exit_without_entry",
+        "world_resource_graph_scopes",
+        "world_resource_graph_cache_hits",
+        "world_resource_graph_cache_misses",
+        "world_resource_graph_reference_overflow",
+        "world_resource_shared_identity_joins",
         *RELATIONS,
+        *WORLD_RELATIONS,
+        *SHARED_WORLD_RELATIONS,
     )
     totals = {key: integer(summary, key) for key in keys}
     failures = []
@@ -162,6 +197,39 @@ def build(events, requested_session=None):
         totals[key] for key in RELATIONS
     ):
         failures.append("shared identity relation accounting is empty")
+    if (
+        totals["world_resource_graph_cache_hits"]
+        + totals["world_resource_graph_cache_misses"]
+        != totals["exact_scopes"]
+    ):
+        failures.append("world-resource graph cache accounting drifted")
+    if totals["world_resource_graph_scopes"] > totals["exact_scopes"]:
+        failures.append("world-resource graph scopes exceed exact scopes")
+    if totals["world_resource_graph_reference_overflow"]:
+        failures.append("world-resource graph reference overflow is nonzero")
+    if totals["world_resource_graph_scopes"] and not any(
+        totals[key] for key in WORLD_RELATIONS
+    ):
+        failures.append("world-resource graph relation accounting is empty")
+    if any(
+        totals[key] > totals["world_resource_graph_scopes"]
+        for key in WORLD_RELATIONS
+    ):
+        failures.append("world-resource graph relation exceeds graph scopes")
+    if (
+        totals["world_resource_shared_identity_joins"]
+        > totals["submission_joins"]
+    ):
+        failures.append("world-resource shared joins exceed submission joins")
+    if totals["world_resource_shared_identity_joins"] and not any(
+        totals[key] for key in SHARED_WORLD_RELATIONS
+    ):
+        failures.append("shared world-resource relation accounting is empty")
+    if any(
+        totals[key] > totals["world_resource_shared_identity_joins"]
+        for key in SHARED_WORLD_RELATIONS
+    ):
+        failures.append("shared world-resource relation exceeds shared joins")
     expected_status = "complete" if not failures else "incomplete"
     if summary.get("status") != expected_status:
         failures.append("runtime status does not match qualification outcome")
@@ -179,10 +247,23 @@ def build(events, requested_session=None):
         "shared_identity_relations": {
             key: totals[key] for key in RELATIONS
         },
+        "world_resource_relations": {
+            key: totals[key] for key in WORLD_RELATIONS
+        },
+        "shared_world_resource_relations": {
+            key: totals[key] for key in SHARED_WORLD_RELATIONS
+        },
         "qualification": {
             "track_render_model_scope_to_submission_proved": not failures,
             "shared_object_or_resource_identity_proved": (
                 not failures and totals["shared_identity_joins"] > 0
+            ),
+            "track_world_resource_graph_identity_proved": (
+                not failures and totals["world_resource_graph_scopes"] > 0
+            ),
+            "track_world_resource_to_submission_identity_proved": (
+                not failures
+                and totals["world_resource_shared_identity_joins"] > 0
             ),
             "terrain_or_road_visual_identity_proved": False,
             "native_admission": False,

--- a/tools/summarize-native-renderer-visibility-prepared-candidates.py
+++ b/tools/summarize-native-renderer-visibility-prepared-candidates.py
@@ -7,7 +7,7 @@ import pathlib
 import sys
 
 
-SCHEMA = "pinyon-shift.native-renderer-visibility-prepared-candidates.v6"
+SCHEMA = "pinyon-shift.native-renderer-visibility-prepared-candidates.v7"
 STATIC_SCHEMA = "pinyon-shift.native-renderer-dispatch-static.v3"
 CONFIG = (
     "native_renderer.discovery."
@@ -182,6 +182,8 @@ def build(events, static, requested_session=None):
         != "exact_primary_provider_vtable_and_four_methods"
         or summary.get("track_render_model_lineage")
         != "exact_unified_instance_model_nested_dispatch_scope"
+        or summary.get("track_world_resource_lineage")
+        != "bounded_direct_vtable_identity_from_exact_model_graph"
         or summary.get("mechanical_admission_contract") != "isolated_draw_v1"
     ):
         raise ValueError("prepared-candidate summary is incomplete")
@@ -208,6 +210,10 @@ def build(events, static, requested_session=None):
         "track_render_model_scope_draws",
         "track_render_shared_identity_entries",
         "track_render_shared_identity_draws",
+        "track_world_resource_identity_entries",
+        "track_world_resource_identity_draws",
+        "track_world_resource_shared_identity_entries",
+        "track_world_resource_shared_identity_draws",
         "capacity",
         "overflow",
         "policy_age_limit_frames",
@@ -267,6 +273,15 @@ def build(events, static, requested_session=None):
         item["track_render_shared_identity_mask"] = int(
             hexadecimal(event, "track_render_shared_identity_mask", 8), 16
         )
+        item["track_world_resource_identity_mask"] = int(
+            hexadecimal(event, "track_world_resource_identity_mask", 8), 16
+        )
+        item["track_world_resource_shared_identity_mask"] = int(
+            hexadecimal(
+                event, "track_world_resource_shared_identity_mask", 8
+            ),
+            16,
+        )
         item["mechanical_rejections"] = [
             name
             for bit, name in MECHANICAL_REJECTIONS.items()
@@ -295,9 +310,21 @@ def build(events, static, requested_session=None):
             or event.get("track_render_model_scope") not in ("true", "false")
             or event.get("track_render_model_lineage")
             != "exact_unified_instance_model_nested_dispatch_scope"
+            or event.get("track_world_resource_lineage")
+            != "bounded_direct_vtable_identity_from_exact_model_graph"
             or (
                 item["track_render_shared_identity_mask"]
                 and not item["track_render_model_scope"]
+            )
+            or item["track_render_shared_identity_mask"] & ~0xFF
+            or (
+                item["track_world_resource_identity_mask"]
+                and not item["track_render_model_scope"]
+            )
+            or item["track_world_resource_identity_mask"] & ~0x7F
+            or (
+                item["track_world_resource_shared_identity_mask"]
+                & ~item["track_world_resource_identity_mask"]
             )
             or (item["title_lod_valid"] and item["title_lod_index"] >= 32)
             or integer(event, "policy_age_limit_frames")
@@ -391,6 +418,30 @@ def build(events, static, requested_session=None):
         != sum(entry["draws"] for entry in shared_identity_entries)
     ):
         failures.append("track render shared-identity totals drifted")
+    world_resource_entries = [
+        entry
+        for entry in entries
+        if entry["track_world_resource_identity_mask"]
+    ]
+    if (
+        totals["track_world_resource_identity_entries"]
+        != len(world_resource_entries)
+        or totals["track_world_resource_identity_draws"]
+        != sum(entry["draws"] for entry in world_resource_entries)
+    ):
+        failures.append("track world-resource identity totals drifted")
+    shared_world_resource_entries = [
+        entry
+        for entry in entries
+        if entry["track_world_resource_shared_identity_mask"]
+    ]
+    if (
+        totals["track_world_resource_shared_identity_entries"]
+        != len(shared_world_resource_entries)
+        or totals["track_world_resource_shared_identity_draws"]
+        != sum(entry["draws"] for entry in shared_world_resource_entries)
+    ):
+        failures.append("track world-resource shared-identity totals drifted")
     if totals["capacity"] != 4096 or totals["policy_age_limit_frames"] != 1:
         failures.append("prepared-candidate bounds drifted")
     if totals["selected_joins"] > integer(workset, "selected_joins"):
@@ -422,6 +473,12 @@ def build(events, static, requested_session=None):
             ),
             "track_render_shared_identity_proved": (
                 not failures and bool(shared_identity_entries)
+            ),
+            "track_world_resource_identity_proved": (
+                not failures and bool(world_resource_entries)
+            ),
+            "track_world_resource_shared_identity_proved": (
+                not failures and bool(shared_world_resource_entries)
             ),
             "native_draw_enabled": False,
             "suppression_allowed": False,

--- a/tools/tests/test_native_renderer_track_ingress.py
+++ b/tools/tests/test_native_renderer_track_ingress.py
@@ -66,6 +66,12 @@ class NativeRendererTrackIngressTests(unittest.TestCase):
             135,
             document["classes"]["track_presentation_unified"]["vtable_slot_count"],
         )
+        self.assertEqual(64, document["runtime_graph_probe"]["child_bytes"])
+        self.assertEqual(248, document["runtime_graph_probe"]["descriptor_bytes"])
+        self.assertEqual(
+            7, len(document["runtime_graph_probe"]["direct_vtable_classes"])
+        )
+        self.assertFalse(document["runtime_graph_probe"]["native_admission"])
         self.assertEqual(
             "82DF3F00",
             next(

--- a/tools/tests/test_native_renderer_track_model_runtime_join.py
+++ b/tools/tests/test_native_renderer_track_model_runtime_join.py
@@ -41,12 +41,32 @@ def fixture(shared=3):
         descriptor_flag="1",
         join="synchronous_scope_to_procedural_model_submission",
         shared_identity="descriptor_payload_or_object_address_exact_equality",
-        guest_payload_read="bounded_308_bytes_per_scope",
+        world_resource_vtables=(
+            "820016B4,8200143C,82001474,82144CF8,82144D7C,82144DE0,"
+            "82144E64"
+        ),
+        world_resource_graph=(
+            "direct_child_or_descriptor_pointer_with_exact_rtti_vtable"
+        ),
+        world_resource_shared_identity=(
+            "exact_address_equality_to_submission_objects_or_resources"
+        ),
+        world_resource_graph_cache_capacity="1024",
+        world_resource_reference_capacity="16",
+        guest_payload_read=(
+            "bounded_320_bytes_plus_direct_vtable_words_per_cache_miss"
+        ),
         **safety(),
     )
     relations = {key: "0" for key in MODULE.RELATIONS}
+    world_relations = {key: "0" for key in MODULE.WORLD_RELATIONS}
+    shared_world_relations = {
+        key: "0" for key in MODULE.SHARED_WORLD_RELATIONS
+    }
     if shared:
         relations["shared_descriptor_payload_bound_resource"] = str(shared)
+        world_relations["world_track_mesh"] = "6"
+        shared_world_relations["shared_world_track_mesh"] = str(shared)
     summary = event(
         MODULE.SUMMARY,
         status="complete",
@@ -61,12 +81,19 @@ def fixture(shared=3):
         unjoined_scopes="2",
         submission_joins="12",
         shared_identity_joins=str(shared),
+        world_resource_graph_scopes="6" if shared else "0",
+        world_resource_graph_cache_hits="8",
+        world_resource_graph_cache_misses="2",
+        world_resource_graph_reference_overflow="0",
+        world_resource_shared_identity_joins=str(shared),
         scope_overlaps="0",
         exit_without_entry="0",
         accounting_complete="true",
         qualification_complete="true",
         classification="exact_unified_track_render_model_nested_submission_join",
         **relations,
+        **world_relations,
+        **shared_world_relations,
         **safety(),
     )
     return [config, summary]
@@ -86,6 +113,11 @@ class TrackModelRuntimeJoinTests(unittest.TestCase):
                 "shared_object_or_resource_identity_proved"
             ]
         )
+        self.assertTrue(
+            document["qualification"][
+                "track_world_resource_to_submission_identity_proved"
+            ]
+        )
 
     def test_qualifies_scope_without_claiming_shared_identity(self):
         document = MODULE.build(fixture(shared=0))
@@ -93,6 +125,11 @@ class TrackModelRuntimeJoinTests(unittest.TestCase):
         self.assertFalse(
             document["qualification"][
                 "shared_object_or_resource_identity_proved"
+            ]
+        )
+        self.assertFalse(
+            document["qualification"][
+                "track_world_resource_graph_identity_proved"
             ]
         )
 
@@ -106,6 +143,10 @@ class TrackModelRuntimeJoinTests(unittest.TestCase):
             submission_joins="0",
             shared_identity_joins="0",
             shared_descriptor_payload_bound_resource="0",
+            world_resource_graph_scopes="0",
+            world_resource_shared_identity_joins="0",
+            world_track_mesh="0",
+            shared_world_track_mesh="0",
             qualification_complete="false",
         )
         document = MODULE.build(events)

--- a/tools/tests/test_native_renderer_visibility_prepared_candidates.py
+++ b/tools/tests/test_native_renderer_visibility_prepared_candidates.py
@@ -94,6 +94,11 @@ class VisibilityPreparedCandidateReportTests(unittest.TestCase):
             "track_render_model_lineage": (
                 "exact_unified_instance_model_nested_dispatch_scope"
             ),
+            "track_world_resource_identity_mask": "00000012",
+            "track_world_resource_shared_identity_mask": "00000002",
+            "track_world_resource_lineage": (
+                "bounded_direct_vtable_identity_from_exact_model_graph"
+            ),
             "draws": "7",
             "first_frame": "10",
             "last_frame": "12",
@@ -131,6 +136,10 @@ class VisibilityPreparedCandidateReportTests(unittest.TestCase):
             "track_render_model_scope_draws": "7",
             "track_render_shared_identity_entries": "1",
             "track_render_shared_identity_draws": "7",
+            "track_world_resource_identity_entries": "1",
+            "track_world_resource_identity_draws": "7",
+            "track_world_resource_shared_identity_entries": "1",
+            "track_world_resource_shared_identity_draws": "7",
             "capacity": "4096",
             "overflow": "0",
             "policy_age_limit_frames": "1",
@@ -144,6 +153,9 @@ class VisibilityPreparedCandidateReportTests(unittest.TestCase):
             ),
             "track_render_model_lineage": (
                 "exact_unified_instance_model_nested_dispatch_scope"
+            ),
+            "track_world_resource_lineage": (
+                "bounded_direct_vtable_identity_from_exact_model_graph"
             ),
             **self.safety(),
         }
@@ -179,6 +191,14 @@ class VisibilityPreparedCandidateReportTests(unittest.TestCase):
         )
         self.assertTrue(
             document["qualification"]["track_render_shared_identity_proved"]
+        )
+        self.assertTrue(
+            document["qualification"]["track_world_resource_identity_proved"]
+        )
+        self.assertTrue(
+            document["qualification"][
+                "track_world_resource_shared_identity_proved"
+            ]
         )
 
     def test_build_accepts_candidate_without_title_lod(self):


### PR DESCRIPTION
Recognize exact track model, mesh, procedural-geometry, and PVS
resource vtables inside the accepted render-model graph. Carry graph and
shared-address identity separately into prepared candidate evidence.

Tests: python -m unittest discover -s tools/tests -p test_*.py
Tests: .\tools\build-preview.ps1 -Parallel 16
