### PR TITLE
fix(native-renderer): guard track graph host reads

### DIFF
--- a/docs/native-renderer/REPRIORITIZED_PLAN.md
+++ b/docs/native-renderer/REPRIORITIZED_PLAN.md
@@ -278,6 +278,13 @@ submission objects/resources are carried separately into prepared records.
 This is ready for the same deferred AppData checkpoint; it still changes no
 admission, draw, authority, or suppression decision.
 
+Safety correction: the first batched run exposed that the guest heap page
+table can label an arbitrary descriptor word readable while its translated
+host page remains uncommitted. The exact classifier's speculative vtable load
+faulted on guest `40D8D0D8` (RVA `5D0616F`). Every candidate pointer now also
+passes the host mapping/protection query before dereference, with explicit
+rejection accounting. C1 qualification remains pending a clean rerun.
+
 ### C2. Static world buildings and props
 
 - Expand opaque-world material and geometry coverage.

--- a/docs/native-renderer/TERRAIN_ROAD_RENDER_PATH.md
+++ b/docs/native-renderer/TERRAIN_ROAD_RENDER_PATH.md
@@ -302,3 +302,19 @@ This instrumentation is part of the next batched AppData checkpoint. A graph
 identity alone is useful track ownership evidence, while exact shared identity
 is the preferred C1 terrain/road admission gate. Until runtime qualification,
 Xenos remains authoritative and no native admission or suppression is enabled.
+
+### First-run host mapping correction
+
+The first merged AppData run reached 8,700 frames before an access violation at
+native RVA `5D0616F`, reading guest value `40D8D0D8`. The local dump and binary
+disassembly identify that RVA as the new direct-pointer vtable load immediately
+before comparisons with the exact procedural-geometry vtables. This was not a
+title, save, or Xenos draw failure.
+
+The guest heap page table had reported that arbitrary descriptor word readable,
+but the translated host page was still uncommitted. The classifier now requires
+both the guest heap range check and the platform host mapping/protection query
+before loading a candidate vtable. Rejected host-unmapped values are counted in
+the runtime summary. Optimized binary disassembly confirms the protection query
+and fail-closed branch execute before the vtable load. The failed session is
+crash evidence only and cannot qualify C1; a clean batched rerun is required.

--- a/src/native_renderer/graphics_hooks.cpp
+++ b/src/native_renderer/graphics_hooks.cpp
@@ -1940,6 +1940,7 @@ std::array<std::atomic<uint64_t>, 8>
 std::atomic<uint64_t> g_track_world_resource_graph_cache_hits{};
 std::atomic<uint64_t> g_track_world_resource_graph_cache_misses{};
 std::atomic<uint64_t> g_track_world_resource_graph_reference_overflow{};
+std::atomic<uint64_t> g_track_world_resource_graph_host_unmapped_rejections{};
 std::atomic<uint64_t> g_track_world_resource_graph_scopes{};
 std::atomic<uint64_t> g_track_world_resource_shared_identity_joins{};
 std::array<std::atomic<uint64_t>, 7>
@@ -2481,8 +2482,18 @@ void ScanTrackWorldResourcePointers(
         !IsReadableVehicleGuestRange(memory, address, sizeof(uint32_t))) {
       continue;
     }
+    size_t host_region_length = 0;
+    rex::memory::PageAccess host_access = rex::memory::PageAccess::kNoAccess;
+    void *host_address = memory->TranslateVirtual<void *>(address);
+    if (!rex::memory::QueryProtect(host_address, host_region_length,
+                                   host_access) ||
+        host_access == rex::memory::PageAccess::kNoAccess) {
+      ++g_track_world_resource_graph_host_unmapped_rejections;
+      continue;
+    }
     const uint32_t identity = ClassifyTrackWorldResourceVtable(
-        LoadSemanticGuestU32(memory, address));
+        static_cast<uint32_t>(
+            *memory->TranslateVirtual<rex::be_u32 *>(address)));
     AddTrackWorldResourceReference(entry, address, identity);
   }
 }
@@ -9527,6 +9538,10 @@ void EmitTrackRenderModelRuntimeJoinSummary() {
        {"world_resource_graph_reference_overflow",
         std::to_string(g_track_world_resource_graph_reference_overflow.load(
             std::memory_order_relaxed))},
+       {"world_resource_graph_host_unmapped_rejections",
+        std::to_string(
+            g_track_world_resource_graph_host_unmapped_rejections.load(
+                std::memory_order_relaxed))},
        {"world_resource_shared_identity_joins",
         std::to_string(g_track_world_resource_shared_identity_joins.load(
             std::memory_order_relaxed))},
@@ -15891,7 +15906,7 @@ void EmitSemanticVisibilityPreparedCandidates() {
           fmt::format("{:08X}",
                       entry.track_world_resource_shared_identity_mask)},
          {"track_world_resource_lineage",
-          "bounded_direct_vtable_identity_from_exact_model_graph"},
+          "host_mapped_direct_vtable_identity_from_exact_model_graph"},
          {"draws", std::to_string(entry.draws)},
          {"first_frame", std::to_string(entry.first_frame)},
          {"last_frame", std::to_string(entry.last_frame)},
@@ -16014,7 +16029,7 @@ void EmitSemanticVisibilityPreparedCandidates() {
        {"track_render_model_lineage",
         "exact_unified_instance_model_nested_dispatch_scope"},
        {"track_world_resource_lineage",
-        "bounded_direct_vtable_identity_from_exact_model_graph"},
+        "host_mapped_direct_vtable_identity_from_exact_model_graph"},
        {"guest_state_changed", "false"},
        {"control_flow_changed", "false"},
        {"native_upload", "false"},
@@ -20794,7 +20809,7 @@ void InstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system,
        {"world_resource_vtables",
         "820016B4,8200143C,82001474,82144CF8,82144D7C,82144DE0,82144E64"},
        {"world_resource_graph",
-        "direct_child_or_descriptor_pointer_with_exact_rtti_vtable"},
+        "host_mapped_direct_child_or_descriptor_pointer_with_exact_rtti_vtable"},
        {"world_resource_shared_identity",
         "exact_address_equality_to_submission_objects_or_resources"},
        {"world_resource_graph_cache_capacity", "1024"},

--- a/tools/discover-native-renderer-track-ingress.py
+++ b/tools/discover-native-renderer-track-ingress.py
@@ -279,6 +279,7 @@ def build(functions: set[int], image: bytes) -> dict:
             "identity_join": (
                 "exact_address_equality_to_procedural_submission_objects_or_resources"
             ),
+            "pointer_validation": "heap_readable_and_host_page_mapped",
             "guest_state_changed": False,
             "native_admission": False,
             "suppression_allowed": False,

--- a/tools/summarize-native-renderer-track-model-runtime-join.py
+++ b/tools/summarize-native-renderer-track-model-runtime-join.py
@@ -113,7 +113,7 @@ def build(events, requested_session=None):
             "82144E64"
         ),
         "world_resource_graph": (
-            "direct_child_or_descriptor_pointer_with_exact_rtti_vtable"
+            "host_mapped_direct_child_or_descriptor_pointer_with_exact_rtti_vtable"
         ),
         "world_resource_shared_identity": (
             "exact_address_equality_to_submission_objects_or_resources"
@@ -153,6 +153,7 @@ def build(events, requested_session=None):
         "world_resource_graph_cache_hits",
         "world_resource_graph_cache_misses",
         "world_resource_graph_reference_overflow",
+        "world_resource_graph_host_unmapped_rejections",
         "world_resource_shared_identity_joins",
         *RELATIONS,
         *WORLD_RELATIONS,

--- a/tools/summarize-native-renderer-visibility-prepared-candidates.py
+++ b/tools/summarize-native-renderer-visibility-prepared-candidates.py
@@ -7,7 +7,7 @@ import pathlib
 import sys
 
 
-SCHEMA = "pinyon-shift.native-renderer-visibility-prepared-candidates.v7"
+SCHEMA = "pinyon-shift.native-renderer-visibility-prepared-candidates.v8"
 STATIC_SCHEMA = "pinyon-shift.native-renderer-dispatch-static.v3"
 CONFIG = (
     "native_renderer.discovery."
@@ -183,7 +183,7 @@ def build(events, static, requested_session=None):
         or summary.get("track_render_model_lineage")
         != "exact_unified_instance_model_nested_dispatch_scope"
         or summary.get("track_world_resource_lineage")
-        != "bounded_direct_vtable_identity_from_exact_model_graph"
+        != "host_mapped_direct_vtable_identity_from_exact_model_graph"
         or summary.get("mechanical_admission_contract") != "isolated_draw_v1"
     ):
         raise ValueError("prepared-candidate summary is incomplete")
@@ -311,7 +311,7 @@ def build(events, static, requested_session=None):
             or event.get("track_render_model_lineage")
             != "exact_unified_instance_model_nested_dispatch_scope"
             or event.get("track_world_resource_lineage")
-            != "bounded_direct_vtable_identity_from_exact_model_graph"
+            != "host_mapped_direct_vtable_identity_from_exact_model_graph"
             or (
                 item["track_render_shared_identity_mask"]
                 and not item["track_render_model_scope"]

--- a/tools/tests/test_native_renderer_track_ingress.py
+++ b/tools/tests/test_native_renderer_track_ingress.py
@@ -73,6 +73,10 @@ class NativeRendererTrackIngressTests(unittest.TestCase):
         )
         self.assertFalse(document["runtime_graph_probe"]["native_admission"])
         self.assertEqual(
+            "heap_readable_and_host_page_mapped",
+            document["runtime_graph_probe"]["pointer_validation"],
+        )
+        self.assertEqual(
             "82DF3F00",
             next(
                 row["target"]

--- a/tools/tests/test_native_renderer_track_model_runtime_join.py
+++ b/tools/tests/test_native_renderer_track_model_runtime_join.py
@@ -46,7 +46,7 @@ def fixture(shared=3):
             "82144E64"
         ),
         world_resource_graph=(
-            "direct_child_or_descriptor_pointer_with_exact_rtti_vtable"
+            "host_mapped_direct_child_or_descriptor_pointer_with_exact_rtti_vtable"
         ),
         world_resource_shared_identity=(
             "exact_address_equality_to_submission_objects_or_resources"
@@ -85,6 +85,7 @@ def fixture(shared=3):
         world_resource_graph_cache_hits="8",
         world_resource_graph_cache_misses="2",
         world_resource_graph_reference_overflow="0",
+        world_resource_graph_host_unmapped_rejections="3",
         world_resource_shared_identity_joins=str(shared),
         scope_overlaps="0",
         exit_without_entry="0",
@@ -179,6 +180,7 @@ class TrackModelRuntimeJoinTests(unittest.TestCase):
         self.assertIn("kTrackRenderModelUnifiedVtable = 0x82001D74", hooks)
         self.assertIn("BeginTrackRenderModelDispatch", hooks)
         self.assertIn("EndTrackRenderModelDispatch", hooks)
+        self.assertIn("rex::memory::QueryProtect", hooks)
         self.assertIn("address = 0x8240EC80", analysis)
         self.assertIn("address = 0x8240ECAC", analysis)
 

--- a/tools/tests/test_native_renderer_visibility_prepared_candidates.py
+++ b/tools/tests/test_native_renderer_visibility_prepared_candidates.py
@@ -97,7 +97,7 @@ class VisibilityPreparedCandidateReportTests(unittest.TestCase):
             "track_world_resource_identity_mask": "00000012",
             "track_world_resource_shared_identity_mask": "00000002",
             "track_world_resource_lineage": (
-                "bounded_direct_vtable_identity_from_exact_model_graph"
+                "host_mapped_direct_vtable_identity_from_exact_model_graph"
             ),
             "draws": "7",
             "first_frame": "10",
@@ -155,7 +155,7 @@ class VisibilityPreparedCandidateReportTests(unittest.TestCase):
                 "exact_unified_instance_model_nested_dispatch_scope"
             ),
             "track_world_resource_lineage": (
-                "bounded_direct_vtable_identity_from_exact_model_graph"
+                "host_mapped_direct_vtable_identity_from_exact_model_graph"
             ),
             **self.safety(),
         }


### PR DESCRIPTION
Require both guest heap readability and a committed host mapping before
loading a speculative track resource vtable. Record rejected mappings and
the failed qualification session without changing renderer authority.

Tests: python -m unittest discover -s tools/tests -p test_*.py
Tests: incremental release preview build and optimized disassembly
