### PR TITLE
feat(native-renderer): trace static-world mesh streaming

### DIFF
--- a/config/rexglue/analysis/main-xex.toml
+++ b/config/rexglue/analysis/main-xex.toml
@@ -239,6 +239,19 @@ registers = ["r3", "r4"]
 address = 0x82C4DEA0
 name = "PinyonShiftObserveStaticWorldRendererDispatchExit"
 
+# Immediately around the exact indexed-draw call, r26 is the embedded
+# CSimpleModel, r29 is its selected CSimpleSubModel, and r28 is the selected
+# CSimpleMesh. Runtime validates all three RTTI vtables and the resource+112
+# relation before carrying these addresses into packet provenance.
+[[midasm_hook]]
+address = 0x82C4DC54
+name = "PinyonShiftObserveStaticWorldMemberDrawEntry"
+registers = ["r26", "r29", "r28"]
+
+[[midasm_hook]]
+address = 0x82C4DC58
+name = "PinyonShiftObserveStaticWorldMemberDrawExit"
+
 # The exact CSimpleModelRenderer lifecycle and its owned offset-72 graph
 # boundary. Construction publishes only after the complete 368-byte object is
 # initialized. Destruction is balanced around the complete destructor. Slot 1
@@ -297,6 +310,30 @@ registers = ["r3"]
 [[midasm_hook]]
 address = 0x82C47E44
 name = "PinyonShiftObserveStaticWorldResourceDestructorExit"
+
+# CSimpleModelResource slots 16 and 22 both clear and release the owned
+# pointer at offset 64. Observe balanced entry/exit boundaries so each exact
+# completed reset invalidates the passive payload generation. Slot 22 is
+# shared by other resource classes, which remain explicitly excluded by RTTI.
+[[midasm_hook]]
+address = 0x82C46440
+name = "PinyonShiftObserveStaticWorldResourceDirectResetEntry"
+registers = ["r3"]
+
+[[midasm_hook]]
+address = 0x82C46480
+name = "PinyonShiftObserveStaticWorldResourceDirectResetExit"
+registers = ["r31"]
+
+[[midasm_hook]]
+address = 0x82C222C8
+name = "PinyonShiftObserveStaticWorldResourceRefreshResetEntry"
+registers = ["r3"]
+
+[[midasm_hook]]
+address = 0x82C2231C
+name = "PinyonShiftObserveStaticWorldResourceRefreshResetExit"
+registers = ["r30"]
 
 # Immediately before 8240E7B0 submits its 64-byte matrix payload to 82435E78,
 # r22 still owns the original r7 object/reference matrix and r5 points at the

--- a/docs/native-renderer/REPRIORITIZED_PLAN.md
+++ b/docs/native-renderer/REPRIORITIZED_PLAN.md
@@ -334,6 +334,26 @@ with C1/C2 and documented in
 identity, mesh/material decoding, and independent streaming invalidation paths
 remain required; no admission or suppression is enabled.
 
+Payload-reset checkpoint: exact resource slots 16 and 22 both clear and
+release the offset-64 owned payload, while slot 15 rebuilds through the
+offset-112 graph and offset-76 binding object. Balanced hooks now advance an
+independent payload generation, so a same-address resource reset cannot reuse
+stale prepared-draw provenance. Static proof and the deferred runtime gate are
+documented in
+[`STATIC_WORLD_STREAMING.md`](STATIC_WORLD_STREAMING.md). Representative
+runtime transition coverage, any additional invalidation routes, concrete
+building/prop identity, and mesh/material decoding remain pending. Xenos stays
+authoritative and no admission or suppression is enabled.
+
+Member-graph checkpoint: the exact live resource now joins its embedded
+`CSimpleModel` at offset 112, selected `CSimpleSubModel`, and selected
+`CSimpleMesh` to the direct indexed-draw call and prepared PM4 provenance.
+All three RTTI vtables and the resource-to-model address equation are checked
+at runtime. Static proof and the deferred combined qualifier are documented
+in [`STATIC_WORLD_GRAPH.md`](STATIC_WORLD_GRAPH.md). This closes the generic
+SimpleModel member lineage, not concrete building-versus-prop semantics or
+mesh/material decoding; native admission and suppression remain off.
+
 ### C3. Semantic batching, culling, and LOD
 
 - Promote the existing visibility and prepared-draw evidence into production

--- a/docs/native-renderer/STATIC_WORLD_GRAPH.md
+++ b/docs/native-renderer/STATIC_WORLD_GRAPH.md
@@ -1,0 +1,68 @@
+# Static-world SimpleModel resource-to-mesh draw graph
+
+Status: exact model/submodel/mesh draw lineage implemented; runtime
+qualification pending
+
+## Purpose
+
+An exact renderer and resource generation still do not identify which title
+model members emitted a draw. Phase C2 needs the title-owned resource graph to
+reach each PM4 packet without inferring ownership from shader frequency or
+visual resemblance.
+
+`tools/discover-native-renderer-static-world-graph.py` validates the graph
+against retail RTTI/vtables and generated AOT instructions. It exports only
+class, address, slot, and offset facts.
+
+## Exact graph
+
+- `CSimpleModelResource` constructor `82C47DA0` constructs a
+  `CSimpleModel` at resource offset 112 through `82C47CA0`.
+- That model installs primary vtable `82229208` and secondary vtable
+  `822291E8`.
+- Renderer slot 12 copies its offset-72 resource reference, derives the exact
+  embedded model at `resource + 112`, and calls model slots 2 and 4 to count
+  and select a submodel.
+- The selected `CSimpleSubModel` uses exact vtable `822291BC`; slots 3 and 5
+  count and select a `CSimpleMesh` with exact vtable `822291A0`.
+- Immediately around the direct indexed-draw call at `82C4DC54`, registers
+  `r26`, `r29`, and `r28` contain that model, submodel, and mesh respectively.
+  The balanced exit is `82C4DC58`.
+
+The passive hook accepts the member tuple only inside an already exact live
+renderer/resource/payload-generation scope, validates all three vtables, and
+requires `model == resource + 112`. The tuple is then carried through physical
+PM4 provenance into the prepared-draw record. Unknown or mismatched tuples
+remain Xenos-only and are fail-visible in cumulative accounting.
+
+## Generate the static report
+
+```powershell
+python tools/discover-native-renderer-static-world-graph.py `
+  .local/generated/default `
+  --image .local/analysis/default-image.bin `
+  --output .local/qualification/native-renderer-static-world-graph.json
+```
+
+The combined runtime qualifier consumes the report with:
+
+```powershell
+python tools/summarize-native-renderer-static-world-runtime-join.py `
+  .local/preview/logs/<session>.jsonl `
+  --static .local/qualification/native-renderer-static-world-ingress.json `
+  --lifetime .local/qualification/native-renderer-static-world-lifetime.json `
+  --resource .local/qualification/native-renderer-static-world-resource.json `
+  --streaming .local/qualification/native-renderer-static-world-streaming.json `
+  --graph .local/qualification/native-renderer-static-world-graph.json `
+  --session <session> `
+  --output .local/qualification/native-renderer-static-world-runtime-join.json
+```
+
+## Remaining boundary
+
+This identifies the exact generic SimpleModel member graph behind each joined
+draw. It does not distinguish an individual building from a prop, classify
+mesh/material fields, or authorize native replay. Runtime qualification must
+also prove the graph and payload-reset transitions under representative
+streaming. Native admission, publication, and suppression remain disabled;
+Xenos stays authoritative.

--- a/docs/native-renderer/STATIC_WORLD_INGRESS.md
+++ b/docs/native-renderer/STATIC_WORLD_INGRESS.md
@@ -99,6 +99,8 @@ python tools/summarize-native-renderer-static-world-runtime-join.py `
   --static .local/qualification/native-renderer-static-world-ingress.json `
   --lifetime .local/qualification/native-renderer-static-world-lifetime.json `
   --resource .local/qualification/native-renderer-static-world-resource.json `
+  --streaming .local/qualification/native-renderer-static-world-streaming.json `
+  --graph .local/qualification/native-renderer-static-world-graph.json `
   --session <session> `
   --output .local/qualification/native-renderer-static-world-runtime-join.json
 ```

--- a/docs/native-renderer/STATIC_WORLD_LIFETIME.md
+++ b/docs/native-renderer/STATIC_WORLD_LIFETIME.md
@@ -57,8 +57,8 @@ python tools/discover-native-renderer-static-world-lifetime.py `
   --output .local/qualification/native-renderer-static-world-lifetime.json
 ```
 
-The runtime join now requires the ingress, renderer-lifetime, and exact
-resource reports:
+The runtime join now requires the ingress, renderer-lifetime, exact-resource,
+payload-reset, and member-graph reports:
 
 ```powershell
 python tools/summarize-native-renderer-static-world-runtime-join.py `
@@ -66,6 +66,8 @@ python tools/summarize-native-renderer-static-world-runtime-join.py `
   --static .local/qualification/native-renderer-static-world-ingress.json `
   --lifetime .local/qualification/native-renderer-static-world-lifetime.json `
   --resource .local/qualification/native-renderer-static-world-resource.json `
+  --streaming .local/qualification/native-renderer-static-world-streaming.json `
+  --graph .local/qualification/native-renderer-static-world-graph.json `
   --session <session> `
   --output .local/qualification/native-renderer-static-world-runtime-join.json
 ```

--- a/docs/native-renderer/STATIC_WORLD_RESOURCE.md
+++ b/docs/native-renderer/STATIC_WORLD_RESOURCE.md
@@ -44,7 +44,7 @@ python tools/discover-native-renderer-static-world-resource.py `
   --output .local/qualification/native-renderer-static-world-resource.json
 ```
 
-The batched runtime qualifier requires all three static reports:
+The batched runtime qualifier requires all five static reports:
 
 ```powershell
 python tools/summarize-native-renderer-static-world-runtime-join.py `
@@ -52,6 +52,8 @@ python tools/summarize-native-renderer-static-world-runtime-join.py `
   --static .local/qualification/native-renderer-static-world-ingress.json `
   --lifetime .local/qualification/native-renderer-static-world-lifetime.json `
   --resource .local/qualification/native-renderer-static-world-resource.json `
+  --streaming .local/qualification/native-renderer-static-world-streaming.json `
+  --graph .local/qualification/native-renderer-static-world-graph.json `
   --session <session> `
   --output .local/qualification/native-renderer-static-world-runtime-join.json
 ```
@@ -64,6 +66,8 @@ prove clean shutdown and never enables native admission.
 This proves the exact dynamic type and generation of the resource bound to a
 live renderer, plus the factory registration boundary and resource destructor.
 It does not identify a concrete building or prop, decode mesh/material
-members, or prove every independent streaming invalidation route. Native
-upload, draw, publication, and suppression remain disabled; Xenos stays
-authoritative.
+members, or prove every independent streaming invalidation route. The first
+two exact payload-reset transitions and their independent generation boundary
+are documented in
+[`STATIC_WORLD_STREAMING.md`](STATIC_WORLD_STREAMING.md). Native upload, draw,
+publication, and suppression remain disabled; Xenos stays authoritative.

--- a/docs/native-renderer/STATIC_WORLD_STREAMING.md
+++ b/docs/native-renderer/STATIC_WORLD_STREAMING.md
@@ -1,0 +1,75 @@
+# Static-world SimpleModel payload-reset transitions
+
+Status: exact payload-reset boundaries and generation invalidation implemented;
+runtime qualification pending
+
+## Purpose
+
+An allocation generation is not sufficient for open-world streaming. A live
+`CSimpleModelResource` can release and replace owned payload while retaining
+the same object address. Prepared-draw provenance must become stale when that
+happens, even if the renderer still points at the same resource object.
+
+`tools/discover-native-renderer-static-world-streaming.py` proves the minimum
+exact reset surface against the retail image and generated AOT instructions.
+It names only structural behavior visible in those instructions; it does not
+claim that these two methods cover every title streaming route.
+
+## Exact transitions
+
+The resource's vtable and instruction flow prove:
+
+- slot 15, `82C46410`, refreshes the offset-112 graph using the offset-76
+  binding object through `82C462D0`;
+- slot 16, `82C46440`, reads the owned pointer at offset 64, clears it before
+  invoking release slot 3, then checks the offset-112 graph. Balanced hooks
+  are `82C46440` and `82C46480`;
+- slot 22, shared method `82C222C8`, invokes virtual slot 15, preserves its
+  result, then clears and releases the same offset-64 pointer. Balanced hooks
+  are `82C222C8` and `82C2231C`; exact RTTI excludes other resource classes.
+
+Every completed exact transition must leave offset 64 null. The passive
+registry then increments a payload generation independently from the resource
+allocation generation. Renderer binding snapshots both generations, and an
+exact draw scope, PM4 packet, or prepared-draw join fails closed when either
+one is stale. The hook never changes guest data, title control flow, native
+admission, or Xenos authority.
+
+## Generate the static report
+
+```powershell
+python tools/discover-native-renderer-static-world-streaming.py `
+  .local/generated/default `
+  --image .local/analysis/default-image.bin `
+  --output .local/qualification/native-renderer-static-world-streaming.json
+```
+
+The combined runtime qualifier now requires the streaming report:
+
+```powershell
+python tools/summarize-native-renderer-static-world-runtime-join.py `
+  .local/preview/logs/<session>.jsonl `
+  --static .local/qualification/native-renderer-static-world-ingress.json `
+  --lifetime .local/qualification/native-renderer-static-world-lifetime.json `
+  --resource .local/qualification/native-renderer-static-world-resource.json `
+  --streaming .local/qualification/native-renderer-static-world-streaming.json `
+  --graph .local/qualification/native-renderer-static-world-graph.json `
+  --session <session> `
+  --output .local/qualification/native-renderer-static-world-runtime-join.json
+```
+
+The report requires a balanced exact payload reset and verifies that every
+completion advances the payload generation. Non-SimpleModel calls through the
+shared slot-22 implementation are counted as exclusions, not faults.
+
+## Remaining boundary
+
+Runtime evidence must show which transition paths occur during representative
+driving and streaming, whether every later draw is rebound to the new payload
+generation, and whether other independent invalidation routes exist. Concrete
+building/prop identity and mesh/material ownership also remain open. Therefore
+this checkpoint enables no native upload, draw, publication, or suppression;
+Xenos remains authoritative.
+
+The adjacent member-lineage proof is documented in
+[`STATIC_WORLD_GRAPH.md`](STATIC_WORLD_GRAPH.md).

--- a/src/native_renderer/graphics_hooks.cpp
+++ b/src/native_renderer/graphics_hooks.cpp
@@ -176,6 +176,11 @@ constexpr uint32_t kTrackRenderModelGraphBytes = 64;
 constexpr uint32_t kSimpleModelRendererVtable = 0x82001B64;
 constexpr uint32_t kSimpleModelRendererGraphOffset = 72;
 constexpr uint32_t kSimpleModelResourceVtable = 0x82229294;
+constexpr uint32_t kSimpleModelResourcePayloadOffset = 64;
+constexpr uint32_t kSimpleModelVtable = 0x82229208;
+constexpr uint32_t kSimpleSubModelVtable = 0x822291BC;
+constexpr uint32_t kSimpleMeshVtable = 0x822291A0;
+constexpr uint32_t kSimpleModelResourceModelOffset = 112;
 constexpr uint32_t kTrackModelVtable = 0x820016B4;
 constexpr uint32_t kTrackMeshVtable = 0x8200143C;
 constexpr uint32_t kTrackSubModelVtable = 0x82001474;
@@ -476,6 +481,10 @@ struct StaticWorldDrawIdentity {
   uint32_t model_graph_address = 0;
   uint32_t model_graph_generation = 0;
   uint32_t model_resource_generation = 0;
+  uint32_t model_resource_payload_generation = 0;
+  uint32_t simple_model_address = 0;
+  uint32_t simple_submodel_address = 0;
+  uint32_t simple_mesh_address = 0;
   bool valid = false;
 };
 
@@ -1890,6 +1899,13 @@ struct StaticWorldRendererDispatchScope {
   uint32_t model_graph_address = 0;
   uint32_t model_graph_generation = 0;
   uint32_t model_resource_generation = 0;
+  uint32_t model_resource_payload_generation = 0;
+  uint64_t member_packet_origins = 0;
+  uint32_t simple_model_address = 0;
+  uint32_t simple_submodel_address = 0;
+  uint32_t simple_mesh_address = 0;
+  bool member_active = false;
+  bool member_exact = false;
   bool active = false;
   bool exact = false;
 };
@@ -1901,6 +1917,20 @@ enum class StaticWorldRendererState : uint32_t {
   kDestroyed = 3,
 };
 
+enum class StaticWorldResourceTransitionKind : uint32_t {
+  kDirectPayloadReset = 0,
+  kRefreshThenPayloadReset = 1,
+};
+
+struct StaticWorldResourceTransitionScope {
+  uint32_t address = 0;
+  uint32_t generation = 0;
+  uint32_t payload_before = 0;
+  StaticWorldResourceTransitionKind kind =
+      StaticWorldResourceTransitionKind::kDirectPayloadReset;
+  bool exact = false;
+};
+
 struct StaticWorldRendererLifecycleEntry {
   std::atomic<uint32_t> address{};
   std::atomic<uint32_t> generation{};
@@ -1908,6 +1938,7 @@ struct StaticWorldRendererLifecycleEntry {
   std::atomic<uint32_t> model_graph_address{};
   std::atomic<uint32_t> model_graph_generation{};
   std::atomic<uint32_t> model_resource_generation{};
+  std::atomic<uint32_t> model_resource_payload_generation{};
   std::atomic<uint64_t> dispatches{};
   std::atomic<uint64_t> graph_binds{};
   std::atomic<uint64_t> graph_releases{};
@@ -1918,6 +1949,7 @@ struct StaticWorldResourceLifecycleEntry {
   std::atomic<uint32_t> generation{};
   std::atomic<uint32_t> state{};
   std::atomic<bool> registered{};
+  std::atomic<uint32_t> payload_generation{};
   std::atomic<uint64_t> registrations{};
   std::atomic<uint64_t> renderer_joins{};
 };
@@ -2066,6 +2098,37 @@ std::atomic<uint64_t> g_static_world_resource_registration_faults{};
 std::atomic<uint64_t> g_static_world_resource_graph_bind_joins{};
 std::atomic<uint64_t> g_static_world_resource_scope_joins{};
 std::atomic<uint64_t> g_static_world_resource_scope_mismatches{};
+std::atomic<uint64_t> g_static_world_resource_transition_entries{};
+std::atomic<uint64_t> g_static_world_resource_transition_exits{};
+std::atomic<uint64_t> g_static_world_resource_transitions_open{};
+std::atomic<uint64_t> g_static_world_resource_transition_overflow{};
+std::atomic<uint64_t> g_static_world_resource_transition_exit_without_entry{};
+std::atomic<uint64_t> g_static_world_resource_transition_exact{};
+std::atomic<uint64_t> g_static_world_resource_direct_resets{};
+std::atomic<uint64_t> g_static_world_resource_refresh_resets{};
+std::atomic<uint64_t> g_static_world_resource_transition_invalid_root{};
+std::atomic<uint64_t> g_static_world_resource_transition_vtable_mismatches{};
+std::atomic<uint64_t> g_static_world_resource_transition_unregistered{};
+std::atomic<uint64_t> g_static_world_resource_transition_nonlive{};
+std::atomic<uint64_t> g_static_world_resource_transition_begin_read_faults{};
+std::atomic<uint64_t> g_static_world_resource_transition_completions{};
+std::atomic<uint64_t> g_static_world_resource_transition_completion_faults{};
+std::atomic<uint64_t> g_static_world_resource_payload_resets_with_reference{};
+std::atomic<uint64_t> g_static_world_resource_payload_resets_empty{};
+std::atomic<uint64_t> g_static_world_resource_payload_generation_invalidations{};
+std::atomic<uint64_t> g_static_world_member_entries{};
+std::atomic<uint64_t> g_static_world_member_exits{};
+std::atomic<uint64_t> g_static_world_member_exact{};
+std::atomic<uint64_t> g_static_world_member_scope_missing{};
+std::atomic<uint64_t> g_static_world_member_relation_mismatches{};
+std::atomic<uint64_t> g_static_world_member_vtable_read_faults{};
+std::atomic<uint64_t> g_static_world_member_vtable_mismatches{};
+std::atomic<uint64_t> g_static_world_member_overlaps{};
+std::atomic<uint64_t> g_static_world_member_exit_without_entry{};
+std::atomic<uint64_t> g_static_world_member_draws_with_packets{};
+std::atomic<uint64_t> g_static_world_member_draws_without_packets{};
+std::atomic<uint64_t> g_static_world_member_packets_recorded{};
+std::atomic<uint64_t> g_static_world_member_packet_mismatches{};
 std::array<SemanticBindingCacheSlot, 5> g_semantic_binding_cache_slots{};
 std::array<SemanticResolverCacheSlot, 5> g_semantic_resolver_cache_slots{};
 thread_local PendingSemanticResourceBindings g_pending_semantic_bindings{};
@@ -2086,6 +2149,11 @@ thread_local std::array<uint32_t, kSemanticReceiverStackCapacity>
     g_static_world_resource_destructor_stack{};
 thread_local size_t g_static_world_resource_destructor_stack_depth = 0;
 thread_local size_t g_static_world_resource_destructor_overflow_depth = 0;
+thread_local std::array<StaticWorldResourceTransitionScope,
+                        kSemanticReceiverStackCapacity>
+    g_static_world_resource_transition_stack{};
+thread_local size_t g_static_world_resource_transition_stack_depth = 0;
+thread_local size_t g_static_world_resource_transition_overflow_depth = 0;
 thread_local std::array<TrackWorldResourceGraphCacheEntry,
                         kTrackWorldResourceGraphCacheCapacity>
     g_track_world_resource_graph_cache{};
@@ -2900,6 +2968,7 @@ void PublishStaticWorldResource(uint32_t address) {
         1, std::memory_order_relaxed);
   }
   entry->registered.store(false, std::memory_order_relaxed);
+  entry->payload_generation.store(1, std::memory_order_relaxed);
   entry->registrations.store(0, std::memory_order_relaxed);
   entry->renderer_joins.store(0, std::memory_order_relaxed);
   entry->generation.store(generation, std::memory_order_relaxed);
@@ -2949,6 +3018,133 @@ void ObserveStaticWorldResourceRegistration(uint32_t output_address) {
   entry->registrations.fetch_add(1, std::memory_order_relaxed);
   g_static_world_resource_registration_successes.fetch_add(
       1, std::memory_order_relaxed);
+}
+
+void BeginStaticWorldResourceTransition(
+    uint32_t address, StaticWorldResourceTransitionKind kind) {
+  if (!g_title_provenance_installed.load(std::memory_order_acquire)) {
+    return;
+  }
+  g_static_world_resource_transition_entries.fetch_add(
+      1, std::memory_order_relaxed);
+  if (g_static_world_resource_transition_stack_depth ==
+      g_static_world_resource_transition_stack.size()) {
+    ++g_static_world_resource_transition_overflow_depth;
+    g_static_world_resource_transition_overflow.fetch_add(
+        1, std::memory_order_relaxed);
+    return;
+  }
+  StaticWorldResourceTransitionScope &scope =
+      g_static_world_resource_transition_stack
+          [g_static_world_resource_transition_stack_depth++];
+  scope = {};
+  scope.address = address;
+  scope.kind = kind;
+  g_static_world_resource_transitions_open.fetch_add(
+      1, std::memory_order_relaxed);
+
+  rex::memory::Memory *memory =
+      g_title_provenance_memory.load(std::memory_order_acquire);
+  uint32_t vtable = 0;
+  if (!LoadMappedGuestU32(memory, address, vtable)) {
+    g_static_world_resource_transition_invalid_root.fetch_add(
+        1, std::memory_order_relaxed);
+    return;
+  }
+  if (vtable != kSimpleModelResourceVtable) {
+    g_static_world_resource_transition_vtable_mismatches.fetch_add(
+        1, std::memory_order_relaxed);
+    return;
+  }
+  StaticWorldResourceLifecycleEntry *entry =
+      FindStaticWorldResourceLifecycle(address);
+  if (!entry) {
+    g_static_world_resource_transition_unregistered.fetch_add(
+        1, std::memory_order_relaxed);
+    return;
+  }
+  if (entry->state.load(std::memory_order_acquire) !=
+      uint32_t(StaticWorldRendererState::kLive)) {
+    g_static_world_resource_transition_nonlive.fetch_add(
+        1, std::memory_order_relaxed);
+    return;
+  }
+  uint32_t payload_before = 0;
+  if (address > UINT32_MAX - kSimpleModelResourcePayloadOffset ||
+      !LoadMappedGuestU32(
+          memory, address + kSimpleModelResourcePayloadOffset,
+          payload_before)) {
+    g_static_world_resource_transition_begin_read_faults.fetch_add(
+        1, std::memory_order_relaxed);
+    return;
+  }
+  scope.generation = entry->generation.load(std::memory_order_relaxed);
+  scope.payload_before = payload_before;
+  scope.exact = true;
+  g_static_world_resource_transition_exact.fetch_add(
+      1, std::memory_order_relaxed);
+  (kind == StaticWorldResourceTransitionKind::kDirectPayloadReset
+       ? g_static_world_resource_direct_resets
+       : g_static_world_resource_refresh_resets)
+      .fetch_add(1, std::memory_order_relaxed);
+}
+
+void EndStaticWorldResourceTransition(uint32_t address) {
+  if (!g_title_provenance_installed.load(std::memory_order_acquire)) {
+    return;
+  }
+  g_static_world_resource_transition_exits.fetch_add(
+      1, std::memory_order_relaxed);
+  if (g_static_world_resource_transition_overflow_depth) {
+    --g_static_world_resource_transition_overflow_depth;
+    return;
+  }
+  if (!g_static_world_resource_transition_stack_depth) {
+    g_static_world_resource_transition_exit_without_entry.fetch_add(
+        1, std::memory_order_relaxed);
+    return;
+  }
+  const StaticWorldResourceTransitionScope scope =
+      g_static_world_resource_transition_stack
+          [--g_static_world_resource_transition_stack_depth];
+  g_static_world_resource_transitions_open.fetch_sub(
+      1, std::memory_order_relaxed);
+  if (!scope.exact) {
+    return;
+  }
+  StaticWorldResourceLifecycleEntry *entry =
+      FindStaticWorldResourceLifecycle(scope.address);
+  rex::memory::Memory *memory =
+      g_title_provenance_memory.load(std::memory_order_acquire);
+  uint32_t payload_after = 0;
+  if (address != scope.address || !entry ||
+      entry->state.load(std::memory_order_acquire) !=
+          uint32_t(StaticWorldRendererState::kLive) ||
+      entry->generation.load(std::memory_order_relaxed) != scope.generation ||
+      scope.address > UINT32_MAX - kSimpleModelResourcePayloadOffset ||
+      !LoadMappedGuestU32(
+          memory, scope.address + kSimpleModelResourcePayloadOffset,
+          payload_after) ||
+      payload_after) {
+    g_static_world_resource_transition_completion_faults.fetch_add(
+        1, std::memory_order_relaxed);
+    return;
+  }
+  uint32_t payload_generation =
+      entry->payload_generation.load(std::memory_order_relaxed) + 1;
+  if (!payload_generation) {
+    payload_generation = 1;
+  }
+  entry->payload_generation.store(payload_generation,
+                                  std::memory_order_release);
+  g_static_world_resource_transition_completions.fetch_add(
+      1, std::memory_order_relaxed);
+  g_static_world_resource_payload_generation_invalidations.fetch_add(
+      1, std::memory_order_relaxed);
+  (scope.payload_before
+       ? g_static_world_resource_payload_resets_with_reference
+       : g_static_world_resource_payload_resets_empty)
+      .fetch_add(1, std::memory_order_relaxed);
 }
 
 void BeginStaticWorldResourceDestruction(uint32_t address) {
@@ -3047,6 +3243,8 @@ void PublishStaticWorldRenderer(uint32_t address) {
   entry->model_graph_address.store(0, std::memory_order_relaxed);
   entry->model_graph_generation.store(0, std::memory_order_relaxed);
   entry->model_resource_generation.store(0, std::memory_order_relaxed);
+  entry->model_resource_payload_generation.store(
+      0, std::memory_order_relaxed);
   entry->dispatches.store(0, std::memory_order_relaxed);
   entry->graph_binds.store(0, std::memory_order_relaxed);
   entry->graph_releases.store(0, std::memory_order_relaxed);
@@ -3155,6 +3353,8 @@ void ObserveStaticWorldRendererGraphBind(uint32_t renderer_address) {
     entry->model_graph_address.store(0, std::memory_order_release);
     entry->model_resource_generation.store(0,
                                             std::memory_order_relaxed);
+    entry->model_resource_payload_generation.store(
+        0, std::memory_order_relaxed);
     g_static_world_graph_bind_null.fetch_add(1,
                                              std::memory_order_relaxed);
     return;
@@ -3188,6 +3388,9 @@ void ObserveStaticWorldRendererGraphBind(uint32_t renderer_address) {
                                        std::memory_order_relaxed);
   entry->model_resource_generation.store(
       resource->generation.load(std::memory_order_relaxed),
+      std::memory_order_relaxed);
+  entry->model_resource_payload_generation.store(
+      resource->payload_generation.load(std::memory_order_relaxed),
       std::memory_order_relaxed);
   entry->model_graph_address.store(model_graph_address,
                                    std::memory_order_release);
@@ -3237,6 +3440,8 @@ void ObserveStaticWorldRendererGraphRelease(uint32_t renderer_address) {
       entry->model_graph_address.exchange(0, std::memory_order_acq_rel);
   entry->model_resource_generation.store(0,
                                           std::memory_order_relaxed);
+  entry->model_resource_payload_generation.store(
+      0, std::memory_order_relaxed);
   if (!model_graph_address) {
     if (registered_graph) {
       g_static_world_lifecycle_faults.fetch_add(
@@ -3319,11 +3524,16 @@ void BeginStaticWorldRendererDispatch(uint32_t renderer_address,
       FindStaticWorldResourceLifecycle(model_graph_address);
   const uint32_t resource_generation =
       lifecycle->model_resource_generation.load(std::memory_order_relaxed);
+  const uint32_t resource_payload_generation =
+      lifecycle->model_resource_payload_generation.load(
+          std::memory_order_relaxed);
   if (!resource || resource->state.load(std::memory_order_acquire) !=
                        uint32_t(StaticWorldRendererState::kLive) ||
       !resource->registered.load(std::memory_order_acquire) ||
       resource->generation.load(std::memory_order_relaxed) !=
-          resource_generation) {
+          resource_generation ||
+      resource->payload_generation.load(std::memory_order_acquire) !=
+          resource_payload_generation) {
     ++g_static_world_scope_graph_mismatches;
     ++g_static_world_resource_scope_mismatches;
     return;
@@ -3336,11 +3546,83 @@ void BeginStaticWorldRendererDispatch(uint32_t renderer_address,
   scope.model_graph_generation =
       lifecycle->model_graph_generation.load(std::memory_order_relaxed);
   scope.model_resource_generation = resource_generation;
+  scope.model_resource_payload_generation = resource_payload_generation;
   scope.exact = true;
   lifecycle->dispatches.fetch_add(1, std::memory_order_relaxed);
   ++g_static_world_scope_exact;
   resource->renderer_joins.fetch_add(1, std::memory_order_relaxed);
   ++g_static_world_resource_scope_joins;
+}
+
+void BeginStaticWorldMemberDraw(uint32_t model_address,
+                                uint32_t submodel_address,
+                                uint32_t mesh_address) {
+  ++g_static_world_member_entries;
+  StaticWorldRendererDispatchScope &scope = g_static_world_renderer_scope;
+  if (scope.member_active) {
+    ++g_static_world_member_overlaps;
+    scope.member_active = false;
+    scope.member_exact = false;
+  }
+  scope.member_active = true;
+  scope.member_packet_origins = 0;
+  scope.simple_model_address = 0;
+  scope.simple_submodel_address = 0;
+  scope.simple_mesh_address = 0;
+  if (!scope.active || !scope.exact) {
+    ++g_static_world_member_scope_missing;
+    return;
+  }
+  if (scope.model_graph_address >
+          UINT32_MAX - kSimpleModelResourceModelOffset ||
+      scope.model_graph_address + kSimpleModelResourceModelOffset !=
+          model_address) {
+    ++g_static_world_member_relation_mismatches;
+    return;
+  }
+  rex::memory::Memory *memory =
+      g_title_provenance_memory.load(std::memory_order_acquire);
+  uint32_t model_vtable = 0;
+  uint32_t submodel_vtable = 0;
+  uint32_t mesh_vtable = 0;
+  if (!LoadMappedGuestU32(memory, model_address, model_vtable) ||
+      !LoadMappedGuestU32(memory, submodel_address, submodel_vtable) ||
+      !LoadMappedGuestU32(memory, mesh_address, mesh_vtable)) {
+    ++g_static_world_member_vtable_read_faults;
+    return;
+  }
+  if (model_vtable != kSimpleModelVtable ||
+      submodel_vtable != kSimpleSubModelVtable ||
+      mesh_vtable != kSimpleMeshVtable) {
+    ++g_static_world_member_vtable_mismatches;
+    return;
+  }
+  scope.simple_model_address = model_address;
+  scope.simple_submodel_address = submodel_address;
+  scope.simple_mesh_address = mesh_address;
+  scope.member_exact = true;
+  ++g_static_world_member_exact;
+}
+
+void EndStaticWorldMemberDraw() {
+  ++g_static_world_member_exits;
+  StaticWorldRendererDispatchScope &scope = g_static_world_renderer_scope;
+  if (!scope.member_active) {
+    ++g_static_world_member_exit_without_entry;
+    return;
+  }
+  if (scope.member_exact) {
+    (scope.member_packet_origins
+         ? g_static_world_member_draws_with_packets
+         : g_static_world_member_draws_without_packets)
+        .fetch_add(1, std::memory_order_relaxed);
+  }
+  scope.member_active = false;
+  scope.member_exact = false;
+  scope.member_packet_origins = 0;
+  scope.simple_model_address = 0;
+  scope.simple_submodel_address = 0;
+  scope.simple_mesh_address = 0;
 }
 
 void EndStaticWorldRendererDispatch() {
@@ -4630,6 +4912,8 @@ void ResetTitleDrawProvenance() {
     entry.model_graph_address.store(0, std::memory_order_relaxed);
     entry.model_graph_generation.store(0, std::memory_order_relaxed);
     entry.model_resource_generation.store(0, std::memory_order_relaxed);
+    entry.model_resource_payload_generation.store(
+        0, std::memory_order_relaxed);
     entry.dispatches.store(0, std::memory_order_relaxed);
     entry.graph_binds.store(0, std::memory_order_relaxed);
     entry.graph_releases.store(0, std::memory_order_relaxed);
@@ -4640,6 +4924,7 @@ void ResetTitleDrawProvenance() {
     entry.generation.store(0, std::memory_order_relaxed);
     entry.state.store(0, std::memory_order_relaxed);
     entry.registered.store(false, std::memory_order_relaxed);
+    entry.payload_generation.store(0, std::memory_order_relaxed);
     entry.registrations.store(0, std::memory_order_relaxed);
     entry.renderer_joins.store(0, std::memory_order_relaxed);
   }
@@ -4700,6 +4985,37 @@ void ResetTitleDrawProvenance() {
            &g_static_world_resource_graph_bind_joins,
            &g_static_world_resource_scope_joins,
            &g_static_world_resource_scope_mismatches,
+           &g_static_world_resource_transition_entries,
+           &g_static_world_resource_transition_exits,
+           &g_static_world_resource_transitions_open,
+           &g_static_world_resource_transition_overflow,
+           &g_static_world_resource_transition_exit_without_entry,
+           &g_static_world_resource_transition_exact,
+           &g_static_world_resource_direct_resets,
+           &g_static_world_resource_refresh_resets,
+           &g_static_world_resource_transition_invalid_root,
+           &g_static_world_resource_transition_vtable_mismatches,
+           &g_static_world_resource_transition_unregistered,
+           &g_static_world_resource_transition_nonlive,
+           &g_static_world_resource_transition_begin_read_faults,
+           &g_static_world_resource_transition_completions,
+           &g_static_world_resource_transition_completion_faults,
+           &g_static_world_resource_payload_resets_with_reference,
+           &g_static_world_resource_payload_resets_empty,
+           &g_static_world_resource_payload_generation_invalidations,
+           &g_static_world_member_entries,
+           &g_static_world_member_exits,
+           &g_static_world_member_exact,
+           &g_static_world_member_scope_missing,
+           &g_static_world_member_relation_mismatches,
+           &g_static_world_member_vtable_read_faults,
+           &g_static_world_member_vtable_mismatches,
+           &g_static_world_member_overlaps,
+           &g_static_world_member_exit_without_entry,
+           &g_static_world_member_draws_with_packets,
+           &g_static_world_member_draws_without_packets,
+           &g_static_world_member_packets_recorded,
+           &g_static_world_member_packet_mismatches,
        }) {
     counter->store(0, std::memory_order_relaxed);
   }
@@ -4935,6 +5251,9 @@ void ResetTitleDrawProvenance() {
   g_static_world_resource_destructor_stack = {};
   g_static_world_resource_destructor_stack_depth = 0;
   g_static_world_resource_destructor_overflow_depth = 0;
+  g_static_world_resource_transition_stack = {};
+  g_static_world_resource_transition_stack_depth = 0;
+  g_static_world_resource_transition_overflow_depth = 0;
   g_semantic_visibility_stack = {};
   g_semantic_visibility_stack_depth = 0;
   g_semantic_visibility_overflow_depth = 0;
@@ -5116,6 +5435,16 @@ void RecordTitleDrawPacketOrigin(uint32_t packet_guest_address,
     ++g_static_world_renderer_scope.packet_origins;
     g_static_world_packets_recorded.fetch_add(1,
                                                std::memory_order_relaxed);
+    if (origin.static_world_draw.simple_model_address &&
+        origin.static_world_draw.simple_submodel_address &&
+        origin.static_world_draw.simple_mesh_address) {
+      ++g_static_world_renderer_scope.member_packet_origins;
+      g_static_world_member_packets_recorded.fetch_add(
+          1, std::memory_order_relaxed);
+    } else {
+      g_static_world_member_packet_mismatches.fetch_add(
+          1, std::memory_order_relaxed);
+    }
   }
   ++g_title_packets_recorded;
 }
@@ -5181,6 +5510,14 @@ void RecordProceduralModelSemanticDrawPacket(
         .model_graph_address = scope.model_graph_address,
         .model_graph_generation = scope.model_graph_generation,
         .model_resource_generation = scope.model_resource_generation,
+        .model_resource_payload_generation =
+            scope.model_resource_payload_generation,
+        .simple_model_address =
+            scope.member_exact ? scope.simple_model_address : 0,
+        .simple_submodel_address =
+            scope.member_exact ? scope.simple_submodel_address : 0,
+        .simple_mesh_address =
+            scope.member_exact ? scope.simple_mesh_address : 0,
         .valid = true,
     };
   }
@@ -10610,6 +10947,48 @@ void EmitStaticWorldRuntimeJoinEvent(const char *event_name,
   const uint64_t resource_scope_mismatches =
       g_static_world_resource_scope_mismatches.load(
           std::memory_order_relaxed);
+  const uint64_t resource_transition_entries =
+      g_static_world_resource_transition_entries.load(
+          std::memory_order_relaxed);
+  const uint64_t resource_transition_exits =
+      g_static_world_resource_transition_exits.load(
+          std::memory_order_relaxed);
+  const uint64_t resource_transitions_open =
+      g_static_world_resource_transitions_open.load(
+          std::memory_order_relaxed);
+  const uint64_t resource_transition_exact =
+      g_static_world_resource_transition_exact.load(
+          std::memory_order_relaxed);
+  const uint64_t resource_transition_completions =
+      g_static_world_resource_transition_completions.load(
+          std::memory_order_relaxed);
+  const uint64_t resource_transition_completion_faults =
+      g_static_world_resource_transition_completion_faults.load(
+          std::memory_order_relaxed);
+  const uint64_t resource_payload_resets_with_reference =
+      g_static_world_resource_payload_resets_with_reference.load(
+          std::memory_order_relaxed);
+  const uint64_t resource_payload_resets_empty =
+      g_static_world_resource_payload_resets_empty.load(
+          std::memory_order_relaxed);
+  const uint64_t resource_payload_generation_invalidations =
+      g_static_world_resource_payload_generation_invalidations.load(
+          std::memory_order_relaxed);
+  const uint64_t member_entries =
+      g_static_world_member_entries.load(std::memory_order_relaxed);
+  const uint64_t member_exits =
+      g_static_world_member_exits.load(std::memory_order_relaxed);
+  const uint64_t member_exact =
+      g_static_world_member_exact.load(std::memory_order_relaxed);
+  const uint64_t member_draws_with_packets =
+      g_static_world_member_draws_with_packets.load(
+          std::memory_order_relaxed);
+  const uint64_t member_draws_without_packets =
+      g_static_world_member_draws_without_packets.load(
+          std::memory_order_relaxed);
+  const uint64_t member_packets_recorded =
+      g_static_world_member_packets_recorded.load(
+          std::memory_order_relaxed);
   const bool accounting_complete =
       entries == exact + invalid_root + vtable_mismatches +
                            invalid_graph_field + unregistered_renderers +
@@ -10637,6 +11016,48 @@ void EmitStaticWorldRuntimeJoinEvent(const char *event_name,
               resource_registration_faults &&
       resource_graph_bind_joins == graph_bind_successes &&
       resource_scope_joins == exact &&
+      resource_transition_entries ==
+          resource_transition_exact +
+              g_static_world_resource_transition_invalid_root.load(
+                  std::memory_order_relaxed) +
+              g_static_world_resource_transition_vtable_mismatches.load(
+                  std::memory_order_relaxed) +
+              g_static_world_resource_transition_unregistered.load(
+                  std::memory_order_relaxed) +
+              g_static_world_resource_transition_nonlive.load(
+                  std::memory_order_relaxed) +
+              g_static_world_resource_transition_begin_read_faults.load(
+                  std::memory_order_relaxed) +
+              g_static_world_resource_transition_overflow.load(
+                  std::memory_order_relaxed) &&
+      resource_transition_entries == resource_transition_exits &&
+      resource_transition_exact ==
+          g_static_world_resource_direct_resets.load(
+              std::memory_order_relaxed) +
+              g_static_world_resource_refresh_resets.load(
+                  std::memory_order_relaxed) &&
+      resource_transition_exact ==
+          resource_transition_completions +
+              resource_transition_completion_faults &&
+      resource_transition_completions ==
+          resource_payload_resets_with_reference +
+              resource_payload_resets_empty &&
+      resource_payload_generation_invalidations ==
+          resource_transition_completions &&
+      member_entries ==
+          member_exact +
+              g_static_world_member_scope_missing.load(
+                  std::memory_order_relaxed) +
+              g_static_world_member_relation_mismatches.load(
+                  std::memory_order_relaxed) +
+              g_static_world_member_vtable_read_faults.load(
+                  std::memory_order_relaxed) +
+              g_static_world_member_vtable_mismatches.load(
+                  std::memory_order_relaxed) &&
+      member_entries == member_exits &&
+      member_exact ==
+          member_draws_with_packets + member_draws_without_packets &&
+      member_packets_recorded == packets_recorded &&
       !overlaps && !exit_without_entry;
   const bool qualification_complete =
       accounting_complete && exact && packets_recorded && packet_matches &&
@@ -10660,7 +11081,37 @@ void EmitStaticWorldRuntimeJoinEvent(const char *event_name,
           std::memory_order_relaxed) &&
       !resource_registration_unregistered &&
       !resource_registration_type_mismatches &&
-      !resource_registration_faults && !resource_scope_mismatches;
+      !resource_registration_faults && !resource_scope_mismatches &&
+      resource_transition_exact && resource_transition_completions &&
+      !resource_transitions_open &&
+      !g_static_world_resource_transition_overflow.load(
+          std::memory_order_relaxed) &&
+      !g_static_world_resource_transition_exit_without_entry.load(
+          std::memory_order_relaxed) &&
+      !g_static_world_resource_transition_invalid_root.load(
+          std::memory_order_relaxed) &&
+      !g_static_world_resource_transition_unregistered.load(
+          std::memory_order_relaxed) &&
+      !g_static_world_resource_transition_nonlive.load(
+          std::memory_order_relaxed) &&
+      !g_static_world_resource_transition_begin_read_faults.load(
+          std::memory_order_relaxed) &&
+      !resource_transition_completion_faults && member_exact &&
+      member_draws_with_packets && member_packets_recorded &&
+      !member_draws_without_packets &&
+      !g_static_world_member_scope_missing.load(
+          std::memory_order_relaxed) &&
+      !g_static_world_member_relation_mismatches.load(
+          std::memory_order_relaxed) &&
+      !g_static_world_member_vtable_read_faults.load(
+          std::memory_order_relaxed) &&
+      !g_static_world_member_vtable_mismatches.load(
+          std::memory_order_relaxed) &&
+      !g_static_world_member_overlaps.load(std::memory_order_relaxed) &&
+      !g_static_world_member_exit_without_entry.load(
+          std::memory_order_relaxed) &&
+      !g_static_world_member_packet_mismatches.load(
+          std::memory_order_relaxed);
   const uint64_t pending_packets =
       packets_recorded >= packet_matches ? packets_recorded - packet_matches
                                           : 0;
@@ -10765,11 +11216,91 @@ void EmitStaticWorldRuntimeJoinEvent(const char *event_name,
        {"resource_scope_joins", std::to_string(resource_scope_joins)},
        {"resource_scope_mismatches",
         std::to_string(resource_scope_mismatches)},
+       {"resource_transition_entries",
+        std::to_string(resource_transition_entries)},
+       {"resource_transition_exits",
+        std::to_string(resource_transition_exits)},
+       {"resource_transitions_open",
+        std::to_string(resource_transitions_open)},
+       {"resource_transition_overflow",
+        std::to_string(g_static_world_resource_transition_overflow.load(
+            std::memory_order_relaxed))},
+       {"resource_transition_exit_without_entry",
+        std::to_string(
+            g_static_world_resource_transition_exit_without_entry.load(
+                std::memory_order_relaxed))},
+       {"resource_transition_exact",
+        std::to_string(resource_transition_exact)},
+       {"resource_direct_resets",
+        std::to_string(g_static_world_resource_direct_resets.load(
+            std::memory_order_relaxed))},
+       {"resource_refresh_resets",
+        std::to_string(g_static_world_resource_refresh_resets.load(
+            std::memory_order_relaxed))},
+       {"resource_transition_invalid_root",
+        std::to_string(
+            g_static_world_resource_transition_invalid_root.load(
+                std::memory_order_relaxed))},
+       {"resource_transition_vtable_mismatches",
+        std::to_string(
+            g_static_world_resource_transition_vtable_mismatches.load(
+                std::memory_order_relaxed))},
+       {"resource_transition_unregistered",
+        std::to_string(
+            g_static_world_resource_transition_unregistered.load(
+                std::memory_order_relaxed))},
+       {"resource_transition_nonlive",
+        std::to_string(g_static_world_resource_transition_nonlive.load(
+            std::memory_order_relaxed))},
+       {"resource_transition_begin_read_faults",
+        std::to_string(
+            g_static_world_resource_transition_begin_read_faults.load(
+                std::memory_order_relaxed))},
+       {"resource_transition_completions",
+        std::to_string(resource_transition_completions)},
+       {"resource_transition_completion_faults",
+        std::to_string(resource_transition_completion_faults)},
+       {"resource_payload_resets_with_reference",
+        std::to_string(resource_payload_resets_with_reference)},
+       {"resource_payload_resets_empty",
+        std::to_string(resource_payload_resets_empty)},
+       {"resource_payload_generation_invalidations",
+        std::to_string(resource_payload_generation_invalidations)},
+       {"member_entries", std::to_string(member_entries)},
+       {"member_exits", std::to_string(member_exits)},
+       {"member_exact", std::to_string(member_exact)},
+       {"member_scope_missing",
+        std::to_string(g_static_world_member_scope_missing.load(
+            std::memory_order_relaxed))},
+       {"member_relation_mismatches",
+        std::to_string(g_static_world_member_relation_mismatches.load(
+            std::memory_order_relaxed))},
+       {"member_vtable_read_faults",
+        std::to_string(g_static_world_member_vtable_read_faults.load(
+            std::memory_order_relaxed))},
+       {"member_vtable_mismatches",
+        std::to_string(g_static_world_member_vtable_mismatches.load(
+            std::memory_order_relaxed))},
+       {"member_overlaps",
+        std::to_string(g_static_world_member_overlaps.load(
+            std::memory_order_relaxed))},
+       {"member_exit_without_entry",
+        std::to_string(g_static_world_member_exit_without_entry.load(
+            std::memory_order_relaxed))},
+       {"member_draws_with_packets",
+        std::to_string(member_draws_with_packets)},
+       {"member_draws_without_packets",
+        std::to_string(member_draws_without_packets)},
+       {"member_packets_recorded",
+        std::to_string(member_packets_recorded)},
+       {"member_packet_mismatches",
+        std::to_string(g_static_world_member_packet_mismatches.load(
+            std::memory_order_relaxed))},
        {"accounting_complete", accounting_complete ? "true" : "false"},
        {"qualification_complete",
         qualification_complete ? "true" : "false"},
        {"classification",
-        "live_simple_model_resource_to_pm4_prepared_draw"},
+        "live_simple_model_mesh_payload_generation_to_prepared_draw"},
        {"guest_state_changed", "false"},
        {"control_flow_changed", "false"},
        {"native_admission", "false"},
@@ -13469,6 +14000,11 @@ void RecordTitleDrawProvenance(
   key = HashCombine(key, origin.static_world_draw.model_graph_generation);
   key = HashCombine(key,
                     origin.static_world_draw.model_resource_generation);
+  key = HashCombine(
+      key, origin.static_world_draw.model_resource_payload_generation);
+  key = HashCombine(key, origin.static_world_draw.simple_model_address);
+  key = HashCombine(key, origin.static_world_draw.simple_submodel_address);
+  key = HashCombine(key, origin.static_world_draw.simple_mesh_address);
   key = HashCombine(key, current_semantic_contract.template_key);
   size_t index = size_t(key % kTitleDrawProvenanceCapacity);
   for (size_t probe = 0; probe < kTitleDrawProvenanceCapacity; ++probe) {
@@ -13518,6 +14054,14 @@ void RecordTitleDrawProvenance(
             origin.static_world_draw.model_graph_generation &&
         entry.origin.static_world_draw.model_resource_generation ==
             origin.static_world_draw.model_resource_generation &&
+        entry.origin.static_world_draw.model_resource_payload_generation ==
+            origin.static_world_draw.model_resource_payload_generation &&
+        entry.origin.static_world_draw.simple_model_address ==
+            origin.static_world_draw.simple_model_address &&
+        entry.origin.static_world_draw.simple_submodel_address ==
+            origin.static_world_draw.simple_submodel_address &&
+        entry.origin.static_world_draw.simple_mesh_address ==
+            origin.static_world_draw.simple_mesh_address &&
         entry.semantic_contract.template_key ==
             current_semantic_contract.template_key) {
       ++entry.calls;
@@ -13628,6 +14172,26 @@ void EmitTitleDrawProvenanceSummary() {
           entry.origin.static_world_draw.valid
               ? std::to_string(
                     entry.origin.static_world_draw.model_resource_generation)
+              : ""},
+         {"static_world_model_resource_payload_generation",
+          entry.origin.static_world_draw.valid
+              ? std::to_string(entry.origin.static_world_draw
+                                   .model_resource_payload_generation)
+              : ""},
+         {"static_world_simple_model",
+          entry.origin.static_world_draw.valid
+              ? fmt::format("{:08X}", entry.origin.static_world_draw
+                                           .simple_model_address)
+              : ""},
+         {"static_world_simple_submodel",
+          entry.origin.static_world_draw.valid
+              ? fmt::format("{:08X}", entry.origin.static_world_draw
+                                           .simple_submodel_address)
+              : ""},
+         {"static_world_simple_mesh",
+          entry.origin.static_world_draw.valid
+              ? fmt::format("{:08X}", entry.origin.static_world_draw
+                                           .simple_mesh_address)
               : ""},
          {"outcome", entry.prepared ? "prepared" : "not_prepared"},
          {"backend_outcome",
@@ -22094,6 +22658,18 @@ void InstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system,
        {"model_resource_registration_hook", "82C4802C"},
        {"model_resource_destructor_entry_hook", "82C47DF8"},
        {"model_resource_destructor_exit_hook", "82C47E44"},
+       {"model_resource_payload_reference", "resource_plus_64"},
+       {"model_resource_refresh_slot", "15"},
+       {"model_resource_refresh", "82C46410"},
+       {"model_resource_direct_reset_slot", "16"},
+       {"model_resource_direct_reset_hooks", "82C46440,82C46480"},
+       {"model_resource_refresh_reset_slot", "22"},
+       {"model_resource_refresh_reset_hooks", "82C222C8,82C2231C"},
+       {"simple_model_offset", "resource_plus_112"},
+       {"simple_model_vtable", "82229208"},
+       {"simple_submodel_vtable", "822291BC"},
+       {"simple_mesh_vtable", "822291A0"},
+       {"simple_member_draw_hooks", "82C4DC54,82C4DC58"},
        {"draw_emitter", "82416380"},
        {"packet_hooks", "82416260,824162F4"},
        {"join", "synchronous_scope_to_physical_pm4_prepared_draw"},
@@ -23335,6 +23911,15 @@ void PinyonShiftObserveStaticWorldRendererDispatchExit() {
   EndStaticWorldRendererDispatch();
 }
 
+void PinyonShiftObserveStaticWorldMemberDrawEntry(
+    PPCRegister &r26, PPCRegister &r29, PPCRegister &r28) {
+  BeginStaticWorldMemberDraw(r26.u32, r29.u32, r28.u32);
+}
+
+void PinyonShiftObserveStaticWorldMemberDrawExit() {
+  EndStaticWorldMemberDraw();
+}
+
 void PinyonShiftObserveStaticWorldRendererConstructed(PPCRegister &r31) {
   PublishStaticWorldRenderer(r31.u32);
 }
@@ -23369,6 +23954,27 @@ void PinyonShiftObserveStaticWorldResourceDestructorEntry(PPCRegister &r3) {
 
 void PinyonShiftObserveStaticWorldResourceDestructorExit() {
   EndStaticWorldResourceDestruction();
+}
+
+void PinyonShiftObserveStaticWorldResourceDirectResetEntry(PPCRegister &r3) {
+  BeginStaticWorldResourceTransition(
+      r3.u32, StaticWorldResourceTransitionKind::kDirectPayloadReset);
+}
+
+void PinyonShiftObserveStaticWorldResourceDirectResetExit(PPCRegister &r31) {
+  EndStaticWorldResourceTransition(r31.u32);
+}
+
+void PinyonShiftObserveStaticWorldResourceRefreshResetEntry(
+    PPCRegister &r3) {
+  BeginStaticWorldResourceTransition(
+      r3.u32,
+      StaticWorldResourceTransitionKind::kRefreshThenPayloadReset);
+}
+
+void PinyonShiftObserveStaticWorldResourceRefreshResetExit(
+    PPCRegister &r30) {
+  EndStaticWorldResourceTransition(r30.u32);
 }
 
 void PinyonShiftObserveVehicleComposedMatrix(PPCRegister &r5,

--- a/tools/discover-native-renderer-static-world-graph.py
+++ b/tools/discover-native-renderer-static-world-graph.py
@@ -1,0 +1,214 @@
+#!/usr/bin/env python3
+"""Prove the SimpleModel resource-to-mesh draw graph."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import pathlib
+import re
+import sys
+
+
+SCHEMA = "pinyon-shift.native-renderer-static-world-graph.v1"
+IMAGE_BASE = 0x82000000
+FUNCTION_RE = re.compile(r"^DEFINE_REX_FUNC\(sub_([0-9A-F]{8})\) \{")
+LABEL_RE = re.compile(r"^loc_([0-9A-F]{8}):")
+COMMENT_RE = re.compile(r"^\s*//\s+(.+?)\s*$")
+
+RESOURCE_VTABLE = 0x82229294
+MODEL_VTABLE = 0x82229208
+MODEL_SECONDARY_VTABLE = 0x822291E8
+SUBMODEL_VTABLE = 0x822291BC
+MESH_VTABLE = 0x822291A0
+RESOURCE_CONSTRUCTOR = 0x82C47DA0
+MODEL_CONSTRUCTOR = 0x82C47CA0
+RENDERER_DISPATCH = 0x82C4CCC8
+DRAW_MEMBER_ENTRY_HOOK = 0x82C4DC54
+DRAW_MEMBER_EXIT_HOOK = 0x82C4DC58
+DRAW_EMITTER = 0x82416380
+
+
+def parse_functions(paths: list[pathlib.Path]) -> dict[int, dict[int, str]]:
+    functions = {}
+    for path in sorted(paths, key=lambda item: item.as_posix()):
+        current = None
+        address = None
+        for line in path.read_text(encoding="utf-8").splitlines():
+            match = FUNCTION_RE.match(line)
+            if match:
+                function_address = int(match.group(1), 16)
+                current = functions.setdefault(function_address, {})
+                address = function_address
+                continue
+            label = LABEL_RE.match(line)
+            if current is not None and label:
+                address = int(label.group(1), 16)
+                continue
+            comment = COMMENT_RE.match(line)
+            if current is not None and comment and address is not None:
+                current[address] = comment.group(1)
+                address += 4
+    return functions
+
+
+def image_u32(image: bytes, address: int) -> int:
+    offset = address - IMAGE_BASE
+    if offset < 0 or offset + 4 > len(image):
+        raise ValueError(f"image address is out of range: {address:08X}")
+    return int.from_bytes(image[offset : offset + 4], "big")
+
+
+def require_instructions(functions, function_address, expected):
+    instructions = functions.get(function_address)
+    if instructions is None:
+        raise ValueError(f"missing function {function_address:08X}")
+    for address, text in expected.items():
+        if instructions.get(address) != text:
+            raise ValueError(
+                f"instruction drift at {address:08X}: "
+                f"expected {text!r}, got {instructions.get(address)!r}"
+            )
+
+
+def build(functions: dict[int, dict[int, str]], image: bytes) -> dict:
+    expected_slots = (
+        (MODEL_VTABLE, 2, 0x824385D0),
+        (MODEL_VTABLE, 4, 0x82C25388),
+        (SUBMODEL_VTABLE, 3, 0x82C256D0),
+        (SUBMODEL_VTABLE, 5, 0x82C256E8),
+    )
+    for vtable, slot, target in expected_slots:
+        if image_u32(image, vtable + slot * 4) != target:
+            raise ValueError(
+                f"graph dispatch slot drifted at {vtable:08X}[{slot}]"
+            )
+
+    require_instructions(
+        functions,
+        RESOURCE_CONSTRUCTOR,
+        {
+            0x82C47DD4: "addi r3,r31,112",
+            0x82C47DD8: "bl 0x82c47ca0",
+        },
+    )
+    require_instructions(
+        functions,
+        MODEL_CONSTRUCTOR,
+        {
+            0x82C47CB4: "bl 0x82c46760",
+            0x82C47CE0: "addi r9,r9,-28152",
+            0x82C47CE4: "addi r8,r8,-28184",
+            0x82C47CF0: "stw r9,0(r31)",
+            0x82C47CF4: "stw r8,132(r31)",
+            0x82C47D00: "stw r11,176(r31)",
+            0x82C47D10: "stw r11,192(r31)",
+        },
+    )
+    require_instructions(
+        functions,
+        RENDERER_DISPATCH,
+        {
+            0x82C4CCF4: "addi r4,r3,72",
+            0x82C4CD00: "lwz r11,0(r4)",
+            0x82C4CD50: "addi r3,r1,112",
+            0x82C4CD54: "bl 0x82e61748",
+            0x82C4CEDC: "lwz r24,112(r1)",
+            0x82C4DAB8: "addi r26,r24,112",
+            0x82C4DAC8: "lwz r11,8(r11)",
+            0x82C4DAD0: "bctrl",
+            0x82C4DAF0: "lwz r11,16(r11)",
+            0x82C4DAF8: "bctrl",
+            0x82C4DB34: "lwz r11,12(r11)",
+            0x82C4DB3C: "bctrl",
+            0x82C4DB54: "lwz r11,20(r11)",
+            0x82C4DB5C: "bctrl",
+            0x82C4DB60: "lwz r11,128(r3)",
+            0x82C4DC10: "lwz r4,96(r28)",
+            0x82C4DC20: "lwz r3,36(r28)",
+            0x82C4DC24: "lwz r4,100(r28)",
+            0x82C4DC50: "mr r3,r23",
+            DRAW_MEMBER_ENTRY_HOOK: "bl 0x82416380",
+            DRAW_MEMBER_EXIT_HOOK: "li r4,0",
+        },
+    )
+
+    return {
+        "schema": SCHEMA,
+        "status": "complete",
+        "classification": "exact_simple_model_resource_to_mesh_draw_graph",
+        "objects": {
+            "resource": {
+                "class": "CSimpleModelResource",
+                "vtable": f"{RESOURCE_VTABLE:08X}",
+            },
+            "model": {
+                "class": "CSimpleModel",
+                "resource_offset": 112,
+                "primary_vtable": f"{MODEL_VTABLE:08X}",
+                "secondary_vtable": f"{MODEL_SECONDARY_VTABLE:08X}",
+            },
+            "submodel": {
+                "class": "CSimpleSubModel",
+                "vtable": f"{SUBMODEL_VTABLE:08X}",
+            },
+            "mesh": {
+                "class": "CSimpleMesh",
+                "vtable": f"{MESH_VTABLE:08X}",
+            },
+        },
+        "dispatch": {
+            "renderer": f"{RENDERER_DISPATCH:08X}",
+            "model_count_slot": 2,
+            "model_submodel_slot": 4,
+            "submodel_count_slot": 3,
+            "submodel_mesh_slot": 5,
+            "draw_member_entry_hook": f"{DRAW_MEMBER_ENTRY_HOOK:08X}",
+            "draw_member_exit_hook": f"{DRAW_MEMBER_EXIT_HOOK:08X}",
+            "draw_emitter": f"{DRAW_EMITTER:08X}",
+            "entry_model_register": "r26",
+            "entry_submodel_register": "r29",
+            "entry_mesh_register": "r28",
+        },
+        "claims": {
+            "resource_to_embedded_model_proved": True,
+            "model_to_submodel_dispatch_proved": True,
+            "submodel_to_mesh_dispatch_proved": True,
+            "mesh_to_indexed_draw_proved": True,
+            "concrete_building_or_prop_identity_proved": False,
+            "mesh_material_semantics_proved": False,
+        },
+        "safety": {
+            "static_analysis_only": True,
+            "guest_payload_exported": False,
+            "native_admission": False,
+            "suppression_allowed": False,
+            "xenos_authority_required": True,
+        },
+    }
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("generated_root", type=pathlib.Path)
+    parser.add_argument("--image", required=True, type=pathlib.Path)
+    parser.add_argument("--output", required=True, type=pathlib.Path)
+    args = parser.parse_args(argv)
+    try:
+        paths = list(args.generated_root.glob("pinyon_shift_recomp.*.cpp"))
+        if not paths:
+            raise ValueError("no generated AOT C++ files found")
+        document = build(parse_functions(paths), args.image.read_bytes())
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(
+            json.dumps(document, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        return 0
+    except (OSError, UnicodeDecodeError, ValueError) as error:
+        print(f"static-world graph discovery failed: {error}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/discover-native-renderer-static-world-streaming.py
+++ b/tools/discover-native-renderer-static-world-streaming.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+"""Prove exact SimpleModelResource payload-reset transition boundaries."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import pathlib
+import re
+import sys
+
+
+SCHEMA = "pinyon-shift.native-renderer-static-world-streaming.v1"
+IMAGE_BASE = 0x82000000
+RESOURCE_VTABLE = 0x82229294
+FUNCTION_RE = re.compile(r"^DEFINE_REX_FUNC\(sub_([0-9A-F]{8})\) \{")
+LABEL_RE = re.compile(r"^loc_([0-9A-F]{8}):")
+COMMENT_RE = re.compile(r"^\s*//\s+(.+?)\s*$")
+
+RESOURCE_REFRESH = 0x82C46410
+DIRECT_RESET = 0x82C46440
+DIRECT_RESET_EXIT_HOOK = 0x82C46480
+VIRTUAL_RESET = 0x82C222C8
+VIRTUAL_RESET_EXIT_HOOK = 0x82C2231C
+RESOURCE_PAYLOAD_OFFSET = 64
+RESOURCE_GRAPH_OFFSET = 112
+RESOURCE_BINDING_OFFSET = 76
+
+
+def parse_functions(paths: list[pathlib.Path]) -> dict[int, dict[int, str]]:
+    functions = {}
+    for path in sorted(paths, key=lambda item: item.as_posix()):
+        current = None
+        address = None
+        for line in path.read_text(encoding="utf-8").splitlines():
+            match = FUNCTION_RE.match(line)
+            if match:
+                function_address = int(match.group(1), 16)
+                current = functions.setdefault(function_address, {})
+                address = function_address
+                continue
+            label = LABEL_RE.match(line)
+            if current is not None and label:
+                address = int(label.group(1), 16)
+                continue
+            comment = COMMENT_RE.match(line)
+            if current is not None and comment and address is not None:
+                current[address] = comment.group(1)
+                address += 4
+    return functions
+
+
+def image_u32(image: bytes, address: int) -> int:
+    offset = address - IMAGE_BASE
+    if offset < 0 or offset + 4 > len(image):
+        raise ValueError(f"image address is out of range: {address:08X}")
+    return int.from_bytes(image[offset : offset + 4], "big")
+
+
+def require_instructions(
+    functions: dict[int, dict[int, str]],
+    function_address: int,
+    expected: dict[int, str],
+) -> None:
+    instructions = functions.get(function_address)
+    if instructions is None:
+        raise ValueError(f"missing function {function_address:08X}")
+    for address, text in expected.items():
+        if instructions.get(address) != text:
+            raise ValueError(
+                f"instruction drift at {address:08X}: "
+                f"expected {text!r}, got {instructions.get(address)!r}"
+            )
+
+
+def build(functions: dict[int, dict[int, str]], image: bytes) -> dict:
+    if image_u32(image, RESOURCE_VTABLE + 15 * 4) != RESOURCE_REFRESH:
+        raise ValueError("SimpleModelResource refresh slot drifted")
+    if image_u32(image, RESOURCE_VTABLE + 16 * 4) != DIRECT_RESET:
+        raise ValueError("SimpleModelResource direct reset slot drifted")
+    if image_u32(image, RESOURCE_VTABLE + 22 * 4) != VIRTUAL_RESET:
+        raise ValueError("SimpleModelResource virtual reset slot drifted")
+
+    require_instructions(
+        functions,
+        RESOURCE_REFRESH,
+        {
+            0x82C4641C: "addi r5,r3,76",
+            0x82C46420: "addi r3,r3,112",
+            0x82C46424: "bl 0x82c462d0",
+            0x82C46428: "li r3,1",
+        },
+    )
+    require_instructions(
+        functions,
+        DIRECT_RESET,
+        {
+            0x82C46450: "mr r31,r3",
+            0x82C46454: "lwz r3,64(r3)",
+            0x82C46460: "stw r11,64(r31)",
+            0x82C4646C: "lwz r11,12(r11)",
+            0x82C46474: "bctrl",
+            0x82C46478: "addi r3,r31,112",
+            0x82C4647C: "bl 0x82c240e0",
+            DIRECT_RESET_EXIT_HOOK: "clrlwi r11,r3,24",
+        },
+    )
+    require_instructions(
+        functions,
+        VIRTUAL_RESET,
+        {
+            0x82C222DC: "lwz r11,0(r3)",
+            0x82C222E0: "mr r30,r3",
+            0x82C222E4: "lwz r11,60(r11)",
+            0x82C222EC: "bctrl",
+            0x82C222F0: "lwz r11,64(r30)",
+            0x82C222FC: "stw r10,64(r30)",
+            0x82C22310: "lwz r11,12(r10)",
+            0x82C22318: "bctrl",
+            VIRTUAL_RESET_EXIT_HOOK: "mr r3,r31",
+        },
+    )
+
+    return {
+        "schema": SCHEMA,
+        "status": "complete",
+        "classification": "exact_simple_model_resource_payload_reset_paths",
+        "resource": {
+            "class": "CSimpleModelResource",
+            "vtable": f"{RESOURCE_VTABLE:08X}",
+            "payload_reference_offset": RESOURCE_PAYLOAD_OFFSET,
+            "graph_offset": RESOURCE_GRAPH_OFFSET,
+            "binding_offset": RESOURCE_BINDING_OFFSET,
+        },
+        "refresh": {
+            "slot": 15,
+            "method": f"{RESOURCE_REFRESH:08X}",
+            "graph_argument": "resource_plus_112",
+            "binding_argument": "resource_plus_76",
+        },
+        "transitions": [
+            {
+                "kind": "direct_payload_reset",
+                "slot": 16,
+                "entry_hook": f"{DIRECT_RESET:08X}",
+                "exit_hook": f"{DIRECT_RESET_EXIT_HOOK:08X}",
+                "exit_resource_register": "r31",
+            },
+            {
+                "kind": "refresh_then_payload_reset",
+                "slot": 22,
+                "entry_hook": f"{VIRTUAL_RESET:08X}",
+                "exit_hook": f"{VIRTUAL_RESET_EXIT_HOOK:08X}",
+                "exit_resource_register": "r30",
+            },
+        ],
+        "claims": {
+            "owned_payload_reference_field_proved": True,
+            "balanced_payload_reset_boundaries_proved": True,
+            "payload_generation_invalidation_boundary_proved": True,
+            "complete_streaming_invalidation_coverage_proved": False,
+            "concrete_building_or_prop_identity_proved": False,
+        },
+        "safety": {
+            "static_analysis_only": True,
+            "guest_payload_exported": False,
+            "native_admission": False,
+            "suppression_allowed": False,
+            "xenos_authority_required": True,
+        },
+    }
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("generated_root", type=pathlib.Path)
+    parser.add_argument("--image", required=True, type=pathlib.Path)
+    parser.add_argument("--output", required=True, type=pathlib.Path)
+    args = parser.parse_args(argv)
+    try:
+        paths = list(args.generated_root.glob("pinyon_shift_recomp.*.cpp"))
+        if not paths:
+            raise ValueError("no generated AOT C++ files found")
+        document = build(parse_functions(paths), args.image.read_bytes())
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(
+            json.dumps(document, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        return 0
+    except (OSError, UnicodeDecodeError, ValueError) as error:
+        print(f"static-world streaming discovery failed: {error}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/summarize-native-renderer-static-world-runtime-join.py
+++ b/tools/summarize-native-renderer-static-world-runtime-join.py
@@ -9,10 +9,12 @@ import pathlib
 import sys
 
 
-SCHEMA = "pinyon-shift.native-renderer-static-world-runtime-join.v3"
+SCHEMA = "pinyon-shift.native-renderer-static-world-runtime-join.v5"
 STATIC_SCHEMA = "pinyon-shift.native-renderer-static-world-ingress.v2"
 LIFETIME_SCHEMA = "pinyon-shift.native-renderer-static-world-lifetime.v1"
 RESOURCE_SCHEMA = "pinyon-shift.native-renderer-static-world-resource.v1"
+STREAMING_SCHEMA = "pinyon-shift.native-renderer-static-world-streaming.v1"
+GRAPH_SCHEMA = "pinyon-shift.native-renderer-static-world-graph.v1"
 CONFIG = "native_renderer.discovery.static_world_runtime_join_config"
 SUMMARY = "native_renderer.discovery.static_world_runtime_join_summary"
 CHECKPOINT = "native_renderer.discovery.static_world_runtime_join_checkpoint"
@@ -219,10 +221,133 @@ def validate_static_resource(document):
         raise ValueError("static-world resource claims drifted")
 
 
+def validate_static_streaming(document):
+    if (
+        document.get("schema") != STREAMING_SCHEMA
+        or document.get("status") != "complete"
+        or document.get("classification")
+        != "exact_simple_model_resource_payload_reset_paths"
+    ):
+        raise ValueError("static-world streaming proof drifted")
+    try:
+        resource = document["resource"]
+        refresh = document["refresh"]
+        transitions = document["transitions"]
+        claims = document["claims"]
+    except (KeyError, TypeError) as error:
+        raise ValueError("static-world streaming proof is incomplete") from error
+    expected_resource = {
+        "class": "CSimpleModelResource",
+        "vtable": "82229294",
+        "payload_reference_offset": 64,
+        "graph_offset": 112,
+        "binding_offset": 76,
+    }
+    expected_refresh = {
+        "slot": 15,
+        "method": "82C46410",
+        "graph_argument": "resource_plus_112",
+        "binding_argument": "resource_plus_76",
+    }
+    expected_transitions = [
+        {
+            "kind": "direct_payload_reset",
+            "slot": 16,
+            "entry_hook": "82C46440",
+            "exit_hook": "82C46480",
+            "exit_resource_register": "r31",
+        },
+        {
+            "kind": "refresh_then_payload_reset",
+            "slot": 22,
+            "entry_hook": "82C222C8",
+            "exit_hook": "82C2231C",
+            "exit_resource_register": "r30",
+        },
+    ]
+    if any(resource.get(key) != value for key, value in expected_resource.items()):
+        raise ValueError("static-world streaming resource proof drifted")
+    if any(refresh.get(key) != value for key, value in expected_refresh.items()):
+        raise ValueError("static-world streaming refresh proof drifted")
+    if transitions != expected_transitions:
+        raise ValueError("static-world streaming transition proof drifted")
+    if (
+        claims.get("owned_payload_reference_field_proved") is not True
+        or claims.get("balanced_payload_reset_boundaries_proved") is not True
+        or claims.get("payload_generation_invalidation_boundary_proved")
+        is not True
+        or claims.get("complete_streaming_invalidation_coverage_proved")
+        is not False
+        or claims.get("concrete_building_or_prop_identity_proved") is not False
+    ):
+        raise ValueError("static-world streaming claims drifted")
+
+
+def validate_static_graph(document):
+    if (
+        document.get("schema") != GRAPH_SCHEMA
+        or document.get("status") != "complete"
+        or document.get("classification")
+        != "exact_simple_model_resource_to_mesh_draw_graph"
+    ):
+        raise ValueError("static-world graph proof drifted")
+    try:
+        objects = document["objects"]
+        dispatch = document["dispatch"]
+        claims = document["claims"]
+    except (KeyError, TypeError) as error:
+        raise ValueError("static-world graph proof is incomplete") from error
+    expected_objects = {
+        "resource": {
+            "class": "CSimpleModelResource",
+            "vtable": "82229294",
+        },
+        "model": {
+            "class": "CSimpleModel",
+            "resource_offset": 112,
+            "primary_vtable": "82229208",
+            "secondary_vtable": "822291E8",
+        },
+        "submodel": {
+            "class": "CSimpleSubModel",
+            "vtable": "822291BC",
+        },
+        "mesh": {"class": "CSimpleMesh", "vtable": "822291A0"},
+    }
+    expected_dispatch = {
+        "renderer": "82C4CCC8",
+        "model_count_slot": 2,
+        "model_submodel_slot": 4,
+        "submodel_count_slot": 3,
+        "submodel_mesh_slot": 5,
+        "draw_member_entry_hook": "82C4DC54",
+        "draw_member_exit_hook": "82C4DC58",
+        "draw_emitter": "82416380",
+        "entry_model_register": "r26",
+        "entry_submodel_register": "r29",
+        "entry_mesh_register": "r28",
+    }
+    if objects != expected_objects:
+        raise ValueError("static-world graph object proof drifted")
+    if any(dispatch.get(key) != value for key, value in expected_dispatch.items()):
+        raise ValueError("static-world graph dispatch proof drifted")
+    if (
+        claims.get("resource_to_embedded_model_proved") is not True
+        or claims.get("model_to_submodel_dispatch_proved") is not True
+        or claims.get("submodel_to_mesh_dispatch_proved") is not True
+        or claims.get("mesh_to_indexed_draw_proved") is not True
+        or claims.get("concrete_building_or_prop_identity_proved") is not False
+        or claims.get("mesh_material_semantics_proved") is not False
+    ):
+        raise ValueError("static-world graph claims drifted")
+
+
 def build(
     static_ingress,
     static_lifetime,
     static_resource,
+    static_streaming,
+    static_graph,
     events,
     requested_session=None,
     allow_checkpoint=False,
@@ -230,6 +355,8 @@ def build(
     validate_static_ingress(static_ingress)
     validate_static_lifetime(static_lifetime)
     validate_static_resource(static_resource)
+    validate_static_streaming(static_streaming)
+    validate_static_graph(static_graph)
     session = select_session(events, requested_session)
     selected = [event for event in events if event.get("session") == session]
     config = exact_event(selected, CONFIG)
@@ -264,6 +391,18 @@ def build(
         "model_resource_registration_hook": "82C4802C",
         "model_resource_destructor_entry_hook": "82C47DF8",
         "model_resource_destructor_exit_hook": "82C47E44",
+        "model_resource_payload_reference": "resource_plus_64",
+        "model_resource_refresh_slot": "15",
+        "model_resource_refresh": "82C46410",
+        "model_resource_direct_reset_slot": "16",
+        "model_resource_direct_reset_hooks": "82C46440,82C46480",
+        "model_resource_refresh_reset_slot": "22",
+        "model_resource_refresh_reset_hooks": "82C222C8,82C2231C",
+        "simple_model_offset": "resource_plus_112",
+        "simple_model_vtable": "82229208",
+        "simple_submodel_vtable": "822291BC",
+        "simple_mesh_vtable": "822291A0",
+        "simple_member_draw_hooks": "82C4DC54,82C4DC58",
         "draw_emitter": "82416380",
         "packet_hooks": "82416260,824162F4",
         "join": "synchronous_scope_to_physical_pm4_prepared_draw",
@@ -287,7 +426,7 @@ def build(
         or summary.get("checkpoint_kind")
         != ("final" if final_summary else "periodic")
         or summary.get("classification")
-        != "live_simple_model_resource_to_pm4_prepared_draw"
+        != "live_simple_model_mesh_payload_generation_to_prepared_draw"
     ):
         raise ValueError("static-world runtime summary drifted")
 
@@ -349,6 +488,37 @@ def build(
         "resource_graph_bind_joins",
         "resource_scope_joins",
         "resource_scope_mismatches",
+        "resource_transition_entries",
+        "resource_transition_exits",
+        "resource_transitions_open",
+        "resource_transition_overflow",
+        "resource_transition_exit_without_entry",
+        "resource_transition_exact",
+        "resource_direct_resets",
+        "resource_refresh_resets",
+        "resource_transition_invalid_root",
+        "resource_transition_vtable_mismatches",
+        "resource_transition_unregistered",
+        "resource_transition_nonlive",
+        "resource_transition_begin_read_faults",
+        "resource_transition_completions",
+        "resource_transition_completion_faults",
+        "resource_payload_resets_with_reference",
+        "resource_payload_resets_empty",
+        "resource_payload_generation_invalidations",
+        "member_entries",
+        "member_exits",
+        "member_exact",
+        "member_scope_missing",
+        "member_relation_mismatches",
+        "member_vtable_read_faults",
+        "member_vtable_mismatches",
+        "member_overlaps",
+        "member_exit_without_entry",
+        "member_draws_with_packets",
+        "member_draws_without_packets",
+        "member_packets_recorded",
+        "member_packet_mismatches",
     )
     totals = {key: integer(summary, key) for key in keys}
     frame_sequence = integer(summary, "frame_sequence")
@@ -389,6 +559,14 @@ def build(
         failures.append("no renderer bind joined a registered resource")
     if not totals["resource_scope_joins"]:
         failures.append("no exact scope joined a live resource generation")
+    if not totals["resource_transition_exact"]:
+        failures.append("no exact SimpleModel payload reset was observed")
+    if not totals["resource_transition_completions"]:
+        failures.append("no SimpleModel payload reset completed")
+    if not totals["member_exact"]:
+        failures.append("no exact SimpleModel model/submodel/mesh draw was observed")
+    if not totals["member_packets_recorded"]:
+        failures.append("no exact SimpleModel mesh draw emitted a PM4 packet")
     if not totals["scopes_with_packets"] or not totals["packets_recorded"]:
         failures.append("no exact scope emitted a PM4 draw packet")
     if totals["packet_matches"] + totals["pending_packets"] != totals[
@@ -443,6 +621,55 @@ def build(
         failures.append("static-world resource graph-bind accounting drifted")
     if totals["resource_scope_joins"] != totals["exact_scopes"]:
         failures.append("static-world resource scope accounting drifted")
+    resource_transition_classified = (
+        totals["resource_transition_exact"]
+        + totals["resource_transition_invalid_root"]
+        + totals["resource_transition_vtable_mismatches"]
+        + totals["resource_transition_unregistered"]
+        + totals["resource_transition_nonlive"]
+        + totals["resource_transition_begin_read_faults"]
+        + totals["resource_transition_overflow"]
+    )
+    if totals["resource_transition_entries"] != resource_transition_classified:
+        failures.append("static-world resource transition classification drifted")
+    if totals["resource_transition_entries"] != totals["resource_transition_exits"]:
+        failures.append("static-world resource transition entry/exit drifted")
+    if totals["resource_transition_exact"] != (
+        totals["resource_direct_resets"] + totals["resource_refresh_resets"]
+    ):
+        failures.append("static-world resource transition kind accounting drifted")
+    if totals["resource_transition_exact"] != (
+        totals["resource_transition_completions"]
+        + totals["resource_transition_completion_faults"]
+    ):
+        failures.append("static-world resource transition outcome drifted")
+    if totals["resource_transition_completions"] != (
+        totals["resource_payload_resets_with_reference"]
+        + totals["resource_payload_resets_empty"]
+    ):
+        failures.append("static-world resource payload-reset accounting drifted")
+    if totals["resource_payload_generation_invalidations"] != totals[
+        "resource_transition_completions"
+    ]:
+        failures.append("static-world resource payload generation drifted")
+    member_classified = (
+        totals["member_exact"]
+        + totals["member_scope_missing"]
+        + totals["member_relation_mismatches"]
+        + totals["member_vtable_read_faults"]
+        + totals["member_vtable_mismatches"]
+    )
+    if totals["member_entries"] != member_classified:
+        failures.append("static-world member classification drifted")
+    if totals["member_entries"] != totals["member_exits"]:
+        failures.append("static-world member entry/exit accounting drifted")
+    if totals["member_exact"] != (
+        totals["member_draws_with_packets"]
+        + totals["member_draws_without_packets"]
+    ):
+        failures.append("static-world member draw outcome accounting drifted")
+    if totals["member_packets_recorded"] != totals["packets_recorded"]:
+        failures.append("static-world member packet join accounting drifted")
     if not totals["prepared_matches"]:
         failures.append("no static-world PM4 packet joined a prepared draw")
     for key in (
@@ -471,6 +698,22 @@ def build(
         "resource_registration_type_mismatches",
         "resource_registration_faults",
         "resource_scope_mismatches",
+        "resource_transitions_open",
+        "resource_transition_overflow",
+        "resource_transition_exit_without_entry",
+        "resource_transition_invalid_root",
+        "resource_transition_unregistered",
+        "resource_transition_nonlive",
+        "resource_transition_begin_read_faults",
+        "resource_transition_completion_faults",
+        "member_scope_missing",
+        "member_relation_mismatches",
+        "member_vtable_read_faults",
+        "member_vtable_mismatches",
+        "member_overlaps",
+        "member_exit_without_entry",
+        "member_draws_without_packets",
+        "member_packet_mismatches",
     ):
         if totals[key]:
             failures.append(f"{key} is nonzero")
@@ -505,10 +748,17 @@ def build(
             "simple_model_resource_type_proved": not failures,
             "simple_model_resource_lifetime_proved": not failures,
             "renderer_to_registered_resource_proved": not failures,
+            "simple_model_payload_reset_runtime_proved": not failures,
+            "payload_generation_invalidation_proved": not failures,
+            "resource_to_simple_model_proved": not failures,
+            "simple_model_to_submodel_proved": not failures,
+            "simple_submodel_to_mesh_proved": not failures,
+            "simple_mesh_to_prepared_draw_proved": not failures,
             "static_world_scope_to_pm4_proved": not failures,
             "static_world_pm4_to_prepared_draw_proved": not failures,
             "building_or_prop_instance_identity_proved": False,
             "streaming_lifetime_proved": False,
+            "complete_streaming_invalidation_coverage_proved": False,
             "native_admission": False,
             "suppression_allowed": False,
         },
@@ -529,6 +779,8 @@ def main(argv=None):
     parser.add_argument("--static", required=True, type=pathlib.Path)
     parser.add_argument("--lifetime", required=True, type=pathlib.Path)
     parser.add_argument("--resource", required=True, type=pathlib.Path)
+    parser.add_argument("--streaming", required=True, type=pathlib.Path)
+    parser.add_argument("--graph", required=True, type=pathlib.Path)
     parser.add_argument("--session")
     parser.add_argument("--allow-checkpoint", action="store_true")
     parser.add_argument("--output", required=True, type=pathlib.Path)
@@ -538,6 +790,8 @@ def main(argv=None):
             json.loads(args.static.read_text(encoding="utf-8")),
             json.loads(args.lifetime.read_text(encoding="utf-8")),
             json.loads(args.resource.read_text(encoding="utf-8")),
+            json.loads(args.streaming.read_text(encoding="utf-8")),
+            json.loads(args.graph.read_text(encoding="utf-8")),
             read_events(args.events),
             args.session,
             args.allow_checkpoint,

--- a/tools/tests/test_native_renderer_static_world_graph.py
+++ b/tools/tests/test_native_renderer_static_world_graph.py
@@ -1,0 +1,104 @@
+import copy
+import importlib.util
+import sys
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+TOOL = ROOT / "tools" / "discover-native-renderer-static-world-graph.py"
+SPEC = importlib.util.spec_from_file_location("static_world_graph", TOOL)
+assert SPEC and SPEC.loader
+MODULE = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = MODULE
+SPEC.loader.exec_module(MODULE)
+
+
+def fixture():
+    image = bytearray(MODULE.MODEL_VTABLE + 5 * 4 - MODULE.IMAGE_BASE)
+    for vtable, slot, target in (
+        (MODULE.MODEL_VTABLE, 2, 0x824385D0),
+        (MODULE.MODEL_VTABLE, 4, 0x82C25388),
+        (MODULE.SUBMODEL_VTABLE, 3, 0x82C256D0),
+        (MODULE.SUBMODEL_VTABLE, 5, 0x82C256E8),
+    ):
+        offset = vtable + slot * 4 - MODULE.IMAGE_BASE
+        image[offset : offset + 4] = target.to_bytes(4, "big")
+    functions = {
+        MODULE.RESOURCE_CONSTRUCTOR: {
+            0x82C47DD4: "addi r3,r31,112",
+            0x82C47DD8: "bl 0x82c47ca0",
+        },
+        MODULE.MODEL_CONSTRUCTOR: {
+            0x82C47CB4: "bl 0x82c46760",
+            0x82C47CE0: "addi r9,r9,-28152",
+            0x82C47CE4: "addi r8,r8,-28184",
+            0x82C47CF0: "stw r9,0(r31)",
+            0x82C47CF4: "stw r8,132(r31)",
+            0x82C47D00: "stw r11,176(r31)",
+            0x82C47D10: "stw r11,192(r31)",
+        },
+        MODULE.RENDERER_DISPATCH: {
+            0x82C4CCF4: "addi r4,r3,72",
+            0x82C4CD00: "lwz r11,0(r4)",
+            0x82C4CD50: "addi r3,r1,112",
+            0x82C4CD54: "bl 0x82e61748",
+            0x82C4CEDC: "lwz r24,112(r1)",
+            0x82C4DAB8: "addi r26,r24,112",
+            0x82C4DAC8: "lwz r11,8(r11)",
+            0x82C4DAD0: "bctrl",
+            0x82C4DAF0: "lwz r11,16(r11)",
+            0x82C4DAF8: "bctrl",
+            0x82C4DB34: "lwz r11,12(r11)",
+            0x82C4DB3C: "bctrl",
+            0x82C4DB54: "lwz r11,20(r11)",
+            0x82C4DB5C: "bctrl",
+            0x82C4DB60: "lwz r11,128(r3)",
+            0x82C4DC10: "lwz r4,96(r28)",
+            0x82C4DC20: "lwz r3,36(r28)",
+            0x82C4DC24: "lwz r4,100(r28)",
+            0x82C4DC50: "mr r3,r23",
+            MODULE.DRAW_MEMBER_ENTRY_HOOK: "bl 0x82416380",
+            MODULE.DRAW_MEMBER_EXIT_HOOK: "li r4,0",
+        },
+    }
+    return functions, bytes(image)
+
+
+class StaticWorldGraphTests(unittest.TestCase):
+    def test_proves_resource_to_mesh_draw_graph(self):
+        functions, image = fixture()
+        document = MODULE.build(functions, image)
+        self.assertEqual("complete", document["status"])
+        self.assertTrue(document["claims"]["mesh_to_indexed_draw_proved"])
+        self.assertFalse(
+            document["claims"]["concrete_building_or_prop_identity_proved"]
+        )
+
+    def test_rejects_model_embedding_drift(self):
+        functions, image = fixture()
+        corrupted = copy.deepcopy(functions)
+        corrupted[MODULE.RESOURCE_CONSTRUCTOR][0x82C47DD4] = "addi r3,r31,116"
+        with self.assertRaisesRegex(ValueError, "82C47DD4"):
+            MODULE.build(corrupted, image)
+
+    def test_rejects_submodel_dispatch_drift(self):
+        functions, image = fixture()
+        corrupted = bytearray(image)
+        offset = MODULE.SUBMODEL_VTABLE + 5 * 4 - MODULE.IMAGE_BASE
+        corrupted[offset : offset + 4] = (0x82C256EC).to_bytes(4, "big")
+        with self.assertRaisesRegex(ValueError, "graph dispatch slot drifted"):
+            MODULE.build(functions, bytes(corrupted))
+
+    def test_rejects_draw_emitter_drift(self):
+        functions, image = fixture()
+        corrupted = copy.deepcopy(functions)
+        corrupted[MODULE.RENDERER_DISPATCH][
+            MODULE.DRAW_MEMBER_ENTRY_HOOK
+        ] = "bl 0x82416384"
+        with self.assertRaisesRegex(ValueError, "82C4DC54"):
+            MODULE.build(corrupted, image)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/tests/test_native_renderer_static_world_runtime_join.py
+++ b/tools/tests/test_native_renderer_static_world_runtime_join.py
@@ -126,6 +126,96 @@ def static_resource():
     }
 
 
+def static_streaming():
+    return {
+        "schema": MODULE.STREAMING_SCHEMA,
+        "status": "complete",
+        "classification": "exact_simple_model_resource_payload_reset_paths",
+        "resource": {
+            "class": "CSimpleModelResource",
+            "vtable": "82229294",
+            "payload_reference_offset": 64,
+            "graph_offset": 112,
+            "binding_offset": 76,
+        },
+        "refresh": {
+            "slot": 15,
+            "method": "82C46410",
+            "graph_argument": "resource_plus_112",
+            "binding_argument": "resource_plus_76",
+        },
+        "transitions": [
+            {
+                "kind": "direct_payload_reset",
+                "slot": 16,
+                "entry_hook": "82C46440",
+                "exit_hook": "82C46480",
+                "exit_resource_register": "r31",
+            },
+            {
+                "kind": "refresh_then_payload_reset",
+                "slot": 22,
+                "entry_hook": "82C222C8",
+                "exit_hook": "82C2231C",
+                "exit_resource_register": "r30",
+            },
+        ],
+        "claims": {
+            "owned_payload_reference_field_proved": True,
+            "balanced_payload_reset_boundaries_proved": True,
+            "payload_generation_invalidation_boundary_proved": True,
+            "complete_streaming_invalidation_coverage_proved": False,
+            "concrete_building_or_prop_identity_proved": False,
+        },
+    }
+
+
+def static_graph():
+    return {
+        "schema": MODULE.GRAPH_SCHEMA,
+        "status": "complete",
+        "classification": "exact_simple_model_resource_to_mesh_draw_graph",
+        "objects": {
+            "resource": {
+                "class": "CSimpleModelResource",
+                "vtable": "82229294",
+            },
+            "model": {
+                "class": "CSimpleModel",
+                "resource_offset": 112,
+                "primary_vtable": "82229208",
+                "secondary_vtable": "822291E8",
+            },
+            "submodel": {
+                "class": "CSimpleSubModel",
+                "vtable": "822291BC",
+            },
+            "mesh": {"class": "CSimpleMesh", "vtable": "822291A0"},
+        },
+        "dispatch": {
+            "renderer": "82C4CCC8",
+            "model_count_slot": 2,
+            "model_submodel_slot": 4,
+            "submodel_count_slot": 3,
+            "submodel_mesh_slot": 5,
+            "draw_member_entry_hook": "82C4DC54",
+            "draw_member_exit_hook": "82C4DC58",
+            "draw_emitter": "82416380",
+            "entry_model_register": "r26",
+            "entry_submodel_register": "r29",
+            "entry_mesh_register": "r28",
+        },
+        "claims": {
+            "resource_to_embedded_model_proved": True,
+            "model_to_submodel_dispatch_proved": True,
+            "submodel_to_mesh_dispatch_proved": True,
+            "mesh_to_indexed_draw_proved": True,
+            "concrete_building_or_prop_identity_proved": False,
+            "mesh_material_semantics_proved": False,
+        },
+    }
+
+
 def fixture():
     config = event(
         MODULE.CONFIG,
@@ -157,6 +247,18 @@ def fixture():
             "model_resource_registration_hook": "82C4802C",
             "model_resource_destructor_entry_hook": "82C47DF8",
             "model_resource_destructor_exit_hook": "82C47E44",
+            "model_resource_payload_reference": "resource_plus_64",
+            "model_resource_refresh_slot": "15",
+            "model_resource_refresh": "82C46410",
+            "model_resource_direct_reset_slot": "16",
+            "model_resource_direct_reset_hooks": "82C46440,82C46480",
+            "model_resource_refresh_reset_slot": "22",
+            "model_resource_refresh_reset_hooks": "82C222C8,82C2231C",
+            "simple_model_offset": "resource_plus_112",
+            "simple_model_vtable": "82229208",
+            "simple_submodel_vtable": "822291BC",
+            "simple_mesh_vtable": "822291A0",
+            "simple_member_draw_hooks": "82C4DC54,82C4DC58",
             "draw_emitter": "82416380",
             "packet_hooks": "82416260,824162F4",
             "join": "synchronous_scope_to_physical_pm4_prepared_draw",
@@ -226,9 +328,42 @@ def fixture():
         resource_graph_bind_joins="3",
         resource_scope_joins="10",
         resource_scope_mismatches="0",
+        resource_transition_entries="6",
+        resource_transition_exits="6",
+        resource_transitions_open="0",
+        resource_transition_overflow="0",
+        resource_transition_exit_without_entry="0",
+        resource_transition_exact="2",
+        resource_direct_resets="1",
+        resource_refresh_resets="1",
+        resource_transition_invalid_root="0",
+        resource_transition_vtable_mismatches="4",
+        resource_transition_unregistered="0",
+        resource_transition_nonlive="0",
+        resource_transition_begin_read_faults="0",
+        resource_transition_completions="2",
+        resource_transition_completion_faults="0",
+        resource_payload_resets_with_reference="1",
+        resource_payload_resets_empty="1",
+        resource_payload_generation_invalidations="2",
+        member_entries="98",
+        member_exits="98",
+        member_exact="98",
+        member_scope_missing="0",
+        member_relation_mismatches="0",
+        member_vtable_read_faults="0",
+        member_vtable_mismatches="0",
+        member_overlaps="0",
+        member_exit_without_entry="0",
+        member_draws_with_packets="98",
+        member_draws_without_packets="0",
+        member_packets_recorded="100",
+        member_packet_mismatches="0",
         accounting_complete="true",
         qualification_complete="true",
-        classification="live_simple_model_resource_to_pm4_prepared_draw",
+        classification=(
+            "live_simple_model_mesh_payload_generation_to_prepared_draw"
+        ),
         **safety(),
     )
     return [config, summary]
@@ -237,7 +372,12 @@ def fixture():
 class StaticWorldRuntimeJoinTests(unittest.TestCase):
     def test_qualifies_exact_scope_to_prepared_draw(self):
         document = MODULE.build(
-            static_ingress(), static_lifetime(), static_resource(), fixture()
+            static_ingress(),
+            static_lifetime(),
+            static_resource(),
+            static_streaming(),
+            static_graph(),
+            fixture(),
         )
         self.assertEqual("complete", document["status"])
         self.assertTrue(
@@ -248,6 +388,9 @@ class StaticWorldRuntimeJoinTests(unittest.TestCase):
         )
         self.assertTrue(
             document["qualification"]["simple_model_resource_type_proved"]
+        )
+        self.assertTrue(
+            document["qualification"]["simple_mesh_to_prepared_draw_proved"]
         )
         self.assertFalse(
             document["qualification"]["building_or_prop_instance_identity_proved"]
@@ -266,6 +409,8 @@ class StaticWorldRuntimeJoinTests(unittest.TestCase):
             static_ingress(),
             static_lifetime(),
             static_resource(),
+            static_streaming(),
+            static_graph(),
             events + [checkpoint],
             allow_checkpoint=True,
         )
@@ -282,7 +427,12 @@ class StaticWorldRuntimeJoinTests(unittest.TestCase):
             qualification_complete="false",
         )
         document = MODULE.build(
-            static_ingress(), static_lifetime(), static_resource(), events
+            static_ingress(),
+            static_lifetime(),
+            static_resource(),
+            static_streaming(),
+            static_graph(),
+            events,
         )
         self.assertEqual("incomplete", document["status"])
         self.assertIn("unprepared_matches is nonzero", document["failures"])
@@ -296,7 +446,12 @@ class StaticWorldRuntimeJoinTests(unittest.TestCase):
             qualification_complete="false",
         )
         document = MODULE.build(
-            static_ingress(), static_lifetime(), static_resource(), events
+            static_ingress(),
+            static_lifetime(),
+            static_resource(),
+            static_streaming(),
+            static_graph(),
+            events,
         )
         self.assertEqual("incomplete", document["status"])
         self.assertIn(
@@ -310,7 +465,14 @@ class StaticWorldRuntimeJoinTests(unittest.TestCase):
             "slot_targets"
         ][12] = "82C4CCD0"
         with self.assertRaisesRegex(ValueError, "dispatch proof drifted"):
-            MODULE.build(ingress, static_lifetime(), static_resource(), fixture())
+            MODULE.build(
+                ingress,
+                static_lifetime(),
+                static_resource(),
+                static_streaming(),
+                static_graph(),
+                fixture(),
+            )
 
     def test_rejects_unregistered_renderer_dispatch(self):
         events = copy.deepcopy(fixture())
@@ -323,7 +485,12 @@ class StaticWorldRuntimeJoinTests(unittest.TestCase):
             qualification_complete="false",
         )
         document = MODULE.build(
-            static_ingress(), static_lifetime(), static_resource(), events
+            static_ingress(),
+            static_lifetime(),
+            static_resource(),
+            static_streaming(),
+            static_graph(),
+            events,
         )
         self.assertEqual("incomplete", document["status"])
         self.assertIn(
@@ -339,7 +506,12 @@ class StaticWorldRuntimeJoinTests(unittest.TestCase):
             qualification_complete="false",
         )
         document = MODULE.build(
-            static_ingress(), static_lifetime(), static_resource(), events
+            static_ingress(),
+            static_lifetime(),
+            static_resource(),
+            static_streaming(),
+            static_graph(),
+            events,
         )
         self.assertEqual("incomplete", document["status"])
         self.assertIn(
@@ -356,11 +528,40 @@ class StaticWorldRuntimeJoinTests(unittest.TestCase):
             qualification_complete="false",
         )
         document = MODULE.build(
-            static_ingress(), static_lifetime(), static_resource(), events
+            static_ingress(),
+            static_lifetime(),
+            static_resource(),
+            static_streaming(),
+            static_graph(),
+            events,
         )
         self.assertEqual("incomplete", document["status"])
         self.assertIn(
             "resource_registration_unregistered is nonzero",
+            document["failures"],
+        )
+
+    def test_rejects_payload_reset_completion_fault(self):
+        events = copy.deepcopy(fixture())
+        events[-1].update(
+            status="incomplete",
+            resource_transition_completions="1",
+            resource_transition_completion_faults="1",
+            resource_payload_resets_empty="0",
+            resource_payload_generation_invalidations="1",
+            qualification_complete="false",
+        )
+        document = MODULE.build(
+            static_ingress(),
+            static_lifetime(),
+            static_resource(),
+            static_streaming(),
+            static_graph(),
+            events,
+        )
+        self.assertEqual("incomplete", document["status"])
+        self.assertIn(
+            "resource_transition_completion_faults is nonzero",
             document["failures"],
         )
 
@@ -387,6 +588,12 @@ class StaticWorldRuntimeJoinTests(unittest.TestCase):
         self.assertIn("address = 0x82C4802C", analysis)
         self.assertIn("address = 0x82C47DF8", analysis)
         self.assertIn("address = 0x82C47E44", analysis)
+        self.assertIn("address = 0x82C46440", analysis)
+        self.assertIn("address = 0x82C46480", analysis)
+        self.assertIn("address = 0x82C222C8", analysis)
+        self.assertIn("address = 0x82C2231C", analysis)
+        self.assertIn("address = 0x82C4DC54", analysis)
+        self.assertIn("address = 0x82C4DC58", analysis)
 
 
 if __name__ == "__main__":

--- a/tools/tests/test_native_renderer_static_world_streaming.py
+++ b/tools/tests/test_native_renderer_static_world_streaming.py
@@ -1,0 +1,98 @@
+import copy
+import importlib.util
+import sys
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+TOOL = ROOT / "tools" / "discover-native-renderer-static-world-streaming.py"
+SPEC = importlib.util.spec_from_file_location("static_world_streaming", TOOL)
+assert SPEC and SPEC.loader
+MODULE = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = MODULE
+SPEC.loader.exec_module(MODULE)
+
+
+def fixture():
+    image = bytearray(MODULE.RESOURCE_VTABLE + 23 * 4 - MODULE.IMAGE_BASE)
+    for slot, target in (
+        (15, MODULE.RESOURCE_REFRESH),
+        (16, MODULE.DIRECT_RESET),
+        (22, MODULE.VIRTUAL_RESET),
+    ):
+        offset = MODULE.RESOURCE_VTABLE + slot * 4 - MODULE.IMAGE_BASE
+        image[offset : offset + 4] = target.to_bytes(4, "big")
+    functions = {
+        MODULE.RESOURCE_REFRESH: {
+            0x82C4641C: "addi r5,r3,76",
+            0x82C46420: "addi r3,r3,112",
+            0x82C46424: "bl 0x82c462d0",
+            0x82C46428: "li r3,1",
+        },
+        MODULE.DIRECT_RESET: {
+            0x82C46450: "mr r31,r3",
+            0x82C46454: "lwz r3,64(r3)",
+            0x82C46460: "stw r11,64(r31)",
+            0x82C4646C: "lwz r11,12(r11)",
+            0x82C46474: "bctrl",
+            0x82C46478: "addi r3,r31,112",
+            0x82C4647C: "bl 0x82c240e0",
+            MODULE.DIRECT_RESET_EXIT_HOOK: "clrlwi r11,r3,24",
+        },
+        MODULE.VIRTUAL_RESET: {
+            0x82C222DC: "lwz r11,0(r3)",
+            0x82C222E0: "mr r30,r3",
+            0x82C222E4: "lwz r11,60(r11)",
+            0x82C222EC: "bctrl",
+            0x82C222F0: "lwz r11,64(r30)",
+            0x82C222FC: "stw r10,64(r30)",
+            0x82C22310: "lwz r11,12(r10)",
+            0x82C22318: "bctrl",
+            MODULE.VIRTUAL_RESET_EXIT_HOOK: "mr r3,r31",
+        },
+    }
+    return functions, bytes(image)
+
+
+class StaticWorldStreamingTests(unittest.TestCase):
+    def test_proves_exact_payload_reset_paths(self):
+        functions, image = fixture()
+        document = MODULE.build(functions, image)
+        self.assertEqual("complete", document["status"])
+        self.assertEqual(64, document["resource"]["payload_reference_offset"])
+        self.assertEqual(2, len(document["transitions"]))
+        self.assertTrue(
+            document["claims"]["payload_generation_invalidation_boundary_proved"]
+        )
+        self.assertFalse(
+            document["claims"]["complete_streaming_invalidation_coverage_proved"]
+        )
+
+    def test_rejects_reset_slot_drift(self):
+        functions, image = fixture()
+        corrupted = bytearray(image)
+        offset = MODULE.RESOURCE_VTABLE + 16 * 4 - MODULE.IMAGE_BASE
+        corrupted[offset : offset + 4] = (MODULE.DIRECT_RESET + 4).to_bytes(
+            4, "big"
+        )
+        with self.assertRaisesRegex(ValueError, "direct reset slot drifted"):
+            MODULE.build(functions, bytes(corrupted))
+
+    def test_rejects_payload_clear_drift(self):
+        functions, image = fixture()
+        corrupted = copy.deepcopy(functions)
+        corrupted[MODULE.VIRTUAL_RESET][0x82C222FC] = "stw r10,68(r30)"
+        with self.assertRaisesRegex(ValueError, "82C222FC"):
+            MODULE.build(corrupted, image)
+
+    def test_rejects_refresh_graph_drift(self):
+        functions, image = fixture()
+        corrupted = copy.deepcopy(functions)
+        corrupted[MODULE.RESOURCE_REFRESH][0x82C46420] = "addi r3,r3,116"
+        with self.assertRaisesRegex(ValueError, "82C46420"):
+            MODULE.build(corrupted, image)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- prove and instrument two exact CSimpleModelResource payload-reset paths with an independent payload generation
- join the embedded CSimpleModel, selected CSimpleSubModel, and selected CSimpleMesh to physical PM4 and prepared-draw provenance
- extend the fail-closed combined qualifier while keeping concrete building/prop semantics, native admission, and suppression pending

## Validation
- 545 repository tests pass
- Markdown links and diff whitespace checks pass
- real retail-image streaming and member-graph proofs pass
- all generated hook objects and graphics_hooks.cpp compile; final link is blocked only by the intentionally preserved live preview process