### PR TITLE
feat(native-renderer): persist track runtime checkpoints

### DIFF
--- a/docs/native-renderer/REPRIORITIZED_PLAN.md
+++ b/docs/native-renderer/REPRIORITIZED_PLAN.md
@@ -285,6 +285,13 @@ faulted on guest `40D8D0D8` (RVA `5D0616F`). Every candidate pointer now also
 passes the host mapping/protection query before dereference, with explicit
 rejection accounting. C1 qualification remains pending a clean rerun.
 
+Long-session evidence checkpoint: cumulative track render-model and world-graph
+accounting is now durably emitted every 300 observed frames under a distinct
+periodic event. A checkpoint can diagnose an interrupted run, but it explicitly
+does not prove clean shutdown or permit native admission; the unique final
+summary remains authoritative. This removes an observability dead end without
+weakening the pending C1 gate.
+
 ### C2. Static world buildings and props
 
 - Expand opaque-world material and geometry coverage.

--- a/docs/native-renderer/TERRAIN_ROAD_RENDER_PATH.md
+++ b/docs/native-renderer/TERRAIN_ROAD_RENDER_PATH.md
@@ -318,3 +318,18 @@ before loading a candidate vtable. Rejected host-unmapped values are counted in
 the runtime summary. Optimized binary disassembly confirms the protection query
 and fail-closed branch execute before the vtable load. The failed session is
 crash evidence only and cannot qualify C1; a clean batched rerun is required.
+
+### Durable long-session checkpoints
+
+The track render-model join now emits a distinct cumulative checkpoint every
+300 observed frames while renderer census is active. It contains the same
+bounded atomic accounting as the shutdown summary, plus the exact frame number,
+without reading new guest memory or changing guest, draw, authority, or
+suppression state. The final shutdown event remains unique and authoritative.
+
+`summarize-native-renderer-track-model-runtime-join.py --allow-checkpoint` may
+use the latest checkpoint only when the final summary is absent. Its output is
+explicitly `checkpoint_complete` or `checkpoint_incomplete`, records that
+session exit was not proved, and cannot serve as native-admission evidence. A
+later final summary always wins. This makes long-run crash diagnosis durable
+without weakening the clean-shutdown gate that remains required for C1.

--- a/src/native_renderer/graphics_hooks.cpp
+++ b/src/native_renderer/graphics_hooks.cpp
@@ -9446,7 +9446,9 @@ void EmitProceduralModelSemanticSubmissions() {
        {"suppression_allowed", "false"}});
 }
 
-void EmitTrackRenderModelRuntimeJoinSummary() {
+void EmitTrackRenderModelRuntimeJoinEvent(const char *event_name,
+                                          bool final_summary,
+                                          uint64_t frame_sequence) {
   const uint64_t entries =
       g_track_render_model_scope_entries.load(std::memory_order_relaxed);
   const uint64_t exits =
@@ -9483,10 +9485,17 @@ void EmitTrackRenderModelRuntimeJoinSummary() {
       !invalid_root && !invalid_child && !invalid_descriptor &&
       !contract_mismatches;
   pinyon_shift::diagnostics::RecordEvent(
-      "native_renderer.discovery.track_render_model_runtime_join_summary",
-      {{"status", !entries ? "not_observed"
-                            : (qualification_complete ? "complete"
-                                                      : "incomplete")},
+      event_name,
+      {{"status", !entries
+                      ? (final_summary ? "not_observed"
+                                       : "checkpoint_not_observed")
+                      : (qualification_complete
+                             ? (final_summary ? "complete"
+                                              : "checkpoint_complete")
+                             : (final_summary ? "incomplete"
+                                              : "checkpoint_incomplete"))},
+       {"checkpoint_kind", final_summary ? "final" : "periodic"},
+       {"frame_sequence", std::to_string(frame_sequence)},
        {"scope_entries", std::to_string(entries)},
        {"scope_exits", std::to_string(exits)},
        {"exact_scopes", std::to_string(exact)},
@@ -9607,6 +9616,18 @@ void EmitTrackRenderModelRuntimeJoinSummary() {
        {"native_draw", "false"},
        {"xenos_authority", "true"},
        {"suppression_allowed", "false"}});
+}
+
+void EmitTrackRenderModelRuntimeJoinSummary() {
+  EmitTrackRenderModelRuntimeJoinEvent(
+      "native_renderer.discovery.track_render_model_runtime_join_summary",
+      true, g_frame_sequence.load(std::memory_order_relaxed));
+}
+
+void EmitTrackRenderModelRuntimeJoinCheckpoint(uint64_t frame_sequence) {
+  EmitTrackRenderModelRuntimeJoinEvent(
+      "native_renderer.discovery.track_render_model_runtime_join_checkpoint",
+      false, frame_sequence);
 }
 
 uint64_t PreparedPipelineHash(
@@ -21892,6 +21913,9 @@ void PinyonShiftObserveGraphicsFrame() {
                                            {{"frame_sequence", frame},
                                             {"guest_address", "829EFEB8"},
                                             {"mode", "pass_through"}});
+    if (frame_sequence % kFrameSummaryInterval == 0) {
+      EmitTrackRenderModelRuntimeJoinCheckpoint(frame_sequence);
+    }
   }
   if (dispatch_requested) {
     pinyon_shift::diagnostics::RecordEvent(

--- a/tools/summarize-native-renderer-track-model-runtime-join.py
+++ b/tools/summarize-native-renderer-track-model-runtime-join.py
@@ -10,6 +10,9 @@ import sys
 SCHEMA = "pinyon-shift.native-renderer-track-model-runtime-join.v2"
 CONFIG = "native_renderer.discovery.track_render_model_runtime_join_config"
 SUMMARY = "native_renderer.discovery.track_render_model_runtime_join_summary"
+CHECKPOINT = (
+    "native_renderer.discovery.track_render_model_runtime_join_checkpoint"
+)
 
 RELATIONS = (
     "shared_descriptor",
@@ -90,11 +93,35 @@ def require_safety(event):
         raise ValueError("track-model join violates its safety boundary")
 
 
-def build(events, requested_session=None):
+def select_runtime_evidence(events, allow_checkpoint):
+    summaries = [event for event in events if event.get("event") == SUMMARY]
+    if len(summaries) > 1:
+        raise ValueError(f"expected at most one {SUMMARY} event")
+    if summaries:
+        return summaries[0], True
+    if not allow_checkpoint:
+        raise ValueError(f"expected exactly one {SUMMARY} event")
+    checkpoints = [
+        event for event in events if event.get("event") == CHECKPOINT
+    ]
+    if not checkpoints:
+        raise ValueError("no track-model runtime summary or checkpoint")
+    try:
+        checkpoint = max(
+            checkpoints, key=lambda event: integer(event, "frame_sequence")
+        )
+    except ValueError as error:
+        raise ValueError("invalid track-model runtime checkpoint") from error
+    return checkpoint, False
+
+
+def build(events, requested_session=None, allow_checkpoint=False):
     session = select_session(events, requested_session)
     selected = [event for event in events if event.get("session") == session]
     config = exact_event(selected, CONFIG)
-    summary = exact_event(selected, SUMMARY)
+    summary, final_summary = select_runtime_evidence(
+        selected, allow_checkpoint
+    )
     expected_config = {
         "status": "armed",
         "entry_hook": "8240EC80",
@@ -128,12 +155,36 @@ def build(events, requested_session=None):
         raise ValueError("track-model runtime configuration drifted")
     require_safety(config)
     require_safety(summary)
+    expected_kinds = (
+        ("complete", "incomplete", "not_observed")
+        if final_summary
+        else (
+            "checkpoint_complete",
+            "checkpoint_incomplete",
+            "checkpoint_not_observed",
+        )
+    )
     if (
-        summary.get("status") not in ("complete", "incomplete", "not_observed")
+        summary.get("status") not in expected_kinds
+        or (
+            final_summary
+            and summary.get("checkpoint_kind") not in (None, "final")
+        )
+        or (
+            not final_summary
+            and summary.get("checkpoint_kind") != "periodic"
+        )
         or summary.get("classification")
         != "exact_unified_track_render_model_nested_submission_join"
     ):
         raise ValueError("track-model runtime summary drifted")
+    frame_sequence = (
+        integer(summary, "frame_sequence")
+        if "frame_sequence" in summary
+        else None
+    )
+    if not final_summary and not frame_sequence:
+        raise ValueError("periodic checkpoint has no frame sequence")
 
     keys = (
         "scope_entries",
@@ -231,7 +282,11 @@ def build(events, requested_session=None):
         for key in SHARED_WORLD_RELATIONS
     ):
         failures.append("shared world-resource relation exceeds shared joins")
-    expected_status = "complete" if not failures else "incomplete"
+    expected_status = (
+        "complete" if not failures else "incomplete"
+    ) if final_summary else (
+        "checkpoint_complete" if not failures else "checkpoint_incomplete"
+    )
     if summary.get("status") != expected_status:
         failures.append("runtime status does not match qualification outcome")
     if summary.get("qualification_complete") != (
@@ -242,7 +297,13 @@ def build(events, requested_session=None):
     return {
         "schema": SCHEMA,
         "session": session,
-        "status": "complete" if not failures else "incomplete",
+        "status": expected_status,
+        "evidence": {
+            "kind": "final_summary" if final_summary else "periodic_checkpoint",
+            "frame_sequence": frame_sequence,
+            "session_exit_proved": final_summary,
+            "admission_evidence": final_summary and not failures,
+        },
         "failures": failures,
         "totals": totals,
         "shared_identity_relations": {
@@ -285,16 +346,26 @@ def main(argv=None):
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("events", nargs="+", type=pathlib.Path)
     parser.add_argument("--session")
+    parser.add_argument(
+        "--allow-checkpoint",
+        action="store_true",
+        help=(
+            "use the latest periodic checkpoint only when the final shutdown "
+            "summary is absent"
+        ),
+    )
     parser.add_argument("--output", required=True, type=pathlib.Path)
     args = parser.parse_args(argv)
     try:
-        document = build(read_events(args.events), args.session)
+        document = build(
+            read_events(args.events), args.session, args.allow_checkpoint
+        )
         args.output.parent.mkdir(parents=True, exist_ok=True)
         args.output.write_text(
             json.dumps(document, indent=2, sort_keys=True) + "\n",
             encoding="utf-8",
         )
-        if document["status"] != "complete":
+        if document["status"] not in ("complete", "checkpoint_complete"):
             raise ValueError("; ".join(document["failures"]))
         return 0
     except (OSError, ValueError, json.JSONDecodeError) as error:

--- a/tools/tests/test_native_renderer_track_model_runtime_join.py
+++ b/tools/tests/test_native_renderer_track_model_runtime_join.py
@@ -70,6 +70,8 @@ def fixture(shared=3):
     summary = event(
         MODULE.SUMMARY,
         status="complete",
+        checkpoint_kind="final",
+        frame_sequence="1200",
         scope_entries="10",
         scope_exits="10",
         exact_scopes="10",
@@ -134,6 +136,59 @@ class TrackModelRuntimeJoinTests(unittest.TestCase):
             ]
         )
 
+    def test_latest_checkpoint_is_diagnostic_not_admission_evidence(self):
+        events = fixture()
+        checkpoint = copy.deepcopy(events.pop())
+        checkpoint.update(
+            event=MODULE.CHECKPOINT,
+            status="checkpoint_complete",
+            checkpoint_kind="periodic",
+            frame_sequence="900",
+        )
+        older = copy.deepcopy(checkpoint)
+        older["frame_sequence"] = "600"
+        document = MODULE.build(
+            [events[0], checkpoint, older], allow_checkpoint=True
+        )
+        self.assertEqual("checkpoint_complete", document["status"])
+        self.assertEqual(900, document["evidence"]["frame_sequence"])
+        self.assertFalse(document["evidence"]["session_exit_proved"])
+        self.assertFalse(document["evidence"]["admission_evidence"])
+
+    def test_checkpoint_fallback_is_explicit(self):
+        events = fixture()
+        checkpoint = events.pop()
+        checkpoint.update(
+            event=MODULE.CHECKPOINT,
+            status="checkpoint_complete",
+            checkpoint_kind="periodic",
+        )
+        with self.assertRaisesRegex(ValueError, "expected exactly one"):
+            MODULE.build(events)
+
+    def test_final_summary_wins_over_newer_checkpoint(self):
+        events = fixture()
+        checkpoint = copy.deepcopy(events[-1])
+        checkpoint.update(
+            event=MODULE.CHECKPOINT,
+            status="checkpoint_complete",
+            checkpoint_kind="periodic",
+            frame_sequence="1500",
+        )
+        document = MODULE.build(events + [checkpoint], allow_checkpoint=True)
+        self.assertEqual("complete", document["status"])
+        self.assertEqual("final_summary", document["evidence"]["kind"])
+        self.assertEqual(1200, document["evidence"]["frame_sequence"])
+
+    def test_accepts_legacy_final_summary_without_checkpoint_metadata(self):
+        events = fixture()
+        events[-1].pop("checkpoint_kind")
+        events[-1].pop("frame_sequence")
+        document = MODULE.build(events)
+        self.assertEqual("complete", document["status"])
+        self.assertIsNone(document["evidence"]["frame_sequence"])
+        self.assertTrue(document["evidence"]["session_exit_proved"])
+
     def test_rejects_unjoined_scopes(self):
         events = copy.deepcopy(fixture())
         summary = events[-1]
@@ -181,6 +236,11 @@ class TrackModelRuntimeJoinTests(unittest.TestCase):
         self.assertIn("BeginTrackRenderModelDispatch", hooks)
         self.assertIn("EndTrackRenderModelDispatch", hooks)
         self.assertIn("rex::memory::QueryProtect", hooks)
+        self.assertIn("EmitTrackRenderModelRuntimeJoinCheckpoint", hooks)
+        self.assertIn(
+            '"native_renderer.discovery.track_render_model_runtime_join_checkpoint"',
+            hooks,
+        )
         self.assertIn("address = 0x8240EC80", analysis)
         self.assertIn("address = 0x8240ECAC", analysis)
 


### PR DESCRIPTION
## Summary
- emit cumulative track-model/world-graph counters every 300 census frames under a distinct checkpoint event
- let the runtime qualifier explicitly consume the latest checkpoint only when requested and no final summary exists
- preserve legacy-log compatibility, prefer final summaries, and prohibit checkpoint-only evidence from native admission

## Safety
- no additional guest reads
- no guest state, draw, output-authority, or suppression changes
- Xenos remains authoritative

## Validation
- python -m unittest tools.tests.test_native_renderer_track_model_runtime_join (9 tests)
- graphics_hooks.cpp compiled successfully in Release
- local link was correctly blocked because the guarded AppData gameplay process is still running from that output path; CI provides the clean link
- full clean build/AppData matrix remains batched at the C1 checkpoint