### PR TITLE
feat(native-renderer): trace static-world prepared draws

### DIFF
--- a/config/rexglue/analysis/main-xex.toml
+++ b/config/rexglue/analysis/main-xex.toml
@@ -225,6 +225,20 @@ registers = ["r31"]
 address = 0x8240ECAC
 name = "PinyonShiftObserveTrackRenderModelDispatchExit"
 
+# Phase C2 exact SimpleModel renderer scope. Retail RTTI proves vtable slot 12
+# resolves to 0x82C4CCC8. Entry r3 is the CSimpleModelRenderer instance and r4
+# is its render context; every path converges at 0x82C4DEA0. The scope attaches
+# only to PM4_DRAW_INDX headers emitted synchronously through 0x82416380 and
+# changes no registers, guest state, packets, control flow, or Xenos authority.
+[[midasm_hook]]
+address = 0x82C4CCC8
+name = "PinyonShiftObserveStaticWorldRendererDispatchEntry"
+registers = ["r3", "r4"]
+
+[[midasm_hook]]
+address = 0x82C4DEA0
+name = "PinyonShiftObserveStaticWorldRendererDispatchExit"
+
 # Immediately before 8240E7B0 submits its 64-byte matrix payload to 82435E78,
 # r22 still owns the original r7 object/reference matrix and r5 points at the
 # fully composed stack payload. Compare both exact live matrices with admitted

--- a/docs/native-renderer/REPRIORITIZED_PLAN.md
+++ b/docs/native-renderer/REPRIORITIZED_PLAN.md
@@ -306,6 +306,14 @@ recorded in [`STATIC_WORLD_INGRESS.md`](STATIC_WORLD_INGRESS.md). Concrete
 building/prop instance identity, streaming lifetime, prepared-record joining,
 native admission, and suppression remain pending.
 
+Implementation checkpoint: primary `CSimpleModelRenderer` slot 12 now has a
+balanced exact scope from `82C4CCC8` to its common `82C4DEA0` exit. Its direct
+`82416380` indexed-draw emissions carry the exact renderer, render-context, and
+opaque graph identity through physical PM4 generation into prepared-draw
+records, with periodic and final fail-closed accounting. Runtime qualification
+is batched after the current guarded C1 session. This proves no concrete
+building/prop instance or streaming lifetime and enables no native admission.
+
 ### C3. Semantic batching, culling, and LOD
 
 - Promote the existing visibility and prepared-draw evidence into production

--- a/docs/native-renderer/STATIC_WORLD_INGRESS.md
+++ b/docs/native-renderer/STATIC_WORLD_INGRESS.md
@@ -71,3 +71,38 @@ lifetime boundary from generated title flow and join an exact shared
 SimpleModel object/resource identity to the existing procedural-model prepared
 record. Only that joined runtime evidence may classify concrete building/prop
 instances. Missing or ambiguous joins remain per-item Xenos fallback.
+
+## Exact renderer-to-PM4 runtime lineage
+
+Static instruction flow narrows the first runtime boundary further. Primary
+`CSimpleModelRenderer` vtable slot 12 enters `82C4CCC8`, preserves its `r3`
+renderer and `r4` render context, walks its model/submodel graph, and invokes
+the direct indexed-draw emitter at `82416380`. All paths converge at
+`82C4DEA0` before restoring the caller state.
+
+A balanced passive scope now brackets those exact addresses. Entry accepts
+only vtable `82001B64` and reads only the renderer vtable plus its already-used
+offset-72 graph field. Both four-byte reads require guest range access and a
+mapped host page. The existing exact PM4 header hooks at `82416260` and
+`824162F4` attach the renderer, render context, and opaque graph identity only
+when they execute synchronously inside that scope. The normal physical-header
+generation join then carries the identity to the backend prepared-draw
+boundary.
+
+The cumulative scope, packet, and prepared-draw accounting is emitted every
+300 census frames and once authoritatively at shutdown. Generate its report
+with:
+
+```powershell
+python tools/summarize-native-renderer-static-world-runtime-join.py `
+  .local/preview/logs/<session>.jsonl `
+  --static .local/qualification/native-renderer-static-world-ingress.json `
+  --session <session> `
+  --output .local/qualification/native-renderer-static-world-runtime-join.json
+```
+
+`--allow-checkpoint` may diagnose an interrupted run, but checkpoint-only
+evidence never proves session exit or permits admission. Even a clean final
+join proves generic SimpleModel ownership, not concrete building/prop identity
+or streaming lifetime. Native upload, draw, publication, and suppression stay
+disabled until those next exact gates are closed.

--- a/src/native_renderer/graphics_hooks.cpp
+++ b/src/native_renderer/graphics_hooks.cpp
@@ -171,6 +171,8 @@ constexpr uint32_t kTrackRenderModelDescriptorType = 21;
 constexpr uint32_t kTrackRenderModelDescriptorFlag = 1;
 constexpr uint32_t kTrackRenderModelDescriptorBytes = 248;
 constexpr uint32_t kTrackRenderModelGraphBytes = 64;
+constexpr uint32_t kSimpleModelRendererVtable = 0x82001B64;
+constexpr uint32_t kSimpleModelRendererGraphOffset = 72;
 constexpr uint32_t kTrackModelVtable = 0x820016B4;
 constexpr uint32_t kTrackMeshVtable = 0x8200143C;
 constexpr uint32_t kTrackSubModelVtable = 0x82001474;
@@ -408,6 +410,7 @@ enum class DispatchWrapper : uint32_t {
   kBinningScissorState = 9,
   kBinningStateReset = 10,
   kProceduralModelDrawIndexed = 11,
+  kStaticWorldDrawIndexed = 12,
 };
 
 struct DispatchCallerEntry {
@@ -463,11 +466,19 @@ struct SemanticDrawIdentity {
   bool valid = false;
 };
 
+struct StaticWorldDrawIdentity {
+  uint32_t renderer_address = 0;
+  uint32_t render_context_address = 0;
+  uint32_t model_graph_address = 0;
+  bool valid = false;
+};
+
 struct TitleDrawOrigin {
   DispatchWrapper wrapper = DispatchWrapper::kDrawIndexed;
   uint32_t caller = 0;
   std::array<uint32_t, 8> arguments{};
   SemanticDrawIdentity semantic_draw{};
+  StaticWorldDrawIdentity static_world_draw{};
   uint32_t vehicle_owner_method = 0;
   uint32_t vehicle_owner = 0;
   uint32_t vehicle_owner_method_index = 0;
@@ -1865,6 +1876,15 @@ struct TrackRenderModelDispatchScope {
   bool exact = false;
 };
 
+struct StaticWorldRendererDispatchScope {
+  uint64_t packet_origins = 0;
+  uint32_t renderer_address = 0;
+  uint32_t render_context_address = 0;
+  uint32_t model_graph_address = 0;
+  bool active = false;
+  bool exact = false;
+};
+
 std::array<SemanticSubmissionEntry, kSemanticSubmissionCapacity>
     g_semantic_submissions{};
 std::mutex g_semantic_submission_mutex;
@@ -1947,6 +1967,20 @@ std::array<std::atomic<uint64_t>, 7>
     g_track_world_resource_identity_relations{};
 std::array<std::atomic<uint64_t>, 7>
     g_track_world_resource_shared_identity_relations{};
+std::atomic<uint64_t> g_static_world_scope_entries{};
+std::atomic<uint64_t> g_static_world_scope_exits{};
+std::atomic<uint64_t> g_static_world_scope_overlaps{};
+std::atomic<uint64_t> g_static_world_scope_exit_without_entry{};
+std::atomic<uint64_t> g_static_world_scope_exact{};
+std::atomic<uint64_t> g_static_world_scope_invalid_root{};
+std::atomic<uint64_t> g_static_world_scope_vtable_mismatches{};
+std::atomic<uint64_t> g_static_world_scope_invalid_graph_field{};
+std::atomic<uint64_t> g_static_world_scopes_with_packets{};
+std::atomic<uint64_t> g_static_world_scopes_without_packets{};
+std::atomic<uint64_t> g_static_world_packets_recorded{};
+std::atomic<uint64_t> g_static_world_packet_matches{};
+std::atomic<uint64_t> g_static_world_prepared_matches{};
+std::atomic<uint64_t> g_static_world_unprepared_matches{};
 std::array<SemanticBindingCacheSlot, 5> g_semantic_binding_cache_slots{};
 std::array<SemanticResolverCacheSlot, 5> g_semantic_resolver_cache_slots{};
 thread_local PendingSemanticResourceBindings g_pending_semantic_bindings{};
@@ -1958,6 +1992,7 @@ thread_local std::array<SemanticDrawIdentity,
 thread_local size_t g_semantic_render_item_stack_depth = 0;
 thread_local size_t g_semantic_render_item_stack_overflow_depth = 0;
 thread_local TrackRenderModelDispatchScope g_track_render_model_scope{};
+thread_local StaticWorldRendererDispatchScope g_static_world_renderer_scope{};
 thread_local std::array<TrackWorldResourceGraphCacheEntry,
                         kTrackWorldResourceGraphCacheCapacity>
     g_track_world_resource_graph_cache{};
@@ -2211,6 +2246,8 @@ const char *DispatchWrapperName(DispatchWrapper wrapper) {
     return "binning_state_reset";
   case DispatchWrapper::kProceduralModelDrawIndexed:
     return "procedural_model_draw_indexed";
+  case DispatchWrapper::kStaticWorldDrawIndexed:
+    return "static_world_draw_indexed";
   }
   return "unknown";
 }
@@ -2239,6 +2276,8 @@ const char *DispatchWrapperAddress(DispatchWrapper wrapper) {
     return "824736F0";
   case DispatchWrapper::kProceduralModelDrawIndexed:
     return "82415F68";
+  case DispatchWrapper::kStaticWorldDrawIndexed:
+    return "82C4CCC8";
   }
   return "00000000";
 }
@@ -2626,6 +2665,80 @@ void EndTrackRenderModelDispatch() {
     }
   }
   g_track_render_model_scope = {};
+}
+
+bool LoadMappedGuestU32(rex::memory::Memory *memory, uint32_t address,
+                        uint32_t &value) {
+  if (!IsReadableVehicleGuestRange(memory, address, sizeof(uint32_t))) {
+    return false;
+  }
+  size_t host_region_length = 0;
+  rex::memory::PageAccess host_access = rex::memory::PageAccess::kNoAccess;
+  void *host_address = memory->TranslateVirtual<void *>(address);
+  if (!rex::memory::QueryProtect(host_address, host_region_length,
+                                 host_access) ||
+      host_access == rex::memory::PageAccess::kNoAccess) {
+    return false;
+  }
+  value = static_cast<uint32_t>(
+      *memory->TranslateVirtual<rex::be_u32 *>(address));
+  return true;
+}
+
+void BeginStaticWorldRendererDispatch(uint32_t renderer_address,
+                                      uint32_t render_context_address) {
+  ++g_static_world_scope_entries;
+  if (g_static_world_renderer_scope.active) {
+    ++g_static_world_scope_overlaps;
+    g_static_world_renderer_scope = {};
+  }
+  StaticWorldRendererDispatchScope &scope = g_static_world_renderer_scope;
+  scope.active = true;
+  rex::memory::Memory *memory =
+      g_title_provenance_memory.load(std::memory_order_acquire);
+  uint32_t vtable = 0;
+  if (!g_title_provenance_installed.load(std::memory_order_acquire) ||
+      !LoadMappedGuestU32(memory, renderer_address, vtable)) {
+    ++g_static_world_scope_invalid_root;
+    return;
+  }
+  if (vtable != kSimpleModelRendererVtable) {
+    ++g_static_world_scope_vtable_mismatches;
+    return;
+  }
+  if (renderer_address >
+      UINT32_MAX - kSimpleModelRendererGraphOffset) {
+    ++g_static_world_scope_invalid_graph_field;
+    return;
+  }
+  uint32_t model_graph_address = 0;
+  if (!LoadMappedGuestU32(memory,
+                          renderer_address +
+                              kSimpleModelRendererGraphOffset,
+                          model_graph_address)) {
+    ++g_static_world_scope_invalid_graph_field;
+    return;
+  }
+  scope.renderer_address = renderer_address;
+  scope.render_context_address = render_context_address;
+  scope.model_graph_address = model_graph_address;
+  scope.exact = true;
+  ++g_static_world_scope_exact;
+}
+
+void EndStaticWorldRendererDispatch() {
+  ++g_static_world_scope_exits;
+  if (!g_static_world_renderer_scope.active) {
+    ++g_static_world_scope_exit_without_entry;
+    return;
+  }
+  if (g_static_world_renderer_scope.exact) {
+    (g_static_world_renderer_scope.packet_origins
+         ? g_static_world_scopes_with_packets
+         : g_static_world_scopes_without_packets)
+        .fetch_add(1, std::memory_order_relaxed);
+  }
+  g_static_world_renderer_scope = {};
 }
 
 const char *VehicleMatrixLayoutName(VehicleMatrixLayout layout) {
@@ -4294,6 +4407,11 @@ void RecordTitleDrawPacketOrigin(uint32_t packet_guest_address,
     g_semantic_draw_packets_recorded.fetch_add(1,
                                                 std::memory_order_relaxed);
   }
+  if (origin.static_world_draw.valid) {
+    ++g_static_world_renderer_scope.packet_origins;
+    g_static_world_packets_recorded.fetch_add(1,
+                                               std::memory_order_relaxed);
+  }
   ++g_title_packets_recorded;
 }
 
@@ -4317,26 +4435,48 @@ void RecordTitleDrawPacket(uint32_t packet_guest_address) {
 void RecordProceduralModelSemanticDrawPacket(
     uint32_t packet_guest_address, uint32_t constructor_store_address,
     std::array<uint32_t, 8> arguments) {
-  if (!g_title_provenance_installed.load(std::memory_order_acquire) ||
-      !g_semantic_render_item_stack_depth) {
+  if (!g_title_provenance_installed.load(std::memory_order_acquire)) {
     return;
   }
-  SemanticDrawIdentity &semantic_draw =
-      g_semantic_render_item_stack[g_semantic_render_item_stack_depth - 1];
-  if (!semantic_draw.valid) {
-    g_semantic_draw_scope_mismatches.fetch_add(1,
-                                                std::memory_order_relaxed);
+  SemanticDrawIdentity *semantic_draw = nullptr;
+  if (g_semantic_render_item_stack_depth) {
+    SemanticDrawIdentity &candidate =
+        g_semantic_render_item_stack[g_semantic_render_item_stack_depth - 1];
+    if (candidate.valid) {
+      semantic_draw = &candidate;
+    } else {
+      g_semantic_draw_scope_mismatches.fetch_add(1,
+                                                  std::memory_order_relaxed);
+    }
+  }
+  const bool static_world_draw = g_static_world_renderer_scope.active &&
+                                 g_static_world_renderer_scope.exact;
+  if (!semantic_draw && !static_world_draw) {
     return;
   }
   TitleDrawOrigin origin{};
-  origin.wrapper = DispatchWrapper::kProceduralModelDrawIndexed;
+  origin.wrapper = semantic_draw
+                       ? DispatchWrapper::kProceduralModelDrawIndexed
+                       : DispatchWrapper::kStaticWorldDrawIndexed;
   origin.caller = constructor_store_address;
   origin.arguments = arguments;
-  origin.semantic_draw = semantic_draw;
+  if (semantic_draw) {
+    origin.semantic_draw = *semantic_draw;
+    ++semantic_draw->direct_title_origins;
+    g_semantic_draw_origins_captured.fetch_add(1,
+                                                std::memory_order_relaxed);
+  }
+  if (static_world_draw) {
+    const StaticWorldRendererDispatchScope &scope =
+        g_static_world_renderer_scope;
+    origin.static_world_draw = {
+        .renderer_address = scope.renderer_address,
+        .render_context_address = scope.render_context_address,
+        .model_graph_address = scope.model_graph_address,
+        .valid = true,
+    };
+  }
   origin.valid = true;
-  ++semantic_draw.direct_title_origins;
-  g_semantic_draw_origins_captured.fetch_add(1,
-                                              std::memory_order_relaxed);
   RecordTitleDrawPacketOrigin(packet_guest_address, origin);
 }
 
@@ -6135,6 +6275,10 @@ bool ConsumeTitleDrawPacket(uint32_t packet_physical_address,
     if (origin.semantic_draw.valid) {
       g_semantic_draw_packet_matches.fetch_add(1,
                                                 std::memory_order_relaxed);
+    }
+    if (origin.static_world_draw.valid) {
+      g_static_world_packet_matches.fetch_add(1,
+                                               std::memory_order_relaxed);
     }
     ++g_title_packets_matched;
     return true;
@@ -9630,6 +9774,107 @@ void EmitTrackRenderModelRuntimeJoinCheckpoint(uint64_t frame_sequence) {
       false, frame_sequence);
 }
 
+void EmitStaticWorldRuntimeJoinEvent(const char *event_name,
+                                     bool final_summary,
+                                     uint64_t frame_sequence) {
+  const uint64_t entries =
+      g_static_world_scope_entries.load(std::memory_order_relaxed);
+  const uint64_t exits =
+      g_static_world_scope_exits.load(std::memory_order_relaxed);
+  const uint64_t exact =
+      g_static_world_scope_exact.load(std::memory_order_relaxed);
+  const uint64_t invalid_root =
+      g_static_world_scope_invalid_root.load(std::memory_order_relaxed);
+  const uint64_t vtable_mismatches =
+      g_static_world_scope_vtable_mismatches.load(
+          std::memory_order_relaxed);
+  const uint64_t invalid_graph_field =
+      g_static_world_scope_invalid_graph_field.load(
+          std::memory_order_relaxed);
+  const uint64_t scopes_with_packets =
+      g_static_world_scopes_with_packets.load(std::memory_order_relaxed);
+  const uint64_t scopes_without_packets =
+      g_static_world_scopes_without_packets.load(std::memory_order_relaxed);
+  const uint64_t packets_recorded =
+      g_static_world_packets_recorded.load(std::memory_order_relaxed);
+  const uint64_t packet_matches =
+      g_static_world_packet_matches.load(std::memory_order_relaxed);
+  const uint64_t prepared_matches =
+      g_static_world_prepared_matches.load(std::memory_order_relaxed);
+  const uint64_t unprepared_matches =
+      g_static_world_unprepared_matches.load(std::memory_order_relaxed);
+  const uint64_t overlaps =
+      g_static_world_scope_overlaps.load(std::memory_order_relaxed);
+  const uint64_t exit_without_entry =
+      g_static_world_scope_exit_without_entry.load(
+          std::memory_order_relaxed);
+  const bool accounting_complete =
+      entries == exact + invalid_root + vtable_mismatches +
+                           invalid_graph_field &&
+      entries == exits &&
+      exact == scopes_with_packets + scopes_without_packets &&
+      packet_matches == prepared_matches + unprepared_matches &&
+      packet_matches <= packets_recorded && !overlaps &&
+      !exit_without_entry;
+  const bool qualification_complete =
+      accounting_complete && exact && packets_recorded && packet_matches &&
+      prepared_matches && !unprepared_matches && !invalid_root &&
+      !vtable_mismatches && !invalid_graph_field;
+  const uint64_t pending_packets =
+      packets_recorded >= packet_matches ? packets_recorded - packet_matches
+                                          : 0;
+  pinyon_shift::diagnostics::RecordEvent(
+      event_name,
+      {{"status", !entries
+                      ? (final_summary ? "not_observed"
+                                       : "checkpoint_not_observed")
+                      : (qualification_complete
+                             ? (final_summary ? "complete"
+                                              : "checkpoint_complete")
+                             : (final_summary ? "incomplete"
+                                              : "checkpoint_incomplete"))},
+       {"checkpoint_kind", final_summary ? "final" : "periodic"},
+       {"frame_sequence", std::to_string(frame_sequence)},
+       {"scope_entries", std::to_string(entries)},
+       {"scope_exits", std::to_string(exits)},
+       {"exact_scopes", std::to_string(exact)},
+       {"invalid_root", std::to_string(invalid_root)},
+       {"vtable_mismatches", std::to_string(vtable_mismatches)},
+       {"invalid_graph_field", std::to_string(invalid_graph_field)},
+       {"scopes_with_packets", std::to_string(scopes_with_packets)},
+       {"scopes_without_packets", std::to_string(scopes_without_packets)},
+       {"packets_recorded", std::to_string(packets_recorded)},
+       {"packet_matches", std::to_string(packet_matches)},
+       {"pending_packets", std::to_string(pending_packets)},
+       {"prepared_matches", std::to_string(prepared_matches)},
+       {"unprepared_matches", std::to_string(unprepared_matches)},
+       {"scope_overlaps", std::to_string(overlaps)},
+       {"exit_without_entry", std::to_string(exit_without_entry)},
+       {"accounting_complete", accounting_complete ? "true" : "false"},
+       {"qualification_complete",
+        qualification_complete ? "true" : "false"},
+       {"classification",
+        "exact_simple_model_renderer_scope_to_pm4_prepared_draw"},
+       {"guest_state_changed", "false"},
+       {"control_flow_changed", "false"},
+       {"native_admission", "false"},
+       {"native_draw", "false"},
+       {"xenos_authority", "true"},
+       {"suppression_allowed", "false"}});
+}
+
+void EmitStaticWorldRuntimeJoinSummary() {
+  EmitStaticWorldRuntimeJoinEvent(
+      "native_renderer.discovery.static_world_runtime_join_summary", true,
+      g_frame_sequence.load(std::memory_order_relaxed));
+}
+
+void EmitStaticWorldRuntimeJoinCheckpoint(uint64_t frame_sequence) {
+  EmitStaticWorldRuntimeJoinEvent(
+      "native_renderer.discovery.static_world_runtime_join_checkpoint",
+      false, frame_sequence);
+}
+
 uint64_t PreparedPipelineHash(
     const rex::system::GraphicsPreparedDrawObservation &prepared) {
   uint64_t hash = 0xCBF29CE484222325ull;
@@ -11356,6 +11601,7 @@ void EmitCommandBufferLineageSummary() {
   EmitProceduralModelSemanticInstances();
   EmitProceduralModelSemanticSubmissions();
   EmitTrackRenderModelRuntimeJoinSummary();
+  EmitStaticWorldRuntimeJoinSummary();
   for (const CommandBufferLineageEntry &entry : g_command_buffer_lineages) {
     if (!entry.calls) {
       continue;
@@ -12283,8 +12529,16 @@ void RecordTitleDrawProvenance(
               : g_semantic_draw_unprepared_matches)
         .fetch_add(1, std::memory_order_relaxed);
   }
+  if (origin.static_world_draw.valid) {
+    (prepared ? g_static_world_prepared_matches
+              : g_static_world_unprepared_matches)
+        .fetch_add(1, std::memory_order_relaxed);
+  }
+  const bool prepared_contract_requested =
+      (origin.semantic_draw.valid || origin.static_world_draw.valid) &&
+      prepared_observation;
   const SemanticPreparedDrawContract current_semantic_contract =
-      origin.semantic_draw.valid && prepared_observation
+      prepared_contract_requested
           ? BuildSemanticPreparedDrawContract(observation,
                                               *prepared_observation)
           : SemanticPreparedDrawContract{};
@@ -12293,6 +12547,9 @@ void RecordTitleDrawProvenance(
                  (uint64_t(backend_outcome) << 41) ^
                  (prepared ? uint64_t(1) << 63 : 0);
   key = HashCombine(key, origin.semantic_draw.submission_key);
+  key = HashCombine(key, origin.static_world_draw.renderer_address);
+  key = HashCombine(key, origin.static_world_draw.render_context_address);
+  key = HashCombine(key, origin.static_world_draw.model_graph_address);
   key = HashCombine(key, current_semantic_contract.template_key);
   size_t index = size_t(key % kTitleDrawProvenanceCapacity);
   for (size_t probe = 0; probe < kTitleDrawProvenanceCapacity; ++probe) {
@@ -12330,6 +12587,12 @@ void RecordTitleDrawProvenance(
             origin.semantic_draw.receiver_generation &&
         entry.origin.semantic_draw.record_index ==
             origin.semantic_draw.record_index &&
+        entry.origin.static_world_draw.renderer_address ==
+            origin.static_world_draw.renderer_address &&
+        entry.origin.static_world_draw.render_context_address ==
+            origin.static_world_draw.render_context_address &&
+        entry.origin.static_world_draw.model_graph_address ==
+            origin.static_world_draw.model_graph_address &&
         entry.semantic_contract.template_key ==
             current_semantic_contract.template_key) {
       ++entry.calls;
@@ -12344,7 +12607,8 @@ void RecordTitleDrawProvenance(
         entry.maximum_arguments[i] =
             std::max(entry.maximum_arguments[i], origin.arguments[i]);
       }
-      if (origin.semantic_draw.valid && prepared_observation) {
+      if ((origin.semantic_draw.valid || origin.static_world_draw.valid) &&
+          prepared_observation) {
         UpdateSemanticPreparedDrawContract(entry.semantic_contract,
                                            observation,
                                            *prepared_observation);
@@ -12407,6 +12671,24 @@ void EmitTitleDrawProvenanceSummary() {
          {"origin_wrapper_address",
           DispatchWrapperAddress(entry.origin.wrapper)},
          {"origin_caller", fmt::format("{:08X}", entry.origin.caller)},
+         {"static_world_origin",
+          entry.origin.static_world_draw.valid ? "true" : "false"},
+         {"static_world_renderer",
+          entry.origin.static_world_draw.valid
+              ? fmt::format("{:08X}",
+                            entry.origin.static_world_draw.renderer_address)
+              : ""},
+         {"static_world_render_context",
+          entry.origin.static_world_draw.valid
+              ? fmt::format(
+                    "{:08X}",
+                    entry.origin.static_world_draw.render_context_address)
+              : ""},
+         {"static_world_model_graph",
+          entry.origin.static_world_draw.valid
+              ? fmt::format("{:08X}",
+                            entry.origin.static_world_draw.model_graph_address)
+              : ""},
          {"outcome", entry.prepared ? "prepared" : "not_prepared"},
          {"backend_outcome",
           entry.prepared ? "prepared_callback"
@@ -20844,6 +21126,26 @@ void InstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system,
        {"xenos_authority", "true"},
        {"suppression_allowed", "false"}});
   diagnostics::RecordEvent(
+      "native_renderer.discovery.static_world_runtime_join_config",
+      {{"status", lineage_armed ? "armed" : "disabled"},
+       {"class", "CSimpleModelRenderer"},
+       {"vtable", "82001B64"},
+       {"vtable_slot", "12"},
+       {"dispatch", "82C4CCC8"},
+       {"entry_hook", "82C4CCC8"},
+       {"exit_hook", "82C4DEA0"},
+       {"model_graph_field", "renderer_plus_72"},
+       {"draw_emitter", "82416380"},
+       {"packet_hooks", "82416260,824162F4"},
+       {"join", "synchronous_scope_to_physical_pm4_prepared_draw"},
+       {"guest_payload_read", "two_host_mapped_u32_fields_per_scope"},
+       {"guest_state_changed", "false"},
+       {"control_flow_changed", "false"},
+       {"native_admission", "false"},
+       {"native_draw", "false"},
+       {"xenos_authority", "true"},
+       {"suppression_allowed", "false"}});
+  diagnostics::RecordEvent(
       "native_renderer.discovery.semantic_instance_config",
       {{"status", lineage_armed ? "armed" : "disabled"},
        {"class", "proceduralGeometry::CProceduralModels"},
@@ -21915,6 +22217,7 @@ void PinyonShiftObserveGraphicsFrame() {
                                             {"mode", "pass_through"}});
     if (frame_sequence % kFrameSummaryInterval == 0) {
       EmitTrackRenderModelRuntimeJoinCheckpoint(frame_sequence);
+      EmitStaticWorldRuntimeJoinCheckpoint(frame_sequence);
     }
   }
   if (dispatch_requested) {
@@ -22062,6 +22365,15 @@ void PinyonShiftObserveTrackRenderModelDispatchEntry(PPCRegister &r31) {
 
 void PinyonShiftObserveTrackRenderModelDispatchExit() {
   EndTrackRenderModelDispatch();
+}
+
+void PinyonShiftObserveStaticWorldRendererDispatchEntry(PPCRegister &r3,
+                                                        PPCRegister &r4) {
+  BeginStaticWorldRendererDispatch(r3.u32, r4.u32);
+}
+
+void PinyonShiftObserveStaticWorldRendererDispatchExit() {
+  EndStaticWorldRendererDispatch();
 }
 
 void PinyonShiftObserveVehicleComposedMatrix(PPCRegister &r5,

--- a/tools/summarize-native-renderer-static-world-runtime-join.py
+++ b/tools/summarize-native-renderer-static-world-runtime-join.py
@@ -1,0 +1,296 @@
+#!/usr/bin/env python3
+"""Qualify SimpleModel renderer scopes joined to prepared PM4 draws."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import pathlib
+import sys
+
+
+SCHEMA = "pinyon-shift.native-renderer-static-world-runtime-join.v1"
+STATIC_SCHEMA = "pinyon-shift.native-renderer-static-world-ingress.v1"
+CONFIG = "native_renderer.discovery.static_world_runtime_join_config"
+SUMMARY = "native_renderer.discovery.static_world_runtime_join_summary"
+CHECKPOINT = "native_renderer.discovery.static_world_runtime_join_checkpoint"
+
+
+def integer(mapping, key):
+    try:
+        value = int(mapping[key])
+    except (KeyError, TypeError, ValueError) as error:
+        raise ValueError(f"invalid {key}") from error
+    if value < 0:
+        raise ValueError(f"negative {key}")
+    return value
+
+
+def exact_event(events, name):
+    matches = [event for event in events if event.get("event") == name]
+    if len(matches) != 1:
+        raise ValueError(f"expected exactly one {name} event")
+    return matches[0]
+
+
+def read_events(paths):
+    events = []
+    for path in paths:
+        for line in path.read_text(encoding="utf-8").splitlines():
+            if line.strip():
+                events.append(json.loads(line))
+    return events
+
+
+def select_session(events, requested):
+    sessions = {
+        event.get("session") for event in events if event.get("event") == CONFIG
+    }
+    sessions.discard(None)
+    if requested:
+        if requested not in sessions:
+            raise ValueError("requested session has no static-world join config")
+        return requested
+    if len(sessions) != 1:
+        raise ValueError("static-world join input contains multiple sessions")
+    return next(iter(sessions))
+
+
+def select_runtime_evidence(events, allow_checkpoint):
+    summaries = [event for event in events if event.get("event") == SUMMARY]
+    if len(summaries) > 1:
+        raise ValueError(f"expected at most one {SUMMARY} event")
+    if summaries:
+        return summaries[0], True
+    if not allow_checkpoint:
+        raise ValueError(f"expected exactly one {SUMMARY} event")
+    checkpoints = [
+        event for event in events if event.get("event") == CHECKPOINT
+    ]
+    if not checkpoints:
+        raise ValueError("no static-world runtime summary or checkpoint")
+    return max(
+        checkpoints, key=lambda event: integer(event, "frame_sequence")
+    ), False
+
+
+def require_safety(event):
+    expected = {
+        "guest_state_changed": "false",
+        "control_flow_changed": "false",
+        "native_admission": "false",
+        "native_draw": "false",
+        "xenos_authority": "true",
+        "suppression_allowed": "false",
+    }
+    if any(event.get(key) != value for key, value in expected.items()):
+        raise ValueError("static-world join violates its safety boundary")
+
+
+def validate_static_ingress(document):
+    if (
+        document.get("schema") != STATIC_SCHEMA
+        or document.get("status") != "complete"
+        or document.get("classification")
+        != "title_simple_model_static_world_ingress_proved"
+    ):
+        raise ValueError("static-world ingress proof drifted")
+    try:
+        model_renderer = document["classes"]["simple_model_renderer"]
+        primary = next(
+            surface
+            for surface in model_renderer["surfaces"]
+            if surface.get("label") == "primary"
+        )
+    except (KeyError, StopIteration, TypeError) as error:
+        raise ValueError("static-world renderer surface is missing") from error
+    slot_targets = primary.get("slot_targets")
+    if (
+        model_renderer.get("decorated_name") != ".?AVCSimpleModelRenderer@@"
+        or primary.get("vtable_address") != "82001B64"
+        or primary.get("vtable_slot_count") != 17
+        or not isinstance(slot_targets, list)
+        or len(slot_targets) != 17
+        or slot_targets[12] != "82C4CCC8"
+    ):
+        raise ValueError("static-world renderer dispatch proof drifted")
+
+
+def build(static_ingress, events, requested_session=None, allow_checkpoint=False):
+    validate_static_ingress(static_ingress)
+    session = select_session(events, requested_session)
+    selected = [event for event in events if event.get("session") == session]
+    config = exact_event(selected, CONFIG)
+    summary, final_summary = select_runtime_evidence(
+        selected, allow_checkpoint
+    )
+    expected_config = {
+        "status": "armed",
+        "class": "CSimpleModelRenderer",
+        "vtable": "82001B64",
+        "vtable_slot": "12",
+        "dispatch": "82C4CCC8",
+        "entry_hook": "82C4CCC8",
+        "exit_hook": "82C4DEA0",
+        "model_graph_field": "renderer_plus_72",
+        "draw_emitter": "82416380",
+        "packet_hooks": "82416260,824162F4",
+        "join": "synchronous_scope_to_physical_pm4_prepared_draw",
+        "guest_payload_read": "two_host_mapped_u32_fields_per_scope",
+    }
+    if any(config.get(key) != value for key, value in expected_config.items()):
+        raise ValueError("static-world runtime configuration drifted")
+    require_safety(config)
+    require_safety(summary)
+    expected_kinds = (
+        ("complete", "incomplete", "not_observed")
+        if final_summary
+        else (
+            "checkpoint_complete",
+            "checkpoint_incomplete",
+            "checkpoint_not_observed",
+        )
+    )
+    if (
+        summary.get("status") not in expected_kinds
+        or summary.get("checkpoint_kind")
+        != ("final" if final_summary else "periodic")
+        or summary.get("classification")
+        != "exact_simple_model_renderer_scope_to_pm4_prepared_draw"
+    ):
+        raise ValueError("static-world runtime summary drifted")
+
+    keys = (
+        "scope_entries",
+        "scope_exits",
+        "exact_scopes",
+        "invalid_root",
+        "vtable_mismatches",
+        "invalid_graph_field",
+        "scopes_with_packets",
+        "scopes_without_packets",
+        "packets_recorded",
+        "packet_matches",
+        "pending_packets",
+        "prepared_matches",
+        "unprepared_matches",
+        "scope_overlaps",
+        "exit_without_entry",
+    )
+    totals = {key: integer(summary, key) for key in keys}
+    frame_sequence = integer(summary, "frame_sequence")
+    failures = []
+    classified = (
+        totals["exact_scopes"]
+        + totals["invalid_root"]
+        + totals["vtable_mismatches"]
+        + totals["invalid_graph_field"]
+    )
+    if summary.get("accounting_complete") != "true":
+        failures.append("runtime accounting is incomplete")
+    if totals["scope_entries"] != totals["scope_exits"]:
+        failures.append("static-world scope entry/exit accounting drifted")
+    if totals["scope_entries"] != classified:
+        failures.append("static-world scope classification drifted")
+    if totals["exact_scopes"] != (
+        totals["scopes_with_packets"] + totals["scopes_without_packets"]
+    ):
+        failures.append("static-world scope outcome accounting drifted")
+    if not totals["exact_scopes"]:
+        failures.append("no exact SimpleModel renderer scope was observed")
+    if not totals["scopes_with_packets"] or not totals["packets_recorded"]:
+        failures.append("no exact scope emitted a PM4 draw packet")
+    if totals["packet_matches"] + totals["pending_packets"] != totals[
+        "packets_recorded"
+    ]:
+        failures.append("static-world packet outcome accounting drifted")
+    if totals["packet_matches"] != (
+        totals["prepared_matches"] + totals["unprepared_matches"]
+    ):
+        failures.append("static-world prepared accounting drifted")
+    if not totals["prepared_matches"]:
+        failures.append("no static-world PM4 packet joined a prepared draw")
+    for key in (
+        "invalid_root",
+        "vtable_mismatches",
+        "invalid_graph_field",
+        "unprepared_matches",
+        "scope_overlaps",
+        "exit_without_entry",
+    ):
+        if totals[key]:
+            failures.append(f"{key} is nonzero")
+    expected_status = (
+        "complete" if not failures else "incomplete"
+    ) if final_summary else (
+        "checkpoint_complete" if not failures else "checkpoint_incomplete"
+    )
+    if summary.get("status") != expected_status:
+        failures.append("runtime status does not match qualification outcome")
+    if summary.get("qualification_complete") != (
+        "true" if not failures else "false"
+    ):
+        failures.append("runtime qualification flag does not match outcome")
+
+    return {
+        "schema": SCHEMA,
+        "session": session,
+        "status": expected_status,
+        "evidence": {
+            "kind": "final_summary" if final_summary else "periodic_checkpoint",
+            "frame_sequence": frame_sequence,
+            "session_exit_proved": final_summary,
+            "native_admission_evidence": False,
+        },
+        "failures": failures,
+        "totals": totals,
+        "qualification": {
+            "simple_model_renderer_scope_proved": not failures,
+            "static_world_scope_to_pm4_proved": not failures,
+            "static_world_pm4_to_prepared_draw_proved": not failures,
+            "building_or_prop_instance_identity_proved": False,
+            "streaming_lifetime_proved": False,
+            "native_admission": False,
+            "suppression_allowed": False,
+        },
+        "safety": {
+            "guest_state_changed": False,
+            "control_flow_changed": False,
+            "native_admission": False,
+            "native_draw": False,
+            "xenos_authority": True,
+            "suppression_allowed": False,
+        },
+    }
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("events", nargs="+", type=pathlib.Path)
+    parser.add_argument("--static", required=True, type=pathlib.Path)
+    parser.add_argument("--session")
+    parser.add_argument("--allow-checkpoint", action="store_true")
+    parser.add_argument("--output", required=True, type=pathlib.Path)
+    args = parser.parse_args(argv)
+    try:
+        document = build(
+            json.loads(args.static.read_text(encoding="utf-8")),
+            read_events(args.events),
+            args.session,
+            args.allow_checkpoint,
+        )
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(
+            json.dumps(document, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        if document["status"] not in ("complete", "checkpoint_complete"):
+            raise ValueError("; ".join(document["failures"]))
+        return 0
+    except (OSError, ValueError, json.JSONDecodeError) as error:
+        print(f"static-world runtime join failed: {error}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/tests/test_native_renderer_static_world_runtime_join.py
+++ b/tools/tests/test_native_renderer_static_world_runtime_join.py
@@ -1,0 +1,180 @@
+import copy
+import importlib.util
+import sys
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+TOOL = ROOT / "tools" / "summarize-native-renderer-static-world-runtime-join.py"
+SPEC = importlib.util.spec_from_file_location("static_world_runtime_join", TOOL)
+assert SPEC and SPEC.loader
+MODULE = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = MODULE
+SPEC.loader.exec_module(MODULE)
+
+
+def event(name, **values):
+    return {"event": name, "session": "test", **values}
+
+
+def safety():
+    return {
+        "guest_state_changed": "false",
+        "control_flow_changed": "false",
+        "native_admission": "false",
+        "native_draw": "false",
+        "xenos_authority": "true",
+        "suppression_allowed": "false",
+    }
+
+
+def static_ingress():
+    slots = [f"{0x82800000 + index * 4:08X}" for index in range(17)]
+    slots[12] = "82C4CCC8"
+    return {
+        "schema": MODULE.STATIC_SCHEMA,
+        "status": "complete",
+        "classification": "title_simple_model_static_world_ingress_proved",
+        "classes": {
+            "simple_model_renderer": {
+                "decorated_name": ".?AVCSimpleModelRenderer@@",
+                "surfaces": [
+                    {
+                        "label": "primary",
+                        "vtable_address": "82001B64",
+                        "vtable_slot_count": 17,
+                        "slot_targets": slots,
+                    }
+                ],
+            }
+        },
+    }
+
+
+def fixture():
+    config = event(
+        MODULE.CONFIG,
+        status="armed",
+        **{
+            "class": "CSimpleModelRenderer",
+            "vtable": "82001B64",
+            "vtable_slot": "12",
+            "dispatch": "82C4CCC8",
+            "entry_hook": "82C4CCC8",
+            "exit_hook": "82C4DEA0",
+            "model_graph_field": "renderer_plus_72",
+            "draw_emitter": "82416380",
+            "packet_hooks": "82416260,824162F4",
+            "join": "synchronous_scope_to_physical_pm4_prepared_draw",
+            "guest_payload_read": "two_host_mapped_u32_fields_per_scope",
+            **safety(),
+        },
+    )
+    summary = event(
+        MODULE.SUMMARY,
+        status="complete",
+        checkpoint_kind="final",
+        frame_sequence="1200",
+        scope_entries="10",
+        scope_exits="10",
+        exact_scopes="10",
+        invalid_root="0",
+        vtable_mismatches="0",
+        invalid_graph_field="0",
+        scopes_with_packets="8",
+        scopes_without_packets="2",
+        packets_recorded="100",
+        packet_matches="98",
+        pending_packets="2",
+        prepared_matches="98",
+        unprepared_matches="0",
+        scope_overlaps="0",
+        exit_without_entry="0",
+        accounting_complete="true",
+        qualification_complete="true",
+        classification="exact_simple_model_renderer_scope_to_pm4_prepared_draw",
+        **safety(),
+    )
+    return [config, summary]
+
+
+class StaticWorldRuntimeJoinTests(unittest.TestCase):
+    def test_qualifies_exact_scope_to_prepared_draw(self):
+        document = MODULE.build(static_ingress(), fixture())
+        self.assertEqual("complete", document["status"])
+        self.assertTrue(
+            document["qualification"]["static_world_pm4_to_prepared_draw_proved"]
+        )
+        self.assertFalse(
+            document["qualification"]["building_or_prop_instance_identity_proved"]
+        )
+        self.assertFalse(document["qualification"]["native_admission"])
+
+    def test_checkpoint_is_diagnostic_not_admission_evidence(self):
+        events = fixture()
+        checkpoint = events.pop()
+        checkpoint.update(
+            event=MODULE.CHECKPOINT,
+            status="checkpoint_complete",
+            checkpoint_kind="periodic",
+        )
+        document = MODULE.build(
+            static_ingress(), events + [checkpoint], allow_checkpoint=True
+        )
+        self.assertEqual("checkpoint_complete", document["status"])
+        self.assertFalse(document["evidence"]["session_exit_proved"])
+        self.assertFalse(document["evidence"]["native_admission_evidence"])
+
+    def test_rejects_unprepared_packet_match(self):
+        events = copy.deepcopy(fixture())
+        events[-1].update(
+            status="incomplete",
+            prepared_matches="97",
+            unprepared_matches="1",
+            qualification_complete="false",
+        )
+        document = MODULE.build(static_ingress(), events)
+        self.assertEqual("incomplete", document["status"])
+        self.assertIn("unprepared_matches is nonzero", document["failures"])
+
+    def test_rejects_scope_accounting_fault(self):
+        events = copy.deepcopy(fixture())
+        events[-1].update(
+            status="incomplete",
+            scope_exits="9",
+            accounting_complete="false",
+            qualification_complete="false",
+        )
+        document = MODULE.build(static_ingress(), events)
+        self.assertEqual("incomplete", document["status"])
+        self.assertIn(
+            "static-world scope entry/exit accounting drifted",
+            document["failures"],
+        )
+
+    def test_rejects_static_dispatch_drift(self):
+        ingress = static_ingress()
+        ingress["classes"]["simple_model_renderer"]["surfaces"][0][
+            "slot_targets"
+        ][12] = "82C4CCD0"
+        with self.assertRaisesRegex(ValueError, "dispatch proof drifted"):
+            MODULE.build(ingress, fixture())
+
+    def test_source_contract_has_balanced_static_world_hooks(self):
+        hooks = (ROOT / "src/native_renderer/graphics_hooks.cpp").read_text(
+            encoding="utf-8"
+        )
+        analysis = (ROOT / "config/rexglue/analysis/main-xex.toml").read_text(
+            encoding="utf-8"
+        )
+        self.assertIn("kSimpleModelRendererVtable = 0x82001B64", hooks)
+        self.assertIn("BeginStaticWorldRendererDispatch", hooks)
+        self.assertIn("EndStaticWorldRendererDispatch", hooks)
+        self.assertIn("static_world_draw", hooks)
+        self.assertIn("address = 0x82C4CCC8", analysis)
+        self.assertIn("address = 0x82C4DEA0", analysis)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- bracket the exact retail SimpleModel renderer dispatch and preserve renderer/context/graph identity
- join direct indexed PM4 packets to prepared backend draw observations
- add fail-closed periodic/final reporting plus a static-ingress-anchored analyzer

## Safety
- leaves guest state and control flow unchanged
- keeps Xenos authoritative
- enables no native admission or suppression

## Validation
- 77 focused native-renderer tests passed
- Release code generation and affected C++ objects compiled successfully; final link remains intentionally deferred while the guarded AppData process owns the preview executable