### PR TITLE
feat(native-renderer): prove presentation resource identity

### DIFF
--- a/config/rexglue/analysis/main-xex.toml
+++ b/config/rexglue/analysis/main-xex.toml
@@ -228,8 +228,8 @@ name = "PinyonShiftObserveTrackRenderModelDispatchExit"
 # Phase C2 exact model-presentation owner scope. Retail RTTI proves slot 12 of
 # Presentation_Unified::CModelPresentation is 0x823F8DB8 and every path joins
 # at 0x823F8FA0. The nested SimpleModel renderer dispatch is accepted only when
-# the presentation's offset-1608 renderer field equals the dispatch receiver.
-# The offset-148 resource reference is carried as opaque identity only.
+# the presentation's offset-1608 renderer field equals the dispatch receiver
+# and its exact offset-148 CSimpleModelResource equals renderer offset 72.
 [[midasm_hook]]
 address = 0x823F8DB8
 name = "PinyonShiftObserveStaticWorldPresentationDispatchEntry"

--- a/docs/native-renderer/REPRIORITIZED_PLAN.md
+++ b/docs/native-renderer/REPRIORITIZED_PLAN.md
@@ -365,6 +365,17 @@ with an exact offset-1608 renderer equality gate. Runtime qualification remains
 batched with C1/C2. This does not prove building-versus-prop identity or
 mesh/material semantics.
 
+Presentation-type checkpoint: a complete retail RTTI hierarchy census finds
+only generic `CModelPresentation` and its thread-safe reference-count wrapper;
+there is no building- or prop-specific derived presentation class. Slot 7 and
+the renderer bind helpers now also prove that presentation offset 148 and
+renderer offset 72 hold the same exact `CSimpleModelResource`. Runtime lineage
+requires that address equation before attribution. The locked census is
+documented in
+[`STATIC_WORLD_PRESENTATION_TYPES.md`](STATIC_WORLD_PRESENTATION_TYPES.md).
+The next semantic lead is bounded resource/asset metadata, not another RTTI
+subclass search.
+
 ### C3. Semantic batching, culling, and LOD
 
 - Promote the existing visibility and prepared-draw evidence into production

--- a/docs/native-renderer/STATIC_WORLD_OWNER.md
+++ b/docs/native-renderer/STATIC_WORLD_OWNER.md
@@ -17,22 +17,29 @@ Retail RTTI, vtables, and generated AOT instructions prove:
 
 - `Presentation_Unified::CModelPresentation` uses primary vtable `822432D4`;
 - its slot 12 is method `823F8DB8`, with one balanced exit at `823F8FA0`;
-- the owner stores its resource reference at offset 148, state at offset 144,
-  and renderer at offset 1608;
+- the owner stores its exact `CSimpleModelResource` reference at offset 148,
+  state at offset 144, and renderer at offset 1608;
+- slot 7 initializes the normal resource path by passing owner offset 148 to
+  the already-proved `CSimpleModelResource` binder `82C48038`;
 - helper `823F8980` reads the offset-148 reference, constructs the exact
   `CSimpleModelRenderer` through `82C4E3A0`, stores it at offset 1608, and
-  invokes renderer bind slot 0; and
+  invokes renderer bind slot 0; the binding and reference-assignment helpers
+  copy that same resource address into renderer offset 72; and
 - the same slot-12 scope later loads the offset-1608 renderer and invokes
   renderer slot 12, whose exact vtable target is `82C4CCC8`.
 
 This creates a safe synchronous join: an exact SimpleModel renderer dispatch
 occurring inside the balanced presentation slot-12 scope carries the
-`CModelPresentation` and opaque presentation-resource addresses into existing
+`CModelPresentation` and exact `CSimpleModelResource` addresses into existing
 packet and prepared-draw provenance. Runtime also requires the owner's
 offset-1608 renderer field to equal the nested dispatch receiver. Calls on
 other dynamic presentation types that share the implementation are counted as
 excluded vtable mismatches, while exact-owner field mismatches fail closed.
 The join changes no title behavior.
+
+The complete RTTI hierarchy census is documented in
+[`STATIC_WORLD_PRESENTATION_TYPES.md`](STATIC_WORLD_PRESENTATION_TYPES.md). It
+proves there is no more-specific building or prop presentation subclass.
 
 ## Generate the report
 
@@ -45,9 +52,11 @@ python tools/discover-native-renderer-static-world-owner.py `
 
 ## Remaining boundary
 
-`CModelPresentation` is an exact title-owned presentation class, not proof that
-an individual instance is a building rather than a prop. Mesh/material field
-semantics and representative streaming transitions also remain open. This
+`CModelPresentation` plus its identical renderer resource is an exact
+title-owned static-model instance identity, not proof that the asset should be
+called a building rather than a prop. Bounded asset-name/category metadata,
+mesh/material field semantics, and representative streaming transitions remain
+open. This
 checkpoint changes no guest data, native admission, publication, or
 suppression; Xenos remains authoritative.
 

--- a/docs/native-renderer/STATIC_WORLD_PRESENTATION_TYPES.md
+++ b/docs/native-renderer/STATIC_WORLD_PRESENTATION_TYPES.md
@@ -1,0 +1,48 @@
+# Static-world unified presentation type census
+
+Status: complete static RTTI census; concrete asset metadata remains the next
+semantic boundary
+
+## Purpose
+
+The exact `CModelPresentation` owner raised a specific question: do separate
+building or prop subclasses provide the missing semantic label? A complete
+retail-image RTTI hierarchy census answers that question before adding more
+runtime hooks.
+
+`tools/discover-native-renderer-static-world-presentation-types.py` enumerates
+every complete-object locator whose hierarchy contains
+`Presentation_Unified::CModelPresentation`, resolves each associated vtable,
+and locks the exact retail result.
+
+## Exact result
+
+Only two RTTI types exist in this hierarchy:
+
+- `Presentation_Unified::CModelPresentation`; and
+- `TRefCountedObjectThreadSafe<Presentation_Unified::CModelPresentation>`.
+
+Each has one 18-slot primary surface whose slot 12 inherits exact draw method
+`823F8DB8`, plus one one-slot secondary reference-count surface at object
+offset 8. There is no building-, prop-, scenery-, or object-specific derived
+presentation type in the retail image.
+
+This is useful negative evidence. Searching for another semantic subclass
+cannot produce the required classification. Individual identity must instead
+come from the exact presentation/resource address, while a human-meaningful
+building or prop label must come from bounded resource/asset metadata.
+
+## Generate the report
+
+```powershell
+python tools/discover-native-renderer-static-world-presentation-types.py `
+  .local/generated/default `
+  --image .local/analysis/default-image.bin `
+  --output .local/qualification/native-renderer-static-world-presentation-types.json
+```
+
+## Safety boundary
+
+The census reads only retail RTTI, vtables, and generated AOT function
+addresses. It exports no game payload, enables no runtime hook, makes no native
+admission decision, and authorizes no suppression. Xenos remains authoritative.

--- a/src/native_renderer/graphics_hooks.cpp
+++ b/src/native_renderer/graphics_hooks.cpp
@@ -2156,6 +2156,7 @@ std::atomic<uint64_t> g_static_world_presentation_scopes_with_renderer{};
 std::atomic<uint64_t> g_static_world_presentation_scopes_without_renderer{};
 std::atomic<uint64_t> g_static_world_presentation_renderer_joins{};
 std::atomic<uint64_t> g_static_world_presentation_renderer_mismatches{};
+std::atomic<uint64_t> g_static_world_presentation_resource_mismatches{};
 std::array<SemanticBindingCacheSlot, 5> g_semantic_binding_cache_slots{};
 std::array<SemanticResolverCacheSlot, 5> g_semantic_resolver_cache_slots{};
 thread_local PendingSemanticResourceBindings g_pending_semantic_bindings{};
@@ -3631,22 +3632,38 @@ void BeginStaticWorldRendererDispatch(uint32_t renderer_address,
       g_static_world_presentation_scope;
   if (presentation_scope.active && presentation_scope.exact) {
     uint32_t owned_renderer = 0;
-    if (presentation_scope.presentation_address <=
-            UINT32_MAX - kModelPresentationRendererOffset &&
+    uint32_t owned_resource = 0;
+    const bool fields_in_range =
+        presentation_scope.presentation_address <=
+        UINT32_MAX - kModelPresentationRendererOffset;
+    const bool renderer_matches =
+        fields_in_range &&
         LoadMappedGuestU32(
             memory,
             presentation_scope.presentation_address +
                 kModelPresentationRendererOffset,
             owned_renderer) &&
-        owned_renderer == renderer_address) {
+        owned_renderer == renderer_address;
+    const bool resource_matches =
+        fields_in_range &&
+        LoadMappedGuestU32(
+            memory,
+            presentation_scope.presentation_address +
+                kModelPresentationResourceOffset,
+            owned_resource) &&
+        owned_resource == presentation_scope.resource_address &&
+        owned_resource == model_graph_address;
+    if (renderer_matches && resource_matches) {
       scope.model_presentation_address =
           presentation_scope.presentation_address;
       scope.model_presentation_resource_address =
           presentation_scope.resource_address;
       ++presentation_scope.renderer_dispatch_joins;
       ++g_static_world_presentation_renderer_joins;
-    } else {
+    } else if (!renderer_matches) {
       ++g_static_world_presentation_renderer_mismatches;
+    } else {
+      ++g_static_world_presentation_resource_mismatches;
     }
   }
   scope.exact = true;
@@ -5130,6 +5147,7 @@ void ResetTitleDrawProvenance() {
            &g_static_world_presentation_scopes_without_renderer,
            &g_static_world_presentation_renderer_joins,
            &g_static_world_presentation_renderer_mismatches,
+           &g_static_world_presentation_resource_mismatches,
        }) {
     counter->store(0, std::memory_order_relaxed);
   }
@@ -11269,6 +11287,8 @@ void EmitStaticWorldRuntimeJoinEvent(const char *event_name,
       !g_static_world_presentation_exit_without_entry.load(
           std::memory_order_relaxed) &&
       !g_static_world_presentation_renderer_mismatches.load(
+          std::memory_order_relaxed) &&
+      !g_static_world_presentation_resource_mismatches.load(
           std::memory_order_relaxed);
   const uint64_t pending_packets =
       packets_recorded >= packet_matches ? packets_recorded - packet_matches
@@ -11484,6 +11504,10 @@ void EmitStaticWorldRuntimeJoinEvent(const char *event_name,
        {"presentation_renderer_mismatches",
         std::to_string(
             g_static_world_presentation_renderer_mismatches.load(
+                std::memory_order_relaxed))},
+       {"presentation_resource_mismatches",
+        std::to_string(
+            g_static_world_presentation_resource_mismatches.load(
                 std::memory_order_relaxed))},
        {"accounting_complete", accounting_complete ? "true" : "false"},
        {"qualification_complete",
@@ -22886,6 +22910,8 @@ void InstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system,
        {"presentation_draw_hooks", "823F8DB8,823F8FA0"},
        {"presentation_resource_field", "presentation_plus_148"},
        {"presentation_renderer_field", "presentation_plus_1608"},
+       {"presentation_resource_join",
+        "presentation_plus_148_equals_renderer_plus_72"},
        {"draw_emitter", "82416380"},
        {"packet_hooks", "82416260,824162F4"},
        {"join", "synchronous_scope_to_physical_pm4_prepared_draw"},

--- a/tools/discover-native-renderer-static-world-owner.py
+++ b/tools/discover-native-renderer-static-world-owner.py
@@ -25,8 +25,13 @@ PRESENTATION_DRAW_SLOT = 12
 PRESENTATION_DRAW = 0x823F8DB8
 PRESENTATION_DRAW_EXIT = 0x823F8FA0
 PRESENTATION_PREPARE = 0x823F8980
+PRESENTATION_INITIALIZE = 0x82DEA298
 RENDERER_CONSTRUCTOR_WRAPPER = 0x82C4E3A0
 RENDERER_VTABLE = 0x82001B64
+RENDERER_BIND = 0x82C4C838
+RESOURCE_BIND = 0x82C48038
+BINDING_CONSTRUCTOR = 0x824AFB20
+REFERENCE_ASSIGN = 0x826E1B10
 RENDERER_BIND_SLOT = 0
 RENDERER_DRAW_SLOT = 12
 RESOURCE_REFERENCE_OFFSET = 148
@@ -85,6 +90,8 @@ def build(functions: dict[int, dict[int, str]], image: bytes) -> dict:
         raise ValueError("CModelPresentation deleting destructor drifted")
     if slots[PRESENTATION_DRAW_SLOT] != PRESENTATION_DRAW:
         raise ValueError("CModelPresentation draw slot drifted")
+    if slots[7] != PRESENTATION_INITIALIZE:
+        raise ValueError("CModelPresentation initialize slot drifted")
     renderer_slots = [
         image_u32(image, RENDERER_VTABLE + index * 4) for index in range(17)
     ]
@@ -123,16 +130,53 @@ def build(functions: dict[int, dict[int, str]], image: bytes) -> dict:
     )
     require_instructions(
         functions,
+        PRESENTATION_INITIALIZE,
+        {
+            0x82DEA2A4: "mr r31,r3",
+            0x82DEA384: "addi r3,r31,148",
+            0x82DEA388: "bl 0x82c48038",
+            0x82DEA390: "stw r11,144(r31)",
+        },
+    )
+    require_instructions(
+        functions,
         PRESENTATION_PREPARE,
         {
             0x823F89A4: "lwz r11,148(r24)",
             0x823F89A8: "addi r31,r24,148",
             0x823F8A14: "bl 0x82c4e3a0",
             0x823F8A18: "stw r3,1608(r24)",
+            0x823F8A24: "bl 0x824afb20",
             0x823F8A28: "lwz r3,1608(r24)",
             0x823F8A34: "lwz r11,0(r11)",
             0x823F8A3C: "bctrl",
             0x823F8A44: "stw r11,144(r24)",
+        },
+    )
+    require_instructions(
+        functions,
+        BINDING_CONSTRUCTOR,
+        {
+            0x824AFB40: "lwz r31,0(r4)",
+            0x824AFB60: "stw r31,0(r30)",
+        },
+    )
+    require_instructions(
+        functions,
+        RENDERER_BIND,
+        {
+            0x82C4C848: "addi r3,r3,72",
+            0x82C4C84C: "mr r31,r4",
+            0x82C4C850: "bl 0x826e1b10",
+        },
+    )
+    require_instructions(
+        functions,
+        REFERENCE_ASSIGN,
+        {
+            0x826E1B24: "lwz r31,0(r4)",
+            0x826E1B48: "lwz r3,0(r30)",
+            0x826E1B4C: "stw r31,0(r30)",
         },
     )
     require_instructions(
@@ -178,11 +222,25 @@ def build(functions: dict[int, dict[int, str]], image: bytes) -> dict:
             "draw_target": f"{renderer_slots[RENDERER_DRAW_SLOT]:08X}",
             "join_kind": "balanced_synchronous_presentation_draw_scope",
         },
+        "resource_join": {
+            "initialize_slot": 7,
+            "initialize_method": f"{PRESENTATION_INITIALIZE:08X}",
+            "resource_bind": f"{RESOURCE_BIND:08X}",
+            "presentation_resource_field_offset": RESOURCE_REFERENCE_OFFSET,
+            "binding_constructor": f"{BINDING_CONSTRUCTOR:08X}",
+            "renderer_bind": f"{RENDERER_BIND:08X}",
+            "reference_assignment": f"{REFERENCE_ASSIGN:08X}",
+            "renderer_resource_field_offset": 72,
+            "address_equation": (
+                "presentation_plus_148_equals_renderer_plus_72"
+            ),
+        },
         "claims": {
             "exact_model_presentation_owner_proved": True,
             "presentation_to_renderer_field_proved": True,
             "presentation_to_resource_reference_proved": True,
             "renderer_bind_and_draw_dispatch_proved": True,
+            "presentation_to_renderer_resource_identity_proved": True,
             "concrete_building_or_prop_identity_proved": False,
             "mesh_or_material_semantics_proved": False,
         },

--- a/tools/discover-native-renderer-static-world-presentation-types.py
+++ b/tools/discover-native-renderer-static-world-presentation-types.py
@@ -1,0 +1,288 @@
+#!/usr/bin/env python3
+"""Enumerate exact RTTI types derived from unified CModelPresentation."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import pathlib
+import re
+import sys
+
+
+SCHEMA = "pinyon-shift.native-renderer-static-world-presentation-types.v1"
+IMAGE_BASE = 0x82000000
+MODEL_PRESENTATION_TYPE = 0x832B9550
+MODEL_PRESENTATION_DRAW = 0x823F8DB8
+MODEL_PRESENTATION_SLOT = 12
+FUNCTION_RE = re.compile(r"^DEFINE_REX_FUNC\(sub_([0-9A-F]{8})\) \{")
+MODEL_PRESENTATION_NAME = ".?AVCModelPresentation@Presentation_Unified@@"
+REFCOUNTED_PRESENTATION_NAME = (
+    ".?AV?$TRefCountedObjectThreadSafe@"
+    "VCModelPresentation@Presentation_Unified@@@@"
+)
+EXPECTED_SURFACES = {
+    0x823633E8: (MODEL_PRESENTATION_NAME, 0, 0x822432D4, 18, True),
+    0x82363464: (MODEL_PRESENTATION_NAME, 8, 0x822432C8, 1, False),
+    0x82363534: (REFCOUNTED_PRESENTATION_NAME, 0, 0x82002464, 18, True),
+    0x82363598: (REFCOUNTED_PRESENTATION_NAME, 8, 0x822433A0, 1, False),
+}
+
+
+def parse_function_addresses(paths: list[pathlib.Path]) -> set[int]:
+    functions = set()
+    for path in sorted(paths, key=lambda item: item.as_posix()):
+        for line in path.read_text(encoding="utf-8").splitlines():
+            match = FUNCTION_RE.match(line)
+            if match:
+                functions.add(int(match.group(1), 16))
+    return functions
+
+
+def image_u32(image: bytes, address: int) -> int:
+    offset = address - IMAGE_BASE
+    if offset < 0 or offset + 4 > len(image):
+        raise ValueError(f"image address is out of range: {address:08X}")
+    return int.from_bytes(image[offset : offset + 4], "big")
+
+
+def image_string(image: bytes, address: int) -> str:
+    offset = address - IMAGE_BASE
+    if offset < 0 or offset >= len(image):
+        raise ValueError(f"image string is out of range: {address:08X}")
+    end = image.find(b"\0", offset, min(offset + 256, len(image)))
+    if end < 0:
+        raise ValueError(f"image string is unterminated: {address:08X}")
+    return image[offset:end].decode("ascii")
+
+
+def parse_locator(image: bytes, locator: int) -> dict | None:
+    try:
+        if image_u32(image, locator) != 0:
+            return None
+        object_offset = image_u32(image, locator + 4)
+        constructor_displacement = image_u32(image, locator + 8)
+        type_descriptor = image_u32(image, locator + 12)
+        hierarchy = image_u32(image, locator + 16)
+        decorated_name = image_string(image, type_descriptor + 8)
+        if not decorated_name.startswith(".?A"):
+            return None
+        if image_u32(image, hierarchy) != 0:
+            return None
+        hierarchy_attributes = image_u32(image, hierarchy + 4)
+        base_count = image_u32(image, hierarchy + 8)
+        base_array = image_u32(image, hierarchy + 12)
+        if not 1 <= base_count <= 128:
+            return None
+        bases = []
+        for index in range(base_count):
+            descriptor = image_u32(image, base_array + index * 4)
+            base_type = image_u32(image, descriptor)
+            bases.append(
+                {
+                    "type_descriptor": base_type,
+                    "decorated_name": image_string(image, base_type + 8),
+                    "contained_bases": image_u32(image, descriptor + 4),
+                    "member_displacement": image_u32(image, descriptor + 8),
+                    "vbtable_displacement": image_u32(image, descriptor + 12),
+                    "vbase_displacement": image_u32(image, descriptor + 16),
+                    "attributes": image_u32(image, descriptor + 20),
+                }
+            )
+        if bases[0]["type_descriptor"] != type_descriptor:
+            return None
+        return {
+            "locator": locator,
+            "object_offset": object_offset,
+            "constructor_displacement": constructor_displacement,
+            "type_descriptor": type_descriptor,
+            "decorated_name": decorated_name,
+            "hierarchy": hierarchy,
+            "hierarchy_attributes": hierarchy_attributes,
+            "bases": bases,
+        }
+    except (UnicodeDecodeError, ValueError):
+        return None
+
+
+def find_locators(image: bytes) -> list[dict]:
+    locators = []
+    for offset in range(0, len(image) - 20, 4):
+        if image[offset : offset + 4] != b"\0\0\0\0":
+            continue
+        locator = parse_locator(image, IMAGE_BASE + offset)
+        if locator is not None:
+            locators.append(locator)
+    return locators
+
+
+def find_vtables(
+    image: bytes, functions: set[int], locator: int
+) -> list[dict]:
+    needle = locator.to_bytes(4, "big")
+    results = []
+    offset = image.find(needle)
+    while offset >= 0:
+        if offset % 4 == 0:
+            vtable = IMAGE_BASE + offset + 4
+            slots = []
+            for index in range(64):
+                try:
+                    target = image_u32(image, vtable + index * 4)
+                except ValueError:
+                    break
+                if target not in functions:
+                    break
+                slots.append(target)
+            if slots:
+                slot_12_target = (
+                    slots[MODEL_PRESENTATION_SLOT]
+                    if len(slots) > MODEL_PRESENTATION_SLOT
+                    else None
+                )
+                results.append(
+                    {
+                        "vtable": vtable,
+                        "slot_count": len(slots),
+                        "slot_zero_target": slots[0],
+                        "slot_12_target": slot_12_target,
+                        "inherits_model_presentation_draw": (
+                            slot_12_target == MODEL_PRESENTATION_DRAW
+                        ),
+                    }
+                )
+        offset = image.find(needle, offset + 1)
+    return results
+
+
+def build(functions: set[int], image: bytes) -> dict:
+    target_name = image_string(image, MODEL_PRESENTATION_TYPE + 8)
+    if target_name != MODEL_PRESENTATION_NAME:
+        raise ValueError("CModelPresentation RTTI evidence drifted")
+    types = []
+    for locator in find_locators(image):
+        base_types = {base["type_descriptor"] for base in locator["bases"]}
+        if MODEL_PRESENTATION_TYPE not in base_types:
+            continue
+        vtables = find_vtables(image, functions, locator["locator"])
+        types.append(
+            {
+                "decorated_name": locator["decorated_name"],
+                "type_descriptor": f"{locator['type_descriptor']:08X}",
+                "complete_object_locator": f"{locator['locator']:08X}",
+                "object_offset": locator["object_offset"],
+                "constructor_displacement": locator[
+                    "constructor_displacement"
+                ],
+                "hierarchy": f"{locator['hierarchy']:08X}",
+                "base_count": len(locator["bases"]),
+                "base_names": [base["decorated_name"] for base in locator["bases"]],
+                "vtables": [
+                    {
+                        "address": f"{surface['vtable']:08X}",
+                        "slot_count": surface["slot_count"],
+                        "slot_zero_target": f"{surface['slot_zero_target']:08X}",
+                        "slot_12_target": (
+                            f"{surface['slot_12_target']:08X}"
+                            if surface["slot_12_target"] is not None
+                            else None
+                        ),
+                        "inherits_model_presentation_draw": surface[
+                            "inherits_model_presentation_draw"
+                        ],
+                    }
+                    for surface in vtables
+                ],
+            }
+        )
+    types.sort(
+        key=lambda item: (
+            item["decorated_name"],
+            item["complete_object_locator"],
+        )
+    )
+    exact_base = [
+        item
+        for item in types
+        if item["type_descriptor"] == f"{MODEL_PRESENTATION_TYPE:08X}"
+        and item["object_offset"] == 0
+    ]
+    if len(exact_base) != 1:
+        raise ValueError("exact CModelPresentation primary surface drifted")
+    observed = {}
+    for item in types:
+        if len(item["vtables"]) != 1:
+            raise ValueError("presentation surface vtable count drifted")
+        surface = item["vtables"][0]
+        observed[int(item["complete_object_locator"], 16)] = (
+            item["decorated_name"],
+            item["object_offset"],
+            int(surface["address"], 16),
+            surface["slot_count"],
+            surface["inherits_model_presentation_draw"],
+        )
+    if observed != EXPECTED_SURFACES:
+        raise ValueError("unified model-presentation type census drifted")
+    return {
+        "schema": SCHEMA,
+        "status": "complete",
+        "classification": "exact_unified_model_presentation_type_census",
+        "base_class": {
+            "decorated_name": target_name,
+            "type_descriptor": f"{MODEL_PRESENTATION_TYPE:08X}",
+            "draw_slot": MODEL_PRESENTATION_SLOT,
+            "draw_target": f"{MODEL_PRESENTATION_DRAW:08X}",
+        },
+        "types": types,
+        "summary": {
+            "locator_count": len(types),
+            "unique_type_count": len(
+                {item["type_descriptor"] for item in types}
+            ),
+            "inherited_draw_surface_count": sum(
+                surface["inherits_model_presentation_draw"]
+                for item in types
+                for surface in item["vtables"]
+            ),
+            "concrete_building_or_prop_identity_proved": False,
+        },
+        "safety": {
+            "static_analysis_only": True,
+            "guest_payload_exported": False,
+            "runtime_hook_enabled": False,
+            "native_admission": False,
+            "suppression_allowed": False,
+            "xenos_authority_required": True,
+        },
+    }
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("generated_root", type=pathlib.Path)
+    parser.add_argument("--image", required=True, type=pathlib.Path)
+    parser.add_argument("--output", required=True, type=pathlib.Path)
+    args = parser.parse_args(argv)
+    try:
+        paths = list(args.generated_root.glob("pinyon_shift_recomp.*.cpp"))
+        if not paths:
+            raise ValueError("no generated AOT C++ files found")
+        document = build(
+            parse_function_addresses(paths), args.image.read_bytes()
+        )
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(
+            json.dumps(document, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        return 0
+    except (OSError, UnicodeDecodeError, ValueError) as error:
+        print(
+            f"static-world presentation type discovery failed: {error}",
+            file=sys.stderr,
+        )
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/summarize-native-renderer-static-world-runtime-join.py
+++ b/tools/summarize-native-renderer-static-world-runtime-join.py
@@ -354,6 +354,7 @@ def validate_static_owner(document):
     try:
         presentation = document["presentation"]
         renderer_join = document["renderer_join"]
+        resource_join = document["resource_join"]
         claims = document["claims"]
     except (KeyError, TypeError) as error:
         raise ValueError("static-world owner proof is incomplete") from error
@@ -382,6 +383,19 @@ def validate_static_owner(document):
         "draw_target": "82C4CCC8",
         "join_kind": "balanced_synchronous_presentation_draw_scope",
     }
+    expected_resource_join = {
+        "initialize_slot": 7,
+        "initialize_method": "82DEA298",
+        "resource_bind": "82C48038",
+        "presentation_resource_field_offset": 148,
+        "binding_constructor": "824AFB20",
+        "renderer_bind": "82C4C838",
+        "reference_assignment": "826E1B10",
+        "renderer_resource_field_offset": 72,
+        "address_equation": (
+            "presentation_plus_148_equals_renderer_plus_72"
+        ),
+    }
     if any(
         presentation.get(key) != value
         for key, value in expected_presentation.items()
@@ -392,11 +406,18 @@ def validate_static_owner(document):
         for key, value in expected_join.items()
     ):
         raise ValueError("static-world presentation renderer join drifted")
+    if any(
+        resource_join.get(key) != value
+        for key, value in expected_resource_join.items()
+    ):
+        raise ValueError("static-world presentation resource join drifted")
     if (
         claims.get("exact_model_presentation_owner_proved") is not True
         or claims.get("presentation_to_renderer_field_proved") is not True
         or claims.get("presentation_to_resource_reference_proved") is not True
         or claims.get("renderer_bind_and_draw_dispatch_proved") is not True
+        or claims.get("presentation_to_renderer_resource_identity_proved")
+        is not True
         or claims.get("concrete_building_or_prop_identity_proved") is not False
         or claims.get("mesh_or_material_semantics_proved") is not False
     ):
@@ -472,6 +493,9 @@ def build(
         "presentation_draw_hooks": "823F8DB8,823F8FA0",
         "presentation_resource_field": "presentation_plus_148",
         "presentation_renderer_field": "presentation_plus_1608",
+        "presentation_resource_join": (
+            "presentation_plus_148_equals_renderer_plus_72"
+        ),
         "draw_emitter": "82416380",
         "packet_hooks": "82416260,824162F4",
         "join": "synchronous_scope_to_physical_pm4_prepared_draw",
@@ -600,6 +624,7 @@ def build(
         "presentation_scopes_without_renderer",
         "presentation_renderer_joins",
         "presentation_renderer_mismatches",
+        "presentation_resource_mismatches",
     )
     totals = {key: integer(summary, key) for key in keys}
     frame_sequence = integer(summary, "frame_sequence")
@@ -823,6 +848,7 @@ def build(
         "presentation_overlaps",
         "presentation_exit_without_entry",
         "presentation_renderer_mismatches",
+        "presentation_resource_mismatches",
     ):
         if totals[key]:
             failures.append(f"{key} is nonzero")
@@ -865,6 +891,7 @@ def build(
             "simple_mesh_to_prepared_draw_proved": not failures,
             "model_presentation_owner_proved": not failures,
             "model_presentation_to_renderer_proved": not failures,
+            "model_presentation_to_renderer_resource_proved": not failures,
             "static_world_scope_to_pm4_proved": not failures,
             "static_world_pm4_to_prepared_draw_proved": not failures,
             "building_or_prop_instance_identity_proved": False,

--- a/tools/tests/test_native_renderer_static_world_owner.py
+++ b/tools/tests/test_native_renderer_static_world_owner.py
@@ -22,6 +22,7 @@ def fixture():
     image = bytearray(highest - MODULE.IMAGE_BASE)
     presentation_slots = [0x82800000 + index * 4 for index in range(18)]
     presentation_slots[0] = MODULE.PRESENTATION_DELETING_DESTRUCTOR
+    presentation_slots[7] = MODULE.PRESENTATION_INITIALIZE
     presentation_slots[12] = MODULE.PRESENTATION_DRAW
     renderer_slots = [0x82900000 + index * 4 for index in range(17)]
     renderer_slots[0] = 0x82C4C838
@@ -54,15 +55,36 @@ def fixture():
             0x82DEA530: "mr r3,r31",
             0x82DEA534: "bl 0x823fd208",
         },
+        MODULE.PRESENTATION_INITIALIZE: {
+            0x82DEA2A4: "mr r31,r3",
+            0x82DEA384: "addi r3,r31,148",
+            0x82DEA388: "bl 0x82c48038",
+            0x82DEA390: "stw r11,144(r31)",
+        },
         MODULE.PRESENTATION_PREPARE: {
             0x823F89A4: "lwz r11,148(r24)",
             0x823F89A8: "addi r31,r24,148",
             0x823F8A14: "bl 0x82c4e3a0",
             0x823F8A18: "stw r3,1608(r24)",
+            0x823F8A24: "bl 0x824afb20",
             0x823F8A28: "lwz r3,1608(r24)",
             0x823F8A34: "lwz r11,0(r11)",
             0x823F8A3C: "bctrl",
             0x823F8A44: "stw r11,144(r24)",
+        },
+        MODULE.BINDING_CONSTRUCTOR: {
+            0x824AFB40: "lwz r31,0(r4)",
+            0x824AFB60: "stw r31,0(r30)",
+        },
+        MODULE.RENDERER_BIND: {
+            0x82C4C848: "addi r3,r3,72",
+            0x82C4C84C: "mr r31,r4",
+            0x82C4C850: "bl 0x826e1b10",
+        },
+        MODULE.REFERENCE_ASSIGN: {
+            0x826E1B24: "lwz r31,0(r4)",
+            0x826E1B48: "lwz r3,0(r30)",
+            0x826E1B4C: "stw r31,0(r30)",
         },
         MODULE.PRESENTATION_DRAW: {
             0x823F8DC4: "mr r31,r3",
@@ -87,8 +109,17 @@ class StaticWorldOwnerTests(unittest.TestCase):
         )
         self.assertEqual(1608, document["presentation"]["renderer_field_offset"])
         self.assertEqual("82C4CCC8", document["renderer_join"]["draw_target"])
+        self.assertEqual(
+            "presentation_plus_148_equals_renderer_plus_72",
+            document["resource_join"]["address_equation"],
+        )
         self.assertTrue(
             document["claims"]["exact_model_presentation_owner_proved"]
+        )
+        self.assertTrue(
+            document["claims"][
+                "presentation_to_renderer_resource_identity_proved"
+            ]
         )
         self.assertFalse(
             document["claims"]["concrete_building_or_prop_identity_proved"]

--- a/tools/tests/test_native_renderer_static_world_presentation_types.py
+++ b/tools/tests/test_native_renderer_static_world_presentation_types.py
@@ -1,0 +1,123 @@
+import copy
+import importlib.util
+import sys
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+ROOT = Path(__file__).resolve().parents[2]
+TOOL = (
+    ROOT
+    / "tools"
+    / "discover-native-renderer-static-world-presentation-types.py"
+)
+SPEC = importlib.util.spec_from_file_location("static_world_types", TOOL)
+assert SPEC and SPEC.loader
+MODULE = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = MODULE
+SPEC.loader.exec_module(MODULE)
+
+
+def locators():
+    rows = []
+    for locator, expected in MODULE.EXPECTED_SURFACES.items():
+        name, object_offset, _, _, _ = expected
+        type_descriptor = (
+            MODULE.MODEL_PRESENTATION_TYPE
+            if name == MODULE.MODEL_PRESENTATION_NAME
+            else 0x832B9628
+        )
+        rows.append(
+            {
+                "locator": locator,
+                "object_offset": object_offset,
+                "constructor_displacement": 0,
+                "type_descriptor": type_descriptor,
+                "decorated_name": name,
+                "hierarchy": 0x82364000 + len(rows) * 0x40,
+                "hierarchy_attributes": 1,
+                "bases": [
+                    {
+                        "type_descriptor": type_descriptor,
+                        "decorated_name": name,
+                    },
+                    {
+                        "type_descriptor": MODULE.MODEL_PRESENTATION_TYPE,
+                        "decorated_name": MODULE.MODEL_PRESENTATION_NAME,
+                    },
+                ],
+            }
+        )
+    return rows
+
+
+def vtable_for(locator):
+    _, _, vtable, slot_count, inherited = MODULE.EXPECTED_SURFACES[locator]
+    return [
+        {
+            "vtable": vtable,
+            "slot_count": slot_count,
+            "slot_zero_target": 0x82DEA508,
+            "slot_12_target": (
+                MODULE.MODEL_PRESENTATION_DRAW if inherited else None
+            ),
+            "inherits_model_presentation_draw": inherited,
+        }
+    ]
+
+
+class StaticWorldPresentationTypeTests(unittest.TestCase):
+    def test_locks_complete_generic_presentation_type_census(self):
+        rows = locators()
+        with mock.patch.object(
+            MODULE, "image_string", return_value=MODULE.MODEL_PRESENTATION_NAME
+        ), mock.patch.object(MODULE, "find_locators", return_value=rows), mock.patch.object(
+            MODULE,
+            "find_vtables",
+            side_effect=lambda _image, _functions, locator: vtable_for(locator),
+        ):
+            document = MODULE.build({0x82DEA508}, b"")
+        self.assertEqual("complete", document["status"])
+        self.assertEqual(4, document["summary"]["locator_count"])
+        self.assertEqual(2, document["summary"]["unique_type_count"])
+        self.assertEqual(
+            2, document["summary"]["inherited_draw_surface_count"]
+        )
+        self.assertFalse(
+            document["summary"]["concrete_building_or_prop_identity_proved"]
+        )
+
+    def test_rejects_new_or_missing_presentation_surface(self):
+        rows = locators()[:-1]
+        with mock.patch.object(
+            MODULE, "image_string", return_value=MODULE.MODEL_PRESENTATION_NAME
+        ), mock.patch.object(MODULE, "find_locators", return_value=rows), mock.patch.object(
+            MODULE,
+            "find_vtables",
+            side_effect=lambda _image, _functions, locator: vtable_for(locator),
+        ):
+            with self.assertRaisesRegex(ValueError, "census drifted"):
+                MODULE.build({0x82DEA508}, b"")
+
+    def test_rejects_draw_target_drift(self):
+        rows = locators()
+
+        def drifted(_image, _functions, locator):
+            result = copy.deepcopy(vtable_for(locator))
+            if locator == 0x823633E8:
+                result[0]["inherits_model_presentation_draw"] = False
+                result[0]["slot_12_target"] = 0x823F8DBC
+            return result
+
+        with mock.patch.object(
+            MODULE, "image_string", return_value=MODULE.MODEL_PRESENTATION_NAME
+        ), mock.patch.object(MODULE, "find_locators", return_value=rows), mock.patch.object(
+            MODULE, "find_vtables", side_effect=drifted
+        ):
+            with self.assertRaisesRegex(ValueError, "census drifted"):
+                MODULE.build({0x82DEA508}, b"")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/tests/test_native_renderer_static_world_runtime_join.py
+++ b/tools/tests/test_native_renderer_static_world_runtime_join.py
@@ -248,11 +248,25 @@ def static_owner():
             "draw_target": "82C4CCC8",
             "join_kind": "balanced_synchronous_presentation_draw_scope",
         },
+        "resource_join": {
+            "initialize_slot": 7,
+            "initialize_method": "82DEA298",
+            "resource_bind": "82C48038",
+            "presentation_resource_field_offset": 148,
+            "binding_constructor": "824AFB20",
+            "renderer_bind": "82C4C838",
+            "reference_assignment": "826E1B10",
+            "renderer_resource_field_offset": 72,
+            "address_equation": (
+                "presentation_plus_148_equals_renderer_plus_72"
+            ),
+        },
         "claims": {
             "exact_model_presentation_owner_proved": True,
             "presentation_to_renderer_field_proved": True,
             "presentation_to_resource_reference_proved": True,
             "renderer_bind_and_draw_dispatch_proved": True,
+            "presentation_to_renderer_resource_identity_proved": True,
             "concrete_building_or_prop_identity_proved": False,
             "mesh_or_material_semantics_proved": False,
         },
@@ -308,6 +322,9 @@ def fixture():
             "presentation_draw_hooks": "823F8DB8,823F8FA0",
             "presentation_resource_field": "presentation_plus_148",
             "presentation_renderer_field": "presentation_plus_1608",
+            "presentation_resource_join": (
+                "presentation_plus_148_equals_renderer_plus_72"
+            ),
             "draw_emitter": "82416380",
             "packet_hooks": "82416260,824162F4",
             "join": "synchronous_scope_to_physical_pm4_prepared_draw",
@@ -420,6 +437,7 @@ def fixture():
         presentation_scopes_without_renderer="4",
         presentation_renderer_joins="8",
         presentation_renderer_mismatches="0",
+        presentation_resource_mismatches="0",
         accounting_complete="true",
         qualification_complete="true",
         classification=(
@@ -456,6 +474,11 @@ class StaticWorldRuntimeJoinTests(unittest.TestCase):
         )
         self.assertTrue(
             document["qualification"]["model_presentation_owner_proved"]
+        )
+        self.assertTrue(
+            document["qualification"][
+                "model_presentation_to_renderer_resource_proved"
+            ]
         )
         self.assertFalse(
             document["qualification"]["building_or_prop_instance_identity_proved"]
@@ -657,6 +680,28 @@ class StaticWorldRuntimeJoinTests(unittest.TestCase):
         self.assertEqual("incomplete", document["status"])
         self.assertIn(
             "presentation_renderer_mismatches is nonzero",
+            document["failures"],
+        )
+
+    def test_rejects_presentation_resource_mismatch(self):
+        events = copy.deepcopy(fixture())
+        events[-1].update(
+            status="incomplete",
+            presentation_resource_mismatches="1",
+            qualification_complete="false",
+        )
+        document = MODULE.build(
+            static_ingress(),
+            static_lifetime(),
+            static_resource(),
+            static_streaming(),
+            static_graph(),
+            static_owner(),
+            events,
+        )
+        self.assertEqual("incomplete", document["status"])
+        self.assertIn(
+            "presentation_resource_mismatches is nonzero",
             document["failures"],
         )
 


### PR DESCRIPTION
## Summary
- lock the complete unified model-presentation RTTI/vtable census
- prove presentation offset 148 is the same CSimpleModelResource bound at renderer offset 72
- fail closed on mismatched presentation/resource lineage and document the bounded next lead

## Validation
- 554 Python tests passed
- retail static owner and presentation-type reports passed
- host observer compiled successfully
- final executable link was intentionally deferred because the preserved AppData gameplay process still owns the executable