### PR TITLE
feat(native-renderer): classify static world instances

### DIFF
--- a/docs/native-renderer/REPRIORITIZED_PLAN.md
+++ b/docs/native-renderer/REPRIORITIZED_PLAN.md
@@ -418,6 +418,19 @@ The 512-family census and its independent overflow accounting are documented in
 qualification remains batched; resource payload bytes are not exported and
 Xenos remains authoritative.
 
+Instance-classification checkpoint: retail instruction flow now proves the
+complete 64-byte `CModelPresentation` transform at owner offset 80 and its
+slot-6 copy into renderer offset 128 before the exact draw. The passive runtime
+lineage carries all 16 numeric words and their hash into prepared-draw
+provenance with fail-closed accounting. Separately, the title-authored Colorado
+collision and gameplay manifests produce a payload-free catalog of 24,025
+hashed spatial entries (21,877 collision props and 2,148 gameplay objects).
+See
+[`STATIC_WORLD_INSTANCE_CLASSIFICATION.md`](STATIC_WORLD_INSTANCE_CLASSIFICATION.md).
+The next combined C1/C2 AppData run must prove the matrix convention and a
+unique runtime-to-catalog match; no building/prop category, native admission,
+or suppression is claimed yet.
+
 ### C3. Semantic batching, culling, and LOD
 
 - Promote the existing visibility and prepared-draw evidence into production

--- a/docs/native-renderer/STATIC_WORLD_INSTANCE_CLASSIFICATION.md
+++ b/docs/native-renderer/STATIC_WORLD_INSTANCE_CLASSIFICATION.md
@@ -1,0 +1,56 @@
+# Static-world instance classification
+
+Status: title-authored collision-prop and gameplay-object spatial catalogs
+built; exact runtime transform join implemented; category join not yet proved
+
+## Purpose
+
+The generic SimpleModel graph and presentation key identify a concrete rendered
+instance but do not label it as a building or prop. The Colorado ribbon ships
+two title-authored spatial inventories that supply independent categories:
+
+- `CollObjs.xml` contains collision-prop identities, positions, and orientation
+  axes; and
+- `GameObjs.xml` contains gameplay-object identities, positions, and
+  orientation axes.
+
+`tools/build-native-renderer-static-world-instance-catalog.py` turns those
+inputs into a read-only, payload-free spatial catalog. It hashes every identity
+field with FNV-1a 64, retains only numeric position/orientation metadata, and
+records a SHA-256 digest and count for each source. It never exports plaintext
+asset names or game payload bytes.
+
+The current retail Colorado inputs produce 24,025 entries: 21,877 collision
+props and 2,148 gameplay objects. This proves the availability of authoritative
+content categories, not their relationship to runtime draws.
+
+## Build the local catalog
+
+```powershell
+python tools/build-native-renderer-static-world-instance-catalog.py `
+  --collision .local/game/base/media/tracks/colorado/Ribbon_00/CollObjs.xml `
+  --gameplay .local/game/base/media/tracks/colorado/Ribbon_00/GameObjs.xml `
+  --output .local/qualification/native-renderer-static-world-instance-catalog.json
+```
+
+The output stays below `.local`; it is evidence, not a checked-in game-data
+derivative.
+
+## Runtime boundary
+
+Retail instructions prove that `CModelPresentation` stores its complete
+64-byte transform at offset 80 and passes it through renderer slot 6
+(`82C4C568`) to renderer offset 128 before the exact slot-12 draw. The passive
+observer now carries those 16 numeric words and their hash through the
+renderer, physical PM4 packet, and prepared-draw provenance.
+
+The next batched AppData run must determine the title's matrix convention from
+observed values and prove a unique, tolerance-bounded spatial match against the
+catalog. Ambiguous, absent, or out-of-bounds matches must remain unclassified.
+Only then can a prepared draw claim a collision-prop or gameplay-object class.
+Asset-key hashes may strengthen that join, but spatial proximity alone is not
+accepted when multiple catalog entries remain possible.
+
+Until that gate passes, `building_or_prop_instance_identity_proved` remains
+false. Xenos stays authoritative; native admission, publication, and
+suppression remain disabled.

--- a/docs/native-renderer/STATIC_WORLD_OWNER.md
+++ b/docs/native-renderer/STATIC_WORLD_OWNER.md
@@ -1,7 +1,8 @@
 # Static-world model-presentation ownership
 
-Status: exact presentation-to-renderer ownership and passive runtime join
-implemented; runtime qualification pending the next batched C1/C2 run
+Status: exact presentation-to-renderer ownership and transform dispatch proved;
+passive runtime join implemented; qualification pending the next batched C1/C2
+run
 
 ## Purpose
 
@@ -26,7 +27,10 @@ Retail RTTI, vtables, and generated AOT instructions prove:
   invokes renderer bind slot 0; the binding and reference-assignment helpers
   copy that same resource address into renderer offset 72; and
 - the same slot-12 scope later loads the offset-1608 renderer and invokes
-  renderer slot 12, whose exact vtable target is `82C4CCC8`.
+  renderer slot 12, whose exact vtable target is `82C4CCC8`; and
+- immediately before that draw, the scope loads the complete 64-byte transform
+  from owner offset 80 and invokes renderer slot 6 at `82C4C568`, which copies
+  the same 16 words to renderer offset 128.
 
 This creates a safe synchronous join: an exact SimpleModel renderer dispatch
 occurring inside the balanced presentation slot-12 scope carries the
@@ -36,6 +40,12 @@ offset-1608 renderer field to equal the nested dispatch receiver. Calls on
 other dynamic presentation types that share the implementation are counted as
 excluded vtable mismatches, while exact-owner field mismatches fail closed.
 The join changes no title behavior.
+
+The passive observer reads the transform only inside the exact presentation
+scope, exports its hash and 16 numeric words, and carries it through the exact
+renderer, PM4 packet, and prepared-draw lineage. Independent read, renderer
+join, and packet-origin accounting fails closed on missing provenance. No
+matrix convention or building/prop category is inferred from static code.
 
 The complete RTTI hierarchy census is documented in
 [`STATIC_WORLD_PRESENTATION_TYPES.md`](STATIC_WORLD_PRESENTATION_TYPES.md). It
@@ -52,14 +62,16 @@ python tools/discover-native-renderer-static-world-owner.py `
 
 ## Remaining boundary
 
-`CModelPresentation` plus its identical renderer resource is an exact
-title-owned static-model instance identity, not proof that the asset should be
-called a building rather than a prop. The bounded resource-key and
+`CModelPresentation`, its renderer resource, and its complete transform are an
+exact title-owned static-model instance identity, not proof that the asset
+should be called a building rather than a prop. The bounded resource-key and
 effect/texture reference path is now proved in
 [`STATIC_WORLD_ASSET_METADATA.md`](STATIC_WORLD_ASSET_METADATA.md), but its
-payload-free runtime category census, mesh field semantics, and representative
-streaming transitions remain open. This
-checkpoint changes no guest data, native admission, publication, or
+payload-free category join and representative streaming transitions remain
+open. The title-authored offline spatial catalog and its deliberately unproved
+runtime boundary are documented in
+[`STATIC_WORLD_INSTANCE_CLASSIFICATION.md`](STATIC_WORLD_INSTANCE_CLASSIFICATION.md).
+This checkpoint changes no guest data, native admission, publication, or
 suppression; Xenos remains authoritative.
 
 The combined runtime qualifier requires this report through `--owner`, the

--- a/src/native_renderer/graphics_hooks.cpp
+++ b/src/native_renderer/graphics_hooks.cpp
@@ -196,6 +196,8 @@ constexpr uint32_t kSimpleModelResourceEffectCountOffset = 128;
 constexpr uint32_t kSimpleModelResourceTextureVectorOffset = 288;
 constexpr uint32_t kModelPresentationVtable = 0x822432D4;
 constexpr uint32_t kModelPresentationNameOffset = 16;
+constexpr uint32_t kModelPresentationTransformOffset = 80;
+constexpr uint32_t kModelPresentationTransformWordCount = 16;
 constexpr uint32_t kModelPresentationResourceOffset = 148;
 constexpr uint32_t kModelPresentationRendererOffset = 1608;
 constexpr uint32_t kMsvcStringSizeOffset = 16;
@@ -497,6 +499,7 @@ struct SemanticDrawIdentity {
 
 struct StaticWorldDrawIdentity {
   uint64_t asset_key_hash = 0;
+  uint64_t transform_hash = 0;
   uint32_t model_presentation_address = 0;
   uint32_t model_presentation_resource_address = 0;
   uint32_t renderer_address = 0;
@@ -512,6 +515,8 @@ struct StaticWorldDrawIdentity {
   uint32_t asset_key_length = 0;
   uint32_t effect_reference_count = 0;
   uint32_t texture_reference_count = 0;
+  std::array<uint32_t, kModelPresentationTransformWordCount>
+      transform_words{};
   uint32_t mesh_primitive_type = 0;
   uint32_t mesh_index_buffer_binding = 0;
   uint32_t mesh_source_element_count = 0;
@@ -520,6 +525,7 @@ struct StaticWorldDrawIdentity {
   uint8_t submodel_state_selector = 0;
   bool submodel_state_enabled = false;
   bool mesh_semantics_valid = false;
+  bool transform_valid = false;
   bool asset_metadata_valid = false;
   bool valid = false;
 };
@@ -1944,6 +1950,7 @@ struct TrackRenderModelDispatchScope {
 
 struct StaticWorldRendererDispatchScope {
   uint64_t asset_key_hash = 0;
+  uint64_t transform_hash = 0;
   uint64_t packet_origins = 0;
   uint32_t renderer_address = 0;
   uint32_t renderer_generation = 0;
@@ -1961,6 +1968,8 @@ struct StaticWorldRendererDispatchScope {
   uint32_t asset_key_length = 0;
   uint32_t effect_reference_count = 0;
   uint32_t texture_reference_count = 0;
+  std::array<uint32_t, kModelPresentationTransformWordCount>
+      transform_words{};
   uint32_t mesh_primitive_type = 0;
   uint32_t mesh_index_buffer_binding = 0;
   uint32_t mesh_source_element_count = 0;
@@ -1969,6 +1978,7 @@ struct StaticWorldRendererDispatchScope {
   uint8_t submodel_state_selector = 0;
   bool submodel_state_enabled = false;
   bool mesh_semantics_valid = false;
+  bool transform_valid = false;
   bool asset_metadata_valid = false;
   bool member_active = false;
   bool member_exact = false;
@@ -1979,11 +1989,15 @@ struct StaticWorldRendererDispatchScope {
 struct StaticWorldPresentationDispatchScope {
   uint64_t renderer_dispatch_joins = 0;
   uint64_t asset_key_hash = 0;
+  uint64_t transform_hash = 0;
   uint32_t presentation_address = 0;
   uint32_t resource_address = 0;
   uint32_t asset_key_length = 0;
   uint32_t effect_reference_count = 0;
   uint32_t texture_reference_count = 0;
+  std::array<uint32_t, kModelPresentationTransformWordCount>
+      transform_words{};
+  bool transform_valid = false;
   bool asset_metadata_valid = false;
   bool active = false;
   bool exact = false;
@@ -2238,6 +2252,13 @@ std::atomic<uint64_t> g_static_world_asset_metadata_empty_keys{};
 std::atomic<uint64_t> g_static_world_asset_metadata_read_faults{};
 std::atomic<uint64_t> g_static_world_asset_metadata_joins{};
 std::atomic<uint64_t> g_static_world_asset_metadata_missing_joins{};
+std::atomic<uint64_t> g_static_world_transform_observations{};
+std::atomic<uint64_t> g_static_world_transform_exact{};
+std::atomic<uint64_t> g_static_world_transform_read_faults{};
+std::atomic<uint64_t> g_static_world_transform_joins{};
+std::atomic<uint64_t> g_static_world_transform_missing_joins{};
+std::atomic<uint64_t> g_static_world_transform_packet_origins{};
+std::atomic<uint64_t> g_static_world_transform_missing_packet_origins{};
 std::array<SemanticBindingCacheSlot, 5> g_semantic_binding_cache_slots{};
 std::array<SemanticResolverCacheSlot, 5> g_semantic_resolver_cache_slots{};
 thread_local PendingSemanticResourceBindings g_pending_semantic_bindings{};
@@ -3091,6 +3112,37 @@ StaticWorldAssetMetadataResult ReadStaticWorldAssetMetadata(
   return StaticWorldAssetMetadataResult::kExact;
 }
 
+bool ReadStaticWorldPresentationTransform(
+    rex::memory::Memory *memory, uint32_t presentation_address,
+    StaticWorldPresentationDispatchScope &scope) {
+  constexpr uint32_t kTransformBytes =
+      kModelPresentationTransformWordCount * sizeof(uint32_t);
+  if (!memory ||
+      presentation_address >
+          UINT32_MAX - kModelPresentationTransformOffset - kTransformBytes) {
+    return false;
+  }
+  uint64_t hash = UINT64_C(0xCBF29CE484222325);
+  for (uint32_t word = 0;
+       word < kModelPresentationTransformWordCount; ++word) {
+    uint32_t value = 0;
+    if (!LoadMappedGuestU32(
+            memory,
+            presentation_address + kModelPresentationTransformOffset +
+                word * sizeof(uint32_t),
+            value)) {
+      scope.transform_words = {};
+      scope.transform_hash = 0;
+      return false;
+    }
+    scope.transform_words[word] = value;
+    hash = HashCombine(hash, value);
+  }
+  scope.transform_hash = hash ? hash : 1;
+  scope.transform_valid = true;
+  return true;
+}
+
 size_t StaticWorldRendererLifecycleIndex(uint32_t address) {
   return size_t((address >> 4) % kStaticWorldRendererLifecycleCapacity);
 }
@@ -3753,6 +3805,11 @@ void BeginStaticWorldPresentationDispatch(uint32_t presentation_address) {
     ++g_static_world_asset_metadata_read_faults;
     break;
   }
+  ++g_static_world_transform_observations;
+  (ReadStaticWorldPresentationTransform(memory, presentation_address, scope)
+       ? g_static_world_transform_exact
+       : g_static_world_transform_read_faults)
+      .fetch_add(1, std::memory_order_relaxed);
   scope.exact = true;
   ++g_static_world_presentation_exact;
 }
@@ -3886,18 +3943,24 @@ void BeginStaticWorldRendererDispatch(uint32_t renderer_address,
       scope.model_presentation_resource_address =
           presentation_scope.resource_address;
       scope.asset_key_hash = presentation_scope.asset_key_hash;
+      scope.transform_hash = presentation_scope.transform_hash;
       scope.asset_key_length = presentation_scope.asset_key_length;
       scope.effect_reference_count =
           presentation_scope.effect_reference_count;
       scope.texture_reference_count =
           presentation_scope.texture_reference_count;
+      scope.transform_words = presentation_scope.transform_words;
       scope.asset_metadata_valid =
           presentation_scope.asset_metadata_valid;
+      scope.transform_valid = presentation_scope.transform_valid;
       ++presentation_scope.renderer_dispatch_joins;
       ++g_static_world_presentation_renderer_joins;
       (scope.asset_metadata_valid
            ? g_static_world_asset_metadata_joins
            : g_static_world_asset_metadata_missing_joins)
+          .fetch_add(1, std::memory_order_relaxed);
+      (scope.transform_valid ? g_static_world_transform_joins
+                             : g_static_world_transform_missing_joins)
           .fetch_add(1, std::memory_order_relaxed);
     } else if (!renderer_matches) {
       ++g_static_world_presentation_renderer_mismatches;
@@ -5458,6 +5521,13 @@ void ResetTitleDrawProvenance() {
            &g_static_world_asset_metadata_read_faults,
            &g_static_world_asset_metadata_joins,
            &g_static_world_asset_metadata_missing_joins,
+           &g_static_world_transform_observations,
+           &g_static_world_transform_exact,
+           &g_static_world_transform_read_faults,
+           &g_static_world_transform_joins,
+           &g_static_world_transform_missing_joins,
+           &g_static_world_transform_packet_origins,
+           &g_static_world_transform_missing_packet_origins,
        }) {
     counter->store(0, std::memory_order_relaxed);
   }
@@ -5888,6 +5958,10 @@ void RecordTitleDrawPacketOrigin(uint32_t packet_guest_address,
            ? g_static_world_mesh_semantic_packet_origins
            : g_static_world_mesh_semantic_missing_packet_origins)
           .fetch_add(1, std::memory_order_relaxed);
+      (origin.static_world_draw.transform_valid
+           ? g_static_world_transform_packet_origins
+           : g_static_world_transform_missing_packet_origins)
+          .fetch_add(1, std::memory_order_relaxed);
     } else {
       g_static_world_member_packet_mismatches.fetch_add(
           1, std::memory_order_relaxed);
@@ -5952,6 +6026,7 @@ void RecordProceduralModelSemanticDrawPacket(
         g_static_world_renderer_scope;
     origin.static_world_draw = {
         .asset_key_hash = scope.asset_key_hash,
+        .transform_hash = scope.transform_hash,
         .model_presentation_address = scope.model_presentation_address,
         .model_presentation_resource_address =
             scope.model_presentation_resource_address,
@@ -5972,6 +6047,7 @@ void RecordProceduralModelSemanticDrawPacket(
         .asset_key_length = scope.asset_key_length,
         .effect_reference_count = scope.effect_reference_count,
         .texture_reference_count = scope.texture_reference_count,
+        .transform_words = scope.transform_words,
         .mesh_primitive_type = scope.mesh_primitive_type,
         .mesh_index_buffer_binding = scope.mesh_index_buffer_binding,
         .mesh_source_element_count = scope.mesh_source_element_count,
@@ -5981,6 +6057,7 @@ void RecordProceduralModelSemanticDrawPacket(
         .submodel_state_selector = scope.submodel_state_selector,
         .submodel_state_enabled = scope.submodel_state_enabled,
         .mesh_semantics_valid = scope.mesh_semantics_valid,
+        .transform_valid = scope.transform_valid,
         .asset_metadata_valid = scope.asset_metadata_valid,
         .valid = true,
     };
@@ -11513,6 +11590,25 @@ void EmitStaticWorldRuntimeJoinEvent(const char *event_name,
   const uint64_t asset_metadata_missing_joins =
       g_static_world_asset_metadata_missing_joins.load(
           std::memory_order_relaxed);
+  const uint64_t transform_observations =
+      g_static_world_transform_observations.load(
+          std::memory_order_relaxed);
+  const uint64_t transform_exact =
+      g_static_world_transform_exact.load(std::memory_order_relaxed);
+  const uint64_t transform_read_faults =
+      g_static_world_transform_read_faults.load(
+          std::memory_order_relaxed);
+  const uint64_t transform_joins =
+      g_static_world_transform_joins.load(std::memory_order_relaxed);
+  const uint64_t transform_missing_joins =
+      g_static_world_transform_missing_joins.load(
+          std::memory_order_relaxed);
+  const uint64_t transform_packet_origins =
+      g_static_world_transform_packet_origins.load(
+          std::memory_order_relaxed);
+  const uint64_t transform_missing_packet_origins =
+      g_static_world_transform_missing_packet_origins.load(
+          std::memory_order_relaxed);
   const bool accounting_complete =
       entries == exact + invalid_root + vtable_mismatches +
                            invalid_graph_field + unregistered_renderers +
@@ -11611,6 +11707,12 @@ void EmitStaticWorldRuntimeJoinEvent(const char *event_name,
               asset_metadata_read_faults &&
       presentation_renderer_joins ==
           asset_metadata_joins + asset_metadata_missing_joins &&
+      transform_observations == presentation_exact &&
+      transform_observations == transform_exact + transform_read_faults &&
+      presentation_renderer_joins ==
+          transform_joins + transform_missing_joins &&
+      member_packets_recorded ==
+          transform_packet_origins + transform_missing_packet_origins &&
       !overlaps && !exit_without_entry;
   const bool qualification_complete =
       accounting_complete && exact && packets_recorded && packet_matches &&
@@ -11687,7 +11789,10 @@ void EmitStaticWorldRuntimeJoinEvent(const char *event_name,
           std::memory_order_relaxed) &&
       !g_static_world_presentation_resource_mismatches.load(
           std::memory_order_relaxed) &&
-      !asset_metadata_read_faults && !asset_metadata_missing_joins;
+      !asset_metadata_read_faults && !asset_metadata_missing_joins &&
+      transform_exact && transform_joins && transform_packet_origins &&
+      !transform_read_faults && !transform_missing_joins &&
+      !transform_missing_packet_origins;
   const uint64_t pending_packets =
       packets_recorded >= packet_matches ? packets_recorded - packet_matches
                                           : 0;
@@ -11937,6 +12042,16 @@ void EmitStaticWorldRuntimeJoinEvent(const char *event_name,
        {"asset_metadata_joins", std::to_string(asset_metadata_joins)},
        {"asset_metadata_missing_joins",
         std::to_string(asset_metadata_missing_joins)},
+       {"transform_observations", std::to_string(transform_observations)},
+       {"transform_exact", std::to_string(transform_exact)},
+       {"transform_read_faults", std::to_string(transform_read_faults)},
+       {"transform_joins", std::to_string(transform_joins)},
+       {"transform_missing_joins",
+        std::to_string(transform_missing_joins)},
+       {"transform_packet_origins",
+        std::to_string(transform_packet_origins)},
+       {"transform_missing_packet_origins",
+        std::to_string(transform_missing_packet_origins)},
        {"accounting_complete", accounting_complete ? "true" : "false"},
        {"qualification_complete",
         qualification_complete ? "true" : "false"},
@@ -13144,6 +13259,19 @@ std::string SerializeVertexAttributes(
         attribute.result_storage_target, attribute.result_storage_index,
         attribute.result_write_mask, attribute.result_components,
         attribute.flags);
+  }
+  return result;
+}
+
+std::string SerializeStaticWorldTransform(
+    const std::array<uint32_t, kModelPresentationTransformWordCount>
+        &transform_words) {
+  std::string result;
+  for (uint32_t word : transform_words) {
+    if (!result.empty()) {
+      result += ":";
+    }
+    result += fmt::format("{:08X}", word);
   }
   return result;
 }
@@ -14758,6 +14886,7 @@ void RecordTitleDrawProvenance(
                  (prepared ? uint64_t(1) << 63 : 0);
   key = HashCombine(key, origin.semantic_draw.submission_key);
   key = HashCombine(key, origin.static_world_draw.asset_key_hash);
+  key = HashCombine(key, origin.static_world_draw.transform_hash);
   key = HashCombine(
       key, origin.static_world_draw.model_presentation_address);
   key = HashCombine(
@@ -14825,6 +14954,12 @@ void RecordTitleDrawProvenance(
             origin.static_world_draw.renderer_address &&
         entry.origin.static_world_draw.asset_key_hash ==
             origin.static_world_draw.asset_key_hash &&
+        entry.origin.static_world_draw.transform_hash ==
+            origin.static_world_draw.transform_hash &&
+        entry.origin.static_world_draw.transform_words ==
+            origin.static_world_draw.transform_words &&
+        entry.origin.static_world_draw.transform_valid ==
+            origin.static_world_draw.transform_valid &&
         entry.origin.static_world_draw.asset_key_length ==
             origin.static_world_draw.asset_key_length &&
         entry.origin.static_world_draw.effect_reference_count ==
@@ -14966,6 +15101,21 @@ void EmitTitleDrawProvenanceSummary() {
           entry.origin.static_world_draw.asset_metadata_valid
               ? std::to_string(
                     entry.origin.static_world_draw.asset_key_length)
+              : ""},
+         {"static_world_transform_valid",
+          entry.origin.static_world_draw.valid
+              ? (entry.origin.static_world_draw.transform_valid ? "true"
+                                                                : "false")
+              : ""},
+         {"static_world_transform_hash",
+          entry.origin.static_world_draw.transform_valid
+              ? fmt::format("{:016X}",
+                            entry.origin.static_world_draw.transform_hash)
+              : ""},
+         {"static_world_transform_words",
+          entry.origin.static_world_draw.transform_valid
+              ? SerializeStaticWorldTransform(
+                    entry.origin.static_world_draw.transform_words)
               : ""},
          {"static_world_effect_reference_count",
           entry.origin.static_world_draw.asset_metadata_valid
@@ -23648,6 +23798,10 @@ void InstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system,
        {"presentation_renderer_field", "presentation_plus_1608"},
        {"presentation_resource_join",
         "presentation_plus_148_equals_renderer_plus_72"},
+       {"presentation_transform_field", "presentation_plus_80_16_be_u32"},
+       {"presentation_transform_dispatch",
+        "renderer_slot_6_82C4C568_to_renderer_plus_128"},
+       {"transform_export", "hash_and_16_numeric_words_only"},
        {"asset_key_field", "presentation_plus_16_msvc_string"},
        {"asset_key_export", "fnv1a64_hash_and_length_only"},
        {"effect_reference_fields", "resource_plus_124_pointer_plus_128_u16"},

--- a/tools/build-native-renderer-static-world-instance-catalog.py
+++ b/tools/build-native-renderer-static-world-instance-catalog.py
@@ -1,0 +1,165 @@
+"""Build a payload-free spatial catalog of title-authored world instances."""
+
+import argparse
+import hashlib
+import json
+import math
+import pathlib
+import sys
+import xml.etree.ElementTree as ET
+
+
+SCHEMA = "pinyon-shift.native-renderer-static-world-instance-catalog.v1"
+MAX_INSTANCES_PER_SOURCE = 100_000
+AXES = ("XAxis", "YAxis", "ZAxis")
+
+
+def fnv1a64(value):
+    result = 0xCBF29CE484222325
+    for byte in value.encode("utf-8"):
+        result ^= byte
+        result = (result * 0x100000001B3) & 0xFFFFFFFFFFFFFFFF
+    return f"{result:016X}"
+
+
+def source_sha256(path):
+    digest = hashlib.sha256()
+    with path.open("rb") as source:
+        for block in iter(lambda: source.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest().upper()
+
+
+def vector(element, label):
+    if element is None:
+        raise ValueError(f"instance is missing {label}")
+    try:
+        values = [float(element.attrib[axis]) for axis in ("x", "y", "z")]
+    except (KeyError, TypeError, ValueError) as error:
+        raise ValueError(f"instance has an invalid {label}") from error
+    if not all(math.isfinite(value) for value in values):
+        raise ValueError(f"instance has a non-finite {label}")
+    return values
+
+
+def identity_fields(element, category):
+    if category == "collision_prop":
+        fields = ("PhysicsType", "GraphicsName")
+    else:
+        fields = ("GameplayID",)
+    values = []
+    for field in fields:
+        value = element.attrib.get(field)
+        if not isinstance(value, str) or not value:
+            raise ValueError(f"{category} instance is missing {field}")
+        values.append(value)
+    return fields, values
+
+
+def read_instances(path, expected_root, category):
+    instances = []
+    root = None
+    try:
+        for event, element in ET.iterparse(path, events=("start", "end")):
+            if root is None and event == "start":
+                root = element
+                if root.tag != expected_root:
+                    raise ValueError(
+                        f"expected {expected_root} root, found {root.tag}"
+                    )
+            if event != "end" or element is root:
+                continue
+            if not element.tag.startswith("Obj"):
+                continue
+            if len(instances) >= MAX_INSTANCES_PER_SOURCE:
+                raise ValueError(f"{category} instance capacity exceeded")
+            fields, values = identity_fields(element, category)
+            position = vector(element.find("Pos"), "position")
+            orientation = element.find("Orientation")
+            if orientation is None:
+                raise ValueError("instance is missing orientation")
+            axes = [vector(orientation.find(axis), axis) for axis in AXES]
+            joined_identity = "\0".join(values)
+            instances.append(
+                {
+                    "category": category,
+                    "source_ordinal": len(instances),
+                    "identity_hash": fnv1a64(joined_identity),
+                    "identity_field_hashes": {
+                        field: fnv1a64(value)
+                        for field, value in zip(fields, values)
+                    },
+                    "position": position,
+                    "orientation": axes,
+                }
+            )
+            element.clear()
+    except ET.ParseError as error:
+        raise ValueError(f"invalid {category} XML") from error
+    if root is None:
+        raise ValueError(f"empty {category} XML")
+    return instances
+
+
+def build(collision_path, gameplay_path):
+    collision_path = pathlib.Path(collision_path)
+    gameplay_path = pathlib.Path(gameplay_path)
+    collision = read_instances(collision_path, "CollObjs", "collision_prop")
+    gameplay = read_instances(gameplay_path, "GameObjs", "gameplay_object")
+    instances = collision + gameplay
+    return {
+        "schema": SCHEMA,
+        "status": "complete",
+        "sources": [
+            {
+                "kind": "collision_prop",
+                "sha256": source_sha256(collision_path),
+                "instance_count": len(collision),
+            },
+            {
+                "kind": "gameplay_object",
+                "sha256": source_sha256(gameplay_path),
+                "instance_count": len(gameplay),
+            },
+        ],
+        "instance_count": len(instances),
+        "instances": instances,
+        "qualification": {
+            "title_authored_spatial_classes_cataloged": bool(instances),
+            "runtime_transform_join_proved": False,
+            "building_or_prop_instance_identity_proved": False,
+        },
+        "safety": {
+            "source_files_changed": False,
+            "plaintext_identity_exported": False,
+            "game_asset_payload_exported": False,
+            "numeric_spatial_metadata_only": True,
+            "guest_state_changed": False,
+            "native_admission": False,
+            "native_draw": False,
+            "suppression_allowed": False,
+        },
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--collision", required=True, type=pathlib.Path)
+    parser.add_argument("--gameplay", required=True, type=pathlib.Path)
+    parser.add_argument("--output", required=True, type=pathlib.Path)
+    arguments = parser.parse_args()
+    try:
+        document = build(arguments.collision, arguments.gameplay)
+        arguments.output.parent.mkdir(parents=True, exist_ok=True)
+        arguments.output.write_text(
+            json.dumps(document, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+    except (OSError, ValueError) as error:
+        print(error, file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/discover-native-renderer-static-world-owner.py
+++ b/tools/discover-native-renderer-static-world-owner.py
@@ -10,7 +10,7 @@ import re
 import sys
 
 
-SCHEMA = "pinyon-shift.native-renderer-static-world-owner.v1"
+SCHEMA = "pinyon-shift.native-renderer-static-world-owner.v2"
 IMAGE_BASE = 0x82000000
 PRESENTATION_VTABLE = 0x822432D4
 PRESENTATION_SLOT_COUNT = 18
@@ -34,9 +34,13 @@ BINDING_CONSTRUCTOR = 0x824AFB20
 REFERENCE_ASSIGN = 0x826E1B10
 RENDERER_BIND_SLOT = 0
 RENDERER_DRAW_SLOT = 12
+RENDERER_TRANSFORM_SLOT = 6
+RENDERER_TRANSFORM = 0x82C4C568
 RESOURCE_REFERENCE_OFFSET = 148
 RENDERER_FIELD_OFFSET = 1608
 STATE_FIELD_OFFSET = 144
+PRESENTATION_TRANSFORM_OFFSET = 80
+RENDERER_TRANSFORM_OFFSET = 128
 
 
 def parse_functions(paths: list[pathlib.Path]) -> dict[int, dict[int, str]]:
@@ -95,6 +99,8 @@ def build(functions: dict[int, dict[int, str]], image: bytes) -> dict:
     renderer_slots = [
         image_u32(image, RENDERER_VTABLE + index * 4) for index in range(17)
     ]
+    if renderer_slots[RENDERER_TRANSFORM_SLOT] != RENDERER_TRANSFORM:
+        raise ValueError("CSimpleModelRenderer transform slot drifted")
 
     require_instructions(
         functions,
@@ -186,10 +192,40 @@ def build(functions: dict[int, dict[int, str]], image: bytes) -> dict:
             0x823F8DC4: "mr r31,r3",
             0x823F8DDC: "bl 0x823f8980",
             0x823F8E20: "lwz r11,1608(r31)",
+            0x823F8E30: "ld r11,136(r31)",
+            0x823F8E34: "ld r4,80(r31)",
+            0x823F8E38: "ld r5,88(r31)",
+            0x823F8E3C: "ld r6,96(r31)",
+            0x823F8E40: "ld r7,104(r31)",
+            0x823F8E44: "lwz r29,0(r3)",
+            0x823F8E48: "ld r8,112(r31)",
+            0x823F8E4C: "ld r9,120(r31)",
+            0x823F8E50: "ld r10,128(r31)",
+            0x823F8E58: "lwz r29,24(r29)",
+            0x823F8E5C: "mtctr r29",
+            0x823F8E60: "bctrl",
             0x823F8F0C: "lwz r3,1608(r31)",
             0x823F8F18: "lwz r11,48(r11)",
             0x823F8F20: "bctrl",
             PRESENTATION_DRAW_EXIT: "addi r1,r1,160",
+        },
+    )
+    require_instructions(
+        functions,
+        RENDERER_TRANSFORM,
+        {
+            0x82C4C568: "std r4,32(r1)",
+            0x82C4C56C: "addi r11,r3,128",
+            0x82C4C570: "std r6,48(r1)",
+            0x82C4C578: "std r8,64(r1)",
+            0x82C4C580: "std r9,72(r1)",
+            0x82C4C588: "std r10,80(r1)",
+            0x82C4C590: "std r7,56(r1)",
+            0x82C4C598: "std r5,40(r1)",
+            0x82C4C5B4: "stvx128 v61,r11,r10",
+            0x82C4C5B8: "stvx128 v63,r0,r11",
+            0x82C4C5BC: "stvx128 v62,r11,r6",
+            0x82C4C5C0: "stvx128 v60,r11,r9",
         },
     )
 
@@ -235,12 +271,23 @@ def build(functions: dict[int, dict[int, str]], image: bytes) -> dict:
                 "presentation_plus_148_equals_renderer_plus_72"
             ),
         },
+        "transform_join": {
+            "presentation_transform_offset": PRESENTATION_TRANSFORM_OFFSET,
+            "transform_size_bytes": 64,
+            "renderer_transform_slot": RENDERER_TRANSFORM_SLOT,
+            "renderer_transform_target": f"{RENDERER_TRANSFORM:08X}",
+            "renderer_transform_offset": RENDERER_TRANSFORM_OFFSET,
+            "address_equation": (
+                "presentation_plus_80_64_bytes_copied_to_renderer_plus_128"
+            ),
+        },
         "claims": {
             "exact_model_presentation_owner_proved": True,
             "presentation_to_renderer_field_proved": True,
             "presentation_to_resource_reference_proved": True,
             "renderer_bind_and_draw_dispatch_proved": True,
             "presentation_to_renderer_resource_identity_proved": True,
+            "presentation_transform_to_renderer_proved": True,
             "concrete_building_or_prop_identity_proved": False,
             "mesh_or_material_semantics_proved": False,
         },

--- a/tools/summarize-native-renderer-static-world-runtime-join.py
+++ b/tools/summarize-native-renderer-static-world-runtime-join.py
@@ -9,13 +9,13 @@ import pathlib
 import sys
 
 
-SCHEMA = "pinyon-shift.native-renderer-static-world-runtime-join.v9"
+SCHEMA = "pinyon-shift.native-renderer-static-world-runtime-join.v10"
 STATIC_SCHEMA = "pinyon-shift.native-renderer-static-world-ingress.v2"
 LIFETIME_SCHEMA = "pinyon-shift.native-renderer-static-world-lifetime.v1"
 RESOURCE_SCHEMA = "pinyon-shift.native-renderer-static-world-resource.v1"
 STREAMING_SCHEMA = "pinyon-shift.native-renderer-static-world-streaming.v1"
 GRAPH_SCHEMA = "pinyon-shift.native-renderer-static-world-graph.v1"
-OWNER_SCHEMA = "pinyon-shift.native-renderer-static-world-owner.v1"
+OWNER_SCHEMA = "pinyon-shift.native-renderer-static-world-owner.v2"
 ASSET_METADATA_SCHEMA = (
     "pinyon-shift.native-renderer-static-world-asset-metadata.v1"
 )
@@ -361,6 +361,7 @@ def validate_static_owner(document):
         presentation = document["presentation"]
         renderer_join = document["renderer_join"]
         resource_join = document["resource_join"]
+        transform_join = document["transform_join"]
         claims = document["claims"]
     except (KeyError, TypeError) as error:
         raise ValueError("static-world owner proof is incomplete") from error
@@ -402,6 +403,16 @@ def validate_static_owner(document):
             "presentation_plus_148_equals_renderer_plus_72"
         ),
     }
+    expected_transform_join = {
+        "presentation_transform_offset": 80,
+        "transform_size_bytes": 64,
+        "renderer_transform_slot": 6,
+        "renderer_transform_target": "82C4C568",
+        "renderer_transform_offset": 128,
+        "address_equation": (
+            "presentation_plus_80_64_bytes_copied_to_renderer_plus_128"
+        ),
+    }
     if any(
         presentation.get(key) != value
         for key, value in expected_presentation.items()
@@ -417,6 +428,8 @@ def validate_static_owner(document):
         for key, value in expected_resource_join.items()
     ):
         raise ValueError("static-world presentation resource join drifted")
+    if transform_join != expected_transform_join:
+        raise ValueError("static-world presentation transform join drifted")
     if (
         claims.get("exact_model_presentation_owner_proved") is not True
         or claims.get("presentation_to_renderer_field_proved") is not True
@@ -424,6 +437,7 @@ def validate_static_owner(document):
         or claims.get("renderer_bind_and_draw_dispatch_proved") is not True
         or claims.get("presentation_to_renderer_resource_identity_proved")
         is not True
+        or claims.get("presentation_transform_to_renderer_proved") is not True
         or claims.get("concrete_building_or_prop_identity_proved") is not False
         or claims.get("mesh_or_material_semantics_proved") is not False
     ):
@@ -679,6 +693,11 @@ def build(
         "presentation_resource_join": (
             "presentation_plus_148_equals_renderer_plus_72"
         ),
+        "presentation_transform_field": "presentation_plus_80_16_be_u32",
+        "presentation_transform_dispatch": (
+            "renderer_slot_6_82C4C568_to_renderer_plus_128"
+        ),
+        "transform_export": "hash_and_16_numeric_words_only",
         "asset_key_field": "presentation_plus_16_msvc_string",
         "asset_key_export": "fnv1a64_hash_and_length_only",
         "effect_reference_fields": "resource_plus_124_pointer_plus_128_u16",
@@ -848,6 +867,13 @@ def build(
         "asset_metadata_read_faults",
         "asset_metadata_joins",
         "asset_metadata_missing_joins",
+        "transform_observations",
+        "transform_exact",
+        "transform_read_faults",
+        "transform_joins",
+        "transform_missing_joins",
+        "transform_packet_origins",
+        "transform_missing_packet_origins",
     )
     totals = {key: integer(summary, key) for key in keys}
     frame_sequence = integer(summary, "frame_sequence")
@@ -1051,6 +1077,21 @@ def build(
         + totals["asset_metadata_missing_joins"]
     ):
         failures.append("static-world asset metadata join drifted")
+    if totals["transform_observations"] != totals["presentation_exact"]:
+        failures.append("static-world transform observation drifted")
+    if totals["transform_observations"] != (
+        totals["transform_exact"] + totals["transform_read_faults"]
+    ):
+        failures.append("static-world transform classification drifted")
+    if totals["presentation_renderer_joins"] != (
+        totals["transform_joins"] + totals["transform_missing_joins"]
+    ):
+        failures.append("static-world transform renderer join drifted")
+    if totals["member_packets_recorded"] != (
+        totals["transform_packet_origins"]
+        + totals["transform_missing_packet_origins"]
+    ):
+        failures.append("static-world transform packet join drifted")
     if not totals["presentation_exact"]:
         failures.append("no exact CModelPresentation scope was observed")
     if not totals["presentation_renderer_joins"]:
@@ -1059,6 +1100,12 @@ def build(
         failures.append("no bounded static-world asset metadata was observed")
     if not totals["asset_metadata_joins"]:
         failures.append("no asset-key hash joined a SimpleModel renderer")
+    if not totals["transform_exact"]:
+        failures.append("no exact static-world instance transform was observed")
+    if not totals["transform_joins"]:
+        failures.append("no instance transform joined a SimpleModel renderer")
+    if not totals["transform_packet_origins"]:
+        failures.append("no instance transform joined a prepared-draw origin")
     if not totals["mesh_semantic_exact"]:
         failures.append("no bounded static-world mesh semantics were observed")
     if not totals["mesh_semantic_packet_origins"]:
@@ -1124,6 +1171,9 @@ def build(
         "presentation_resource_mismatches",
         "asset_metadata_read_faults",
         "asset_metadata_missing_joins",
+        "transform_read_faults",
+        "transform_missing_joins",
+        "transform_missing_packet_origins",
     ):
         if totals[key]:
             failures.append(f"{key} is nonzero")
@@ -1167,6 +1217,7 @@ def build(
             "model_presentation_owner_proved": not failures,
             "model_presentation_to_renderer_proved": not failures,
             "model_presentation_to_renderer_resource_proved": not failures,
+            "model_presentation_transform_to_prepared_draw_proved": not failures,
             "bounded_asset_reference_metadata_proved": not failures,
             "hashed_asset_identity_to_prepared_draw_proved": not failures,
             "bounded_mesh_draw_semantics_proved": not failures,

--- a/tools/tests/test_native_renderer_static_world_instance_catalog.py
+++ b/tools/tests/test_native_renderer_static_world_instance_catalog.py
@@ -1,0 +1,81 @@
+import importlib.util
+import pathlib
+import tempfile
+import unittest
+
+
+SCRIPT = (
+    pathlib.Path(__file__).resolve().parents[1]
+    / "build-native-renderer-static-world-instance-catalog.py"
+)
+SPEC = importlib.util.spec_from_file_location("static_world_instance_catalog", SCRIPT)
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+COLLISION = """<?xml version="1.0"?>
+<CollObjs>
+  <Obj0 PhysicsType="CO_Prop.rmb" GraphicsName="#17">
+    <Pos x="1.25" y="2.5" z="-3.75"/>
+    <Orientation>
+      <XAxis x="1" y="0" z="0"/>
+      <YAxis x="0" y="1" z="0"/>
+      <ZAxis x="0" y="0" z="1"/>
+    </Orientation>
+  </Obj0>
+</CollObjs>
+"""
+
+GAMEPLAY = """<?xml version="1.0"?>
+<GameObjs>
+  <Obj0 GameplayID="GAMEPLAY_MARKER">
+    <Pos x="10" y="20" z="30"/>
+    <Orientation>
+      <XAxis x="0" y="0" z="1"/>
+      <YAxis x="0" y="1" z="0"/>
+      <ZAxis x="-1" y="0" z="0"/>
+    </Orientation>
+  </Obj0>
+</GameObjs>
+"""
+
+
+class StaticWorldInstanceCatalogTests(unittest.TestCase):
+    def build(self, collision=COLLISION, gameplay=GAMEPLAY):
+        with tempfile.TemporaryDirectory() as directory:
+            root = pathlib.Path(directory)
+            collision_path = root / "CollObjs.xml"
+            gameplay_path = root / "GameObjs.xml"
+            collision_path.write_text(collision, encoding="utf-8")
+            gameplay_path.write_text(gameplay, encoding="utf-8")
+            return MODULE.build(collision_path, gameplay_path)
+
+    def test_catalogs_hashed_spatial_metadata(self):
+        document = self.build()
+        self.assertEqual(MODULE.SCHEMA, document["schema"])
+        self.assertEqual(2, document["instance_count"])
+        self.assertEqual(
+            ["collision_prop", "gameplay_object"],
+            [item["category"] for item in document["instances"]],
+        )
+        self.assertEqual(
+            [1.25, 2.5, -3.75], document["instances"][0]["position"]
+        )
+        self.assertEqual(16, len(document["instances"][0]["identity_hash"]))
+        self.assertFalse(
+            document["qualification"]["runtime_transform_join_proved"]
+        )
+        self.assertNotIn("CO_Prop", str(document))
+        self.assertNotIn("GAMEPLAY_MARKER", str(document))
+
+    def test_rejects_non_finite_spatial_data(self):
+        with self.assertRaisesRegex(ValueError, "non-finite position"):
+            self.build(COLLISION.replace('x="1.25"', 'x="nan"'))
+
+    def test_rejects_wrong_root(self):
+        with self.assertRaisesRegex(ValueError, "expected CollObjs root"):
+            self.build(COLLISION.replace("CollObjs", "WrongRoot"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/tests/test_native_renderer_static_world_owner.py
+++ b/tools/tests/test_native_renderer_static_world_owner.py
@@ -26,6 +26,7 @@ def fixture():
     presentation_slots[12] = MODULE.PRESENTATION_DRAW
     renderer_slots = [0x82900000 + index * 4 for index in range(17)]
     renderer_slots[0] = 0x82C4C838
+    renderer_slots[6] = MODULE.RENDERER_TRANSFORM
     renderer_slots[12] = 0x82C4CCC8
     for base, slots in (
         (MODULE.PRESENTATION_VTABLE, presentation_slots),
@@ -90,10 +91,36 @@ def fixture():
             0x823F8DC4: "mr r31,r3",
             0x823F8DDC: "bl 0x823f8980",
             0x823F8E20: "lwz r11,1608(r31)",
+            0x823F8E30: "ld r11,136(r31)",
+            0x823F8E34: "ld r4,80(r31)",
+            0x823F8E38: "ld r5,88(r31)",
+            0x823F8E3C: "ld r6,96(r31)",
+            0x823F8E40: "ld r7,104(r31)",
+            0x823F8E44: "lwz r29,0(r3)",
+            0x823F8E48: "ld r8,112(r31)",
+            0x823F8E4C: "ld r9,120(r31)",
+            0x823F8E50: "ld r10,128(r31)",
+            0x823F8E58: "lwz r29,24(r29)",
+            0x823F8E5C: "mtctr r29",
+            0x823F8E60: "bctrl",
             0x823F8F0C: "lwz r3,1608(r31)",
             0x823F8F18: "lwz r11,48(r11)",
             0x823F8F20: "bctrl",
             MODULE.PRESENTATION_DRAW_EXIT: "addi r1,r1,160",
+        },
+        MODULE.RENDERER_TRANSFORM: {
+            0x82C4C568: "std r4,32(r1)",
+            0x82C4C56C: "addi r11,r3,128",
+            0x82C4C570: "std r6,48(r1)",
+            0x82C4C578: "std r8,64(r1)",
+            0x82C4C580: "std r9,72(r1)",
+            0x82C4C588: "std r10,80(r1)",
+            0x82C4C590: "std r7,56(r1)",
+            0x82C4C598: "std r5,40(r1)",
+            0x82C4C5B4: "stvx128 v61,r11,r10",
+            0x82C4C5B8: "stvx128 v63,r0,r11",
+            0x82C4C5BC: "stvx128 v62,r11,r6",
+            0x82C4C5C0: "stvx128 v60,r11,r9",
         },
     }
     return functions, bytes(image)
@@ -121,6 +148,11 @@ class StaticWorldOwnerTests(unittest.TestCase):
                 "presentation_to_renderer_resource_identity_proved"
             ]
         )
+        self.assertTrue(
+            document["claims"][
+                "presentation_transform_to_renderer_proved"
+            ]
+        )
         self.assertFalse(
             document["claims"]["concrete_building_or_prop_identity_proved"]
         )
@@ -142,6 +174,18 @@ class StaticWorldOwnerTests(unittest.TestCase):
         )
         with self.assertRaisesRegex(ValueError, "823F8A18"):
             MODULE.build(corrupted, image)
+
+    def test_rejects_renderer_transform_slot_drift(self):
+        functions, image = fixture()
+        corrupted = bytearray(image)
+        offset = (
+            MODULE.RENDERER_VTABLE
+            + MODULE.RENDERER_TRANSFORM_SLOT * 4
+            - MODULE.IMAGE_BASE
+        )
+        corrupted[offset : offset + 4] = (0x82C4C56C).to_bytes(4, "big")
+        with self.assertRaisesRegex(ValueError, "transform slot drifted"):
+            MODULE.build(functions, bytes(corrupted))
 
     def test_rejects_unbalanced_exit_drift(self):
         functions, image = fixture()

--- a/tools/tests/test_native_renderer_static_world_runtime_join.py
+++ b/tools/tests/test_native_renderer_static_world_runtime_join.py
@@ -261,12 +261,23 @@ def static_owner():
                 "presentation_plus_148_equals_renderer_plus_72"
             ),
         },
+        "transform_join": {
+            "presentation_transform_offset": 80,
+            "transform_size_bytes": 64,
+            "renderer_transform_slot": 6,
+            "renderer_transform_target": "82C4C568",
+            "renderer_transform_offset": 128,
+            "address_equation": (
+                "presentation_plus_80_64_bytes_copied_to_renderer_plus_128"
+            ),
+        },
         "claims": {
             "exact_model_presentation_owner_proved": True,
             "presentation_to_renderer_field_proved": True,
             "presentation_to_resource_reference_proved": True,
             "renderer_bind_and_draw_dispatch_proved": True,
             "presentation_to_renderer_resource_identity_proved": True,
+            "presentation_transform_to_renderer_proved": True,
             "concrete_building_or_prop_identity_proved": False,
             "mesh_or_material_semantics_proved": False,
         },
@@ -453,6 +464,13 @@ def fixture():
             "presentation_resource_join": (
                 "presentation_plus_148_equals_renderer_plus_72"
             ),
+            "presentation_transform_field": (
+                "presentation_plus_80_16_be_u32"
+            ),
+            "presentation_transform_dispatch": (
+                "renderer_slot_6_82C4C568_to_renderer_plus_128"
+            ),
+            "transform_export": "hash_and_16_numeric_words_only",
             "asset_key_field": "presentation_plus_16_msvc_string",
             "asset_key_export": "fnv1a64_hash_and_length_only",
             "effect_reference_fields": (
@@ -608,6 +626,13 @@ def fixture():
         asset_metadata_read_faults="0",
         asset_metadata_joins="8",
         asset_metadata_missing_joins="0",
+        transform_observations="12",
+        transform_exact="12",
+        transform_read_faults="0",
+        transform_joins="8",
+        transform_missing_joins="0",
+        transform_packet_origins="100",
+        transform_missing_packet_origins="0",
         accounting_complete="true",
         qualification_complete="true",
         classification=(
@@ -667,6 +692,11 @@ class StaticWorldRuntimeJoinTests(unittest.TestCase):
                 "model_presentation_to_renderer_resource_proved"
             ]
         )
+        self.assertTrue(
+            document["qualification"][
+                "model_presentation_transform_to_prepared_draw_proved"
+            ]
+        )
         self.assertFalse(
             document["qualification"]["building_or_prop_instance_identity_proved"]
         )
@@ -717,6 +747,53 @@ class StaticWorldRuntimeJoinTests(unittest.TestCase):
         )
         self.assertEqual("incomplete", document["status"])
         self.assertIn("unprepared_matches is nonzero", document["failures"])
+
+    def test_rejects_transform_read_fault(self):
+        events = copy.deepcopy(fixture())
+        events[-1].update(
+            status="incomplete",
+            transform_exact="11",
+            transform_read_faults="1",
+            qualification_complete="false",
+        )
+        document = MODULE.build(
+            static_ingress(),
+            static_lifetime(),
+            static_resource(),
+            static_streaming(),
+            static_graph(),
+            static_owner(),
+            static_asset_metadata(),
+            static_mesh_semantics(),
+            events,
+        )
+        self.assertEqual("incomplete", document["status"])
+        self.assertIn("transform_read_faults is nonzero", document["failures"])
+
+    def test_rejects_missing_transform_packet_origin(self):
+        events = copy.deepcopy(fixture())
+        events[-1].update(
+            status="incomplete",
+            transform_packet_origins="99",
+            transform_missing_packet_origins="1",
+            qualification_complete="false",
+        )
+        document = MODULE.build(
+            static_ingress(),
+            static_lifetime(),
+            static_resource(),
+            static_streaming(),
+            static_graph(),
+            static_owner(),
+            static_asset_metadata(),
+            static_mesh_semantics(),
+            events,
+        )
+        self.assertEqual("incomplete", document["status"])
+        self.assertIn(
+            "transform_missing_packet_origins is nonzero",
+            document["failures"],
+        )
 
     def test_rejects_scope_accounting_fault(self):
         events = copy.deepcopy(fixture())
@@ -1086,7 +1163,7 @@ class StaticWorldRuntimeJoinTests(unittest.TestCase):
                 static_streaming(),
                 static_graph(),
                 static_owner(),
-                    static_asset_metadata(),
+                static_asset_metadata(),
                 semantics,
                 fixture(),
             )
@@ -1125,6 +1202,10 @@ class StaticWorldRuntimeJoinTests(unittest.TestCase):
         self.assertIn("address = 0x823F8DB8", analysis)
         self.assertIn("address = 0x823F8FA0", analysis)
         self.assertIn("kModelPresentationNameOffset = 16", hooks)
+        self.assertIn("kModelPresentationTransformOffset = 80", hooks)
+        self.assertIn("ReadStaticWorldPresentationTransform", hooks)
+        self.assertIn("static_world_transform_words", hooks)
+        self.assertIn("transform_missing_packet_origins", hooks)
         self.assertIn("ReadStaticWorldAssetMetadata", hooks)
         self.assertIn("static_world_asset_key_hash", hooks)
         self.assertIn("kSimpleMeshPrimitiveTypeOffset = 36", hooks)


### PR DESCRIPTION
## Summary
- prove and carry the exact model-presentation transform into prepared-draw provenance
- build a payload-free catalog of 21,877 collision props and 2,148 gameplay objects
- keep runtime category qualification, native admission, and suppression fail-closed

## Validation
- 575 Python tests passed
- 30 focused static-world tests passed
- retail owner v2 report passed
- real 24,025-entry catalog report passed
- C++ target compiled; final link is expectedly blocked by the active AppData process (PID 35288)