### PR TITLE
feat(native-renderer): prove static mesh draw semantics

### DIFF
--- a/docs/native-renderer/REPRIORITIZED_PLAN.md
+++ b/docs/native-renderer/REPRIORITIZED_PLAN.md
@@ -394,6 +394,15 @@ join accounting fails closed when a renderer-joined presentation lacks valid
 metadata. Runtime qualification remains batched with C1/C2; concrete
 building-versus-prop labels remain unproved.
 
+Mesh-semantics checkpoint: the SimpleMesh draw path now proves numeric
+primitive type at mesh offset 36, index-buffer binding at 96, source element
+count at 100, the exact primitive-count and scale/bias conversion, and the
+bind/draw/clear sequence. The bounded submodel state and optional mesh material
+resource branches are also locked. See
+[`STATIC_WORLD_MESH_SEMANTICS.md`](STATIC_WORLD_MESH_SEMANTICS.md). Complete
+vertex-fetch layouts and material parameter blocks remain open; no admission
+or suppression is enabled.
+
 ### C3. Semantic batching, culling, and LOD
 
 - Promote the existing visibility and prepared-draw evidence into production

--- a/docs/native-renderer/STATIC_WORLD_ASSET_METADATA.md
+++ b/docs/native-renderer/STATIC_WORLD_ASSET_METADATA.md
@@ -48,4 +48,6 @@ missing-join outcomes are independently accounted and the qualifier fails
 closed on any joined draw without valid metadata.
 
 The combined C1/C2 AppData run remains intentionally batched. Xenos remains
-authoritative; this checkpoint enables no native admission or suppression.
+authoritative; this report and the adjacent mesh-semantics report are required
+static inputs to that qualifier. This checkpoint enables no native admission
+or suppression.

--- a/docs/native-renderer/STATIC_WORLD_GRAPH.md
+++ b/docs/native-renderer/STATIC_WORLD_GRAPH.md
@@ -56,6 +56,7 @@ python tools/summarize-native-renderer-static-world-runtime-join.py `
   --graph .local/qualification/native-renderer-static-world-graph.json `
   --owner .local/qualification/native-renderer-static-world-owner.json `
   --asset-metadata .local/qualification/native-renderer-static-world-asset-metadata.json `
+  --mesh-semantics .local/qualification/native-renderer-static-world-mesh-semantics.json `
   --session <session> `
   --output .local/qualification/native-renderer-static-world-runtime-join.json
 ```
@@ -63,8 +64,10 @@ python tools/summarize-native-renderer-static-world-runtime-join.py `
 ## Remaining boundary
 
 This identifies the exact generic SimpleModel member graph behind each joined
-draw. It does not distinguish an individual building from a prop, classify
-mesh/material fields, or authorize native replay. Runtime qualification must
-also prove the graph and payload-reset transitions under representative
+draw. It does not distinguish an individual building from a prop. The bounded
+fields used by the mesh draw and material binding branches are now proved in
+[`STATIC_WORLD_MESH_SEMANTICS.md`](STATIC_WORLD_MESH_SEMANTICS.md), while
+complete vertex/material payload decoding remains open. Runtime qualification
+must also prove the graph and payload-reset transitions under representative
 streaming. Native admission, publication, and suppression remain disabled;
 Xenos stays authoritative.

--- a/docs/native-renderer/STATIC_WORLD_INGRESS.md
+++ b/docs/native-renderer/STATIC_WORLD_INGRESS.md
@@ -103,6 +103,7 @@ python tools/summarize-native-renderer-static-world-runtime-join.py `
   --graph .local/qualification/native-renderer-static-world-graph.json `
   --owner .local/qualification/native-renderer-static-world-owner.json `
   --asset-metadata .local/qualification/native-renderer-static-world-asset-metadata.json `
+  --mesh-semantics .local/qualification/native-renderer-static-world-mesh-semantics.json `
   --session <session> `
   --output .local/qualification/native-renderer-static-world-runtime-join.json
 ```

--- a/docs/native-renderer/STATIC_WORLD_LIFETIME.md
+++ b/docs/native-renderer/STATIC_WORLD_LIFETIME.md
@@ -70,6 +70,7 @@ python tools/summarize-native-renderer-static-world-runtime-join.py `
   --graph .local/qualification/native-renderer-static-world-graph.json `
   --owner .local/qualification/native-renderer-static-world-owner.json `
   --asset-metadata .local/qualification/native-renderer-static-world-asset-metadata.json `
+  --mesh-semantics .local/qualification/native-renderer-static-world-mesh-semantics.json `
   --session <session> `
   --output .local/qualification/native-renderer-static-world-runtime-join.json
 ```

--- a/docs/native-renderer/STATIC_WORLD_MESH_SEMANTICS.md
+++ b/docs/native-renderer/STATIC_WORLD_MESH_SEMANTICS.md
@@ -1,0 +1,52 @@
+# Static-world SimpleMesh semantics
+
+Status: bounded geometry draw and material-binding fields proved; complete
+vertex layout and material parameters remain open
+
+## Purpose
+
+The member graph proves which `CSimpleMesh` emits a draw. This checkpoint
+identifies the exact fields and helper sequence used to turn that mesh into a
+title indexed draw, without interpreting or exporting mesh payload bytes.
+
+## Geometry contract
+
+`tools/discover-native-renderer-static-world-mesh-semantics.py` proves:
+
+- mesh offset 36 supplies the numeric primitive type;
+- mesh offset 96 supplies the index-buffer binding installed through
+  `8244D760` and cleared immediately after the draw;
+- mesh offset 100 supplies the source element count;
+- helper `82C48558` converts the element count into a primitive count for the
+  supported numeric primitive modes; and
+- the exact scale/bias table at `820023F0` converts that result into draw
+  argument `r7` before indexed-draw emitter `82416380`.
+
+The emitter receives the graphics context in `r3`, primitive type in `r4`,
+zero base/index offsets in `r5`/`r6`, and the derived element count in `r7`.
+
+## Material-binding boundary
+
+The same path proves a bounded state/material branch:
+
+- submodel offsets 112, 39, and 32 gate and supply state binding to
+  `82410A70`; and
+- mesh offset 128 holds an optional reference whose resource at offset 168 is
+  resolved through virtual slot 5 and bound with `8244E728`; the alternate
+  branch binds the renderer's existing `r22` source through the same helper.
+
+This is enough to observe stable geometry/material binding families. Complete
+vertex-fetch layouts, material parameter blocks, building/prop labels, and
+native admission remain unproved.
+
+## Generate the report
+
+```powershell
+python tools/discover-native-renderer-static-world-mesh-semantics.py `
+  .local/generated/default `
+  --image .local/analysis/default-image.bin `
+  --output .local/qualification/native-renderer-static-world-mesh-semantics.json
+```
+
+The proof is static and payload-free. It changes no guest state or title
+control flow; Xenos remains authoritative.

--- a/docs/native-renderer/STATIC_WORLD_OWNER.md
+++ b/docs/native-renderer/STATIC_WORLD_OWNER.md
@@ -62,6 +62,7 @@ streaming transitions remain open. This
 checkpoint changes no guest data, native admission, publication, or
 suppression; Xenos remains authoritative.
 
-The combined runtime qualifier requires this report through `--owner` and the
-bounded metadata report through `--asset-metadata`; both remain static inputs
-to the batched runtime gate.
+The combined runtime qualifier requires this report through `--owner`, the
+bounded metadata report through `--asset-metadata`, and the mesh field proof
+through `--mesh-semantics`; all remain static inputs to the batched runtime
+gate.

--- a/docs/native-renderer/STATIC_WORLD_RESOURCE.md
+++ b/docs/native-renderer/STATIC_WORLD_RESOURCE.md
@@ -56,6 +56,7 @@ python tools/summarize-native-renderer-static-world-runtime-join.py `
   --graph .local/qualification/native-renderer-static-world-graph.json `
   --owner .local/qualification/native-renderer-static-world-owner.json `
   --asset-metadata .local/qualification/native-renderer-static-world-asset-metadata.json `
+  --mesh-semantics .local/qualification/native-renderer-static-world-mesh-semantics.json `
   --session <session> `
   --output .local/qualification/native-renderer-static-world-runtime-join.json
 ```

--- a/docs/native-renderer/STATIC_WORLD_STREAMING.md
+++ b/docs/native-renderer/STATIC_WORLD_STREAMING.md
@@ -56,6 +56,7 @@ python tools/summarize-native-renderer-static-world-runtime-join.py `
   --graph .local/qualification/native-renderer-static-world-graph.json `
   --owner .local/qualification/native-renderer-static-world-owner.json `
   --asset-metadata .local/qualification/native-renderer-static-world-asset-metadata.json `
+  --mesh-semantics .local/qualification/native-renderer-static-world-mesh-semantics.json `
   --session <session> `
   --output .local/qualification/native-renderer-static-world-runtime-join.json
 ```

--- a/tools/discover-native-renderer-static-world-mesh-semantics.py
+++ b/tools/discover-native-renderer-static-world-mesh-semantics.py
@@ -1,0 +1,244 @@
+#!/usr/bin/env python3
+"""Prove bounded SimpleMesh draw and material-binding field semantics."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import pathlib
+import re
+import sys
+
+
+SCHEMA = "pinyon-shift.native-renderer-static-world-mesh-semantics.v1"
+IMAGE_BASE = 0x82000000
+FUNCTION_RE = re.compile(r"^DEFINE_REX_FUNC\(sub_([0-9A-F]{8})\) \{")
+LABEL_RE = re.compile(r"^loc_([0-9A-F]{8}):")
+COMMENT_RE = re.compile(r"^\s*//\s+(.+?)\s*$")
+
+RENDERER_DISPATCH = 0x82C4CCC8
+PRIMITIVE_COUNT_HELPER = 0x82C48558
+PRIMITIVE_SCALE_BIAS_TABLE = 0x820023F0
+INDEX_BUFFER_BIND = 0x8244D760
+MATERIAL_STATE_BIND = 0x82410A70
+MATERIAL_RESOURCE_BIND = 0x8244E728
+DRAW_EMITTER = 0x82416380
+
+EXPECTED_SCALE_BIAS = (
+    (0, 0),
+    (1, 0),
+    (2, 0),
+    (1, 1),
+    (3, 0),
+    (1, 2),
+    (1, 2),
+    (0, 0),
+    (3, 0),
+    (0, 0),
+    (0, 0),
+    (0, 0),
+    (0, 0),
+    (4, 0),
+)
+
+
+def parse_functions(paths: list[pathlib.Path]) -> dict[int, dict[int, str]]:
+    functions = {}
+    for path in sorted(paths, key=lambda item: item.as_posix()):
+        current = None
+        address = None
+        for line in path.read_text(encoding="utf-8").splitlines():
+            match = FUNCTION_RE.match(line)
+            if match:
+                function_address = int(match.group(1), 16)
+                current = functions.setdefault(function_address, {})
+                address = function_address
+                continue
+            label = LABEL_RE.match(line)
+            if current is not None and label:
+                address = int(label.group(1), 16)
+                continue
+            comment = COMMENT_RE.match(line)
+            if current is not None and comment and address is not None:
+                current[address] = comment.group(1)
+                address += 4
+    return functions
+
+
+def image_u32(image: bytes, address: int) -> int:
+    offset = address - IMAGE_BASE
+    if offset < 0 or offset + 4 > len(image):
+        raise ValueError(f"image address is out of range: {address:08X}")
+    return int.from_bytes(image[offset : offset + 4], "big")
+
+
+def require_instructions(functions, function_address, expected) -> None:
+    instructions = functions.get(function_address)
+    if instructions is None:
+        raise ValueError(f"missing function {function_address:08X}")
+    for address, text in expected.items():
+        if instructions.get(address) != text:
+            raise ValueError(
+                f"instruction drift at {address:08X}: "
+                f"expected {text!r}, got {instructions.get(address)!r}"
+            )
+
+
+def build(functions: dict[int, dict[int, str]], image: bytes) -> dict:
+    scale_bias = tuple(
+        (
+            image_u32(image, PRIMITIVE_SCALE_BIAS_TABLE + index * 8),
+            image_u32(image, PRIMITIVE_SCALE_BIAS_TABLE + index * 8 + 4),
+        )
+        for index in range(len(EXPECTED_SCALE_BIAS))
+    )
+    if scale_bias != EXPECTED_SCALE_BIAS:
+        raise ValueError("primitive scale/bias table drifted")
+
+    require_instructions(
+        functions,
+        PRIMITIVE_COUNT_HELPER,
+        {
+            0x82C48558: "mr r11,r3",
+            0x82C48568: "cmpwi cr6,r3,1",
+            0x82C48570: "cmpwi cr6,r3,2",
+            0x82C48578: "cmpwi cr6,r3,3",
+            0x82C48580: "cmpwi cr6,r3,4",
+            0x82C48588: "li r11,3",
+            0x82C4858C: "divw r3,r4,r11",
+            0x82C48594: "addi r3,r4,-1",
+            0x82C4859C: "srawi r11,r4,1",
+            0x82C485A8: "mr r3,r4",
+            0x82C485B0: "cmpwi cr6,r11,6",
+            0x82C485B8: "cmpwi cr6,r11,8",
+            0x82C485C0: "cmpwi cr6,r11,13",
+            0x82C485D0: "srawi r11,r4,2",
+            0x82C485D8: "addi r3,r4,-2",
+        },
+    )
+    require_instructions(
+        functions,
+        RENDERER_DISPATCH,
+        {
+            0x82C4DAF8: "bctrl",
+            0x82C4DAFC: "lbz r11,112(r3)",
+            0x82C4DB0C: "lbz r7,39(r3)",
+            0x82C4DB14: "lwz r5,32(r3)",
+            0x82C4DB24: "bl 0x82410a70",
+            0x82C4DB3C: "bctrl",
+            0x82C4DB5C: "bctrl",
+            0x82C4DB60: "lwz r11,128(r3)",
+            0x82C4DB6C: "addi r4,r3,128",
+            0x82C4DB90: "lwz r3,168(r11)",
+            0x82C4DB9C: "lwz r11,20(r11)",
+            0x82C4DBB4: "bl 0x8244e728",
+            0x82C4DBE4: "bl 0x8244e728",
+            0x82C4DC10: "lwz r4,96(r28)",
+            0x82C4DC14: "bl 0x8244d760",
+            0x82C4DC20: "lwz r3,36(r28)",
+            0x82C4DC24: "lwz r4,100(r28)",
+            0x82C4DC28: "bl 0x82c48558",
+            0x82C4DC2C: "lwz r4,36(r28)",
+            0x82C4DC38: "rlwinm r10,r4,3,0,28",
+            0x82C4DC40: "lwzx r9,r10,r25",
+            0x82C4DC44: "lwzx r11,r10,r11",
+            0x82C4DC48: "mullw r10,r9,r3",
+            0x82C4DC4C: "add r7,r10,r11",
+            0x82C4DC54: "bl 0x82416380",
+            0x82C4DC58: "li r4,0",
+            0x82C4DC60: "bl 0x8244d760",
+        },
+    )
+    require_instructions(
+        functions,
+        INDEX_BUFFER_BIND,
+        {
+            0x8244D76C: "lwz r30,12812(r3)",
+            0x8244D774: "mr r29,r4",
+            0x8244D7E4: "stw r29,12812(r31)",
+        },
+    )
+
+    return {
+        "schema": SCHEMA,
+        "status": "complete",
+        "classification": "bounded_simple_mesh_draw_and_material_binding",
+        "geometry": {
+            "class": "CSimpleMesh",
+            "vtable": "822291A0",
+            "primitive_type_offset": 36,
+            "index_buffer_binding_offset": 96,
+            "source_element_count_offset": 100,
+            "primitive_count_helper": f"{PRIMITIVE_COUNT_HELPER:08X}",
+            "primitive_scale_bias_table": f"{PRIMITIVE_SCALE_BIAS_TABLE:08X}",
+            "primitive_scale_bias": [
+                {"primitive_type": index, "scale": scale, "bias": bias}
+                for index, (scale, bias) in enumerate(scale_bias)
+            ],
+            "index_buffer_bind": f"{INDEX_BUFFER_BIND:08X}",
+            "index_buffer_context_offset": 12812,
+            "draw_emitter": f"{DRAW_EMITTER:08X}",
+            "draw_arguments": {
+                "r3": "graphics_context",
+                "r4": "mesh_plus_36_primitive_type",
+                "r5": "zero_base_index",
+                "r6": "zero_index_offset",
+                "r7": "scale_times_primitive_count_plus_bias",
+            },
+            "index_buffer_clear_after_draw": True,
+        },
+        "material_binding": {
+            "class": "CSimpleSubModel_and_CSimpleMesh",
+            "submodel_state_enabled_offset": 112,
+            "submodel_state_selector_offset": 39,
+            "submodel_state_object_offset": 32,
+            "state_bind": f"{MATERIAL_STATE_BIND:08X}",
+            "mesh_optional_reference_offset": 128,
+            "optional_reference_resource_offset": 168,
+            "optional_reference_dispatch_slot": 5,
+            "resource_bind": f"{MATERIAL_RESOURCE_BIND:08X}",
+            "fallback_source": "renderer_r22",
+        },
+        "claims": {
+            "primitive_and_element_count_fields_proved": True,
+            "index_buffer_bind_draw_clear_sequence_proved": True,
+            "submodel_state_binding_fields_proved": True,
+            "optional_material_resource_branch_proved": True,
+            "complete_vertex_layout_decoding_proved": False,
+            "complete_material_parameter_decoding_proved": False,
+            "native_draw_admission_proved": False,
+        },
+        "safety": {
+            "static_analysis_only": True,
+            "guest_payload_exported": False,
+            "native_admission": False,
+            "suppression_allowed": False,
+            "xenos_authority_required": True,
+        },
+    }
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("generated_root", type=pathlib.Path)
+    parser.add_argument("--image", required=True, type=pathlib.Path)
+    parser.add_argument("--output", required=True, type=pathlib.Path)
+    args = parser.parse_args(argv)
+    try:
+        paths = list(args.generated_root.glob("pinyon_shift_recomp.*.cpp"))
+        if not paths:
+            raise ValueError("no generated AOT C++ files found")
+        document = build(parse_functions(paths), args.image.read_bytes())
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(
+            json.dumps(document, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        return 0
+    except (OSError, UnicodeDecodeError, ValueError) as error:
+        print(f"static-world mesh semantics discovery failed: {error}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/summarize-native-renderer-static-world-runtime-join.py
+++ b/tools/summarize-native-renderer-static-world-runtime-join.py
@@ -19,6 +19,9 @@ OWNER_SCHEMA = "pinyon-shift.native-renderer-static-world-owner.v1"
 ASSET_METADATA_SCHEMA = (
     "pinyon-shift.native-renderer-static-world-asset-metadata.v1"
 )
+MESH_SEMANTICS_SCHEMA = (
+    "pinyon-shift.native-renderer-static-world-mesh-semantics.v1"
+)
 CONFIG = "native_renderer.discovery.static_world_runtime_join_config"
 SUMMARY = "native_renderer.discovery.static_world_runtime_join_summary"
 CHECKPOINT = "native_renderer.discovery.static_world_runtime_join_checkpoint"
@@ -503,6 +506,84 @@ def validate_static_asset_metadata(document):
         raise ValueError("static-world asset metadata claims drifted")
 
 
+def validate_static_mesh_semantics(document):
+    if (
+        document.get("schema") != MESH_SEMANTICS_SCHEMA
+        or document.get("status") != "complete"
+        or document.get("classification")
+        != "bounded_simple_mesh_draw_and_material_binding"
+    ):
+        raise ValueError("static-world mesh semantics proof drifted")
+    try:
+        geometry = document["geometry"]
+        material = document["material_binding"]
+        claims = document["claims"]
+    except (KeyError, TypeError) as error:
+        raise ValueError(
+            "static-world mesh semantics proof is incomplete"
+        ) from error
+    expected_geometry = {
+        "class": "CSimpleMesh",
+        "vtable": "822291A0",
+        "primitive_type_offset": 36,
+        "index_buffer_binding_offset": 96,
+        "source_element_count_offset": 100,
+        "primitive_count_helper": "82C48558",
+        "primitive_scale_bias_table": "820023F0",
+        "index_buffer_bind": "8244D760",
+        "index_buffer_context_offset": 12812,
+        "draw_emitter": "82416380",
+        "draw_arguments": {
+            "r3": "graphics_context",
+            "r4": "mesh_plus_36_primitive_type",
+            "r5": "zero_base_index",
+            "r6": "zero_index_offset",
+            "r7": "scale_times_primitive_count_plus_bias",
+        },
+        "index_buffer_clear_after_draw": True,
+    }
+    for key, value in expected_geometry.items():
+        if geometry.get(key) != value:
+            raise ValueError("static-world mesh geometry proof drifted")
+    expected_scale_bias = [
+        {"primitive_type": index, "scale": scale, "bias": bias}
+        for index, (scale, bias) in enumerate(
+            (
+                (0, 0), (1, 0), (2, 0), (1, 1), (3, 0), (1, 2),
+                (1, 2), (0, 0), (3, 0), (0, 0), (0, 0), (0, 0),
+                (0, 0), (4, 0),
+            )
+        )
+    ]
+    if geometry.get("primitive_scale_bias") != expected_scale_bias:
+        raise ValueError("static-world primitive scale/bias proof drifted")
+    expected_material = {
+        "class": "CSimpleSubModel_and_CSimpleMesh",
+        "submodel_state_enabled_offset": 112,
+        "submodel_state_selector_offset": 39,
+        "submodel_state_object_offset": 32,
+        "state_bind": "82410A70",
+        "mesh_optional_reference_offset": 128,
+        "optional_reference_resource_offset": 168,
+        "optional_reference_dispatch_slot": 5,
+        "resource_bind": "8244E728",
+        "fallback_source": "renderer_r22",
+    }
+    if material != expected_material:
+        raise ValueError("static-world material binding proof drifted")
+    if (
+        claims.get("primitive_and_element_count_fields_proved") is not True
+        or claims.get("index_buffer_bind_draw_clear_sequence_proved")
+        is not True
+        or claims.get("submodel_state_binding_fields_proved") is not True
+        or claims.get("optional_material_resource_branch_proved") is not True
+        or claims.get("complete_vertex_layout_decoding_proved") is not False
+        or claims.get("complete_material_parameter_decoding_proved") is not False
+        or claims.get("native_draw_admission_proved") is not False
+    ):
+        raise ValueError("static-world mesh semantics claims drifted")
+
+
 def build(
     static_ingress,
     static_lifetime,
@@ -511,6 +592,7 @@ def build(
     static_graph,
     static_owner,
     static_asset_metadata,
+    static_mesh_semantics,
     events,
     requested_session=None,
     allow_checkpoint=False,
@@ -522,6 +604,7 @@ def build(
     validate_static_graph(static_graph)
     validate_static_owner(static_owner)
     validate_static_asset_metadata(static_asset_metadata)
+    validate_static_mesh_semantics(static_mesh_semantics)
     session = select_session(events, requested_session)
     selected = [event for event in events if event.get("session") == session]
     config = exact_event(selected, CONFIG)
@@ -1008,6 +1091,8 @@ def build(
             "model_presentation_to_renderer_resource_proved": not failures,
             "bounded_asset_reference_metadata_proved": not failures,
             "hashed_asset_identity_to_prepared_draw_proved": not failures,
+            "bounded_mesh_draw_semantics_proved": not failures,
+            "bounded_material_binding_semantics_proved": not failures,
             "static_world_scope_to_pm4_proved": not failures,
             "static_world_pm4_to_prepared_draw_proved": not failures,
             "building_or_prop_instance_identity_proved": False,
@@ -1037,6 +1122,7 @@ def main(argv=None):
     parser.add_argument("--graph", required=True, type=pathlib.Path)
     parser.add_argument("--owner", required=True, type=pathlib.Path)
     parser.add_argument("--asset-metadata", required=True, type=pathlib.Path)
+    parser.add_argument("--mesh-semantics", required=True, type=pathlib.Path)
     parser.add_argument("--session")
     parser.add_argument("--allow-checkpoint", action="store_true")
     parser.add_argument("--output", required=True, type=pathlib.Path)
@@ -1050,6 +1136,7 @@ def main(argv=None):
             json.loads(args.graph.read_text(encoding="utf-8")),
             json.loads(args.owner.read_text(encoding="utf-8")),
             json.loads(args.asset_metadata.read_text(encoding="utf-8")),
+            json.loads(args.mesh_semantics.read_text(encoding="utf-8")),
             read_events(args.events),
             args.session,
             args.allow_checkpoint,

--- a/tools/tests/test_native_renderer_static_world_mesh_semantics.py
+++ b/tools/tests/test_native_renderer_static_world_mesh_semantics.py
@@ -1,0 +1,127 @@
+import copy
+import importlib.util
+import sys
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+TOOL = ROOT / "tools" / "discover-native-renderer-static-world-mesh-semantics.py"
+SPEC = importlib.util.spec_from_file_location("static_world_mesh_semantics", TOOL)
+assert SPEC and SPEC.loader
+MODULE = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = MODULE
+SPEC.loader.exec_module(MODULE)
+
+
+def fixture():
+    table_bytes = len(MODULE.EXPECTED_SCALE_BIAS) * 8
+    image = bytearray(
+        MODULE.PRIMITIVE_SCALE_BIAS_TABLE + table_bytes - MODULE.IMAGE_BASE
+    )
+    for index, pair in enumerate(MODULE.EXPECTED_SCALE_BIAS):
+        for field, value in enumerate(pair):
+            offset = (
+                MODULE.PRIMITIVE_SCALE_BIAS_TABLE
+                + index * 8
+                + field * 4
+                - MODULE.IMAGE_BASE
+            )
+            image[offset : offset + 4] = value.to_bytes(4, "big")
+    functions = {
+        MODULE.PRIMITIVE_COUNT_HELPER: {
+            0x82C48558: "mr r11,r3",
+            0x82C48568: "cmpwi cr6,r3,1",
+            0x82C48570: "cmpwi cr6,r3,2",
+            0x82C48578: "cmpwi cr6,r3,3",
+            0x82C48580: "cmpwi cr6,r3,4",
+            0x82C48588: "li r11,3",
+            0x82C4858C: "divw r3,r4,r11",
+            0x82C48594: "addi r3,r4,-1",
+            0x82C4859C: "srawi r11,r4,1",
+            0x82C485A8: "mr r3,r4",
+            0x82C485B0: "cmpwi cr6,r11,6",
+            0x82C485B8: "cmpwi cr6,r11,8",
+            0x82C485C0: "cmpwi cr6,r11,13",
+            0x82C485D0: "srawi r11,r4,2",
+            0x82C485D8: "addi r3,r4,-2",
+        },
+        MODULE.RENDERER_DISPATCH: {
+            0x82C4DAF8: "bctrl",
+            0x82C4DAFC: "lbz r11,112(r3)",
+            0x82C4DB0C: "lbz r7,39(r3)",
+            0x82C4DB14: "lwz r5,32(r3)",
+            0x82C4DB24: "bl 0x82410a70",
+            0x82C4DB3C: "bctrl",
+            0x82C4DB5C: "bctrl",
+            0x82C4DB60: "lwz r11,128(r3)",
+            0x82C4DB6C: "addi r4,r3,128",
+            0x82C4DB90: "lwz r3,168(r11)",
+            0x82C4DB9C: "lwz r11,20(r11)",
+            0x82C4DBB4: "bl 0x8244e728",
+            0x82C4DBE4: "bl 0x8244e728",
+            0x82C4DC10: "lwz r4,96(r28)",
+            0x82C4DC14: "bl 0x8244d760",
+            0x82C4DC20: "lwz r3,36(r28)",
+            0x82C4DC24: "lwz r4,100(r28)",
+            0x82C4DC28: "bl 0x82c48558",
+            0x82C4DC2C: "lwz r4,36(r28)",
+            0x82C4DC38: "rlwinm r10,r4,3,0,28",
+            0x82C4DC40: "lwzx r9,r10,r25",
+            0x82C4DC44: "lwzx r11,r10,r11",
+            0x82C4DC48: "mullw r10,r9,r3",
+            0x82C4DC4C: "add r7,r10,r11",
+            0x82C4DC54: "bl 0x82416380",
+            0x82C4DC58: "li r4,0",
+            0x82C4DC60: "bl 0x8244d760",
+        },
+        MODULE.INDEX_BUFFER_BIND: {
+            0x8244D76C: "lwz r30,12812(r3)",
+            0x8244D774: "mr r29,r4",
+            0x8244D7E4: "stw r29,12812(r31)",
+        },
+    }
+    return functions, bytes(image)
+
+
+class StaticWorldMeshSemanticsTests(unittest.TestCase):
+    def test_proves_draw_and_material_binding_fields(self):
+        functions, image = fixture()
+        document = MODULE.build(functions, image)
+        self.assertEqual("complete", document["status"])
+        self.assertEqual(36, document["geometry"]["primitive_type_offset"])
+        self.assertEqual(96, document["geometry"]["index_buffer_binding_offset"])
+        self.assertEqual(100, document["geometry"]["source_element_count_offset"])
+        self.assertTrue(
+            document["claims"]["index_buffer_bind_draw_clear_sequence_proved"]
+        )
+        self.assertTrue(
+            document["claims"]["optional_material_resource_branch_proved"]
+        )
+        self.assertFalse(document["claims"]["native_draw_admission_proved"])
+
+    def test_rejects_primitive_table_drift(self):
+        functions, image = fixture()
+        corrupted = bytearray(image)
+        offset = MODULE.PRIMITIVE_SCALE_BIAS_TABLE - MODULE.IMAGE_BASE + 8
+        corrupted[offset : offset + 4] = (2).to_bytes(4, "big")
+        with self.assertRaisesRegex(ValueError, "scale/bias table drifted"):
+            MODULE.build(functions, bytes(corrupted))
+
+    def test_rejects_index_buffer_offset_drift(self):
+        functions, image = fixture()
+        corrupted = copy.deepcopy(functions)
+        corrupted[MODULE.RENDERER_DISPATCH][0x82C4DC10] = "lwz r4,92(r28)"
+        with self.assertRaisesRegex(ValueError, "82C4DC10"):
+            MODULE.build(corrupted, image)
+
+    def test_rejects_material_reference_offset_drift(self):
+        functions, image = fixture()
+        corrupted = copy.deepcopy(functions)
+        corrupted[MODULE.RENDERER_DISPATCH][0x82C4DB60] = "lwz r11,124(r3)"
+        with self.assertRaisesRegex(ValueError, "82C4DB60"):
+            MODULE.build(corrupted, image)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/tests/test_native_renderer_static_world_runtime_join.py
+++ b/tools/tests/test_native_renderer_static_world_runtime_join.py
@@ -330,6 +330,63 @@ def static_asset_metadata():
     }
 
 
+def static_mesh_semantics():
+    scale_bias = (
+        (0, 0), (1, 0), (2, 0), (1, 1), (3, 0), (1, 2), (1, 2),
+        (0, 0), (3, 0), (0, 0), (0, 0), (0, 0), (0, 0), (4, 0),
+    )
+    return {
+        "schema": MODULE.MESH_SEMANTICS_SCHEMA,
+        "status": "complete",
+        "classification": "bounded_simple_mesh_draw_and_material_binding",
+        "geometry": {
+            "class": "CSimpleMesh",
+            "vtable": "822291A0",
+            "primitive_type_offset": 36,
+            "index_buffer_binding_offset": 96,
+            "source_element_count_offset": 100,
+            "primitive_count_helper": "82C48558",
+            "primitive_scale_bias_table": "820023F0",
+            "primitive_scale_bias": [
+                {"primitive_type": index, "scale": scale, "bias": bias}
+                for index, (scale, bias) in enumerate(scale_bias)
+            ],
+            "index_buffer_bind": "8244D760",
+            "index_buffer_context_offset": 12812,
+            "draw_emitter": "82416380",
+            "draw_arguments": {
+                "r3": "graphics_context",
+                "r4": "mesh_plus_36_primitive_type",
+                "r5": "zero_base_index",
+                "r6": "zero_index_offset",
+                "r7": "scale_times_primitive_count_plus_bias",
+            },
+            "index_buffer_clear_after_draw": True,
+        },
+        "material_binding": {
+            "class": "CSimpleSubModel_and_CSimpleMesh",
+            "submodel_state_enabled_offset": 112,
+            "submodel_state_selector_offset": 39,
+            "submodel_state_object_offset": 32,
+            "state_bind": "82410A70",
+            "mesh_optional_reference_offset": 128,
+            "optional_reference_resource_offset": 168,
+            "optional_reference_dispatch_slot": 5,
+            "resource_bind": "8244E728",
+            "fallback_source": "renderer_r22",
+        },
+        "claims": {
+            "primitive_and_element_count_fields_proved": True,
+            "index_buffer_bind_draw_clear_sequence_proved": True,
+            "submodel_state_binding_fields_proved": True,
+            "optional_material_resource_branch_proved": True,
+            "complete_vertex_layout_decoding_proved": False,
+            "complete_material_parameter_decoding_proved": False,
+            "native_draw_admission_proved": False,
+        },
+    }
+
+
 def fixture():
     config = event(
         MODULE.CONFIG,
@@ -531,6 +588,7 @@ class StaticWorldRuntimeJoinTests(unittest.TestCase):
             static_graph(),
             static_owner(),
             static_asset_metadata(),
+            static_mesh_semantics(),
             fixture(),
         )
         self.assertEqual("complete", document["status"])
@@ -575,6 +633,7 @@ class StaticWorldRuntimeJoinTests(unittest.TestCase):
             static_graph(),
             static_owner(),
             static_asset_metadata(),
+            static_mesh_semantics(),
             events + [checkpoint],
             allow_checkpoint=True,
         )
@@ -598,6 +657,7 @@ class StaticWorldRuntimeJoinTests(unittest.TestCase):
             static_graph(),
             static_owner(),
             static_asset_metadata(),
+            static_mesh_semantics(),
             events,
         )
         self.assertEqual("incomplete", document["status"])
@@ -619,6 +679,7 @@ class StaticWorldRuntimeJoinTests(unittest.TestCase):
             static_graph(),
             static_owner(),
             static_asset_metadata(),
+            static_mesh_semantics(),
             events,
         )
         self.assertEqual("incomplete", document["status"])
@@ -641,6 +702,7 @@ class StaticWorldRuntimeJoinTests(unittest.TestCase):
                 static_graph(),
                 static_owner(),
                 static_asset_metadata(),
+                static_mesh_semantics(),
                 fixture(),
             )
 
@@ -662,6 +724,7 @@ class StaticWorldRuntimeJoinTests(unittest.TestCase):
             static_graph(),
             static_owner(),
             static_asset_metadata(),
+            static_mesh_semantics(),
             events,
         )
         self.assertEqual("incomplete", document["status"])
@@ -685,6 +748,7 @@ class StaticWorldRuntimeJoinTests(unittest.TestCase):
             static_graph(),
             static_owner(),
             static_asset_metadata(),
+            static_mesh_semantics(),
             events,
         )
         self.assertEqual("incomplete", document["status"])
@@ -709,6 +773,7 @@ class StaticWorldRuntimeJoinTests(unittest.TestCase):
             static_graph(),
             static_owner(),
             static_asset_metadata(),
+            static_mesh_semantics(),
             events,
         )
         self.assertEqual("incomplete", document["status"])
@@ -735,6 +800,7 @@ class StaticWorldRuntimeJoinTests(unittest.TestCase):
             static_graph(),
             static_owner(),
             static_asset_metadata(),
+            static_mesh_semantics(),
             events,
         )
         self.assertEqual("incomplete", document["status"])
@@ -758,6 +824,7 @@ class StaticWorldRuntimeJoinTests(unittest.TestCase):
             static_graph(),
             static_owner(),
             static_asset_metadata(),
+            static_mesh_semantics(),
             events,
         )
         self.assertEqual("incomplete", document["status"])
@@ -781,6 +848,7 @@ class StaticWorldRuntimeJoinTests(unittest.TestCase):
             static_graph(),
             static_owner(),
             static_asset_metadata(),
+            static_mesh_semantics(),
             events,
         )
         self.assertEqual("incomplete", document["status"])
@@ -805,6 +873,7 @@ class StaticWorldRuntimeJoinTests(unittest.TestCase):
             static_graph(),
             static_owner(),
             static_asset_metadata(),
+            static_mesh_semantics(),
             events,
         )
         self.assertEqual("incomplete", document["status"])
@@ -824,6 +893,23 @@ class StaticWorldRuntimeJoinTests(unittest.TestCase):
                 static_graph(),
                 static_owner(),
                 metadata,
+                static_mesh_semantics(),
+                fixture(),
+            )
+
+    def test_rejects_static_mesh_primitive_offset_drift(self):
+        semantics = static_mesh_semantics()
+        semantics["geometry"]["primitive_type_offset"] = 40
+        with self.assertRaisesRegex(ValueError, "mesh geometry proof drifted"):
+            MODULE.build(
+                static_ingress(),
+                static_lifetime(),
+                static_resource(),
+                static_streaming(),
+                static_graph(),
+                static_owner(),
+                    static_asset_metadata(),
+                semantics,
                 fixture(),
             )
 


### PR DESCRIPTION
## Summary
- prove SimpleMesh primitive type, index-buffer binding, element count, and exact bind/draw/clear sequence
- lock the retail primitive conversion table and bounded submodel/material-resource branches
- require the new payload-free static report in the combined C1/C2 qualifier

## Safety
- static analysis only; no mesh or material payload export
- no native admission or suppression
- Xenos remains authoritative

## Validation
- 565 Python tests passed
- retail mesh-semantics report passed
- no additional gameplay run or full build was needed for this static-only checkpoint