### PR TITLE
feat(native-renderer): partition semantic batches by LOD

### DIFF
--- a/docs/native-renderer/REPRIORITIZED_PLAN.md
+++ b/docs/native-renderer/REPRIORITIZED_PLAN.md
@@ -501,6 +501,13 @@ their GPU resources match. The report exposes family-local multi-draw evidence
 without admitting an executor; runtime qualification remains in the same
 deferred C1/C2 session.
 
+LOD-safety checkpoint: exact title-LOD validity and the normalized title index
+are now also part of the semantic batch key. Missing observations collapse only
+to `(false, 0)`, while different proved LODs can never share a run. Family-local
+LOD opportunity signals remain measurement-only; independent native LOD
+selection is still disabled until the batched runtime evidence proves this
+passthrough boundary.
+
 ### C4. Player and traffic vehicles
 
 - Resume vehicle work from the documented rejected paths rather than repeating

--- a/docs/native-renderer/SEMANTIC_BATCH_ADMISSION.md
+++ b/docs/native-renderer/SEMANTIC_BATCH_ADMISSION.md
@@ -15,6 +15,8 @@ One opportunity key combines:
 - the title's primary and optional secondary resource keys;
 - a bounded world-family mask that independently marks exact C1 track-world
   and exact C2 static-world lineage; and
+- the title's exact observed LOD-valid bit and normalized index, with every
+  missing observation represented by the single `(false, 0)` identity; and
 - the fail-closed eligibility result.
 
 The title resource keys travel with the already-proved semantic submission
@@ -25,8 +27,9 @@ An executable run exists only while eligible draws with the same exact key are
 adjacent in one frame. A frame boundary, rejected draw, or key transition
 closes the run. Because the world-family mask is part of the key, a generic
 procedural draw cannot extend an exact track/static run even when every GPU
-resource happens to match. The census performs no front-to-back or material
-reordering.
+resource happens to match. Exact title LOD is also part of the key, so two
+otherwise identical draws from different title-selected LODs cannot be merged.
+The census performs no front-to-back or material reordering.
 
 ## Admission boundary
 
@@ -56,7 +59,9 @@ and whether consecutive draws switch semantic instances or repeat the same
 instance. The summary additionally records per-frame density and template,
 geometry, texture, and title-resource transitions. Exact C1 and C2 group,
 draw, and multi-draw-run totals are reconciled independently; they remain
-measurement-only until runtime evidence proves a useful opportunity.
+measurement-only until runtime evidence proves a useful opportunity. The same
+accounting separately measures title-LOD-bearing groups and family-local LOD
+multi-draw opportunities.
 
 Projected command count is conservative:
 
@@ -81,7 +86,7 @@ python tools/summarize-native-renderer-semantic-batches.py `
   --output <semantic-batch-admission.json>
 ```
 
-Schema `pinyon-shift.native-renderer-semantic-batch-admission.v4` requires:
+Schema `pinyon-shift.native-renderer-semantic-batch-admission.v5` requires:
 
 - one armed provenance configuration and one batch summary;
 - exact equality with the prepared semantic-contract call count;
@@ -89,6 +94,8 @@ Schema `pinyon-shift.native-renderer-semantic-batch-admission.v4` requires:
 - entry, run, rejection, projected-command, and reduction accounting to
   reconcile exactly;
 - exact world-family partitions to reconcile to the tagged opportunity groups;
+- exact title-LOD partitions to reconcile, with indices below 32 and all
+  missing observations normalized to zero;
 - explicit Xenos authority with native execution and suppression disabled.
 
 `conservative_batch_plan_proved` also requires at least one eligible draw, one
@@ -99,6 +106,11 @@ the plan unproved and does not change runtime rendering.
 `static_world_batch_opportunity_proved` are stricter family-local signals. Each
 requires an eligible tagged group with a multi-draw run; neither signal admits
 an executor, culling, LOD selection, publication, or suppression.
+
+The title-LOD variants additionally require the family-local run to carry an
+exact title observation. This proves only that later native batching can retain
+the title's already-selected LOD; it does not yet authorize an independent LOD
+choice.
 
 ## Qualification result
 

--- a/src/native_renderer/graphics_hooks.cpp
+++ b/src/native_renderer/graphics_hooks.cpp
@@ -628,8 +628,10 @@ struct SemanticBatchOpportunityEntry {
   uint32_t primary_resource_key = 0;
   uint32_t secondary_resource_key = 0;
   uint32_t world_family_mask = 0;
+  uint32_t title_lod_index = 0;
   SemanticBatchRejection rejection = SemanticBatchRejection::kNone;
   bool secondary_resource_present = false;
+  bool title_lod_valid = false;
 };
 
 constexpr uint32_t kSemanticWorldFamilyTrack = 1u << 0;
@@ -5833,6 +5835,8 @@ void ConfigureTitleDrawProvenance(bool requested,
         "exact_consecutive_opaque_prepared_draw_order"},
        {"semantic_batch_world_family_partition",
         "none_or_exact_track_or_exact_static_or_both"},
+       {"semantic_batch_lod_partition",
+        "exact_title_observation_or_missing"},
        {"semantic_batch_equivalence_ladder",
         "mesh_material,material,pipeline"},
        {"semantic_batch_pipeline_identity",
@@ -16859,7 +16863,10 @@ size_t FindOrCreateSemanticBatchOpportunity(
       entry.primary_resource_key = identity.primary_resource_key;
       entry.secondary_resource_key = identity.secondary_resource_key;
       entry.world_family_mask = world_family_mask;
+      entry.title_lod_index =
+          identity.title_lod_valid ? identity.title_lod_index : 0;
       entry.secondary_resource_present = identity.secondary_resource_present;
+      entry.title_lod_valid = identity.title_lod_valid;
       entry.rejection = rejection;
       ++g_semantic_batch_opportunity_count;
       return index;
@@ -16872,6 +16879,9 @@ size_t FindOrCreateSemanticBatchOpportunity(
         entry.secondary_resource_present ==
             identity.secondary_resource_present &&
         entry.world_family_mask == world_family_mask &&
+        entry.title_lod_index ==
+            (identity.title_lod_valid ? identity.title_lod_index : 0) &&
+        entry.title_lod_valid == identity.title_lod_valid &&
         entry.rejection == rejection) {
       return index;
     }
@@ -17235,7 +17245,7 @@ bool RecordSemanticVisibilityPreparedCandidate(
         uint64_t(identity.visibility_category),
         uint64_t(identity.visibility_result_mask),
         uint64_t(identity.title_lod_valid),
-        uint64_t(identity.title_lod_index),
+        uint64_t(identity.title_lod_valid ? identity.title_lod_index : 0),
         uint64_t(identity.primary_resource_key),
         uint64_t(identity.secondary_resource_present),
         uint64_t(identity.secondary_resource_key),
@@ -17421,6 +17431,8 @@ SemanticVisibilityPreparedAdmission RecordSemanticBatchOpportunity(
         contract.texture_resource_hash, uint64_t(identity.primary_resource_key),
         uint64_t(identity.secondary_resource_present),
         uint64_t(identity.secondary_resource_key), uint64_t(world_family_mask),
+        uint64_t(identity.title_lod_valid),
+        uint64_t(identity.title_lod_index),
         uint64_t(rejection)}) {
     key = HashCombine(key, value);
   }
@@ -19141,6 +19153,9 @@ void EmitSemanticBatchOpportunitySummary() {
   uint64_t static_world_entries = 0;
   uint64_t static_world_draws = 0;
   uint64_t static_world_multi_draw_runs = 0;
+  uint64_t title_lod_entries = 0;
+  uint64_t title_lod_draws = 0;
+  uint64_t title_lod_multi_draw_runs = 0;
   for (uint64_t count : g_semantic_batch_rejections) {
     rejection_total += count;
   }
@@ -19168,6 +19183,11 @@ void EmitSemanticBatchOpportunitySummary() {
       static_world_draws += entry.draws;
       static_world_multi_draw_runs += entry.multi_draw_runs;
     }
+    if (entry.title_lod_valid) {
+      ++title_lod_entries;
+      title_lod_draws += entry.draws;
+      title_lod_multi_draw_runs += entry.multi_draw_runs;
+    }
     pinyon_shift::diagnostics::RecordEvent(
         "native_renderer.discovery.semantic_batch_entry",
         {{"opportunity_key", fmt::format("{:016X}", entry.key)},
@@ -19186,6 +19206,9 @@ void EmitSemanticBatchOpportunitySummary() {
           fmt::format("{:08X}", entry.world_family_mask)},
          {"world_family_partition",
           "none_or_exact_track_or_exact_static_or_both"},
+         {"title_lod_valid", entry.title_lod_valid ? "true" : "false"},
+         {"title_lod_index", std::to_string(entry.title_lod_index)},
+         {"title_lod_partition", "exact_title_observation_or_missing"},
          {"draws", std::to_string(entry.draws)},
          {"frames", std::to_string(entry.frames)},
          {"first_frame", std::to_string(entry.first_frame)},
@@ -19224,7 +19247,9 @@ void EmitSemanticBatchOpportunitySummary() {
       track_world_entries <= g_semantic_batch_opportunity_count &&
       track_world_draws <= g_semantic_batch_observations &&
       static_world_entries <= g_semantic_batch_opportunity_count &&
-      static_world_draws <= g_semantic_batch_observations;
+      static_world_draws <= g_semantic_batch_observations &&
+      title_lod_entries <= g_semantic_batch_opportunity_count &&
+      title_lod_draws <= g_semantic_batch_observations;
   const uint64_t projected_commands =
       g_semantic_batch_consecutive_runs + g_semantic_batch_rejected_draws;
   const uint64_t potential_command_reduction =
@@ -19293,6 +19318,11 @@ void EmitSemanticBatchOpportunitySummary() {
         std::to_string(static_world_multi_draw_runs)},
        {"world_family_partition",
         "none_or_exact_track_or_exact_static_or_both"},
+       {"title_lod_entries", std::to_string(title_lod_entries)},
+       {"title_lod_draws", std::to_string(title_lod_draws)},
+       {"title_lod_multi_draw_runs",
+        std::to_string(title_lod_multi_draw_runs)},
+       {"title_lod_partition", "exact_title_observation_or_missing"},
        {"reject_missing_title_resource",
         std::to_string(g_semantic_batch_rejections[size_t(
             SemanticBatchRejection::kMissingTitleResource)])},

--- a/tools/discover-native-renderer-dispatch.py
+++ b/tools/discover-native-renderer-dispatch.py
@@ -1869,6 +1869,9 @@ def procedural_model_receiver_lifecycle(
             "semantic_batch_world_family_partition": (
                 "none_or_exact_track_or_exact_static_or_both"
             ),
+            "semantic_batch_lod_partition": (
+                "exact_title_observation_or_missing"
+            ),
             "semantic_batch_equivalence_ladder_required": True,
             "semantic_batch_pipeline_identity": (
                 "resource_free_layout_and_prepared_state"

--- a/tools/summarize-native-renderer-semantic-batches.py
+++ b/tools/summarize-native-renderer-semantic-batches.py
@@ -8,7 +8,7 @@ import pathlib
 import sys
 
 
-SCHEMA = "pinyon-shift.native-renderer-semantic-batch-admission.v4"
+SCHEMA = "pinyon-shift.native-renderer-semantic-batch-admission.v5"
 STATIC_SCHEMA = "pinyon-shift.native-renderer-dispatch-static.v3"
 TITLE_CONFIG = "native_renderer.discovery.title_provenance_config"
 TITLE_SUMMARY = "native_renderer.discovery.title_provenance_summary"
@@ -150,6 +150,7 @@ def _validate_static(static: dict) -> dict:
         "semantic_batch_world_family_partition": (
             "none_or_exact_track_or_exact_static_or_both"
         ),
+        "semantic_batch_lod_partition": "exact_title_observation_or_missing",
         "semantic_batch_equivalence_ladder_required": True,
         "semantic_batch_pipeline_identity": (
             "resource_free_layout_and_prepared_state"
@@ -555,6 +556,8 @@ def build(events: list[dict], static: dict, requested: str | None = None) -> dic
         != "disabled_measurement_only"
         or config.get("semantic_batch_world_family_partition")
         != "none_or_exact_track_or_exact_static_or_both"
+        or config.get("semantic_batch_lod_partition")
+        != "exact_title_observation_or_missing"
         or config.get("semantic_batch_equivalence_ladder")
         != "mesh_material,material,pipeline"
         or config.get("semantic_batch_pipeline_identity")
@@ -649,6 +652,8 @@ def build(events: list[dict], static: dict, requested: str | None = None) -> dic
             "world_family_mask": int(
                 _hex(event, "world_family_mask", 8), 16
             ),
+            "title_lod_valid": _boolean(event, "title_lod_valid"),
+            "title_lod_index": _integer(event, "title_lod_index"),
             "draws": _integer(event, "draws"),
             "frames": _integer(event, "frames"),
             "first_frame": _integer(event, "first_frame"),
@@ -672,6 +677,10 @@ def build(events: list[dict], static: dict, requested: str | None = None) -> dic
             or item["world_family_mask"] & ~0x3
             or event.get("world_family_partition")
             != "none_or_exact_track_or_exact_static_or_both"
+            or event.get("title_lod_partition")
+            != "exact_title_observation_or_missing"
+            or (item["title_lod_valid"] and item["title_lod_index"] >= 32)
+            or (not item["title_lod_valid"] and item["title_lod_index"] != 0)
             or any(
                 item[key] < 0
                 for key in (
@@ -747,6 +756,9 @@ def build(events: list[dict], static: dict, requested: str | None = None) -> dic
             "static_world_entries",
             "static_world_draws",
             "static_world_multi_draw_runs",
+            "title_lod_entries",
+            "title_lod_draws",
+            "title_lod_multi_draw_runs",
         )
     }
     totals["potential_command_reduction_percent"] = _number(
@@ -794,6 +806,8 @@ def build(events: list[dict], static: dict, requested: str | None = None) -> dic
         )
         or summary.get("world_family_partition")
         != "none_or_exact_track_or_exact_static_or_both"
+        or summary.get("title_lod_partition")
+        != "exact_title_observation_or_missing"
     ):
         raise ValueError("semantic-batch aggregate accounting failed")
     track_world_groups = [
@@ -815,6 +829,15 @@ def build(events: list[dict], static: dict, requested: str | None = None) -> dic
         != sum(group["multi_draw_runs"] for group in static_world_groups)
     ):
         raise ValueError("semantic world-family partition accounting failed")
+    title_lod_groups = [group for group in entries if group["title_lod_valid"]]
+    if (
+        totals["title_lod_entries"] != len(title_lod_groups)
+        or totals["title_lod_draws"]
+        != sum(group["draws"] for group in title_lod_groups)
+        or totals["title_lod_multi_draw_runs"]
+        != sum(group["multi_draw_runs"] for group in title_lod_groups)
+    ):
+        raise ValueError("semantic title-LOD partition accounting failed")
     expected_percent = (
         100.0 * totals["potential_command_reduction"] / totals["observations"]
     )
@@ -870,6 +893,24 @@ def build(events: list[dict], static: dict, requested: str | None = None) -> dic
         "static_world_batch_opportunity_proved": any(
             group["eligible"] and group["multi_draw_runs"] > 0
             for group in static_world_groups
+        ),
+        "title_lod_batch_opportunity_proved": any(
+            group["eligible"] and group["multi_draw_runs"] > 0
+            for group in title_lod_groups
+        ),
+        "track_world_title_lod_batch_opportunity_proved": any(
+            group["eligible"]
+            and group["multi_draw_runs"] > 0
+            and group["title_lod_valid"]
+            and group["world_family_mask"] & 0x1
+            for group in entries
+        ),
+        "static_world_title_lod_batch_opportunity_proved": any(
+            group["eligible"]
+            and group["multi_draw_runs"] > 0
+            and group["title_lod_valid"]
+            and group["world_family_mask"] & 0x2
+            for group in entries
         ),
         "mesh_material_instancing_opportunity_proved": (
             mesh_material_instancing_opportunity_proved

--- a/tools/tests/test_native_renderer_dispatch_discovery.py
+++ b/tools/tests/test_native_renderer_dispatch_discovery.py
@@ -1530,6 +1530,10 @@ class NativeRendererDispatchDiscoveryTests(unittest.TestCase):
             "none_or_exact_track_or_exact_static_or_both",
             draw_association["semantic_batch_world_family_partition"],
         )
+        self.assertEqual(
+            "exact_title_observation_or_missing",
+            draw_association["semantic_batch_lod_partition"],
+        )
         self.assertFalse(
             draw_association["semantic_batch_execution_enabled"]
         )

--- a/tools/tests/test_native_renderer_semantic_batches.py
+++ b/tools/tests/test_native_renderer_semantic_batches.py
@@ -30,6 +30,9 @@ def static_inventory():
                 "semantic_batch_world_family_partition": (
                     "none_or_exact_track_or_exact_static_or_both"
                 ),
+                "semantic_batch_lod_partition": (
+                    "exact_title_observation_or_missing"
+                ),
                 "semantic_batch_equivalence_ladder_required": True,
                 "semantic_batch_pipeline_identity": (
                     "resource_free_layout_and_prepared_state"
@@ -83,9 +86,13 @@ def events():
         "static_world_entries": "1",
         "static_world_draws": "10",
         "static_world_multi_draw_runs": "2",
+        "title_lod_entries": "1",
+        "title_lod_draws": "10",
+        "title_lod_multi_draw_runs": "2",
         "world_family_partition": (
             "none_or_exact_track_or_exact_static_or_both"
         ),
+        "title_lod_partition": "exact_title_observation_or_missing",
         "accounting_complete": "true",
         "ordering": MODULE.EXPECTED_ORDERING,
         "reordering": "false",
@@ -262,6 +269,9 @@ def events():
             "semantic_batch_world_family_partition": (
                 "none_or_exact_track_or_exact_static_or_both"
             ),
+            "semantic_batch_lod_partition": (
+                "exact_title_observation_or_missing"
+            ),
             "semantic_batch_equivalence_ladder": (
                 "mesh_material,material,pipeline"
             ),
@@ -299,6 +309,9 @@ def events():
             "world_family_partition": (
                 "none_or_exact_track_or_exact_static_or_both"
             ),
+            "title_lod_valid": "true",
+            "title_lod_index": "2",
+            "title_lod_partition": "exact_title_observation_or_missing",
             "draws": "10",
             "frames": "2",
             "first_frame": "20",
@@ -331,6 +344,9 @@ def events():
             "world_family_partition": (
                 "none_or_exact_track_or_exact_static_or_both"
             ),
+            "title_lod_valid": "false",
+            "title_lod_index": "0",
+            "title_lod_partition": "exact_title_observation_or_missing",
             "draws": "2",
             "frames": "1",
             "first_frame": "21",
@@ -367,6 +383,13 @@ class SemanticBatchTests(unittest.TestCase):
         self.assertTrue(document["conservative_batch_plan_proved"])
         self.assertTrue(document["track_world_batch_opportunity_proved"])
         self.assertTrue(document["static_world_batch_opportunity_proved"])
+        self.assertTrue(document["title_lod_batch_opportunity_proved"])
+        self.assertTrue(
+            document["track_world_title_lod_batch_opportunity_proved"]
+        )
+        self.assertTrue(
+            document["static_world_title_lod_batch_opportunity_proved"]
+        )
         self.assertFalse(document["execution_admitted"])
         self.assertEqual(10, document["totals"]["eligible_draws"])
         self.assertEqual(6, document["totals"]["potential_command_reduction"])
@@ -415,6 +438,18 @@ class SemanticBatchTests(unittest.TestCase):
         observed = events()
         observed[-1]["potential_command_reduction"] = "5"
         with self.assertRaisesRegex(ValueError, "aggregate accounting"):
+            MODULE.build(observed, static_inventory())
+
+    def test_rejects_nonzero_index_without_title_lod(self):
+        observed = events()
+        rejected = next(
+            event
+            for event in observed
+            if event.get("event") == MODULE.BATCH_ENTRY
+            and event.get("eligible") == "false"
+        )
+        rejected["title_lod_index"] = "3"
+        with self.assertRaisesRegex(ValueError, "invalid counters"):
             MODULE.build(observed, static_inventory())
 
     def test_requires_static_admission_contract(self):


### PR DESCRIPTION
## Summary
- include exact title-LOD validity and normalized index in conservative semantic batch keys
- prevent otherwise identical draws from different title-selected LODs from sharing a run
- expose reconciled global and C1/C2 family-local title-LOD batching evidence while keeping independent native LOD disabled

## Validation
- python -m unittest discover -s tools/tests (596 tests)
- compile CMakeFiles/pinyon_shift.dir/src/native_renderer/graphics_hooks.cpp.obj
- git diff --check

Full link and AppData qualification remain batched with the next representative C1/C2 checkpoint.