### PR TITLE
feat(native-renderer): join static world categories

### DIFF
--- a/docs/native-renderer/REPRIORITIZED_PLAN.md
+++ b/docs/native-renderer/REPRIORITIZED_PLAN.md
@@ -431,6 +431,14 @@ The next combined C1/C2 AppData run must prove the matrix convention and a
 unique runtime-to-catalog match; no building/prop category, native admission,
 or suppression is claimed yet.
 
+Category-join implementation checkpoint: the offline qualifier now tests both
+plausible 4x4 translation layouts against the hashed spatial catalog. It
+requires a unique convention, at least eight distinct exact matches including
+a collision prop, zero ambiguous/unmatched/non-finite transforms, a clean
+process lifecycle, and a complete static-world runtime summary. The qualifier
+is ready for the deferred combined AppData run; it cannot self-qualify from
+static fixtures and still enables no native admission or suppression.
+
 ### C3. Semantic batching, culling, and LOD
 
 - Promote the existing visibility and prepared-draw evidence into production

--- a/docs/native-renderer/STATIC_WORLD_INSTANCE_CLASSIFICATION.md
+++ b/docs/native-renderer/STATIC_WORLD_INSTANCE_CLASSIFICATION.md
@@ -44,13 +44,28 @@ Retail instructions prove that `CModelPresentation` stores its complete
 observer now carries those 16 numeric words and their hash through the
 renderer, physical PM4 packet, and prepared-draw provenance.
 
-The next batched AppData run must determine the title's matrix convention from
-observed values and prove a unique, tolerance-bounded spatial match against the
-catalog. Ambiguous, absent, or out-of-bounds matches must remain unclassified.
-Only then can a prepared draw claim a collision-prop or gameplay-object class.
-Asset-key hashes may strengthen that join, but spatial proximity alone is not
-accepted when multiple catalog entries remain possible.
+`tools/summarize-native-renderer-static-world-instance-classification.py`
+implements the next fail-closed gate. It evaluates the two plausible 4x4
+translation layouts independently, uses a 0.05-world-unit spatial bound, and
+requires at least eight distinct prepared-draw transforms. Every observed
+transform must match exactly one catalog entry, exactly one matrix convention
+must pass, and at least one collision prop must be present. Ambiguous, absent,
+non-finite, or unsafe observations reject the whole report. The input session
+must also have a unique clean process lifecycle and a complete static-world
+runtime summary.
 
-Until that gate passes, `building_or_prop_instance_identity_proved` remains
-false. Xenos stays authoritative; native admission, publication, and
-suppression remain disabled.
+```powershell
+python tools/summarize-native-renderer-static-world-instance-classification.py `
+  <session.jsonl> `
+  --catalog .local/qualification/native-renderer-static-world-instance-catalog.json `
+  --output .local/qualification/native-renderer-static-world-instance-classification.json
+```
+
+This matcher is implemented but cannot qualify until a build containing the
+new transform observer completes the deferred AppData run. Asset-key hashes
+may later strengthen the join, but spatial proximity is never accepted when
+multiple catalog entries remain possible.
+
+Until that run passes, `building_or_prop_instance_identity_proved` remains
+false. Even a successful category report does not independently enable native
+admission, publication, or suppression; Xenos stays authoritative.

--- a/tools/summarize-native-renderer-static-world-instance-classification.py
+++ b/tools/summarize-native-renderer-static-world-instance-classification.py
@@ -1,0 +1,361 @@
+"""Join exact runtime static-world transforms to title-authored categories."""
+
+from __future__ import annotations
+
+import argparse
+import collections
+import itertools
+import json
+import math
+import pathlib
+import struct
+import sys
+
+
+SCHEMA = "pinyon-shift.native-renderer-static-world-instance-classification.v1"
+CATALOG_SCHEMA = "pinyon-shift.native-renderer-static-world-instance-catalog.v1"
+CONFIG = "native_renderer.discovery.static_world_runtime_join_config"
+SUMMARY = "native_renderer.discovery.static_world_runtime_join_summary"
+PROVENANCE = "native_renderer.discovery.title_provenance_entry"
+DEFAULT_TOLERANCE = 0.05
+DEFAULT_MINIMUM_MATCHES = 8
+CONVENTIONS = {
+    "translation_words_12_13_14": (12, 13, 14),
+    "translation_words_3_7_11": (3, 7, 11),
+}
+
+
+def read_events(paths):
+    events = []
+    for path in paths:
+        with path.open(encoding="utf-8") as stream:
+            for line_number, line in enumerate(stream, 1):
+                try:
+                    event = json.loads(line)
+                except json.JSONDecodeError as error:
+                    raise ValueError(
+                        f"invalid JSON at {path}:{line_number}: {error}"
+                    ) from error
+                if isinstance(event, dict):
+                    events.append(event)
+    return events
+
+
+def boolean(event, key):
+    value = event.get(key)
+    if value not in ("true", "false"):
+        raise ValueError(f"invalid {key} in {event.get('event', 'event')}")
+    return value == "true"
+
+
+def integer(event, key):
+    try:
+        value = int(event[key])
+    except (KeyError, TypeError, ValueError) as error:
+        raise ValueError(f"invalid {key} in {event.get('event', 'event')}") from error
+    if value < 0:
+        raise ValueError(f"negative {key} in {event.get('event', 'event')}")
+    return value
+
+
+def hexadecimal(value, width, label):
+    value = str(value).upper()
+    if len(value) != width or any(
+        character not in "0123456789ABCDEF" for character in value
+    ):
+        raise ValueError(f"invalid {label}")
+    return value
+
+
+def parse_transform(event):
+    words = str(event.get("static_world_transform_words", "")).split(":")
+    if len(words) != 16:
+        raise ValueError("runtime transform does not contain 16 words")
+    values = tuple(int(hexadecimal(word, 8, "transform word"), 16) for word in words)
+    transform_hash = hexadecimal(
+        event.get("static_world_transform_hash", ""), 16, "transform hash"
+    )
+    return transform_hash, values
+
+
+def float_word(word):
+    value = struct.unpack(">f", word.to_bytes(4, "big"))[0]
+    return value if math.isfinite(value) else None
+
+
+def translation(words, indices):
+    values = tuple(float_word(words[index]) for index in indices)
+    return None if any(value is None for value in values) else values
+
+
+def validate_catalog(document):
+    if document.get("schema") != CATALOG_SCHEMA or document.get("status") != "complete":
+        raise ValueError("static-world instance catalog is unsupported")
+    safety = document.get("safety", {})
+    if (
+        safety.get("source_files_changed") is not False
+        or safety.get("plaintext_identity_exported") is not False
+        or safety.get("numeric_spatial_metadata_only") is not True
+        or safety.get("native_admission") is not False
+        or safety.get("suppression_allowed") is not False
+    ):
+        raise ValueError("static-world instance catalog safety drifted")
+    instances = document.get("instances")
+    if not isinstance(instances, list) or len(instances) != document.get(
+        "instance_count"
+    ):
+        raise ValueError("static-world instance catalog count drifted")
+    validated = []
+    for index, instance in enumerate(instances):
+        category = instance.get("category")
+        if category not in ("collision_prop", "gameplay_object"):
+            raise ValueError("static-world instance category is invalid")
+        identity_hash = hexadecimal(
+            instance.get("identity_hash", ""), 16, "catalog identity hash"
+        )
+        position = instance.get("position")
+        if (
+            not isinstance(position, list)
+            or len(position) != 3
+            or not all(
+                isinstance(value, (int, float)) and math.isfinite(value)
+                for value in position
+            )
+        ):
+            raise ValueError("static-world catalog position is invalid")
+        validated.append(
+            {
+                "catalog_index": index,
+                "category": category,
+                "identity_hash": identity_hash,
+                "position": tuple(float(value) for value in position),
+            }
+        )
+    return validated
+
+
+def spatial_index(instances, tolerance):
+    result = collections.defaultdict(list)
+    for instance in instances:
+        key = tuple(math.floor(value / tolerance) for value in instance["position"])
+        result[key].append(instance)
+    return result
+
+
+def match_position(index, position, tolerance):
+    key = tuple(math.floor(value / tolerance) for value in position)
+    candidates = []
+    for offset in itertools.product((-1, 0, 1), repeat=3):
+        adjacent = tuple(key[axis] + offset[axis] for axis in range(3))
+        for instance in index.get(adjacent, ()):
+            distance = math.dist(position, instance["position"])
+            if distance <= tolerance:
+                candidates.append((distance, instance))
+    candidates.sort(key=lambda item: (item[0], item[1]["catalog_index"]))
+    if not candidates:
+        return "unmatched", None
+    if len(candidates) != 1:
+        return "ambiguous", None
+    return "matched", candidates[0]
+
+
+def select_session(events, requested_session):
+    sessions = {
+        str(event.get("session"))
+        for event in events
+        if event.get("event") == CONFIG and event.get("session")
+    }
+    if requested_session:
+        if requested_session not in sessions:
+            raise ValueError("requested static-world session is missing")
+        session = requested_session
+    elif len(sessions) == 1:
+        session = next(iter(sessions))
+    else:
+        raise ValueError("input must contain exactly one static-world session")
+    return session, [event for event in events if str(event.get("session")) == session]
+
+
+def build(
+    catalog,
+    events,
+    requested_session=None,
+    tolerance=DEFAULT_TOLERANCE,
+    minimum_matches=DEFAULT_MINIMUM_MATCHES,
+):
+    if not math.isfinite(tolerance) or tolerance <= 0 or tolerance > 1:
+        raise ValueError("match tolerance is outside the safe range")
+    if minimum_matches < 1:
+        raise ValueError("minimum matches must be positive")
+    instances = validate_catalog(catalog)
+    session, selected = select_session(events, requested_session)
+    configs = [event for event in selected if event.get("event") == CONFIG]
+    summaries = [event for event in selected if event.get("event") == SUMMARY]
+    starts = [event for event in selected if event.get("event") == "process.start"]
+    shutdowns = [
+        event for event in selected if event.get("event") == "process.shutdown"
+    ]
+    if len(configs) != 1 or len(summaries) != 1:
+        raise ValueError("static-world runtime lifecycle is incomplete")
+    if len(starts) != 1 or len(shutdowns) != 1:
+        raise ValueError("process lifecycle is incomplete")
+    if (
+        summaries[0].get("status") != "complete"
+        or summaries[0].get("qualification_complete") != "true"
+    ):
+        raise ValueError("static-world runtime qualification is incomplete")
+
+    transforms = {}
+    failures = []
+    for event in selected:
+        if event.get("event") != PROVENANCE or event.get("outcome") != "prepared":
+            continue
+        if event.get("static_world_origin") != "true":
+            continue
+        if event.get("static_world_transform_valid") != "true":
+            failures.append("prepared static-world origin lacks a valid transform")
+            continue
+        if (
+            event.get("xenos_draw") != "preserved"
+            or event.get("suppression_eligible") != "false"
+        ):
+            failures.append("runtime provenance violated Xenos authority")
+        transform_hash, words = parse_transform(event)
+        calls = integer(event, "calls")
+        previous = transforms.get(transform_hash)
+        if previous and previous["words"] != words:
+            failures.append("runtime transform hash collision was observed")
+            continue
+        if previous:
+            previous["calls"] += calls
+        else:
+            transforms[transform_hash] = {"words": words, "calls": calls}
+    if not transforms:
+        failures.append("no prepared static-world transforms were observed")
+
+    index = spatial_index(instances, tolerance)
+    convention_reports = {}
+    qualified_conventions = []
+    for name, indices in CONVENTIONS.items():
+        matches = []
+        unmatched = 0
+        ambiguous = 0
+        non_finite = 0
+        for transform_hash, observed in sorted(transforms.items()):
+            position = translation(observed["words"], indices)
+            if position is None:
+                non_finite += 1
+                continue
+            outcome, match = match_position(index, position, tolerance)
+            if outcome == "unmatched":
+                unmatched += 1
+                continue
+            if outcome == "ambiguous":
+                ambiguous += 1
+                continue
+            distance, instance = match
+            matches.append(
+                {
+                    "transform_hash": transform_hash,
+                    "calls": observed["calls"],
+                    "category": instance["category"],
+                    "catalog_identity_hash": instance["identity_hash"],
+                    "catalog_index": instance["catalog_index"],
+                    "distance": round(distance, 9),
+                }
+            )
+        complete = (
+            len(matches) >= minimum_matches
+            and len(matches) == len(transforms)
+            and not unmatched
+            and not ambiguous
+            and not non_finite
+        )
+        if complete:
+            qualified_conventions.append(name)
+        convention_reports[name] = {
+            "matched": len(matches),
+            "unmatched": unmatched,
+            "ambiguous": ambiguous,
+            "non_finite": non_finite,
+            "complete": complete,
+            "matches": matches,
+        }
+    if len(qualified_conventions) != 1:
+        failures.append("runtime matrix convention is not uniquely proved")
+    selected_convention = (
+        qualified_conventions[0] if len(qualified_conventions) == 1 else None
+    )
+    selected_report = (
+        convention_reports[selected_convention]
+        if selected_convention is not None
+        else None
+    )
+    category_counts = collections.Counter(
+        match["category"] for match in (selected_report or {}).get("matches", [])
+    )
+    if selected_report is not None and not category_counts["collision_prop"]:
+        failures.append("no collision-prop runtime transform was classified")
+    return {
+        "schema": SCHEMA,
+        "session": session,
+        "status": "complete" if not failures else "incomplete",
+        "failures": failures,
+        "catalog_instance_count": len(instances),
+        "unique_runtime_transforms": len(transforms),
+        "minimum_matches": minimum_matches,
+        "position_tolerance": tolerance,
+        "selected_matrix_convention": selected_convention,
+        "category_counts": dict(sorted(category_counts.items())),
+        "conventions": convention_reports,
+        "qualification": {
+            "runtime_transform_join_proved": not failures,
+            "building_or_prop_instance_identity_proved": not failures,
+            "native_admission": False,
+            "suppression_allowed": False,
+        },
+        "safety": {
+            "guest_state_changed": False,
+            "source_files_changed": False,
+            "plaintext_identity_exported": False,
+            "xenos_draw": "preserved",
+            "native_admission": False,
+            "native_draw": False,
+            "suppression_allowed": False,
+        },
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("logs", nargs="+", type=pathlib.Path)
+    parser.add_argument("--catalog", required=True, type=pathlib.Path)
+    parser.add_argument("--output", required=True, type=pathlib.Path)
+    parser.add_argument("--session")
+    parser.add_argument("--tolerance", type=float, default=DEFAULT_TOLERANCE)
+    parser.add_argument(
+        "--minimum-matches", type=int, default=DEFAULT_MINIMUM_MATCHES
+    )
+    arguments = parser.parse_args()
+    try:
+        catalog = json.loads(arguments.catalog.read_text(encoding="utf-8"))
+        document = build(
+            catalog,
+            read_events(arguments.logs),
+            requested_session=arguments.session,
+            tolerance=arguments.tolerance,
+            minimum_matches=arguments.minimum_matches,
+        )
+        arguments.output.parent.mkdir(parents=True, exist_ok=True)
+        arguments.output.write_text(
+            json.dumps(document, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+    except (json.JSONDecodeError, OSError, ValueError) as error:
+        print(error, file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/tests/test_native_renderer_static_world_instance_classification.py
+++ b/tools/tests/test_native_renderer_static_world_instance_classification.py
@@ -1,0 +1,158 @@
+import copy
+import importlib.util
+import pathlib
+import struct
+import sys
+import unittest
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+TOOL = (
+    ROOT
+    / "tools"
+    / "summarize-native-renderer-static-world-instance-classification.py"
+)
+SPEC = importlib.util.spec_from_file_location(
+    "static_world_instance_classification", TOOL
+)
+MODULE = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = MODULE
+SPEC.loader.exec_module(MODULE)
+
+
+def word(value):
+    return f"{int.from_bytes(struct.pack('>f', value), 'big'):08X}"
+
+
+def catalog(duplicate=False):
+    instances = []
+    for index in range(8):
+        instances.append(
+            {
+                "category": "collision_prop" if index < 6 else "gameplay_object",
+                "source_ordinal": index,
+                "identity_hash": f"{index + 1:016X}",
+                "identity_field_hashes": {},
+                "position": [float(index * 10 + 1), float(index + 2), float(-index)],
+                "orientation": [[1, 0, 0], [0, 1, 0], [0, 0, 1]],
+            }
+        )
+    if duplicate:
+        extra = copy.deepcopy(instances[0])
+        extra["identity_hash"] = "00000000000000FF"
+        instances.append(extra)
+    return {
+        "schema": MODULE.CATALOG_SCHEMA,
+        "status": "complete",
+        "sources": [],
+        "instance_count": len(instances),
+        "instances": instances,
+        "safety": {
+            "source_files_changed": False,
+            "plaintext_identity_exported": False,
+            "numeric_spatial_metadata_only": True,
+            "native_admission": False,
+            "suppression_allowed": False,
+        },
+    }
+
+
+def events():
+    session = "session-1"
+    result = [
+        {"event": "process.start", "session": session},
+        {"event": MODULE.CONFIG, "session": session},
+    ]
+    for index in range(8):
+        words = [word(0.0)] * 16
+        words[0] = words[5] = words[10] = words[15] = word(1.0)
+        words[12] = word(float(index * 10 + 1))
+        words[13] = word(float(index + 2))
+        words[14] = word(float(-index))
+        result.append(
+            {
+                "event": MODULE.PROVENANCE,
+                "session": session,
+                "outcome": "prepared",
+                "static_world_origin": "true",
+                "static_world_transform_valid": "true",
+                "static_world_transform_hash": f"{index + 100:016X}",
+                "static_world_transform_words": ":".join(words),
+                "calls": str(index + 1),
+                "xenos_draw": "preserved",
+                "suppression_eligible": "false",
+            }
+        )
+    result.extend(
+        [
+            {
+                "event": MODULE.SUMMARY,
+                "session": session,
+                "status": "complete",
+                "qualification_complete": "true",
+            },
+            {"event": "process.shutdown", "session": session},
+        ]
+    )
+    return result
+
+
+class StaticWorldInstanceClassificationTests(unittest.TestCase):
+    def test_proves_unique_row_translation_join(self):
+        document = MODULE.build(catalog(), events())
+        self.assertEqual("complete", document["status"])
+        self.assertEqual(
+            "translation_words_12_13_14",
+            document["selected_matrix_convention"],
+        )
+        self.assertEqual(
+            {"collision_prop": 6, "gameplay_object": 2},
+            document["category_counts"],
+        )
+        self.assertTrue(
+            document["qualification"][
+                "building_or_prop_instance_identity_proved"
+            ]
+        )
+        self.assertFalse(document["qualification"]["native_admission"])
+
+    def test_rejects_ambiguous_spatial_match(self):
+        document = MODULE.build(catalog(duplicate=True), events())
+        self.assertEqual("incomplete", document["status"])
+        self.assertEqual(
+            1,
+            document["conventions"]["translation_words_12_13_14"]["ambiguous"],
+        )
+        self.assertFalse(
+            document["qualification"]["runtime_transform_join_proved"]
+        )
+
+    def test_rejects_incomplete_runtime_summary(self):
+        observed = events()
+        observed[-2]["status"] = "incomplete"
+        with self.assertRaisesRegex(ValueError, "qualification is incomplete"):
+            MODULE.build(catalog(), observed)
+
+    def test_rejects_gameplay_only_classification(self):
+        gameplay_catalog = catalog()
+        for instance in gameplay_catalog["instances"]:
+            instance["category"] = "gameplay_object"
+        document = MODULE.build(gameplay_catalog, events())
+        self.assertEqual("incomplete", document["status"])
+        self.assertIn(
+            "no collision-prop runtime transform was classified",
+            document["failures"],
+        )
+
+    def test_rejects_unsafe_runtime_provenance(self):
+        observed = events()
+        observed[2]["suppression_eligible"] = "true"
+        document = MODULE.build(catalog(), observed)
+        self.assertEqual("incomplete", document["status"])
+        self.assertIn(
+            "runtime provenance violated Xenos authority", document["failures"]
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- match exact prepared-draw transforms against the title-authored spatial catalog
- prove one matrix convention with bounded, unique collision/gameplay matches
- reject incomplete, ambiguous, unsafe, or gameplay-only sessions

## Validation
- 8 focused Python tests passed
- Python compilation passed

This is observation-only and remains pending the deferred new-build AppData run.