### PR TITLE
feat(native-renderer): trace model presentation ownership

### DIFF
--- a/config/rexglue/analysis/main-xex.toml
+++ b/config/rexglue/analysis/main-xex.toml
@@ -225,6 +225,20 @@ registers = ["r31"]
 address = 0x8240ECAC
 name = "PinyonShiftObserveTrackRenderModelDispatchExit"
 
+# Phase C2 exact model-presentation owner scope. Retail RTTI proves slot 12 of
+# Presentation_Unified::CModelPresentation is 0x823F8DB8 and every path joins
+# at 0x823F8FA0. The nested SimpleModel renderer dispatch is accepted only when
+# the presentation's offset-1608 renderer field equals the dispatch receiver.
+# The offset-148 resource reference is carried as opaque identity only.
+[[midasm_hook]]
+address = 0x823F8DB8
+name = "PinyonShiftObserveStaticWorldPresentationDispatchEntry"
+registers = ["r3"]
+
+[[midasm_hook]]
+address = 0x823F8FA0
+name = "PinyonShiftObserveStaticWorldPresentationDispatchExit"
+
 # Phase C2 exact SimpleModel renderer scope. Retail RTTI proves vtable slot 12
 # resolves to 0x82C4CCC8. Entry r3 is the CSimpleModelRenderer instance and r4
 # is its render context; every path converges at 0x82C4DEA0. The scope attaches

--- a/docs/native-renderer/REPRIORITIZED_PLAN.md
+++ b/docs/native-renderer/REPRIORITIZED_PLAN.md
@@ -359,8 +359,11 @@ prove `Presentation_Unified::CModelPresentation` as the synchronous owner above
 the SimpleModel resource reference and renderer. Its balanced slot-12 scope
 constructs/binds the renderer and invokes the renderer's exact slot-12 draw
 path. The proof is documented in [`STATIC_WORLD_OWNER.md`](STATIC_WORLD_OWNER.md).
-This closes title presentation ownership, not building-versus-prop identity or
-mesh/material semantics; the passive runtime join remains batched with C1/C2.
+The passive runtime scope now carries the exact presentation owner and opaque
+resource identity through the existing renderer/PM4/prepared-draw lineage,
+with an exact offset-1608 renderer equality gate. Runtime qualification remains
+batched with C1/C2. This does not prove building-versus-prop identity or
+mesh/material semantics.
 
 ### C3. Semantic batching, culling, and LOD
 

--- a/docs/native-renderer/STATIC_WORLD_GRAPH.md
+++ b/docs/native-renderer/STATIC_WORLD_GRAPH.md
@@ -54,6 +54,7 @@ python tools/summarize-native-renderer-static-world-runtime-join.py `
   --resource .local/qualification/native-renderer-static-world-resource.json `
   --streaming .local/qualification/native-renderer-static-world-streaming.json `
   --graph .local/qualification/native-renderer-static-world-graph.json `
+  --owner .local/qualification/native-renderer-static-world-owner.json `
   --session <session> `
   --output .local/qualification/native-renderer-static-world-runtime-join.json
 ```

--- a/docs/native-renderer/STATIC_WORLD_INGRESS.md
+++ b/docs/native-renderer/STATIC_WORLD_INGRESS.md
@@ -101,6 +101,7 @@ python tools/summarize-native-renderer-static-world-runtime-join.py `
   --resource .local/qualification/native-renderer-static-world-resource.json `
   --streaming .local/qualification/native-renderer-static-world-streaming.json `
   --graph .local/qualification/native-renderer-static-world-graph.json `
+  --owner .local/qualification/native-renderer-static-world-owner.json `
   --session <session> `
   --output .local/qualification/native-renderer-static-world-runtime-join.json
 ```

--- a/docs/native-renderer/STATIC_WORLD_LIFETIME.md
+++ b/docs/native-renderer/STATIC_WORLD_LIFETIME.md
@@ -68,6 +68,7 @@ python tools/summarize-native-renderer-static-world-runtime-join.py `
   --resource .local/qualification/native-renderer-static-world-resource.json `
   --streaming .local/qualification/native-renderer-static-world-streaming.json `
   --graph .local/qualification/native-renderer-static-world-graph.json `
+  --owner .local/qualification/native-renderer-static-world-owner.json `
   --session <session> `
   --output .local/qualification/native-renderer-static-world-runtime-join.json
 ```

--- a/docs/native-renderer/STATIC_WORLD_OWNER.md
+++ b/docs/native-renderer/STATIC_WORLD_OWNER.md
@@ -1,7 +1,7 @@
 # Static-world model-presentation ownership
 
-Status: exact presentation-to-renderer ownership proved; passive runtime join
-pending the next batched C1/C2 qualification
+Status: exact presentation-to-renderer ownership and passive runtime join
+implemented; runtime qualification pending the next batched C1/C2 run
 
 ## Purpose
 
@@ -26,9 +26,13 @@ Retail RTTI, vtables, and generated AOT instructions prove:
   renderer slot 12, whose exact vtable target is `82C4CCC8`.
 
 This creates a safe synchronous join: an exact SimpleModel renderer dispatch
-occurring inside the balanced presentation slot-12 scope may carry the
-`CModelPresentation` address into existing packet and prepared-draw
-provenance. The runtime join still needs to be implemented and qualified.
+occurring inside the balanced presentation slot-12 scope carries the
+`CModelPresentation` and opaque presentation-resource addresses into existing
+packet and prepared-draw provenance. Runtime also requires the owner's
+offset-1608 renderer field to equal the nested dispatch receiver. Calls on
+other dynamic presentation types that share the implementation are counted as
+excluded vtable mismatches, while exact-owner field mismatches fail closed.
+The join changes no title behavior.
 
 ## Generate the report
 
@@ -46,3 +50,6 @@ an individual instance is a building rather than a prop. Mesh/material field
 semantics and representative streaming transitions also remain open. This
 checkpoint changes no guest data, native admission, publication, or
 suppression; Xenos remains authoritative.
+
+The combined runtime qualifier now also requires this static report through
+`--owner .local/qualification/native-renderer-static-world-owner.json`.

--- a/docs/native-renderer/STATIC_WORLD_RESOURCE.md
+++ b/docs/native-renderer/STATIC_WORLD_RESOURCE.md
@@ -54,6 +54,7 @@ python tools/summarize-native-renderer-static-world-runtime-join.py `
   --resource .local/qualification/native-renderer-static-world-resource.json `
   --streaming .local/qualification/native-renderer-static-world-streaming.json `
   --graph .local/qualification/native-renderer-static-world-graph.json `
+  --owner .local/qualification/native-renderer-static-world-owner.json `
   --session <session> `
   --output .local/qualification/native-renderer-static-world-runtime-join.json
 ```

--- a/docs/native-renderer/STATIC_WORLD_STREAMING.md
+++ b/docs/native-renderer/STATIC_WORLD_STREAMING.md
@@ -54,6 +54,7 @@ python tools/summarize-native-renderer-static-world-runtime-join.py `
   --resource .local/qualification/native-renderer-static-world-resource.json `
   --streaming .local/qualification/native-renderer-static-world-streaming.json `
   --graph .local/qualification/native-renderer-static-world-graph.json `
+  --owner .local/qualification/native-renderer-static-world-owner.json `
   --session <session> `
   --output .local/qualification/native-renderer-static-world-runtime-join.json
 ```

--- a/src/native_renderer/graphics_hooks.cpp
+++ b/src/native_renderer/graphics_hooks.cpp
@@ -181,6 +181,9 @@ constexpr uint32_t kSimpleModelVtable = 0x82229208;
 constexpr uint32_t kSimpleSubModelVtable = 0x822291BC;
 constexpr uint32_t kSimpleMeshVtable = 0x822291A0;
 constexpr uint32_t kSimpleModelResourceModelOffset = 112;
+constexpr uint32_t kModelPresentationVtable = 0x822432D4;
+constexpr uint32_t kModelPresentationResourceOffset = 148;
+constexpr uint32_t kModelPresentationRendererOffset = 1608;
 constexpr uint32_t kTrackModelVtable = 0x820016B4;
 constexpr uint32_t kTrackMeshVtable = 0x8200143C;
 constexpr uint32_t kTrackSubModelVtable = 0x82001474;
@@ -475,6 +478,8 @@ struct SemanticDrawIdentity {
 };
 
 struct StaticWorldDrawIdentity {
+  uint32_t model_presentation_address = 0;
+  uint32_t model_presentation_resource_address = 0;
   uint32_t renderer_address = 0;
   uint32_t renderer_generation = 0;
   uint32_t render_context_address = 0;
@@ -1900,12 +1905,22 @@ struct StaticWorldRendererDispatchScope {
   uint32_t model_graph_generation = 0;
   uint32_t model_resource_generation = 0;
   uint32_t model_resource_payload_generation = 0;
+  uint32_t model_presentation_address = 0;
+  uint32_t model_presentation_resource_address = 0;
   uint64_t member_packet_origins = 0;
   uint32_t simple_model_address = 0;
   uint32_t simple_submodel_address = 0;
   uint32_t simple_mesh_address = 0;
   bool member_active = false;
   bool member_exact = false;
+  bool active = false;
+  bool exact = false;
+};
+
+struct StaticWorldPresentationDispatchScope {
+  uint64_t renderer_dispatch_joins = 0;
+  uint32_t presentation_address = 0;
+  uint32_t resource_address = 0;
   bool active = false;
   bool exact = false;
 };
@@ -2129,6 +2144,18 @@ std::atomic<uint64_t> g_static_world_member_draws_with_packets{};
 std::atomic<uint64_t> g_static_world_member_draws_without_packets{};
 std::atomic<uint64_t> g_static_world_member_packets_recorded{};
 std::atomic<uint64_t> g_static_world_member_packet_mismatches{};
+std::atomic<uint64_t> g_static_world_presentation_entries{};
+std::atomic<uint64_t> g_static_world_presentation_exits{};
+std::atomic<uint64_t> g_static_world_presentation_exact{};
+std::atomic<uint64_t> g_static_world_presentation_invalid_root{};
+std::atomic<uint64_t> g_static_world_presentation_vtable_mismatches{};
+std::atomic<uint64_t> g_static_world_presentation_resource_read_faults{};
+std::atomic<uint64_t> g_static_world_presentation_overlaps{};
+std::atomic<uint64_t> g_static_world_presentation_exit_without_entry{};
+std::atomic<uint64_t> g_static_world_presentation_scopes_with_renderer{};
+std::atomic<uint64_t> g_static_world_presentation_scopes_without_renderer{};
+std::atomic<uint64_t> g_static_world_presentation_renderer_joins{};
+std::atomic<uint64_t> g_static_world_presentation_renderer_mismatches{};
 std::array<SemanticBindingCacheSlot, 5> g_semantic_binding_cache_slots{};
 std::array<SemanticResolverCacheSlot, 5> g_semantic_resolver_cache_slots{};
 thread_local PendingSemanticResourceBindings g_pending_semantic_bindings{};
@@ -2141,6 +2168,8 @@ thread_local size_t g_semantic_render_item_stack_depth = 0;
 thread_local size_t g_semantic_render_item_stack_overflow_depth = 0;
 thread_local TrackRenderModelDispatchScope g_track_render_model_scope{};
 thread_local StaticWorldRendererDispatchScope g_static_world_renderer_scope{};
+thread_local StaticWorldPresentationDispatchScope
+    g_static_world_presentation_scope{};
 thread_local std::array<uint32_t, kSemanticReceiverStackCapacity>
     g_static_world_renderer_destructor_stack{};
 thread_local size_t g_static_world_renderer_destructor_stack_depth = 0;
@@ -3466,6 +3495,57 @@ void ObserveStaticWorldRendererGraphRelease(uint32_t renderer_address) {
       1, std::memory_order_relaxed);
 }
 
+void BeginStaticWorldPresentationDispatch(uint32_t presentation_address) {
+  ++g_static_world_presentation_entries;
+  if (g_static_world_presentation_scope.active) {
+    ++g_static_world_presentation_overlaps;
+    g_static_world_presentation_scope = {};
+  }
+  StaticWorldPresentationDispatchScope &scope =
+      g_static_world_presentation_scope;
+  scope.active = true;
+  scope.presentation_address = presentation_address;
+  rex::memory::Memory *memory =
+      g_title_provenance_memory.load(std::memory_order_acquire);
+  uint32_t vtable = 0;
+  if (!g_title_provenance_installed.load(std::memory_order_acquire) ||
+      !LoadMappedGuestU32(memory, presentation_address, vtable)) {
+    ++g_static_world_presentation_invalid_root;
+    return;
+  }
+  if (vtable != kModelPresentationVtable) {
+    ++g_static_world_presentation_vtable_mismatches;
+    return;
+  }
+  if (presentation_address >
+          UINT32_MAX - kModelPresentationResourceOffset ||
+      !LoadMappedGuestU32(
+          memory, presentation_address + kModelPresentationResourceOffset,
+          scope.resource_address)) {
+    ++g_static_world_presentation_resource_read_faults;
+    return;
+  }
+  scope.exact = true;
+  ++g_static_world_presentation_exact;
+}
+
+void EndStaticWorldPresentationDispatch() {
+  ++g_static_world_presentation_exits;
+  StaticWorldPresentationDispatchScope &scope =
+      g_static_world_presentation_scope;
+  if (!scope.active) {
+    ++g_static_world_presentation_exit_without_entry;
+    return;
+  }
+  if (scope.exact) {
+    (scope.renderer_dispatch_joins
+         ? g_static_world_presentation_scopes_with_renderer
+         : g_static_world_presentation_scopes_without_renderer)
+        .fetch_add(1, std::memory_order_relaxed);
+  }
+  scope = {};
+}
+
 void BeginStaticWorldRendererDispatch(uint32_t renderer_address,
                                       uint32_t render_context_address) {
   ++g_static_world_scope_entries;
@@ -3547,6 +3627,28 @@ void BeginStaticWorldRendererDispatch(uint32_t renderer_address,
       lifecycle->model_graph_generation.load(std::memory_order_relaxed);
   scope.model_resource_generation = resource_generation;
   scope.model_resource_payload_generation = resource_payload_generation;
+  StaticWorldPresentationDispatchScope &presentation_scope =
+      g_static_world_presentation_scope;
+  if (presentation_scope.active && presentation_scope.exact) {
+    uint32_t owned_renderer = 0;
+    if (presentation_scope.presentation_address <=
+            UINT32_MAX - kModelPresentationRendererOffset &&
+        LoadMappedGuestU32(
+            memory,
+            presentation_scope.presentation_address +
+                kModelPresentationRendererOffset,
+            owned_renderer) &&
+        owned_renderer == renderer_address) {
+      scope.model_presentation_address =
+          presentation_scope.presentation_address;
+      scope.model_presentation_resource_address =
+          presentation_scope.resource_address;
+      ++presentation_scope.renderer_dispatch_joins;
+      ++g_static_world_presentation_renderer_joins;
+    } else {
+      ++g_static_world_presentation_renderer_mismatches;
+    }
+  }
   scope.exact = true;
   lifecycle->dispatches.fetch_add(1, std::memory_order_relaxed);
   ++g_static_world_scope_exact;
@@ -5016,6 +5118,18 @@ void ResetTitleDrawProvenance() {
            &g_static_world_member_draws_without_packets,
            &g_static_world_member_packets_recorded,
            &g_static_world_member_packet_mismatches,
+           &g_static_world_presentation_entries,
+           &g_static_world_presentation_exits,
+           &g_static_world_presentation_exact,
+           &g_static_world_presentation_invalid_root,
+           &g_static_world_presentation_vtable_mismatches,
+           &g_static_world_presentation_resource_read_faults,
+           &g_static_world_presentation_overlaps,
+           &g_static_world_presentation_exit_without_entry,
+           &g_static_world_presentation_scopes_with_renderer,
+           &g_static_world_presentation_scopes_without_renderer,
+           &g_static_world_presentation_renderer_joins,
+           &g_static_world_presentation_renderer_mismatches,
        }) {
     counter->store(0, std::memory_order_relaxed);
   }
@@ -5245,6 +5359,7 @@ void ResetTitleDrawProvenance() {
   g_semantic_receiver_destructor_stack_depth = 0;
   g_semantic_receiver_destructor_overflow_depth = 0;
   g_static_world_renderer_scope = {};
+  g_static_world_presentation_scope = {};
   g_static_world_renderer_destructor_stack = {};
   g_static_world_renderer_destructor_stack_depth = 0;
   g_static_world_renderer_destructor_overflow_depth = 0;
@@ -5504,6 +5619,9 @@ void RecordProceduralModelSemanticDrawPacket(
     const StaticWorldRendererDispatchScope &scope =
         g_static_world_renderer_scope;
     origin.static_world_draw = {
+        .model_presentation_address = scope.model_presentation_address,
+        .model_presentation_resource_address =
+            scope.model_presentation_resource_address,
         .renderer_address = scope.renderer_address,
         .renderer_generation = scope.renderer_generation,
         .render_context_address = scope.render_context_address,
@@ -10989,6 +11107,21 @@ void EmitStaticWorldRuntimeJoinEvent(const char *event_name,
   const uint64_t member_packets_recorded =
       g_static_world_member_packets_recorded.load(
           std::memory_order_relaxed);
+  const uint64_t presentation_entries =
+      g_static_world_presentation_entries.load(std::memory_order_relaxed);
+  const uint64_t presentation_exits =
+      g_static_world_presentation_exits.load(std::memory_order_relaxed);
+  const uint64_t presentation_exact =
+      g_static_world_presentation_exact.load(std::memory_order_relaxed);
+  const uint64_t presentation_scopes_with_renderer =
+      g_static_world_presentation_scopes_with_renderer.load(
+          std::memory_order_relaxed);
+  const uint64_t presentation_scopes_without_renderer =
+      g_static_world_presentation_scopes_without_renderer.load(
+          std::memory_order_relaxed);
+  const uint64_t presentation_renderer_joins =
+      g_static_world_presentation_renderer_joins.load(
+          std::memory_order_relaxed);
   const bool accounting_complete =
       entries == exact + invalid_root + vtable_mismatches +
                            invalid_graph_field + unregistered_renderers +
@@ -11058,6 +11191,19 @@ void EmitStaticWorldRuntimeJoinEvent(const char *event_name,
       member_exact ==
           member_draws_with_packets + member_draws_without_packets &&
       member_packets_recorded == packets_recorded &&
+      presentation_entries ==
+          presentation_exact +
+              g_static_world_presentation_invalid_root.load(
+                  std::memory_order_relaxed) +
+              g_static_world_presentation_vtable_mismatches.load(
+                  std::memory_order_relaxed) +
+              g_static_world_presentation_resource_read_faults.load(
+                  std::memory_order_relaxed) &&
+      presentation_entries == presentation_exits &&
+      presentation_exact ==
+          presentation_scopes_with_renderer +
+              presentation_scopes_without_renderer &&
+      presentation_scopes_with_renderer <= presentation_renderer_joins &&
       !overlaps && !exit_without_entry;
   const bool qualification_complete =
       accounting_complete && exact && packets_recorded && packet_matches &&
@@ -11111,6 +11257,18 @@ void EmitStaticWorldRuntimeJoinEvent(const char *event_name,
       !g_static_world_member_exit_without_entry.load(
           std::memory_order_relaxed) &&
       !g_static_world_member_packet_mismatches.load(
+          std::memory_order_relaxed) &&
+      presentation_exact && presentation_renderer_joins &&
+      presentation_scopes_with_renderer &&
+      !g_static_world_presentation_invalid_root.load(
+          std::memory_order_relaxed) &&
+      !g_static_world_presentation_resource_read_faults.load(
+          std::memory_order_relaxed) &&
+      !g_static_world_presentation_overlaps.load(
+          std::memory_order_relaxed) &&
+      !g_static_world_presentation_exit_without_entry.load(
+          std::memory_order_relaxed) &&
+      !g_static_world_presentation_renderer_mismatches.load(
           std::memory_order_relaxed);
   const uint64_t pending_packets =
       packets_recorded >= packet_matches ? packets_recorded - packet_matches
@@ -11296,11 +11454,42 @@ void EmitStaticWorldRuntimeJoinEvent(const char *event_name,
        {"member_packet_mismatches",
         std::to_string(g_static_world_member_packet_mismatches.load(
             std::memory_order_relaxed))},
+       {"presentation_entries", std::to_string(presentation_entries)},
+       {"presentation_exits", std::to_string(presentation_exits)},
+       {"presentation_exact", std::to_string(presentation_exact)},
+       {"presentation_invalid_root",
+        std::to_string(g_static_world_presentation_invalid_root.load(
+            std::memory_order_relaxed))},
+       {"presentation_vtable_mismatches",
+        std::to_string(
+            g_static_world_presentation_vtable_mismatches.load(
+                std::memory_order_relaxed))},
+       {"presentation_resource_read_faults",
+        std::to_string(
+            g_static_world_presentation_resource_read_faults.load(
+                std::memory_order_relaxed))},
+       {"presentation_overlaps",
+        std::to_string(g_static_world_presentation_overlaps.load(
+            std::memory_order_relaxed))},
+       {"presentation_exit_without_entry",
+        std::to_string(
+            g_static_world_presentation_exit_without_entry.load(
+                std::memory_order_relaxed))},
+       {"presentation_scopes_with_renderer",
+        std::to_string(presentation_scopes_with_renderer)},
+       {"presentation_scopes_without_renderer",
+        std::to_string(presentation_scopes_without_renderer)},
+       {"presentation_renderer_joins",
+        std::to_string(presentation_renderer_joins)},
+       {"presentation_renderer_mismatches",
+        std::to_string(
+            g_static_world_presentation_renderer_mismatches.load(
+                std::memory_order_relaxed))},
        {"accounting_complete", accounting_complete ? "true" : "false"},
        {"qualification_complete",
         qualification_complete ? "true" : "false"},
        {"classification",
-        "live_simple_model_mesh_payload_generation_to_prepared_draw"},
+        "live_model_presentation_simple_model_mesh_to_prepared_draw"},
        {"guest_state_changed", "false"},
        {"control_flow_changed", "false"},
        {"native_admission", "false"},
@@ -13993,6 +14182,10 @@ void RecordTitleDrawProvenance(
                  (uint64_t(backend_outcome) << 41) ^
                  (prepared ? uint64_t(1) << 63 : 0);
   key = HashCombine(key, origin.semantic_draw.submission_key);
+  key = HashCombine(
+      key, origin.static_world_draw.model_presentation_address);
+  key = HashCombine(
+      key, origin.static_world_draw.model_presentation_resource_address);
   key = HashCombine(key, origin.static_world_draw.renderer_address);
   key = HashCombine(key, origin.static_world_draw.renderer_generation);
   key = HashCombine(key, origin.static_world_draw.render_context_address);
@@ -14044,6 +14237,10 @@ void RecordTitleDrawProvenance(
             origin.semantic_draw.record_index &&
         entry.origin.static_world_draw.renderer_address ==
             origin.static_world_draw.renderer_address &&
+        entry.origin.static_world_draw.model_presentation_address ==
+            origin.static_world_draw.model_presentation_address &&
+        entry.origin.static_world_draw.model_presentation_resource_address ==
+            origin.static_world_draw.model_presentation_resource_address &&
         entry.origin.static_world_draw.renderer_generation ==
             origin.static_world_draw.renderer_generation &&
         entry.origin.static_world_draw.render_context_address ==
@@ -14142,6 +14339,19 @@ void EmitTitleDrawProvenanceSummary() {
          {"origin_caller", fmt::format("{:08X}", entry.origin.caller)},
          {"static_world_origin",
           entry.origin.static_world_draw.valid ? "true" : "false"},
+         {"static_world_model_presentation",
+          entry.origin.static_world_draw.valid &&
+                  entry.origin.static_world_draw.model_presentation_address
+              ? fmt::format("{:08X}", entry.origin.static_world_draw
+                                           .model_presentation_address)
+              : ""},
+         {"static_world_model_presentation_resource",
+          entry.origin.static_world_draw.valid &&
+                  entry.origin.static_world_draw
+                      .model_presentation_resource_address
+              ? fmt::format("{:08X}", entry.origin.static_world_draw
+                                           .model_presentation_resource_address)
+              : ""},
          {"static_world_renderer",
           entry.origin.static_world_draw.valid
               ? fmt::format("{:08X}",
@@ -22670,10 +22880,16 @@ void InstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system,
        {"simple_submodel_vtable", "822291BC"},
        {"simple_mesh_vtable", "822291A0"},
        {"simple_member_draw_hooks", "82C4DC54,82C4DC58"},
+       {"presentation_class", "Presentation_Unified::CModelPresentation"},
+       {"presentation_vtable", "822432D4"},
+       {"presentation_draw_slot", "12"},
+       {"presentation_draw_hooks", "823F8DB8,823F8FA0"},
+       {"presentation_resource_field", "presentation_plus_148"},
+       {"presentation_renderer_field", "presentation_plus_1608"},
        {"draw_emitter", "82416380"},
        {"packet_hooks", "82416260,824162F4"},
        {"join", "synchronous_scope_to_physical_pm4_prepared_draw"},
-       {"guest_payload_read", "two_host_mapped_u32_fields_per_scope"},
+       {"guest_payload_read", "bounded_host_mapped_identity_fields"},
        {"guest_state_changed", "false"},
        {"control_flow_changed", "false"},
        {"native_admission", "false"},
@@ -23903,8 +24119,17 @@ void PinyonShiftObserveTrackRenderModelDispatchExit() {
 }
 
 void PinyonShiftObserveStaticWorldRendererDispatchEntry(PPCRegister &r3,
-                                                        PPCRegister &r4) {
+                                                         PPCRegister &r4) {
   BeginStaticWorldRendererDispatch(r3.u32, r4.u32);
+}
+
+void PinyonShiftObserveStaticWorldPresentationDispatchEntry(
+    PPCRegister &r3) {
+  BeginStaticWorldPresentationDispatch(r3.u32);
+}
+
+void PinyonShiftObserveStaticWorldPresentationDispatchExit() {
+  EndStaticWorldPresentationDispatch();
 }
 
 void PinyonShiftObserveStaticWorldRendererDispatchExit() {

--- a/tools/summarize-native-renderer-static-world-runtime-join.py
+++ b/tools/summarize-native-renderer-static-world-runtime-join.py
@@ -9,12 +9,13 @@ import pathlib
 import sys
 
 
-SCHEMA = "pinyon-shift.native-renderer-static-world-runtime-join.v5"
+SCHEMA = "pinyon-shift.native-renderer-static-world-runtime-join.v6"
 STATIC_SCHEMA = "pinyon-shift.native-renderer-static-world-ingress.v2"
 LIFETIME_SCHEMA = "pinyon-shift.native-renderer-static-world-lifetime.v1"
 RESOURCE_SCHEMA = "pinyon-shift.native-renderer-static-world-resource.v1"
 STREAMING_SCHEMA = "pinyon-shift.native-renderer-static-world-streaming.v1"
 GRAPH_SCHEMA = "pinyon-shift.native-renderer-static-world-graph.v1"
+OWNER_SCHEMA = "pinyon-shift.native-renderer-static-world-owner.v1"
 CONFIG = "native_renderer.discovery.static_world_runtime_join_config"
 SUMMARY = "native_renderer.discovery.static_world_runtime_join_summary"
 CHECKPOINT = "native_renderer.discovery.static_world_runtime_join_checkpoint"
@@ -342,12 +343,73 @@ def validate_static_graph(document):
         raise ValueError("static-world graph claims drifted")
 
 
+def validate_static_owner(document):
+    if (
+        document.get("schema") != OWNER_SCHEMA
+        or document.get("status") != "complete"
+        or document.get("classification")
+        != "exact_model_presentation_to_simple_model_renderer_owner"
+    ):
+        raise ValueError("static-world owner proof drifted")
+    try:
+        presentation = document["presentation"]
+        renderer_join = document["renderer_join"]
+        claims = document["claims"]
+    except (KeyError, TypeError) as error:
+        raise ValueError("static-world owner proof is incomplete") from error
+    expected_presentation = {
+        "class": "Presentation_Unified::CModelPresentation",
+        "vtable": "822432D4",
+        "constructor": "82DE9840",
+        "destructor": "82DEA218",
+        "deleting_destructor_slot": 0,
+        "deleting_destructor": "82DEA508",
+        "draw_slot": 12,
+        "draw_method": "823F8DB8",
+        "draw_entry_hook": "823F8DB8",
+        "draw_exit_hook": "823F8FA0",
+        "state_field_offset": 144,
+        "resource_reference_offset": 148,
+        "renderer_field_offset": 1608,
+    }
+    expected_join = {
+        "prepare_helper": "823F8980",
+        "constructor_wrapper": "82C4E3A0",
+        "renderer_vtable": "82001B64",
+        "bind_slot": 0,
+        "bind_target": "82C4C838",
+        "draw_slot": 12,
+        "draw_target": "82C4CCC8",
+        "join_kind": "balanced_synchronous_presentation_draw_scope",
+    }
+    if any(
+        presentation.get(key) != value
+        for key, value in expected_presentation.items()
+    ):
+        raise ValueError("static-world presentation proof drifted")
+    if any(
+        renderer_join.get(key) != value
+        for key, value in expected_join.items()
+    ):
+        raise ValueError("static-world presentation renderer join drifted")
+    if (
+        claims.get("exact_model_presentation_owner_proved") is not True
+        or claims.get("presentation_to_renderer_field_proved") is not True
+        or claims.get("presentation_to_resource_reference_proved") is not True
+        or claims.get("renderer_bind_and_draw_dispatch_proved") is not True
+        or claims.get("concrete_building_or_prop_identity_proved") is not False
+        or claims.get("mesh_or_material_semantics_proved") is not False
+    ):
+        raise ValueError("static-world owner claims drifted")
+
+
 def build(
     static_ingress,
     static_lifetime,
     static_resource,
     static_streaming,
     static_graph,
+    static_owner,
     events,
     requested_session=None,
     allow_checkpoint=False,
@@ -357,6 +419,7 @@ def build(
     validate_static_resource(static_resource)
     validate_static_streaming(static_streaming)
     validate_static_graph(static_graph)
+    validate_static_owner(static_owner)
     session = select_session(events, requested_session)
     selected = [event for event in events if event.get("session") == session]
     config = exact_event(selected, CONFIG)
@@ -403,10 +466,16 @@ def build(
         "simple_submodel_vtable": "822291BC",
         "simple_mesh_vtable": "822291A0",
         "simple_member_draw_hooks": "82C4DC54,82C4DC58",
+        "presentation_class": "Presentation_Unified::CModelPresentation",
+        "presentation_vtable": "822432D4",
+        "presentation_draw_slot": "12",
+        "presentation_draw_hooks": "823F8DB8,823F8FA0",
+        "presentation_resource_field": "presentation_plus_148",
+        "presentation_renderer_field": "presentation_plus_1608",
         "draw_emitter": "82416380",
         "packet_hooks": "82416260,824162F4",
         "join": "synchronous_scope_to_physical_pm4_prepared_draw",
-        "guest_payload_read": "two_host_mapped_u32_fields_per_scope",
+        "guest_payload_read": "bounded_host_mapped_identity_fields",
     }
     if any(config.get(key) != value for key, value in expected_config.items()):
         raise ValueError("static-world runtime configuration drifted")
@@ -426,7 +495,7 @@ def build(
         or summary.get("checkpoint_kind")
         != ("final" if final_summary else "periodic")
         or summary.get("classification")
-        != "live_simple_model_mesh_payload_generation_to_prepared_draw"
+        != "live_model_presentation_simple_model_mesh_to_prepared_draw"
     ):
         raise ValueError("static-world runtime summary drifted")
 
@@ -519,6 +588,18 @@ def build(
         "member_draws_without_packets",
         "member_packets_recorded",
         "member_packet_mismatches",
+        "presentation_entries",
+        "presentation_exits",
+        "presentation_exact",
+        "presentation_invalid_root",
+        "presentation_vtable_mismatches",
+        "presentation_resource_read_faults",
+        "presentation_overlaps",
+        "presentation_exit_without_entry",
+        "presentation_scopes_with_renderer",
+        "presentation_scopes_without_renderer",
+        "presentation_renderer_joins",
+        "presentation_renderer_mismatches",
     )
     totals = {key: integer(summary, key) for key in keys}
     frame_sequence = integer(summary, "frame_sequence")
@@ -670,6 +751,29 @@ def build(
         failures.append("static-world member draw outcome accounting drifted")
     if totals["member_packets_recorded"] != totals["packets_recorded"]:
         failures.append("static-world member packet join accounting drifted")
+    presentation_classified = (
+        totals["presentation_exact"]
+        + totals["presentation_invalid_root"]
+        + totals["presentation_vtable_mismatches"]
+        + totals["presentation_resource_read_faults"]
+    )
+    if totals["presentation_entries"] != presentation_classified:
+        failures.append("static-world presentation classification drifted")
+    if totals["presentation_entries"] != totals["presentation_exits"]:
+        failures.append("static-world presentation entry/exit accounting drifted")
+    if totals["presentation_exact"] != (
+        totals["presentation_scopes_with_renderer"]
+        + totals["presentation_scopes_without_renderer"]
+    ):
+        failures.append("static-world presentation outcome accounting drifted")
+    if totals["presentation_scopes_with_renderer"] > totals[
+        "presentation_renderer_joins"
+    ]:
+        failures.append("static-world presentation renderer join drifted")
+    if not totals["presentation_exact"]:
+        failures.append("no exact CModelPresentation scope was observed")
+    if not totals["presentation_renderer_joins"]:
+        failures.append("no CModelPresentation joined its SimpleModel renderer")
     if not totals["prepared_matches"]:
         failures.append("no static-world PM4 packet joined a prepared draw")
     for key in (
@@ -714,6 +818,11 @@ def build(
         "member_exit_without_entry",
         "member_draws_without_packets",
         "member_packet_mismatches",
+        "presentation_invalid_root",
+        "presentation_resource_read_faults",
+        "presentation_overlaps",
+        "presentation_exit_without_entry",
+        "presentation_renderer_mismatches",
     ):
         if totals[key]:
             failures.append(f"{key} is nonzero")
@@ -754,6 +863,8 @@ def build(
             "simple_model_to_submodel_proved": not failures,
             "simple_submodel_to_mesh_proved": not failures,
             "simple_mesh_to_prepared_draw_proved": not failures,
+            "model_presentation_owner_proved": not failures,
+            "model_presentation_to_renderer_proved": not failures,
             "static_world_scope_to_pm4_proved": not failures,
             "static_world_pm4_to_prepared_draw_proved": not failures,
             "building_or_prop_instance_identity_proved": False,
@@ -781,6 +892,7 @@ def main(argv=None):
     parser.add_argument("--resource", required=True, type=pathlib.Path)
     parser.add_argument("--streaming", required=True, type=pathlib.Path)
     parser.add_argument("--graph", required=True, type=pathlib.Path)
+    parser.add_argument("--owner", required=True, type=pathlib.Path)
     parser.add_argument("--session")
     parser.add_argument("--allow-checkpoint", action="store_true")
     parser.add_argument("--output", required=True, type=pathlib.Path)
@@ -792,6 +904,7 @@ def main(argv=None):
             json.loads(args.resource.read_text(encoding="utf-8")),
             json.loads(args.streaming.read_text(encoding="utf-8")),
             json.loads(args.graph.read_text(encoding="utf-8")),
+            json.loads(args.owner.read_text(encoding="utf-8")),
             read_events(args.events),
             args.session,
             args.allow_checkpoint,

--- a/tools/tests/test_native_renderer_static_world_runtime_join.py
+++ b/tools/tests/test_native_renderer_static_world_runtime_join.py
@@ -216,6 +216,49 @@ def static_graph():
     }
 
 
+def static_owner():
+    return {
+        "schema": MODULE.OWNER_SCHEMA,
+        "status": "complete",
+        "classification": (
+            "exact_model_presentation_to_simple_model_renderer_owner"
+        ),
+        "presentation": {
+            "class": "Presentation_Unified::CModelPresentation",
+            "vtable": "822432D4",
+            "constructor": "82DE9840",
+            "destructor": "82DEA218",
+            "deleting_destructor_slot": 0,
+            "deleting_destructor": "82DEA508",
+            "draw_slot": 12,
+            "draw_method": "823F8DB8",
+            "draw_entry_hook": "823F8DB8",
+            "draw_exit_hook": "823F8FA0",
+            "state_field_offset": 144,
+            "resource_reference_offset": 148,
+            "renderer_field_offset": 1608,
+        },
+        "renderer_join": {
+            "prepare_helper": "823F8980",
+            "constructor_wrapper": "82C4E3A0",
+            "renderer_vtable": "82001B64",
+            "bind_slot": 0,
+            "bind_target": "82C4C838",
+            "draw_slot": 12,
+            "draw_target": "82C4CCC8",
+            "join_kind": "balanced_synchronous_presentation_draw_scope",
+        },
+        "claims": {
+            "exact_model_presentation_owner_proved": True,
+            "presentation_to_renderer_field_proved": True,
+            "presentation_to_resource_reference_proved": True,
+            "renderer_bind_and_draw_dispatch_proved": True,
+            "concrete_building_or_prop_identity_proved": False,
+            "mesh_or_material_semantics_proved": False,
+        },
+    }
+
+
 def fixture():
     config = event(
         MODULE.CONFIG,
@@ -259,10 +302,16 @@ def fixture():
             "simple_submodel_vtable": "822291BC",
             "simple_mesh_vtable": "822291A0",
             "simple_member_draw_hooks": "82C4DC54,82C4DC58",
+            "presentation_class": "Presentation_Unified::CModelPresentation",
+            "presentation_vtable": "822432D4",
+            "presentation_draw_slot": "12",
+            "presentation_draw_hooks": "823F8DB8,823F8FA0",
+            "presentation_resource_field": "presentation_plus_148",
+            "presentation_renderer_field": "presentation_plus_1608",
             "draw_emitter": "82416380",
             "packet_hooks": "82416260,824162F4",
             "join": "synchronous_scope_to_physical_pm4_prepared_draw",
-            "guest_payload_read": "two_host_mapped_u32_fields_per_scope",
+            "guest_payload_read": "bounded_host_mapped_identity_fields",
             **safety(),
         },
     )
@@ -359,10 +408,22 @@ def fixture():
         member_draws_without_packets="0",
         member_packets_recorded="100",
         member_packet_mismatches="0",
+        presentation_entries="12",
+        presentation_exits="12",
+        presentation_exact="12",
+        presentation_invalid_root="0",
+        presentation_vtable_mismatches="0",
+        presentation_resource_read_faults="0",
+        presentation_overlaps="0",
+        presentation_exit_without_entry="0",
+        presentation_scopes_with_renderer="8",
+        presentation_scopes_without_renderer="4",
+        presentation_renderer_joins="8",
+        presentation_renderer_mismatches="0",
         accounting_complete="true",
         qualification_complete="true",
         classification=(
-            "live_simple_model_mesh_payload_generation_to_prepared_draw"
+            "live_model_presentation_simple_model_mesh_to_prepared_draw"
         ),
         **safety(),
     )
@@ -377,6 +438,7 @@ class StaticWorldRuntimeJoinTests(unittest.TestCase):
             static_resource(),
             static_streaming(),
             static_graph(),
+            static_owner(),
             fixture(),
         )
         self.assertEqual("complete", document["status"])
@@ -391,6 +453,9 @@ class StaticWorldRuntimeJoinTests(unittest.TestCase):
         )
         self.assertTrue(
             document["qualification"]["simple_mesh_to_prepared_draw_proved"]
+        )
+        self.assertTrue(
+            document["qualification"]["model_presentation_owner_proved"]
         )
         self.assertFalse(
             document["qualification"]["building_or_prop_instance_identity_proved"]
@@ -411,6 +476,7 @@ class StaticWorldRuntimeJoinTests(unittest.TestCase):
             static_resource(),
             static_streaming(),
             static_graph(),
+            static_owner(),
             events + [checkpoint],
             allow_checkpoint=True,
         )
@@ -432,6 +498,7 @@ class StaticWorldRuntimeJoinTests(unittest.TestCase):
             static_resource(),
             static_streaming(),
             static_graph(),
+            static_owner(),
             events,
         )
         self.assertEqual("incomplete", document["status"])
@@ -451,6 +518,7 @@ class StaticWorldRuntimeJoinTests(unittest.TestCase):
             static_resource(),
             static_streaming(),
             static_graph(),
+            static_owner(),
             events,
         )
         self.assertEqual("incomplete", document["status"])
@@ -471,6 +539,7 @@ class StaticWorldRuntimeJoinTests(unittest.TestCase):
                 static_resource(),
                 static_streaming(),
                 static_graph(),
+                static_owner(),
                 fixture(),
             )
 
@@ -490,6 +559,7 @@ class StaticWorldRuntimeJoinTests(unittest.TestCase):
             static_resource(),
             static_streaming(),
             static_graph(),
+            static_owner(),
             events,
         )
         self.assertEqual("incomplete", document["status"])
@@ -511,6 +581,7 @@ class StaticWorldRuntimeJoinTests(unittest.TestCase):
             static_resource(),
             static_streaming(),
             static_graph(),
+            static_owner(),
             events,
         )
         self.assertEqual("incomplete", document["status"])
@@ -533,6 +604,7 @@ class StaticWorldRuntimeJoinTests(unittest.TestCase):
             static_resource(),
             static_streaming(),
             static_graph(),
+            static_owner(),
             events,
         )
         self.assertEqual("incomplete", document["status"])
@@ -557,11 +629,34 @@ class StaticWorldRuntimeJoinTests(unittest.TestCase):
             static_resource(),
             static_streaming(),
             static_graph(),
+            static_owner(),
             events,
         )
         self.assertEqual("incomplete", document["status"])
         self.assertIn(
             "resource_transition_completion_faults is nonzero",
+            document["failures"],
+        )
+
+    def test_rejects_presentation_renderer_mismatch(self):
+        events = copy.deepcopy(fixture())
+        events[-1].update(
+            status="incomplete",
+            presentation_renderer_mismatches="1",
+            qualification_complete="false",
+        )
+        document = MODULE.build(
+            static_ingress(),
+            static_lifetime(),
+            static_resource(),
+            static_streaming(),
+            static_graph(),
+            static_owner(),
+            events,
+        )
+        self.assertEqual("incomplete", document["status"])
+        self.assertIn(
+            "presentation_renderer_mismatches is nonzero",
             document["failures"],
         )
 
@@ -575,6 +670,8 @@ class StaticWorldRuntimeJoinTests(unittest.TestCase):
         self.assertIn("kSimpleModelRendererVtable = 0x82001B64", hooks)
         self.assertIn("BeginStaticWorldRendererDispatch", hooks)
         self.assertIn("EndStaticWorldRendererDispatch", hooks)
+        self.assertIn("BeginStaticWorldPresentationDispatch", hooks)
+        self.assertIn("EndStaticWorldPresentationDispatch", hooks)
         self.assertIn("static_world_draw", hooks)
         self.assertIn("address = 0x82C4CCC8", analysis)
         self.assertIn("address = 0x82C4DEA0", analysis)
@@ -594,6 +691,8 @@ class StaticWorldRuntimeJoinTests(unittest.TestCase):
         self.assertIn("address = 0x82C2231C", analysis)
         self.assertIn("address = 0x82C4DC54", analysis)
         self.assertIn("address = 0x82C4DC58", analysis)
+        self.assertIn("address = 0x823F8DB8", analysis)
+        self.assertIn("address = 0x823F8FA0", analysis)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- bracket exact CModelPresentation slot-12 dispatch and join its offset-1608 renderer
- carry presentation owner and opaque resource identity through PM4 and prepared-draw provenance
- extend the combined C1/C2 qualifier while excluding shared derived-type calls

## Tests
- 550 Python tests passed
- real retail static-owner report regenerated successfully
- generated presentation hooks compiled
- graphics_hooks.cpp compiled
- final executable link reached the known permission-denied lock from the preserved AppData process