### PR TITLE
docs(native-renderer): prove static-world presentation owner

### DIFF
--- a/docs/native-renderer/REPRIORITIZED_PLAN.md
+++ b/docs/native-renderer/REPRIORITIZED_PLAN.md
@@ -354,6 +354,14 @@ in [`STATIC_WORLD_GRAPH.md`](STATIC_WORLD_GRAPH.md). This closes the generic
 SimpleModel member lineage, not concrete building-versus-prop semantics or
 mesh/material decoding; native admission and suppression remain off.
 
+Presentation-owner checkpoint: exact retail vtable and instruction flow now
+prove `Presentation_Unified::CModelPresentation` as the synchronous owner above
+the SimpleModel resource reference and renderer. Its balanced slot-12 scope
+constructs/binds the renderer and invokes the renderer's exact slot-12 draw
+path. The proof is documented in [`STATIC_WORLD_OWNER.md`](STATIC_WORLD_OWNER.md).
+This closes title presentation ownership, not building-versus-prop identity or
+mesh/material semantics; the passive runtime join remains batched with C1/C2.
+
 ### C3. Semantic batching, culling, and LOD
 
 - Promote the existing visibility and prepared-draw evidence into production

--- a/docs/native-renderer/STATIC_WORLD_OWNER.md
+++ b/docs/native-renderer/STATIC_WORLD_OWNER.md
@@ -1,0 +1,48 @@
+# Static-world model-presentation ownership
+
+Status: exact presentation-to-renderer ownership proved; passive runtime join
+pending the next batched C1/C2 qualification
+
+## Purpose
+
+The generic `CSimpleModelResource` member graph identifies the model, submodel,
+and mesh that emitted a draw, but it does not identify the title object that
+owns the renderer. `tools/discover-native-renderer-static-world-owner.py`
+closes that structural gap without assigning unproved building or prop
+semantics.
+
+## Exact owner path
+
+Retail RTTI, vtables, and generated AOT instructions prove:
+
+- `Presentation_Unified::CModelPresentation` uses primary vtable `822432D4`;
+- its slot 12 is method `823F8DB8`, with one balanced exit at `823F8FA0`;
+- the owner stores its resource reference at offset 148, state at offset 144,
+  and renderer at offset 1608;
+- helper `823F8980` reads the offset-148 reference, constructs the exact
+  `CSimpleModelRenderer` through `82C4E3A0`, stores it at offset 1608, and
+  invokes renderer bind slot 0; and
+- the same slot-12 scope later loads the offset-1608 renderer and invokes
+  renderer slot 12, whose exact vtable target is `82C4CCC8`.
+
+This creates a safe synchronous join: an exact SimpleModel renderer dispatch
+occurring inside the balanced presentation slot-12 scope may carry the
+`CModelPresentation` address into existing packet and prepared-draw
+provenance. The runtime join still needs to be implemented and qualified.
+
+## Generate the report
+
+```powershell
+python tools/discover-native-renderer-static-world-owner.py `
+  .local/generated/default `
+  --image .local/analysis/default-image.bin `
+  --output .local/qualification/native-renderer-static-world-owner.json
+```
+
+## Remaining boundary
+
+`CModelPresentation` is an exact title-owned presentation class, not proof that
+an individual instance is a building rather than a prop. Mesh/material field
+semantics and representative streaming transitions also remain open. This
+checkpoint changes no guest data, native admission, publication, or
+suppression; Xenos remains authoritative.

--- a/tools/discover-native-renderer-static-world-owner.py
+++ b/tools/discover-native-renderer-static-world-owner.py
@@ -1,0 +1,222 @@
+#!/usr/bin/env python3
+"""Prove the CModelPresentation owner above the SimpleModel renderer."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import pathlib
+import re
+import sys
+
+
+SCHEMA = "pinyon-shift.native-renderer-static-world-owner.v1"
+IMAGE_BASE = 0x82000000
+PRESENTATION_VTABLE = 0x822432D4
+PRESENTATION_SLOT_COUNT = 18
+FUNCTION_RE = re.compile(r"^DEFINE_REX_FUNC\(sub_([0-9A-F]{8})\) \{")
+LABEL_RE = re.compile(r"^loc_([0-9A-F]{8}):")
+COMMENT_RE = re.compile(r"^\s*//\s+(.+?)\s*$")
+
+PRESENTATION_CONSTRUCTOR = 0x82DE9840
+PRESENTATION_DESTRUCTOR = 0x82DEA218
+PRESENTATION_DELETING_DESTRUCTOR = 0x82DEA508
+PRESENTATION_DRAW_SLOT = 12
+PRESENTATION_DRAW = 0x823F8DB8
+PRESENTATION_DRAW_EXIT = 0x823F8FA0
+PRESENTATION_PREPARE = 0x823F8980
+RENDERER_CONSTRUCTOR_WRAPPER = 0x82C4E3A0
+RENDERER_VTABLE = 0x82001B64
+RENDERER_BIND_SLOT = 0
+RENDERER_DRAW_SLOT = 12
+RESOURCE_REFERENCE_OFFSET = 148
+RENDERER_FIELD_OFFSET = 1608
+STATE_FIELD_OFFSET = 144
+
+
+def parse_functions(paths: list[pathlib.Path]) -> dict[int, dict[int, str]]:
+    functions = {}
+    for path in sorted(paths, key=lambda item: item.as_posix()):
+        current = None
+        address = None
+        for line in path.read_text(encoding="utf-8").splitlines():
+            match = FUNCTION_RE.match(line)
+            if match:
+                function_address = int(match.group(1), 16)
+                current = functions.setdefault(function_address, {})
+                address = function_address
+                continue
+            label = LABEL_RE.match(line)
+            if current is not None and label:
+                address = int(label.group(1), 16)
+                continue
+            comment = COMMENT_RE.match(line)
+            if current is not None and comment and address is not None:
+                current[address] = comment.group(1)
+                address += 4
+    return functions
+
+
+def image_u32(image: bytes, address: int) -> int:
+    offset = address - IMAGE_BASE
+    if offset < 0 or offset + 4 > len(image):
+        raise ValueError(f"image address is out of range: {address:08X}")
+    return int.from_bytes(image[offset : offset + 4], "big")
+
+
+def require_instructions(functions, function_address, expected) -> None:
+    instructions = functions.get(function_address)
+    if instructions is None:
+        raise ValueError(f"missing function {function_address:08X}")
+    for address, text in expected.items():
+        if instructions.get(address) != text:
+            raise ValueError(
+                f"instruction drift at {address:08X}: "
+                f"expected {text!r}, got {instructions.get(address)!r}"
+            )
+
+
+def build(functions: dict[int, dict[int, str]], image: bytes) -> dict:
+    slots = [
+        image_u32(image, PRESENTATION_VTABLE + index * 4)
+        for index in range(PRESENTATION_SLOT_COUNT)
+    ]
+    if slots[0] != PRESENTATION_DELETING_DESTRUCTOR:
+        raise ValueError("CModelPresentation deleting destructor drifted")
+    if slots[PRESENTATION_DRAW_SLOT] != PRESENTATION_DRAW:
+        raise ValueError("CModelPresentation draw slot drifted")
+    renderer_slots = [
+        image_u32(image, RENDERER_VTABLE + index * 4) for index in range(17)
+    ]
+
+    require_instructions(
+        functions,
+        PRESENTATION_CONSTRUCTOR,
+        {
+            0x82DE9864: "lis r11,-32220",
+            0x82DE9878: "addi r10,r10,13012",
+            0x82DE9884: "stw r10,0(r31)",
+            0x82DE98E0: "stw r30,144(r31)",
+            0x82DE98E4: "stw r30,148(r31)",
+            0x82DE993C: "stw r30,1608(r31)",
+        },
+    )
+    require_instructions(
+        functions,
+        PRESENTATION_DESTRUCTOR,
+        {
+            0x82DEA230: "addi r11,r11,13012",
+            0x82DEA238: "stw r11,0(r3)",
+            0x82DEA244: "bl 0x82de9f10",
+            0x82DEA260: "addi r3,r31,148",
+            0x82DEA264: "bl 0x82de7330",
+        },
+    )
+    require_instructions(
+        functions,
+        PRESENTATION_DELETING_DESTRUCTOR,
+        {
+            0x82DEA524: "bl 0x82dea218",
+            0x82DEA530: "mr r3,r31",
+            0x82DEA534: "bl 0x823fd208",
+        },
+    )
+    require_instructions(
+        functions,
+        PRESENTATION_PREPARE,
+        {
+            0x823F89A4: "lwz r11,148(r24)",
+            0x823F89A8: "addi r31,r24,148",
+            0x823F8A14: "bl 0x82c4e3a0",
+            0x823F8A18: "stw r3,1608(r24)",
+            0x823F8A28: "lwz r3,1608(r24)",
+            0x823F8A34: "lwz r11,0(r11)",
+            0x823F8A3C: "bctrl",
+            0x823F8A44: "stw r11,144(r24)",
+        },
+    )
+    require_instructions(
+        functions,
+        PRESENTATION_DRAW,
+        {
+            0x823F8DC4: "mr r31,r3",
+            0x823F8DDC: "bl 0x823f8980",
+            0x823F8E20: "lwz r11,1608(r31)",
+            0x823F8F0C: "lwz r3,1608(r31)",
+            0x823F8F18: "lwz r11,48(r11)",
+            0x823F8F20: "bctrl",
+            PRESENTATION_DRAW_EXIT: "addi r1,r1,160",
+        },
+    )
+
+    return {
+        "schema": SCHEMA,
+        "status": "complete",
+        "classification": "exact_model_presentation_to_simple_model_renderer_owner",
+        "presentation": {
+            "class": "Presentation_Unified::CModelPresentation",
+            "vtable": f"{PRESENTATION_VTABLE:08X}",
+            "constructor": f"{PRESENTATION_CONSTRUCTOR:08X}",
+            "destructor": f"{PRESENTATION_DESTRUCTOR:08X}",
+            "deleting_destructor_slot": 0,
+            "deleting_destructor": f"{PRESENTATION_DELETING_DESTRUCTOR:08X}",
+            "draw_slot": PRESENTATION_DRAW_SLOT,
+            "draw_method": f"{PRESENTATION_DRAW:08X}",
+            "draw_entry_hook": f"{PRESENTATION_DRAW:08X}",
+            "draw_exit_hook": f"{PRESENTATION_DRAW_EXIT:08X}",
+            "state_field_offset": STATE_FIELD_OFFSET,
+            "resource_reference_offset": RESOURCE_REFERENCE_OFFSET,
+            "renderer_field_offset": RENDERER_FIELD_OFFSET,
+        },
+        "renderer_join": {
+            "prepare_helper": f"{PRESENTATION_PREPARE:08X}",
+            "constructor_wrapper": f"{RENDERER_CONSTRUCTOR_WRAPPER:08X}",
+            "renderer_vtable": f"{RENDERER_VTABLE:08X}",
+            "bind_slot": RENDERER_BIND_SLOT,
+            "bind_target": f"{renderer_slots[RENDERER_BIND_SLOT]:08X}",
+            "draw_slot": RENDERER_DRAW_SLOT,
+            "draw_target": f"{renderer_slots[RENDERER_DRAW_SLOT]:08X}",
+            "join_kind": "balanced_synchronous_presentation_draw_scope",
+        },
+        "claims": {
+            "exact_model_presentation_owner_proved": True,
+            "presentation_to_renderer_field_proved": True,
+            "presentation_to_resource_reference_proved": True,
+            "renderer_bind_and_draw_dispatch_proved": True,
+            "concrete_building_or_prop_identity_proved": False,
+            "mesh_or_material_semantics_proved": False,
+        },
+        "safety": {
+            "static_analysis_only": True,
+            "guest_payload_exported": False,
+            "native_admission": False,
+            "suppression_allowed": False,
+            "xenos_authority_required": True,
+        },
+    }
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("generated_root", type=pathlib.Path)
+    parser.add_argument("--image", required=True, type=pathlib.Path)
+    parser.add_argument("--output", required=True, type=pathlib.Path)
+    args = parser.parse_args(argv)
+    try:
+        paths = list(args.generated_root.glob("pinyon_shift_recomp.*.cpp"))
+        if not paths:
+            raise ValueError("no generated AOT C++ files found")
+        document = build(parse_functions(paths), args.image.read_bytes())
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(
+            json.dumps(document, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        return 0
+    except (OSError, UnicodeDecodeError, ValueError) as error:
+        print(f"static-world owner discovery failed: {error}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/tests/test_native_renderer_static_world_owner.py
+++ b/tools/tests/test_native_renderer_static_world_owner.py
@@ -1,0 +1,126 @@
+import copy
+import importlib.util
+import sys
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+TOOL = ROOT / "tools" / "discover-native-renderer-static-world-owner.py"
+SPEC = importlib.util.spec_from_file_location("static_world_owner", TOOL)
+assert SPEC and SPEC.loader
+MODULE = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = MODULE
+SPEC.loader.exec_module(MODULE)
+
+
+def fixture():
+    highest = max(
+        MODULE.PRESENTATION_VTABLE + MODULE.PRESENTATION_SLOT_COUNT * 4,
+        MODULE.RENDERER_VTABLE + 17 * 4,
+    )
+    image = bytearray(highest - MODULE.IMAGE_BASE)
+    presentation_slots = [0x82800000 + index * 4 for index in range(18)]
+    presentation_slots[0] = MODULE.PRESENTATION_DELETING_DESTRUCTOR
+    presentation_slots[12] = MODULE.PRESENTATION_DRAW
+    renderer_slots = [0x82900000 + index * 4 for index in range(17)]
+    renderer_slots[0] = 0x82C4C838
+    renderer_slots[12] = 0x82C4CCC8
+    for base, slots in (
+        (MODULE.PRESENTATION_VTABLE, presentation_slots),
+        (MODULE.RENDERER_VTABLE, renderer_slots),
+    ):
+        for index, target in enumerate(slots):
+            offset = base + index * 4 - MODULE.IMAGE_BASE
+            image[offset : offset + 4] = target.to_bytes(4, "big")
+    functions = {
+        MODULE.PRESENTATION_CONSTRUCTOR: {
+            0x82DE9864: "lis r11,-32220",
+            0x82DE9878: "addi r10,r10,13012",
+            0x82DE9884: "stw r10,0(r31)",
+            0x82DE98E0: "stw r30,144(r31)",
+            0x82DE98E4: "stw r30,148(r31)",
+            0x82DE993C: "stw r30,1608(r31)",
+        },
+        MODULE.PRESENTATION_DESTRUCTOR: {
+            0x82DEA230: "addi r11,r11,13012",
+            0x82DEA238: "stw r11,0(r3)",
+            0x82DEA244: "bl 0x82de9f10",
+            0x82DEA260: "addi r3,r31,148",
+            0x82DEA264: "bl 0x82de7330",
+        },
+        MODULE.PRESENTATION_DELETING_DESTRUCTOR: {
+            0x82DEA524: "bl 0x82dea218",
+            0x82DEA530: "mr r3,r31",
+            0x82DEA534: "bl 0x823fd208",
+        },
+        MODULE.PRESENTATION_PREPARE: {
+            0x823F89A4: "lwz r11,148(r24)",
+            0x823F89A8: "addi r31,r24,148",
+            0x823F8A14: "bl 0x82c4e3a0",
+            0x823F8A18: "stw r3,1608(r24)",
+            0x823F8A28: "lwz r3,1608(r24)",
+            0x823F8A34: "lwz r11,0(r11)",
+            0x823F8A3C: "bctrl",
+            0x823F8A44: "stw r11,144(r24)",
+        },
+        MODULE.PRESENTATION_DRAW: {
+            0x823F8DC4: "mr r31,r3",
+            0x823F8DDC: "bl 0x823f8980",
+            0x823F8E20: "lwz r11,1608(r31)",
+            0x823F8F0C: "lwz r3,1608(r31)",
+            0x823F8F18: "lwz r11,48(r11)",
+            0x823F8F20: "bctrl",
+            MODULE.PRESENTATION_DRAW_EXIT: "addi r1,r1,160",
+        },
+    }
+    return functions, bytes(image)
+
+
+class StaticWorldOwnerTests(unittest.TestCase):
+    def test_proves_exact_presentation_to_renderer_owner(self):
+        functions, image = fixture()
+        document = MODULE.build(functions, image)
+        self.assertEqual("complete", document["status"])
+        self.assertEqual(
+            148, document["presentation"]["resource_reference_offset"]
+        )
+        self.assertEqual(1608, document["presentation"]["renderer_field_offset"])
+        self.assertEqual("82C4CCC8", document["renderer_join"]["draw_target"])
+        self.assertTrue(
+            document["claims"]["exact_model_presentation_owner_proved"]
+        )
+        self.assertFalse(
+            document["claims"]["concrete_building_or_prop_identity_proved"]
+        )
+        self.assertFalse(document["safety"]["native_admission"])
+
+    def test_rejects_presentation_draw_slot_drift(self):
+        functions, image = fixture()
+        corrupted = bytearray(image)
+        offset = MODULE.PRESENTATION_VTABLE + 12 * 4 - MODULE.IMAGE_BASE
+        corrupted[offset : offset + 4] = (0x823F8DBC).to_bytes(4, "big")
+        with self.assertRaisesRegex(ValueError, "draw slot drifted"):
+            MODULE.build(functions, bytes(corrupted))
+
+    def test_rejects_renderer_field_drift(self):
+        functions, image = fixture()
+        corrupted = copy.deepcopy(functions)
+        corrupted[MODULE.PRESENTATION_PREPARE][0x823F8A18] = (
+            "stw r3,1604(r24)"
+        )
+        with self.assertRaisesRegex(ValueError, "823F8A18"):
+            MODULE.build(corrupted, image)
+
+    def test_rejects_unbalanced_exit_drift(self):
+        functions, image = fixture()
+        corrupted = copy.deepcopy(functions)
+        corrupted[MODULE.PRESENTATION_DRAW][MODULE.PRESENTATION_DRAW_EXIT] = (
+            "addi r1,r1,156"
+        )
+        with self.assertRaisesRegex(ValueError, "823F8FA0"):
+            MODULE.build(corrupted, image)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- prove exact CModelPresentation ownership above the SimpleModel resource and renderer
- verify the balanced presentation draw scope and exact renderer bind/draw targets against the retail image
- document the boundary without claiming building/prop or mesh/material semantics

## Tests
- python -m unittest discover -s tools/tests -p test_*.py (549 passed)
- real retail static-owner report generated successfully
- git diff --check