### PR TITLE
feat(native-renderer): census static invalidation surface

### DIFF
--- a/docs/native-renderer/REPRIORITIZED_PLAN.md
+++ b/docs/native-renderer/REPRIORITIZED_PLAN.md
@@ -345,6 +345,15 @@ runtime transition coverage, any additional invalidation routes, concrete
 building/prop identity, and mesh/material decoding remain pending. Xenos stays
 authoritative and no admission or suppression is enabled.
 
+Invalidation-census checkpoint: all 23 `CSimpleModelResource` vtable slots are
+now locked to their retail targets. Only slots 16 and 22 reset the live
+offset-64 payload; slot 0 destruction reaches the base destructor that releases
+the same reference. This closes the class-exposed invalidation surface while
+leaving representative runtime transition coverage, external invalidation
+routes, and post-transition rebinding for the batched C1/C2 AppData run. The
+proof is recorded in
+[`STATIC_WORLD_STREAMING.md`](STATIC_WORLD_STREAMING.md).
+
 Member-graph checkpoint: the exact live resource now joins its embedded
 `CSimpleModel` at offset 112, selected `CSimpleSubModel`, and selected
 `CSimpleMesh` to the direct indexed-draw call and prepared PM4 provenance.

--- a/docs/native-renderer/STATIC_WORLD_STREAMING.md
+++ b/docs/native-renderer/STATIC_WORLD_STREAMING.md
@@ -1,7 +1,7 @@
 # Static-world SimpleModel payload-reset transitions
 
-Status: exact payload-reset boundaries and generation invalidation implemented;
-runtime qualification pending
+Status: complete class-exposed invalidation surface and generation tracking
+proved; representative runtime qualification pending
 
 ## Purpose
 
@@ -10,15 +10,21 @@ An allocation generation is not sufficient for open-world streaming. A live
 the same object address. Prepared-draw provenance must become stale when that
 happens, even if the renderer still points at the same resource object.
 
-`tools/discover-native-renderer-static-world-streaming.py` proves the minimum
-exact reset surface against the retail image and generated AOT instructions.
-It names only structural behavior visible in those instructions; it does not
-claim that these two methods cover every title streaming route.
+`tools/discover-native-renderer-static-world-streaming.py` proves the complete
+23-slot class vtable and its exact reset surface against the retail image and
+generated AOT instructions. It names only structural behavior visible in those
+instructions; external callers and representative title streaming behavior
+still require runtime qualification.
 
 ## Exact transitions
 
 The resource's vtable and instruction flow prove:
 
+- all 23 vtable slots resolve to the locked retail target census, covering 14
+  unique functions;
+- slot 0 destruction reaches `82C47DF8`, which calls base destructor
+  `82E45B20`; the base destructor clears/releases the same offset-64 owned
+  reference;
 - slot 15, `82C46410`, refreshes the offset-112 graph using the offset-76
   binding object through `82C462D0`;
 - slot 16, `82C46440`, reads the owned pointer at offset 64, clears it before
@@ -27,6 +33,11 @@ The resource's vtable and instruction flow prove:
 - slot 22, shared method `82C222C8`, invokes virtual slot 15, preserves its
   result, then clears and releases the same offset-64 pointer. Balanced hooks
   are `82C222C8` and `82C2231C`; exact RTTI excludes other resource classes.
+
+No other class-vtable target clears the live offset-64 payload. Slots 16 and 22
+therefore cover every live-object payload reset exposed by this class, while
+slot 0 covers destruction. The broader claim that representative gameplay
+exercises every relevant streaming transition intentionally remains false.
 
 Every completed exact transition must leave offset 64 null. The passive
 registry then increments a payload generation independently from the resource
@@ -68,11 +79,11 @@ shared slot-22 implementation are counted as exclusions, not faults.
 ## Remaining boundary
 
 Runtime evidence must show which transition paths occur during representative
-driving and streaming, whether every later draw is rebound to the new payload
-generation, and whether other independent invalidation routes exist. Concrete
-building/prop identity and mesh/material ownership also remain open. Therefore
-this checkpoint enables no native upload, draw, publication, or suppression;
-Xenos remains authoritative.
+driving and streaming and whether every later draw is rebound to the new
+payload generation. Any invalidation route outside the complete class vtable
+must also be identified from that evidence. Concrete building/prop identity
+and mesh/material ownership remain open. Therefore this checkpoint enables no
+native upload, draw, publication, or suppression; Xenos remains authoritative.
 
 The adjacent member-lineage proof is documented in
 [`STATIC_WORLD_GRAPH.md`](STATIC_WORLD_GRAPH.md).

--- a/tools/discover-native-renderer-static-world-streaming.py
+++ b/tools/discover-native-renderer-static-world-streaming.py
@@ -10,7 +10,7 @@ import re
 import sys
 
 
-SCHEMA = "pinyon-shift.native-renderer-static-world-streaming.v1"
+SCHEMA = "pinyon-shift.native-renderer-static-world-streaming.v2"
 IMAGE_BASE = 0x82000000
 RESOURCE_VTABLE = 0x82229294
 FUNCTION_RE = re.compile(r"^DEFINE_REX_FUNC\(sub_([0-9A-F]{8})\) \{")
@@ -25,6 +25,33 @@ VIRTUAL_RESET_EXIT_HOOK = 0x82C2231C
 RESOURCE_PAYLOAD_OFFSET = 64
 RESOURCE_GRAPH_OFFSET = 112
 RESOURCE_BINDING_OFFSET = 76
+RESOURCE_VTABLE_TARGETS = (
+    0x82C47EC0,
+    0x82A0E238,
+    0x824493C0,
+    0x82448FD8,
+    0x82B755A8,
+    0x82D68710,
+    0x830B2320,
+    0x82611B80,
+    0x82D68710,
+    0x82D68710,
+    0x82D68710,
+    0x82D68710,
+    0x82D68710,
+    0x82611B80,
+    0x824D7F98,
+    RESOURCE_REFRESH,
+    DIRECT_RESET,
+    0x82D68710,
+    0x830B2320,
+    0x82C462C0,
+    0x824D7FA8,
+    0x82611B80,
+    VIRTUAL_RESET,
+)
+RESOURCE_DESTRUCTOR = 0x82C47DF8
+BASE_RESOURCE_DESTRUCTOR = 0x82E45B20
 
 
 def parse_functions(paths: list[pathlib.Path]) -> dict[int, dict[int, str]]:
@@ -74,6 +101,12 @@ def require_instructions(
 
 
 def build(functions: dict[int, dict[int, str]], image: bytes) -> dict:
+    observed_targets = tuple(
+        image_u32(image, RESOURCE_VTABLE + slot * 4)
+        for slot in range(len(RESOURCE_VTABLE_TARGETS))
+    )
+    if observed_targets != RESOURCE_VTABLE_TARGETS:
+        raise ValueError("SimpleModelResource complete vtable drifted")
     if image_u32(image, RESOURCE_VTABLE + 15 * 4) != RESOURCE_REFRESH:
         raise ValueError("SimpleModelResource refresh slot drifted")
     if image_u32(image, RESOURCE_VTABLE + 16 * 4) != DIRECT_RESET:
@@ -120,6 +153,22 @@ def build(functions: dict[int, dict[int, str]], image: bytes) -> dict:
             VIRTUAL_RESET_EXIT_HOOK: "mr r3,r31",
         },
     )
+    require_instructions(
+        functions,
+        RESOURCE_DESTRUCTOR,
+        {
+            0x82C47E3C: "mr r3,r30",
+            0x82C47E40: "bl 0x82e45b20",
+        },
+    )
+    require_instructions(
+        functions,
+        BASE_RESOURCE_DESTRUCTOR,
+        {
+            0x82E45BB4: "addi r3,r31,64",
+            0x82E45BB8: "bl 0x82de7330",
+        },
+    )
 
     return {
         "schema": SCHEMA,
@@ -137,6 +186,17 @@ def build(functions: dict[int, dict[int, str]], image: bytes) -> dict:
             "method": f"{RESOURCE_REFRESH:08X}",
             "graph_argument": "resource_plus_112",
             "binding_argument": "resource_plus_76",
+        },
+        "invalidation_surface": {
+            "vtable_slot_count": len(RESOURCE_VTABLE_TARGETS),
+            "vtable_targets": [f"{target:08X}" for target in observed_targets],
+            "unique_target_count": len(set(observed_targets)),
+            "destruction_slot": 0,
+            "destructor": f"{RESOURCE_DESTRUCTOR:08X}",
+            "base_destructor": f"{BASE_RESOURCE_DESTRUCTOR:08X}",
+            "destructor_payload_release": "resource_plus_64_reference_clear",
+            "live_payload_reset_slots": [16, 22],
+            "other_live_payload_reset_slots": [],
         },
         "transitions": [
             {
@@ -158,6 +218,7 @@ def build(functions: dict[int, dict[int, str]], image: bytes) -> dict:
             "owned_payload_reference_field_proved": True,
             "balanced_payload_reset_boundaries_proved": True,
             "payload_generation_invalidation_boundary_proved": True,
+            "complete_class_vtable_invalidation_coverage_proved": True,
             "complete_streaming_invalidation_coverage_proved": False,
             "concrete_building_or_prop_identity_proved": False,
         },

--- a/tools/summarize-native-renderer-static-world-runtime-join.py
+++ b/tools/summarize-native-renderer-static-world-runtime-join.py
@@ -13,7 +13,7 @@ SCHEMA = "pinyon-shift.native-renderer-static-world-runtime-join.v10"
 STATIC_SCHEMA = "pinyon-shift.native-renderer-static-world-ingress.v2"
 LIFETIME_SCHEMA = "pinyon-shift.native-renderer-static-world-lifetime.v1"
 RESOURCE_SCHEMA = "pinyon-shift.native-renderer-static-world-resource.v1"
-STREAMING_SCHEMA = "pinyon-shift.native-renderer-static-world-streaming.v1"
+STREAMING_SCHEMA = "pinyon-shift.native-renderer-static-world-streaming.v2"
 GRAPH_SCHEMA = "pinyon-shift.native-renderer-static-world-graph.v1"
 OWNER_SCHEMA = "pinyon-shift.native-renderer-static-world-owner.v2"
 ASSET_METADATA_SCHEMA = (
@@ -239,6 +239,7 @@ def validate_static_streaming(document):
     try:
         resource = document["resource"]
         refresh = document["refresh"]
+        invalidation_surface = document["invalidation_surface"]
         transitions = document["transitions"]
         claims = document["claims"]
     except (KeyError, TypeError) as error:
@@ -272,16 +273,38 @@ def validate_static_streaming(document):
             "exit_resource_register": "r30",
         },
     ]
+    expected_invalidation_surface = {
+        "vtable_slot_count": 23,
+        "vtable_targets": [
+            "82C47EC0", "82A0E238", "824493C0", "82448FD8",
+            "82B755A8", "82D68710", "830B2320", "82611B80",
+            "82D68710", "82D68710", "82D68710", "82D68710",
+            "82D68710", "82611B80", "824D7F98", "82C46410",
+            "82C46440", "82D68710", "830B2320", "82C462C0",
+            "824D7FA8", "82611B80", "82C222C8",
+        ],
+        "unique_target_count": 14,
+        "destruction_slot": 0,
+        "destructor": "82C47DF8",
+        "base_destructor": "82E45B20",
+        "destructor_payload_release": "resource_plus_64_reference_clear",
+        "live_payload_reset_slots": [16, 22],
+        "other_live_payload_reset_slots": [],
+    }
     if any(resource.get(key) != value for key, value in expected_resource.items()):
         raise ValueError("static-world streaming resource proof drifted")
     if any(refresh.get(key) != value for key, value in expected_refresh.items()):
         raise ValueError("static-world streaming refresh proof drifted")
     if transitions != expected_transitions:
         raise ValueError("static-world streaming transition proof drifted")
+    if invalidation_surface != expected_invalidation_surface:
+        raise ValueError("static-world streaming invalidation surface drifted")
     if (
         claims.get("owned_payload_reference_field_proved") is not True
         or claims.get("balanced_payload_reset_boundaries_proved") is not True
         or claims.get("payload_generation_invalidation_boundary_proved")
+        is not True
+        or claims.get("complete_class_vtable_invalidation_coverage_proved")
         is not True
         or claims.get("complete_streaming_invalidation_coverage_proved")
         is not False

--- a/tools/tests/test_native_renderer_static_world_runtime_join.py
+++ b/tools/tests/test_native_renderer_static_world_runtime_join.py
@@ -144,6 +144,24 @@ def static_streaming():
             "graph_argument": "resource_plus_112",
             "binding_argument": "resource_plus_76",
         },
+        "invalidation_surface": {
+            "vtable_slot_count": 23,
+            "vtable_targets": [
+                "82C47EC0", "82A0E238", "824493C0", "82448FD8",
+                "82B755A8", "82D68710", "830B2320", "82611B80",
+                "82D68710", "82D68710", "82D68710", "82D68710",
+                "82D68710", "82611B80", "824D7F98", "82C46410",
+                "82C46440", "82D68710", "830B2320", "82C462C0",
+                "824D7FA8", "82611B80", "82C222C8",
+            ],
+            "unique_target_count": 14,
+            "destruction_slot": 0,
+            "destructor": "82C47DF8",
+            "base_destructor": "82E45B20",
+            "destructor_payload_release": "resource_plus_64_reference_clear",
+            "live_payload_reset_slots": [16, 22],
+            "other_live_payload_reset_slots": [],
+        },
         "transitions": [
             {
                 "kind": "direct_payload_reset",
@@ -164,6 +182,7 @@ def static_streaming():
             "owned_payload_reference_field_proved": True,
             "balanced_payload_reset_boundaries_proved": True,
             "payload_generation_invalidation_boundary_proved": True,
+            "complete_class_vtable_invalidation_coverage_proved": True,
             "complete_streaming_invalidation_coverage_proved": False,
             "concrete_building_or_prop_identity_proved": False,
         },

--- a/tools/tests/test_native_renderer_static_world_streaming.py
+++ b/tools/tests/test_native_renderer_static_world_streaming.py
@@ -15,12 +15,12 @@ SPEC.loader.exec_module(MODULE)
 
 
 def fixture():
-    image = bytearray(MODULE.RESOURCE_VTABLE + 23 * 4 - MODULE.IMAGE_BASE)
-    for slot, target in (
-        (15, MODULE.RESOURCE_REFRESH),
-        (16, MODULE.DIRECT_RESET),
-        (22, MODULE.VIRTUAL_RESET),
-    ):
+    image = bytearray(
+        MODULE.RESOURCE_VTABLE
+        + len(MODULE.RESOURCE_VTABLE_TARGETS) * 4
+        - MODULE.IMAGE_BASE
+    )
+    for slot, target in enumerate(MODULE.RESOURCE_VTABLE_TARGETS):
         offset = MODULE.RESOURCE_VTABLE + slot * 4 - MODULE.IMAGE_BASE
         image[offset : offset + 4] = target.to_bytes(4, "big")
     functions = {
@@ -51,6 +51,14 @@ def fixture():
             0x82C22318: "bctrl",
             MODULE.VIRTUAL_RESET_EXIT_HOOK: "mr r3,r31",
         },
+        MODULE.RESOURCE_DESTRUCTOR: {
+            0x82C47E3C: "mr r3,r30",
+            0x82C47E40: "bl 0x82e45b20",
+        },
+        MODULE.BASE_RESOURCE_DESTRUCTOR: {
+            0x82E45BB4: "addi r3,r31,64",
+            0x82E45BB8: "bl 0x82de7330",
+        },
     }
     return functions, bytes(image)
 
@@ -65,6 +73,15 @@ class StaticWorldStreamingTests(unittest.TestCase):
         self.assertTrue(
             document["claims"]["payload_generation_invalidation_boundary_proved"]
         )
+        self.assertTrue(
+            document["claims"][
+                "complete_class_vtable_invalidation_coverage_proved"
+            ]
+        )
+        self.assertEqual(
+            [16, 22],
+            document["invalidation_surface"]["live_payload_reset_slots"],
+        )
         self.assertFalse(
             document["claims"]["complete_streaming_invalidation_coverage_proved"]
         )
@@ -76,7 +93,7 @@ class StaticWorldStreamingTests(unittest.TestCase):
         corrupted[offset : offset + 4] = (MODULE.DIRECT_RESET + 4).to_bytes(
             4, "big"
         )
-        with self.assertRaisesRegex(ValueError, "direct reset slot drifted"):
+        with self.assertRaisesRegex(ValueError, "complete vtable drifted"):
             MODULE.build(functions, bytes(corrupted))
 
     def test_rejects_payload_clear_drift(self):
@@ -85,6 +102,14 @@ class StaticWorldStreamingTests(unittest.TestCase):
         corrupted[MODULE.VIRTUAL_RESET][0x82C222FC] = "stw r10,68(r30)"
         with self.assertRaisesRegex(ValueError, "82C222FC"):
             MODULE.build(corrupted, image)
+
+    def test_rejects_unclassified_vtable_slot(self):
+        functions, image = fixture()
+        corrupted = bytearray(image)
+        offset = MODULE.RESOURCE_VTABLE + 19 * 4 - MODULE.IMAGE_BASE
+        corrupted[offset : offset + 4] = (0x82C462C4).to_bytes(4, "big")
+        with self.assertRaisesRegex(ValueError, "complete vtable drifted"):
+            MODULE.build(functions, bytes(corrupted))
 
     def test_rejects_refresh_graph_drift(self):
         functions, image = fixture()


### PR DESCRIPTION
## Summary
- lock the complete 23-slot SimpleModelResource vtable census
- prove slots 16 and 22 are the only class-exposed live payload reset routes
- trace slot 0 destruction through the base offset-64 payload release
- keep representative streaming coverage and native authority explicitly pending

## Validation
- retail-image static-world streaming v2 report: complete
- python -m unittest discover -s tools/tests -p test_*.py (583 passed)