### PR TITLE
feat(native-renderer): trace static-world resources

### DIFF
--- a/config/rexglue/analysis/main-xex.toml
+++ b/config/rexglue/analysis/main-xex.toml
@@ -274,6 +274,30 @@ address = 0x82C4E0A0
 name = "PinyonShiftObserveStaticWorldRendererGraphRelease"
 registers = ["r3"]
 
+# Slot-1 binding creates or retrieves an exact 320-byte
+# CSimpleModelResource. Publish only after the derived vtable is installed,
+# observe both the new and existing-resource paths at their shared output
+# join, and balance the complete resource destructor. The title's reference
+# assignment, registration, and release calls remain authoritative.
+[[midasm_hook]]
+address = 0x82C47FBC
+name = "PinyonShiftObserveStaticWorldResourceConstructed"
+registers = ["r29"]
+
+[[midasm_hook]]
+address = 0x82C4802C
+name = "PinyonShiftObserveStaticWorldResourceRegistration"
+registers = ["r31"]
+
+[[midasm_hook]]
+address = 0x82C47DF8
+name = "PinyonShiftObserveStaticWorldResourceDestructorEntry"
+registers = ["r3"]
+
+[[midasm_hook]]
+address = 0x82C47E44
+name = "PinyonShiftObserveStaticWorldResourceDestructorExit"
+
 # Immediately before 8240E7B0 submits its 64-byte matrix payload to 82435E78,
 # r22 still owns the original r7 object/reference matrix and r5 points at the
 # fully composed stack payload. Compare both exact live matrices with admitted

--- a/docs/native-renderer/REPRIORITIZED_PLAN.md
+++ b/docs/native-renderer/REPRIORITIZED_PLAN.md
@@ -321,7 +321,18 @@ Runtime lineage carries independent renderer and graph generations and rejects
 unregistered, non-live, unbound, or mismatched ownership before attribution.
 The proof and batched qualifier are documented in
 [`STATIC_WORLD_LIFETIME.md`](STATIC_WORLD_LIFETIME.md). Concrete graph dynamic
-type, building/prop identity, and streaming registration remain pending.
+type and registration are closed by the next checkpoint; building/prop
+identity and complete streaming invalidation remain pending.
+
+Resource checkpoint: the renderer's bound graph is now statically proved as
+the exact 320-byte `CSimpleModelResource` produced by factory `82C47F10`.
+Allocation and reuse paths converge at one registration boundary, while
+generation-aware construction and destruction hooks prevent address reuse
+from contaminating prepared-draw provenance. Runtime qualification is batched
+with C1/C2 and documented in
+[`STATIC_WORLD_RESOURCE.md`](STATIC_WORLD_RESOURCE.md). Concrete building/prop
+identity, mesh/material decoding, and independent streaming invalidation paths
+remain required; no admission or suppression is enabled.
 
 ### C3. Semantic batching, culling, and LOD
 

--- a/docs/native-renderer/STATIC_WORLD_INGRESS.md
+++ b/docs/native-renderer/STATIC_WORLD_INGRESS.md
@@ -98,6 +98,7 @@ python tools/summarize-native-renderer-static-world-runtime-join.py `
   .local/preview/logs/<session>.jsonl `
   --static .local/qualification/native-renderer-static-world-ingress.json `
   --lifetime .local/qualification/native-renderer-static-world-lifetime.json `
+  --resource .local/qualification/native-renderer-static-world-resource.json `
   --session <session> `
   --output .local/qualification/native-renderer-static-world-runtime-join.json
 ```
@@ -111,4 +112,6 @@ disabled until those next exact gates are closed.
 The renderer lifetime and owned graph field are now independently proved in
 [`STATIC_WORLD_LIFETIME.md`](STATIC_WORLD_LIFETIME.md). The runtime join
 requires a completed renderer generation and matching graph-binding generation
-before it attributes any PM4 packet.
+before it attributes any PM4 packet. The bound graph is now independently
+proved as an exact, live, registered `CSimpleModelResource` generation in
+[`STATIC_WORLD_RESOURCE.md`](STATIC_WORLD_RESOURCE.md).

--- a/docs/native-renderer/STATIC_WORLD_LIFETIME.md
+++ b/docs/native-renderer/STATIC_WORLD_LIFETIME.md
@@ -57,21 +57,25 @@ python tools/discover-native-renderer-static-world-lifetime.py `
   --output .local/qualification/native-renderer-static-world-lifetime.json
 ```
 
-The runtime join now requires both static reports:
+The runtime join now requires the ingress, renderer-lifetime, and exact
+resource reports:
 
 ```powershell
 python tools/summarize-native-renderer-static-world-runtime-join.py `
   .local/preview/logs/<session>.jsonl `
   --static .local/qualification/native-renderer-static-world-ingress.json `
   --lifetime .local/qualification/native-renderer-static-world-lifetime.json `
+  --resource .local/qualification/native-renderer-static-world-resource.json `
   --session <session> `
   --output .local/qualification/native-renderer-static-world-runtime-join.json
 ```
 
 ## Remaining boundary
 
-This proves a live renderer generation and the exact graph it owns at draw
-time. It does not yet identify that graph's dynamic type, concrete building or
-prop instances, mesh/material members, or streaming registration and
-destruction. Native admission, publication, and suppression remain disabled;
-Xenos stays authoritative.
+This proves a live renderer generation and the graph it owns at draw time.
+The graph's exact dynamic type, factory registration, and resource generation
+are proved separately in
+[`STATIC_WORLD_RESOURCE.md`](STATIC_WORLD_RESOURCE.md). Concrete building or
+prop instances, mesh/material members, and every streaming invalidation route
+remain pending. Native admission, publication, and suppression remain
+disabled; Xenos stays authoritative.

--- a/docs/native-renderer/STATIC_WORLD_RESOURCE.md
+++ b/docs/native-renderer/STATIC_WORLD_RESOURCE.md
@@ -1,0 +1,69 @@
+# Static-world SimpleModel resource boundary
+
+Status: exact resource type, factory registration, and lifetime proved; runtime
+qualification pending
+
+## Purpose
+
+The renderer's offset-72 graph cannot safely identify static-world work while
+it is only an opaque pointer. Phase C2 needs proof that the bound object is an
+exact `CSimpleModelResource`, that both factory reuse and allocation paths
+cross one registration boundary, and that allocation reuse cannot join an old
+prepared draw to a new resource generation.
+
+`tools/discover-native-renderer-static-world-resource.py` validates those
+facts against the payload-free retail image and generated AOT instruction
+flow. The report contains addresses and structural facts only.
+
+## Exact factory and binding path
+
+- Renderer bind helper `82C48038` passes `renderer + 72` as the output of
+  factory callback `82C47F10`.
+- The allocation path reserves 320 bytes, invokes constructor `82C47DA0`, and
+  installs exact `CSimpleModelResource` vtable `82229294`.
+- Hook `82C47FBC` publishes the generation after that final vtable store and
+  before reference assignment helper `824E81A8` publishes the pointer.
+- Existing and newly allocated resources converge at `82C4802C`, after the
+  factory's registration/list insertion. The hook observes the final output
+  pointer without changing title state or control flow.
+- Vtable slot zero is deleting destructor `82C47EC0`. Complete destructor
+  `82C47DF8` and exit hook `82C47E44` bound the exact resource lifetime.
+
+The runtime registry assigns an independent generation to every published
+resource address. Registration, renderer binding, exact renderer scope, PM4
+packet provenance, and prepared-draw provenance must agree on the same live
+generation. Null, unregistered, wrong-vtable, destroying, destroyed, stale,
+unmapped, or overflowing entries fail closed and remain Xenos-owned.
+
+## Generate the static report
+
+```powershell
+python tools/discover-native-renderer-static-world-resource.py `
+  .local/generated/default `
+  --image .local/analysis/default-image.bin `
+  --output .local/qualification/native-renderer-static-world-resource.json
+```
+
+The batched runtime qualifier requires all three static reports:
+
+```powershell
+python tools/summarize-native-renderer-static-world-runtime-join.py `
+  .local/preview/logs/<session>.jsonl `
+  --static .local/qualification/native-renderer-static-world-ingress.json `
+  --lifetime .local/qualification/native-renderer-static-world-lifetime.json `
+  --resource .local/qualification/native-renderer-static-world-resource.json `
+  --session <session> `
+  --output .local/qualification/native-renderer-static-world-runtime-join.json
+```
+
+`--allow-checkpoint` remains diagnostic only. A periodic checkpoint cannot
+prove clean shutdown and never enables native admission.
+
+## Remaining boundary
+
+This proves the exact dynamic type and generation of the resource bound to a
+live renderer, plus the factory registration boundary and resource destructor.
+It does not identify a concrete building or prop, decode mesh/material
+members, or prove every independent streaming invalidation route. Native
+upload, draw, publication, and suppression remain disabled; Xenos stays
+authoritative.

--- a/src/native_renderer/graphics_hooks.cpp
+++ b/src/native_renderer/graphics_hooks.cpp
@@ -99,6 +99,7 @@ constexpr size_t kIndirectContextStackCapacity = 32;
 constexpr size_t kSemanticReceiverLifecycleCapacity = 1024;
 constexpr size_t kSemanticReceiverStackCapacity = 32;
 constexpr size_t kStaticWorldRendererLifecycleCapacity = 256;
+constexpr size_t kStaticWorldResourceLifecycleCapacity = 4096;
 constexpr size_t kSemanticVisibilityCategoryCapacity = 32;
 constexpr size_t kSemanticVisibilityLodCapacity = 32;
 constexpr size_t kSemanticVisibilityResultValueCapacity = 256;
@@ -174,6 +175,7 @@ constexpr uint32_t kTrackRenderModelDescriptorBytes = 248;
 constexpr uint32_t kTrackRenderModelGraphBytes = 64;
 constexpr uint32_t kSimpleModelRendererVtable = 0x82001B64;
 constexpr uint32_t kSimpleModelRendererGraphOffset = 72;
+constexpr uint32_t kSimpleModelResourceVtable = 0x82229294;
 constexpr uint32_t kTrackModelVtable = 0x820016B4;
 constexpr uint32_t kTrackMeshVtable = 0x8200143C;
 constexpr uint32_t kTrackSubModelVtable = 0x82001474;
@@ -473,6 +475,7 @@ struct StaticWorldDrawIdentity {
   uint32_t render_context_address = 0;
   uint32_t model_graph_address = 0;
   uint32_t model_graph_generation = 0;
+  uint32_t model_resource_generation = 0;
   bool valid = false;
 };
 
@@ -1886,6 +1889,7 @@ struct StaticWorldRendererDispatchScope {
   uint32_t render_context_address = 0;
   uint32_t model_graph_address = 0;
   uint32_t model_graph_generation = 0;
+  uint32_t model_resource_generation = 0;
   bool active = false;
   bool exact = false;
 };
@@ -1903,9 +1907,19 @@ struct StaticWorldRendererLifecycleEntry {
   std::atomic<uint32_t> state{};
   std::atomic<uint32_t> model_graph_address{};
   std::atomic<uint32_t> model_graph_generation{};
+  std::atomic<uint32_t> model_resource_generation{};
   std::atomic<uint64_t> dispatches{};
   std::atomic<uint64_t> graph_binds{};
   std::atomic<uint64_t> graph_releases{};
+};
+
+struct StaticWorldResourceLifecycleEntry {
+  std::atomic<uint32_t> address{};
+  std::atomic<uint32_t> generation{};
+  std::atomic<uint32_t> state{};
+  std::atomic<bool> registered{};
+  std::atomic<uint64_t> registrations{};
+  std::atomic<uint64_t> renderer_joins{};
 };
 
 std::array<SemanticSubmissionEntry, kSemanticSubmissionCapacity>
@@ -2031,6 +2045,27 @@ std::atomic<uint64_t> g_static_world_graph_release_successes{};
 std::atomic<uint64_t> g_static_world_graph_release_empty{};
 std::atomic<uint64_t> g_static_world_graph_release_unregistered{};
 std::atomic<uint64_t> g_static_world_graph_release_faults{};
+std::array<StaticWorldResourceLifecycleEntry,
+           kStaticWorldResourceLifecycleCapacity>
+    g_static_world_resource_lifecycles{};
+std::atomic<uint64_t> g_static_world_resource_instances_published{};
+std::atomic<uint64_t> g_static_world_resource_instances_destroyed{};
+std::atomic<uint64_t> g_static_world_resource_address_reuses{};
+std::atomic<uint64_t> g_static_world_resource_table_overflow{};
+std::atomic<uint64_t> g_static_world_resource_lifecycle_faults{};
+std::atomic<uint64_t> g_static_world_resource_destructor_entries{};
+std::atomic<uint64_t> g_static_world_resource_destructor_exits{};
+std::atomic<uint64_t> g_static_world_resource_destructors_open{};
+std::atomic<uint64_t> g_static_world_resource_destructors_without_instance{};
+std::atomic<uint64_t> g_static_world_resource_registration_observations{};
+std::atomic<uint64_t> g_static_world_resource_registration_successes{};
+std::atomic<uint64_t> g_static_world_resource_registration_null{};
+std::atomic<uint64_t> g_static_world_resource_registration_unregistered{};
+std::atomic<uint64_t> g_static_world_resource_registration_type_mismatches{};
+std::atomic<uint64_t> g_static_world_resource_registration_faults{};
+std::atomic<uint64_t> g_static_world_resource_graph_bind_joins{};
+std::atomic<uint64_t> g_static_world_resource_scope_joins{};
+std::atomic<uint64_t> g_static_world_resource_scope_mismatches{};
 std::array<SemanticBindingCacheSlot, 5> g_semantic_binding_cache_slots{};
 std::array<SemanticResolverCacheSlot, 5> g_semantic_resolver_cache_slots{};
 thread_local PendingSemanticResourceBindings g_pending_semantic_bindings{};
@@ -2047,6 +2082,10 @@ thread_local std::array<uint32_t, kSemanticReceiverStackCapacity>
     g_static_world_renderer_destructor_stack{};
 thread_local size_t g_static_world_renderer_destructor_stack_depth = 0;
 thread_local size_t g_static_world_renderer_destructor_overflow_depth = 0;
+thread_local std::array<uint32_t, kSemanticReceiverStackCapacity>
+    g_static_world_resource_destructor_stack{};
+thread_local size_t g_static_world_resource_destructor_stack_depth = 0;
+thread_local size_t g_static_world_resource_destructor_overflow_depth = 0;
 thread_local std::array<TrackWorldResourceGraphCacheEntry,
                         kTrackWorldResourceGraphCacheCapacity>
     g_track_world_resource_graph_cache{};
@@ -2787,6 +2826,198 @@ StaticWorldRendererLifecycleEntry *FindOrClaimStaticWorldRendererLifecycle(
   return nullptr;
 }
 
+size_t StaticWorldResourceLifecycleIndex(uint32_t address) {
+  return size_t((address >> 4) % kStaticWorldResourceLifecycleCapacity);
+}
+
+StaticWorldResourceLifecycleEntry *FindStaticWorldResourceLifecycle(
+    uint32_t address) {
+  size_t index = StaticWorldResourceLifecycleIndex(address);
+  for (size_t probe = 0; probe < kStaticWorldResourceLifecycleCapacity;
+       ++probe) {
+    StaticWorldResourceLifecycleEntry &entry =
+        g_static_world_resource_lifecycles[index];
+    const uint32_t observed =
+        entry.address.load(std::memory_order_acquire);
+    if (observed == address) {
+      return &entry;
+    }
+    if (!observed) {
+      return nullptr;
+    }
+    index = (index + 1) % kStaticWorldResourceLifecycleCapacity;
+  }
+  return nullptr;
+}
+
+StaticWorldResourceLifecycleEntry *FindOrClaimStaticWorldResourceLifecycle(
+    uint32_t address) {
+  size_t index = StaticWorldResourceLifecycleIndex(address);
+  for (size_t probe = 0; probe < kStaticWorldResourceLifecycleCapacity;
+       ++probe) {
+    StaticWorldResourceLifecycleEntry &entry =
+        g_static_world_resource_lifecycles[index];
+    uint32_t observed = entry.address.load(std::memory_order_acquire);
+    if (observed == address) {
+      return &entry;
+    }
+    if (!observed && entry.address.compare_exchange_strong(
+                         observed, address, std::memory_order_acq_rel,
+                         std::memory_order_acquire)) {
+      return &entry;
+    }
+    index = (index + 1) % kStaticWorldResourceLifecycleCapacity;
+  }
+  g_static_world_resource_table_overflow.fetch_add(
+      1, std::memory_order_relaxed);
+  return nullptr;
+}
+
+void PublishStaticWorldResource(uint32_t address) {
+  if (!g_title_provenance_installed.load(std::memory_order_acquire)) {
+    return;
+  }
+  StaticWorldResourceLifecycleEntry *entry =
+      FindOrClaimStaticWorldResourceLifecycle(address);
+  if (!entry) {
+    return;
+  }
+  const auto previous = static_cast<StaticWorldRendererState>(
+      entry->state.load(std::memory_order_acquire));
+  if (previous == StaticWorldRendererState::kLive ||
+      previous == StaticWorldRendererState::kDestroying) {
+    g_static_world_resource_lifecycle_faults.fetch_add(
+        1, std::memory_order_relaxed);
+    return;
+  }
+  uint32_t generation =
+      entry->generation.load(std::memory_order_relaxed) + 1;
+  if (!generation) {
+    generation = 1;
+  }
+  if (previous == StaticWorldRendererState::kDestroyed) {
+    g_static_world_resource_address_reuses.fetch_add(
+        1, std::memory_order_relaxed);
+  }
+  entry->registered.store(false, std::memory_order_relaxed);
+  entry->registrations.store(0, std::memory_order_relaxed);
+  entry->renderer_joins.store(0, std::memory_order_relaxed);
+  entry->generation.store(generation, std::memory_order_relaxed);
+  entry->state.store(uint32_t(StaticWorldRendererState::kLive),
+                     std::memory_order_release);
+  g_static_world_resource_instances_published.fetch_add(
+      1, std::memory_order_relaxed);
+}
+
+void ObserveStaticWorldResourceRegistration(uint32_t output_address) {
+  if (!g_title_provenance_installed.load(std::memory_order_acquire)) {
+    return;
+  }
+  g_static_world_resource_registration_observations.fetch_add(
+      1, std::memory_order_relaxed);
+  rex::memory::Memory *memory =
+      g_title_provenance_memory.load(std::memory_order_acquire);
+  uint32_t resource_address = 0;
+  if (!LoadMappedGuestU32(memory, output_address, resource_address)) {
+    g_static_world_resource_lifecycle_faults.fetch_add(
+        1, std::memory_order_relaxed);
+    g_static_world_resource_registration_faults.fetch_add(
+        1, std::memory_order_relaxed);
+    return;
+  }
+  if (!resource_address) {
+    g_static_world_resource_registration_null.fetch_add(
+        1, std::memory_order_relaxed);
+    return;
+  }
+  uint32_t vtable = 0;
+  if (!LoadMappedGuestU32(memory, resource_address, vtable) ||
+      vtable != kSimpleModelResourceVtable) {
+    g_static_world_resource_registration_type_mismatches.fetch_add(
+        1, std::memory_order_relaxed);
+    return;
+  }
+  StaticWorldResourceLifecycleEntry *entry =
+      FindStaticWorldResourceLifecycle(resource_address);
+  if (!entry || entry->state.load(std::memory_order_acquire) !=
+                    uint32_t(StaticWorldRendererState::kLive)) {
+    g_static_world_resource_registration_unregistered.fetch_add(
+        1, std::memory_order_relaxed);
+    return;
+  }
+  entry->registered.store(true, std::memory_order_release);
+  entry->registrations.fetch_add(1, std::memory_order_relaxed);
+  g_static_world_resource_registration_successes.fetch_add(
+      1, std::memory_order_relaxed);
+}
+
+void BeginStaticWorldResourceDestruction(uint32_t address) {
+  if (!g_title_provenance_installed.load(std::memory_order_acquire)) {
+    return;
+  }
+  g_static_world_resource_destructor_entries.fetch_add(
+      1, std::memory_order_relaxed);
+  if (g_static_world_resource_destructor_stack_depth ==
+      g_static_world_resource_destructor_stack.size()) {
+    ++g_static_world_resource_destructor_overflow_depth;
+    g_static_world_resource_lifecycle_faults.fetch_add(
+        1, std::memory_order_relaxed);
+    return;
+  }
+  g_static_world_resource_destructor_stack
+      [g_static_world_resource_destructor_stack_depth++] = address;
+  g_static_world_resource_destructors_open.fetch_add(
+      1, std::memory_order_relaxed);
+  StaticWorldResourceLifecycleEntry *entry =
+      FindStaticWorldResourceLifecycle(address);
+  uint32_t expected_state = uint32_t(StaticWorldRendererState::kLive);
+  if (!entry || !entry->state.compare_exchange_strong(
+                    expected_state,
+                    uint32_t(StaticWorldRendererState::kDestroying),
+                    std::memory_order_acq_rel,
+                    std::memory_order_acquire)) {
+    g_static_world_resource_destructors_without_instance.fetch_add(
+        1, std::memory_order_relaxed);
+    return;
+  }
+  entry->registered.store(false, std::memory_order_release);
+}
+
+void EndStaticWorldResourceDestruction() {
+  if (!g_title_provenance_installed.load(std::memory_order_acquire)) {
+    return;
+  }
+  g_static_world_resource_destructor_exits.fetch_add(
+      1, std::memory_order_relaxed);
+  if (g_static_world_resource_destructor_overflow_depth) {
+    --g_static_world_resource_destructor_overflow_depth;
+    return;
+  }
+  if (!g_static_world_resource_destructor_stack_depth) {
+    g_static_world_resource_lifecycle_faults.fetch_add(
+        1, std::memory_order_relaxed);
+    return;
+  }
+  const uint32_t address = g_static_world_resource_destructor_stack
+      [--g_static_world_resource_destructor_stack_depth];
+  g_static_world_resource_destructors_open.fetch_sub(
+      1, std::memory_order_relaxed);
+  StaticWorldResourceLifecycleEntry *entry =
+      FindStaticWorldResourceLifecycle(address);
+  uint32_t expected_state = uint32_t(StaticWorldRendererState::kDestroying);
+  if (!entry || !entry->state.compare_exchange_strong(
+                    expected_state,
+                    uint32_t(StaticWorldRendererState::kDestroyed),
+                    std::memory_order_acq_rel,
+                    std::memory_order_acquire)) {
+    g_static_world_resource_lifecycle_faults.fetch_add(
+        1, std::memory_order_relaxed);
+    return;
+  }
+  g_static_world_resource_instances_destroyed.fetch_add(
+      1, std::memory_order_relaxed);
+}
+
 void PublishStaticWorldRenderer(uint32_t address) {
   if (!g_title_provenance_installed.load(std::memory_order_acquire)) {
     return;
@@ -2815,6 +3046,7 @@ void PublishStaticWorldRenderer(uint32_t address) {
   }
   entry->model_graph_address.store(0, std::memory_order_relaxed);
   entry->model_graph_generation.store(0, std::memory_order_relaxed);
+  entry->model_resource_generation.store(0, std::memory_order_relaxed);
   entry->dispatches.store(0, std::memory_order_relaxed);
   entry->graph_binds.store(0, std::memory_order_relaxed);
   entry->graph_releases.store(0, std::memory_order_relaxed);
@@ -2921,8 +3153,26 @@ void ObserveStaticWorldRendererGraphBind(uint32_t renderer_address) {
       entry->model_graph_address.load(std::memory_order_acquire);
   if (!model_graph_address) {
     entry->model_graph_address.store(0, std::memory_order_release);
+    entry->model_resource_generation.store(0,
+                                            std::memory_order_relaxed);
     g_static_world_graph_bind_null.fetch_add(1,
                                              std::memory_order_relaxed);
+    return;
+  }
+  uint32_t resource_vtable = 0;
+  if (!LoadMappedGuestU32(memory, model_graph_address, resource_vtable) ||
+      resource_vtable != kSimpleModelResourceVtable) {
+    g_static_world_graph_bind_faults.fetch_add(1,
+                                               std::memory_order_relaxed);
+    return;
+  }
+  StaticWorldResourceLifecycleEntry *resource =
+      FindStaticWorldResourceLifecycle(model_graph_address);
+  if (!resource || resource->state.load(std::memory_order_acquire) !=
+                       uint32_t(StaticWorldRendererState::kLive) ||
+      !resource->registered.load(std::memory_order_acquire)) {
+    g_static_world_graph_bind_faults.fetch_add(1,
+                                               std::memory_order_relaxed);
     return;
   }
   if (previous && previous != model_graph_address) {
@@ -2936,10 +3186,16 @@ void ObserveStaticWorldRendererGraphBind(uint32_t renderer_address) {
   }
   entry->model_graph_generation.store(graph_generation,
                                        std::memory_order_relaxed);
+  entry->model_resource_generation.store(
+      resource->generation.load(std::memory_order_relaxed),
+      std::memory_order_relaxed);
   entry->model_graph_address.store(model_graph_address,
                                    std::memory_order_release);
   entry->graph_binds.fetch_add(1, std::memory_order_relaxed);
   g_static_world_graph_bind_successes.fetch_add(
+      1, std::memory_order_relaxed);
+  resource->renderer_joins.fetch_add(1, std::memory_order_relaxed);
+  g_static_world_resource_graph_bind_joins.fetch_add(
       1, std::memory_order_relaxed);
 }
 
@@ -2979,6 +3235,8 @@ void ObserveStaticWorldRendererGraphRelease(uint32_t renderer_address) {
   }
   const uint32_t registered_graph =
       entry->model_graph_address.exchange(0, std::memory_order_acq_rel);
+  entry->model_resource_generation.store(0,
+                                          std::memory_order_relaxed);
   if (!model_graph_address) {
     if (registered_graph) {
       g_static_world_lifecycle_faults.fetch_add(
@@ -3057,6 +3315,19 @@ void BeginStaticWorldRendererDispatch(uint32_t renderer_address,
     ++g_static_world_scope_graph_mismatches;
     return;
   }
+  StaticWorldResourceLifecycleEntry *resource =
+      FindStaticWorldResourceLifecycle(model_graph_address);
+  const uint32_t resource_generation =
+      lifecycle->model_resource_generation.load(std::memory_order_relaxed);
+  if (!resource || resource->state.load(std::memory_order_acquire) !=
+                       uint32_t(StaticWorldRendererState::kLive) ||
+      !resource->registered.load(std::memory_order_acquire) ||
+      resource->generation.load(std::memory_order_relaxed) !=
+          resource_generation) {
+    ++g_static_world_scope_graph_mismatches;
+    ++g_static_world_resource_scope_mismatches;
+    return;
+  }
   scope.renderer_address = renderer_address;
   scope.renderer_generation =
       lifecycle->generation.load(std::memory_order_relaxed);
@@ -3064,9 +3335,12 @@ void BeginStaticWorldRendererDispatch(uint32_t renderer_address,
   scope.model_graph_address = model_graph_address;
   scope.model_graph_generation =
       lifecycle->model_graph_generation.load(std::memory_order_relaxed);
+  scope.model_resource_generation = resource_generation;
   scope.exact = true;
   lifecycle->dispatches.fetch_add(1, std::memory_order_relaxed);
   ++g_static_world_scope_exact;
+  resource->renderer_joins.fetch_add(1, std::memory_order_relaxed);
+  ++g_static_world_resource_scope_joins;
 }
 
 void EndStaticWorldRendererDispatch() {
@@ -4355,9 +4629,19 @@ void ResetTitleDrawProvenance() {
     entry.state.store(0, std::memory_order_relaxed);
     entry.model_graph_address.store(0, std::memory_order_relaxed);
     entry.model_graph_generation.store(0, std::memory_order_relaxed);
+    entry.model_resource_generation.store(0, std::memory_order_relaxed);
     entry.dispatches.store(0, std::memory_order_relaxed);
     entry.graph_binds.store(0, std::memory_order_relaxed);
     entry.graph_releases.store(0, std::memory_order_relaxed);
+  }
+  for (StaticWorldResourceLifecycleEntry &entry :
+       g_static_world_resource_lifecycles) {
+    entry.address.store(0, std::memory_order_relaxed);
+    entry.generation.store(0, std::memory_order_relaxed);
+    entry.state.store(0, std::memory_order_relaxed);
+    entry.registered.store(false, std::memory_order_relaxed);
+    entry.registrations.store(0, std::memory_order_relaxed);
+    entry.renderer_joins.store(0, std::memory_order_relaxed);
   }
   for (std::atomic<uint64_t> *counter : {
            &g_static_world_scope_entries,
@@ -4398,6 +4682,24 @@ void ResetTitleDrawProvenance() {
            &g_static_world_graph_release_empty,
            &g_static_world_graph_release_unregistered,
            &g_static_world_graph_release_faults,
+           &g_static_world_resource_instances_published,
+           &g_static_world_resource_instances_destroyed,
+           &g_static_world_resource_address_reuses,
+           &g_static_world_resource_table_overflow,
+           &g_static_world_resource_lifecycle_faults,
+           &g_static_world_resource_destructor_entries,
+           &g_static_world_resource_destructor_exits,
+           &g_static_world_resource_destructors_open,
+           &g_static_world_resource_destructors_without_instance,
+           &g_static_world_resource_registration_observations,
+           &g_static_world_resource_registration_successes,
+           &g_static_world_resource_registration_null,
+           &g_static_world_resource_registration_unregistered,
+           &g_static_world_resource_registration_type_mismatches,
+           &g_static_world_resource_registration_faults,
+           &g_static_world_resource_graph_bind_joins,
+           &g_static_world_resource_scope_joins,
+           &g_static_world_resource_scope_mismatches,
        }) {
     counter->store(0, std::memory_order_relaxed);
   }
@@ -4630,6 +4932,9 @@ void ResetTitleDrawProvenance() {
   g_static_world_renderer_destructor_stack = {};
   g_static_world_renderer_destructor_stack_depth = 0;
   g_static_world_renderer_destructor_overflow_depth = 0;
+  g_static_world_resource_destructor_stack = {};
+  g_static_world_resource_destructor_stack_depth = 0;
+  g_static_world_resource_destructor_overflow_depth = 0;
   g_semantic_visibility_stack = {};
   g_semantic_visibility_stack_depth = 0;
   g_semantic_visibility_overflow_depth = 0;
@@ -4875,6 +5180,7 @@ void RecordProceduralModelSemanticDrawPacket(
         .render_context_address = scope.render_context_address,
         .model_graph_address = scope.model_graph_address,
         .model_graph_generation = scope.model_graph_generation,
+        .model_resource_generation = scope.model_resource_generation,
         .valid = true,
     };
   }
@@ -10263,6 +10569,47 @@ void EmitStaticWorldRuntimeJoinEvent(const char *event_name,
   const uint64_t graph_release_faults =
       g_static_world_graph_release_faults.load(
           std::memory_order_relaxed);
+  const uint64_t resource_instances_published =
+      g_static_world_resource_instances_published.load(
+          std::memory_order_relaxed);
+  const uint64_t resource_instances_destroyed =
+      g_static_world_resource_instances_destroyed.load(
+          std::memory_order_relaxed);
+  const uint64_t resource_destructor_entries =
+      g_static_world_resource_destructor_entries.load(
+          std::memory_order_relaxed);
+  const uint64_t resource_destructor_exits =
+      g_static_world_resource_destructor_exits.load(
+          std::memory_order_relaxed);
+  const uint64_t resource_destructors_open =
+      g_static_world_resource_destructors_open.load(
+          std::memory_order_relaxed);
+  const uint64_t resource_registration_observations =
+      g_static_world_resource_registration_observations.load(
+          std::memory_order_relaxed);
+  const uint64_t resource_registration_successes =
+      g_static_world_resource_registration_successes.load(
+          std::memory_order_relaxed);
+  const uint64_t resource_registration_null =
+      g_static_world_resource_registration_null.load(
+          std::memory_order_relaxed);
+  const uint64_t resource_registration_unregistered =
+      g_static_world_resource_registration_unregistered.load(
+          std::memory_order_relaxed);
+  const uint64_t resource_registration_type_mismatches =
+      g_static_world_resource_registration_type_mismatches.load(
+          std::memory_order_relaxed);
+  const uint64_t resource_registration_faults =
+      g_static_world_resource_registration_faults.load(
+          std::memory_order_relaxed);
+  const uint64_t resource_graph_bind_joins =
+      g_static_world_resource_graph_bind_joins.load(
+          std::memory_order_relaxed);
+  const uint64_t resource_scope_joins =
+      g_static_world_resource_scope_joins.load(std::memory_order_relaxed);
+  const uint64_t resource_scope_mismatches =
+      g_static_world_resource_scope_mismatches.load(
+          std::memory_order_relaxed);
   const bool accounting_complete =
       entries == exact + invalid_root + vtable_mismatches +
                            invalid_graph_field + unregistered_renderers +
@@ -10280,6 +10627,16 @@ void EmitStaticWorldRuntimeJoinEvent(const char *event_name,
       graph_release_observations ==
           graph_release_successes + graph_release_empty +
               graph_release_unregistered + graph_release_faults &&
+      resource_destructor_entries ==
+          resource_destructor_exits + resource_destructors_open &&
+      resource_instances_destroyed <= resource_instances_published &&
+      resource_registration_observations ==
+          resource_registration_successes + resource_registration_null +
+              resource_registration_unregistered +
+              resource_registration_type_mismatches +
+              resource_registration_faults &&
+      resource_graph_bind_joins == graph_bind_successes &&
+      resource_scope_joins == exact &&
       !overlaps && !exit_without_entry;
   const bool qualification_complete =
       accounting_complete && exact && packets_recorded && packet_matches &&
@@ -10291,7 +10648,19 @@ void EmitStaticWorldRuntimeJoinEvent(const char *event_name,
       !graph_bind_unregistered && !graph_bind_faults &&
       !g_static_world_destructors_without_instance.load(
           std::memory_order_relaxed) &&
-      !graph_release_unregistered && !graph_release_faults;
+      !graph_release_unregistered && !graph_release_faults &&
+      resource_instances_published && resource_registration_successes &&
+      resource_graph_bind_joins && resource_scope_joins &&
+      !resource_destructors_open &&
+      !g_static_world_resource_table_overflow.load(
+          std::memory_order_relaxed) &&
+      !g_static_world_resource_lifecycle_faults.load(
+          std::memory_order_relaxed) &&
+      !g_static_world_resource_destructors_without_instance.load(
+          std::memory_order_relaxed) &&
+      !resource_registration_unregistered &&
+      !resource_registration_type_mismatches &&
+      !resource_registration_faults && !resource_scope_mismatches;
   const uint64_t pending_packets =
       packets_recorded >= packet_matches ? packets_recorded - packet_matches
                                           : 0;
@@ -10356,11 +10725,51 @@ void EmitStaticWorldRuntimeJoinEvent(const char *event_name,
        {"graph_release_unregistered",
         std::to_string(graph_release_unregistered)},
        {"graph_release_faults", std::to_string(graph_release_faults)},
+       {"resource_instances_published",
+        std::to_string(resource_instances_published)},
+       {"resource_instances_destroyed",
+        std::to_string(resource_instances_destroyed)},
+       {"resource_address_reuses",
+        std::to_string(g_static_world_resource_address_reuses.load(
+            std::memory_order_relaxed))},
+       {"resource_table_overflow",
+        std::to_string(g_static_world_resource_table_overflow.load(
+            std::memory_order_relaxed))},
+       {"resource_lifecycle_faults",
+        std::to_string(g_static_world_resource_lifecycle_faults.load(
+            std::memory_order_relaxed))},
+       {"resource_destructor_entries",
+        std::to_string(resource_destructor_entries)},
+       {"resource_destructor_exits",
+        std::to_string(resource_destructor_exits)},
+       {"resource_destructors_open",
+        std::to_string(resource_destructors_open)},
+       {"resource_destructors_without_instance",
+        std::to_string(
+            g_static_world_resource_destructors_without_instance.load(
+                std::memory_order_relaxed))},
+       {"resource_registration_observations",
+        std::to_string(resource_registration_observations)},
+       {"resource_registration_successes",
+        std::to_string(resource_registration_successes)},
+       {"resource_registration_null",
+        std::to_string(resource_registration_null)},
+       {"resource_registration_unregistered",
+        std::to_string(resource_registration_unregistered)},
+       {"resource_registration_type_mismatches",
+        std::to_string(resource_registration_type_mismatches)},
+       {"resource_registration_faults",
+        std::to_string(resource_registration_faults)},
+       {"resource_graph_bind_joins",
+        std::to_string(resource_graph_bind_joins)},
+       {"resource_scope_joins", std::to_string(resource_scope_joins)},
+       {"resource_scope_mismatches",
+        std::to_string(resource_scope_mismatches)},
        {"accounting_complete", accounting_complete ? "true" : "false"},
        {"qualification_complete",
         qualification_complete ? "true" : "false"},
        {"classification",
-        "live_simple_model_renderer_graph_to_pm4_prepared_draw"},
+        "live_simple_model_resource_to_pm4_prepared_draw"},
        {"guest_state_changed", "false"},
        {"control_flow_changed", "false"},
        {"native_admission", "false"},
@@ -13058,6 +13467,8 @@ void RecordTitleDrawProvenance(
   key = HashCombine(key, origin.static_world_draw.render_context_address);
   key = HashCombine(key, origin.static_world_draw.model_graph_address);
   key = HashCombine(key, origin.static_world_draw.model_graph_generation);
+  key = HashCombine(key,
+                    origin.static_world_draw.model_resource_generation);
   key = HashCombine(key, current_semantic_contract.template_key);
   size_t index = size_t(key % kTitleDrawProvenanceCapacity);
   for (size_t probe = 0; probe < kTitleDrawProvenanceCapacity; ++probe) {
@@ -13105,6 +13516,8 @@ void RecordTitleDrawProvenance(
             origin.static_world_draw.model_graph_address &&
         entry.origin.static_world_draw.model_graph_generation ==
             origin.static_world_draw.model_graph_generation &&
+        entry.origin.static_world_draw.model_resource_generation ==
+            origin.static_world_draw.model_resource_generation &&
         entry.semantic_contract.template_key ==
             current_semantic_contract.template_key) {
       ++entry.calls;
@@ -13210,6 +13623,11 @@ void EmitTitleDrawProvenanceSummary() {
           entry.origin.static_world_draw.valid
               ? std::to_string(
                     entry.origin.static_world_draw.model_graph_generation)
+              : ""},
+         {"static_world_model_resource_generation",
+          entry.origin.static_world_draw.valid
+              ? std::to_string(
+                    entry.origin.static_world_draw.model_resource_generation)
               : ""},
          {"outcome", entry.prepared ? "prepared" : "not_prepared"},
          {"backend_outcome",
@@ -21668,6 +22086,14 @@ void InstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system,
        {"model_graph_bind_hook", "82C4CCB0"},
        {"model_graph_release_slot", "15"},
        {"model_graph_release_hook", "82C4C6A8,82C4E0A0"},
+       {"model_resource_class", "CSimpleModelResource"},
+       {"model_resource_vtable", "82229294"},
+       {"model_resource_bytes", "320"},
+       {"model_resource_factory", "82C47F10"},
+       {"model_resource_publish_hook", "82C47FBC"},
+       {"model_resource_registration_hook", "82C4802C"},
+       {"model_resource_destructor_entry_hook", "82C47DF8"},
+       {"model_resource_destructor_exit_hook", "82C47E44"},
        {"draw_emitter", "82416380"},
        {"packet_hooks", "82416260,824162F4"},
        {"join", "synchronous_scope_to_physical_pm4_prepared_draw"},
@@ -22927,6 +23353,22 @@ void PinyonShiftObserveStaticWorldRendererGraphBind(PPCRegister &r30) {
 
 void PinyonShiftObserveStaticWorldRendererGraphRelease(PPCRegister &r3) {
   ObserveStaticWorldRendererGraphRelease(r3.u32);
+}
+
+void PinyonShiftObserveStaticWorldResourceConstructed(PPCRegister &r29) {
+  PublishStaticWorldResource(r29.u32);
+}
+
+void PinyonShiftObserveStaticWorldResourceRegistration(PPCRegister &r31) {
+  ObserveStaticWorldResourceRegistration(r31.u32);
+}
+
+void PinyonShiftObserveStaticWorldResourceDestructorEntry(PPCRegister &r3) {
+  BeginStaticWorldResourceDestruction(r3.u32);
+}
+
+void PinyonShiftObserveStaticWorldResourceDestructorExit() {
+  EndStaticWorldResourceDestruction();
 }
 
 void PinyonShiftObserveVehicleComposedMatrix(PPCRegister &r5,

--- a/tools/discover-native-renderer-static-world-resource.py
+++ b/tools/discover-native-renderer-static-world-resource.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+"""Prove the SimpleModelResource factory, registration, and lifetime path."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import pathlib
+import re
+import sys
+
+
+SCHEMA = "pinyon-shift.native-renderer-static-world-resource.v1"
+IMAGE_BASE = 0x82000000
+RESOURCE_VTABLE = 0x82229294
+FUNCTION_RE = re.compile(r"^DEFINE_REX_FUNC\(sub_([0-9A-F]{8})\) \{")
+LABEL_RE = re.compile(r"^loc_([0-9A-F]{8}):")
+COMMENT_RE = re.compile(r"^\s*//\s+(.+?)\s*$")
+
+RENDERER_BIND = 0x82C48038
+RESOURCE_FACTORY = 0x82C47F10
+RESOURCE_CONSTRUCTOR = 0x82C47DA0
+RESOURCE_PUBLISH_HOOK = 0x82C47FBC
+RESOURCE_REGISTRATION_HOOK = 0x82C4802C
+RESOURCE_DELETING_DESTRUCTOR = 0x82C47EC0
+RESOURCE_DESTRUCTOR = 0x82C47DF8
+RESOURCE_DESTRUCTOR_EXIT_HOOK = 0x82C47E44
+REFERENCE_ASSIGN = 0x824E81A8
+
+
+def parse_functions(paths: list[pathlib.Path]) -> dict[int, dict[int, str]]:
+    functions = {}
+    for path in sorted(paths, key=lambda item: item.as_posix()):
+        current = None
+        address = None
+        for line in path.read_text(encoding="utf-8").splitlines():
+            match = FUNCTION_RE.match(line)
+            if match:
+                function_address = int(match.group(1), 16)
+                current = functions.setdefault(function_address, {})
+                address = function_address
+                continue
+            label = LABEL_RE.match(line)
+            if current is not None and label:
+                address = int(label.group(1), 16)
+                continue
+            comment = COMMENT_RE.match(line)
+            if current is not None and comment and address is not None:
+                current[address] = comment.group(1)
+                address += 4
+    return functions
+
+
+def image_u32(image: bytes, address: int) -> int:
+    offset = address - IMAGE_BASE
+    if offset < 0 or offset + 4 > len(image):
+        raise ValueError(f"image address is out of range: {address:08X}")
+    return int.from_bytes(image[offset : offset + 4], "big")
+
+
+def require_instructions(
+    functions: dict[int, dict[int, str]],
+    function_address: int,
+    expected: dict[int, str],
+) -> None:
+    instructions = functions.get(function_address)
+    if instructions is None:
+        raise ValueError(f"missing function {function_address:08X}")
+    for address, text in expected.items():
+        if instructions.get(address) != text:
+            raise ValueError(
+                f"instruction drift at {address:08X}: "
+                f"expected {text!r}, got {instructions.get(address)!r}"
+            )
+
+
+def build(functions: dict[int, dict[int, str]], image: bytes) -> dict:
+    if image_u32(image, RESOURCE_VTABLE) != RESOURCE_DELETING_DESTRUCTOR:
+        raise ValueError("SimpleModelResource deleting destructor drifted")
+
+    require_instructions(
+        functions,
+        RENDERER_BIND,
+        {
+            0x82C48044: "mr r30,r3",
+            0x82C480A8: "mr r5,r30",
+            0x82C480B4: "bl 0x82c47f10",
+            0x82C480C4: "lwz r30,0(r30)",
+            0x82C480E4: "bl 0x82e4bff8",
+        },
+    )
+    require_instructions(
+        functions,
+        RESOURCE_FACTORY,
+        {
+            0x82C47F70: "lwz r11,0(r31)",
+            0x82C47F78: "bne cr6,0x82c4802c",
+            0x82C47F94: "li r3,320",
+            0x82C47F98: "bl 0x82c0f6c0",
+            0x82C47FA8: "bl 0x82c47da0",
+            0x82C47FAC: "lis r11,-32221",
+            0x82C47FB4: "addi r11,r11,-28012",
+            0x82C47FB8: "stw r11,0(r29)",
+            RESOURCE_PUBLISH_HOOK: "b 0x82c47fc4",
+            0x82C47FC4: "mr r3,r31",
+            0x82C47FC8: "bl 0x824e81a8",
+            0x82C4800C: "bl 0x82d842f8",
+            0x82C48010: "lwz r11,0(r31)",
+            RESOURCE_REGISTRATION_HOOK: "mr r3,r27",
+        },
+    )
+    require_instructions(
+        functions,
+        RESOURCE_CONSTRUCTOR,
+        {
+            0x82C47DB4: "bl 0x82e45a78",
+            0x82C47DC8: "stw r11,0(r31)",
+            0x82C47DD8: "bl 0x82c47ca0",
+        },
+    )
+    require_instructions(
+        functions,
+        REFERENCE_ASSIGN,
+        {
+            0x824E81CC: "lwz r11,0(r4)",
+            0x824E81D4: "lwz r11,8(r11)",
+            0x824E81E0: "lwz r3,0(r30)",
+            0x824E81E4: "stw r31,0(r30)",
+            0x824E81F4: "lwz r11,12(r11)",
+        },
+    )
+    require_instructions(
+        functions,
+        RESOURCE_DELETING_DESTRUCTOR,
+        {
+            0x82C47EDC: "bl 0x82c47df8",
+            0x82C47EE0: "clrlwi. r11,r30,31",
+            0x82C47EEC: "bl 0x823fd208",
+        },
+    )
+    require_instructions(
+        functions,
+        RESOURCE_DESTRUCTOR,
+        {
+            0x82C47E10: "mr r30,r3",
+            0x82C47E40: "bl 0x82e45b20",
+            RESOURCE_DESTRUCTOR_EXIT_HOOK: "addi r1,r1,112",
+        },
+    )
+
+    return {
+        "schema": SCHEMA,
+        "status": "complete",
+        "classification": "exact_simple_model_resource_factory_and_lifetime",
+        "resource": {
+            "class": "CSimpleModelResource",
+            "vtable": f"{RESOURCE_VTABLE:08X}",
+            "object_bytes": 320,
+            "factory": f"{RESOURCE_FACTORY:08X}",
+            "constructor": f"{RESOURCE_CONSTRUCTOR:08X}",
+            "publish_hook": f"{RESOURCE_PUBLISH_HOOK:08X}",
+            "registration_hook": f"{RESOURCE_REGISTRATION_HOOK:08X}",
+            "deleting_destructor_slot": 0,
+            "deleting_destructor": f"{RESOURCE_DELETING_DESTRUCTOR:08X}",
+            "destructor": f"{RESOURCE_DESTRUCTOR:08X}",
+            "destructor_entry_hook": f"{RESOURCE_DESTRUCTOR:08X}",
+            "destructor_exit_hook": f"{RESOURCE_DESTRUCTOR_EXIT_HOOK:08X}",
+        },
+        "binding": {
+            "renderer_bind": f"{RENDERER_BIND:08X}",
+            "renderer_graph_field_offset": 72,
+            "factory_output_argument": "r5",
+            "reference_assignment": f"{REFERENCE_ASSIGN:08X}",
+            "existing_resource_path_join": f"{RESOURCE_REGISTRATION_HOOK:08X}",
+            "new_resource_path_join": f"{RESOURCE_REGISTRATION_HOOK:08X}",
+        },
+        "claims": {
+            "bound_graph_dynamic_type_proved": True,
+            "resource_generation_boundary_proved": True,
+            "factory_registration_boundary_proved": True,
+            "concrete_building_or_prop_identity_proved": False,
+            "streaming_invalidation_proved": False,
+        },
+        "safety": {
+            "static_analysis_only": True,
+            "guest_payload_exported": False,
+            "native_admission": False,
+            "suppression_allowed": False,
+            "xenos_authority_required": True,
+        },
+    }
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("generated_root", type=pathlib.Path)
+    parser.add_argument("--image", required=True, type=pathlib.Path)
+    parser.add_argument("--output", required=True, type=pathlib.Path)
+    args = parser.parse_args(argv)
+    try:
+        paths = list(args.generated_root.glob("pinyon_shift_recomp.*.cpp"))
+        if not paths:
+            raise ValueError("no generated AOT C++ files found")
+        document = build(parse_functions(paths), args.image.read_bytes())
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(
+            json.dumps(document, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        return 0
+    except (OSError, UnicodeDecodeError, ValueError) as error:
+        print(f"static-world resource discovery failed: {error}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/summarize-native-renderer-static-world-runtime-join.py
+++ b/tools/summarize-native-renderer-static-world-runtime-join.py
@@ -9,9 +9,10 @@ import pathlib
 import sys
 
 
-SCHEMA = "pinyon-shift.native-renderer-static-world-runtime-join.v2"
+SCHEMA = "pinyon-shift.native-renderer-static-world-runtime-join.v3"
 STATIC_SCHEMA = "pinyon-shift.native-renderer-static-world-ingress.v2"
 LIFETIME_SCHEMA = "pinyon-shift.native-renderer-static-world-lifetime.v1"
+RESOURCE_SCHEMA = "pinyon-shift.native-renderer-static-world-resource.v1"
 CONFIG = "native_renderer.discovery.static_world_runtime_join_config"
 SUMMARY = "native_renderer.discovery.static_world_runtime_join_summary"
 CHECKPOINT = "native_renderer.discovery.static_world_runtime_join_checkpoint"
@@ -168,15 +169,67 @@ def validate_static_lifetime(document):
         raise ValueError("static-world lifetime claims drifted")
 
 
+def validate_static_resource(document):
+    if (
+        document.get("schema") != RESOURCE_SCHEMA
+        or document.get("status") != "complete"
+        or document.get("classification")
+        != "exact_simple_model_resource_factory_and_lifetime"
+    ):
+        raise ValueError("static-world resource proof drifted")
+    try:
+        resource = document["resource"]
+        binding = document["binding"]
+        claims = document["claims"]
+    except (KeyError, TypeError) as error:
+        raise ValueError("static-world resource proof is incomplete") from error
+    expected_resource = {
+        "class": "CSimpleModelResource",
+        "vtable": "82229294",
+        "object_bytes": 320,
+        "factory": "82C47F10",
+        "constructor": "82C47DA0",
+        "publish_hook": "82C47FBC",
+        "registration_hook": "82C4802C",
+        "deleting_destructor_slot": 0,
+        "deleting_destructor": "82C47EC0",
+        "destructor": "82C47DF8",
+        "destructor_entry_hook": "82C47DF8",
+        "destructor_exit_hook": "82C47E44",
+    }
+    expected_binding = {
+        "renderer_bind": "82C48038",
+        "renderer_graph_field_offset": 72,
+        "factory_output_argument": "r5",
+        "reference_assignment": "824E81A8",
+        "existing_resource_path_join": "82C4802C",
+        "new_resource_path_join": "82C4802C",
+    }
+    if any(resource.get(key) != value for key, value in expected_resource.items()):
+        raise ValueError("static-world resource lifetime proof drifted")
+    if any(binding.get(key) != value for key, value in expected_binding.items()):
+        raise ValueError("static-world resource binding proof drifted")
+    if (
+        claims.get("bound_graph_dynamic_type_proved") is not True
+        or claims.get("resource_generation_boundary_proved") is not True
+        or claims.get("factory_registration_boundary_proved") is not True
+        or claims.get("concrete_building_or_prop_identity_proved") is not False
+        or claims.get("streaming_invalidation_proved") is not False
+    ):
+        raise ValueError("static-world resource claims drifted")
+
+
 def build(
     static_ingress,
     static_lifetime,
+    static_resource,
     events,
     requested_session=None,
     allow_checkpoint=False,
 ):
     validate_static_ingress(static_ingress)
     validate_static_lifetime(static_lifetime)
+    validate_static_resource(static_resource)
     session = select_session(events, requested_session)
     selected = [event for event in events if event.get("session") == session]
     config = exact_event(selected, CONFIG)
@@ -203,6 +256,14 @@ def build(
         "model_graph_bind_hook": "82C4CCB0",
         "model_graph_release_slot": "15",
         "model_graph_release_hook": "82C4C6A8,82C4E0A0",
+        "model_resource_class": "CSimpleModelResource",
+        "model_resource_vtable": "82229294",
+        "model_resource_bytes": "320",
+        "model_resource_factory": "82C47F10",
+        "model_resource_publish_hook": "82C47FBC",
+        "model_resource_registration_hook": "82C4802C",
+        "model_resource_destructor_entry_hook": "82C47DF8",
+        "model_resource_destructor_exit_hook": "82C47E44",
         "draw_emitter": "82416380",
         "packet_hooks": "82416260,824162F4",
         "join": "synchronous_scope_to_physical_pm4_prepared_draw",
@@ -226,7 +287,7 @@ def build(
         or summary.get("checkpoint_kind")
         != ("final" if final_summary else "periodic")
         or summary.get("classification")
-        != "live_simple_model_renderer_graph_to_pm4_prepared_draw"
+        != "live_simple_model_resource_to_pm4_prepared_draw"
     ):
         raise ValueError("static-world runtime summary drifted")
 
@@ -270,6 +331,24 @@ def build(
         "graph_release_empty",
         "graph_release_unregistered",
         "graph_release_faults",
+        "resource_instances_published",
+        "resource_instances_destroyed",
+        "resource_address_reuses",
+        "resource_table_overflow",
+        "resource_lifecycle_faults",
+        "resource_destructor_entries",
+        "resource_destructor_exits",
+        "resource_destructors_open",
+        "resource_destructors_without_instance",
+        "resource_registration_observations",
+        "resource_registration_successes",
+        "resource_registration_null",
+        "resource_registration_unregistered",
+        "resource_registration_type_mismatches",
+        "resource_registration_faults",
+        "resource_graph_bind_joins",
+        "resource_scope_joins",
+        "resource_scope_mismatches",
     )
     totals = {key: integer(summary, key) for key in keys}
     frame_sequence = integer(summary, "frame_sequence")
@@ -302,6 +381,14 @@ def build(
         )
     if not totals["graph_bind_successes"]:
         failures.append("no owned SimpleModel renderer graph was observed")
+    if not totals["resource_instances_published"]:
+        failures.append("no completed SimpleModel resource lifetime was observed")
+    if not totals["resource_registration_successes"]:
+        failures.append("no registered SimpleModel resource was observed")
+    if not totals["resource_graph_bind_joins"]:
+        failures.append("no renderer bind joined a registered resource")
+    if not totals["resource_scope_joins"]:
+        failures.append("no exact scope joined a live resource generation")
     if not totals["scopes_with_packets"] or not totals["packets_recorded"]:
         failures.append("no exact scope emitted a PM4 draw packet")
     if totals["packet_matches"] + totals["pending_packets"] != totals[
@@ -334,6 +421,28 @@ def build(
         != totals["graph_release_observations"]
     ):
         failures.append("static-world graph release accounting drifted")
+    if totals["resource_destructor_entries"] != (
+        totals["resource_destructor_exits"]
+        + totals["resource_destructors_open"]
+    ):
+        failures.append("static-world resource destructor accounting drifted")
+    if totals["resource_instances_destroyed"] > totals[
+        "resource_instances_published"
+    ]:
+        failures.append("static-world resource lifetime accounting drifted")
+    if (
+        totals["resource_registration_successes"]
+        + totals["resource_registration_null"]
+        + totals["resource_registration_unregistered"]
+        + totals["resource_registration_type_mismatches"]
+        + totals["resource_registration_faults"]
+        != totals["resource_registration_observations"]
+    ):
+        failures.append("static-world resource registration accounting drifted")
+    if totals["resource_graph_bind_joins"] != totals["graph_bind_successes"]:
+        failures.append("static-world resource graph-bind accounting drifted")
+    if totals["resource_scope_joins"] != totals["exact_scopes"]:
+        failures.append("static-world resource scope accounting drifted")
     if not totals["prepared_matches"]:
         failures.append("no static-world PM4 packet joined a prepared draw")
     for key in (
@@ -354,6 +463,14 @@ def build(
         "graph_bind_faults",
         "graph_release_unregistered",
         "graph_release_faults",
+        "resource_table_overflow",
+        "resource_lifecycle_faults",
+        "resource_destructors_without_instance",
+        "resource_destructors_open",
+        "resource_registration_unregistered",
+        "resource_registration_type_mismatches",
+        "resource_registration_faults",
+        "resource_scope_mismatches",
     ):
         if totals[key]:
             failures.append(f"{key} is nonzero")
@@ -385,6 +502,9 @@ def build(
             "simple_model_renderer_scope_proved": not failures,
             "simple_model_renderer_lifetime_proved": not failures,
             "renderer_to_owned_graph_field_proved": not failures,
+            "simple_model_resource_type_proved": not failures,
+            "simple_model_resource_lifetime_proved": not failures,
+            "renderer_to_registered_resource_proved": not failures,
             "static_world_scope_to_pm4_proved": not failures,
             "static_world_pm4_to_prepared_draw_proved": not failures,
             "building_or_prop_instance_identity_proved": False,
@@ -408,6 +528,7 @@ def main(argv=None):
     parser.add_argument("events", nargs="+", type=pathlib.Path)
     parser.add_argument("--static", required=True, type=pathlib.Path)
     parser.add_argument("--lifetime", required=True, type=pathlib.Path)
+    parser.add_argument("--resource", required=True, type=pathlib.Path)
     parser.add_argument("--session")
     parser.add_argument("--allow-checkpoint", action="store_true")
     parser.add_argument("--output", required=True, type=pathlib.Path)
@@ -416,6 +537,7 @@ def main(argv=None):
         document = build(
             json.loads(args.static.read_text(encoding="utf-8")),
             json.loads(args.lifetime.read_text(encoding="utf-8")),
+            json.loads(args.resource.read_text(encoding="utf-8")),
             read_events(args.events),
             args.session,
             args.allow_checkpoint,

--- a/tools/tests/test_native_renderer_static_world_resource.py
+++ b/tools/tests/test_native_renderer_static_world_resource.py
@@ -1,0 +1,112 @@
+import copy
+import importlib.util
+import sys
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+TOOL = ROOT / "tools" / "discover-native-renderer-static-world-resource.py"
+SPEC = importlib.util.spec_from_file_location("static_world_resource", TOOL)
+assert SPEC and SPEC.loader
+MODULE = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = MODULE
+SPEC.loader.exec_module(MODULE)
+
+
+def fixture():
+    image = bytearray(MODULE.RESOURCE_VTABLE + 4 - MODULE.IMAGE_BASE)
+    offset = MODULE.RESOURCE_VTABLE - MODULE.IMAGE_BASE
+    image[offset : offset + 4] = MODULE.RESOURCE_DELETING_DESTRUCTOR.to_bytes(
+        4, "big"
+    )
+    functions = {
+        MODULE.RENDERER_BIND: {
+            0x82C48044: "mr r30,r3",
+            0x82C480A8: "mr r5,r30",
+            0x82C480B4: "bl 0x82c47f10",
+            0x82C480C4: "lwz r30,0(r30)",
+            0x82C480E4: "bl 0x82e4bff8",
+        },
+        MODULE.RESOURCE_FACTORY: {
+            0x82C47F70: "lwz r11,0(r31)",
+            0x82C47F78: "bne cr6,0x82c4802c",
+            0x82C47F94: "li r3,320",
+            0x82C47F98: "bl 0x82c0f6c0",
+            0x82C47FA8: "bl 0x82c47da0",
+            0x82C47FAC: "lis r11,-32221",
+            0x82C47FB4: "addi r11,r11,-28012",
+            0x82C47FB8: "stw r11,0(r29)",
+            MODULE.RESOURCE_PUBLISH_HOOK: "b 0x82c47fc4",
+            0x82C47FC4: "mr r3,r31",
+            0x82C47FC8: "bl 0x824e81a8",
+            0x82C4800C: "bl 0x82d842f8",
+            0x82C48010: "lwz r11,0(r31)",
+            MODULE.RESOURCE_REGISTRATION_HOOK: "mr r3,r27",
+        },
+        MODULE.RESOURCE_CONSTRUCTOR: {
+            0x82C47DB4: "bl 0x82e45a78",
+            0x82C47DC8: "stw r11,0(r31)",
+            0x82C47DD8: "bl 0x82c47ca0",
+        },
+        MODULE.REFERENCE_ASSIGN: {
+            0x824E81CC: "lwz r11,0(r4)",
+            0x824E81D4: "lwz r11,8(r11)",
+            0x824E81E0: "lwz r3,0(r30)",
+            0x824E81E4: "stw r31,0(r30)",
+            0x824E81F4: "lwz r11,12(r11)",
+        },
+        MODULE.RESOURCE_DELETING_DESTRUCTOR: {
+            0x82C47EDC: "bl 0x82c47df8",
+            0x82C47EE0: "clrlwi. r11,r30,31",
+            0x82C47EEC: "bl 0x823fd208",
+        },
+        MODULE.RESOURCE_DESTRUCTOR: {
+            0x82C47E10: "mr r30,r3",
+            0x82C47E40: "bl 0x82e45b20",
+            MODULE.RESOURCE_DESTRUCTOR_EXIT_HOOK: "addi r1,r1,112",
+        },
+    }
+    return functions, bytes(image)
+
+
+class StaticWorldResourceTests(unittest.TestCase):
+    def test_proves_bound_graph_resource_type_and_lifetime(self):
+        functions, image = fixture()
+        document = MODULE.build(functions, image)
+        self.assertEqual("complete", document["status"])
+        self.assertEqual("82229294", document["resource"]["vtable"])
+        self.assertEqual(320, document["resource"]["object_bytes"])
+        self.assertTrue(
+            document["claims"]["bound_graph_dynamic_type_proved"]
+        )
+        self.assertFalse(
+            document["claims"]["concrete_building_or_prop_identity_proved"]
+        )
+        self.assertFalse(document["safety"]["native_admission"])
+
+    def test_rejects_resource_vtable_drift(self):
+        functions, image = fixture()
+        corrupted = bytearray(image)
+        offset = MODULE.RESOURCE_VTABLE - MODULE.IMAGE_BASE
+        corrupted[offset : offset + 4] = (0x82C47EC4).to_bytes(4, "big")
+        with self.assertRaisesRegex(ValueError, "deleting destructor drifted"):
+            MODULE.build(functions, bytes(corrupted))
+
+    def test_rejects_factory_output_drift(self):
+        functions, image = fixture()
+        corrupted = copy.deepcopy(functions)
+        corrupted[MODULE.RENDERER_BIND][0x82C480A8] = "mr r5,r31"
+        with self.assertRaisesRegex(ValueError, "82C480A8"):
+            MODULE.build(corrupted, image)
+
+    def test_rejects_registration_join_drift(self):
+        functions, image = fixture()
+        corrupted = copy.deepcopy(functions)
+        corrupted[MODULE.RESOURCE_FACTORY][0x82C48010] = "lwz r11,4(r31)"
+        with self.assertRaisesRegex(ValueError, "82C48010"):
+            MODULE.build(corrupted, image)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/tests/test_native_renderer_static_world_runtime_join.py
+++ b/tools/tests/test_native_renderer_static_world_runtime_join.py
@@ -89,6 +89,43 @@ def static_lifetime():
     }
 
 
+def static_resource():
+    return {
+        "schema": MODULE.RESOURCE_SCHEMA,
+        "status": "complete",
+        "classification": "exact_simple_model_resource_factory_and_lifetime",
+        "resource": {
+            "class": "CSimpleModelResource",
+            "vtable": "82229294",
+            "object_bytes": 320,
+            "factory": "82C47F10",
+            "constructor": "82C47DA0",
+            "publish_hook": "82C47FBC",
+            "registration_hook": "82C4802C",
+            "deleting_destructor_slot": 0,
+            "deleting_destructor": "82C47EC0",
+            "destructor": "82C47DF8",
+            "destructor_entry_hook": "82C47DF8",
+            "destructor_exit_hook": "82C47E44",
+        },
+        "binding": {
+            "renderer_bind": "82C48038",
+            "renderer_graph_field_offset": 72,
+            "factory_output_argument": "r5",
+            "reference_assignment": "824E81A8",
+            "existing_resource_path_join": "82C4802C",
+            "new_resource_path_join": "82C4802C",
+        },
+        "claims": {
+            "bound_graph_dynamic_type_proved": True,
+            "resource_generation_boundary_proved": True,
+            "factory_registration_boundary_proved": True,
+            "concrete_building_or_prop_identity_proved": False,
+            "streaming_invalidation_proved": False,
+        },
+    }
+
+
 def fixture():
     config = event(
         MODULE.CONFIG,
@@ -112,6 +149,14 @@ def fixture():
             "model_graph_bind_hook": "82C4CCB0",
             "model_graph_release_slot": "15",
             "model_graph_release_hook": "82C4C6A8,82C4E0A0",
+            "model_resource_class": "CSimpleModelResource",
+            "model_resource_vtable": "82229294",
+            "model_resource_bytes": "320",
+            "model_resource_factory": "82C47F10",
+            "model_resource_publish_hook": "82C47FBC",
+            "model_resource_registration_hook": "82C4802C",
+            "model_resource_destructor_entry_hook": "82C47DF8",
+            "model_resource_destructor_exit_hook": "82C47E44",
             "draw_emitter": "82416380",
             "packet_hooks": "82416260,824162F4",
             "join": "synchronous_scope_to_physical_pm4_prepared_draw",
@@ -163,9 +208,27 @@ def fixture():
         graph_release_empty="0",
         graph_release_unregistered="0",
         graph_release_faults="0",
+        resource_instances_published="3",
+        resource_instances_destroyed="1",
+        resource_address_reuses="0",
+        resource_table_overflow="0",
+        resource_lifecycle_faults="0",
+        resource_destructor_entries="1",
+        resource_destructor_exits="1",
+        resource_destructors_open="0",
+        resource_destructors_without_instance="0",
+        resource_registration_observations="4",
+        resource_registration_successes="3",
+        resource_registration_null="1",
+        resource_registration_unregistered="0",
+        resource_registration_type_mismatches="0",
+        resource_registration_faults="0",
+        resource_graph_bind_joins="3",
+        resource_scope_joins="10",
+        resource_scope_mismatches="0",
         accounting_complete="true",
         qualification_complete="true",
-        classification="live_simple_model_renderer_graph_to_pm4_prepared_draw",
+        classification="live_simple_model_resource_to_pm4_prepared_draw",
         **safety(),
     )
     return [config, summary]
@@ -173,13 +236,18 @@ def fixture():
 
 class StaticWorldRuntimeJoinTests(unittest.TestCase):
     def test_qualifies_exact_scope_to_prepared_draw(self):
-        document = MODULE.build(static_ingress(), static_lifetime(), fixture())
+        document = MODULE.build(
+            static_ingress(), static_lifetime(), static_resource(), fixture()
+        )
         self.assertEqual("complete", document["status"])
         self.assertTrue(
             document["qualification"]["static_world_pm4_to_prepared_draw_proved"]
         )
         self.assertTrue(
             document["qualification"]["simple_model_renderer_lifetime_proved"]
+        )
+        self.assertTrue(
+            document["qualification"]["simple_model_resource_type_proved"]
         )
         self.assertFalse(
             document["qualification"]["building_or_prop_instance_identity_proved"]
@@ -197,6 +265,7 @@ class StaticWorldRuntimeJoinTests(unittest.TestCase):
         document = MODULE.build(
             static_ingress(),
             static_lifetime(),
+            static_resource(),
             events + [checkpoint],
             allow_checkpoint=True,
         )
@@ -212,7 +281,9 @@ class StaticWorldRuntimeJoinTests(unittest.TestCase):
             unprepared_matches="1",
             qualification_complete="false",
         )
-        document = MODULE.build(static_ingress(), static_lifetime(), events)
+        document = MODULE.build(
+            static_ingress(), static_lifetime(), static_resource(), events
+        )
         self.assertEqual("incomplete", document["status"])
         self.assertIn("unprepared_matches is nonzero", document["failures"])
 
@@ -224,7 +295,9 @@ class StaticWorldRuntimeJoinTests(unittest.TestCase):
             accounting_complete="false",
             qualification_complete="false",
         )
-        document = MODULE.build(static_ingress(), static_lifetime(), events)
+        document = MODULE.build(
+            static_ingress(), static_lifetime(), static_resource(), events
+        )
         self.assertEqual("incomplete", document["status"])
         self.assertIn(
             "static-world scope entry/exit accounting drifted",
@@ -237,7 +310,7 @@ class StaticWorldRuntimeJoinTests(unittest.TestCase):
             "slot_targets"
         ][12] = "82C4CCD0"
         with self.assertRaisesRegex(ValueError, "dispatch proof drifted"):
-            MODULE.build(ingress, static_lifetime(), fixture())
+            MODULE.build(ingress, static_lifetime(), static_resource(), fixture())
 
     def test_rejects_unregistered_renderer_dispatch(self):
         events = copy.deepcopy(fixture())
@@ -249,10 +322,46 @@ class StaticWorldRuntimeJoinTests(unittest.TestCase):
             accounting_complete="true",
             qualification_complete="false",
         )
-        document = MODULE.build(static_ingress(), static_lifetime(), events)
+        document = MODULE.build(
+            static_ingress(), static_lifetime(), static_resource(), events
+        )
         self.assertEqual("incomplete", document["status"])
         self.assertIn(
             "unregistered_renderers is nonzero", document["failures"]
+        )
+
+    def test_rejects_resource_type_mismatch(self):
+        events = copy.deepcopy(fixture())
+        events[-1].update(
+            status="incomplete",
+            resource_registration_successes="2",
+            resource_registration_type_mismatches="1",
+            qualification_complete="false",
+        )
+        document = MODULE.build(
+            static_ingress(), static_lifetime(), static_resource(), events
+        )
+        self.assertEqual("incomplete", document["status"])
+        self.assertIn(
+            "resource_registration_type_mismatches is nonzero",
+            document["failures"],
+        )
+
+    def test_rejects_unregistered_resource(self):
+        events = copy.deepcopy(fixture())
+        events[-1].update(
+            status="incomplete",
+            resource_registration_successes="2",
+            resource_registration_unregistered="1",
+            qualification_complete="false",
+        )
+        document = MODULE.build(
+            static_ingress(), static_lifetime(), static_resource(), events
+        )
+        self.assertEqual("incomplete", document["status"])
+        self.assertIn(
+            "resource_registration_unregistered is nonzero",
+            document["failures"],
         )
 
     def test_source_contract_has_balanced_static_world_hooks(self):
@@ -274,6 +383,10 @@ class StaticWorldRuntimeJoinTests(unittest.TestCase):
         self.assertIn("address = 0x82C4CCB0", analysis)
         self.assertIn("address = 0x82C4C6A8", analysis)
         self.assertIn("address = 0x82C4E0A0", analysis)
+        self.assertIn("address = 0x82C47FBC", analysis)
+        self.assertIn("address = 0x82C4802C", analysis)
+        self.assertIn("address = 0x82C47DF8", analysis)
+        self.assertIn("address = 0x82C47E44", analysis)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- prove the exact CSimpleModelResource factory, registration, and destructor path from retail instructions
- carry generation-aware registered resource identity from renderer bind through PM4 prepared-draw provenance
- extend fail-closed runtime qualification and document the remaining C2 boundary

## Validation
- 536 repository tests pass
- Markdown links and diff whitespace checks pass
- real retail-image static resource proof passes
- generated hooks and graphics_hooks.cpp compile; final link is blocked only by the intentionally preserved live preview process