### PR TITLE
feat(native-renderer): join C1 C2 batch evidence

### DIFF
--- a/docs/native-renderer/C1_C2_BATCH_QUALIFICATION.md
+++ b/docs/native-renderer/C1_C2_BATCH_QUALIFICATION.md
@@ -1,0 +1,37 @@
+# Combined C1/C2 qualification gate
+
+Status: implementation complete; first clean AppData batch pending
+
+The combined gate turns one exact runtime session into a single promotion
+decision. It joins four independently strict, payload-free reports:
+
+- unified track render-model and shared world-resource identity;
+- complete SimpleModel presentation/resource/mesh lineage;
+- runtime transform classification against the title-authored spatial catalog;
+  and
+- swap-committed continuous output with exact C1 and C2 selection enabled.
+
+Every input must have status `complete`, name the same session, contain no
+failures, and preserve its safety boundary. Track, static-world, and continuous
+output reports must prove a final shutdown summary; periodic checkpoints are
+useful for diagnosis but cannot satisfy this gate.
+
+Run the four component qualifiers first, then join them:
+
+```powershell
+python tools/summarize-native-renderer-c1-c2-batch.py `
+  --track .local/qualification/track-model-runtime-join.json `
+  --static-world .local/qualification/static-world-runtime-join.json `
+  --classification .local/qualification/static-world-classification.json `
+  --workset .local/qualification/continuous-world-workset.json `
+  --output .local/qualification/c1-c2-batch.json
+```
+
+A complete report proves exact C1 track-world and classified C2 static-world
+draws reached fresh, multi-draw, swap-committed native output in one clean
+session while every Xenos draw remained intact. It deliberately does not claim
+manual visual acceptance, race coverage, representative high-speed streaming,
+family promotion, or suppression. Those remain the next gates.
+
+This report never reads or modifies the AppData save and cannot enable runtime
+behavior. It only joins existing payload-free evidence.

--- a/docs/native-renderer/REPRIORITIZED_PLAN.md
+++ b/docs/native-renderer/REPRIORITIZED_PLAN.md
@@ -274,6 +274,13 @@ requires explicit checkpoint opt-in, records session exit as unproved, and
 always prefers the unique final summary. This preserves evidence from long C1/C2
 runs without weakening the clean-shutdown admission gate.
 
+Combined qualification checkpoint: the payload-free C1/C2 batch gate now
+requires the exact track join, complete static-world join, catalog-backed
+instance classification, and swap-committed workset reports to describe one
+clean final session. It proves neither manual visual acceptance nor race and
+streaming coverage. The contract and command are documented in
+[`C1_C2_BATCH_QUALIFICATION.md`](C1_C2_BATCH_QUALIFICATION.md).
+
 Next runtime checkpoint: the old typed-render-item evidence is now correctly
 classified by RTTI as the unified track render-model instance/model pair. A
 balanced passive scope at its accepted nested dispatch (`8240EC80`-`8240ECAC`)

--- a/tools/summarize-native-renderer-c1-c2-batch.py
+++ b/tools/summarize-native-renderer-c1-c2-batch.py
@@ -1,0 +1,224 @@
+#!/usr/bin/env python3
+"""Join one clean C1/C2 AppData qualification batch."""
+
+import argparse
+import json
+import pathlib
+import sys
+
+
+SCHEMA = "pinyon-shift.native-renderer-c1-c2-batch.v1"
+INPUT_SCHEMAS = {
+    "track": "pinyon-shift.native-renderer-track-model-runtime-join.v2",
+    "static_world": "pinyon-shift.native-renderer-static-world-runtime-join.v10",
+    "classification": (
+        "pinyon-shift.native-renderer-static-world-instance-classification.v1"
+    ),
+    "workset": "pinyon-shift.native-renderer-continuous-world-workset.v6",
+}
+
+
+def read_document(path):
+    with path.open(encoding="utf-8") as stream:
+        document = json.load(stream)
+    if not isinstance(document, dict):
+        raise ValueError(f"{path} is not a JSON object")
+    return document
+
+
+def require_mapping(document, key, label):
+    value = document.get(key)
+    if not isinstance(value, dict):
+        raise ValueError(f"{label} {key} is missing")
+    return value
+
+
+def validate_safety(reports):
+    track = require_mapping(reports["track"], "safety", "track report")
+    static_world = require_mapping(
+        reports["static_world"], "safety", "static-world report"
+    )
+    classification = require_mapping(
+        reports["classification"], "safety", "classification report"
+    )
+    workset = require_mapping(reports["workset"], "safety", "workset report")
+    passive = {
+        "guest_state_changed": False,
+        "native_admission": False,
+        "native_draw": False,
+        "suppression_allowed": False,
+    }
+    for label, safety in (
+        ("track", track),
+        ("static-world", static_world),
+    ):
+        if any(safety.get(key) != value for key, value in passive.items()):
+            raise ValueError(f"{label} safety boundary drifted")
+        if safety.get("xenos_authority") is not True:
+            raise ValueError(f"{label} Xenos authority drifted")
+    if (
+        classification.get("guest_state_changed") is not False
+        or classification.get("source_files_changed") is not False
+        or classification.get("plaintext_identity_exported") is not False
+        or classification.get("xenos_draw") != "preserved"
+        or classification.get("native_admission") is not False
+        or classification.get("native_draw") is not False
+        or classification.get("suppression_allowed") is not False
+    ):
+        raise ValueError("classification safety boundary drifted")
+    if (
+        workset.get("readback") is not False
+        or workset.get("xenos_draw_preserved") is not True
+        or workset.get("output_authority") != "renderer_selector"
+        or workset.get("suppression_allowed") is not False
+    ):
+        raise ValueError("workset safety boundary drifted")
+
+
+def build(reports):
+    for label, schema in INPUT_SCHEMAS.items():
+        if reports[label].get("schema") != schema:
+            raise ValueError(f"{label} report schema drifted")
+    sessions = {reports[label].get("session") for label in INPUT_SCHEMAS}
+    if None in sessions or len(sessions) != 1:
+        raise ValueError("C1/C2 reports do not describe one exact session")
+    session = next(iter(sessions))
+    validate_safety(reports)
+
+    failures = []
+    for label, document in reports.items():
+        if document.get("status") != "complete":
+            failures.append(f"{label} report is not final and complete")
+        if document.get("failures"):
+            failures.append(f"{label} report contains failures")
+
+    for label in ("track", "static_world", "workset"):
+        evidence = require_mapping(reports[label], "evidence", f"{label} report")
+        if evidence.get("session_exit_proved") is not True:
+            failures.append(f"{label} report does not prove session exit")
+
+    track = require_mapping(reports["track"], "qualification", "track report")
+    static_world = require_mapping(
+        reports["static_world"], "qualification", "static-world report"
+    )
+    classification = require_mapping(
+        reports["classification"], "qualification", "classification report"
+    )
+    workset = require_mapping(
+        reports["workset"], "qualification", "workset report"
+    )
+
+    required_track = (
+        "track_render_model_scope_to_submission_proved",
+        "track_world_resource_graph_identity_proved",
+        "track_world_resource_to_submission_identity_proved",
+    )
+    for key in required_track:
+        if track.get(key) is not True:
+            failures.append(f"track gate is unproved: {key}")
+
+    required_static = (
+        "simple_model_renderer_scope_proved",
+        "simple_model_resource_lifetime_proved",
+        "payload_generation_invalidation_proved",
+        "simple_mesh_to_prepared_draw_proved",
+        "model_presentation_transform_to_prepared_draw_proved",
+        "hashed_asset_identity_to_prepared_draw_proved",
+        "complete_vertex_layout_to_prepared_draw_proved",
+        "static_world_pm4_to_prepared_draw_proved",
+    )
+    for key in required_static:
+        if static_world.get(key) is not True:
+            failures.append(f"static-world gate is unproved: {key}")
+
+    if classification.get("runtime_transform_join_proved") is not True:
+        failures.append("static-world runtime transform join is unproved")
+    if classification.get("building_or_prop_instance_identity_proved") is not True:
+        failures.append("static-world building/prop identity is unproved")
+
+    required_workset = (
+        "continuous_multi_draw_workset_proved",
+        "swap_committed_freshness_proved",
+        "clean_xenos_fallback_proved",
+        "track_world_selection_proved",
+        "static_world_selection_proved",
+    )
+    for key in required_workset:
+        if workset.get(key) is not True:
+            failures.append(f"continuous-output gate is unproved: {key}")
+
+    track_ready = not any(
+        failure.startswith("track gate")
+        or failure.startswith("continuous-output gate")
+        for failure in failures
+    )
+    static_ready = not any(
+        failure.startswith("static-world")
+        or failure.startswith("continuous-output gate")
+        for failure in failures
+    )
+    return {
+        "schema": SCHEMA,
+        "session": session,
+        "status": "complete" if not failures else "incomplete",
+        "failures": failures,
+        "qualification": {
+            "c1_exact_track_world_output_proved": track_ready and not failures,
+            "c2_exact_classified_static_world_output_proved": (
+                static_ready and not failures
+            ),
+            "combined_swap_committed_output_proved": not failures,
+            "session_exit_proved": not failures,
+            "manual_visual_acceptance_proved": False,
+            "representative_race_coverage_proved": False,
+            "representative_streaming_coverage_proved": False,
+            "family_promotion_allowed": False,
+            "suppression_allowed": False,
+        },
+        "next_gate": (
+            "manual_visual_and_representative_race_streaming_qualification"
+            if not failures
+            else "resolve_reported_batch_failures"
+        ),
+        "safety": {
+            "xenos_authority_preserved": True,
+            "guest_state_changed": False,
+            "save_files_changed": False,
+            "family_promotion_allowed": False,
+            "suppression_allowed": False,
+        },
+    }
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--track", required=True, type=pathlib.Path)
+    parser.add_argument("--static-world", required=True, type=pathlib.Path)
+    parser.add_argument("--classification", required=True, type=pathlib.Path)
+    parser.add_argument("--workset", required=True, type=pathlib.Path)
+    parser.add_argument("--output", required=True, type=pathlib.Path)
+    args = parser.parse_args(argv)
+    try:
+        document = build(
+            {
+                "track": read_document(args.track),
+                "static_world": read_document(args.static_world),
+                "classification": read_document(args.classification),
+                "workset": read_document(args.workset),
+            }
+        )
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(
+            json.dumps(document, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        if document["status"] != "complete":
+            raise ValueError("; ".join(document["failures"]))
+        return 0
+    except (OSError, ValueError, json.JSONDecodeError) as error:
+        print(f"native renderer C1/C2 batch failed: {error}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/tests/test_native_renderer_c1_c2_batch.py
+++ b/tools/tests/test_native_renderer_c1_c2_batch.py
@@ -1,0 +1,152 @@
+import copy
+import importlib.util
+import pathlib
+import unittest
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+TOOL = ROOT / "tools/summarize-native-renderer-c1-c2-batch.py"
+SPEC = importlib.util.spec_from_file_location(
+    "summarize_native_renderer_c1_c2_batch", TOOL
+)
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+def fixture():
+    passive_safety = {
+        "guest_state_changed": False,
+        "native_admission": False,
+        "native_draw": False,
+        "suppression_allowed": False,
+        "xenos_authority": True,
+    }
+    return {
+        "track": {
+            "schema": MODULE.INPUT_SCHEMAS["track"],
+            "session": "session-1",
+            "status": "complete",
+            "failures": [],
+            "evidence": {"session_exit_proved": True},
+            "qualification": {
+                "track_render_model_scope_to_submission_proved": True,
+                "track_world_resource_graph_identity_proved": True,
+                "track_world_resource_to_submission_identity_proved": True,
+            },
+            "safety": passive_safety,
+        },
+        "static_world": {
+            "schema": MODULE.INPUT_SCHEMAS["static_world"],
+            "session": "session-1",
+            "status": "complete",
+            "failures": [],
+            "evidence": {"session_exit_proved": True},
+            "qualification": {
+                "simple_model_renderer_scope_proved": True,
+                "simple_model_resource_lifetime_proved": True,
+                "payload_generation_invalidation_proved": True,
+                "simple_mesh_to_prepared_draw_proved": True,
+                "model_presentation_transform_to_prepared_draw_proved": True,
+                "hashed_asset_identity_to_prepared_draw_proved": True,
+                "complete_vertex_layout_to_prepared_draw_proved": True,
+                "static_world_pm4_to_prepared_draw_proved": True,
+            },
+            "safety": passive_safety,
+        },
+        "classification": {
+            "schema": MODULE.INPUT_SCHEMAS["classification"],
+            "session": "session-1",
+            "status": "complete",
+            "failures": [],
+            "qualification": {
+                "runtime_transform_join_proved": True,
+                "building_or_prop_instance_identity_proved": True,
+            },
+            "safety": {
+                "guest_state_changed": False,
+                "source_files_changed": False,
+                "plaintext_identity_exported": False,
+                "xenos_draw": "preserved",
+                "native_admission": False,
+                "native_draw": False,
+                "suppression_allowed": False,
+            },
+        },
+        "workset": {
+            "schema": MODULE.INPUT_SCHEMAS["workset"],
+            "session": "session-1",
+            "status": "complete",
+            "failures": [],
+            "evidence": {"session_exit_proved": True},
+            "qualification": {
+                "continuous_multi_draw_workset_proved": True,
+                "swap_committed_freshness_proved": True,
+                "clean_xenos_fallback_proved": True,
+                "track_world_selection_proved": True,
+                "static_world_selection_proved": True,
+            },
+            "safety": {
+                "readback": False,
+                "xenos_draw_preserved": True,
+                "output_authority": "renderer_selector",
+                "suppression_allowed": False,
+            },
+        },
+    }
+
+
+class NativeRendererC1C2BatchTests(unittest.TestCase):
+    def test_qualifies_one_clean_exact_session(self):
+        document = MODULE.build(fixture())
+        self.assertEqual("complete", document["status"])
+        self.assertTrue(
+            document["qualification"]["c1_exact_track_world_output_proved"]
+        )
+        self.assertTrue(
+            document["qualification"][
+                "c2_exact_classified_static_world_output_proved"
+            ]
+        )
+        self.assertFalse(
+            document["qualification"]["manual_visual_acceptance_proved"]
+        )
+        self.assertFalse(document["qualification"]["suppression_allowed"])
+
+    def test_rejects_cross_session_evidence(self):
+        reports = fixture()
+        reports["workset"]["session"] = "session-2"
+        with self.assertRaisesRegex(ValueError, "one exact session"):
+            MODULE.build(reports)
+
+    def test_rejects_checkpoint_only_evidence(self):
+        reports = fixture()
+        reports["workset"]["status"] = "checkpoint_complete"
+        reports["workset"]["evidence"]["session_exit_proved"] = False
+        document = MODULE.build(reports)
+        self.assertEqual("incomplete", document["status"])
+        self.assertIn(
+            "workset report does not prove session exit", document["failures"]
+        )
+
+    def test_reports_missing_shared_track_world_identity(self):
+        reports = fixture()
+        reports["track"]["qualification"][
+            "track_world_resource_to_submission_identity_proved"
+        ] = False
+        document = MODULE.build(reports)
+        self.assertEqual("incomplete", document["status"])
+        self.assertIn(
+            "track gate is unproved: "
+            "track_world_resource_to_submission_identity_proved",
+            document["failures"],
+        )
+
+    def test_rejects_safety_drift(self):
+        reports = copy.deepcopy(fixture())
+        reports["static_world"]["safety"]["native_draw"] = True
+        with self.assertRaisesRegex(ValueError, "safety boundary drifted"):
+            MODULE.build(reports)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add one strict payload-free gate for the combined C1/C2 AppData run
- require track ownership, static-world lineage, category classification, and continuous output from the same clean final session
- reject checkpoint-only, cross-session, incomplete, or safety-drifted evidence
- keep visual acceptance, race/streaming coverage, promotion, and suppression explicitly pending

## Validation
- python -m unittest discover -s tools/tests -p test_*.py (593 passed)
- batch-gate CLI help/argument contract