### PR TITLE
feat(native-renderer): checkpoint continuous world output

### DIFF
--- a/docs/native-renderer/CONTINUOUS_WORLD_WORKSET.md
+++ b/docs/native-renderer/CONTINUOUS_WORLD_WORKSET.md
@@ -59,7 +59,13 @@ frame comparison and the complete Xenos output remains authoritative.
 The runtime emits:
 
 - `native_renderer.continuous_world_workset.config`; and
+- `native_renderer.continuous_world_workset.checkpoint` every 300 observed
+  frames while the mode is armed; and
 - `native_renderer.continuous_world_workset.summary`.
+
+Periodic checkpoints derive the current frame outcome without finalizing or
+mutating the live workset. They are diagnostic evidence only: session exit is
+unproved, and a later unique shutdown summary always takes precedence.
 
 The summary reconciles prepared observations, selection outcomes, replay
 outcomes, target reuse, complete frames, failed frames, and the 64-draw bound.
@@ -75,7 +81,7 @@ When exact track-world selection is armed, accepted requests and provider-only
 identity exclusions are reported separately as `track_world_requests` and
 `track_world_identity_exclusions`.
 Static-world requests and incomplete-lineage rejections are reported
-independently. The v5 qualifier requires at least one exact static-world
+independently. The v6 qualifier requires at least one exact static-world
 request and zero static-world lineage rejection when that optional selection
 is armed.
 Build a payload-free qualification report with:
@@ -85,6 +91,10 @@ python .\tools\summarize-native-renderer-continuous-world-workset.py `
   .local\preview\logs\events.jsonl `
   --output .local\qualification\continuous-world-workset.json
 ```
+
+For an interrupted long-session diagnosis only, add `--allow-checkpoint`. The
+latest checkpoint may produce `checkpoint_complete`, but cannot satisfy any
+gate that requires a normal process exit.
 
 Arm the still-default-off static-world extension for the deferred C1/C2 run:
 

--- a/docs/native-renderer/REPRIORITIZED_PLAN.md
+++ b/docs/native-renderer/REPRIORITIZED_PLAN.md
@@ -268,6 +268,12 @@ independent exact C2 selection, Xenos draws, and fallback remain intact. The
 next combined AppData run arms `-ContinuousTrackWorld`; runtime and visual
 qualification remain pending before any family promotion or suppression.
 
+Long-session output checkpoint: the continuous workset now emits a
+non-mutating cumulative checkpoint every 300 observed frames. Its qualifier
+requires explicit checkpoint opt-in, records session exit as unproved, and
+always prefers the unique final summary. This preserves evidence from long C1/C2
+runs without weakening the clean-shutdown admission gate.
+
 Next runtime checkpoint: the old typed-render-item evidence is now correctly
 classified by RTTI as the unified track render-model instance/model pair. A
 balanced passive scope at its accepted nested dispatch (`8240EC80`-`8240ECAC`)

--- a/src/native_renderer/graphics_hooks.cpp
+++ b/src/native_renderer/graphics_hooks.cpp
@@ -20802,11 +20802,15 @@ void CompleteContinuousWorldWorksetReplay(
   }
 }
 
-void EmitContinuousWorldWorksetSummary() {
+void EmitContinuousWorldWorksetEvent(const char *event_name,
+                                     bool final_summary,
+                                     uint64_t frame_sequence) {
   if (!g_continuous_world_workset.requested) {
     return;
   }
-  FinalizeContinuousWorldWorksetFrame();
+  if (final_summary) {
+    FinalizeContinuousWorldWorksetFrame();
+  }
   const uint64_t outcomes = g_continuous_world_workset.recorded +
                             g_continuous_world_workset.target_creation_failures +
                             g_continuous_world_workset.unsupported;
@@ -20819,15 +20823,34 @@ void EmitContinuousWorldWorksetSummary() {
       g_continuous_world_workset.static_world_lineage_rejections +
       g_continuous_world_workset.per_frame_quota_yields +
       g_continuous_world_workset.fail_closed_yields;
+  uint64_t frames_completed = g_continuous_world_workset.frames_completed;
+  uint64_t frames_failed = g_continuous_world_workset.frames_failed;
+  if (!final_summary &&
+      g_continuous_world_workset.current_frame != UINT64_MAX &&
+      g_continuous_world_workset.current_frame_requests) {
+    if (g_continuous_world_workset.current_frame_failed) {
+      ++frames_failed;
+    } else if (g_continuous_world_workset.current_frame_recorded ==
+               g_continuous_world_workset.current_frame_requests) {
+      ++frames_completed;
+    }
+  }
   pinyon_shift::diagnostics::RecordEvent(
-      "native_renderer.continuous_world_workset.summary",
+      event_name,
       {{"status", !g_continuous_world_workset.valid
-                      ? "invalid_configuration"
-                      : (g_continuous_world_workset.frames_failed
-                             ? "fallback_observed"
-                             : (g_continuous_world_workset.frames_completed
-                                    ? "complete"
-                                    : "not_observed"))},
+                      ? (final_summary ? "invalid_configuration"
+                                       : "checkpoint_invalid_configuration")
+                      : (frames_failed
+                             ? (final_summary ? "fallback_observed"
+                                              : "checkpoint_fallback_observed")
+                             : (frames_completed
+                                    ? (final_summary ? "complete"
+                                                     : "checkpoint_complete")
+                                    : (final_summary
+                                           ? "not_observed"
+                                           : "checkpoint_not_observed")))},
+       {"final_summary", final_summary ? "true" : "false"},
+       {"frame_sequence", std::to_string(frame_sequence)},
        {"prepared_observations",
         std::to_string(g_continuous_world_workset.prepared_observations)},
        {"requests", std::to_string(g_continuous_world_workset.requests)},
@@ -20864,10 +20887,8 @@ void EmitContinuousWorldWorksetSummary() {
         std::to_string(g_continuous_world_workset.reused_target_requests)},
        {"frames_started",
         std::to_string(g_continuous_world_workset.frames_started)},
-       {"frames_completed",
-        std::to_string(g_continuous_world_workset.frames_completed)},
-       {"frames_failed",
-        std::to_string(g_continuous_world_workset.frames_failed)},
+       {"frames_completed", std::to_string(frames_completed)},
+       {"frames_failed", std::to_string(frames_failed)},
        {"accounting_complete",
         outcomes == g_continuous_world_workset.requests ? "true" : "false"},
        {"selection_accounting_complete",
@@ -20893,6 +20914,18 @@ void EmitContinuousWorldWorksetSummary() {
        {"output_authority", "renderer_selector"},
        {"draw_suppression", "false"},
        {"suppression_eligible", "false"}});
+}
+
+void EmitContinuousWorldWorksetSummary() {
+  EmitContinuousWorldWorksetEvent(
+      "native_renderer.continuous_world_workset.summary", true,
+      g_frame_sequence.load(std::memory_order_relaxed));
+}
+
+void EmitContinuousWorldWorksetCheckpoint(uint64_t frame_sequence) {
+  EmitContinuousWorldWorksetEvent(
+      "native_renderer.continuous_world_workset.checkpoint", false,
+      frame_sequence);
 }
 
 void EmitVisibilityShadowReplaySummary() {
@@ -25037,6 +25070,9 @@ void PinyonShiftObserveGraphicsFrame() {
       EmitTrackRenderModelRuntimeJoinCheckpoint(frame_sequence);
       EmitStaticWorldRuntimeJoinCheckpoint(frame_sequence);
     }
+  }
+  if (frame_sequence % kFrameSummaryInterval == 0) {
+    EmitContinuousWorldWorksetCheckpoint(frame_sequence);
   }
   if (dispatch_requested) {
     pinyon_shift::diagnostics::RecordEvent(

--- a/tools/summarize-native-renderer-continuous-world-workset.py
+++ b/tools/summarize-native-renderer-continuous-world-workset.py
@@ -7,7 +7,7 @@ import pathlib
 import sys
 
 
-SCHEMA = "pinyon-shift.native-renderer-continuous-world-workset.v5"
+SCHEMA = "pinyon-shift.native-renderer-continuous-world-workset.v6"
 SELECTION = (
     "fresh_track_texture_provider_visibility_or_qualified_"
     "sky_horizon_or_optional_exact_track_or_static_world_and_mechanical"
@@ -18,6 +18,7 @@ TRACK_WORLD_SELECTION = (
 STATIC_WORLD_SELECTION = "exact_presentation_resource_mesh_transform_lineage"
 CONFIG = "native_renderer.continuous_world_workset.config"
 SUMMARY = "native_renderer.continuous_world_workset.summary"
+CHECKPOINT = "native_renderer.continuous_world_workset.checkpoint"
 OUTPUT_FRAME = "native_renderer.output.frame"
 OUTPUT_WAITING = "native_renderer.output.waiting"
 
@@ -75,11 +76,30 @@ def require_safety(event):
         raise ValueError("workset evidence violates safety boundary")
 
 
-def build(events, requested_session=None):
+def select_runtime_event(events, allow_checkpoint):
+    summaries = [event for event in events if event.get("event") == SUMMARY]
+    if len(summaries) > 1:
+        raise ValueError("expected at most one continuous workset summary")
+    if summaries:
+        return summaries[0], True
+    if not allow_checkpoint:
+        raise ValueError("expected exactly one continuous workset summary")
+    checkpoints = [
+        event for event in events if event.get("event") == CHECKPOINT
+    ]
+    if not checkpoints:
+        raise ValueError("no continuous workset summary or checkpoint")
+    return max(checkpoints, key=lambda event: integer(event, "frame_sequence")), False
+
+
+def build(events, requested_session=None, allow_checkpoint=False):
     session = select_session(events, requested_session)
     selected = [event for event in events if event.get("session") == session]
     config = exact_event(selected, CONFIG)
-    summary = exact_event(selected, SUMMARY)
+    summary, final_summary = select_runtime_event(selected, allow_checkpoint)
+    evidence_frame = integer(summary, "frame_sequence")
+    if summary.get("final_summary") != ("true" if final_summary else "false"):
+        raise ValueError("workset evidence finality drifted")
     expected_config = {
         "status": "armed_deferred_private_composition",
         "activation": "startup_environment_only",
@@ -157,6 +177,12 @@ def build(events, requested_session=None):
     output_frames = [
         event for event in selected if event.get("event") == OUTPUT_FRAME
     ]
+    if not final_summary:
+        output_frames = [
+            event
+            for event in output_frames
+            if integer(event, "callback") <= evidence_frame
+        ]
     output_waiting = [
         event for event in selected if event.get("event") == OUTPUT_WAITING
     ]
@@ -218,9 +244,16 @@ def build(events, requested_session=None):
         failures.append("no frame accumulated multiple native draws")
     if totals["maximum_draws_per_frame"] != 64:
         failures.append("per-frame workset bound drifted")
-    expected_summary_status = (
-        "fallback_observed" if totals["frames_failed"] else "complete"
-    )
+    if final_summary:
+        expected_summary_status = (
+            "fallback_observed" if totals["frames_failed"] else "complete"
+        )
+    else:
+        expected_summary_status = (
+            "checkpoint_fallback_observed"
+            if totals["frames_failed"]
+            else "checkpoint_complete"
+        )
     if summary.get("status") != expected_summary_status:
         failures.append("runtime workset status does not match its outcomes")
 
@@ -338,7 +371,16 @@ def build(events, requested_session=None):
     return {
         "schema": SCHEMA,
         "session": session,
-        "status": "complete" if not failures else "incomplete",
+        "status": (
+            ("complete" if final_summary else "checkpoint_complete")
+            if not failures
+            else ("incomplete" if final_summary else "checkpoint_incomplete")
+        ),
+        "evidence": {
+            "kind": "final_summary" if final_summary else "checkpoint",
+            "frame_sequence": evidence_frame,
+            "session_exit_proved": final_summary,
+        },
         "failures": failures,
         "totals": totals,
         "qualification": {
@@ -365,16 +407,23 @@ def main(argv=None):
     parser = argparse.ArgumentParser()
     parser.add_argument("events", nargs="+", type=pathlib.Path)
     parser.add_argument("--session")
+    parser.add_argument(
+        "--allow-checkpoint",
+        action="store_true",
+        help="use the latest checkpoint only when the final summary is absent",
+    )
     parser.add_argument("--output", required=True, type=pathlib.Path)
     args = parser.parse_args(argv)
     try:
-        document = build(read_events(args.events), args.session)
+        document = build(
+            read_events(args.events), args.session, args.allow_checkpoint
+        )
         args.output.parent.mkdir(parents=True, exist_ok=True)
         args.output.write_text(
             json.dumps(document, indent=2, sort_keys=True) + "\n",
             encoding="utf-8",
         )
-        if document["status"] != "complete":
+        if document["status"] not in ("complete", "checkpoint_complete"):
             raise ValueError("; ".join(document["failures"]))
         return 0
     except (OSError, ValueError, json.JSONDecodeError) as error:

--- a/tools/tests/test_native_renderer_continuous_world_workset.py
+++ b/tools/tests/test_native_renderer_continuous_world_workset.py
@@ -40,6 +40,8 @@ def fixture():
     summary = event(
         MODULE.SUMMARY,
         status="complete",
+        final_summary="true",
+        frame_sequence="900",
         prepared_observations="20",
         requests="8",
         recorded="8",
@@ -122,6 +124,9 @@ class ContinuousWorldWorksetTests(unittest.TestCase):
         self.assertIn("kTrackTextureUnifiedVtable = 0x82001708", source)
         self.assertIn("non_track_provider_rejections", source)
         self.assertIn('"native_renderer.continuous_world_workset.summary"', source)
+        self.assertIn(
+            '"native_renderer.continuous_world_workset.checkpoint"', source
+        )
         self.assertIn('{"xenos_draw", "preserved"}', source)
         self.assertIn('{"draw_suppression", "false"}', source)
 
@@ -160,6 +165,43 @@ class ContinuousWorldWorksetTests(unittest.TestCase):
             document["qualification"]["static_world_selection_proved"]
         )
         self.assertFalse(document["qualification"]["suppression_allowed"])
+        self.assertTrue(document["evidence"]["session_exit_proved"])
+
+    def test_qualifies_latest_non_mutating_checkpoint(self):
+        events = fixture()
+        checkpoint = events[-1]
+        checkpoint.update(
+            event=MODULE.CHECKPOINT,
+            status="checkpoint_complete",
+            final_summary="false",
+        )
+        document = MODULE.build(events, allow_checkpoint=True)
+        self.assertEqual("checkpoint_complete", document["status"])
+        self.assertEqual("checkpoint", document["evidence"]["kind"])
+        self.assertFalse(document["evidence"]["session_exit_proved"])
+
+    def test_requires_explicit_checkpoint_opt_in(self):
+        events = fixture()
+        events[-1].update(
+            event=MODULE.CHECKPOINT,
+            status="checkpoint_complete",
+            final_summary="false",
+        )
+        with self.assertRaisesRegex(ValueError, "exactly one.*summary"):
+            MODULE.build(events)
+
+    def test_final_summary_wins_over_later_checkpoint_input(self):
+        events = fixture()
+        checkpoint = copy.deepcopy(events[-1])
+        checkpoint.update(
+            event=MODULE.CHECKPOINT,
+            status="checkpoint_complete",
+            final_summary="false",
+            frame_sequence="1200",
+        )
+        document = MODULE.build([*events, checkpoint], allow_checkpoint=True)
+        self.assertEqual("complete", document["status"])
+        self.assertTrue(document["evidence"]["session_exit_proved"])
 
     def test_rejects_single_draw_frames(self):
         events = fixture()


### PR DESCRIPTION
## Summary
- emit non-mutating continuous-world-workset checkpoints every 300 observed frames
- derive current-frame completion without changing live replay state
- require explicit checkpoint opt-in and keep final-summary precedence
- record session exit as unproved for checkpoint-only evidence

## Validation
- graphics_hooks.cpp object build
- python -m unittest discover -s tools/tests -p test_*.py (588 passed)
- staged full response-file link remains available while the guarded process owns the canonical executable