### PR TITLE
feat(native-renderer): trace static-world lifetimes

### DIFF
--- a/config/rexglue/analysis/main-xex.toml
+++ b/config/rexglue/analysis/main-xex.toml
@@ -239,6 +239,41 @@ registers = ["r3", "r4"]
 address = 0x82C4DEA0
 name = "PinyonShiftObserveStaticWorldRendererDispatchExit"
 
+# The exact CSimpleModelRenderer lifecycle and its owned offset-72 graph
+# boundary. Construction publishes only after the complete 368-byte object is
+# initialized. Destruction is balanced around the complete destructor. Slot 1
+# observes graph binding after 0x82C48038 returns; slot 15 and the destructor
+# cleanup observe the old graph before clearing/releasing it. These hooks are
+# passive and preserve every title release and allocation side effect.
+[[midasm_hook]]
+address = 0x82C4E094
+name = "PinyonShiftObserveStaticWorldRendererConstructed"
+registers = ["r31"]
+
+[[midasm_hook]]
+address = 0x82C4E1F8
+name = "PinyonShiftObserveStaticWorldRendererDestructorEntry"
+registers = ["r3"]
+
+[[midasm_hook]]
+address = 0x82C4E264
+name = "PinyonShiftObserveStaticWorldRendererDestructorExit"
+
+[[midasm_hook]]
+address = 0x82C4CCB0
+name = "PinyonShiftObserveStaticWorldRendererGraphBind"
+registers = ["r30"]
+
+[[midasm_hook]]
+address = 0x82C4C6A8
+name = "PinyonShiftObserveStaticWorldRendererGraphRelease"
+registers = ["r3"]
+
+[[midasm_hook]]
+address = 0x82C4E0A0
+name = "PinyonShiftObserveStaticWorldRendererGraphRelease"
+registers = ["r3"]
+
 # Immediately before 8240E7B0 submits its 64-byte matrix payload to 82435E78,
 # r22 still owns the original r7 object/reference matrix and r5 points at the
 # fully composed stack payload. Compare both exact live matrices with admitted

--- a/docs/native-renderer/REPRIORITIZED_PLAN.md
+++ b/docs/native-renderer/REPRIORITIZED_PLAN.md
@@ -314,6 +314,15 @@ records, with periodic and final fail-closed accounting. Runtime qualification
 is batched after the current guarded C1 session. This proves no concrete
 building/prop instance or streaming lifetime and enables no native admission.
 
+Lifetime checkpoint: static instruction flow now proves the 368-byte
+`CSimpleModelRenderer` construction, its actual slot-16 deleting destructor,
+and the bind/clear/release ownership protocol for its offset-72 graph field.
+Runtime lineage carries independent renderer and graph generations and rejects
+unregistered, non-live, unbound, or mismatched ownership before attribution.
+The proof and batched qualifier are documented in
+[`STATIC_WORLD_LIFETIME.md`](STATIC_WORLD_LIFETIME.md). Concrete graph dynamic
+type, building/prop identity, and streaming registration remain pending.
+
 ### C3. Semantic batching, culling, and LOD
 
 - Promote the existing visibility and prepared-draw evidence into production

--- a/docs/native-renderer/STATIC_WORLD_INGRESS.md
+++ b/docs/native-renderer/STATIC_WORLD_INGRESS.md
@@ -97,6 +97,7 @@ with:
 python tools/summarize-native-renderer-static-world-runtime-join.py `
   .local/preview/logs/<session>.jsonl `
   --static .local/qualification/native-renderer-static-world-ingress.json `
+  --lifetime .local/qualification/native-renderer-static-world-lifetime.json `
   --session <session> `
   --output .local/qualification/native-renderer-static-world-runtime-join.json
 ```
@@ -106,3 +107,8 @@ evidence never proves session exit or permits admission. Even a clean final
 join proves generic SimpleModel ownership, not concrete building/prop identity
 or streaming lifetime. Native upload, draw, publication, and suppression stay
 disabled until those next exact gates are closed.
+
+The renderer lifetime and owned graph field are now independently proved in
+[`STATIC_WORLD_LIFETIME.md`](STATIC_WORLD_LIFETIME.md). The runtime join
+requires a completed renderer generation and matching graph-binding generation
+before it attributes any PM4 packet.

--- a/docs/native-renderer/STATIC_WORLD_LIFETIME.md
+++ b/docs/native-renderer/STATIC_WORLD_LIFETIME.md
@@ -1,0 +1,77 @@
+# Static-world SimpleModel renderer lifetime
+
+Status: static lifetime and owned-graph boundary proved; runtime qualification
+pending
+
+## Purpose
+
+The generic `CSimpleModelRenderer` draw ingress is useful only if its object
+and graph identities cannot be confused across allocation reuse, rebinding, or
+destruction. Phase C2 therefore needs a generation boundary around the exact
+renderer lifetime and its owned offset-72 graph field before runtime evidence
+may classify its prepared draws.
+
+`tools/discover-native-renderer-static-world-lifetime.py` validates that
+boundary against the payload-free retail image and generated AOT instruction
+flow. It exports addresses and structural facts only.
+
+## Exact lifetime
+
+- `82C4E3A0` allocates 368 bytes and invokes complete constructor `82C4DF78`.
+- The constructor installs vtable `82001B64`, initializes offset 72 to null,
+  and reaches the post-construction publication hook at `82C4E094`.
+- Vtable slot 16 is deleting destructor `82C4E420`. It invokes complete
+  destructor `82C4E1F8`, whose balanced runtime hooks are `82C4E1F8` and
+  `82C4E264`, then conditionally frees the allocation.
+- Destructor cleanup `82C4E0A0` clears the offset-72 graph field and invokes
+  release slot 3 on the previous graph.
+
+The earlier ingress report intentionally proves vtable extents but does not
+assign lifecycle semantics to slot zero. Its field is now named
+`slot_zero_target`; the exact analysis above proves the renderer's deleting
+destructor at slot 16.
+
+## Exact graph ownership
+
+- Vtable slot 1 (`82C4CC50`) passes `renderer + 72` to binding helper
+  `82C48038`; the completion hook is `82C4CCB0`.
+- Vtable slot 15 (`82C4C6A8`) reads and clears offset 72, then tail-dispatches
+  release slot 3 on the previous graph.
+- Destructor cleanup `82C4E0A0` performs the same clear-before-release
+  ownership transition.
+- Vtable slot 12 (`82C4CCC8`) reads that exact field before emitting any
+  indexed draw.
+
+The runtime registry publishes a new renderer generation only after completed
+construction. Graph binds receive a separate generation, and prepared-draw
+provenance carries both generations. Unregistered, destroying, destroyed,
+unbound, or mismatched objects fail closed before packet attribution. All
+title allocation, release, draw, and control-flow behavior remains unchanged.
+
+## Generate the static report
+
+```powershell
+python tools/discover-native-renderer-static-world-lifetime.py `
+  .local/generated/default `
+  --image .local/analysis/default-image.bin `
+  --output .local/qualification/native-renderer-static-world-lifetime.json
+```
+
+The runtime join now requires both static reports:
+
+```powershell
+python tools/summarize-native-renderer-static-world-runtime-join.py `
+  .local/preview/logs/<session>.jsonl `
+  --static .local/qualification/native-renderer-static-world-ingress.json `
+  --lifetime .local/qualification/native-renderer-static-world-lifetime.json `
+  --session <session> `
+  --output .local/qualification/native-renderer-static-world-runtime-join.json
+```
+
+## Remaining boundary
+
+This proves a live renderer generation and the exact graph it owns at draw
+time. It does not yet identify that graph's dynamic type, concrete building or
+prop instances, mesh/material members, or streaming registration and
+destruction. Native admission, publication, and suppression remain disabled;
+Xenos stays authoritative.

--- a/src/native_renderer/graphics_hooks.cpp
+++ b/src/native_renderer/graphics_hooks.cpp
@@ -98,6 +98,7 @@ constexpr size_t kIndirectProducerStackCapacity = 32;
 constexpr size_t kIndirectContextStackCapacity = 32;
 constexpr size_t kSemanticReceiverLifecycleCapacity = 1024;
 constexpr size_t kSemanticReceiverStackCapacity = 32;
+constexpr size_t kStaticWorldRendererLifecycleCapacity = 256;
 constexpr size_t kSemanticVisibilityCategoryCapacity = 32;
 constexpr size_t kSemanticVisibilityLodCapacity = 32;
 constexpr size_t kSemanticVisibilityResultValueCapacity = 256;
@@ -468,8 +469,10 @@ struct SemanticDrawIdentity {
 
 struct StaticWorldDrawIdentity {
   uint32_t renderer_address = 0;
+  uint32_t renderer_generation = 0;
   uint32_t render_context_address = 0;
   uint32_t model_graph_address = 0;
+  uint32_t model_graph_generation = 0;
   bool valid = false;
 };
 
@@ -1879,10 +1882,30 @@ struct TrackRenderModelDispatchScope {
 struct StaticWorldRendererDispatchScope {
   uint64_t packet_origins = 0;
   uint32_t renderer_address = 0;
+  uint32_t renderer_generation = 0;
   uint32_t render_context_address = 0;
   uint32_t model_graph_address = 0;
+  uint32_t model_graph_generation = 0;
   bool active = false;
   bool exact = false;
+};
+
+enum class StaticWorldRendererState : uint32_t {
+  kEmpty = 0,
+  kLive = 1,
+  kDestroying = 2,
+  kDestroyed = 3,
+};
+
+struct StaticWorldRendererLifecycleEntry {
+  std::atomic<uint32_t> address{};
+  std::atomic<uint32_t> generation{};
+  std::atomic<uint32_t> state{};
+  std::atomic<uint32_t> model_graph_address{};
+  std::atomic<uint32_t> model_graph_generation{};
+  std::atomic<uint64_t> dispatches{};
+  std::atomic<uint64_t> graph_binds{};
+  std::atomic<uint64_t> graph_releases{};
 };
 
 std::array<SemanticSubmissionEntry, kSemanticSubmissionCapacity>
@@ -1975,12 +1998,39 @@ std::atomic<uint64_t> g_static_world_scope_exact{};
 std::atomic<uint64_t> g_static_world_scope_invalid_root{};
 std::atomic<uint64_t> g_static_world_scope_vtable_mismatches{};
 std::atomic<uint64_t> g_static_world_scope_invalid_graph_field{};
+std::atomic<uint64_t> g_static_world_scope_unregistered_renderers{};
+std::atomic<uint64_t> g_static_world_scope_nonlive_renderers{};
+std::atomic<uint64_t> g_static_world_scope_unbound_graphs{};
+std::atomic<uint64_t> g_static_world_scope_graph_mismatches{};
 std::atomic<uint64_t> g_static_world_scopes_with_packets{};
 std::atomic<uint64_t> g_static_world_scopes_without_packets{};
 std::atomic<uint64_t> g_static_world_packets_recorded{};
 std::atomic<uint64_t> g_static_world_packet_matches{};
 std::atomic<uint64_t> g_static_world_prepared_matches{};
 std::atomic<uint64_t> g_static_world_unprepared_matches{};
+std::array<StaticWorldRendererLifecycleEntry,
+           kStaticWorldRendererLifecycleCapacity>
+    g_static_world_renderer_lifecycles{};
+std::atomic<uint64_t> g_static_world_instances_published{};
+std::atomic<uint64_t> g_static_world_instances_destroyed{};
+std::atomic<uint64_t> g_static_world_instance_address_reuses{};
+std::atomic<uint64_t> g_static_world_lifecycle_table_overflow{};
+std::atomic<uint64_t> g_static_world_lifecycle_faults{};
+std::atomic<uint64_t> g_static_world_destructor_entries{};
+std::atomic<uint64_t> g_static_world_destructor_exits{};
+std::atomic<uint64_t> g_static_world_destructors_open{};
+std::atomic<uint64_t> g_static_world_destructors_without_instance{};
+std::atomic<uint64_t> g_static_world_graph_bind_observations{};
+std::atomic<uint64_t> g_static_world_graph_bind_successes{};
+std::atomic<uint64_t> g_static_world_graph_bind_null{};
+std::atomic<uint64_t> g_static_world_graph_bind_unregistered{};
+std::atomic<uint64_t> g_static_world_graph_bind_faults{};
+std::atomic<uint64_t> g_static_world_graph_replacements{};
+std::atomic<uint64_t> g_static_world_graph_release_observations{};
+std::atomic<uint64_t> g_static_world_graph_release_successes{};
+std::atomic<uint64_t> g_static_world_graph_release_empty{};
+std::atomic<uint64_t> g_static_world_graph_release_unregistered{};
+std::atomic<uint64_t> g_static_world_graph_release_faults{};
 std::array<SemanticBindingCacheSlot, 5> g_semantic_binding_cache_slots{};
 std::array<SemanticResolverCacheSlot, 5> g_semantic_resolver_cache_slots{};
 thread_local PendingSemanticResourceBindings g_pending_semantic_bindings{};
@@ -1993,6 +2043,10 @@ thread_local size_t g_semantic_render_item_stack_depth = 0;
 thread_local size_t g_semantic_render_item_stack_overflow_depth = 0;
 thread_local TrackRenderModelDispatchScope g_track_render_model_scope{};
 thread_local StaticWorldRendererDispatchScope g_static_world_renderer_scope{};
+thread_local std::array<uint32_t, kSemanticReceiverStackCapacity>
+    g_static_world_renderer_destructor_stack{};
+thread_local size_t g_static_world_renderer_destructor_stack_depth = 0;
+thread_local size_t g_static_world_renderer_destructor_overflow_depth = 0;
 thread_local std::array<TrackWorldResourceGraphCacheEntry,
                         kTrackWorldResourceGraphCacheCapacity>
     g_track_world_resource_graph_cache{};
@@ -2677,12 +2731,276 @@ bool LoadMappedGuestU32(rex::memory::Memory *memory, uint32_t address,
   void *host_address = memory->TranslateVirtual<void *>(address);
   if (!rex::memory::QueryProtect(host_address, host_region_length,
                                  host_access) ||
+      host_region_length < sizeof(uint32_t) ||
       host_access == rex::memory::PageAccess::kNoAccess) {
     return false;
   }
   value = static_cast<uint32_t>(
       *memory->TranslateVirtual<rex::be_u32 *>(address));
   return true;
+}
+
+size_t StaticWorldRendererLifecycleIndex(uint32_t address) {
+  return size_t((address >> 4) % kStaticWorldRendererLifecycleCapacity);
+}
+
+StaticWorldRendererLifecycleEntry *FindStaticWorldRendererLifecycle(
+    uint32_t address) {
+  size_t index = StaticWorldRendererLifecycleIndex(address);
+  for (size_t probe = 0; probe < kStaticWorldRendererLifecycleCapacity;
+       ++probe) {
+    StaticWorldRendererLifecycleEntry &entry =
+        g_static_world_renderer_lifecycles[index];
+    const uint32_t observed =
+        entry.address.load(std::memory_order_acquire);
+    if (observed == address) {
+      return &entry;
+    }
+    if (!observed) {
+      return nullptr;
+    }
+    index = (index + 1) % kStaticWorldRendererLifecycleCapacity;
+  }
+  return nullptr;
+}
+
+StaticWorldRendererLifecycleEntry *FindOrClaimStaticWorldRendererLifecycle(
+    uint32_t address) {
+  size_t index = StaticWorldRendererLifecycleIndex(address);
+  for (size_t probe = 0; probe < kStaticWorldRendererLifecycleCapacity;
+       ++probe) {
+    StaticWorldRendererLifecycleEntry &entry =
+        g_static_world_renderer_lifecycles[index];
+    uint32_t observed = entry.address.load(std::memory_order_acquire);
+    if (observed == address) {
+      return &entry;
+    }
+    if (!observed && entry.address.compare_exchange_strong(
+                         observed, address, std::memory_order_acq_rel,
+                         std::memory_order_acquire)) {
+      return &entry;
+    }
+    index = (index + 1) % kStaticWorldRendererLifecycleCapacity;
+  }
+  g_static_world_lifecycle_table_overflow.fetch_add(
+      1, std::memory_order_relaxed);
+  return nullptr;
+}
+
+void PublishStaticWorldRenderer(uint32_t address) {
+  if (!g_title_provenance_installed.load(std::memory_order_acquire)) {
+    return;
+  }
+  StaticWorldRendererLifecycleEntry *entry =
+      FindOrClaimStaticWorldRendererLifecycle(address);
+  if (!entry) {
+    return;
+  }
+  const auto previous = static_cast<StaticWorldRendererState>(
+      entry->state.load(std::memory_order_acquire));
+  if (previous == StaticWorldRendererState::kLive ||
+      previous == StaticWorldRendererState::kDestroying) {
+    g_static_world_lifecycle_faults.fetch_add(1,
+                                               std::memory_order_relaxed);
+    return;
+  }
+  uint32_t generation =
+      entry->generation.load(std::memory_order_relaxed) + 1;
+  if (!generation) {
+    generation = 1;
+  }
+  if (previous == StaticWorldRendererState::kDestroyed) {
+    g_static_world_instance_address_reuses.fetch_add(
+        1, std::memory_order_relaxed);
+  }
+  entry->model_graph_address.store(0, std::memory_order_relaxed);
+  entry->model_graph_generation.store(0, std::memory_order_relaxed);
+  entry->dispatches.store(0, std::memory_order_relaxed);
+  entry->graph_binds.store(0, std::memory_order_relaxed);
+  entry->graph_releases.store(0, std::memory_order_relaxed);
+  entry->generation.store(generation, std::memory_order_relaxed);
+  entry->state.store(uint32_t(StaticWorldRendererState::kLive),
+                     std::memory_order_release);
+  g_static_world_instances_published.fetch_add(1,
+                                                std::memory_order_relaxed);
+}
+
+void BeginStaticWorldRendererDestruction(uint32_t address) {
+  if (!g_title_provenance_installed.load(std::memory_order_acquire)) {
+    return;
+  }
+  g_static_world_destructor_entries.fetch_add(1,
+                                               std::memory_order_relaxed);
+  if (g_static_world_renderer_destructor_stack_depth ==
+      g_static_world_renderer_destructor_stack.size()) {
+    ++g_static_world_renderer_destructor_overflow_depth;
+    g_static_world_lifecycle_faults.fetch_add(1,
+                                               std::memory_order_relaxed);
+    return;
+  }
+  g_static_world_renderer_destructor_stack
+      [g_static_world_renderer_destructor_stack_depth++] = address;
+  g_static_world_destructors_open.fetch_add(1,
+                                             std::memory_order_relaxed);
+  StaticWorldRendererLifecycleEntry *entry =
+      FindStaticWorldRendererLifecycle(address);
+  uint32_t expected_state = uint32_t(StaticWorldRendererState::kLive);
+  if (!entry || !entry->state.compare_exchange_strong(
+                    expected_state,
+                    uint32_t(StaticWorldRendererState::kDestroying),
+                    std::memory_order_acq_rel,
+                    std::memory_order_acquire)) {
+    g_static_world_destructors_without_instance.fetch_add(
+        1, std::memory_order_relaxed);
+  }
+}
+
+void EndStaticWorldRendererDestruction() {
+  if (!g_title_provenance_installed.load(std::memory_order_acquire)) {
+    return;
+  }
+  g_static_world_destructor_exits.fetch_add(1,
+                                             std::memory_order_relaxed);
+  if (g_static_world_renderer_destructor_overflow_depth) {
+    --g_static_world_renderer_destructor_overflow_depth;
+    return;
+  }
+  if (!g_static_world_renderer_destructor_stack_depth) {
+    g_static_world_lifecycle_faults.fetch_add(1,
+                                               std::memory_order_relaxed);
+    return;
+  }
+  const uint32_t address = g_static_world_renderer_destructor_stack
+      [--g_static_world_renderer_destructor_stack_depth];
+  g_static_world_destructors_open.fetch_sub(1,
+                                             std::memory_order_relaxed);
+  StaticWorldRendererLifecycleEntry *entry =
+      FindStaticWorldRendererLifecycle(address);
+  uint32_t expected_state = uint32_t(StaticWorldRendererState::kDestroying);
+  if (!entry || entry->model_graph_address.load(std::memory_order_acquire) ||
+      !entry->state.compare_exchange_strong(
+          expected_state, uint32_t(StaticWorldRendererState::kDestroyed),
+          std::memory_order_acq_rel, std::memory_order_acquire)) {
+    g_static_world_lifecycle_faults.fetch_add(1,
+                                               std::memory_order_relaxed);
+    return;
+  }
+  g_static_world_instances_destroyed.fetch_add(1,
+                                                std::memory_order_relaxed);
+}
+
+void ObserveStaticWorldRendererGraphBind(uint32_t renderer_address) {
+  if (!g_title_provenance_installed.load(std::memory_order_acquire)) {
+    return;
+  }
+  g_static_world_graph_bind_observations.fetch_add(
+      1, std::memory_order_relaxed);
+  StaticWorldRendererLifecycleEntry *entry =
+      FindStaticWorldRendererLifecycle(renderer_address);
+  if (!entry || entry->state.load(std::memory_order_acquire) !=
+                    uint32_t(StaticWorldRendererState::kLive)) {
+    g_static_world_graph_bind_unregistered.fetch_add(
+        1, std::memory_order_relaxed);
+    return;
+  }
+  rex::memory::Memory *memory =
+      g_title_provenance_memory.load(std::memory_order_acquire);
+  uint32_t model_graph_address = 0;
+  if (renderer_address > UINT32_MAX - kSimpleModelRendererGraphOffset ||
+      !LoadMappedGuestU32(memory,
+                          renderer_address +
+                              kSimpleModelRendererGraphOffset,
+                          model_graph_address)) {
+    g_static_world_lifecycle_faults.fetch_add(1,
+                                               std::memory_order_relaxed);
+    g_static_world_graph_bind_faults.fetch_add(1,
+                                               std::memory_order_relaxed);
+    return;
+  }
+  const uint32_t previous =
+      entry->model_graph_address.load(std::memory_order_acquire);
+  if (!model_graph_address) {
+    entry->model_graph_address.store(0, std::memory_order_release);
+    g_static_world_graph_bind_null.fetch_add(1,
+                                             std::memory_order_relaxed);
+    return;
+  }
+  if (previous && previous != model_graph_address) {
+    g_static_world_graph_replacements.fetch_add(1,
+                                                 std::memory_order_relaxed);
+  }
+  uint32_t graph_generation =
+      entry->model_graph_generation.load(std::memory_order_relaxed) + 1;
+  if (!graph_generation) {
+    graph_generation = 1;
+  }
+  entry->model_graph_generation.store(graph_generation,
+                                       std::memory_order_relaxed);
+  entry->model_graph_address.store(model_graph_address,
+                                   std::memory_order_release);
+  entry->graph_binds.fetch_add(1, std::memory_order_relaxed);
+  g_static_world_graph_bind_successes.fetch_add(
+      1, std::memory_order_relaxed);
+}
+
+void ObserveStaticWorldRendererGraphRelease(uint32_t renderer_address) {
+  if (!g_title_provenance_installed.load(std::memory_order_acquire)) {
+    return;
+  }
+  g_static_world_graph_release_observations.fetch_add(
+      1, std::memory_order_relaxed);
+  StaticWorldRendererLifecycleEntry *entry =
+      FindStaticWorldRendererLifecycle(renderer_address);
+  if (!entry) {
+    g_static_world_graph_release_unregistered.fetch_add(
+        1, std::memory_order_relaxed);
+    return;
+  }
+  const uint32_t state = entry->state.load(std::memory_order_acquire);
+  if (state != uint32_t(StaticWorldRendererState::kLive) &&
+      state != uint32_t(StaticWorldRendererState::kDestroying)) {
+    g_static_world_graph_release_unregistered.fetch_add(
+        1, std::memory_order_relaxed);
+    return;
+  }
+  rex::memory::Memory *memory =
+      g_title_provenance_memory.load(std::memory_order_acquire);
+  uint32_t model_graph_address = 0;
+  if (renderer_address > UINT32_MAX - kSimpleModelRendererGraphOffset ||
+      !LoadMappedGuestU32(memory,
+                          renderer_address +
+                              kSimpleModelRendererGraphOffset,
+                          model_graph_address)) {
+    g_static_world_lifecycle_faults.fetch_add(1,
+                                               std::memory_order_relaxed);
+    g_static_world_graph_release_faults.fetch_add(
+        1, std::memory_order_relaxed);
+    return;
+  }
+  const uint32_t registered_graph =
+      entry->model_graph_address.exchange(0, std::memory_order_acq_rel);
+  if (!model_graph_address) {
+    if (registered_graph) {
+      g_static_world_lifecycle_faults.fetch_add(
+          1, std::memory_order_relaxed);
+      g_static_world_graph_release_faults.fetch_add(
+          1, std::memory_order_relaxed);
+      return;
+    }
+    g_static_world_graph_release_empty.fetch_add(
+        1, std::memory_order_relaxed);
+    return;
+  }
+  if (registered_graph != model_graph_address) {
+    g_static_world_lifecycle_faults.fetch_add(1,
+                                               std::memory_order_relaxed);
+    g_static_world_graph_release_faults.fetch_add(
+        1, std::memory_order_relaxed);
+    return;
+  }
+  entry->graph_releases.fetch_add(1, std::memory_order_relaxed);
+  g_static_world_graph_release_successes.fetch_add(
+      1, std::memory_order_relaxed);
 }
 
 void BeginStaticWorldRendererDispatch(uint32_t renderer_address,
@@ -2719,10 +3037,35 @@ void BeginStaticWorldRendererDispatch(uint32_t renderer_address,
     ++g_static_world_scope_invalid_graph_field;
     return;
   }
+  StaticWorldRendererLifecycleEntry *lifecycle =
+      FindStaticWorldRendererLifecycle(renderer_address);
+  if (!lifecycle) {
+    ++g_static_world_scope_unregistered_renderers;
+    return;
+  }
+  if (lifecycle->state.load(std::memory_order_acquire) !=
+      uint32_t(StaticWorldRendererState::kLive)) {
+    ++g_static_world_scope_nonlive_renderers;
+    return;
+  }
+  if (!model_graph_address) {
+    ++g_static_world_scope_unbound_graphs;
+    return;
+  }
+  if (lifecycle->model_graph_address.load(std::memory_order_acquire) !=
+      model_graph_address) {
+    ++g_static_world_scope_graph_mismatches;
+    return;
+  }
   scope.renderer_address = renderer_address;
+  scope.renderer_generation =
+      lifecycle->generation.load(std::memory_order_relaxed);
   scope.render_context_address = render_context_address;
   scope.model_graph_address = model_graph_address;
+  scope.model_graph_generation =
+      lifecycle->model_graph_generation.load(std::memory_order_relaxed);
   scope.exact = true;
+  lifecycle->dispatches.fetch_add(1, std::memory_order_relaxed);
   ++g_static_world_scope_exact;
 }
 
@@ -4005,6 +4348,59 @@ void ResetTitleDrawProvenance() {
       0, std::memory_order_relaxed);
   g_semantic_receiver_destructors_without_instance.store(
       0, std::memory_order_relaxed);
+  for (StaticWorldRendererLifecycleEntry &entry :
+       g_static_world_renderer_lifecycles) {
+    entry.address.store(0, std::memory_order_relaxed);
+    entry.generation.store(0, std::memory_order_relaxed);
+    entry.state.store(0, std::memory_order_relaxed);
+    entry.model_graph_address.store(0, std::memory_order_relaxed);
+    entry.model_graph_generation.store(0, std::memory_order_relaxed);
+    entry.dispatches.store(0, std::memory_order_relaxed);
+    entry.graph_binds.store(0, std::memory_order_relaxed);
+    entry.graph_releases.store(0, std::memory_order_relaxed);
+  }
+  for (std::atomic<uint64_t> *counter : {
+           &g_static_world_scope_entries,
+           &g_static_world_scope_exits,
+           &g_static_world_scope_overlaps,
+           &g_static_world_scope_exit_without_entry,
+           &g_static_world_scope_exact,
+           &g_static_world_scope_invalid_root,
+           &g_static_world_scope_vtable_mismatches,
+           &g_static_world_scope_invalid_graph_field,
+           &g_static_world_scope_unregistered_renderers,
+           &g_static_world_scope_nonlive_renderers,
+           &g_static_world_scope_unbound_graphs,
+           &g_static_world_scope_graph_mismatches,
+           &g_static_world_scopes_with_packets,
+           &g_static_world_scopes_without_packets,
+           &g_static_world_packets_recorded,
+           &g_static_world_packet_matches,
+           &g_static_world_prepared_matches,
+           &g_static_world_unprepared_matches,
+           &g_static_world_instances_published,
+           &g_static_world_instances_destroyed,
+           &g_static_world_instance_address_reuses,
+           &g_static_world_lifecycle_table_overflow,
+           &g_static_world_lifecycle_faults,
+           &g_static_world_destructor_entries,
+           &g_static_world_destructor_exits,
+           &g_static_world_destructors_open,
+           &g_static_world_destructors_without_instance,
+           &g_static_world_graph_bind_observations,
+           &g_static_world_graph_bind_successes,
+           &g_static_world_graph_bind_null,
+           &g_static_world_graph_bind_unregistered,
+           &g_static_world_graph_bind_faults,
+           &g_static_world_graph_replacements,
+           &g_static_world_graph_release_observations,
+           &g_static_world_graph_release_successes,
+           &g_static_world_graph_release_empty,
+           &g_static_world_graph_release_unregistered,
+           &g_static_world_graph_release_faults,
+       }) {
+    counter->store(0, std::memory_order_relaxed);
+  }
   g_semantic_visibility_entries.store(0, std::memory_order_relaxed);
   g_semantic_visibility_exits.store(0, std::memory_order_relaxed);
   g_semantic_visibility_open.store(0, std::memory_order_relaxed);
@@ -4230,6 +4626,10 @@ void ResetTitleDrawProvenance() {
   g_semantic_receiver_destructor_stack = {};
   g_semantic_receiver_destructor_stack_depth = 0;
   g_semantic_receiver_destructor_overflow_depth = 0;
+  g_static_world_renderer_scope = {};
+  g_static_world_renderer_destructor_stack = {};
+  g_static_world_renderer_destructor_stack_depth = 0;
+  g_static_world_renderer_destructor_overflow_depth = 0;
   g_semantic_visibility_stack = {};
   g_semantic_visibility_stack_depth = 0;
   g_semantic_visibility_overflow_depth = 0;
@@ -4471,8 +4871,10 @@ void RecordProceduralModelSemanticDrawPacket(
         g_static_world_renderer_scope;
     origin.static_world_draw = {
         .renderer_address = scope.renderer_address,
+        .renderer_generation = scope.renderer_generation,
         .render_context_address = scope.render_context_address,
         .model_graph_address = scope.model_graph_address,
+        .model_graph_generation = scope.model_graph_generation,
         .valid = true,
     };
   }
@@ -9791,6 +10193,17 @@ void EmitStaticWorldRuntimeJoinEvent(const char *event_name,
   const uint64_t invalid_graph_field =
       g_static_world_scope_invalid_graph_field.load(
           std::memory_order_relaxed);
+  const uint64_t unregistered_renderers =
+      g_static_world_scope_unregistered_renderers.load(
+          std::memory_order_relaxed);
+  const uint64_t nonlive_renderers =
+      g_static_world_scope_nonlive_renderers.load(
+          std::memory_order_relaxed);
+  const uint64_t unbound_graphs =
+      g_static_world_scope_unbound_graphs.load(std::memory_order_relaxed);
+  const uint64_t graph_mismatches =
+      g_static_world_scope_graph_mismatches.load(
+          std::memory_order_relaxed);
   const uint64_t scopes_with_packets =
       g_static_world_scopes_with_packets.load(std::memory_order_relaxed);
   const uint64_t scopes_without_packets =
@@ -9808,18 +10221,77 @@ void EmitStaticWorldRuntimeJoinEvent(const char *event_name,
   const uint64_t exit_without_entry =
       g_static_world_scope_exit_without_entry.load(
           std::memory_order_relaxed);
+  const uint64_t instances_published =
+      g_static_world_instances_published.load(std::memory_order_relaxed);
+  const uint64_t instances_destroyed =
+      g_static_world_instances_destroyed.load(std::memory_order_relaxed);
+  const uint64_t destructor_entries =
+      g_static_world_destructor_entries.load(std::memory_order_relaxed);
+  const uint64_t destructor_exits =
+      g_static_world_destructor_exits.load(std::memory_order_relaxed);
+  const uint64_t destructors_open =
+      g_static_world_destructors_open.load(std::memory_order_relaxed);
+  const uint64_t lifecycle_faults =
+      g_static_world_lifecycle_faults.load(std::memory_order_relaxed);
+  const uint64_t lifecycle_overflow =
+      g_static_world_lifecycle_table_overflow.load(
+          std::memory_order_relaxed);
+  const uint64_t graph_bind_observations =
+      g_static_world_graph_bind_observations.load(
+          std::memory_order_relaxed);
+  const uint64_t graph_bind_successes =
+      g_static_world_graph_bind_successes.load(
+          std::memory_order_relaxed);
+  const uint64_t graph_bind_null =
+      g_static_world_graph_bind_null.load(std::memory_order_relaxed);
+  const uint64_t graph_bind_unregistered =
+      g_static_world_graph_bind_unregistered.load(
+          std::memory_order_relaxed);
+  const uint64_t graph_bind_faults =
+      g_static_world_graph_bind_faults.load(std::memory_order_relaxed);
+  const uint64_t graph_release_observations =
+      g_static_world_graph_release_observations.load(
+          std::memory_order_relaxed);
+  const uint64_t graph_release_successes =
+      g_static_world_graph_release_successes.load(
+          std::memory_order_relaxed);
+  const uint64_t graph_release_empty =
+      g_static_world_graph_release_empty.load(std::memory_order_relaxed);
+  const uint64_t graph_release_unregistered =
+      g_static_world_graph_release_unregistered.load(
+          std::memory_order_relaxed);
+  const uint64_t graph_release_faults =
+      g_static_world_graph_release_faults.load(
+          std::memory_order_relaxed);
   const bool accounting_complete =
       entries == exact + invalid_root + vtable_mismatches +
-                           invalid_graph_field &&
+                           invalid_graph_field + unregistered_renderers +
+                           nonlive_renderers + unbound_graphs +
+                           graph_mismatches &&
       entries == exits &&
       exact == scopes_with_packets + scopes_without_packets &&
       packet_matches == prepared_matches + unprepared_matches &&
-      packet_matches <= packets_recorded && !overlaps &&
-      !exit_without_entry;
+      packet_matches <= packets_recorded &&
+      destructor_entries == destructor_exits + destructors_open &&
+      instances_destroyed <= instances_published &&
+      graph_bind_observations ==
+          graph_bind_successes + graph_bind_null +
+              graph_bind_unregistered + graph_bind_faults &&
+      graph_release_observations ==
+          graph_release_successes + graph_release_empty +
+              graph_release_unregistered + graph_release_faults &&
+      !overlaps && !exit_without_entry;
   const bool qualification_complete =
       accounting_complete && exact && packets_recorded && packet_matches &&
-      prepared_matches && !unprepared_matches && !invalid_root &&
-      !vtable_mismatches && !invalid_graph_field;
+      prepared_matches && instances_published && graph_bind_successes &&
+      !unprepared_matches && !invalid_root && !vtable_mismatches &&
+      !invalid_graph_field && !unregistered_renderers &&
+      !nonlive_renderers && !graph_mismatches && !lifecycle_faults &&
+      !lifecycle_overflow && !destructors_open &&
+      !graph_bind_unregistered && !graph_bind_faults &&
+      !g_static_world_destructors_without_instance.load(
+          std::memory_order_relaxed) &&
+      !graph_release_unregistered && !graph_release_faults;
   const uint64_t pending_packets =
       packets_recorded >= packet_matches ? packets_recorded - packet_matches
                                           : 0;
@@ -9841,6 +10313,10 @@ void EmitStaticWorldRuntimeJoinEvent(const char *event_name,
        {"invalid_root", std::to_string(invalid_root)},
        {"vtable_mismatches", std::to_string(vtable_mismatches)},
        {"invalid_graph_field", std::to_string(invalid_graph_field)},
+       {"unregistered_renderers", std::to_string(unregistered_renderers)},
+       {"nonlive_renderers", std::to_string(nonlive_renderers)},
+       {"unbound_graphs", std::to_string(unbound_graphs)},
+       {"graph_mismatches", std::to_string(graph_mismatches)},
        {"scopes_with_packets", std::to_string(scopes_with_packets)},
        {"scopes_without_packets", std::to_string(scopes_without_packets)},
        {"packets_recorded", std::to_string(packets_recorded)},
@@ -9850,11 +10326,41 @@ void EmitStaticWorldRuntimeJoinEvent(const char *event_name,
        {"unprepared_matches", std::to_string(unprepared_matches)},
        {"scope_overlaps", std::to_string(overlaps)},
        {"exit_without_entry", std::to_string(exit_without_entry)},
+       {"instances_published", std::to_string(instances_published)},
+       {"instances_destroyed", std::to_string(instances_destroyed)},
+       {"instance_address_reuses",
+        std::to_string(g_static_world_instance_address_reuses.load(
+            std::memory_order_relaxed))},
+       {"lifecycle_table_overflow", std::to_string(lifecycle_overflow)},
+       {"lifecycle_faults", std::to_string(lifecycle_faults)},
+       {"destructor_entries", std::to_string(destructor_entries)},
+       {"destructor_exits", std::to_string(destructor_exits)},
+       {"destructors_open", std::to_string(destructors_open)},
+       {"destructors_without_instance",
+        std::to_string(g_static_world_destructors_without_instance.load(
+            std::memory_order_relaxed))},
+       {"graph_bind_observations",
+        std::to_string(graph_bind_observations)},
+       {"graph_bind_successes", std::to_string(graph_bind_successes)},
+       {"graph_bind_null", std::to_string(graph_bind_null)},
+       {"graph_bind_unregistered",
+        std::to_string(graph_bind_unregistered)},
+       {"graph_bind_faults", std::to_string(graph_bind_faults)},
+       {"graph_replacements",
+        std::to_string(g_static_world_graph_replacements.load(
+            std::memory_order_relaxed))},
+       {"graph_release_observations",
+        std::to_string(graph_release_observations)},
+       {"graph_release_successes", std::to_string(graph_release_successes)},
+       {"graph_release_empty", std::to_string(graph_release_empty)},
+       {"graph_release_unregistered",
+        std::to_string(graph_release_unregistered)},
+       {"graph_release_faults", std::to_string(graph_release_faults)},
        {"accounting_complete", accounting_complete ? "true" : "false"},
        {"qualification_complete",
         qualification_complete ? "true" : "false"},
        {"classification",
-        "exact_simple_model_renderer_scope_to_pm4_prepared_draw"},
+        "live_simple_model_renderer_graph_to_pm4_prepared_draw"},
        {"guest_state_changed", "false"},
        {"control_flow_changed", "false"},
        {"native_admission", "false"},
@@ -12548,8 +13054,10 @@ void RecordTitleDrawProvenance(
                  (prepared ? uint64_t(1) << 63 : 0);
   key = HashCombine(key, origin.semantic_draw.submission_key);
   key = HashCombine(key, origin.static_world_draw.renderer_address);
+  key = HashCombine(key, origin.static_world_draw.renderer_generation);
   key = HashCombine(key, origin.static_world_draw.render_context_address);
   key = HashCombine(key, origin.static_world_draw.model_graph_address);
+  key = HashCombine(key, origin.static_world_draw.model_graph_generation);
   key = HashCombine(key, current_semantic_contract.template_key);
   size_t index = size_t(key % kTitleDrawProvenanceCapacity);
   for (size_t probe = 0; probe < kTitleDrawProvenanceCapacity; ++probe) {
@@ -12589,10 +13097,14 @@ void RecordTitleDrawProvenance(
             origin.semantic_draw.record_index &&
         entry.origin.static_world_draw.renderer_address ==
             origin.static_world_draw.renderer_address &&
+        entry.origin.static_world_draw.renderer_generation ==
+            origin.static_world_draw.renderer_generation &&
         entry.origin.static_world_draw.render_context_address ==
             origin.static_world_draw.render_context_address &&
         entry.origin.static_world_draw.model_graph_address ==
             origin.static_world_draw.model_graph_address &&
+        entry.origin.static_world_draw.model_graph_generation ==
+            origin.static_world_draw.model_graph_generation &&
         entry.semantic_contract.template_key ==
             current_semantic_contract.template_key) {
       ++entry.calls;
@@ -12678,6 +13190,11 @@ void EmitTitleDrawProvenanceSummary() {
               ? fmt::format("{:08X}",
                             entry.origin.static_world_draw.renderer_address)
               : ""},
+         {"static_world_renderer_generation",
+          entry.origin.static_world_draw.valid
+              ? std::to_string(
+                    entry.origin.static_world_draw.renderer_generation)
+              : ""},
          {"static_world_render_context",
           entry.origin.static_world_draw.valid
               ? fmt::format(
@@ -12688,6 +13205,11 @@ void EmitTitleDrawProvenanceSummary() {
           entry.origin.static_world_draw.valid
               ? fmt::format("{:08X}",
                             entry.origin.static_world_draw.model_graph_address)
+              : ""},
+         {"static_world_model_graph_generation",
+          entry.origin.static_world_draw.valid
+              ? std::to_string(
+                    entry.origin.static_world_draw.model_graph_generation)
               : ""},
          {"outcome", entry.prepared ? "prepared" : "not_prepared"},
          {"backend_outcome",
@@ -21130,11 +21652,22 @@ void InstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system,
       {{"status", lineage_armed ? "armed" : "disabled"},
        {"class", "CSimpleModelRenderer"},
        {"vtable", "82001B64"},
+       {"object_bytes", "368"},
+       {"constructor", "82C4DF78"},
+       {"constructor_publish_hook", "82C4E094"},
+       {"deleting_destructor_slot", "16"},
+       {"deleting_destructor", "82C4E420"},
+       {"destructor_entry_hook", "82C4E1F8"},
+       {"destructor_exit_hook", "82C4E264"},
        {"vtable_slot", "12"},
        {"dispatch", "82C4CCC8"},
        {"entry_hook", "82C4CCC8"},
        {"exit_hook", "82C4DEA0"},
        {"model_graph_field", "renderer_plus_72"},
+       {"model_graph_bind_slot", "1"},
+       {"model_graph_bind_hook", "82C4CCB0"},
+       {"model_graph_release_slot", "15"},
+       {"model_graph_release_hook", "82C4C6A8,82C4E0A0"},
        {"draw_emitter", "82416380"},
        {"packet_hooks", "82416260,824162F4"},
        {"join", "synchronous_scope_to_physical_pm4_prepared_draw"},
@@ -22374,6 +22907,26 @@ void PinyonShiftObserveStaticWorldRendererDispatchEntry(PPCRegister &r3,
 
 void PinyonShiftObserveStaticWorldRendererDispatchExit() {
   EndStaticWorldRendererDispatch();
+}
+
+void PinyonShiftObserveStaticWorldRendererConstructed(PPCRegister &r31) {
+  PublishStaticWorldRenderer(r31.u32);
+}
+
+void PinyonShiftObserveStaticWorldRendererDestructorEntry(PPCRegister &r3) {
+  BeginStaticWorldRendererDestruction(r3.u32);
+}
+
+void PinyonShiftObserveStaticWorldRendererDestructorExit() {
+  EndStaticWorldRendererDestruction();
+}
+
+void PinyonShiftObserveStaticWorldRendererGraphBind(PPCRegister &r30) {
+  ObserveStaticWorldRendererGraphBind(r30.u32);
+}
+
+void PinyonShiftObserveStaticWorldRendererGraphRelease(PPCRegister &r3) {
+  ObserveStaticWorldRendererGraphRelease(r3.u32);
 }
 
 void PinyonShiftObserveVehicleComposedMatrix(PPCRegister &r5,

--- a/tools/discover-native-renderer-static-world-ingress.py
+++ b/tools/discover-native-renderer-static-world-ingress.py
@@ -10,7 +10,7 @@ import re
 import sys
 
 
-SCHEMA = "pinyon-shift.native-renderer-static-world-ingress.v1"
+SCHEMA = "pinyon-shift.native-renderer-static-world-ingress.v2"
 IMAGE_BASE = 0x82000000
 FUNCTION_RE = re.compile(r"^DEFINE_REX_FUNC\(sub_([0-9A-F]{8})\) \{")
 REVIEWED_THUNKS = {
@@ -125,7 +125,13 @@ def build(functions: set[int], image: bytes) -> dict:
         if decorated_name != spec["decorated_name"]:
             raise ValueError(f"{name} RTTI evidence drifted")
         surfaces = []
-        for label, locator, vtable, slot_count, destructor in spec["surfaces"]:
+        for (
+            label,
+            locator,
+            vtable,
+            slot_count,
+            slot_zero_target,
+        ) in spec["surfaces"]:
             if vtable in all_vtables:
                 raise ValueError(f"duplicate static-world vtable: {vtable:08X}")
             all_vtables.add(vtable)
@@ -137,8 +143,8 @@ def build(functions: set[int], image: bytes) -> dict:
                 image_u32(image, vtable + index * 4)
                 for index in range(slot_count)
             ]
-            if slots[0] != destructor:
-                raise ValueError(f"{name} {label} destructor drifted")
+            if slots[0] != slot_zero_target:
+                raise ValueError(f"{name} {label} slot-zero target drifted")
             ungenerated = [
                 target
                 for target in slots
@@ -155,7 +161,7 @@ def build(functions: set[int], image: bytes) -> dict:
                     "complete_object_locator": f"{locator:08X}",
                     "vtable_address": f"{vtable:08X}",
                     "vtable_slot_count": slot_count,
-                    "deleting_destructor": f"{destructor:08X}",
+                    "slot_zero_target": f"{slot_zero_target:08X}",
                     "slot_targets": [f"{target:08X}" for target in slots],
                     "reviewed_thunk_slots": [
                         index

--- a/tools/discover-native-renderer-static-world-lifetime.py
+++ b/tools/discover-native-renderer-static-world-lifetime.py
@@ -1,0 +1,234 @@
+#!/usr/bin/env python3
+"""Prove the SimpleModel renderer lifetime and graph ownership boundary."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import pathlib
+import re
+import sys
+
+
+SCHEMA = "pinyon-shift.native-renderer-static-world-lifetime.v1"
+IMAGE_BASE = 0x82000000
+RENDERER_VTABLE = 0x82001B64
+FUNCTION_RE = re.compile(r"^DEFINE_REX_FUNC\(sub_([0-9A-F]{8})\) \{")
+LABEL_RE = re.compile(r"^loc_([0-9A-F]{8}):")
+COMMENT_RE = re.compile(r"^\s*//\s+(.+?)\s*$")
+
+CONSTRUCTOR_WRAPPER = 0x82C4E3A0
+CONSTRUCTOR = 0x82C4DF78
+CONSTRUCTOR_PUBLISH_HOOK = 0x82C4E094
+DELETING_DESTRUCTOR = 0x82C4E420
+DESTRUCTOR = 0x82C4E1F8
+DESTRUCTOR_EXIT_HOOK = 0x82C4E264
+CLEANUP = 0x82C4E0A0
+GRAPH_BIND = 0x82C4CC50
+GRAPH_BIND_HOOK = 0x82C4CCB0
+GRAPH_RELEASE = 0x82C4C6A8
+DRAW_DISPATCH = 0x82C4CCC8
+
+
+def parse_functions(paths: list[pathlib.Path]) -> dict[int, dict[int, str]]:
+    functions = {}
+    for path in sorted(paths, key=lambda item: item.as_posix()):
+        current = None
+        address = None
+        for line in path.read_text(encoding="utf-8").splitlines():
+            match = FUNCTION_RE.match(line)
+            if match:
+                function_address = int(match.group(1), 16)
+                current = functions.setdefault(function_address, {})
+                address = function_address
+                continue
+            label = LABEL_RE.match(line)
+            if current is not None and label:
+                address = int(label.group(1), 16)
+                continue
+            comment = COMMENT_RE.match(line)
+            if current is not None and comment and address is not None:
+                current[address] = comment.group(1)
+                address += 4
+    return functions
+
+
+def image_u32(image: bytes, address: int) -> int:
+    offset = address - IMAGE_BASE
+    if offset < 0 or offset + 4 > len(image):
+        raise ValueError(f"image address is out of range: {address:08X}")
+    return int.from_bytes(image[offset : offset + 4], "big")
+
+
+def require_instructions(
+    functions: dict[int, dict[int, str]],
+    function_address: int,
+    expected: dict[int, str],
+) -> None:
+    instructions = functions.get(function_address)
+    if instructions is None:
+        raise ValueError(f"missing function {function_address:08X}")
+    for address, text in expected.items():
+        if instructions.get(address) != text:
+            raise ValueError(
+                f"instruction drift at {address:08X}: "
+                f"expected {text!r}, got {instructions.get(address)!r}"
+            )
+
+
+def build(functions: dict[int, dict[int, str]], image: bytes) -> dict:
+    slots = [image_u32(image, RENDERER_VTABLE + index * 4) for index in range(17)]
+    expected_slots = {
+        1: GRAPH_BIND,
+        12: DRAW_DISPATCH,
+        15: GRAPH_RELEASE,
+        16: DELETING_DESTRUCTOR,
+    }
+    if any(slots[index] != target for index, target in expected_slots.items()):
+        raise ValueError("SimpleModel renderer lifecycle vtable drifted")
+
+    require_instructions(
+        functions,
+        CONSTRUCTOR_WRAPPER,
+        {
+            0x82C4E3B0: "li r3,368",
+            0x82C4E3B4: "bl 0x82c0f6c0",
+            0x82C4E3C0: "bl 0x82c4df78",
+            0x82C4E3EC: "li r4,1",
+            0x82C4E3F4: "lwz r11,64(r11)",
+            0x82C4E3FC: "bctrl",
+        },
+    )
+    require_instructions(
+        functions,
+        CONSTRUCTOR,
+        {
+            0x82C4DF88: "lis r11,-32256",
+            0x82C4DF90: "addi r11,r11,7012",
+            0x82C4DF98: "stw r11,0(r31)",
+            0x82C4DFCC: "stw r30,72(r31)",
+            CONSTRUCTOR_PUBLISH_HOOK: "addi r1,r1,112",
+        },
+    )
+    require_instructions(
+        functions,
+        DELETING_DESTRUCTOR,
+        {
+            0x82C4E43C: "bl 0x82c4e1f8",
+            0x82C4E440: "clrlwi. r11,r30,31",
+            0x82C4E44C: "bl 0x823fd208",
+        },
+    )
+    require_instructions(
+        functions,
+        DESTRUCTOR,
+        {
+            0x82C4E210: "addi r11,r11,7012",
+            0x82C4E214: "stw r11,0(r3)",
+            0x82C4E218: "bl 0x82c4e0a0",
+            DESTRUCTOR_EXIT_HOOK: "addi r1,r1,96",
+        },
+    )
+    require_instructions(
+        functions,
+        CLEANUP,
+        {
+            0x82C4E0DC: "lwz r3,72(r31)",
+            0x82C4E0E0: "stw r30,72(r31)",
+            0x82C4E0F0: "lwz r11,12(r11)",
+            0x82C4E0F8: "bctrl",
+        },
+    )
+    require_instructions(
+        functions,
+        GRAPH_BIND,
+        {
+            0x82C4CC64: "mr r30,r3",
+            0x82C4CC98: "addi r3,r30,72",
+            0x82C4CC9C: "bl 0x82c48038",
+            GRAPH_BIND_HOOK: "addi r1,r1,112",
+        },
+    )
+    require_instructions(
+        functions,
+        GRAPH_RELEASE,
+        {
+            0x82C4C6AC: "lwz r3,72(r3)",
+            0x82C4C6B8: "stw r10,72(r11)",
+            0x82C4C6C4: "lwz r11,12(r11)",
+            0x82C4C6CC: "bctr",
+        },
+    )
+
+    return {
+        "schema": SCHEMA,
+        "status": "complete",
+        "classification": "exact_simple_model_renderer_lifetime_and_graph_owner",
+        "renderer": {
+            "class": "CSimpleModelRenderer",
+            "vtable": f"{RENDERER_VTABLE:08X}",
+            "object_bytes": 368,
+            "constructor_wrapper": f"{CONSTRUCTOR_WRAPPER:08X}",
+            "constructor": f"{CONSTRUCTOR:08X}",
+            "constructor_publish_hook": f"{CONSTRUCTOR_PUBLISH_HOOK:08X}",
+            "deleting_destructor_slot": 16,
+            "deleting_destructor": f"{DELETING_DESTRUCTOR:08X}",
+            "destructor": f"{DESTRUCTOR:08X}",
+            "destructor_entry_hook": f"{DESTRUCTOR:08X}",
+            "destructor_exit_hook": f"{DESTRUCTOR_EXIT_HOOK:08X}",
+        },
+        "graph_ownership": {
+            "field_offset": 72,
+            "constructor_initial_value": 0,
+            "bind_slot": 1,
+            "bind_method": f"{GRAPH_BIND:08X}",
+            "bind_completion_hook": f"{GRAPH_BIND_HOOK:08X}",
+            "bind_helper": "82C48038",
+            "release_slot": 15,
+            "release_method": f"{GRAPH_RELEASE:08X}",
+            "destructor_cleanup": f"{CLEANUP:08X}",
+            "release_dispatch_slot": 3,
+            "draw_slot": 12,
+            "draw_dispatch": f"{DRAW_DISPATCH:08X}",
+        },
+        "claims": {
+            "renderer_generation_boundary_proved": True,
+            "renderer_to_owned_graph_field_proved": True,
+            "concrete_building_or_prop_identity_proved": False,
+            "graph_dynamic_type_proved": False,
+            "streaming_lifetime_proved": False,
+        },
+        "safety": {
+            "static_analysis_only": True,
+            "guest_payload_exported": False,
+            "native_admission": False,
+            "suppression_allowed": False,
+            "xenos_authority_required": True,
+        },
+    }
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("generated_root", type=pathlib.Path)
+    parser.add_argument("--image", required=True, type=pathlib.Path)
+    parser.add_argument("--output", required=True, type=pathlib.Path)
+    args = parser.parse_args(argv)
+    try:
+        paths = list(args.generated_root.glob("pinyon_shift_recomp.*.cpp"))
+        if not paths:
+            raise ValueError("no generated AOT C++ files found")
+        document = build(parse_functions(paths), args.image.read_bytes())
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(
+            json.dumps(document, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        return 0
+    except (OSError, UnicodeDecodeError, ValueError) as error:
+        print(f"static-world lifetime discovery failed: {error}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/summarize-native-renderer-static-world-runtime-join.py
+++ b/tools/summarize-native-renderer-static-world-runtime-join.py
@@ -9,8 +9,9 @@ import pathlib
 import sys
 
 
-SCHEMA = "pinyon-shift.native-renderer-static-world-runtime-join.v1"
-STATIC_SCHEMA = "pinyon-shift.native-renderer-static-world-ingress.v1"
+SCHEMA = "pinyon-shift.native-renderer-static-world-runtime-join.v2"
+STATIC_SCHEMA = "pinyon-shift.native-renderer-static-world-ingress.v2"
+LIFETIME_SCHEMA = "pinyon-shift.native-renderer-static-world-lifetime.v1"
 CONFIG = "native_renderer.discovery.static_world_runtime_join_config"
 SUMMARY = "native_renderer.discovery.static_world_runtime_join_summary"
 CHECKPOINT = "native_renderer.discovery.static_world_runtime_join_checkpoint"
@@ -116,8 +117,66 @@ def validate_static_ingress(document):
         raise ValueError("static-world renderer dispatch proof drifted")
 
 
-def build(static_ingress, events, requested_session=None, allow_checkpoint=False):
+def validate_static_lifetime(document):
+    if (
+        document.get("schema") != LIFETIME_SCHEMA
+        or document.get("status") != "complete"
+        or document.get("classification")
+        != "exact_simple_model_renderer_lifetime_and_graph_owner"
+    ):
+        raise ValueError("static-world lifetime proof drifted")
+    try:
+        renderer = document["renderer"]
+        graph = document["graph_ownership"]
+        claims = document["claims"]
+    except (KeyError, TypeError) as error:
+        raise ValueError("static-world lifetime proof is incomplete") from error
+    expected_renderer = {
+        "class": "CSimpleModelRenderer",
+        "vtable": "82001B64",
+        "object_bytes": 368,
+        "constructor": "82C4DF78",
+        "constructor_publish_hook": "82C4E094",
+        "deleting_destructor_slot": 16,
+        "deleting_destructor": "82C4E420",
+        "destructor_entry_hook": "82C4E1F8",
+        "destructor_exit_hook": "82C4E264",
+    }
+    expected_graph = {
+        "field_offset": 72,
+        "bind_slot": 1,
+        "bind_method": "82C4CC50",
+        "bind_completion_hook": "82C4CCB0",
+        "release_slot": 15,
+        "release_method": "82C4C6A8",
+        "destructor_cleanup": "82C4E0A0",
+        "draw_slot": 12,
+        "draw_dispatch": "82C4CCC8",
+    }
+    if any(
+        renderer.get(key) != value
+        for key, value in expected_renderer.items()
+    ):
+        raise ValueError("static-world renderer lifetime proof drifted")
+    if any(graph.get(key) != value for key, value in expected_graph.items()):
+        raise ValueError("static-world graph ownership proof drifted")
+    if (
+        claims.get("renderer_generation_boundary_proved") is not True
+        or claims.get("renderer_to_owned_graph_field_proved") is not True
+        or claims.get("concrete_building_or_prop_identity_proved") is not False
+    ):
+        raise ValueError("static-world lifetime claims drifted")
+
+
+def build(
+    static_ingress,
+    static_lifetime,
+    events,
+    requested_session=None,
+    allow_checkpoint=False,
+):
     validate_static_ingress(static_ingress)
+    validate_static_lifetime(static_lifetime)
     session = select_session(events, requested_session)
     selected = [event for event in events if event.get("session") == session]
     config = exact_event(selected, CONFIG)
@@ -128,11 +187,22 @@ def build(static_ingress, events, requested_session=None, allow_checkpoint=False
         "status": "armed",
         "class": "CSimpleModelRenderer",
         "vtable": "82001B64",
+        "object_bytes": "368",
+        "constructor": "82C4DF78",
+        "constructor_publish_hook": "82C4E094",
+        "deleting_destructor_slot": "16",
+        "deleting_destructor": "82C4E420",
+        "destructor_entry_hook": "82C4E1F8",
+        "destructor_exit_hook": "82C4E264",
         "vtable_slot": "12",
         "dispatch": "82C4CCC8",
         "entry_hook": "82C4CCC8",
         "exit_hook": "82C4DEA0",
         "model_graph_field": "renderer_plus_72",
+        "model_graph_bind_slot": "1",
+        "model_graph_bind_hook": "82C4CCB0",
+        "model_graph_release_slot": "15",
+        "model_graph_release_hook": "82C4C6A8,82C4E0A0",
         "draw_emitter": "82416380",
         "packet_hooks": "82416260,824162F4",
         "join": "synchronous_scope_to_physical_pm4_prepared_draw",
@@ -156,7 +226,7 @@ def build(static_ingress, events, requested_session=None, allow_checkpoint=False
         or summary.get("checkpoint_kind")
         != ("final" if final_summary else "periodic")
         or summary.get("classification")
-        != "exact_simple_model_renderer_scope_to_pm4_prepared_draw"
+        != "live_simple_model_renderer_graph_to_pm4_prepared_draw"
     ):
         raise ValueError("static-world runtime summary drifted")
 
@@ -167,6 +237,10 @@ def build(static_ingress, events, requested_session=None, allow_checkpoint=False
         "invalid_root",
         "vtable_mismatches",
         "invalid_graph_field",
+        "unregistered_renderers",
+        "nonlive_renderers",
+        "unbound_graphs",
+        "graph_mismatches",
         "scopes_with_packets",
         "scopes_without_packets",
         "packets_recorded",
@@ -176,6 +250,26 @@ def build(static_ingress, events, requested_session=None, allow_checkpoint=False
         "unprepared_matches",
         "scope_overlaps",
         "exit_without_entry",
+        "instances_published",
+        "instances_destroyed",
+        "instance_address_reuses",
+        "lifecycle_table_overflow",
+        "lifecycle_faults",
+        "destructor_entries",
+        "destructor_exits",
+        "destructors_open",
+        "destructors_without_instance",
+        "graph_bind_observations",
+        "graph_bind_successes",
+        "graph_bind_null",
+        "graph_bind_unregistered",
+        "graph_bind_faults",
+        "graph_replacements",
+        "graph_release_observations",
+        "graph_release_successes",
+        "graph_release_empty",
+        "graph_release_unregistered",
+        "graph_release_faults",
     )
     totals = {key: integer(summary, key) for key in keys}
     frame_sequence = integer(summary, "frame_sequence")
@@ -185,6 +279,10 @@ def build(static_ingress, events, requested_session=None, allow_checkpoint=False
         + totals["invalid_root"]
         + totals["vtable_mismatches"]
         + totals["invalid_graph_field"]
+        + totals["unregistered_renderers"]
+        + totals["nonlive_renderers"]
+        + totals["unbound_graphs"]
+        + totals["graph_mismatches"]
     )
     if summary.get("accounting_complete") != "true":
         failures.append("runtime accounting is incomplete")
@@ -198,6 +296,12 @@ def build(static_ingress, events, requested_session=None, allow_checkpoint=False
         failures.append("static-world scope outcome accounting drifted")
     if not totals["exact_scopes"]:
         failures.append("no exact SimpleModel renderer scope was observed")
+    if not totals["instances_published"]:
+        failures.append(
+            "no completed SimpleModel renderer lifetime was observed"
+        )
+    if not totals["graph_bind_successes"]:
+        failures.append("no owned SimpleModel renderer graph was observed")
     if not totals["scopes_with_packets"] or not totals["packets_recorded"]:
         failures.append("no exact scope emitted a PM4 draw packet")
     if totals["packet_matches"] + totals["pending_packets"] != totals[
@@ -208,15 +312,48 @@ def build(static_ingress, events, requested_session=None, allow_checkpoint=False
         totals["prepared_matches"] + totals["unprepared_matches"]
     ):
         failures.append("static-world prepared accounting drifted")
+    if totals["destructor_entries"] != (
+        totals["destructor_exits"] + totals["destructors_open"]
+    ):
+        failures.append("static-world destructor accounting drifted")
+    if totals["instances_destroyed"] > totals["instances_published"]:
+        failures.append("static-world instance lifetime accounting drifted")
+    if (
+        totals["graph_bind_successes"]
+        + totals["graph_bind_null"]
+        + totals["graph_bind_unregistered"]
+        + totals["graph_bind_faults"]
+        != totals["graph_bind_observations"]
+    ):
+        failures.append("static-world graph bind accounting drifted")
+    if (
+        totals["graph_release_successes"]
+        + totals["graph_release_empty"]
+        + totals["graph_release_unregistered"]
+        + totals["graph_release_faults"]
+        != totals["graph_release_observations"]
+    ):
+        failures.append("static-world graph release accounting drifted")
     if not totals["prepared_matches"]:
         failures.append("no static-world PM4 packet joined a prepared draw")
     for key in (
         "invalid_root",
         "vtable_mismatches",
         "invalid_graph_field",
+        "unregistered_renderers",
+        "nonlive_renderers",
+        "graph_mismatches",
         "unprepared_matches",
         "scope_overlaps",
         "exit_without_entry",
+        "lifecycle_table_overflow",
+        "lifecycle_faults",
+        "destructors_without_instance",
+        "destructors_open",
+        "graph_bind_unregistered",
+        "graph_bind_faults",
+        "graph_release_unregistered",
+        "graph_release_faults",
     ):
         if totals[key]:
             failures.append(f"{key} is nonzero")
@@ -246,6 +383,8 @@ def build(static_ingress, events, requested_session=None, allow_checkpoint=False
         "totals": totals,
         "qualification": {
             "simple_model_renderer_scope_proved": not failures,
+            "simple_model_renderer_lifetime_proved": not failures,
+            "renderer_to_owned_graph_field_proved": not failures,
             "static_world_scope_to_pm4_proved": not failures,
             "static_world_pm4_to_prepared_draw_proved": not failures,
             "building_or_prop_instance_identity_proved": False,
@@ -268,6 +407,7 @@ def main(argv=None):
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("events", nargs="+", type=pathlib.Path)
     parser.add_argument("--static", required=True, type=pathlib.Path)
+    parser.add_argument("--lifetime", required=True, type=pathlib.Path)
     parser.add_argument("--session")
     parser.add_argument("--allow-checkpoint", action="store_true")
     parser.add_argument("--output", required=True, type=pathlib.Path)
@@ -275,6 +415,7 @@ def main(argv=None):
     try:
         document = build(
             json.loads(args.static.read_text(encoding="utf-8")),
+            json.loads(args.lifetime.read_text(encoding="utf-8")),
             read_events(args.events),
             args.session,
             args.allow_checkpoint,

--- a/tools/tests/test_native_renderer_static_world_ingress.py
+++ b/tools/tests/test_native_renderer_static_world_ingress.py
@@ -30,7 +30,7 @@ def fixture():
         offset = type_descriptor + 8 - MODULE.IMAGE_BASE
         image[offset : offset + len(encoded)] = encoded
         for surface_index, surface in enumerate(spec["surfaces"]):
-            _, locator, vtable, slot_count, destructor = surface
+            _, locator, vtable, slot_count, slot_zero_target = surface
             u32(locator + 12, type_descriptor)
             u32(vtable - 4, locator)
             slots = [
@@ -40,7 +40,7 @@ def fixture():
                 + index * 4
                 for index in range(slot_count)
             ]
-            slots[0] = destructor
+            slots[0] = slot_zero_target
             for index, target in enumerate(slots):
                 u32(vtable + index * 4, target)
                 if target not in MODULE.REVIEWED_THUNKS:
@@ -70,6 +70,11 @@ class StaticWorldIngressTests(unittest.TestCase):
                 "surfaces"
             ][0]["reviewed_thunk_slots"],
         )
+        renderer_surface = document["classes"]["simple_model_renderer"][
+            "surfaces"
+        ][0]
+        self.assertEqual("82C4C838", renderer_surface["slot_zero_target"])
+        self.assertNotIn("deleting_destructor", renderer_surface)
         self.assertFalse(
             document["topology"]["building_or_prop_instance_identity_proved"]
         )

--- a/tools/tests/test_native_renderer_static_world_lifetime.py
+++ b/tools/tests/test_native_renderer_static_world_lifetime.py
@@ -1,0 +1,117 @@
+import copy
+import importlib.util
+import sys
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+TOOL = ROOT / "tools" / "discover-native-renderer-static-world-lifetime.py"
+SPEC = importlib.util.spec_from_file_location("static_world_lifetime", TOOL)
+assert SPEC and SPEC.loader
+MODULE = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = MODULE
+SPEC.loader.exec_module(MODULE)
+
+
+def fixture():
+    highest = MODULE.RENDERER_VTABLE + 17 * 4
+    image = bytearray(highest - MODULE.IMAGE_BASE)
+    slots = [0x82800000 + index * 4 for index in range(17)]
+    slots[1] = MODULE.GRAPH_BIND
+    slots[12] = MODULE.DRAW_DISPATCH
+    slots[15] = MODULE.GRAPH_RELEASE
+    slots[16] = MODULE.DELETING_DESTRUCTOR
+    for index, target in enumerate(slots):
+        offset = MODULE.RENDERER_VTABLE + index * 4 - MODULE.IMAGE_BASE
+        image[offset : offset + 4] = target.to_bytes(4, "big")
+    functions = {
+        MODULE.CONSTRUCTOR_WRAPPER: {
+            0x82C4E3B0: "li r3,368",
+            0x82C4E3B4: "bl 0x82c0f6c0",
+            0x82C4E3C0: "bl 0x82c4df78",
+            0x82C4E3EC: "li r4,1",
+            0x82C4E3F4: "lwz r11,64(r11)",
+            0x82C4E3FC: "bctrl",
+        },
+        MODULE.CONSTRUCTOR: {
+            0x82C4DF88: "lis r11,-32256",
+            0x82C4DF90: "addi r11,r11,7012",
+            0x82C4DF98: "stw r11,0(r31)",
+            0x82C4DFCC: "stw r30,72(r31)",
+            MODULE.CONSTRUCTOR_PUBLISH_HOOK: "addi r1,r1,112",
+        },
+        MODULE.DELETING_DESTRUCTOR: {
+            0x82C4E43C: "bl 0x82c4e1f8",
+            0x82C4E440: "clrlwi. r11,r30,31",
+            0x82C4E44C: "bl 0x823fd208",
+        },
+        MODULE.DESTRUCTOR: {
+            0x82C4E210: "addi r11,r11,7012",
+            0x82C4E214: "stw r11,0(r3)",
+            0x82C4E218: "bl 0x82c4e0a0",
+            MODULE.DESTRUCTOR_EXIT_HOOK: "addi r1,r1,96",
+        },
+        MODULE.CLEANUP: {
+            0x82C4E0DC: "lwz r3,72(r31)",
+            0x82C4E0E0: "stw r30,72(r31)",
+            0x82C4E0F0: "lwz r11,12(r11)",
+            0x82C4E0F8: "bctrl",
+        },
+        MODULE.GRAPH_BIND: {
+            0x82C4CC64: "mr r30,r3",
+            0x82C4CC98: "addi r3,r30,72",
+            0x82C4CC9C: "bl 0x82c48038",
+            MODULE.GRAPH_BIND_HOOK: "addi r1,r1,112",
+        },
+        MODULE.GRAPH_RELEASE: {
+            0x82C4C6AC: "lwz r3,72(r3)",
+            0x82C4C6B8: "stw r10,72(r11)",
+            0x82C4C6C4: "lwz r11,12(r11)",
+            0x82C4C6CC: "bctr",
+        },
+    }
+    return functions, bytes(image)
+
+
+class StaticWorldLifetimeTests(unittest.TestCase):
+    def test_proves_renderer_generation_and_owned_graph_field(self):
+        functions, image = fixture()
+        document = MODULE.build(functions, image)
+        self.assertEqual("complete", document["status"])
+        self.assertEqual(368, document["renderer"]["object_bytes"])
+        self.assertEqual(16, document["renderer"]["deleting_destructor_slot"])
+        self.assertEqual(72, document["graph_ownership"]["field_offset"])
+        self.assertTrue(
+            document["claims"]["renderer_generation_boundary_proved"]
+        )
+        self.assertFalse(
+            document["claims"]["concrete_building_or_prop_identity_proved"]
+        )
+        self.assertFalse(document["safety"]["native_admission"])
+
+    def test_rejects_vtable_slot_drift(self):
+        functions, image = fixture()
+        corrupted = bytearray(image)
+        offset = MODULE.RENDERER_VTABLE + 16 * 4 - MODULE.IMAGE_BASE
+        corrupted[offset : offset + 4] = (0x82C4E424).to_bytes(4, "big")
+        with self.assertRaisesRegex(ValueError, "lifecycle vtable drifted"):
+            MODULE.build(functions, bytes(corrupted))
+
+    def test_rejects_graph_bind_field_drift(self):
+        functions, image = fixture()
+        corrupted = copy.deepcopy(functions)
+        corrupted[MODULE.GRAPH_BIND][0x82C4CC98] = "addi r3,r30,76"
+        with self.assertRaisesRegex(ValueError, "82C4CC98"):
+            MODULE.build(corrupted, image)
+
+    def test_rejects_constructor_extent_drift(self):
+        functions, image = fixture()
+        corrupted = copy.deepcopy(functions)
+        corrupted[MODULE.CONSTRUCTOR_WRAPPER][0x82C4E3B0] = "li r3,364"
+        with self.assertRaisesRegex(ValueError, "82C4E3B0"):
+            MODULE.build(corrupted, image)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/tests/test_native_renderer_static_world_runtime_join.py
+++ b/tools/tests/test_native_renderer_static_world_runtime_join.py
@@ -52,6 +52,43 @@ def static_ingress():
     }
 
 
+def static_lifetime():
+    return {
+        "schema": MODULE.LIFETIME_SCHEMA,
+        "status": "complete",
+        "classification": (
+            "exact_simple_model_renderer_lifetime_and_graph_owner"
+        ),
+        "renderer": {
+            "class": "CSimpleModelRenderer",
+            "vtable": "82001B64",
+            "object_bytes": 368,
+            "constructor": "82C4DF78",
+            "constructor_publish_hook": "82C4E094",
+            "deleting_destructor_slot": 16,
+            "deleting_destructor": "82C4E420",
+            "destructor_entry_hook": "82C4E1F8",
+            "destructor_exit_hook": "82C4E264",
+        },
+        "graph_ownership": {
+            "field_offset": 72,
+            "bind_slot": 1,
+            "bind_method": "82C4CC50",
+            "bind_completion_hook": "82C4CCB0",
+            "release_slot": 15,
+            "release_method": "82C4C6A8",
+            "destructor_cleanup": "82C4E0A0",
+            "draw_slot": 12,
+            "draw_dispatch": "82C4CCC8",
+        },
+        "claims": {
+            "renderer_generation_boundary_proved": True,
+            "renderer_to_owned_graph_field_proved": True,
+            "concrete_building_or_prop_identity_proved": False,
+        },
+    }
+
+
 def fixture():
     config = event(
         MODULE.CONFIG,
@@ -59,11 +96,22 @@ def fixture():
         **{
             "class": "CSimpleModelRenderer",
             "vtable": "82001B64",
+            "object_bytes": "368",
+            "constructor": "82C4DF78",
+            "constructor_publish_hook": "82C4E094",
+            "deleting_destructor_slot": "16",
+            "deleting_destructor": "82C4E420",
+            "destructor_entry_hook": "82C4E1F8",
+            "destructor_exit_hook": "82C4E264",
             "vtable_slot": "12",
             "dispatch": "82C4CCC8",
             "entry_hook": "82C4CCC8",
             "exit_hook": "82C4DEA0",
             "model_graph_field": "renderer_plus_72",
+            "model_graph_bind_slot": "1",
+            "model_graph_bind_hook": "82C4CCB0",
+            "model_graph_release_slot": "15",
+            "model_graph_release_hook": "82C4C6A8,82C4E0A0",
             "draw_emitter": "82416380",
             "packet_hooks": "82416260,824162F4",
             "join": "synchronous_scope_to_physical_pm4_prepared_draw",
@@ -76,12 +124,16 @@ def fixture():
         status="complete",
         checkpoint_kind="final",
         frame_sequence="1200",
-        scope_entries="10",
-        scope_exits="10",
+        scope_entries="12",
+        scope_exits="12",
         exact_scopes="10",
         invalid_root="0",
         vtable_mismatches="0",
         invalid_graph_field="0",
+        unregistered_renderers="0",
+        nonlive_renderers="0",
+        unbound_graphs="2",
+        graph_mismatches="0",
         scopes_with_packets="8",
         scopes_without_packets="2",
         packets_recorded="100",
@@ -91,9 +143,29 @@ def fixture():
         unprepared_matches="0",
         scope_overlaps="0",
         exit_without_entry="0",
+        instances_published="3",
+        instances_destroyed="1",
+        instance_address_reuses="0",
+        lifecycle_table_overflow="0",
+        lifecycle_faults="0",
+        destructor_entries="1",
+        destructor_exits="1",
+        destructors_open="0",
+        destructors_without_instance="0",
+        graph_bind_observations="4",
+        graph_bind_successes="3",
+        graph_bind_null="1",
+        graph_bind_unregistered="0",
+        graph_bind_faults="0",
+        graph_replacements="0",
+        graph_release_observations="1",
+        graph_release_successes="1",
+        graph_release_empty="0",
+        graph_release_unregistered="0",
+        graph_release_faults="0",
         accounting_complete="true",
         qualification_complete="true",
-        classification="exact_simple_model_renderer_scope_to_pm4_prepared_draw",
+        classification="live_simple_model_renderer_graph_to_pm4_prepared_draw",
         **safety(),
     )
     return [config, summary]
@@ -101,10 +173,13 @@ def fixture():
 
 class StaticWorldRuntimeJoinTests(unittest.TestCase):
     def test_qualifies_exact_scope_to_prepared_draw(self):
-        document = MODULE.build(static_ingress(), fixture())
+        document = MODULE.build(static_ingress(), static_lifetime(), fixture())
         self.assertEqual("complete", document["status"])
         self.assertTrue(
             document["qualification"]["static_world_pm4_to_prepared_draw_proved"]
+        )
+        self.assertTrue(
+            document["qualification"]["simple_model_renderer_lifetime_proved"]
         )
         self.assertFalse(
             document["qualification"]["building_or_prop_instance_identity_proved"]
@@ -120,7 +195,10 @@ class StaticWorldRuntimeJoinTests(unittest.TestCase):
             checkpoint_kind="periodic",
         )
         document = MODULE.build(
-            static_ingress(), events + [checkpoint], allow_checkpoint=True
+            static_ingress(),
+            static_lifetime(),
+            events + [checkpoint],
+            allow_checkpoint=True,
         )
         self.assertEqual("checkpoint_complete", document["status"])
         self.assertFalse(document["evidence"]["session_exit_proved"])
@@ -134,7 +212,7 @@ class StaticWorldRuntimeJoinTests(unittest.TestCase):
             unprepared_matches="1",
             qualification_complete="false",
         )
-        document = MODULE.build(static_ingress(), events)
+        document = MODULE.build(static_ingress(), static_lifetime(), events)
         self.assertEqual("incomplete", document["status"])
         self.assertIn("unprepared_matches is nonzero", document["failures"])
 
@@ -146,7 +224,7 @@ class StaticWorldRuntimeJoinTests(unittest.TestCase):
             accounting_complete="false",
             qualification_complete="false",
         )
-        document = MODULE.build(static_ingress(), events)
+        document = MODULE.build(static_ingress(), static_lifetime(), events)
         self.assertEqual("incomplete", document["status"])
         self.assertIn(
             "static-world scope entry/exit accounting drifted",
@@ -159,7 +237,23 @@ class StaticWorldRuntimeJoinTests(unittest.TestCase):
             "slot_targets"
         ][12] = "82C4CCD0"
         with self.assertRaisesRegex(ValueError, "dispatch proof drifted"):
-            MODULE.build(ingress, fixture())
+            MODULE.build(ingress, static_lifetime(), fixture())
+
+    def test_rejects_unregistered_renderer_dispatch(self):
+        events = copy.deepcopy(fixture())
+        events[-1].update(
+            status="incomplete",
+            exact_scopes="9",
+            unregistered_renderers="1",
+            scopes_with_packets="7",
+            accounting_complete="true",
+            qualification_complete="false",
+        )
+        document = MODULE.build(static_ingress(), static_lifetime(), events)
+        self.assertEqual("incomplete", document["status"])
+        self.assertIn(
+            "unregistered_renderers is nonzero", document["failures"]
+        )
 
     def test_source_contract_has_balanced_static_world_hooks(self):
         hooks = (ROOT / "src/native_renderer/graphics_hooks.cpp").read_text(
@@ -174,6 +268,12 @@ class StaticWorldRuntimeJoinTests(unittest.TestCase):
         self.assertIn("static_world_draw", hooks)
         self.assertIn("address = 0x82C4CCC8", analysis)
         self.assertIn("address = 0x82C4DEA0", analysis)
+        self.assertIn("address = 0x82C4E094", analysis)
+        self.assertIn("address = 0x82C4E1F8", analysis)
+        self.assertIn("address = 0x82C4E264", analysis)
+        self.assertIn("address = 0x82C4CCB0", analysis)
+        self.assertIn("address = 0x82C4C6A8", analysis)
+        self.assertIn("address = 0x82C4E0A0", analysis)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- prove the exact 368-byte SimpleModel renderer construction and slot-16 deleting destructor
- trace offset-72 graph bind, release, and destructor cleanup ownership transitions
- carry independent renderer/graph generations through PM4 prepared-draw provenance
- reject stale, unregistered, non-live, unbound, or mismatched ownership without changing title behavior

## Safety
- metadata-only; guest allocation, release, state, packets, and control flow remain unchanged
- Xenos stays authoritative
- enables no native admission, publication, or suppression

## Validation
- 530 repository tool tests passed
- retail/AOT lifetime report generated successfully
- all generated hook sites and affected Release objects compiled
- final executable link remains intentionally deferred while the guarded AppData process owns it