### PR TITLE
feat(native-renderer): replay exact static world draws

### DIFF
--- a/docs/native-renderer/CONTINUOUS_WORLD_WORKSET.md
+++ b/docs/native-renderer/CONTINUOUS_WORLD_WORKSET.md
@@ -16,8 +16,11 @@ census and semantic dispatch discovery so every admitted draw has:
 
 - a mechanically replayable prepared-draw contract;
 - either a current, selected semantic visibility decision carrying the exact
-  unified track-texture provider vtable and four-method tuple, or the exact
-  previously qualified sky/horizon follower signature; and
+  unified track-texture provider vtable and four-method tuple, the exact
+  previously qualified sky/horizon follower signature, or, only when the
+  additional `-ContinuousStaticWorld` capture switch is set, exact
+  `CModelPresentation` resource, asset-key, transform, member-mesh, and
+  prepared-layout lineage; and
 - exact title-to-backend lineage.
 
 The exact retained family supplies a current-frame seed in supported gameplay
@@ -61,12 +64,26 @@ authority with suppression disabled.
 It reports the exact-family seed count separately as
 `qualified_retained_family_requests`, and reports fresh visibility candidates
 excluded by the track-provider gate as `non_track_provider_rejections`.
+Static-world requests and incomplete-lineage rejections are reported
+independently. The v4 qualifier requires at least one exact static-world
+request and zero static-world lineage rejection when that optional selection
+is armed.
 Build a payload-free qualification report with:
 
 ```powershell
 python .\tools\summarize-native-renderer-continuous-world-workset.py `
   .local\preview\logs\events.jsonl `
   --output .local\qualification\continuous-world-workset.json
+```
+
+Arm the still-default-off static-world extension for the deferred C1/C2 run:
+
+```powershell
+.\tools\capture-native-renderer-census.ps1 `
+  -StateRoot $stateRoot `
+  -Scene open_world_day `
+  -ContinuousWorldWorkset `
+  -ContinuousStaticWorld
 ```
 
 Qualification requires at least one exact track-provider visibility request,
@@ -85,6 +102,10 @@ failures, exact accounting, preserved Xenos draws, and disabled suppression.
 - Track-texture ownership is a precision filter for the existing prototype
   workset. It is not a terrain/road mesh ownership claim and does not satisfy
   the C1 semantic-family admission gate by itself.
+- The optional static-world extension accepts only exact lineage already
+  carried into a mechanically replayable prepared draw. It does not embed the
+  local category catalog, infer a content class, suppress Xenos, or enable
+  itself for the normal prototype selector.
 - This checkpoint does not yet prove recognizable world coverage; that requires
   a clean build, an AppData run, and visual inspection after the broader Phase B
   implementation batch is ready.

--- a/docs/native-renderer/REPRIORITIZED_PLAN.md
+++ b/docs/native-renderer/REPRIORITIZED_PLAN.md
@@ -439,6 +439,15 @@ process lifecycle, and a complete static-world runtime summary. The qualifier
 is ready for the deferred combined AppData run; it cannot self-qualify from
 static fixtures and still enables no native admission or suppression.
 
+Native-output implementation checkpoint: the existing one-frame,
+swap-committed continuous world target now has an independent default-off
+static-world selection. It admits only mechanically replayable draws carrying
+the exact presentation/resource, hashed asset, transform, member-mesh, and
+bounded prepared-layout lineage, with separate request and rejection
+accounting. It neither embeds the local catalog nor changes the normal
+prototype selector, Xenos execution, publication authority, or suppression.
+Runtime and visual proof is batched with the pending C1/C2 AppData run.
+
 ### C3. Semantic batching, culling, and LOD
 
 - Promote the existing visibility and prepared-draw evidence into production

--- a/docs/native-renderer/STATIC_WORLD_INSTANCE_CLASSIFICATION.md
+++ b/docs/native-renderer/STATIC_WORLD_INSTANCE_CLASSIFICATION.md
@@ -69,3 +69,17 @@ multiple catalog entries remain possible.
 Until that run passes, `building_or_prop_instance_identity_proved` remains
 false. Even a successful category report does not independently enable native
 admission, publication, or suppression; Xenos stays authoritative.
+
+## Default-off native-output probe
+
+The continuous private world workset can now optionally accept an exact
+static-world prepared draw when presentation, resource, hashed asset key,
+transform, model/submodel/mesh, and bounded prepared-layout lineage are all
+present. It uses the existing one-frame, 64-draw, swap-committed retained
+target and preserves the complete Xenos path. Missing lineage is separately
+accounted and rejected.
+
+This probe is armed only by combining `-ContinuousWorldWorkset` and
+`-ContinuousStaticWorld`; it is not enabled by the normal prototype selector.
+Its runtime and visual qualification is intentionally batched with the new
+transform/category capture.

--- a/src/native_renderer/graphics_hooks.cpp
+++ b/src/native_renderer/graphics_hooks.cpp
@@ -8103,6 +8103,8 @@ struct IsolatedDrawState {
   bool prepared_visibility_candidate_fresh = false;
   bool prepared_title_lod_valid = false;
   bool prepared_track_texture_provider = false;
+  bool prepared_static_world_origin = false;
+  bool prepared_static_world_exact = false;
   bool require_fresh_visibility_candidate = false;
   bool require_title_lod_candidate = false;
   bool auto_select_fresh_visibility_candidate = false;
@@ -8201,6 +8203,8 @@ struct ContinuousWorldWorksetState {
   uint64_t mechanical_rejections = 0;
   uint64_t stale_or_unselected_rejections = 0;
   uint64_t non_track_provider_rejections = 0;
+  uint64_t static_world_lineage_rejections = 0;
+  uint64_t static_world_requests = 0;
   uint64_t per_frame_quota_yields = 0;
   uint64_t fail_closed_yields = 0;
   uint64_t qualified_retained_family_requests = 0;
@@ -8213,6 +8217,7 @@ struct ContinuousWorldWorksetState {
   uint64_t current_frame_recorded = 0;
   bool current_frame_failed = false;
   bool requested = false;
+  bool static_world_requested = false;
   bool valid = true;
 };
 
@@ -8880,15 +8885,34 @@ void ConfigureContinuousWorldWorkset() {
     std::free(value);
     g_continuous_world_workset.requested = prototype_selected;
     g_continuous_world_workset.valid = true;
-    return;
+  } else {
+    const std::string setting(value);
+    std::free(value);
+    if (setting != "false") {
+      g_continuous_world_workset.requested = true;
+      g_continuous_world_workset.valid = setting == "true";
+    }
   }
-  const std::string setting(value);
+
+  value = nullptr;
+  length = 0;
+  if (_dupenv_s(
+          &value, &length,
+          "PINYON_SHIFT_NATIVE_RENDERER_CONTINUOUS_STATIC_WORLD") == 0 &&
+      value && length > 1) {
+    const std::string setting(value);
+    if (setting != "false") {
+      g_continuous_world_workset.static_world_requested = true;
+      if (setting != "true") {
+        g_continuous_world_workset.valid = false;
+      }
+    }
+  }
   std::free(value);
-  if (setting == "false") {
-    return;
+  if (g_continuous_world_workset.static_world_requested &&
+      !g_continuous_world_workset.requested) {
+    g_continuous_world_workset.valid = false;
   }
-  g_continuous_world_workset.requested = true;
-  g_continuous_world_workset.valid = setting == "true";
 }
 
 void ValidateAndEmitVisibilityShadowReplayConfiguration() {
@@ -8957,7 +8981,11 @@ void ValidateAndEmitContinuousWorldWorksetConfiguration() {
        {"activation", "startup_environment_only"},
        {"default_enabled", "false"},
        {"selection",
-        "fresh_track_texture_provider_visibility_or_qualified_sky_horizon_and_mechanical"},
+        "fresh_track_texture_provider_visibility_or_qualified_sky_horizon_or_optional_exact_static_world_and_mechanical"},
+       {"static_world_selection",
+        g_continuous_world_workset.static_world_requested
+            ? "exact_presentation_resource_mesh_transform_lineage"
+            : "disabled"},
        {"maximum_draws_per_frame",
         std::to_string(kContinuousWorldWorksetMaximumDrawsPerFrame)},
        {"target_lifetime", "one_guest_frame"},
@@ -17258,6 +17286,8 @@ struct SemanticVisibilityPreparedAdmission {
   bool fresh = false;
   bool title_lod_valid = false;
   bool track_texture_provider = false;
+  bool static_world_origin = false;
+  bool static_world_exact = false;
   uint32_t title_lod_index = 0;
 };
 
@@ -17266,8 +17296,17 @@ SemanticVisibilityPreparedAdmission RecordSemanticBatchOpportunity(
     bool samples_resolved_target,
     const rex::system::GraphicsPreparedDrawObservation &prepared,
     const TitleDrawOrigin &origin, uint64_t prepared_signature) {
+  const bool static_world_origin = origin.static_world_draw.valid;
+  const bool static_world_exact =
+      static_world_origin &&
+      origin.static_world_draw.asset_metadata_valid &&
+      origin.static_world_draw.transform_valid &&
+      origin.static_world_draw.mesh_semantics_valid;
   if (!origin.semantic_draw.valid) {
-    return {};
+    return {
+        .static_world_origin = static_world_origin,
+        .static_world_exact = static_world_exact,
+    };
   }
   const SemanticDrawIdentity &identity = origin.semantic_draw;
   const SemanticPreparedDrawContract contract =
@@ -17284,6 +17323,8 @@ SemanticVisibilityPreparedAdmission RecordSemanticBatchOpportunity(
       .title_lod_valid = fresh_visibility_candidate && identity.title_lod_valid,
       .track_texture_provider =
           fresh_visibility_candidate && identity.track_texture_provider,
+      .static_world_origin = static_world_origin,
+      .static_world_exact = static_world_exact,
       .title_lod_index = identity.title_lod_index,
   };
   const SemanticBatchRejection rejection =
@@ -19338,6 +19379,10 @@ void ObservePreparedDraw(
         visibility_admission.title_lod_valid;
     g_isolated_draw.prepared_track_texture_provider =
         visibility_admission.track_texture_provider;
+    g_isolated_draw.prepared_static_world_origin =
+        visibility_admission.static_world_origin;
+    g_isolated_draw.prepared_static_world_exact =
+        visibility_admission.static_world_exact;
     g_isolated_draw.prepared_title_lod_index =
         visibility_admission.title_lod_index;
     g_isolated_draw.prepared_candidate_valid = true;
@@ -20729,6 +20774,7 @@ void EmitContinuousWorldWorksetSummary() {
       g_continuous_world_workset.mechanical_rejections +
       g_continuous_world_workset.stale_or_unselected_rejections +
       g_continuous_world_workset.non_track_provider_rejections +
+      g_continuous_world_workset.static_world_lineage_rejections +
       g_continuous_world_workset.per_frame_quota_yields +
       g_continuous_world_workset.fail_closed_yields;
   pinyon_shift::diagnostics::RecordEvent(
@@ -20755,6 +20801,11 @@ void EmitContinuousWorldWorksetSummary() {
        {"non_track_provider_rejections",
         std::to_string(
             g_continuous_world_workset.non_track_provider_rejections)},
+       {"static_world_lineage_rejections",
+        std::to_string(
+            g_continuous_world_workset.static_world_lineage_rejections)},
+       {"static_world_requests",
+        std::to_string(g_continuous_world_workset.static_world_requests)},
        {"per_frame_quota_yields",
         std::to_string(g_continuous_world_workset.per_frame_quota_yields)},
        {"fail_closed_yields",
@@ -20779,7 +20830,11 @@ void EmitContinuousWorldWorksetSummary() {
        {"maximum_draws_per_frame",
         std::to_string(kContinuousWorldWorksetMaximumDrawsPerFrame)},
        {"selection",
-        "fresh_track_texture_provider_visibility_or_qualified_sky_horizon_and_mechanical"},
+        "fresh_track_texture_provider_visibility_or_qualified_sky_horizon_or_optional_exact_static_world_and_mechanical"},
+       {"static_world_selection",
+        g_continuous_world_workset.static_world_requested
+            ? "exact_presentation_resource_mesh_transform_lineage"
+            : "disabled"},
        {"freshness_commit", "matching_swap_after_complete_accumulation"},
        {"readback", "disabled"},
        {"native_draw", "continuous_world_workset"},
@@ -21117,12 +21172,22 @@ void RequestIsolatedDraw(
     }
     const bool qualified_retained_family =
         g_isolated_draw.prepared_signature == kSkyHorizonFollowerSignature;
+    const bool exact_static_world =
+        g_continuous_world_workset.static_world_requested &&
+        g_isolated_draw.prepared_static_world_exact;
+    if (g_continuous_world_workset.static_world_requested &&
+        g_isolated_draw.prepared_static_world_origin &&
+        !g_isolated_draw.prepared_static_world_exact) {
+      ++g_continuous_world_workset.static_world_lineage_rejections;
+      return;
+    }
     if (!g_isolated_draw.prepared_visibility_candidate_fresh &&
-        !qualified_retained_family) {
+        !qualified_retained_family && !exact_static_world) {
       ++g_continuous_world_workset.stale_or_unselected_rejections;
       return;
     }
     if (!qualified_retained_family &&
+        !exact_static_world &&
         !g_isolated_draw.prepared_track_texture_provider) {
       ++g_continuous_world_workset.non_track_provider_rejections;
       return;
@@ -21147,6 +21212,9 @@ void RequestIsolatedDraw(
     ++g_continuous_world_workset.requests;
     if (qualified_retained_family) {
       ++g_continuous_world_workset.qualified_retained_family_requests;
+    }
+    if (exact_static_world) {
+      ++g_continuous_world_workset.static_world_requests;
     }
     request.requested = true;
     request.retain_target = true;

--- a/tools/capture-native-renderer-census.ps1
+++ b/tools/capture-native-renderer-census.ps1
@@ -28,6 +28,7 @@ param(
     [switch]$RequireTitleLodCandidate,
     [switch]$VisibilityShadowReplay,
     [switch]$ContinuousWorldWorkset,
+    [switch]$ContinuousStaticWorld,
     [switch]$VehicleDrawCorrelation,
     [switch]$ShadowCasterProvenance,
     [ValidateSet(
@@ -139,6 +140,9 @@ if ($ContinuousWorldWorkset -and
         $PassAnchorSignature -or $PublishRetainedPass)) {
     throw 'ContinuousWorldWorkset is mutually exclusive with isolated/pass replay options.'
 }
+if ($ContinuousStaticWorld -and -not $ContinuousWorldWorkset) {
+    throw 'ContinuousStaticWorld requires ContinuousWorldWorkset.'
+}
 if ($PublishRetainedPass -and
     (-not $IsolatedDrawSignature -or -not $PassAnchorSignature)) {
     throw 'PublishRetainedPass requires IsolatedDrawSignature and PassAnchorSignature.'
@@ -238,6 +242,8 @@ $savedVisibilityShadowReplay =
     $env:PINYON_SHIFT_NATIVE_RENDERER_VISIBILITY_SHADOW_REPLAY
 $savedContinuousWorldWorkset =
     $env:PINYON_SHIFT_NATIVE_RENDERER_CONTINUOUS_WORLD_WORKSET
+$savedContinuousStaticWorld =
+    $env:PINYON_SHIFT_NATIVE_RENDERER_CONTINUOUS_STATIC_WORLD
 $savedShadowCasterProvenance =
     $env:PINYON_SHIFT_NATIVE_RENDERER_SHADOW_CASTER_PROVENANCE
 $savedTrackRenderMode = $env:PINYON_SHIFT_NATIVE_RENDERER_TRACK_RENDER_MODE
@@ -288,6 +294,8 @@ try {
         if ($VisibilityShadowReplay) { 'true' } else { $null }
     $env:PINYON_SHIFT_NATIVE_RENDERER_CONTINUOUS_WORLD_WORKSET =
         if ($ContinuousWorldWorkset) { 'true' } else { $null }
+    $env:PINYON_SHIFT_NATIVE_RENDERER_CONTINUOUS_STATIC_WORLD =
+        if ($ContinuousStaticWorld) { 'true' } else { $null }
     $env:PINYON_SHIFT_NATIVE_RENDERER_SHADOW_CASTER_PROVENANCE =
         if ($ShadowCasterProvenance) { 'true' } else { $null }
     $env:PINYON_SHIFT_NATIVE_RENDERER_TRACK_RENDER_MODE = $TrackRenderMode
@@ -333,6 +341,8 @@ finally {
         $savedVisibilityShadowReplay
     $env:PINYON_SHIFT_NATIVE_RENDERER_CONTINUOUS_WORLD_WORKSET =
         $savedContinuousWorldWorkset
+    $env:PINYON_SHIFT_NATIVE_RENDERER_CONTINUOUS_STATIC_WORLD =
+        $savedContinuousStaticWorld
     $env:PINYON_SHIFT_NATIVE_RENDERER_SHADOW_CASTER_PROVENANCE =
         $savedShadowCasterProvenance
     $env:PINYON_SHIFT_NATIVE_RENDERER_TRACK_RENDER_MODE = $savedTrackRenderMode

--- a/tools/summarize-native-renderer-continuous-world-workset.py
+++ b/tools/summarize-native-renderer-continuous-world-workset.py
@@ -7,11 +7,12 @@ import pathlib
 import sys
 
 
-SCHEMA = "pinyon-shift.native-renderer-continuous-world-workset.v3"
+SCHEMA = "pinyon-shift.native-renderer-continuous-world-workset.v4"
 SELECTION = (
     "fresh_track_texture_provider_visibility_or_qualified_"
-    "sky_horizon_and_mechanical"
+    "sky_horizon_or_optional_exact_static_world_and_mechanical"
 )
+STATIC_WORLD_SELECTION = "exact_presentation_resource_mesh_transform_lineage"
 CONFIG = "native_renderer.continuous_world_workset.config"
 SUMMARY = "native_renderer.continuous_world_workset.summary"
 OUTPUT_FRAME = "native_renderer.output.frame"
@@ -85,6 +86,7 @@ def build(events, requested_session=None):
         "target_lifetime": "one_guest_frame",
         "freshness_commit": "matching_swap_after_complete_accumulation",
         "semantic_lineage": "armed",
+        "static_world_selection": config.get("static_world_selection"),
         "readback": "disabled",
         "native_draw": "continuous_world_workset",
         "xenos_draw": "preserved",
@@ -94,6 +96,14 @@ def build(events, requested_session=None):
     }
     if any(config.get(key) != value for key, value in expected_config.items()):
         raise ValueError("workset runtime configuration drifted")
+    static_world_requested = (
+        config.get("static_world_selection") == STATIC_WORLD_SELECTION
+    )
+    if config.get("static_world_selection") not in (
+        "disabled",
+        STATIC_WORLD_SELECTION,
+    ):
+        raise ValueError("workset static-world configuration drifted")
     require_safety(summary)
     if (
         summary.get("accounting_complete") != "true"
@@ -102,6 +112,8 @@ def build(events, requested_session=None):
         != "matching_swap_after_complete_accumulation"
         or summary.get("maximum_draws_per_frame") != "64"
         or summary.get("selection") != SELECTION
+        or summary.get("static_world_selection")
+        != config.get("static_world_selection")
     ):
         raise ValueError("workset summary is incomplete")
 
@@ -114,6 +126,8 @@ def build(events, requested_session=None):
         "mechanical_rejections",
         "stale_or_unselected_rejections",
         "non_track_provider_rejections",
+        "static_world_lineage_rejections",
+        "static_world_requests",
         "per_frame_quota_yields",
         "fail_closed_yields",
         "qualified_retained_family_requests",
@@ -136,6 +150,7 @@ def build(events, requested_session=None):
         + totals["mechanical_rejections"]
         + totals["stale_or_unselected_rejections"]
         + totals["non_track_provider_rejections"]
+        + totals["static_world_lineage_rejections"]
         + totals["per_frame_quota_yields"]
         + totals["fail_closed_yields"]
     )
@@ -160,8 +175,19 @@ def build(events, requested_session=None):
         failures.append("failed frames do not reconcile with replay fallbacks")
     if not totals["qualified_retained_family_requests"]:
         failures.append("qualified retained-family seed was not observed")
-    if totals["requests"] <= totals["qualified_retained_family_requests"]:
+    track_provider_requests = (
+        totals["requests"]
+        - totals["qualified_retained_family_requests"]
+        - totals["static_world_requests"]
+    )
+    if track_provider_requests <= 0:
         failures.append("no track-provider visibility request was observed")
+    if static_world_requested and not totals["static_world_requests"]:
+        failures.append("no exact static-world request was observed")
+    if not static_world_requested and totals["static_world_requests"]:
+        failures.append("static-world request occurred while disabled")
+    if totals["static_world_lineage_rejections"]:
+        failures.append("static-world lineage rejection was observed")
     if not totals["reused_target_requests"]:
         failures.append("no frame accumulated multiple native draws")
     if totals["maximum_draws_per_frame"] != 64:
@@ -251,7 +277,21 @@ def build(events, requested_session=None):
                 "no track-provider visibility request was observed",
             )
         )
-        and totals["requests"] > totals["qualified_retained_family_requests"]
+        and track_provider_requests > 0
+    )
+    static_world_selection_proved = (
+        static_world_requested
+        and totals["static_world_requests"] > 0
+        and not any(
+            message
+            in failures
+            for message in (
+                "prepared selection accounting drifted",
+                "runtime workset status does not match its outcomes",
+                "no exact static-world request was observed",
+                "static-world lineage rejection was observed",
+            )
+        )
     )
 
     return {
@@ -265,6 +305,7 @@ def build(events, requested_session=None):
             "swap_committed_freshness_proved": freshness_proved,
             "clean_xenos_fallback_proved": clean_fallback_proved,
             "track_provider_selection_proved": track_provider_selection_proved,
+            "static_world_selection_proved": static_world_selection_proved,
             "native_output_markers": len(exact_output_frames),
             "xenos_fallback_markers": len(output_waiting),
             "suppression_allowed": False,

--- a/tools/tests/test_native_renderer_continuous_world_workset.py
+++ b/tools/tests/test_native_renderer_continuous_world_workset.py
@@ -28,6 +28,7 @@ def fixture():
         target_lifetime="one_guest_frame",
         freshness_commit="matching_swap_after_complete_accumulation",
         semantic_lineage="armed",
+        static_world_selection=MODULE.STATIC_WORLD_SELECTION,
         readback="disabled",
         native_draw="continuous_world_workset",
         xenos_draw="preserved",
@@ -46,6 +47,8 @@ def fixture():
         mechanical_rejections="4",
         stale_or_unselected_rejections="3",
         non_track_provider_rejections="2",
+        static_world_lineage_rejections="0",
+        static_world_requests="3",
         per_frame_quota_yields="2",
         fail_closed_yields="0",
         qualified_retained_family_requests="2",
@@ -56,6 +59,7 @@ def fixture():
         accounting_complete="true",
         selection_accounting_complete="true",
         selection=MODULE.SELECTION,
+        static_world_selection=MODULE.STATIC_WORLD_SELECTION,
         maximum_draws_per_frame="64",
         freshness_commit="matching_swap_after_complete_accumulation",
         readback="disabled",
@@ -100,6 +104,10 @@ class ContinuousWorldWorksetTests(unittest.TestCase):
         self.assertIn("request.defer_preview_publication_until_swap = true", source)
         self.assertIn("qualified_retained_family_requests", source)
         self.assertIn("prepared_track_texture_provider", source)
+        self.assertIn("prepared_static_world_exact", source)
+        self.assertIn(
+            "PINYON_SHIFT_NATIVE_RENDERER_CONTINUOUS_STATIC_WORLD", source
+        )
         self.assertIn("kTrackTextureUnifiedVtable = 0x82001708", source)
         self.assertIn("non_track_provider_rejections", source)
         self.assertIn('"native_renderer.continuous_world_workset.summary"', source)
@@ -133,6 +141,9 @@ class ContinuousWorldWorksetTests(unittest.TestCase):
         self.assertTrue(
             document["qualification"]["track_provider_selection_proved"]
         )
+        self.assertTrue(
+            document["qualification"]["static_world_selection_proved"]
+        )
         self.assertFalse(document["qualification"]["suppression_allowed"])
 
     def test_rejects_single_draw_frames(self):
@@ -151,10 +162,22 @@ class ContinuousWorldWorksetTests(unittest.TestCase):
         summary["requests"] = "2"
         summary["recorded"] = "2"
         summary["qualified_retained_family_requests"] = "2"
+        summary["static_world_requests"] = "0"
         document = MODULE.build(events)
         self.assertEqual("incomplete", document["status"])
         self.assertIn(
             "no track-provider visibility request was observed",
+            document["failures"],
+        )
+
+    def test_rejects_static_world_lineage_failure(self):
+        events = fixture()
+        events[-1]["static_world_lineage_rejections"] = "1"
+        events[-1]["stale_or_unselected_rejections"] = "2"
+        document = MODULE.build(events)
+        self.assertEqual("incomplete", document["status"])
+        self.assertIn(
+            "static-world lineage rejection was observed",
             document["failures"],
         )
 

--- a/tools/tests/test_native_renderer_prototype_comparison.py
+++ b/tools/tests/test_native_renderer_prototype_comparison.py
@@ -115,9 +115,11 @@ class NativeRendererPrototypeComparisonTests(unittest.TestCase):
         )
         self.assertIn("qualified_retained_family_requests", hooks)
         self.assertIn(
-            "fresh_track_texture_provider_visibility_or_qualified_sky_horizon_and_mechanical",
+            "fresh_track_texture_provider_visibility_or_qualified_sky_horizon_or_optional_exact_static_world_and_mechanical",
             hooks,
         )
+        self.assertIn("static_world_requested = false", hooks)
+        self.assertIn("prepared_static_world_exact", hooks)
         self.assertIn("!g_isolated_draw.prepared_candidate_eligible", hooks)
 
     def test_capture_does_not_inject_legacy_isolated_draw_configuration(self):


### PR DESCRIPTION
## Summary
- extend the swap-committed continuous private target with opt-in exact static-world draws
- require complete presentation/resource/asset/transform/mesh/prepared-layout lineage
- preserve normal prototype behavior, Xenos execution, and zero suppression

## Validation
- 582 Python tests passed
- PowerShell parsing passed
- C++ compilation passed
- final link remains expectedly blocked by the healthy active AppData process (PID 35288)

Runtime and visual qualification stays batched with the pending C1/C2 AppData run.