### PR TITLE
feat(native-renderer): carry hashed static asset lineage

### DIFF
--- a/docs/native-renderer/REPRIORITIZED_PLAN.md
+++ b/docs/native-renderer/REPRIORITIZED_PLAN.md
@@ -386,6 +386,14 @@ documented in
 payload-free hashed runtime category census remains required before assigning
 building-versus-prop semantics. No native admission or suppression is enabled.
 
+Hashed asset-lineage checkpoint: the passive presentation observer now reads
+only the proved bounded key and reference-count fields, exports no plaintext,
+and carries their stable hash/length and effect/texture counts through the
+renderer, PM4 packet, and prepared-draw provenance. Independent outcome and
+join accounting fails closed when a renderer-joined presentation lacks valid
+metadata. Runtime qualification remains batched with C1/C2; concrete
+building-versus-prop labels remain unproved.
+
 ### C3. Semantic batching, culling, and LOD
 
 - Promote the existing visibility and prepared-draw evidence into production

--- a/docs/native-renderer/STATIC_WORLD_ASSET_METADATA.md
+++ b/docs/native-renderer/STATIC_WORLD_ASSET_METADATA.md
@@ -1,7 +1,7 @@
 # Static-world asset-reference metadata
 
 Status: bounded resource-key and effect/texture reference paths proved;
-runtime hashed-category census pending
+passive hashed runtime lineage implemented; qualification pending
 
 ## Purpose
 
@@ -40,7 +40,12 @@ python tools/discover-native-renderer-static-world-asset-metadata.py `
 
 ## Runtime boundary
 
-The next runtime census may read only these proved, bounded string records. It
-must emit hashes and structural categories, never plaintext asset names or
-payload bytes. Xenos remains authoritative; this checkpoint enables no native
-admission or suppression.
+The passive runtime observer reads only these proved fields. It emits the
+FNV-1a hash and length of the presentation key plus effect/texture counts,
+then carries them through the renderer, physical PM4 packet, and prepared-draw
+lineage. Plaintext names are never emitted. Exact, empty, faulted, joined, and
+missing-join outcomes are independently accounted and the qualifier fails
+closed on any joined draw without valid metadata.
+
+The combined C1/C2 AppData run remains intentionally batched. Xenos remains
+authoritative; this checkpoint enables no native admission or suppression.

--- a/docs/native-renderer/STATIC_WORLD_GRAPH.md
+++ b/docs/native-renderer/STATIC_WORLD_GRAPH.md
@@ -55,6 +55,7 @@ python tools/summarize-native-renderer-static-world-runtime-join.py `
   --streaming .local/qualification/native-renderer-static-world-streaming.json `
   --graph .local/qualification/native-renderer-static-world-graph.json `
   --owner .local/qualification/native-renderer-static-world-owner.json `
+  --asset-metadata .local/qualification/native-renderer-static-world-asset-metadata.json `
   --session <session> `
   --output .local/qualification/native-renderer-static-world-runtime-join.json
 ```

--- a/docs/native-renderer/STATIC_WORLD_INGRESS.md
+++ b/docs/native-renderer/STATIC_WORLD_INGRESS.md
@@ -102,6 +102,7 @@ python tools/summarize-native-renderer-static-world-runtime-join.py `
   --streaming .local/qualification/native-renderer-static-world-streaming.json `
   --graph .local/qualification/native-renderer-static-world-graph.json `
   --owner .local/qualification/native-renderer-static-world-owner.json `
+  --asset-metadata .local/qualification/native-renderer-static-world-asset-metadata.json `
   --session <session> `
   --output .local/qualification/native-renderer-static-world-runtime-join.json
 ```

--- a/docs/native-renderer/STATIC_WORLD_LIFETIME.md
+++ b/docs/native-renderer/STATIC_WORLD_LIFETIME.md
@@ -69,6 +69,7 @@ python tools/summarize-native-renderer-static-world-runtime-join.py `
   --streaming .local/qualification/native-renderer-static-world-streaming.json `
   --graph .local/qualification/native-renderer-static-world-graph.json `
   --owner .local/qualification/native-renderer-static-world-owner.json `
+  --asset-metadata .local/qualification/native-renderer-static-world-asset-metadata.json `
   --session <session> `
   --output .local/qualification/native-renderer-static-world-runtime-join.json
 ```

--- a/docs/native-renderer/STATIC_WORLD_OWNER.md
+++ b/docs/native-renderer/STATIC_WORLD_OWNER.md
@@ -62,5 +62,6 @@ streaming transitions remain open. This
 checkpoint changes no guest data, native admission, publication, or
 suppression; Xenos remains authoritative.
 
-The combined runtime qualifier now also requires this static report through
-`--owner .local/qualification/native-renderer-static-world-owner.json`.
+The combined runtime qualifier requires this report through `--owner` and the
+bounded metadata report through `--asset-metadata`; both remain static inputs
+to the batched runtime gate.

--- a/docs/native-renderer/STATIC_WORLD_RESOURCE.md
+++ b/docs/native-renderer/STATIC_WORLD_RESOURCE.md
@@ -55,6 +55,7 @@ python tools/summarize-native-renderer-static-world-runtime-join.py `
   --streaming .local/qualification/native-renderer-static-world-streaming.json `
   --graph .local/qualification/native-renderer-static-world-graph.json `
   --owner .local/qualification/native-renderer-static-world-owner.json `
+  --asset-metadata .local/qualification/native-renderer-static-world-asset-metadata.json `
   --session <session> `
   --output .local/qualification/native-renderer-static-world-runtime-join.json
 ```

--- a/docs/native-renderer/STATIC_WORLD_STREAMING.md
+++ b/docs/native-renderer/STATIC_WORLD_STREAMING.md
@@ -55,6 +55,7 @@ python tools/summarize-native-renderer-static-world-runtime-join.py `
   --streaming .local/qualification/native-renderer-static-world-streaming.json `
   --graph .local/qualification/native-renderer-static-world-graph.json `
   --owner .local/qualification/native-renderer-static-world-owner.json `
+  --asset-metadata .local/qualification/native-renderer-static-world-asset-metadata.json `
   --session <session> `
   --output .local/qualification/native-renderer-static-world-runtime-join.json
 ```

--- a/src/native_renderer/graphics_hooks.cpp
+++ b/src/native_renderer/graphics_hooks.cpp
@@ -100,6 +100,8 @@ constexpr size_t kSemanticReceiverLifecycleCapacity = 1024;
 constexpr size_t kSemanticReceiverStackCapacity = 32;
 constexpr size_t kStaticWorldRendererLifecycleCapacity = 256;
 constexpr size_t kStaticWorldResourceLifecycleCapacity = 4096;
+constexpr uint32_t kStaticWorldAssetKeyMaximumBytes = 512;
+constexpr uint32_t kStaticWorldReferenceCountMaximum = 4096;
 constexpr size_t kSemanticVisibilityCategoryCapacity = 32;
 constexpr size_t kSemanticVisibilityLodCapacity = 32;
 constexpr size_t kSemanticVisibilityResultValueCapacity = 256;
@@ -181,9 +183,17 @@ constexpr uint32_t kSimpleModelVtable = 0x82229208;
 constexpr uint32_t kSimpleSubModelVtable = 0x822291BC;
 constexpr uint32_t kSimpleMeshVtable = 0x822291A0;
 constexpr uint32_t kSimpleModelResourceModelOffset = 112;
+constexpr uint32_t kSimpleModelResourceEffectRecordsOffset = 124;
+constexpr uint32_t kSimpleModelResourceEffectCountOffset = 128;
+constexpr uint32_t kSimpleModelResourceTextureVectorOffset = 288;
 constexpr uint32_t kModelPresentationVtable = 0x822432D4;
+constexpr uint32_t kModelPresentationNameOffset = 16;
 constexpr uint32_t kModelPresentationResourceOffset = 148;
 constexpr uint32_t kModelPresentationRendererOffset = 1608;
+constexpr uint32_t kMsvcStringSizeOffset = 16;
+constexpr uint32_t kMsvcStringCapacityOffset = 20;
+constexpr uint32_t kMsvcStringInlineCapacity = 16;
+constexpr uint32_t kMsvcStringRecordBytes = 28;
 constexpr uint32_t kTrackModelVtable = 0x820016B4;
 constexpr uint32_t kTrackMeshVtable = 0x8200143C;
 constexpr uint32_t kTrackSubModelVtable = 0x82001474;
@@ -478,6 +488,7 @@ struct SemanticDrawIdentity {
 };
 
 struct StaticWorldDrawIdentity {
+  uint64_t asset_key_hash = 0;
   uint32_t model_presentation_address = 0;
   uint32_t model_presentation_resource_address = 0;
   uint32_t renderer_address = 0;
@@ -490,6 +501,10 @@ struct StaticWorldDrawIdentity {
   uint32_t simple_model_address = 0;
   uint32_t simple_submodel_address = 0;
   uint32_t simple_mesh_address = 0;
+  uint32_t asset_key_length = 0;
+  uint32_t effect_reference_count = 0;
+  uint32_t texture_reference_count = 0;
+  bool asset_metadata_valid = false;
   bool valid = false;
 };
 
@@ -1897,6 +1912,7 @@ struct TrackRenderModelDispatchScope {
 };
 
 struct StaticWorldRendererDispatchScope {
+  uint64_t asset_key_hash = 0;
   uint64_t packet_origins = 0;
   uint32_t renderer_address = 0;
   uint32_t renderer_generation = 0;
@@ -1911,6 +1927,10 @@ struct StaticWorldRendererDispatchScope {
   uint32_t simple_model_address = 0;
   uint32_t simple_submodel_address = 0;
   uint32_t simple_mesh_address = 0;
+  uint32_t asset_key_length = 0;
+  uint32_t effect_reference_count = 0;
+  uint32_t texture_reference_count = 0;
+  bool asset_metadata_valid = false;
   bool member_active = false;
   bool member_exact = false;
   bool active = false;
@@ -1919,8 +1939,13 @@ struct StaticWorldRendererDispatchScope {
 
 struct StaticWorldPresentationDispatchScope {
   uint64_t renderer_dispatch_joins = 0;
+  uint64_t asset_key_hash = 0;
   uint32_t presentation_address = 0;
   uint32_t resource_address = 0;
+  uint32_t asset_key_length = 0;
+  uint32_t effect_reference_count = 0;
+  uint32_t texture_reference_count = 0;
+  bool asset_metadata_valid = false;
   bool active = false;
   bool exact = false;
 };
@@ -2157,6 +2182,12 @@ std::atomic<uint64_t> g_static_world_presentation_scopes_without_renderer{};
 std::atomic<uint64_t> g_static_world_presentation_renderer_joins{};
 std::atomic<uint64_t> g_static_world_presentation_renderer_mismatches{};
 std::atomic<uint64_t> g_static_world_presentation_resource_mismatches{};
+std::atomic<uint64_t> g_static_world_asset_metadata_observations{};
+std::atomic<uint64_t> g_static_world_asset_metadata_exact{};
+std::atomic<uint64_t> g_static_world_asset_metadata_empty_keys{};
+std::atomic<uint64_t> g_static_world_asset_metadata_read_faults{};
+std::atomic<uint64_t> g_static_world_asset_metadata_joins{};
+std::atomic<uint64_t> g_static_world_asset_metadata_missing_joins{};
 std::array<SemanticBindingCacheSlot, 5> g_semantic_binding_cache_slots{};
 std::array<SemanticResolverCacheSlot, 5> g_semantic_resolver_cache_slots{};
 thread_local PendingSemanticResourceBindings g_pending_semantic_bindings{};
@@ -2877,6 +2908,121 @@ bool LoadMappedGuestU32(rex::memory::Memory *memory, uint32_t address,
   return true;
 }
 
+bool LoadMappedGuestU16(rex::memory::Memory *memory, uint32_t address,
+                        uint16_t &value) {
+  if (!IsReadableVehicleGuestRange(memory, address, sizeof(uint16_t))) {
+    return false;
+  }
+  size_t host_region_length = 0;
+  rex::memory::PageAccess host_access = rex::memory::PageAccess::kNoAccess;
+  void *host_address = memory->TranslateVirtual<void *>(address);
+  if (!rex::memory::QueryProtect(host_address, host_region_length,
+                                 host_access) ||
+      host_region_length < sizeof(uint16_t) ||
+      host_access == rex::memory::PageAccess::kNoAccess) {
+    return false;
+  }
+  value = static_cast<uint16_t>(
+      *memory->TranslateVirtual<rex::be_u16 *>(address));
+  return true;
+}
+
+enum class StaticWorldAssetMetadataResult {
+  kExact,
+  kEmptyKey,
+  kReadFault,
+};
+
+StaticWorldAssetMetadataResult ReadStaticWorldAssetMetadata(
+    rex::memory::Memory *memory, uint32_t presentation_address,
+    uint32_t resource_address, StaticWorldPresentationDispatchScope &scope) {
+  if (!memory || !resource_address ||
+      presentation_address >
+          UINT32_MAX - kModelPresentationNameOffset -
+              kMsvcStringCapacityOffset - sizeof(uint32_t)) {
+    return StaticWorldAssetMetadataResult::kReadFault;
+  }
+  const uint32_t string_address =
+      presentation_address + kModelPresentationNameOffset;
+  uint32_t string_size = 0;
+  uint32_t string_capacity = 0;
+  if (!LoadMappedGuestU32(memory, string_address + kMsvcStringSizeOffset,
+                          string_size) ||
+      !LoadMappedGuestU32(memory,
+                          string_address + kMsvcStringCapacityOffset,
+                          string_capacity) ||
+      string_size > kStaticWorldAssetKeyMaximumBytes ||
+      string_capacity < string_size) {
+    return StaticWorldAssetMetadataResult::kReadFault;
+  }
+  if (!string_size) {
+    return StaticWorldAssetMetadataResult::kEmptyKey;
+  }
+  uint32_t string_data_address = string_address;
+  if (string_capacity >= kMsvcStringInlineCapacity &&
+      !LoadMappedGuestU32(memory, string_address, string_data_address)) {
+    return StaticWorldAssetMetadataResult::kReadFault;
+  }
+  if (!IsReadableVehicleGuestRange(memory, string_data_address,
+                                   string_size)) {
+    return StaticWorldAssetMetadataResult::kReadFault;
+  }
+  size_t host_region_length = 0;
+  rex::memory::PageAccess host_access = rex::memory::PageAccess::kNoAccess;
+  const uint8_t *string_data =
+      memory->TranslateVirtual<const uint8_t *>(string_data_address);
+  if (!rex::memory::QueryProtect(const_cast<uint8_t *>(string_data),
+                                 host_region_length, host_access) ||
+      host_region_length < string_size ||
+      host_access == rex::memory::PageAccess::kNoAccess) {
+    return StaticWorldAssetMetadataResult::kReadFault;
+  }
+
+  uint16_t effect_count = 0;
+  uint32_t effect_records = 0;
+  uint32_t texture_begin = 0;
+  uint32_t texture_end = 0;
+  if (resource_address >
+          UINT32_MAX - kSimpleModelResourceTextureVectorOffset - 4 ||
+      !LoadMappedGuestU16(
+          memory, resource_address + kSimpleModelResourceEffectCountOffset,
+          effect_count) ||
+      !LoadMappedGuestU32(
+          memory, resource_address + kSimpleModelResourceEffectRecordsOffset,
+          effect_records) ||
+      !LoadMappedGuestU32(
+          memory, resource_address + kSimpleModelResourceTextureVectorOffset,
+          texture_begin) ||
+      !LoadMappedGuestU32(
+          memory,
+          resource_address + kSimpleModelResourceTextureVectorOffset + 4,
+          texture_end) ||
+      (effect_count && !effect_records) || texture_end < texture_begin) {
+    return StaticWorldAssetMetadataResult::kReadFault;
+  }
+  const uint32_t texture_bytes = texture_end - texture_begin;
+  if (texture_bytes % kMsvcStringRecordBytes) {
+    return StaticWorldAssetMetadataResult::kReadFault;
+  }
+  const uint32_t texture_count = texture_bytes / kMsvcStringRecordBytes;
+  if (effect_count > kStaticWorldReferenceCountMaximum ||
+      texture_count > kStaticWorldReferenceCountMaximum) {
+    return StaticWorldAssetMetadataResult::kReadFault;
+  }
+
+  uint64_t hash = UINT64_C(0xCBF29CE484222325);
+  for (uint32_t index = 0; index < string_size; ++index) {
+    hash ^= string_data[index];
+    hash *= UINT64_C(0x100000001B3);
+  }
+  scope.asset_key_hash = hash ? hash : 1;
+  scope.asset_key_length = string_size;
+  scope.effect_reference_count = effect_count;
+  scope.texture_reference_count = texture_count;
+  scope.asset_metadata_valid = true;
+  return StaticWorldAssetMetadataResult::kExact;
+}
+
 size_t StaticWorldRendererLifecycleIndex(uint32_t address) {
   return size_t((address >> 4) % kStaticWorldRendererLifecycleCapacity);
 }
@@ -3526,6 +3672,19 @@ void BeginStaticWorldPresentationDispatch(uint32_t presentation_address) {
     ++g_static_world_presentation_resource_read_faults;
     return;
   }
+  ++g_static_world_asset_metadata_observations;
+  switch (ReadStaticWorldAssetMetadata(
+      memory, presentation_address, scope.resource_address, scope)) {
+  case StaticWorldAssetMetadataResult::kExact:
+    ++g_static_world_asset_metadata_exact;
+    break;
+  case StaticWorldAssetMetadataResult::kEmptyKey:
+    ++g_static_world_asset_metadata_empty_keys;
+    break;
+  case StaticWorldAssetMetadataResult::kReadFault:
+    ++g_static_world_asset_metadata_read_faults;
+    break;
+  }
   scope.exact = true;
   ++g_static_world_presentation_exact;
 }
@@ -3658,8 +3817,20 @@ void BeginStaticWorldRendererDispatch(uint32_t renderer_address,
           presentation_scope.presentation_address;
       scope.model_presentation_resource_address =
           presentation_scope.resource_address;
+      scope.asset_key_hash = presentation_scope.asset_key_hash;
+      scope.asset_key_length = presentation_scope.asset_key_length;
+      scope.effect_reference_count =
+          presentation_scope.effect_reference_count;
+      scope.texture_reference_count =
+          presentation_scope.texture_reference_count;
+      scope.asset_metadata_valid =
+          presentation_scope.asset_metadata_valid;
       ++presentation_scope.renderer_dispatch_joins;
       ++g_static_world_presentation_renderer_joins;
+      (scope.asset_metadata_valid
+           ? g_static_world_asset_metadata_joins
+           : g_static_world_asset_metadata_missing_joins)
+          .fetch_add(1, std::memory_order_relaxed);
     } else if (!renderer_matches) {
       ++g_static_world_presentation_renderer_mismatches;
     } else {
@@ -5148,6 +5319,12 @@ void ResetTitleDrawProvenance() {
            &g_static_world_presentation_renderer_joins,
            &g_static_world_presentation_renderer_mismatches,
            &g_static_world_presentation_resource_mismatches,
+           &g_static_world_asset_metadata_observations,
+           &g_static_world_asset_metadata_exact,
+           &g_static_world_asset_metadata_empty_keys,
+           &g_static_world_asset_metadata_read_faults,
+           &g_static_world_asset_metadata_joins,
+           &g_static_world_asset_metadata_missing_joins,
        }) {
     counter->store(0, std::memory_order_relaxed);
   }
@@ -5637,6 +5814,7 @@ void RecordProceduralModelSemanticDrawPacket(
     const StaticWorldRendererDispatchScope &scope =
         g_static_world_renderer_scope;
     origin.static_world_draw = {
+        .asset_key_hash = scope.asset_key_hash,
         .model_presentation_address = scope.model_presentation_address,
         .model_presentation_resource_address =
             scope.model_presentation_resource_address,
@@ -5654,6 +5832,10 @@ void RecordProceduralModelSemanticDrawPacket(
             scope.member_exact ? scope.simple_submodel_address : 0,
         .simple_mesh_address =
             scope.member_exact ? scope.simple_mesh_address : 0,
+        .asset_key_length = scope.asset_key_length,
+        .effect_reference_count = scope.effect_reference_count,
+        .texture_reference_count = scope.texture_reference_count,
+        .asset_metadata_valid = scope.asset_metadata_valid,
         .valid = true,
     };
   }
@@ -11140,6 +11322,22 @@ void EmitStaticWorldRuntimeJoinEvent(const char *event_name,
   const uint64_t presentation_renderer_joins =
       g_static_world_presentation_renderer_joins.load(
           std::memory_order_relaxed);
+  const uint64_t asset_metadata_observations =
+      g_static_world_asset_metadata_observations.load(
+          std::memory_order_relaxed);
+  const uint64_t asset_metadata_exact =
+      g_static_world_asset_metadata_exact.load(std::memory_order_relaxed);
+  const uint64_t asset_metadata_empty_keys =
+      g_static_world_asset_metadata_empty_keys.load(
+          std::memory_order_relaxed);
+  const uint64_t asset_metadata_read_faults =
+      g_static_world_asset_metadata_read_faults.load(
+          std::memory_order_relaxed);
+  const uint64_t asset_metadata_joins =
+      g_static_world_asset_metadata_joins.load(std::memory_order_relaxed);
+  const uint64_t asset_metadata_missing_joins =
+      g_static_world_asset_metadata_missing_joins.load(
+          std::memory_order_relaxed);
   const bool accounting_complete =
       entries == exact + invalid_root + vtable_mismatches +
                            invalid_graph_field + unregistered_renderers +
@@ -11222,6 +11420,12 @@ void EmitStaticWorldRuntimeJoinEvent(const char *event_name,
           presentation_scopes_with_renderer +
               presentation_scopes_without_renderer &&
       presentation_scopes_with_renderer <= presentation_renderer_joins &&
+      asset_metadata_observations == presentation_exact &&
+      asset_metadata_observations ==
+          asset_metadata_exact + asset_metadata_empty_keys +
+              asset_metadata_read_faults &&
+      presentation_renderer_joins ==
+          asset_metadata_joins + asset_metadata_missing_joins &&
       !overlaps && !exit_without_entry;
   const bool qualification_complete =
       accounting_complete && exact && packets_recorded && packet_matches &&
@@ -11277,6 +11481,7 @@ void EmitStaticWorldRuntimeJoinEvent(const char *event_name,
       !g_static_world_member_packet_mismatches.load(
           std::memory_order_relaxed) &&
       presentation_exact && presentation_renderer_joins &&
+      asset_metadata_exact && asset_metadata_joins &&
       presentation_scopes_with_renderer &&
       !g_static_world_presentation_invalid_root.load(
           std::memory_order_relaxed) &&
@@ -11289,7 +11494,8 @@ void EmitStaticWorldRuntimeJoinEvent(const char *event_name,
       !g_static_world_presentation_renderer_mismatches.load(
           std::memory_order_relaxed) &&
       !g_static_world_presentation_resource_mismatches.load(
-          std::memory_order_relaxed);
+          std::memory_order_relaxed) &&
+      !asset_metadata_read_faults && !asset_metadata_missing_joins;
   const uint64_t pending_packets =
       packets_recorded >= packet_matches ? packets_recorded - packet_matches
                                           : 0;
@@ -11509,6 +11715,16 @@ void EmitStaticWorldRuntimeJoinEvent(const char *event_name,
         std::to_string(
             g_static_world_presentation_resource_mismatches.load(
                 std::memory_order_relaxed))},
+       {"asset_metadata_observations",
+        std::to_string(asset_metadata_observations)},
+       {"asset_metadata_exact", std::to_string(asset_metadata_exact)},
+       {"asset_metadata_empty_keys",
+        std::to_string(asset_metadata_empty_keys)},
+       {"asset_metadata_read_faults",
+        std::to_string(asset_metadata_read_faults)},
+       {"asset_metadata_joins", std::to_string(asset_metadata_joins)},
+       {"asset_metadata_missing_joins",
+        std::to_string(asset_metadata_missing_joins)},
        {"accounting_complete", accounting_complete ? "true" : "false"},
        {"qualification_complete",
         qualification_complete ? "true" : "false"},
@@ -14206,6 +14422,7 @@ void RecordTitleDrawProvenance(
                  (uint64_t(backend_outcome) << 41) ^
                  (prepared ? uint64_t(1) << 63 : 0);
   key = HashCombine(key, origin.semantic_draw.submission_key);
+  key = HashCombine(key, origin.static_world_draw.asset_key_hash);
   key = HashCombine(
       key, origin.static_world_draw.model_presentation_address);
   key = HashCombine(
@@ -14261,6 +14478,16 @@ void RecordTitleDrawProvenance(
             origin.semantic_draw.record_index &&
         entry.origin.static_world_draw.renderer_address ==
             origin.static_world_draw.renderer_address &&
+        entry.origin.static_world_draw.asset_key_hash ==
+            origin.static_world_draw.asset_key_hash &&
+        entry.origin.static_world_draw.asset_key_length ==
+            origin.static_world_draw.asset_key_length &&
+        entry.origin.static_world_draw.effect_reference_count ==
+            origin.static_world_draw.effect_reference_count &&
+        entry.origin.static_world_draw.texture_reference_count ==
+            origin.static_world_draw.texture_reference_count &&
+        entry.origin.static_world_draw.asset_metadata_valid ==
+            origin.static_world_draw.asset_metadata_valid &&
         entry.origin.static_world_draw.model_presentation_address ==
             origin.static_world_draw.model_presentation_address &&
         entry.origin.static_world_draw.model_presentation_resource_address ==
@@ -14363,6 +14590,32 @@ void EmitTitleDrawProvenanceSummary() {
          {"origin_caller", fmt::format("{:08X}", entry.origin.caller)},
          {"static_world_origin",
           entry.origin.static_world_draw.valid ? "true" : "false"},
+         {"static_world_asset_metadata_valid",
+          entry.origin.static_world_draw.valid
+              ? (entry.origin.static_world_draw.asset_metadata_valid
+                     ? "true"
+                     : "false")
+              : ""},
+         {"static_world_asset_key_hash",
+          entry.origin.static_world_draw.asset_metadata_valid
+              ? fmt::format("{:016X}",
+                            entry.origin.static_world_draw.asset_key_hash)
+              : ""},
+         {"static_world_asset_key_length",
+          entry.origin.static_world_draw.asset_metadata_valid
+              ? std::to_string(
+                    entry.origin.static_world_draw.asset_key_length)
+              : ""},
+         {"static_world_effect_reference_count",
+          entry.origin.static_world_draw.asset_metadata_valid
+              ? std::to_string(
+                    entry.origin.static_world_draw.effect_reference_count)
+              : ""},
+         {"static_world_texture_reference_count",
+          entry.origin.static_world_draw.asset_metadata_valid
+              ? std::to_string(
+                    entry.origin.static_world_draw.texture_reference_count)
+              : ""},
          {"static_world_model_presentation",
           entry.origin.static_world_draw.valid &&
                   entry.origin.static_world_draw.model_presentation_address
@@ -22912,10 +23165,17 @@ void InstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system,
        {"presentation_renderer_field", "presentation_plus_1608"},
        {"presentation_resource_join",
         "presentation_plus_148_equals_renderer_plus_72"},
+       {"asset_key_field", "presentation_plus_16_msvc_string"},
+       {"asset_key_export", "fnv1a64_hash_and_length_only"},
+       {"effect_reference_fields", "resource_plus_124_pointer_plus_128_u16"},
+       {"texture_reference_vector", "resource_plus_288_stride_28"},
+       {"asset_metadata_limits", "key_bytes_512_reference_count_4096"},
        {"draw_emitter", "82416380"},
        {"packet_hooks", "82416260,824162F4"},
        {"join", "synchronous_scope_to_physical_pm4_prepared_draw"},
-       {"guest_payload_read", "bounded_host_mapped_identity_fields"},
+       {"guest_payload_read",
+        "bounded_host_mapped_identity_and_asset_metadata_fields"},
+       {"plaintext_asset_names_exported", "false"},
        {"guest_state_changed", "false"},
        {"control_flow_changed", "false"},
        {"native_admission", "false"},

--- a/tools/summarize-native-renderer-static-world-runtime-join.py
+++ b/tools/summarize-native-renderer-static-world-runtime-join.py
@@ -9,13 +9,16 @@ import pathlib
 import sys
 
 
-SCHEMA = "pinyon-shift.native-renderer-static-world-runtime-join.v6"
+SCHEMA = "pinyon-shift.native-renderer-static-world-runtime-join.v7"
 STATIC_SCHEMA = "pinyon-shift.native-renderer-static-world-ingress.v2"
 LIFETIME_SCHEMA = "pinyon-shift.native-renderer-static-world-lifetime.v1"
 RESOURCE_SCHEMA = "pinyon-shift.native-renderer-static-world-resource.v1"
 STREAMING_SCHEMA = "pinyon-shift.native-renderer-static-world-streaming.v1"
 GRAPH_SCHEMA = "pinyon-shift.native-renderer-static-world-graph.v1"
 OWNER_SCHEMA = "pinyon-shift.native-renderer-static-world-owner.v1"
+ASSET_METADATA_SCHEMA = (
+    "pinyon-shift.native-renderer-static-world-asset-metadata.v1"
+)
 CONFIG = "native_renderer.discovery.static_world_runtime_join_config"
 SUMMARY = "native_renderer.discovery.static_world_runtime_join_summary"
 CHECKPOINT = "native_renderer.discovery.static_world_runtime_join_checkpoint"
@@ -424,6 +427,82 @@ def validate_static_owner(document):
         raise ValueError("static-world owner claims drifted")
 
 
+def validate_static_asset_metadata(document):
+    if (
+        document.get("schema") != ASSET_METADATA_SCHEMA
+        or document.get("status") != "complete"
+        or document.get("classification")
+        != "bounded_simple_model_asset_reference_metadata"
+    ):
+        raise ValueError("static-world asset metadata proof drifted")
+    try:
+        resource_key = document["resource_key"]
+        effects = document["effect_references"]
+        textures = document["texture_references"]
+        claims = document["claims"]
+        boundary = document["next_boundary"]
+    except (KeyError, TypeError) as error:
+        raise ValueError(
+            "static-world asset metadata proof is incomplete"
+        ) from error
+    expected_resource_key = {
+        "presentation_class": "Presentation_Unified::CModelPresentation",
+        "initialize_method": "82DEA298",
+        "stored_name_offset": 16,
+        "string_layout": "msvc_string_28_bytes_inline_capacity_below_16",
+        "resource_reference_offset": 148,
+        "resource_bind": "82C48038",
+        "resource_type_argument": "00060000",
+        "address_equation": (
+            "resource_bind_key_equals_presentation_plus_16_string_bytes"
+        ),
+    }
+    expected_effects = {
+        "resource_class": "CSimpleModelResource",
+        "prepare_helper": "823F8980",
+        "records_pointer_offset": 124,
+        "record_count_offset": 128,
+        "record_count_width_bits": 16,
+        "record_stride": 28,
+        "record_layout": "msvc_string_28_bytes_inline_capacity_below_16",
+        "suffix": ".fx",
+        "suffix_address": "8224332C",
+        "lookup": "82C39B78",
+        "lookup_type_argument": "00060000",
+    }
+    expected_textures = {
+        "resource_class": "CSimpleModelResource",
+        "records_vector_offset": 288,
+        "vector_begin_offset": 0,
+        "vector_end_offset": 4,
+        "record_stride": 28,
+        "record_layout": "msvc_string_28_bytes_inline_capacity_below_16",
+        "id_marker": "Id=",
+        "id_marker_address": "8201C108",
+        "path_format": "%s%stextures\\%s",
+        "path_format_address": "8224331C",
+        "lookup": "82C39730",
+    }
+    if resource_key != expected_resource_key:
+        raise ValueError("static-world resource key proof drifted")
+    if effects != expected_effects:
+        raise ValueError("static-world effect reference proof drifted")
+    if textures != expected_textures:
+        raise ValueError("static-world texture reference proof drifted")
+    if (
+        claims.get("presentation_name_to_resource_key_proved") is not True
+        or claims.get("bounded_effect_reference_table_proved") is not True
+        or claims.get("bounded_texture_reference_table_proved") is not True
+        or claims.get("effect_and_texture_path_construction_proved")
+        is not True
+        or claims.get("concrete_building_or_prop_category_proved") is not False
+        or boundary.get("runtime_export")
+        != "hash_and_structural_category_only"
+        or boundary.get("plaintext_asset_names_allowed") is not False
+    ):
+        raise ValueError("static-world asset metadata claims drifted")
+
+
 def build(
     static_ingress,
     static_lifetime,
@@ -431,6 +510,7 @@ def build(
     static_streaming,
     static_graph,
     static_owner,
+    static_asset_metadata,
     events,
     requested_session=None,
     allow_checkpoint=False,
@@ -441,6 +521,7 @@ def build(
     validate_static_streaming(static_streaming)
     validate_static_graph(static_graph)
     validate_static_owner(static_owner)
+    validate_static_asset_metadata(static_asset_metadata)
     session = select_session(events, requested_session)
     selected = [event for event in events if event.get("session") == session]
     config = exact_event(selected, CONFIG)
@@ -496,10 +577,18 @@ def build(
         "presentation_resource_join": (
             "presentation_plus_148_equals_renderer_plus_72"
         ),
+        "asset_key_field": "presentation_plus_16_msvc_string",
+        "asset_key_export": "fnv1a64_hash_and_length_only",
+        "effect_reference_fields": "resource_plus_124_pointer_plus_128_u16",
+        "texture_reference_vector": "resource_plus_288_stride_28",
+        "asset_metadata_limits": "key_bytes_512_reference_count_4096",
         "draw_emitter": "82416380",
         "packet_hooks": "82416260,824162F4",
         "join": "synchronous_scope_to_physical_pm4_prepared_draw",
-        "guest_payload_read": "bounded_host_mapped_identity_fields",
+        "guest_payload_read": (
+            "bounded_host_mapped_identity_and_asset_metadata_fields"
+        ),
+        "plaintext_asset_names_exported": "false",
     }
     if any(config.get(key) != value for key, value in expected_config.items()):
         raise ValueError("static-world runtime configuration drifted")
@@ -625,6 +714,12 @@ def build(
         "presentation_renderer_joins",
         "presentation_renderer_mismatches",
         "presentation_resource_mismatches",
+        "asset_metadata_observations",
+        "asset_metadata_exact",
+        "asset_metadata_empty_keys",
+        "asset_metadata_read_faults",
+        "asset_metadata_joins",
+        "asset_metadata_missing_joins",
     )
     totals = {key: integer(summary, key) for key in keys}
     frame_sequence = integer(summary, "frame_sequence")
@@ -795,10 +890,27 @@ def build(
         "presentation_renderer_joins"
     ]:
         failures.append("static-world presentation renderer join drifted")
+    if totals["asset_metadata_observations"] != totals["presentation_exact"]:
+        failures.append("static-world asset metadata observation drifted")
+    if totals["asset_metadata_observations"] != (
+        totals["asset_metadata_exact"]
+        + totals["asset_metadata_empty_keys"]
+        + totals["asset_metadata_read_faults"]
+    ):
+        failures.append("static-world asset metadata classification drifted")
+    if totals["presentation_renderer_joins"] != (
+        totals["asset_metadata_joins"]
+        + totals["asset_metadata_missing_joins"]
+    ):
+        failures.append("static-world asset metadata join drifted")
     if not totals["presentation_exact"]:
         failures.append("no exact CModelPresentation scope was observed")
     if not totals["presentation_renderer_joins"]:
         failures.append("no CModelPresentation joined its SimpleModel renderer")
+    if not totals["asset_metadata_exact"]:
+        failures.append("no bounded static-world asset metadata was observed")
+    if not totals["asset_metadata_joins"]:
+        failures.append("no asset-key hash joined a SimpleModel renderer")
     if not totals["prepared_matches"]:
         failures.append("no static-world PM4 packet joined a prepared draw")
     for key in (
@@ -849,6 +961,8 @@ def build(
         "presentation_exit_without_entry",
         "presentation_renderer_mismatches",
         "presentation_resource_mismatches",
+        "asset_metadata_read_faults",
+        "asset_metadata_missing_joins",
     ):
         if totals[key]:
             failures.append(f"{key} is nonzero")
@@ -892,6 +1006,8 @@ def build(
             "model_presentation_owner_proved": not failures,
             "model_presentation_to_renderer_proved": not failures,
             "model_presentation_to_renderer_resource_proved": not failures,
+            "bounded_asset_reference_metadata_proved": not failures,
+            "hashed_asset_identity_to_prepared_draw_proved": not failures,
             "static_world_scope_to_pm4_proved": not failures,
             "static_world_pm4_to_prepared_draw_proved": not failures,
             "building_or_prop_instance_identity_proved": False,
@@ -920,6 +1036,7 @@ def main(argv=None):
     parser.add_argument("--streaming", required=True, type=pathlib.Path)
     parser.add_argument("--graph", required=True, type=pathlib.Path)
     parser.add_argument("--owner", required=True, type=pathlib.Path)
+    parser.add_argument("--asset-metadata", required=True, type=pathlib.Path)
     parser.add_argument("--session")
     parser.add_argument("--allow-checkpoint", action="store_true")
     parser.add_argument("--output", required=True, type=pathlib.Path)
@@ -932,6 +1049,7 @@ def main(argv=None):
             json.loads(args.streaming.read_text(encoding="utf-8")),
             json.loads(args.graph.read_text(encoding="utf-8")),
             json.loads(args.owner.read_text(encoding="utf-8")),
+            json.loads(args.asset_metadata.read_text(encoding="utf-8")),
             read_events(args.events),
             args.session,
             args.allow_checkpoint,

--- a/tools/tests/test_native_renderer_static_world_runtime_join.py
+++ b/tools/tests/test_native_renderer_static_world_runtime_join.py
@@ -273,6 +273,63 @@ def static_owner():
     }
 
 
+def static_asset_metadata():
+    return {
+        "schema": MODULE.ASSET_METADATA_SCHEMA,
+        "status": "complete",
+        "classification": "bounded_simple_model_asset_reference_metadata",
+        "resource_key": {
+            "presentation_class": "Presentation_Unified::CModelPresentation",
+            "initialize_method": "82DEA298",
+            "stored_name_offset": 16,
+            "string_layout": "msvc_string_28_bytes_inline_capacity_below_16",
+            "resource_reference_offset": 148,
+            "resource_bind": "82C48038",
+            "resource_type_argument": "00060000",
+            "address_equation": (
+                "resource_bind_key_equals_presentation_plus_16_string_bytes"
+            ),
+        },
+        "effect_references": {
+            "resource_class": "CSimpleModelResource",
+            "prepare_helper": "823F8980",
+            "records_pointer_offset": 124,
+            "record_count_offset": 128,
+            "record_count_width_bits": 16,
+            "record_stride": 28,
+            "record_layout": "msvc_string_28_bytes_inline_capacity_below_16",
+            "suffix": ".fx",
+            "suffix_address": "8224332C",
+            "lookup": "82C39B78",
+            "lookup_type_argument": "00060000",
+        },
+        "texture_references": {
+            "resource_class": "CSimpleModelResource",
+            "records_vector_offset": 288,
+            "vector_begin_offset": 0,
+            "vector_end_offset": 4,
+            "record_stride": 28,
+            "record_layout": "msvc_string_28_bytes_inline_capacity_below_16",
+            "id_marker": "Id=",
+            "id_marker_address": "8201C108",
+            "path_format": "%s%stextures\\%s",
+            "path_format_address": "8224331C",
+            "lookup": "82C39730",
+        },
+        "claims": {
+            "presentation_name_to_resource_key_proved": True,
+            "bounded_effect_reference_table_proved": True,
+            "bounded_texture_reference_table_proved": True,
+            "effect_and_texture_path_construction_proved": True,
+            "concrete_building_or_prop_category_proved": False,
+        },
+        "next_boundary": {
+            "runtime_export": "hash_and_structural_category_only",
+            "plaintext_asset_names_allowed": False,
+        },
+    }
+
+
 def fixture():
     config = event(
         MODULE.CONFIG,
@@ -325,10 +382,20 @@ def fixture():
             "presentation_resource_join": (
                 "presentation_plus_148_equals_renderer_plus_72"
             ),
+            "asset_key_field": "presentation_plus_16_msvc_string",
+            "asset_key_export": "fnv1a64_hash_and_length_only",
+            "effect_reference_fields": (
+                "resource_plus_124_pointer_plus_128_u16"
+            ),
+            "texture_reference_vector": "resource_plus_288_stride_28",
+            "asset_metadata_limits": "key_bytes_512_reference_count_4096",
             "draw_emitter": "82416380",
             "packet_hooks": "82416260,824162F4",
             "join": "synchronous_scope_to_physical_pm4_prepared_draw",
-            "guest_payload_read": "bounded_host_mapped_identity_fields",
+            "guest_payload_read": (
+                "bounded_host_mapped_identity_and_asset_metadata_fields"
+            ),
+            "plaintext_asset_names_exported": "false",
             **safety(),
         },
     )
@@ -438,6 +505,12 @@ def fixture():
         presentation_renderer_joins="8",
         presentation_renderer_mismatches="0",
         presentation_resource_mismatches="0",
+        asset_metadata_observations="12",
+        asset_metadata_exact="10",
+        asset_metadata_empty_keys="2",
+        asset_metadata_read_faults="0",
+        asset_metadata_joins="8",
+        asset_metadata_missing_joins="0",
         accounting_complete="true",
         qualification_complete="true",
         classification=(
@@ -457,6 +530,7 @@ class StaticWorldRuntimeJoinTests(unittest.TestCase):
             static_streaming(),
             static_graph(),
             static_owner(),
+            static_asset_metadata(),
             fixture(),
         )
         self.assertEqual("complete", document["status"])
@@ -500,6 +574,7 @@ class StaticWorldRuntimeJoinTests(unittest.TestCase):
             static_streaming(),
             static_graph(),
             static_owner(),
+            static_asset_metadata(),
             events + [checkpoint],
             allow_checkpoint=True,
         )
@@ -522,6 +597,7 @@ class StaticWorldRuntimeJoinTests(unittest.TestCase):
             static_streaming(),
             static_graph(),
             static_owner(),
+            static_asset_metadata(),
             events,
         )
         self.assertEqual("incomplete", document["status"])
@@ -542,6 +618,7 @@ class StaticWorldRuntimeJoinTests(unittest.TestCase):
             static_streaming(),
             static_graph(),
             static_owner(),
+            static_asset_metadata(),
             events,
         )
         self.assertEqual("incomplete", document["status"])
@@ -563,6 +640,7 @@ class StaticWorldRuntimeJoinTests(unittest.TestCase):
                 static_streaming(),
                 static_graph(),
                 static_owner(),
+                static_asset_metadata(),
                 fixture(),
             )
 
@@ -583,6 +661,7 @@ class StaticWorldRuntimeJoinTests(unittest.TestCase):
             static_streaming(),
             static_graph(),
             static_owner(),
+            static_asset_metadata(),
             events,
         )
         self.assertEqual("incomplete", document["status"])
@@ -605,6 +684,7 @@ class StaticWorldRuntimeJoinTests(unittest.TestCase):
             static_streaming(),
             static_graph(),
             static_owner(),
+            static_asset_metadata(),
             events,
         )
         self.assertEqual("incomplete", document["status"])
@@ -628,6 +708,7 @@ class StaticWorldRuntimeJoinTests(unittest.TestCase):
             static_streaming(),
             static_graph(),
             static_owner(),
+            static_asset_metadata(),
             events,
         )
         self.assertEqual("incomplete", document["status"])
@@ -653,6 +734,7 @@ class StaticWorldRuntimeJoinTests(unittest.TestCase):
             static_streaming(),
             static_graph(),
             static_owner(),
+            static_asset_metadata(),
             events,
         )
         self.assertEqual("incomplete", document["status"])
@@ -675,6 +757,7 @@ class StaticWorldRuntimeJoinTests(unittest.TestCase):
             static_streaming(),
             static_graph(),
             static_owner(),
+            static_asset_metadata(),
             events,
         )
         self.assertEqual("incomplete", document["status"])
@@ -697,6 +780,7 @@ class StaticWorldRuntimeJoinTests(unittest.TestCase):
             static_streaming(),
             static_graph(),
             static_owner(),
+            static_asset_metadata(),
             events,
         )
         self.assertEqual("incomplete", document["status"])
@@ -704,6 +788,44 @@ class StaticWorldRuntimeJoinTests(unittest.TestCase):
             "presentation_resource_mismatches is nonzero",
             document["failures"],
         )
+
+    def test_rejects_asset_metadata_missing_from_renderer_join(self):
+        events = copy.deepcopy(fixture())
+        events[-1].update(
+            status="incomplete",
+            asset_metadata_joins="7",
+            asset_metadata_missing_joins="1",
+            qualification_complete="false",
+        )
+        document = MODULE.build(
+            static_ingress(),
+            static_lifetime(),
+            static_resource(),
+            static_streaming(),
+            static_graph(),
+            static_owner(),
+            static_asset_metadata(),
+            events,
+        )
+        self.assertEqual("incomplete", document["status"])
+        self.assertIn(
+            "asset_metadata_missing_joins is nonzero", document["failures"]
+        )
+
+    def test_rejects_static_asset_key_offset_drift(self):
+        metadata = static_asset_metadata()
+        metadata["resource_key"]["stored_name_offset"] = 20
+        with self.assertRaisesRegex(ValueError, "resource key proof drifted"):
+            MODULE.build(
+                static_ingress(),
+                static_lifetime(),
+                static_resource(),
+                static_streaming(),
+                static_graph(),
+                static_owner(),
+                metadata,
+                fixture(),
+            )
 
     def test_source_contract_has_balanced_static_world_hooks(self):
         hooks = (ROOT / "src/native_renderer/graphics_hooks.cpp").read_text(
@@ -738,6 +860,9 @@ class StaticWorldRuntimeJoinTests(unittest.TestCase):
         self.assertIn("address = 0x82C4DC58", analysis)
         self.assertIn("address = 0x823F8DB8", analysis)
         self.assertIn("address = 0x823F8FA0", analysis)
+        self.assertIn("kModelPresentationNameOffset = 16", hooks)
+        self.assertIn("ReadStaticWorldAssetMetadata", hooks)
+        self.assertIn("static_world_asset_key_hash", hooks)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- hash the proved presentation resource key without exporting plaintext names
- carry key hash/length and bounded effect/texture counts through renderer, PM4, and prepared-draw provenance
- extend the fail-closed combined C1/C2 qualifier and all qualification docs

## Safety
- no guest writes or control-flow changes
- no native admission or suppression
- Xenos remains authoritative

## Validation
- 560 Python tests passed
- retail asset-metadata report passed
- host observer compiled successfully
- final executable link remains intentionally blocked by the preserved AppData gameplay process