### PR TITLE
feat(native-renderer): gate exact track world replay

### DIFF
--- a/docs/native-renderer/CONTINUOUS_WORLD_WORKSET.md
+++ b/docs/native-renderer/CONTINUOUS_WORLD_WORKSET.md
@@ -23,6 +23,13 @@ census and semantic dispatch discovery so every admitted draw has:
   prepared-layout lineage; and
 - exact title-to-backend lineage.
 
+For the C1 qualification probe, add `-ContinuousTrackWorld`. Semantic draws
+then require both the exact unified track render-model scope and a nonzero
+shared world-resource identity mask: the same RTTI-proved track model, mesh,
+submodel, procedural-geometry, or PVS-zone object/resource address must occur
+at the title scope and procedural submission boundary. A provider-only match
+is excluded rather than promoted to terrain/road evidence.
+
 The exact retained family supplies a current-frame seed in supported gameplay
 scenes where the visibility-selected opaque set contains no mechanically
 replayable color target. It does not admit unknown signatures. The mode accepts
@@ -64,8 +71,11 @@ authority with suppression disabled.
 It reports the exact-family seed count separately as
 `qualified_retained_family_requests`, and reports fresh visibility candidates
 excluded by the track-provider gate as `non_track_provider_rejections`.
+When exact track-world selection is armed, accepted requests and provider-only
+identity exclusions are reported separately as `track_world_requests` and
+`track_world_identity_exclusions`.
 Static-world requests and incomplete-lineage rejections are reported
-independently. The v4 qualifier requires at least one exact static-world
+independently. The v5 qualifier requires at least one exact static-world
 request and zero static-world lineage rejection when that optional selection
 is armed.
 Build a payload-free qualification report with:
@@ -83,12 +93,15 @@ Arm the still-default-off static-world extension for the deferred C1/C2 run:
   -StateRoot $stateRoot `
   -Scene open_world_day `
   -ContinuousWorldWorkset `
+  -ContinuousTrackWorld `
   -ContinuousStaticWorld
 ```
 
 Qualification requires at least one exact track-provider visibility request,
 one complete frame with multiple accumulated draws, zero replay or frame
 failures, exact accounting, preserved Xenos draws, and disabled suppression.
+When `-ContinuousTrackWorld` is armed, at least one accepted semantic request
+must also satisfy the exact shared-resource gate.
 
 ## Safety boundary
 
@@ -102,6 +115,9 @@ failures, exact accounting, preserved Xenos draws, and disabled suppression.
 - Track-texture ownership is a precision filter for the existing prototype
   workset. It is not a terrain/road mesh ownership claim and does not satisfy
   the C1 semantic-family admission gate by itself.
+- The optional exact track-world selector admits semantic draws only after the
+  strongest already-carried shared-resource identity join. It does not infer
+  a road/terrain label from shaders, frequency, or provider identity.
 - The optional static-world extension accepts only exact lineage already
   carried into a mechanically replayable prepared draw. It does not embed the
   local category catalog, infer a content class, suppress Xenos, or enable

--- a/docs/native-renderer/REPRIORITIZED_PLAN.md
+++ b/docs/native-renderer/REPRIORITIZED_PLAN.md
@@ -260,6 +260,14 @@ qualified sky/horizon seed remains available. Runtime qualification is deferred
 to the next batched build/AppData checkpoint. This precision filter is not yet
 a terrain/road mesh identity or C1 family-admission claim.
 
+Exact-output checkpoint: the default-off continuous workset now has a stricter
+C1 selector that requires the exact unified track render-model scope and a
+nonzero shared RTTI-proved world-resource identity at the procedural submission
+boundary. Provider-only candidates are excluded, while the qualified sky seed,
+independent exact C2 selection, Xenos draws, and fallback remain intact. The
+next combined AppData run arms `-ContinuousTrackWorld`; runtime and visual
+qualification remain pending before any family promotion or suppression.
+
 Next runtime checkpoint: the old typed-render-item evidence is now correctly
 classified by RTTI as the unified track render-model instance/model pair. A
 balanced passive scope at its accepted nested dispatch (`8240EC80`-`8240ECAC`)

--- a/docs/native-renderer/TERRAIN_ROAD_RENDER_PATH.md
+++ b/docs/native-renderer/TERRAIN_ROAD_RENDER_PATH.md
@@ -303,6 +303,22 @@ identity alone is useful track ownership evidence, while exact shared identity
 is the preferred C1 terrain/road admission gate. Until runtime qualification,
 Xenos remains authoritative and no native admission or suppression is enabled.
 
+## Exact track-world native selection
+
+The default-off continuous workset can now apply that preferred gate directly.
+`-ContinuousTrackWorld` requires an exact unified render-model scope and a
+nonzero shared world-resource identity mask before a fresh, mechanically
+eligible semantic draw is replayed into the private native target. Merely
+sharing the track-texture provider is insufficient in this mode and is counted
+as an identity exclusion.
+
+This is an isolated C1 qualification path, not a default family promotion. It
+keeps the independently qualified sky seed, can run beside the exact C2
+static-world selector, preserves every Xenos draw, and enables no suppression.
+The combined AppData run must observe at least one exact request and coherent
+multi-draw output before this selector can establish visible terrain/road
+progress.
+
 ### First-run host mapping correction
 
 The first merged AppData run reached 8,700 frames before an access violation at

--- a/src/native_renderer/graphics_hooks.cpp
+++ b/src/native_renderer/graphics_hooks.cpp
@@ -8103,6 +8103,8 @@ struct IsolatedDrawState {
   bool prepared_visibility_candidate_fresh = false;
   bool prepared_title_lod_valid = false;
   bool prepared_track_texture_provider = false;
+  bool prepared_track_render_model_scope = false;
+  uint32_t prepared_track_world_resource_shared_identity_mask = 0;
   bool prepared_static_world_origin = false;
   bool prepared_static_world_exact = false;
   bool require_fresh_visibility_candidate = false;
@@ -8203,6 +8205,8 @@ struct ContinuousWorldWorksetState {
   uint64_t mechanical_rejections = 0;
   uint64_t stale_or_unselected_rejections = 0;
   uint64_t non_track_provider_rejections = 0;
+  uint64_t track_world_identity_exclusions = 0;
+  uint64_t track_world_requests = 0;
   uint64_t static_world_lineage_rejections = 0;
   uint64_t static_world_requests = 0;
   uint64_t per_frame_quota_yields = 0;
@@ -8217,6 +8221,7 @@ struct ContinuousWorldWorksetState {
   uint64_t current_frame_recorded = 0;
   bool current_frame_failed = false;
   bool requested = false;
+  bool track_world_requested = false;
   bool static_world_requested = false;
   bool valid = true;
 };
@@ -8909,6 +8914,26 @@ void ConfigureContinuousWorldWorkset() {
     }
   }
   std::free(value);
+
+  value = nullptr;
+  length = 0;
+  if (_dupenv_s(
+          &value, &length,
+          "PINYON_SHIFT_NATIVE_RENDERER_CONTINUOUS_TRACK_WORLD") == 0 &&
+      value && length > 1) {
+    const std::string setting(value);
+    if (setting != "false") {
+      g_continuous_world_workset.track_world_requested = true;
+      if (setting != "true") {
+        g_continuous_world_workset.valid = false;
+      }
+    }
+  }
+  std::free(value);
+  if (g_continuous_world_workset.track_world_requested &&
+      !g_continuous_world_workset.requested) {
+    g_continuous_world_workset.valid = false;
+  }
   if (g_continuous_world_workset.static_world_requested &&
       !g_continuous_world_workset.requested) {
     g_continuous_world_workset.valid = false;
@@ -8981,7 +9006,11 @@ void ValidateAndEmitContinuousWorldWorksetConfiguration() {
        {"activation", "startup_environment_only"},
        {"default_enabled", "false"},
        {"selection",
-        "fresh_track_texture_provider_visibility_or_qualified_sky_horizon_or_optional_exact_static_world_and_mechanical"},
+        "fresh_track_texture_provider_visibility_or_qualified_sky_horizon_or_optional_exact_track_or_static_world_and_mechanical"},
+       {"track_world_selection",
+        g_continuous_world_workset.track_world_requested
+            ? "exact_track_render_model_scope_and_shared_world_resource_identity"
+            : "disabled"},
        {"static_world_selection",
         g_continuous_world_workset.static_world_requested
             ? "exact_presentation_resource_mesh_transform_lineage"
@@ -17286,9 +17315,11 @@ struct SemanticVisibilityPreparedAdmission {
   bool fresh = false;
   bool title_lod_valid = false;
   bool track_texture_provider = false;
+  bool track_render_model_scope = false;
   bool static_world_origin = false;
   bool static_world_exact = false;
   uint32_t title_lod_index = 0;
+  uint32_t track_world_resource_shared_identity_mask = 0;
 };
 
 SemanticVisibilityPreparedAdmission RecordSemanticBatchOpportunity(
@@ -17323,9 +17354,15 @@ SemanticVisibilityPreparedAdmission RecordSemanticBatchOpportunity(
       .title_lod_valid = fresh_visibility_candidate && identity.title_lod_valid,
       .track_texture_provider =
           fresh_visibility_candidate && identity.track_texture_provider,
+      .track_render_model_scope =
+          fresh_visibility_candidate && identity.track_render_model_scope,
       .static_world_origin = static_world_origin,
       .static_world_exact = static_world_exact,
       .title_lod_index = identity.title_lod_index,
+      .track_world_resource_shared_identity_mask =
+          fresh_visibility_candidate
+              ? identity.track_world_resource_shared_identity_mask
+              : 0,
   };
   const SemanticBatchRejection rejection =
       ClassifySemanticBatchRejection(observation, samples_resolved_target,
@@ -19379,6 +19416,10 @@ void ObservePreparedDraw(
         visibility_admission.title_lod_valid;
     g_isolated_draw.prepared_track_texture_provider =
         visibility_admission.track_texture_provider;
+    g_isolated_draw.prepared_track_render_model_scope =
+        visibility_admission.track_render_model_scope;
+    g_isolated_draw.prepared_track_world_resource_shared_identity_mask =
+        visibility_admission.track_world_resource_shared_identity_mask;
     g_isolated_draw.prepared_static_world_origin =
         visibility_admission.static_world_origin;
     g_isolated_draw.prepared_static_world_exact =
@@ -20774,6 +20815,7 @@ void EmitContinuousWorldWorksetSummary() {
       g_continuous_world_workset.mechanical_rejections +
       g_continuous_world_workset.stale_or_unselected_rejections +
       g_continuous_world_workset.non_track_provider_rejections +
+      g_continuous_world_workset.track_world_identity_exclusions +
       g_continuous_world_workset.static_world_lineage_rejections +
       g_continuous_world_workset.per_frame_quota_yields +
       g_continuous_world_workset.fail_closed_yields;
@@ -20801,6 +20843,11 @@ void EmitContinuousWorldWorksetSummary() {
        {"non_track_provider_rejections",
         std::to_string(
             g_continuous_world_workset.non_track_provider_rejections)},
+       {"track_world_identity_exclusions",
+        std::to_string(
+            g_continuous_world_workset.track_world_identity_exclusions)},
+       {"track_world_requests",
+        std::to_string(g_continuous_world_workset.track_world_requests)},
        {"static_world_lineage_rejections",
         std::to_string(
             g_continuous_world_workset.static_world_lineage_rejections)},
@@ -20830,7 +20877,11 @@ void EmitContinuousWorldWorksetSummary() {
        {"maximum_draws_per_frame",
         std::to_string(kContinuousWorldWorksetMaximumDrawsPerFrame)},
        {"selection",
-        "fresh_track_texture_provider_visibility_or_qualified_sky_horizon_or_optional_exact_static_world_and_mechanical"},
+        "fresh_track_texture_provider_visibility_or_qualified_sky_horizon_or_optional_exact_track_or_static_world_and_mechanical"},
+       {"track_world_selection",
+        g_continuous_world_workset.track_world_requested
+            ? "exact_track_render_model_scope_and_shared_world_resource_identity"
+            : "disabled"},
        {"static_world_selection",
         g_continuous_world_workset.static_world_requested
             ? "exact_presentation_resource_mesh_transform_lineage"
@@ -21192,6 +21243,16 @@ void RequestIsolatedDraw(
       ++g_continuous_world_workset.non_track_provider_rejections;
       return;
     }
+    const bool exact_track_world =
+        g_continuous_world_workset.track_world_requested &&
+        g_isolated_draw.prepared_track_render_model_scope &&
+        g_isolated_draw.prepared_track_world_resource_shared_identity_mask;
+    if (g_continuous_world_workset.track_world_requested &&
+        !qualified_retained_family && !exact_static_world &&
+        !exact_track_world) {
+      ++g_continuous_world_workset.track_world_identity_exclusions;
+      return;
+    }
     if (g_continuous_world_workset.current_frame_failed) {
       ++g_continuous_world_workset.fail_closed_yields;
       return;
@@ -21212,6 +21273,9 @@ void RequestIsolatedDraw(
     ++g_continuous_world_workset.requests;
     if (qualified_retained_family) {
       ++g_continuous_world_workset.qualified_retained_family_requests;
+    }
+    if (exact_track_world) {
+      ++g_continuous_world_workset.track_world_requests;
     }
     if (exact_static_world) {
       ++g_continuous_world_workset.static_world_requests;

--- a/tools/capture-native-renderer-census.ps1
+++ b/tools/capture-native-renderer-census.ps1
@@ -28,6 +28,7 @@ param(
     [switch]$RequireTitleLodCandidate,
     [switch]$VisibilityShadowReplay,
     [switch]$ContinuousWorldWorkset,
+    [switch]$ContinuousTrackWorld,
     [switch]$ContinuousStaticWorld,
     [switch]$VehicleDrawCorrelation,
     [switch]$ShadowCasterProvenance,
@@ -143,6 +144,9 @@ if ($ContinuousWorldWorkset -and
 if ($ContinuousStaticWorld -and -not $ContinuousWorldWorkset) {
     throw 'ContinuousStaticWorld requires ContinuousWorldWorkset.'
 }
+if ($ContinuousTrackWorld -and -not $ContinuousWorldWorkset) {
+    throw 'ContinuousTrackWorld requires ContinuousWorldWorkset.'
+}
 if ($PublishRetainedPass -and
     (-not $IsolatedDrawSignature -or -not $PassAnchorSignature)) {
     throw 'PublishRetainedPass requires IsolatedDrawSignature and PassAnchorSignature.'
@@ -242,6 +246,8 @@ $savedVisibilityShadowReplay =
     $env:PINYON_SHIFT_NATIVE_RENDERER_VISIBILITY_SHADOW_REPLAY
 $savedContinuousWorldWorkset =
     $env:PINYON_SHIFT_NATIVE_RENDERER_CONTINUOUS_WORLD_WORKSET
+$savedContinuousTrackWorld =
+    $env:PINYON_SHIFT_NATIVE_RENDERER_CONTINUOUS_TRACK_WORLD
 $savedContinuousStaticWorld =
     $env:PINYON_SHIFT_NATIVE_RENDERER_CONTINUOUS_STATIC_WORLD
 $savedShadowCasterProvenance =
@@ -294,6 +300,8 @@ try {
         if ($VisibilityShadowReplay) { 'true' } else { $null }
     $env:PINYON_SHIFT_NATIVE_RENDERER_CONTINUOUS_WORLD_WORKSET =
         if ($ContinuousWorldWorkset) { 'true' } else { $null }
+    $env:PINYON_SHIFT_NATIVE_RENDERER_CONTINUOUS_TRACK_WORLD =
+        if ($ContinuousTrackWorld) { 'true' } else { $null }
     $env:PINYON_SHIFT_NATIVE_RENDERER_CONTINUOUS_STATIC_WORLD =
         if ($ContinuousStaticWorld) { 'true' } else { $null }
     $env:PINYON_SHIFT_NATIVE_RENDERER_SHADOW_CASTER_PROVENANCE =
@@ -341,6 +349,8 @@ finally {
         $savedVisibilityShadowReplay
     $env:PINYON_SHIFT_NATIVE_RENDERER_CONTINUOUS_WORLD_WORKSET =
         $savedContinuousWorldWorkset
+    $env:PINYON_SHIFT_NATIVE_RENDERER_CONTINUOUS_TRACK_WORLD =
+        $savedContinuousTrackWorld
     $env:PINYON_SHIFT_NATIVE_RENDERER_CONTINUOUS_STATIC_WORLD =
         $savedContinuousStaticWorld
     $env:PINYON_SHIFT_NATIVE_RENDERER_SHADOW_CASTER_PROVENANCE =

--- a/tools/summarize-native-renderer-continuous-world-workset.py
+++ b/tools/summarize-native-renderer-continuous-world-workset.py
@@ -7,10 +7,13 @@ import pathlib
 import sys
 
 
-SCHEMA = "pinyon-shift.native-renderer-continuous-world-workset.v4"
+SCHEMA = "pinyon-shift.native-renderer-continuous-world-workset.v5"
 SELECTION = (
     "fresh_track_texture_provider_visibility_or_qualified_"
-    "sky_horizon_or_optional_exact_static_world_and_mechanical"
+    "sky_horizon_or_optional_exact_track_or_static_world_and_mechanical"
+)
+TRACK_WORLD_SELECTION = (
+    "exact_track_render_model_scope_and_shared_world_resource_identity"
 )
 STATIC_WORLD_SELECTION = "exact_presentation_resource_mesh_transform_lineage"
 CONFIG = "native_renderer.continuous_world_workset.config"
@@ -86,6 +89,7 @@ def build(events, requested_session=None):
         "target_lifetime": "one_guest_frame",
         "freshness_commit": "matching_swap_after_complete_accumulation",
         "semantic_lineage": "armed",
+        "track_world_selection": config.get("track_world_selection"),
         "static_world_selection": config.get("static_world_selection"),
         "readback": "disabled",
         "native_draw": "continuous_world_workset",
@@ -99,6 +103,14 @@ def build(events, requested_session=None):
     static_world_requested = (
         config.get("static_world_selection") == STATIC_WORLD_SELECTION
     )
+    track_world_requested = (
+        config.get("track_world_selection") == TRACK_WORLD_SELECTION
+    )
+    if config.get("track_world_selection") not in (
+        "disabled",
+        TRACK_WORLD_SELECTION,
+    ):
+        raise ValueError("workset track-world configuration drifted")
     if config.get("static_world_selection") not in (
         "disabled",
         STATIC_WORLD_SELECTION,
@@ -112,6 +124,8 @@ def build(events, requested_session=None):
         != "matching_swap_after_complete_accumulation"
         or summary.get("maximum_draws_per_frame") != "64"
         or summary.get("selection") != SELECTION
+        or summary.get("track_world_selection")
+        != config.get("track_world_selection")
         or summary.get("static_world_selection")
         != config.get("static_world_selection")
     ):
@@ -126,6 +140,8 @@ def build(events, requested_session=None):
         "mechanical_rejections",
         "stale_or_unselected_rejections",
         "non_track_provider_rejections",
+        "track_world_identity_exclusions",
+        "track_world_requests",
         "static_world_lineage_rejections",
         "static_world_requests",
         "per_frame_quota_yields",
@@ -150,6 +166,7 @@ def build(events, requested_session=None):
         + totals["mechanical_rejections"]
         + totals["stale_or_unselected_rejections"]
         + totals["non_track_provider_rejections"]
+        + totals["track_world_identity_exclusions"]
         + totals["static_world_lineage_rejections"]
         + totals["per_frame_quota_yields"]
         + totals["fail_closed_yields"]
@@ -182,6 +199,15 @@ def build(events, requested_session=None):
     )
     if track_provider_requests <= 0:
         failures.append("no track-provider visibility request was observed")
+    if track_world_requested and not totals["track_world_requests"]:
+        failures.append("no exact track-world request was observed")
+    if not track_world_requested and (
+        totals["track_world_requests"]
+        or totals["track_world_identity_exclusions"]
+    ):
+        failures.append("track-world selection occurred while disabled")
+    if totals["track_world_requests"] > track_provider_requests:
+        failures.append("track-world requests exceed track-provider requests")
     if static_world_requested and not totals["static_world_requests"]:
         failures.append("no exact static-world request was observed")
     if not static_world_requested and totals["static_world_requests"]:
@@ -279,6 +305,21 @@ def build(events, requested_session=None):
         )
         and track_provider_requests > 0
     )
+    track_world_selection_proved = (
+        track_world_requested
+        and totals["track_world_requests"] > 0
+        and totals["track_world_requests"] <= track_provider_requests
+        and not any(
+            message
+            in failures
+            for message in (
+                "prepared selection accounting drifted",
+                "runtime workset status does not match its outcomes",
+                "no exact track-world request was observed",
+                "track-world requests exceed track-provider requests",
+            )
+        )
+    )
     static_world_selection_proved = (
         static_world_requested
         and totals["static_world_requests"] > 0
@@ -305,6 +346,7 @@ def build(events, requested_session=None):
             "swap_committed_freshness_proved": freshness_proved,
             "clean_xenos_fallback_proved": clean_fallback_proved,
             "track_provider_selection_proved": track_provider_selection_proved,
+            "track_world_selection_proved": track_world_selection_proved,
             "static_world_selection_proved": static_world_selection_proved,
             "native_output_markers": len(exact_output_frames),
             "xenos_fallback_markers": len(output_waiting),

--- a/tools/tests/test_native_renderer_continuous_world_workset.py
+++ b/tools/tests/test_native_renderer_continuous_world_workset.py
@@ -28,6 +28,7 @@ def fixture():
         target_lifetime="one_guest_frame",
         freshness_commit="matching_swap_after_complete_accumulation",
         semantic_lineage="armed",
+        track_world_selection=MODULE.TRACK_WORLD_SELECTION,
         static_world_selection=MODULE.STATIC_WORLD_SELECTION,
         readback="disabled",
         native_draw="continuous_world_workset",
@@ -39,7 +40,7 @@ def fixture():
     summary = event(
         MODULE.SUMMARY,
         status="complete",
-        prepared_observations="19",
+        prepared_observations="20",
         requests="8",
         recorded="8",
         target_creation_failures="0",
@@ -47,6 +48,8 @@ def fixture():
         mechanical_rejections="4",
         stale_or_unselected_rejections="3",
         non_track_provider_rejections="2",
+        track_world_identity_exclusions="1",
+        track_world_requests="3",
         static_world_lineage_rejections="0",
         static_world_requests="3",
         per_frame_quota_yields="2",
@@ -59,6 +62,7 @@ def fixture():
         accounting_complete="true",
         selection_accounting_complete="true",
         selection=MODULE.SELECTION,
+        track_world_selection=MODULE.TRACK_WORLD_SELECTION,
         static_world_selection=MODULE.STATIC_WORLD_SELECTION,
         maximum_draws_per_frame="64",
         freshness_commit="matching_swap_after_complete_accumulation",
@@ -104,9 +108,16 @@ class ContinuousWorldWorksetTests(unittest.TestCase):
         self.assertIn("request.defer_preview_publication_until_swap = true", source)
         self.assertIn("qualified_retained_family_requests", source)
         self.assertIn("prepared_track_texture_provider", source)
+        self.assertIn("prepared_track_render_model_scope", source)
+        self.assertIn(
+            "prepared_track_world_resource_shared_identity_mask", source
+        )
         self.assertIn("prepared_static_world_exact", source)
         self.assertIn(
             "PINYON_SHIFT_NATIVE_RENDERER_CONTINUOUS_STATIC_WORLD", source
+        )
+        self.assertIn(
+            "PINYON_SHIFT_NATIVE_RENDERER_CONTINUOUS_TRACK_WORLD", source
         )
         self.assertIn("kTrackTextureUnifiedVtable = 0x82001708", source)
         self.assertIn("non_track_provider_rejections", source)
@@ -128,6 +139,7 @@ class ContinuousWorldWorksetTests(unittest.TestCase):
             encoding="utf-8"
         )
         self.assertIn("[switch]$ContinuousWorldWorkset", capture)
+        self.assertIn("[switch]$ContinuousTrackWorld", capture)
         self.assertIn(
             "PINYON_SHIFT_NATIVE_RENDERER_CONTINUOUS_WORLD_WORKSET", capture
         )
@@ -140,6 +152,9 @@ class ContinuousWorldWorksetTests(unittest.TestCase):
         )
         self.assertTrue(
             document["qualification"]["track_provider_selection_proved"]
+        )
+        self.assertTrue(
+            document["qualification"]["track_world_selection_proved"]
         )
         self.assertTrue(
             document["qualification"]["static_world_selection_proved"]
@@ -179,6 +194,30 @@ class ContinuousWorldWorksetTests(unittest.TestCase):
         self.assertIn(
             "static-world lineage rejection was observed",
             document["failures"],
+        )
+
+    def test_rejects_missing_exact_track_world_request(self):
+        events = fixture()
+        events[-1]["track_world_requests"] = "0"
+        document = MODULE.build(events)
+        self.assertEqual("incomplete", document["status"])
+        self.assertIn(
+            "no exact track-world request was observed", document["failures"]
+        )
+
+    def test_keeps_exact_track_world_selection_optional(self):
+        events = fixture()
+        events[0]["track_world_selection"] = "disabled"
+        events[-1].update(
+            prepared_observations="19",
+            track_world_selection="disabled",
+            track_world_identity_exclusions="0",
+            track_world_requests="0",
+        )
+        document = MODULE.build(events)
+        self.assertEqual("complete", document["status"])
+        self.assertFalse(
+            document["qualification"]["track_world_selection_proved"]
         )
 
     def test_qualifies_an_accounted_fail_closed_frame(self):

--- a/tools/tests/test_native_renderer_prototype_comparison.py
+++ b/tools/tests/test_native_renderer_prototype_comparison.py
@@ -115,7 +115,7 @@ class NativeRendererPrototypeComparisonTests(unittest.TestCase):
         )
         self.assertIn("qualified_retained_family_requests", hooks)
         self.assertIn(
-            "fresh_track_texture_provider_visibility_or_qualified_sky_horizon_or_optional_exact_static_world_and_mechanical",
+            "fresh_track_texture_provider_visibility_or_qualified_sky_horizon_or_optional_exact_track_or_static_world_and_mechanical",
             hooks,
         )
         self.assertIn("static_world_requested = false", hooks)


### PR DESCRIPTION
## Summary
- add a default-off exact C1 track-world selector to the continuous native workset
- require the unified track render-model scope and a shared RTTI-proved world resource identity
- account provider-only exclusions separately while preserving sky, exact C2, Xenos, and fallback paths
- add the capture switch, strict v5 qualifier, tests, and roadmap checkpoints

## Validation
- graphics_hooks.cpp object build
- PowerShell capture-script parse
- python -m unittest discover -s tools/tests -p test_*.py (585 passed)

The full executable link and AppData run remain intentionally batched because the guarded gameplay process still owns the current binary.