### PR TITLE
feat(native-renderer): classify semantic world families

### DIFF
--- a/docs/native-renderer/REPRIORITIZED_PLAN.md
+++ b/docs/native-renderer/REPRIORITIZED_PLAN.md
@@ -486,6 +486,14 @@ Runtime and visual proof is batched with the pending C1/C2 AppData run.
 - Preserve query and guest-visible behavior independently from visual culling.
 - Prove material reductions in draw count and submission time.
 
+Implementation checkpoint: the bounded visibility-to-prepared candidate table
+now preserves independent exact C1 track-world and C2 static-world family tags.
+Its payload-free report reconciles generic static origins and the stricter
+presentation/resource/mesh/transform-qualified subset before any production
+batch, native culling, or native LOD policy is enabled. Runtime qualification is
+batched with the pending representative C1/C2 AppData session; Xenos remains
+authoritative and suppression stays disabled.
+
 ### C4. Player and traffic vehicles
 
 - Resume vehicle work from the documented rejected paths rather than repeating

--- a/docs/native-renderer/VISIBILITY_PREPARED_CANDIDATES.md
+++ b/docs/native-renderer/VISIBILITY_PREPARED_CANDIDATES.md
@@ -34,7 +34,10 @@ superset.
 Fresh candidates are aggregated in a fixed 4,096-entry table keyed by exact
 semantic identity plus immutable prepared template, geometry-resource, texture-
 resource, prepared-signature, visibility-category, result-mask, and title-LOD
-identities. A record without an observed title LOD remains a distinct candidate
+identities. The key also preserves the independently proved C2 static-world
+origin and exact-lineage bits, so generic procedural candidates cannot merge
+with presentation/resource/mesh/transform-qualified static-world candidates.
+A record without an observed title LOD remains a distinct candidate
 with `title_lod_valid=false`; zero is never inferred to be a valid LOD.
 The exact prepared signature prevents a resource family from merging a
 replayable draw with a resolved-input or otherwise mechanically ineligible
@@ -48,6 +51,9 @@ variant. The runtime records:
   eligibility;
 - title-LOD-bearing candidate entries and draws, reconciled with the exact
   visibility-record workset lineage;
+- exact C1 track render-model/world-resource identity and exact C2 static-world
+  origin/lineage partitions, with the latter constrained to be a subset of the
+  former static-world origin population;
 - the complete isolated-draw mechanical rejection mask for every ineligible
   entry, preserving simultaneous failures instead of reporting only the first;
 - table occupancy, overflow, and complete partition accounting.
@@ -78,7 +84,8 @@ python tools/summarize-native-renderer-visibility-prepared-candidates.py `
 Qualification requires exact accounting, at least one fresh prepared
 candidate, zero future decisions, and zero table overflow. Stale, rejected, and
 missing observations remain measured exclusions and never enter the candidate
-table.
+table. The report exposes C1 and C2 lineage proof independently; neither proof
+enables semantic batching, culling, native LOD selection, or suppression.
 
 ## Safety boundary
 

--- a/src/native_renderer/graphics_hooks.cpp
+++ b/src/native_renderer/graphics_hooks.cpp
@@ -659,6 +659,8 @@ struct SemanticVisibilityPreparedCandidateEntry {
   uint32_t track_render_shared_identity_mask = 0;
   uint32_t track_world_resource_identity_mask = 0;
   uint32_t track_world_resource_shared_identity_mask = 0;
+  bool static_world_origin = false;
+  bool static_world_exact = false;
 };
 
 struct SemanticBatchRun {
@@ -17182,7 +17184,8 @@ bool RecordSemanticVisibilityPreparedCandidate(
     const rex::system::GraphicsDrawObservation &observation,
     const SemanticDrawIdentity &identity,
     const SemanticPreparedDrawContract &contract,
-    uint64_t prepared_signature, uint32_t mechanical_rejection_mask) {
+    uint64_t prepared_signature, uint32_t mechanical_rejection_mask,
+    bool static_world_origin, bool static_world_exact) {
   ++g_semantic_visibility_prepared_observations;
   if (identity.visibility_workset_join ==
       SemanticVisibilityWorksetJoin::kMissing) {
@@ -17224,6 +17227,7 @@ bool RecordSemanticVisibilityPreparedCandidate(
         uint64_t(identity.track_render_shared_identity_mask),
         uint64_t(identity.track_world_resource_identity_mask),
         uint64_t(identity.track_world_resource_shared_identity_mask),
+        uint64_t(static_world_origin), uint64_t(static_world_exact),
         uint64_t(mechanical_rejection_mask)}) {
     key = HashCombine(key, value);
   }
@@ -17267,6 +17271,8 @@ bool RecordSemanticVisibilityPreparedCandidate(
               identity.track_world_resource_identity_mask,
           .track_world_resource_shared_identity_mask =
               identity.track_world_resource_shared_identity_mask,
+          .static_world_origin = static_world_origin,
+          .static_world_exact = static_world_exact,
       };
       ++g_semantic_visibility_prepared_candidate_count;
       return true;
@@ -17297,7 +17303,9 @@ bool RecordSemanticVisibilityPreparedCandidate(
         entry.track_world_resource_identity_mask ==
             identity.track_world_resource_identity_mask &&
         entry.track_world_resource_shared_identity_mask ==
-            identity.track_world_resource_shared_identity_mask) {
+            identity.track_world_resource_shared_identity_mask &&
+        entry.static_world_origin == static_world_origin &&
+        entry.static_world_exact == static_world_exact) {
       ++entry.draws;
       entry.last_frame = observation.frame_sequence;
       entry.maximum_policy_age_frames =
@@ -17348,7 +17356,9 @@ SemanticVisibilityPreparedAdmission RecordSemanticBatchOpportunity(
   const bool fresh_visibility_candidate =
       RecordSemanticVisibilityPreparedCandidate(observation, identity,
                                                 contract, prepared_signature,
-                                                 mechanical_rejection_mask);
+                                                mechanical_rejection_mask,
+                                                static_world_origin,
+                                                static_world_exact);
   const SemanticVisibilityPreparedAdmission visibility_admission = {
       .fresh = fresh_visibility_candidate,
       .title_lod_valid = fresh_visibility_candidate && identity.title_lod_valid,
@@ -18827,6 +18837,10 @@ void EmitSemanticVisibilityPreparedCandidates() {
   uint64_t track_world_resource_identity_entries = 0;
   uint64_t track_world_resource_shared_identity_draws = 0;
   uint64_t track_world_resource_shared_identity_entries = 0;
+  uint64_t static_world_origin_draws = 0;
+  uint64_t static_world_origin_entries = 0;
+  uint64_t static_world_exact_draws = 0;
+  uint64_t static_world_exact_entries = 0;
   for (const SemanticVisibilityPreparedCandidateEntry &entry :
        g_semantic_visibility_prepared_candidates) {
     if (!entry.key) {
@@ -18864,6 +18878,14 @@ void EmitSemanticVisibilityPreparedCandidates() {
     if (entry.track_world_resource_shared_identity_mask) {
       track_world_resource_shared_identity_draws += entry.draws;
       ++track_world_resource_shared_identity_entries;
+    }
+    if (entry.static_world_origin) {
+      static_world_origin_draws += entry.draws;
+      ++static_world_origin_entries;
+    }
+    if (entry.static_world_exact) {
+      static_world_exact_draws += entry.draws;
+      ++static_world_exact_entries;
     }
     pinyon_shift::diagnostics::RecordEvent(
         "native_renderer.discovery.semantic_visibility_prepared_candidate_entry",
@@ -18912,6 +18934,12 @@ void EmitSemanticVisibilityPreparedCandidates() {
                       entry.track_world_resource_shared_identity_mask)},
          {"track_world_resource_lineage",
           "host_mapped_direct_vtable_identity_from_exact_model_graph"},
+         {"static_world_origin",
+          entry.static_world_origin ? "true" : "false"},
+         {"static_world_exact",
+          entry.static_world_exact ? "true" : "false"},
+         {"static_world_lineage",
+          "exact_presentation_resource_mesh_transform_lineage"},
          {"draws", std::to_string(entry.draws)},
          {"first_frame", std::to_string(entry.first_frame)},
          {"last_frame", std::to_string(entry.last_frame)},
@@ -18964,7 +18992,11 @@ void EmitSemanticVisibilityPreparedCandidates() {
       track_world_resource_shared_identity_draws <=
           track_world_resource_identity_draws &&
       track_world_resource_shared_identity_entries <=
-          track_world_resource_identity_entries;
+          track_world_resource_identity_entries &&
+      static_world_origin_draws <= entry_draws &&
+      static_world_origin_entries <= entry_count &&
+      static_world_exact_draws <= static_world_origin_draws &&
+      static_world_exact_entries <= static_world_origin_entries;
   pinyon_shift::diagnostics::RecordEvent(
       "native_renderer.discovery.semantic_visibility_prepared_candidate_summary",
       {{"status", !g_semantic_visibility_prepared_observations
@@ -19018,6 +19050,14 @@ void EmitSemanticVisibilityPreparedCandidates() {
         std::to_string(track_world_resource_shared_identity_entries)},
        {"track_world_resource_shared_identity_draws",
         std::to_string(track_world_resource_shared_identity_draws)},
+       {"static_world_origin_entries",
+        std::to_string(static_world_origin_entries)},
+       {"static_world_origin_draws",
+        std::to_string(static_world_origin_draws)},
+       {"static_world_exact_entries",
+        std::to_string(static_world_exact_entries)},
+       {"static_world_exact_draws",
+        std::to_string(static_world_exact_draws)},
        {"capacity",
         std::to_string(kSemanticVisibilityPreparedCandidateCapacity)},
        {"overflow",
@@ -19035,6 +19075,8 @@ void EmitSemanticVisibilityPreparedCandidates() {
         "exact_unified_instance_model_nested_dispatch_scope"},
        {"track_world_resource_lineage",
         "host_mapped_direct_vtable_identity_from_exact_model_graph"},
+       {"static_world_lineage",
+        "exact_presentation_resource_mesh_transform_lineage"},
        {"guest_state_changed", "false"},
        {"control_flow_changed", "false"},
        {"native_upload", "false"},
@@ -23876,6 +23918,8 @@ void InstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system,
        {"selection", "independent_visibility_selected_and_fresh"},
        {"prepared_lineage", "exact_semantic_pm4_prepared_draw"},
        {"title_lod_lineage", "exact_visibility_identity_to_prepared_draw"},
+       {"static_world_lineage",
+        "exact_presentation_resource_mesh_transform_lineage"},
        {"mechanical_admission_contract", "isolated_draw_v1"},
        {"guest_state_changed", "false"},
        {"control_flow_changed", "false"},

--- a/tools/discover-native-renderer-dispatch.py
+++ b/tools/discover-native-renderer-dispatch.py
@@ -1628,6 +1628,9 @@ def procedural_model_receiver_lifecycle(
             "selection": "independent_visibility_selected_and_fresh",
             "prepared_lineage": "exact_semantic_pm4_prepared_draw",
             "title_lod_lineage": "exact_visibility_identity_to_prepared_draw",
+            "static_world_lineage": (
+                "exact_presentation_resource_mesh_transform_lineage"
+            ),
             "title_lod_capture_gate": "optional_exact_observation_startup_gate",
             "mechanical_admission_contract": "isolated_draw_v1",
             "guest_state_changed": False,

--- a/tools/summarize-native-renderer-visibility-prepared-candidates.py
+++ b/tools/summarize-native-renderer-visibility-prepared-candidates.py
@@ -7,7 +7,7 @@ import pathlib
 import sys
 
 
-SCHEMA = "pinyon-shift.native-renderer-visibility-prepared-candidates.v8"
+SCHEMA = "pinyon-shift.native-renderer-visibility-prepared-candidates.v9"
 STATIC_SCHEMA = "pinyon-shift.native-renderer-dispatch-static.v3"
 CONFIG = (
     "native_renderer.discovery."
@@ -112,6 +112,9 @@ def static_contract(document):
         "selection": "independent_visibility_selected_and_fresh",
         "prepared_lineage": "exact_semantic_pm4_prepared_draw",
         "title_lod_lineage": "exact_visibility_identity_to_prepared_draw",
+        "static_world_lineage": (
+            "exact_presentation_resource_mesh_transform_lineage"
+        ),
         "mechanical_admission_contract": "isolated_draw_v1",
         "guest_state_changed": False,
         "control_flow_changed": False,
@@ -157,6 +160,9 @@ def build(events, static, requested_session=None):
         "selection": "independent_visibility_selected_and_fresh",
         "prepared_lineage": "exact_semantic_pm4_prepared_draw",
         "title_lod_lineage": "exact_visibility_identity_to_prepared_draw",
+        "static_world_lineage": (
+            "exact_presentation_resource_mesh_transform_lineage"
+        ),
         "mechanical_admission_contract": "isolated_draw_v1",
         "guest_state_changed": "false",
         "control_flow_changed": "false",
@@ -184,6 +190,8 @@ def build(events, static, requested_session=None):
         != "exact_unified_instance_model_nested_dispatch_scope"
         or summary.get("track_world_resource_lineage")
         != "host_mapped_direct_vtable_identity_from_exact_model_graph"
+        or summary.get("static_world_lineage")
+        != "exact_presentation_resource_mesh_transform_lineage"
         or summary.get("mechanical_admission_contract") != "isolated_draw_v1"
     ):
         raise ValueError("prepared-candidate summary is incomplete")
@@ -214,6 +222,10 @@ def build(events, static, requested_session=None):
         "track_world_resource_identity_draws",
         "track_world_resource_shared_identity_entries",
         "track_world_resource_shared_identity_draws",
+        "static_world_origin_entries",
+        "static_world_origin_draws",
+        "static_world_exact_entries",
+        "static_world_exact_draws",
         "capacity",
         "overflow",
         "policy_age_limit_frames",
@@ -282,6 +294,8 @@ def build(events, static, requested_session=None):
             ),
             16,
         )
+        item["static_world_origin"] = event.get("static_world_origin") == "true"
+        item["static_world_exact"] = event.get("static_world_exact") == "true"
         item["mechanical_rejections"] = [
             name
             for bit, name in MECHANICAL_REJECTIONS.items()
@@ -312,6 +326,11 @@ def build(events, static, requested_session=None):
             != "exact_unified_instance_model_nested_dispatch_scope"
             or event.get("track_world_resource_lineage")
             != "host_mapped_direct_vtable_identity_from_exact_model_graph"
+            or event.get("static_world_origin") not in ("true", "false")
+            or event.get("static_world_exact") not in ("true", "false")
+            or event.get("static_world_lineage")
+            != "exact_presentation_resource_mesh_transform_lineage"
+            or (item["static_world_exact"] and not item["static_world_origin"])
             or (
                 item["track_render_shared_identity_mask"]
                 and not item["track_render_model_scope"]
@@ -442,6 +461,30 @@ def build(events, static, requested_session=None):
         != sum(entry["draws"] for entry in shared_world_resource_entries)
     ):
         failures.append("track world-resource shared-identity totals drifted")
+    exact_track_world_entries = [
+        entry
+        for entry in entries
+        if entry["track_render_model_scope"]
+        and entry["track_world_resource_shared_identity_mask"]
+    ]
+    static_world_origin_entries = [
+        entry for entry in entries if entry["static_world_origin"]
+    ]
+    if (
+        totals["static_world_origin_entries"] != len(static_world_origin_entries)
+        or totals["static_world_origin_draws"]
+        != sum(entry["draws"] for entry in static_world_origin_entries)
+    ):
+        failures.append("static-world origin totals drifted")
+    static_world_exact_entries = [
+        entry for entry in entries if entry["static_world_exact"]
+    ]
+    if (
+        totals["static_world_exact_entries"] != len(static_world_exact_entries)
+        or totals["static_world_exact_draws"]
+        != sum(entry["draws"] for entry in static_world_exact_entries)
+    ):
+        failures.append("exact static-world totals drifted")
     if totals["capacity"] != 4096 or totals["policy_age_limit_frames"] != 1:
         failures.append("prepared-candidate bounds drifted")
     if totals["selected_joins"] > integer(workset, "selected_joins"):
@@ -479,6 +522,15 @@ def build(events, static, requested_session=None):
             ),
             "track_world_resource_shared_identity_proved": (
                 not failures and bool(shared_world_resource_entries)
+            ),
+            "track_world_exact_lineage_proved": (
+                not failures and bool(exact_track_world_entries)
+            ),
+            "static_world_origin_lineage_proved": (
+                not failures and bool(static_world_origin_entries)
+            ),
+            "static_world_exact_lineage_proved": (
+                not failures and bool(static_world_exact_entries)
             ),
             "native_draw_enabled": False,
             "suppression_allowed": False,

--- a/tools/tests/test_native_renderer_dispatch_discovery.py
+++ b/tools/tests/test_native_renderer_dispatch_discovery.py
@@ -1423,6 +1423,10 @@ class NativeRendererDispatchDiscoveryTests(unittest.TestCase):
             prepared_candidates["title_lod_lineage"],
         )
         self.assertEqual(
+            "exact_presentation_resource_mesh_transform_lineage",
+            prepared_candidates["static_world_lineage"],
+        )
+        self.assertEqual(
             "isolated_draw_v1",
             prepared_candidates["mechanical_admission_contract"],
         )

--- a/tools/tests/test_native_renderer_visibility_prepared_candidates.py
+++ b/tools/tests/test_native_renderer_visibility_prepared_candidates.py
@@ -25,6 +25,9 @@ class VisibilityPreparedCandidateReportTests(unittest.TestCase):
                     "selection": "independent_visibility_selected_and_fresh",
                     "prepared_lineage": "exact_semantic_pm4_prepared_draw",
                     "title_lod_lineage": "exact_visibility_identity_to_prepared_draw",
+                    "static_world_lineage": (
+                        "exact_presentation_resource_mesh_transform_lineage"
+                    ),
                     "mechanical_admission_contract": "isolated_draw_v1",
                     "guest_state_changed": False,
                     "control_flow_changed": False,
@@ -61,6 +64,9 @@ class VisibilityPreparedCandidateReportTests(unittest.TestCase):
             "selection": "independent_visibility_selected_and_fresh",
             "prepared_lineage": "exact_semantic_pm4_prepared_draw",
             "title_lod_lineage": "exact_visibility_identity_to_prepared_draw",
+            "static_world_lineage": (
+                "exact_presentation_resource_mesh_transform_lineage"
+            ),
             "mechanical_admission_contract": "isolated_draw_v1",
             **self.safety(),
         }
@@ -98,6 +104,11 @@ class VisibilityPreparedCandidateReportTests(unittest.TestCase):
             "track_world_resource_shared_identity_mask": "00000002",
             "track_world_resource_lineage": (
                 "host_mapped_direct_vtable_identity_from_exact_model_graph"
+            ),
+            "static_world_origin": "true",
+            "static_world_exact": "true",
+            "static_world_lineage": (
+                "exact_presentation_resource_mesh_transform_lineage"
             ),
             "draws": "7",
             "first_frame": "10",
@@ -140,6 +151,10 @@ class VisibilityPreparedCandidateReportTests(unittest.TestCase):
             "track_world_resource_identity_draws": "7",
             "track_world_resource_shared_identity_entries": "1",
             "track_world_resource_shared_identity_draws": "7",
+            "static_world_origin_entries": "1",
+            "static_world_origin_draws": "7",
+            "static_world_exact_entries": "1",
+            "static_world_exact_draws": "7",
             "capacity": "4096",
             "overflow": "0",
             "policy_age_limit_frames": "1",
@@ -156,6 +171,9 @@ class VisibilityPreparedCandidateReportTests(unittest.TestCase):
             ),
             "track_world_resource_lineage": (
                 "host_mapped_direct_vtable_identity_from_exact_model_graph"
+            ),
+            "static_world_lineage": (
+                "exact_presentation_resource_mesh_transform_lineage"
             ),
             **self.safety(),
         }
@@ -199,6 +217,15 @@ class VisibilityPreparedCandidateReportTests(unittest.TestCase):
             document["qualification"][
                 "track_world_resource_shared_identity_proved"
             ]
+        )
+        self.assertTrue(
+            document["qualification"]["track_world_exact_lineage_proved"]
+        )
+        self.assertTrue(
+            document["qualification"]["static_world_origin_lineage_proved"]
+        )
+        self.assertTrue(
+            document["qualification"]["static_world_exact_lineage_proved"]
         )
 
     def test_build_accepts_candidate_without_title_lod(self):
@@ -266,6 +293,32 @@ class VisibilityPreparedCandidateReportTests(unittest.TestCase):
         self.assertFalse(
             document["qualification"]["track_render_shared_identity_proved"]
         )
+
+    def test_build_accepts_non_static_world_partition(self):
+        events = copy.deepcopy(self.events())
+        entry = next(event for event in events if event["event"] == MODULE.ENTRY)
+        entry["static_world_origin"] = "false"
+        entry["static_world_exact"] = "false"
+        summary = next(event for event in events if event["event"] == MODULE.SUMMARY)
+        summary["static_world_origin_entries"] = "0"
+        summary["static_world_origin_draws"] = "0"
+        summary["static_world_exact_entries"] = "0"
+        summary["static_world_exact_draws"] = "0"
+        document = MODULE.build(events, self.static())
+        self.assertEqual("complete", document["status"])
+        self.assertFalse(
+            document["qualification"]["static_world_origin_lineage_proved"]
+        )
+        self.assertFalse(
+            document["qualification"]["static_world_exact_lineage_proved"]
+        )
+
+    def test_build_rejects_exact_static_world_without_origin(self):
+        events = copy.deepcopy(self.events())
+        entry = next(event for event in events if event["event"] == MODULE.ENTRY)
+        entry["static_world_origin"] = "false"
+        with self.assertRaisesRegex(ValueError, "entry evidence drifted"):
+            MODULE.build(events, self.static())
 
     def test_build_rejects_eligibility_mask_drift(self):
         events = copy.deepcopy(self.events())


### PR DESCRIPTION
## Summary
- retain exact C1 track-world and C2 static-world lineage in the bounded semantic prepared-candidate census
- reconcile static origin and stricter exact-lineage partitions with fail-closed report validation
- document the first C3 semantic-workset checkpoint while preserving Xenos authority

## Validation
- python -m unittest discover -s tools/tests (595 tests)
- compile CMakeFiles/pinyon_shift.dir/src/native_renderer/graphics_hooks.cpp.obj
- git diff --check

Full link and AppData qualification remain batched with the next representative C1/C2 checkpoint.