### PR TITLE
feat(native-renderer): prove static-world ingress

### DIFF
--- a/docs/native-renderer/REPRIORITIZED_PLAN.md
+++ b/docs/native-renderer/REPRIORITIZED_PLAN.md
@@ -298,6 +298,14 @@ weakening the pending C1 gate.
 - Preserve exceptional shader states through exact replay fallback.
 - Track streaming registration, invalidation, and destruction.
 
+Static ingress checkpoint: retail RTTI and complete-object locators now prove
+the generic SimpleModel mesh/submodel/model/resource chain plus immediate,
+deferred, and unified presentation surfaces. All vtable extents resolve to AOT
+functions or one exact reviewed adjustment thunk. The payload-free proof is
+recorded in [`STATIC_WORLD_INGRESS.md`](STATIC_WORLD_INGRESS.md). Concrete
+building/prop instance identity, streaming lifetime, prepared-record joining,
+native admission, and suppression remain pending.
+
 ### C3. Semantic batching, culling, and LOD
 
 - Promote the existing visibility and prepared-draw evidence into production

--- a/docs/native-renderer/STATIC_WORLD_INGRESS.md
+++ b/docs/native-renderer/STATIC_WORLD_INGRESS.md
@@ -1,0 +1,73 @@
+# Static-world SimpleModel ingress
+
+Status: static title proof; runtime identity join pending
+
+## Purpose
+
+Phase C2 needs an exact title-owned boundary for buildings and props before
+native work can be admitted. Broad shader, draw-frequency, and texture
+similarity are not sufficient. The retail RTTI graph exposes a narrower lead:
+the generic `CSimpleMesh`, `CSimpleSubModel`, `CSimpleModel`, streamed
+`CSimpleModelResource`, renderer, deferred renderer, and unified model
+presentation surfaces.
+
+`tools/discover-native-renderer-static-world-ingress.py` validates those
+surfaces directly against the payload-free retail image and generated AOT
+function inventory. It does not inspect game assets or runtime payloads.
+
+## Exact surfaces
+
+| Class | Surface | Locator | Vtable | Slots |
+|---|---|---:|---:|---:|
+| `CSimpleMesh` | primary | `823521C4` | `822291A0` | 6 |
+| `CSimpleSubModel` | primary | `82352214` | `822291BC` | 7 |
+| `CSimpleModel` | secondary | `823522C0` | `822291E8` | 7 |
+| `CSimpleModel` | primary | `82352268` | `82229208` | 9 |
+| `CSimpleModelResource` | primary | `82352328` | `82229294` | 23 |
+| `CSimpleModelRenderer` | primary | `8235275C` | `82001B64` | 17 |
+| `CSimpleModelRendererDeferred` | secondary | `822EF198` | `82021328` | 1 |
+| `CSimpleModelRendererDeferred` | primary | `822EF148` | `82021334` | 16 |
+| `Presentation_Unified::CModelPresentation` | secondary | `82363464` | `822432C8` | 1 |
+| `Presentation_Unified::CModelPresentation` | primary | `823633E8` | `822432D4` | 18 |
+
+Every complete-object locator resolves to the expected type descriptor and
+decorated class name. Every slot resolves to a generated AOT function except
+the deferred renderer's one reviewed eight-byte `r3 - 4` adjustment/tail
+thunk at `82585FB8`; its exact retail bytes are part of the proof. The word
+after each declared surface is not another generated function, so the vtable
+extent is also fail-closed rather than inferred from a convenient prefix.
+
+## Generate the report
+
+```powershell
+python tools/discover-native-renderer-static-world-ingress.py `
+  .local/generated/default `
+  --image .local/analysis/default-image.bin `
+  --output .local/qualification/native-renderer-static-world-ingress.json
+```
+
+The image may live in another local worktree; pass that explicit path when
+needed. The generated report contains addresses and method identities only.
+
+## What this proves
+
+This establishes two exact title-owned candidate chains:
+
+1. mesh to submodel to model to streamed model resource; and
+2. immediate/deferred SimpleModel renderer to unified model presentation.
+
+It gives C2 a bounded alternative to another broad draw census and makes the
+next runtime probe reviewable against exact RTTI surfaces.
+
+It does **not** yet prove that any observed instance is a building or prop,
+that the graph owns a prepared procedural-model record, or that its streaming
+lifetime has been captured. It therefore enables no native upload, draw,
+publication, or suppression. Xenos remains authoritative.
+
+## Next gate
+
+The next slice must select the minimum balanced renderer or presentation
+lifetime boundary from generated title flow and join an exact shared
+SimpleModel object/resource identity to the existing procedural-model prepared
+record. Only that joined runtime evidence may classify concrete building/prop
+instances. Missing or ambiguous joins remain per-item Xenos fallback.

--- a/tools/discover-native-renderer-static-world-ingress.py
+++ b/tools/discover-native-renderer-static-world-ingress.py
@@ -1,0 +1,240 @@
+#!/usr/bin/env python3
+"""Prove title-owned SimpleModel static-world ingress surfaces."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import pathlib
+import re
+import sys
+
+
+SCHEMA = "pinyon-shift.native-renderer-static-world-ingress.v1"
+IMAGE_BASE = 0x82000000
+FUNCTION_RE = re.compile(r"^DEFINE_REX_FUNC\(sub_([0-9A-F]{8})\) \{")
+REVIEWED_THUNKS = {
+    0x82585FB8: bytes.fromhex("38 63 FF FC 48 00 01 64"),
+}
+
+
+CLASSES = {
+    "simple_mesh": {
+        "decorated_name": ".?AVCSimpleMesh@@",
+        "type_descriptor": 0x832A62B0,
+        "role": "static_world_mesh_resource",
+        "surfaces": (
+            ("primary", 0x823521C4, 0x822291A0, 6, 0x82C46A08),
+        ),
+    },
+    "simple_sub_model": {
+        "decorated_name": ".?AVCSimpleSubModel@@",
+        "type_descriptor": 0x832A62CC,
+        "role": "static_world_submodel_resource",
+        "surfaces": (
+            ("primary", 0x82352214, 0x822291BC, 7, 0x82C47A90),
+        ),
+    },
+    "simple_model": {
+        "decorated_name": ".?AVCSimpleModel@@",
+        "type_descriptor": 0x832A62EC,
+        "role": "static_world_model_resource_graph",
+        "surfaces": (
+            ("secondary", 0x823522C0, 0x822291E8, 7, 0x82C47D98),
+            ("primary", 0x82352268, 0x82229208, 9, 0x82C46758),
+        ),
+    },
+    "simple_model_resource": {
+        "decorated_name": ".?AVCSimpleModelResource@@",
+        "type_descriptor": 0x832A635C,
+        "role": "streamed_static_world_model_resource",
+        "surfaces": (
+            ("primary", 0x82352328, 0x82229294, 23, 0x82C47EC0),
+        ),
+    },
+    "simple_model_renderer": {
+        "decorated_name": ".?AVCSimpleModelRenderer@@",
+        "type_descriptor": 0x832A671C,
+        "role": "static_world_model_renderer",
+        "surfaces": (
+            ("primary", 0x8235275C, 0x82001B64, 17, 0x82C4C838),
+        ),
+    },
+    "simple_model_renderer_deferred": {
+        "decorated_name": ".?AVCSimpleModelRendererDeferred@@",
+        "type_descriptor": 0x8322F2AC,
+        "role": "deferred_static_world_model_renderer",
+        "surfaces": (
+            ("secondary", 0x822EF198, 0x82021328, 1, 0x82585FB8),
+            ("primary", 0x822EF148, 0x82021334, 16, 0x82596C70),
+        ),
+    },
+    "model_presentation_unified": {
+        "decorated_name": ".?AVCModelPresentation@Presentation_Unified@@",
+        "type_descriptor": 0x832B9550,
+        "role": "unified_static_model_presentation",
+        "surfaces": (
+            ("secondary", 0x82363464, 0x822432C8, 1, 0x82DE9960),
+            ("primary", 0x823633E8, 0x822432D4, 18, 0x82DEA508),
+        ),
+    },
+}
+
+
+def parse_function_addresses(paths: list[pathlib.Path]) -> set[int]:
+    functions = set()
+    for path in sorted(paths, key=lambda item: item.as_posix()):
+        for line in path.read_text(encoding="utf-8").splitlines():
+            match = FUNCTION_RE.match(line)
+            if match:
+                functions.add(int(match.group(1), 16))
+    return functions
+
+
+def image_u32(image: bytes, address: int) -> int:
+    offset = address - IMAGE_BASE
+    if offset < 0 or offset + 4 > len(image):
+        raise ValueError(f"image address is out of range: {address:08X}")
+    return int.from_bytes(image[offset : offset + 4], "big")
+
+
+def image_string(image: bytes, address: int) -> str:
+    offset = address - IMAGE_BASE
+    if offset < 0 or offset >= len(image):
+        raise ValueError(f"image string is out of range: {address:08X}")
+    end = image.find(b"\0", offset, min(offset + 192, len(image)))
+    if end < 0:
+        raise ValueError(f"image string is unterminated: {address:08X}")
+    return image[offset:end].decode("ascii")
+
+
+def reviewed_thunk_matches(image: bytes, address: int) -> bool:
+    expected = REVIEWED_THUNKS.get(address)
+    if expected is None:
+        return False
+    offset = address - IMAGE_BASE
+    return image[offset : offset + len(expected)] == expected
+
+
+def build(functions: set[int], image: bytes) -> dict:
+    classes = {}
+    all_vtables = set()
+    for name, spec in CLASSES.items():
+        type_descriptor = spec["type_descriptor"]
+        decorated_name = image_string(image, type_descriptor + 8)
+        if decorated_name != spec["decorated_name"]:
+            raise ValueError(f"{name} RTTI evidence drifted")
+        surfaces = []
+        for label, locator, vtable, slot_count, destructor in spec["surfaces"]:
+            if vtable in all_vtables:
+                raise ValueError(f"duplicate static-world vtable: {vtable:08X}")
+            all_vtables.add(vtable)
+            if image_u32(image, locator + 12) != type_descriptor:
+                raise ValueError(f"{name} {label} locator drifted")
+            if image_u32(image, vtable - 4) != locator:
+                raise ValueError(f"{name} {label} vtable locator drifted")
+            slots = [
+                image_u32(image, vtable + index * 4)
+                for index in range(slot_count)
+            ]
+            if slots[0] != destructor:
+                raise ValueError(f"{name} {label} destructor drifted")
+            ungenerated = [
+                target
+                for target in slots
+                if target not in functions
+                and not reviewed_thunk_matches(image, target)
+            ]
+            if ungenerated:
+                raise ValueError(f"{name} {label} has an unknown slot target")
+            if image_u32(image, vtable + slot_count * 4) in functions:
+                raise ValueError(f"{name} {label} vtable extent drifted")
+            surfaces.append(
+                {
+                    "label": label,
+                    "complete_object_locator": f"{locator:08X}",
+                    "vtable_address": f"{vtable:08X}",
+                    "vtable_slot_count": slot_count,
+                    "deleting_destructor": f"{destructor:08X}",
+                    "slot_targets": [f"{target:08X}" for target in slots],
+                    "reviewed_thunk_slots": [
+                        index
+                        for index, target in enumerate(slots)
+                        if target in REVIEWED_THUNKS
+                    ],
+                }
+            )
+        classes[name] = {
+            "decorated_name": decorated_name,
+            "type_descriptor": f"{type_descriptor:08X}",
+            "role": spec["role"],
+            "surfaces": surfaces,
+        }
+
+    return {
+        "schema": SCHEMA,
+        "status": "complete",
+        "classification": "title_simple_model_static_world_ingress_proved",
+        "classes": classes,
+        "topology": {
+            "mesh_submodel_model_resource_chain": [
+                "simple_mesh",
+                "simple_sub_model",
+                "simple_model",
+                "simple_model_resource",
+            ],
+            "renderer_presentation_chain": [
+                "simple_model_renderer",
+                "simple_model_renderer_deferred",
+                "model_presentation_unified",
+            ],
+            "all_vtables_distinct": True,
+            "all_slots_aot_or_reviewed_thunk_backed": True,
+            "streaming_lifetime_proved": False,
+            "building_or_prop_instance_identity_proved": False,
+        },
+        "next_runtime_join": {
+            "source": "title_simple_model_renderer_and_presentation_lifetimes",
+            "destination": "procedural_model_prepared_record_identity",
+            "required_evidence": (
+                "exact_shared_object_or_resource_identity_at_both_boundaries"
+            ),
+            "proved": False,
+        },
+        "safety": {
+            "static_analysis_only": True,
+            "guest_payload_exported": False,
+            "runtime_hook_enabled": False,
+            "native_admission": False,
+            "suppression_allowed": False,
+            "xenos_authority_required": True,
+        },
+    }
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("generated_root", type=pathlib.Path)
+    parser.add_argument("--image", required=True, type=pathlib.Path)
+    parser.add_argument("--output", required=True, type=pathlib.Path)
+    args = parser.parse_args(argv)
+    try:
+        paths = list(args.generated_root.glob("pinyon_shift_recomp.*.cpp"))
+        if not paths:
+            raise ValueError("no generated AOT C++ files found")
+        document = build(
+            parse_function_addresses(paths), args.image.read_bytes()
+        )
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(
+            json.dumps(document, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        return 0
+    except (OSError, UnicodeDecodeError, ValueError) as error:
+        print(f"static-world ingress discovery failed: {error}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/tests/test_native_renderer_static_world_ingress.py
+++ b/tools/tests/test_native_renderer_static_world_ingress.py
@@ -1,0 +1,123 @@
+import importlib.util
+import sys
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+TOOL = ROOT / "tools" / "discover-native-renderer-static-world-ingress.py"
+SPEC = importlib.util.spec_from_file_location("static_world_ingress", TOOL)
+assert SPEC and SPEC.loader
+MODULE = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = MODULE
+SPEC.loader.exec_module(MODULE)
+
+
+def fixture():
+    highest = max(
+        spec["type_descriptor"] for spec in MODULE.CLASSES.values()
+    ) + 0x200
+    image = bytearray(highest - MODULE.IMAGE_BASE)
+    functions = set()
+
+    def u32(address, value):
+        offset = address - MODULE.IMAGE_BASE
+        image[offset : offset + 4] = value.to_bytes(4, "big")
+
+    for class_index, spec in enumerate(MODULE.CLASSES.values()):
+        type_descriptor = spec["type_descriptor"]
+        encoded = spec["decorated_name"].encode() + b"\0"
+        offset = type_descriptor + 8 - MODULE.IMAGE_BASE
+        image[offset : offset + len(encoded)] = encoded
+        for surface_index, surface in enumerate(spec["surfaces"]):
+            _, locator, vtable, slot_count, destructor = surface
+            u32(locator + 12, type_descriptor)
+            u32(vtable - 4, locator)
+            slots = [
+                0x82800000
+                + class_index * 0x1000
+                + surface_index * 0x100
+                + index * 4
+                for index in range(slot_count)
+            ]
+            slots[0] = destructor
+            for index, target in enumerate(slots):
+                u32(vtable + index * 4, target)
+                if target not in MODULE.REVIEWED_THUNKS:
+                    functions.add(target)
+
+    for address, body in MODULE.REVIEWED_THUNKS.items():
+        offset = address - MODULE.IMAGE_BASE
+        image[offset : offset + len(body)] = body
+    return functions, bytes(image)
+
+
+class StaticWorldIngressTests(unittest.TestCase):
+    def test_proves_simple_model_surfaces_without_runtime_claims(self):
+        functions, image = fixture()
+        document = MODULE.build(functions, image)
+        self.assertEqual("complete", document["status"])
+        self.assertEqual(7, len(document["classes"]))
+        self.assertEqual(
+            6,
+            document["classes"]["simple_mesh"]["surfaces"][0][
+                "vtable_slot_count"
+            ],
+        )
+        self.assertEqual(
+            [0],
+            document["classes"]["simple_model_renderer_deferred"][
+                "surfaces"
+            ][0]["reviewed_thunk_slots"],
+        )
+        self.assertFalse(
+            document["topology"]["building_or_prop_instance_identity_proved"]
+        )
+        self.assertFalse(document["next_runtime_join"]["proved"])
+        self.assertFalse(document["safety"]["runtime_hook_enabled"])
+        self.assertFalse(document["safety"]["native_admission"])
+        self.assertTrue(document["safety"]["xenos_authority_required"])
+
+    def test_rejects_rtti_name_drift(self):
+        functions, image = fixture()
+        corrupted = bytearray(image)
+        type_descriptor = MODULE.CLASSES["simple_mesh"]["type_descriptor"]
+        corrupted[type_descriptor + 8 - MODULE.IMAGE_BASE] = ord("!")
+        with self.assertRaisesRegex(ValueError, "simple_mesh RTTI evidence"):
+            MODULE.build(functions, bytes(corrupted))
+
+    def test_rejects_vtable_locator_drift(self):
+        functions, image = fixture()
+        corrupted = bytearray(image)
+        surface = MODULE.CLASSES["simple_model"]["surfaces"][1]
+        _, _, vtable, _, _ = surface
+        offset = vtable - 4 - MODULE.IMAGE_BASE
+        corrupted[offset : offset + 4] = (0).to_bytes(4, "big")
+        with self.assertRaisesRegex(ValueError, "vtable locator drifted"):
+            MODULE.build(functions, bytes(corrupted))
+
+    def test_rejects_unknown_slot_target(self):
+        functions, image = fixture()
+        corrupted = bytearray(image)
+        surface = MODULE.CLASSES["simple_model_renderer"]["surfaces"][0]
+        _, _, vtable, _, _ = surface
+        offset = vtable + 4 - MODULE.IMAGE_BASE
+        corrupted[offset : offset + 4] = (0x82000004).to_bytes(4, "big")
+        with self.assertRaisesRegex(ValueError, "unknown slot target"):
+            MODULE.build(functions, bytes(corrupted))
+
+    def test_rejects_vtable_extent_drift(self):
+        functions, image = fixture()
+        corrupted = bytearray(image)
+        surface = MODULE.CLASSES["simple_mesh"]["surfaces"][0]
+        _, _, vtable, slot_count, _ = surface
+        target = 0x8287F000
+        offset = vtable + slot_count * 4 - MODULE.IMAGE_BASE
+        corrupted[offset : offset + 4] = target.to_bytes(4, "big")
+        functions.add(target)
+        with self.assertRaisesRegex(ValueError, "vtable extent drifted"):
+            MODULE.build(functions, bytes(corrupted))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- validate seven retail SimpleModel/static-world RTTI classes and ten complete vtable surfaces
- prove the mesh/submodel/model/streamed-resource and immediate/deferred/unified-presentation candidate chains
- validate every slot against generated AOT code or one exact reviewed adjustment thunk
- document the fail-closed runtime join still required before any building/prop classification or native admission

## Safety
- static analysis only
- payload-free report
- no runtime hook, guest read, native draw, publication, or suppression
- Xenos remains authoritative

## Validation
- python -m unittest tools.tests.test_native_renderer_static_world_ingress tools.tests.test_native_renderer_track_ingress (8 tests)
- real retail-image discovery completed successfully
- full build/AppData validation remains batched at the next material runtime checkpoint