### PR TITLE
feat(native-renderer): census static prepared layouts

### DIFF
--- a/docs/native-renderer/REPRIORITIZED_PLAN.md
+++ b/docs/native-renderer/REPRIORITIZED_PLAN.md
@@ -400,8 +400,8 @@ count at 100, the exact primitive-count and scale/bias conversion, and the
 bind/draw/clear sequence. The bounded submodel state and optional mesh material
 resource branches are also locked. See
 [`STATIC_WORLD_MESH_SEMANTICS.md`](STATIC_WORLD_MESH_SEMANTICS.md). Complete
-vertex-fetch layouts and material parameter blocks remain open; no admission
-or suppression is enabled.
+shader-derived layouts and parameter metadata are handled by the prepared-layout
+checkpoint below; no admission or suppression is enabled.
 
 Runtime-lineage checkpoint: those bounded mesh and material-selection fields
 are now sampled only after the exact live member-graph gates and carried through
@@ -409,6 +409,14 @@ the physical PM4 origin into prepared-draw provenance. Separate fail-closed
 observation, read-fault, and packet-origin accounting is ready for the next
 combined C1/C2 AppData qualification. This exports numeric identity only and
 does not enable native admission or suppression.
+
+Prepared-layout checkpoint: the exact mesh-to-PM4 join now snapshots the
+complete bounded shader-derived vertex bindings and attributes plus the float,
+bool, loop, and texture parameter boundary needed by a native implementation.
+The 512-family census and its independent overflow accounting are documented in
+[`STATIC_WORLD_PREPARED_LAYOUT.md`](STATIC_WORLD_PREPARED_LAYOUT.md). Runtime
+qualification remains batched; resource payload bytes are not exported and
+Xenos remains authoritative.
 
 ### C3. Semantic batching, culling, and LOD
 

--- a/docs/native-renderer/STATIC_WORLD_MESH_SEMANTICS.md
+++ b/docs/native-renderer/STATIC_WORLD_MESH_SEMANTICS.md
@@ -35,9 +35,9 @@ The same path proves a bounded state/material branch:
   resolved through virtual slot 5 and bound with `8244E728`; the alternate
   branch binds the renderer's existing `r22` source through the same helper.
 
-This is enough to observe stable geometry/material binding families. Complete
-vertex-fetch layouts, material parameter blocks, building/prop labels, and
-native admission remain unproved.
+This is enough to observe stable geometry/material binding families. The
+shader-derived layout and parameter boundary is captured separately at the
+prepared draw; building/prop labels and native admission remain unproved.
 
 ## Runtime lineage
 
@@ -52,6 +52,11 @@ qualifier fail closed. No vertex or material payload bytes are exported.
 Runtime evidence remains deferred to the next combined C1/C2 AppData session.
 Until that session qualifies the lineage, this checkpoint is implementation
 complete but not runtime-qualified.
+
+The complete shader-derived vertex-fetch, attribute, and bounded material
+parameter snapshot is handled at the prepared-draw boundary documented in
+[`STATIC_WORLD_PREPARED_LAYOUT.md`](STATIC_WORLD_PREPARED_LAYOUT.md). This
+avoids inventing a duplicate title-side vertex declaration.
 
 ## Generate the report
 

--- a/docs/native-renderer/STATIC_WORLD_PREPARED_LAYOUT.md
+++ b/docs/native-renderer/STATIC_WORLD_PREPARED_LAYOUT.md
@@ -1,0 +1,43 @@
+# Static-world prepared layout boundary
+
+Status: complete bounded vertex/material snapshot implementation; batched
+runtime qualification remains pending
+
+## Purpose
+
+The title's `CSimpleMesh` object proves primitive, index-buffer, and selected
+material ownership, but the complete vertex layout is shader-derived and only
+exists after Xenos decodes the draw state. This checkpoint joins those two
+surfaces without guessing a second title-side layout.
+
+## Exact boundary
+
+The static SimpleModel path binds the mesh index buffer, flushes draw state
+through `8240BB40`, and then calls indexed-draw emitter `82416380`. The existing
+physical-PM4 provenance join identifies the exact prepared draw produced by
+that mesh. At that point the observer has bounded metadata for:
+
+- up to 8 vertex bindings, including fetch constant, address, size, stride,
+  and endianness;
+- up to 32 shader-derived vertex attributes with complete fetch and result
+  descriptors;
+- up to 64 float constants per shader stage, plus bool and loop constants;
+- up to 16 decoded texture states; and
+- shader, pipeline, geometry-layout, texture-layout, and render-state hashes.
+
+The implementation retains at most 512 distinct static-world layout families.
+Each family records one complete bounded metadata sample, call/frame coverage,
+and dynamic parameter-hash variation. Resource payload bytes are never copied
+or exported.
+
+## Fail-closed runtime gate
+
+Every prepared static-world match must classify as exactly one of bounded,
+unbounded geometry, or parameter overflow. Qualification requires all matches
+to be bounded, at least one retained layout family, and zero table overflow.
+Independent counters are emitted in the static-world runtime summary.
+
+This is observation only. Xenos remains authoritative; native admission and
+draw suppression remain disabled until the combined C1/C2 AppData run proves
+the boundary in representative gameplay.
+

--- a/src/native_renderer/graphics_hooks.cpp
+++ b/src/native_renderer/graphics_hooks.cpp
@@ -86,6 +86,7 @@ constexpr uint64_t kSuppressionStateDetailLimit = 32;
 constexpr size_t kDispatchCallerCapacity = 256;
 constexpr size_t kTitlePacketProvenanceCapacity = 16384;
 constexpr size_t kTitleDrawProvenanceCapacity = 4096;
+constexpr size_t kStaticWorldPreparedLayoutCapacity = 512;
 constexpr size_t kTitleOriginStackCapacity = 32;
 constexpr size_t kTitleIndirectPacketBucketCount = 4096;
 constexpr size_t kTitleIndirectPacketWays = 4;
@@ -758,6 +759,18 @@ struct TitleDrawProvenanceEntry {
   bool prepared = false;
 };
 
+struct StaticWorldPreparedLayoutEntry {
+  uint64_t key = 0;
+  uint64_t calls = 0;
+  uint64_t first_frame = 0;
+  uint64_t last_frame = 0;
+  uint64_t parameter_hash = 0;
+  uint64_t parameter_variations = 0;
+  StaticWorldDrawIdentity identity{};
+  SemanticPreparedDrawContract contract{};
+  rex::system::GraphicsDrawObservation sample{};
+};
+
 struct TitleIndirectPacketEntry {
   uint32_t packet_physical_address = UINT32_MAX;
   uint32_t constructor_store_address = 0;
@@ -834,6 +847,9 @@ std::array<TitlePacketProvenanceEntry, kTitlePacketProvenanceCapacity>
     g_title_packet_provenance{};
 std::array<TitleDrawProvenanceEntry, kTitleDrawProvenanceCapacity>
     g_title_draw_provenance{};
+std::array<StaticWorldPreparedLayoutEntry,
+           kStaticWorldPreparedLayoutCapacity>
+    g_static_world_prepared_layouts{};
 std::array<SemanticBatchOpportunityEntry,
            kSemanticBatchOpportunityCapacity>
     g_semantic_batch_opportunities{};
@@ -2197,6 +2213,12 @@ std::atomic<uint64_t> g_static_world_mesh_semantic_exact{};
 std::atomic<uint64_t> g_static_world_mesh_semantic_read_faults{};
 std::atomic<uint64_t> g_static_world_mesh_semantic_packet_origins{};
 std::atomic<uint64_t> g_static_world_mesh_semantic_missing_packet_origins{};
+std::atomic<uint64_t> g_static_world_prepared_layout_observations{};
+std::atomic<uint64_t> g_static_world_prepared_layout_exact{};
+std::atomic<uint64_t> g_static_world_prepared_layout_unbounded_geometry{};
+std::atomic<uint64_t> g_static_world_prepared_layout_parameter_overflows{};
+std::atomic<uint64_t> g_static_world_prepared_layout_table_overflow{};
+size_t g_static_world_prepared_layout_count = 0;
 std::atomic<uint64_t> g_static_world_presentation_entries{};
 std::atomic<uint64_t> g_static_world_presentation_exits{};
 std::atomic<uint64_t> g_static_world_presentation_exact{};
@@ -5114,6 +5136,10 @@ void ResetTitleDrawProvenance() {
   for (TitleDrawProvenanceEntry &entry : g_title_draw_provenance) {
     entry = {};
   }
+  for (StaticWorldPreparedLayoutEntry &entry :
+       g_static_world_prepared_layouts) {
+    entry = {};
+  }
   for (SemanticBatchOpportunityEntry &entry :
        g_semantic_batch_opportunities) {
     entry = {};
@@ -5156,6 +5182,7 @@ void ResetTitleDrawProvenance() {
   g_title_packets_without_origin.store(0, std::memory_order_relaxed);
   g_title_draw_provenance_count = 0;
   g_title_draw_provenance_overflow = 0;
+  g_static_world_prepared_layout_count = 0;
   g_semantic_batch_observations = 0;
   g_semantic_visibility_prepared_observations = 0;
   g_semantic_visibility_prepared_selected_joins = 0;
@@ -5407,6 +5434,11 @@ void ResetTitleDrawProvenance() {
            &g_static_world_mesh_semantic_read_faults,
            &g_static_world_mesh_semantic_packet_origins,
            &g_static_world_mesh_semantic_missing_packet_origins,
+           &g_static_world_prepared_layout_observations,
+           &g_static_world_prepared_layout_exact,
+           &g_static_world_prepared_layout_unbounded_geometry,
+           &g_static_world_prepared_layout_parameter_overflows,
+           &g_static_world_prepared_layout_table_overflow,
            &g_static_world_presentation_entries,
            &g_static_world_presentation_exits,
            &g_static_world_presentation_exact,
@@ -11435,6 +11467,21 @@ void EmitStaticWorldRuntimeJoinEvent(const char *event_name,
   const uint64_t mesh_semantic_missing_packet_origins =
       g_static_world_mesh_semantic_missing_packet_origins.load(
           std::memory_order_relaxed);
+  const uint64_t prepared_layout_observations =
+      g_static_world_prepared_layout_observations.load(
+          std::memory_order_relaxed);
+  const uint64_t prepared_layout_exact =
+      g_static_world_prepared_layout_exact.load(
+          std::memory_order_relaxed);
+  const uint64_t prepared_layout_unbounded_geometry =
+      g_static_world_prepared_layout_unbounded_geometry.load(
+          std::memory_order_relaxed);
+  const uint64_t prepared_layout_parameter_overflows =
+      g_static_world_prepared_layout_parameter_overflows.load(
+          std::memory_order_relaxed);
+  const uint64_t prepared_layout_table_overflow =
+      g_static_world_prepared_layout_table_overflow.load(
+          std::memory_order_relaxed);
   const uint64_t presentation_entries =
       g_static_world_presentation_entries.load(std::memory_order_relaxed);
   const uint64_t presentation_exits =
@@ -11541,6 +11588,10 @@ void EmitStaticWorldRuntimeJoinEvent(const char *event_name,
       member_packets_recorded ==
           mesh_semantic_packet_origins +
               mesh_semantic_missing_packet_origins &&
+      prepared_layout_observations == prepared_matches &&
+      prepared_layout_observations ==
+          prepared_layout_exact + prepared_layout_unbounded_geometry +
+              prepared_layout_parameter_overflows &&
       presentation_entries ==
           presentation_exact +
               g_static_world_presentation_invalid_root.load(
@@ -11617,6 +11668,10 @@ void EmitStaticWorldRuntimeJoinEvent(const char *event_name,
       mesh_semantic_exact && mesh_semantic_packet_origins &&
       !mesh_semantic_read_faults &&
       !mesh_semantic_missing_packet_origins &&
+      prepared_layout_exact && g_static_world_prepared_layout_count &&
+      !prepared_layout_unbounded_geometry &&
+      !prepared_layout_parameter_overflows &&
+      !prepared_layout_table_overflow &&
       presentation_exact && presentation_renderer_joins &&
       asset_metadata_exact && asset_metadata_joins &&
       presentation_scopes_with_renderer &&
@@ -11826,6 +11881,17 @@ void EmitStaticWorldRuntimeJoinEvent(const char *event_name,
         std::to_string(mesh_semantic_packet_origins)},
        {"mesh_semantic_missing_packet_origins",
         std::to_string(mesh_semantic_missing_packet_origins)},
+       {"prepared_layout_observations",
+        std::to_string(prepared_layout_observations)},
+       {"prepared_layout_exact", std::to_string(prepared_layout_exact)},
+       {"prepared_layout_unbounded_geometry",
+        std::to_string(prepared_layout_unbounded_geometry)},
+       {"prepared_layout_parameter_overflows",
+        std::to_string(prepared_layout_parameter_overflows)},
+       {"prepared_layout_entries",
+        std::to_string(g_static_world_prepared_layout_count)},
+       {"prepared_layout_table_overflow",
+        std::to_string(prepared_layout_table_overflow)},
        {"presentation_entries", std::to_string(presentation_entries)},
        {"presentation_exits", std::to_string(presentation_exits)},
        {"presentation_exact", std::to_string(presentation_exact)},
@@ -13036,6 +13102,48 @@ std::string SerializeTextureStates(
         state.lod_bias, state.offsets, state.result_storage_target,
         state.result_storage_index, state.result_write_mask,
         state.result_components);
+  }
+  return result;
+}
+
+std::string SerializeVertexBindings(
+    const rex::system::GraphicsDrawObservation &observation) {
+  std::string result;
+  const uint32_t bounded_count = std::min(
+      observation.vertex_binding_count,
+      rex::system::kGraphicsVertexBindingObservationLimit);
+  for (uint32_t i = 0; i < bounded_count; ++i) {
+    const auto &binding = observation.vertex_bindings[i];
+    if (!result.empty()) {
+      result += ";";
+    }
+    result += fmt::format("{}:{:08X}:{}:{}:{}", binding.fetch_constant,
+                          binding.address, binding.size,
+                          binding.stride_words, binding.endianness);
+  }
+  return result;
+}
+
+std::string SerializeVertexAttributes(
+    const rex::system::GraphicsDrawObservation &observation) {
+  std::string result;
+  const uint32_t bounded_count = std::min(
+      observation.vertex_attribute_count,
+      rex::system::kGraphicsVertexAttributeObservationLimit);
+  for (uint32_t i = 0; i < bounded_count; ++i) {
+    const auto &attribute = observation.vertex_attributes[i];
+    if (!result.empty()) {
+      result += ";";
+    }
+    result += fmt::format(
+        "{}:{}:{}:{}:{}:{:X}:{}:{}:{}:{}:{:X}:{:X}:{:X}",
+        attribute.binding_index, attribute.fetch_constant,
+        attribute.offset_words, attribute.stride_words,
+        attribute.data_format, attribute.fetch_word_mask,
+        attribute.exp_adjust, attribute.signed_rf_mode,
+        attribute.result_storage_target, attribute.result_storage_index,
+        attribute.result_write_mask, attribute.result_components,
+        attribute.flags);
   }
   return result;
 }
@@ -14499,6 +14607,82 @@ SemanticPreparedDrawContract BuildSemanticPreparedDrawContract(
   return contract;
 }
 
+void RecordStaticWorldPreparedLayout(
+    const rex::system::GraphicsDrawObservation &observation,
+    const StaticWorldDrawIdentity &identity,
+    const SemanticPreparedDrawContract &contract) {
+  g_static_world_prepared_layout_observations.fetch_add(
+      1, std::memory_order_relaxed);
+  if (!contract.geometry_bounded) {
+    g_static_world_prepared_layout_unbounded_geometry.fetch_add(
+        1, std::memory_order_relaxed);
+    return;
+  }
+  if (!contract.texture_layout_bounded ||
+      observation.vertex_float_constant_overflow ||
+      observation.pixel_float_constant_overflow ||
+      observation.texture_state_overflow) {
+    g_static_world_prepared_layout_parameter_overflows.fetch_add(
+        1, std::memory_order_relaxed);
+    return;
+  }
+  g_static_world_prepared_layout_exact.fetch_add(
+      1, std::memory_order_relaxed);
+
+  uint64_t key = UINT64_C(0xCBF29CE484222325);
+  key = HashCombine(key, identity.asset_key_hash);
+  key = HashCombine(key, identity.simple_mesh_address);
+  key = HashCombine(key, identity.model_resource_generation);
+  key = HashCombine(key, identity.model_resource_payload_generation);
+  key = HashCombine(key, contract.prepared_pipeline_hash);
+  key = HashCombine(key, contract.geometry_layout_hash);
+  key = HashCombine(key, contract.texture_layout_hash);
+  key = HashCombine(key, contract.render_state_hash);
+  key = key ? key : 1;
+  const uint64_t parameter_hash = SemanticInstanceParameterHash(observation);
+  size_t index = size_t(key % kStaticWorldPreparedLayoutCapacity);
+  for (size_t probe = 0; probe < kStaticWorldPreparedLayoutCapacity;
+       ++probe) {
+    StaticWorldPreparedLayoutEntry &entry =
+        g_static_world_prepared_layouts[index];
+    if (!entry.calls) {
+      entry.key = key;
+      entry.calls = 1;
+      entry.first_frame = observation.frame_sequence;
+      entry.last_frame = observation.frame_sequence;
+      entry.parameter_hash = parameter_hash;
+      entry.identity = identity;
+      entry.contract = contract;
+      entry.sample = observation;
+      ++g_static_world_prepared_layout_count;
+      return;
+    }
+    if (entry.key == key &&
+        entry.identity.asset_key_hash == identity.asset_key_hash &&
+        entry.identity.simple_mesh_address == identity.simple_mesh_address &&
+        entry.identity.model_resource_generation ==
+            identity.model_resource_generation &&
+        entry.identity.model_resource_payload_generation ==
+            identity.model_resource_payload_generation &&
+        entry.contract.prepared_pipeline_hash ==
+            contract.prepared_pipeline_hash &&
+        entry.contract.geometry_layout_hash ==
+            contract.geometry_layout_hash &&
+        entry.contract.texture_layout_hash == contract.texture_layout_hash &&
+        entry.contract.render_state_hash == contract.render_state_hash) {
+      ++entry.calls;
+      entry.last_frame = observation.frame_sequence;
+      entry.parameter_variations +=
+          entry.parameter_hash != parameter_hash ? 1 : 0;
+      entry.parameter_hash = parameter_hash;
+      return;
+    }
+    index = (index + 1) % kStaticWorldPreparedLayoutCapacity;
+  }
+  g_static_world_prepared_layout_table_overflow.fetch_add(
+      1, std::memory_order_relaxed);
+}
+
 void UpdateSemanticPreparedDrawContract(
     SemanticPreparedDrawContract &contract,
     const rex::system::GraphicsDrawObservation &observation,
@@ -14563,6 +14747,11 @@ void RecordTitleDrawProvenance(
           ? BuildSemanticPreparedDrawContract(observation,
                                               *prepared_observation)
           : SemanticPreparedDrawContract{};
+  if (origin.static_world_draw.valid && prepared &&
+      current_semantic_contract.valid) {
+    RecordStaticWorldPreparedLayout(observation, origin.static_world_draw,
+                                    current_semantic_contract);
+  }
   uint64_t key = backend_signature ^ (uint64_t(origin.caller) << 17) ^
                  (uint64_t(origin.wrapper) << 57) ^
                  (uint64_t(backend_outcome) << 41) ^
@@ -15225,6 +15414,86 @@ void EmitTitleDrawProvenanceSummary() {
           semantic_prepared_matches + semantic_unprepared_matches &&
       semantic_render_item_entries ==
           semantic_render_item_exits + semantic_render_items_open;
+  for (const StaticWorldPreparedLayoutEntry &entry :
+       g_static_world_prepared_layouts) {
+    if (!entry.calls) {
+      continue;
+    }
+    const auto &sample = entry.sample;
+    const auto &contract = entry.contract;
+    pinyon_shift::diagnostics::RecordEvent(
+        "native_renderer.discovery.static_world_prepared_layout_entry",
+        {{"layout_key", fmt::format("{:016X}", entry.key)},
+         {"asset_key_hash",
+          entry.identity.asset_metadata_valid
+              ? fmt::format("{:016X}", entry.identity.asset_key_hash)
+              : ""},
+         {"simple_mesh",
+          fmt::format("{:08X}", entry.identity.simple_mesh_address)},
+         {"model_resource_generation",
+          std::to_string(entry.identity.model_resource_generation)},
+         {"model_resource_payload_generation",
+          std::to_string(
+              entry.identity.model_resource_payload_generation)},
+         {"calls", std::to_string(entry.calls)},
+         {"first_frame", std::to_string(entry.first_frame)},
+         {"last_frame", std::to_string(entry.last_frame)},
+         {"parameter_hash", fmt::format("{:016X}", entry.parameter_hash)},
+         {"parameter_variations",
+          std::to_string(entry.parameter_variations)},
+         {"prepared_pipeline_hash",
+          fmt::format("{:016X}", contract.prepared_pipeline_hash)},
+         {"geometry_layout_hash",
+          fmt::format("{:016X}", contract.geometry_layout_hash)},
+         {"texture_layout_hash",
+          fmt::format("{:016X}", contract.texture_layout_hash)},
+         {"render_state_hash",
+          fmt::format("{:016X}", contract.render_state_hash)},
+         {"vertex_shader",
+          fmt::format("{:016X}", contract.vertex_shader_hash)},
+         {"pixel_shader",
+          fmt::format("{:016X}", contract.pixel_shader_hash)},
+         {"primitive_type", std::to_string(sample.primitive_type)},
+         {"index_count", std::to_string(sample.index_count)},
+         {"index_buffer_address",
+          fmt::format("{:08X}", sample.index_buffer_address)},
+         {"index_buffer_length",
+          std::to_string(sample.index_buffer_length)},
+         {"index_format", std::to_string(sample.index_format)},
+         {"index_endianness", std::to_string(sample.index_endianness)},
+         {"vertex_binding_count",
+          std::to_string(sample.vertex_binding_count)},
+         {"vertex_bindings", SerializeVertexBindings(sample)},
+         {"vertex_attribute_count",
+          std::to_string(sample.vertex_attribute_count)},
+         {"vertex_attributes", SerializeVertexAttributes(sample)},
+         {"vertex_float_constant_count",
+          std::to_string(sample.vertex_float_constant_count)},
+         {"vertex_float_constants",
+          SerializeFloatConstants(sample.vertex_float_constants,
+                                  sample.vertex_float_constant_count)},
+         {"pixel_float_constant_count",
+          std::to_string(sample.pixel_float_constant_count)},
+         {"pixel_float_constants",
+          SerializeFloatConstants(sample.pixel_float_constants,
+                                  sample.pixel_float_constant_count)},
+         {"bool_constants",
+          SerializeWordConstants(sample.bool_constant_bitmap,
+                                 sample.bool_constant_values,
+                                 std::size(sample.bool_constant_bitmap))},
+         {"loop_constants",
+          SerializeLoopConstants(sample.loop_constant_bitmap,
+                                 sample.loop_constant_values)},
+         {"texture_state_count",
+          std::to_string(sample.texture_state_count)},
+         {"texture_states", SerializeTextureStates(sample)},
+         {"guest_payload_read", "bounded_prepared_draw_metadata_only"},
+         {"guest_state_changed", "false"},
+         {"control_flow_changed", "false"},
+         {"native_admission", "false"},
+         {"xenos_authority", "true"},
+         {"suppression_allowed", "false"}});
+  }
   uint64_t title_backend_outcomes = 0;
   for (size_t outcome = 1; outcome < g_backend_draw_outcome_counts.size();
        ++outcome) {
@@ -23390,6 +23659,12 @@ void InstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system,
        {"submodel_state_fields", "submodel_plus_32_u32_39_u8_112_u8"},
        {"mesh_optional_material_reference_field", "mesh_plus_128_u32"},
        {"mesh_semantics_export", "bounded_numeric_identity_fields_only"},
+       {"prepared_layout_boundary",
+        "xenos_decoded_draw_observation_joined_by_physical_pm4_origin"},
+       {"prepared_layout_capacity",
+        std::to_string(kStaticWorldPreparedLayoutCapacity)},
+       {"prepared_layout_export",
+        "complete_bounded_vertex_fetch_attribute_constant_and_texture_metadata"},
        {"draw_emitter", "82416380"},
        {"packet_hooks", "82416260,824162F4"},
        {"join", "synchronous_scope_to_physical_pm4_prepared_draw"},

--- a/tools/discover-native-renderer-static-world-mesh-semantics.py
+++ b/tools/discover-native-renderer-static-world-mesh-semantics.py
@@ -10,7 +10,7 @@ import re
 import sys
 
 
-SCHEMA = "pinyon-shift.native-renderer-static-world-mesh-semantics.v1"
+SCHEMA = "pinyon-shift.native-renderer-static-world-mesh-semantics.v2"
 IMAGE_BASE = 0x82000000
 FUNCTION_RE = re.compile(r"^DEFINE_REX_FUNC\(sub_([0-9A-F]{8})\) \{")
 LABEL_RE = re.compile(r"^loc_([0-9A-F]{8}):")
@@ -20,6 +20,7 @@ RENDERER_DISPATCH = 0x82C4CCC8
 PRIMITIVE_COUNT_HELPER = 0x82C48558
 PRIMITIVE_SCALE_BIAS_TABLE = 0x820023F0
 INDEX_BUFFER_BIND = 0x8244D760
+DRAW_STATE_FLUSH = 0x8240BB40
 MATERIAL_STATE_BIND = 0x82410A70
 MATERIAL_RESOURCE_BIND = 0x8244E728
 DRAW_EMITTER = 0x82416380
@@ -135,6 +136,8 @@ def build(functions: dict[int, dict[int, str]], image: bytes) -> dict:
             0x82C4DBE4: "bl 0x8244e728",
             0x82C4DC10: "lwz r4,96(r28)",
             0x82C4DC14: "bl 0x8244d760",
+            0x82C4DC18: "lwz r3,68(r30)",
+            0x82C4DC1C: "bl 0x8240bb40",
             0x82C4DC20: "lwz r3,36(r28)",
             0x82C4DC24: "lwz r4,100(r28)",
             0x82C4DC28: "bl 0x82c48558",
@@ -199,11 +202,25 @@ def build(functions: dict[int, dict[int, str]], image: bytes) -> dict:
             "resource_bind": f"{MATERIAL_RESOURCE_BIND:08X}",
             "fallback_source": "renderer_r22",
         },
+        "prepared_layout_boundary": {
+            "draw_state_flush": f"{DRAW_STATE_FLUSH:08X}",
+            "flush_after_index_buffer_bind": True,
+            "flush_before_draw_emitter": True,
+            "runtime_source": "xenos_decoded_draw_observation",
+            "runtime_join": "exact_physical_pm4_header_origin",
+            "vertex_binding_limit": 8,
+            "vertex_attribute_limit": 32,
+            "float_constant_limit_per_stage": 64,
+            "texture_state_limit": 16,
+            "payload_bytes_exported": False,
+        },
         "claims": {
             "primitive_and_element_count_fields_proved": True,
             "index_buffer_bind_draw_clear_sequence_proved": True,
             "submodel_state_binding_fields_proved": True,
             "optional_material_resource_branch_proved": True,
+            "complete_vertex_layout_runtime_boundary_proved": True,
+            "bounded_material_parameter_runtime_boundary_proved": True,
             "complete_vertex_layout_decoding_proved": False,
             "complete_material_parameter_decoding_proved": False,
             "native_draw_admission_proved": False,

--- a/tools/summarize-native-renderer-static-world-runtime-join.py
+++ b/tools/summarize-native-renderer-static-world-runtime-join.py
@@ -9,7 +9,7 @@ import pathlib
 import sys
 
 
-SCHEMA = "pinyon-shift.native-renderer-static-world-runtime-join.v8"
+SCHEMA = "pinyon-shift.native-renderer-static-world-runtime-join.v9"
 STATIC_SCHEMA = "pinyon-shift.native-renderer-static-world-ingress.v2"
 LIFETIME_SCHEMA = "pinyon-shift.native-renderer-static-world-lifetime.v1"
 RESOURCE_SCHEMA = "pinyon-shift.native-renderer-static-world-resource.v1"
@@ -20,7 +20,7 @@ ASSET_METADATA_SCHEMA = (
     "pinyon-shift.native-renderer-static-world-asset-metadata.v1"
 )
 MESH_SEMANTICS_SCHEMA = (
-    "pinyon-shift.native-renderer-static-world-mesh-semantics.v1"
+    "pinyon-shift.native-renderer-static-world-mesh-semantics.v2"
 )
 CONFIG = "native_renderer.discovery.static_world_runtime_join_config"
 SUMMARY = "native_renderer.discovery.static_world_runtime_join_summary"
@@ -517,6 +517,7 @@ def validate_static_mesh_semantics(document):
     try:
         geometry = document["geometry"]
         material = document["material_binding"]
+        prepared_layout = document["prepared_layout_boundary"]
         claims = document["claims"]
     except (KeyError, TypeError) as error:
         raise ValueError(
@@ -571,12 +572,30 @@ def validate_static_mesh_semantics(document):
     }
     if material != expected_material:
         raise ValueError("static-world material binding proof drifted")
+    expected_prepared_layout = {
+        "draw_state_flush": "8240BB40",
+        "flush_after_index_buffer_bind": True,
+        "flush_before_draw_emitter": True,
+        "runtime_source": "xenos_decoded_draw_observation",
+        "runtime_join": "exact_physical_pm4_header_origin",
+        "vertex_binding_limit": 8,
+        "vertex_attribute_limit": 32,
+        "float_constant_limit_per_stage": 64,
+        "texture_state_limit": 16,
+        "payload_bytes_exported": False,
+    }
+    if prepared_layout != expected_prepared_layout:
+        raise ValueError("static-world prepared layout boundary drifted")
     if (
         claims.get("primitive_and_element_count_fields_proved") is not True
         or claims.get("index_buffer_bind_draw_clear_sequence_proved")
         is not True
         or claims.get("submodel_state_binding_fields_proved") is not True
         or claims.get("optional_material_resource_branch_proved") is not True
+        or claims.get("complete_vertex_layout_runtime_boundary_proved")
+        is not True
+        or claims.get("bounded_material_parameter_runtime_boundary_proved")
+        is not True
         or claims.get("complete_vertex_layout_decoding_proved") is not False
         or claims.get("complete_material_parameter_decoding_proved") is not False
         or claims.get("native_draw_admission_proved") is not False
@@ -671,6 +690,14 @@ def build(
         "submodel_state_fields": "submodel_plus_32_u32_39_u8_112_u8",
         "mesh_optional_material_reference_field": "mesh_plus_128_u32",
         "mesh_semantics_export": "bounded_numeric_identity_fields_only",
+        "prepared_layout_boundary": (
+            "xenos_decoded_draw_observation_joined_by_physical_pm4_origin"
+        ),
+        "prepared_layout_capacity": "512",
+        "prepared_layout_export": (
+            "complete_bounded_vertex_fetch_attribute_constant_and_"
+            "texture_metadata"
+        ),
         "draw_emitter": "82416380",
         "packet_hooks": "82416260,824162F4",
         "join": "synchronous_scope_to_physical_pm4_prepared_draw",
@@ -796,6 +823,12 @@ def build(
         "mesh_semantic_read_faults",
         "mesh_semantic_packet_origins",
         "mesh_semantic_missing_packet_origins",
+        "prepared_layout_observations",
+        "prepared_layout_exact",
+        "prepared_layout_unbounded_geometry",
+        "prepared_layout_parameter_overflows",
+        "prepared_layout_entries",
+        "prepared_layout_table_overflow",
         "presentation_entries",
         "presentation_exits",
         "presentation_exact",
@@ -978,6 +1011,14 @@ def build(
         + totals["mesh_semantic_missing_packet_origins"]
     ):
         failures.append("static-world mesh semantic packet join drifted")
+    if totals["prepared_layout_observations"] != totals["prepared_matches"]:
+        failures.append("static-world prepared layout observation drifted")
+    if totals["prepared_layout_observations"] != (
+        totals["prepared_layout_exact"]
+        + totals["prepared_layout_unbounded_geometry"]
+        + totals["prepared_layout_parameter_overflows"]
+    ):
+        failures.append("static-world prepared layout classification drifted")
     presentation_classified = (
         totals["presentation_exact"]
         + totals["presentation_invalid_root"]
@@ -1022,6 +1063,10 @@ def build(
         failures.append("no bounded static-world mesh semantics were observed")
     if not totals["mesh_semantic_packet_origins"]:
         failures.append("no mesh semantics joined a prepared-draw origin")
+    if not totals["prepared_layout_exact"]:
+        failures.append("no bounded static-world prepared layout was observed")
+    if not totals["prepared_layout_entries"]:
+        failures.append("no static-world prepared layout entry was retained")
     if not totals["prepared_matches"]:
         failures.append("no static-world PM4 packet joined a prepared draw")
     for key in (
@@ -1068,6 +1113,9 @@ def build(
         "member_packet_mismatches",
         "mesh_semantic_read_faults",
         "mesh_semantic_missing_packet_origins",
+        "prepared_layout_unbounded_geometry",
+        "prepared_layout_parameter_overflows",
+        "prepared_layout_table_overflow",
         "presentation_invalid_root",
         "presentation_resource_read_faults",
         "presentation_overlaps",
@@ -1124,6 +1172,8 @@ def build(
             "bounded_mesh_draw_semantics_proved": not failures,
             "bounded_material_binding_semantics_proved": not failures,
             "mesh_semantics_to_prepared_draw_proved": not failures,
+            "complete_vertex_layout_to_prepared_draw_proved": not failures,
+            "bounded_material_parameter_boundary_proved": not failures,
             "static_world_scope_to_pm4_proved": not failures,
             "static_world_pm4_to_prepared_draw_proved": not failures,
             "building_or_prop_instance_identity_proved": False,

--- a/tools/tests/test_native_renderer_static_world_mesh_semantics.py
+++ b/tools/tests/test_native_renderer_static_world_mesh_semantics.py
@@ -62,6 +62,8 @@ def fixture():
             0x82C4DBE4: "bl 0x8244e728",
             0x82C4DC10: "lwz r4,96(r28)",
             0x82C4DC14: "bl 0x8244d760",
+            0x82C4DC18: "lwz r3,68(r30)",
+            0x82C4DC1C: "bl 0x8240bb40",
             0x82C4DC20: "lwz r3,36(r28)",
             0x82C4DC24: "lwz r4,100(r28)",
             0x82C4DC28: "bl 0x82c48558",
@@ -97,6 +99,11 @@ class StaticWorldMeshSemanticsTests(unittest.TestCase):
         )
         self.assertTrue(
             document["claims"]["optional_material_resource_branch_proved"]
+        )
+        self.assertTrue(
+            document["claims"][
+                "complete_vertex_layout_runtime_boundary_proved"
+            ]
         )
         self.assertFalse(document["claims"]["native_draw_admission_proved"])
 

--- a/tools/tests/test_native_renderer_static_world_runtime_join.py
+++ b/tools/tests/test_native_renderer_static_world_runtime_join.py
@@ -375,11 +375,25 @@ def static_mesh_semantics():
             "resource_bind": "8244E728",
             "fallback_source": "renderer_r22",
         },
+        "prepared_layout_boundary": {
+            "draw_state_flush": "8240BB40",
+            "flush_after_index_buffer_bind": True,
+            "flush_before_draw_emitter": True,
+            "runtime_source": "xenos_decoded_draw_observation",
+            "runtime_join": "exact_physical_pm4_header_origin",
+            "vertex_binding_limit": 8,
+            "vertex_attribute_limit": 32,
+            "float_constant_limit_per_stage": 64,
+            "texture_state_limit": 16,
+            "payload_bytes_exported": False,
+        },
         "claims": {
             "primitive_and_element_count_fields_proved": True,
             "index_buffer_bind_draw_clear_sequence_proved": True,
             "submodel_state_binding_fields_proved": True,
             "optional_material_resource_branch_proved": True,
+            "complete_vertex_layout_runtime_boundary_proved": True,
+            "bounded_material_parameter_runtime_boundary_proved": True,
             "complete_vertex_layout_decoding_proved": False,
             "complete_material_parameter_decoding_proved": False,
             "native_draw_admission_proved": False,
@@ -452,6 +466,14 @@ def fixture():
             "submodel_state_fields": "submodel_plus_32_u32_39_u8_112_u8",
             "mesh_optional_material_reference_field": "mesh_plus_128_u32",
             "mesh_semantics_export": "bounded_numeric_identity_fields_only",
+            "prepared_layout_boundary": (
+                "xenos_decoded_draw_observation_joined_by_physical_pm4_origin"
+            ),
+            "prepared_layout_capacity": "512",
+            "prepared_layout_export": (
+                "complete_bounded_vertex_fetch_attribute_constant_and_"
+                "texture_metadata"
+            ),
             "draw_emitter": "82416380",
             "packet_hooks": "82416260,824162F4",
             "join": "synchronous_scope_to_physical_pm4_prepared_draw",
@@ -561,6 +583,12 @@ def fixture():
         mesh_semantic_read_faults="0",
         mesh_semantic_packet_origins="100",
         mesh_semantic_missing_packet_origins="0",
+        prepared_layout_observations="98",
+        prepared_layout_exact="98",
+        prepared_layout_unbounded_geometry="0",
+        prepared_layout_parameter_overflows="0",
+        prepared_layout_entries="12",
+        prepared_layout_table_overflow="0",
         presentation_entries="12",
         presentation_exits="12",
         presentation_exact="12",
@@ -619,6 +647,16 @@ class StaticWorldRuntimeJoinTests(unittest.TestCase):
         self.assertTrue(
             document["qualification"][
                 "mesh_semantics_to_prepared_draw_proved"
+            ]
+        )
+        self.assertTrue(
+            document["qualification"][
+                "complete_vertex_layout_to_prepared_draw_proved"
+            ]
+        )
+        self.assertTrue(
+            document["qualification"][
+                "bounded_material_parameter_boundary_proved"
             ]
         )
         self.assertTrue(
@@ -947,6 +985,80 @@ class StaticWorldRuntimeJoinTests(unittest.TestCase):
             document["failures"],
         )
 
+    def test_rejects_unbounded_prepared_vertex_layout(self):
+        events = copy.deepcopy(fixture())
+        events[-1].update(
+            status="incomplete",
+            prepared_layout_exact="97",
+            prepared_layout_unbounded_geometry="1",
+            qualification_complete="false",
+        )
+        document = MODULE.build(
+            static_ingress(),
+            static_lifetime(),
+            static_resource(),
+            static_streaming(),
+            static_graph(),
+            static_owner(),
+            static_asset_metadata(),
+            static_mesh_semantics(),
+            events,
+        )
+        self.assertEqual("incomplete", document["status"])
+        self.assertIn(
+            "prepared_layout_unbounded_geometry is nonzero",
+            document["failures"],
+        )
+
+    def test_rejects_prepared_layout_table_overflow(self):
+        events = copy.deepcopy(fixture())
+        events[-1].update(
+            status="incomplete",
+            prepared_layout_table_overflow="1",
+            qualification_complete="false",
+        )
+        document = MODULE.build(
+            static_ingress(),
+            static_lifetime(),
+            static_resource(),
+            static_streaming(),
+            static_graph(),
+            static_owner(),
+            static_asset_metadata(),
+            static_mesh_semantics(),
+            events,
+        )
+        self.assertEqual("incomplete", document["status"])
+        self.assertIn(
+            "prepared_layout_table_overflow is nonzero",
+            document["failures"],
+        )
+
+    def test_rejects_prepared_material_parameter_overflow(self):
+        events = copy.deepcopy(fixture())
+        events[-1].update(
+            status="incomplete",
+            prepared_layout_exact="97",
+            prepared_layout_parameter_overflows="1",
+            qualification_complete="false",
+        )
+        document = MODULE.build(
+            static_ingress(),
+            static_lifetime(),
+            static_resource(),
+            static_streaming(),
+            static_graph(),
+            static_owner(),
+            static_asset_metadata(),
+            static_mesh_semantics(),
+            events,
+        )
+        self.assertEqual("incomplete", document["status"])
+        self.assertIn(
+            "prepared_layout_parameter_overflows is nonzero",
+            document["failures"],
+        )
+
     def test_rejects_static_asset_key_offset_drift(self):
         metadata = static_asset_metadata()
         metadata["resource_key"]["stored_name_offset"] = 20
@@ -1018,6 +1130,8 @@ class StaticWorldRuntimeJoinTests(unittest.TestCase):
         self.assertIn("kSimpleMeshPrimitiveTypeOffset = 36", hooks)
         self.assertIn("mesh_semantic_packet_origins", hooks)
         self.assertIn("static_world_mesh_primitive_type", hooks)
+        self.assertIn("RecordStaticWorldPreparedLayout", hooks)
+        self.assertIn("static_world_prepared_layout_entry", hooks)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- prove the post-index-bind draw-state flush as the exact shader-derived layout boundary
- join each exact static-world mesh to its prepared Xenos draw and retain complete bounded vertex binding/attribute metadata
- retain representative float, bool, loop, texture, shader, and render-state parameter metadata per layout family
- fail closed on unbounded geometry, parameter overflow, or the 512-family catalog limit
- preserve Xenos authority; native admission and suppression remain disabled

## Validation
- `python -m unittest discover -s tools/tests -p 'test_*.py'` (569 passed)
- retail static mesh-semantics v2 report regenerated successfully
- `graphics_hooks.cpp` compiled successfully
- final executable link remains blocked only by the preserved active AppData gameplay process