### PR TITLE
feat(native-renderer): correlate vehicle shadow geometry

### DIFF
--- a/docs/native-renderer/REPRIORITIZED_PLAN.md
+++ b/docs/native-renderer/REPRIORITIZED_PLAN.md
@@ -517,6 +517,18 @@ passthrough boundary.
 - Implement player vehicle first, then traffic and exceptional materials.
 - Retain per-item replay fallback until semantic coverage is complete.
 
+Shadow-geometry ingress checkpoint: the already qualified exact 80-draw
+dynamic-vehicle shadow epoch now seeds a bounded, default-off cross-pass
+resource correlation. Geometry is staged during the consecutive epoch and
+committed only after backend confirmation of all 80 draws; interruptions and
+replay failures discard the entire set. Later indexed color draws must share
+either the complete geometry resource set or the exact index buffer plus an
+exact vertex resource. The observer exports only hashes and numeric resource
+identity, captures no guest payload, draws nothing, preserves Xenos authority,
+and cannot suppress. The next batched gameplay run determines whether this
+produces a working player-vehicle color ingress before transform, wheel,
+livery, traffic, and full material contracts are added.
+
 ### C5. Sky, atmosphere, and global lighting
 
 - Replace the qualified sky/global-light families.

--- a/docs/native-renderer/VEHICLE_INSTANCE_SEMANTIC_SEED.md
+++ b/docs/native-renderer/VEHICLE_INSTANCE_SEMANTIC_SEED.md
@@ -429,3 +429,44 @@ python .\tools\inventory-native-renderer-vehicle-vtables.py `
   --generated-root .local\generated\default `
   --output .local\qualification\native-renderer-vehicle-vtables.json
 ```
+
+## Capture-proven shadow geometry ingress
+
+The next C4 route deliberately leaves the exhausted title-object searches
+behind. The independently qualified shadow-depth batch already identifies one
+exact, consecutive 80-draw dynamic-vehicle atlas epoch: 64 primary draws,
+followed by 12 secondary and four tertiary draws in a fixed order. A new
+default-off observer stages only the bounded geometry resource identities of
+those draws. Nothing is promoted until the native backend reports the complete
+80-draw epoch recorded successfully; interruption or replay failure discards
+the entire staging set.
+
+After that boundary, the observer compares ordinary indexed color draws with
+the committed set. It records either an exact full geometry-resource match or
+an exact index-buffer identity plus at least one exact shared vertex resource.
+The resulting prepared signature, pipeline/template hashes, geometry hash, and
+texture hash form a bounded candidate table for the player-vehicle color
+bridge. This is a cross-pass resource correlation, not yet object identity:
+transform, wheel, livery, traffic, and complete material semantics remain open.
+
+The mode captures no guest payload, submits no native color draw, preserves all
+Xenos draws, and cannot suppress anything. Qualify it in a representative
+driving session with:
+
+```powershell
+.\tools\capture-native-renderer-census.ps1 `
+  -StateRoot $stateRoot `
+  -Scene open_world_day `
+  -ShadowDepthBatch `
+  -VehicleShadowGeometryCorrelation `
+  -IsolatedDrawDir .local\qualification\vehicle-shadow-geometry
+
+python .\tools\summarize-native-renderer-vehicle-shadow-geometry.py `
+  $eventLog `
+  --output .local\qualification\native-renderer-vehicle-shadow-geometry.json
+```
+
+The qualifier requires a backend-confirmed full epoch, exact seed and
+correlation accounting, zero table overflow, unchanged Xenos authority, and no
+native draw or suppression. A non-empty correlation set is only a working C4
+color-ingress candidate; it is not native admission.

--- a/src/native_renderer/graphics_hooks.cpp
+++ b/src/native_renderer/graphics_hooks.cpp
@@ -139,6 +139,8 @@ constexpr size_t kVehicleTypedDescriptorCorrelationCapacity = 512;
 constexpr uint32_t kVehicleComposedMatrixHook = 0x8240EB5C;
 constexpr uint32_t kVehicleComposedMatrixCallee = 0x82435E78;
 constexpr size_t kVehicleComposedMatrixCorrelationCapacity = 1024;
+constexpr size_t kVehicleShadowGeometrySeedCapacity = 256;
+constexpr size_t kVehicleShadowGeometryCorrelationCapacity = 1024;
 constexpr size_t kShadowCasterProvenanceSampleCapacity = 4096;
 constexpr uint64_t kShadowCasterMaximumVehicleIdentityAgeFrames = 1;
 constexpr size_t kSemanticInstanceCapacity = 4096;
@@ -591,6 +593,32 @@ struct SemanticPreparedDrawContract {
   bool geometry_bounded = false;
   bool texture_layout_bounded = false;
   bool valid = false;
+};
+
+struct VehicleShadowGeometryIdentity {
+  uint64_t geometry_resource_hash = 0;
+  uint32_t index_buffer_address = 0;
+  uint32_t index_buffer_length = 0;
+  std::array<uint32_t, rex::system::kGraphicsVertexBindingObservationLimit>
+      vertex_addresses{};
+  std::array<uint32_t, rex::system::kGraphicsVertexBindingObservationLimit>
+      vertex_sizes{};
+  uint32_t vertex_binding_count = 0;
+  bool occupied = false;
+};
+
+struct VehicleShadowGeometryCorrelationEntry {
+  uint64_t prepared_signature = 0;
+  uint64_t template_key = 0;
+  uint64_t geometry_resource_hash = 0;
+  uint64_t texture_resource_hash = 0;
+  uint64_t prepared_pipeline_hash = 0;
+  uint64_t draws = 0;
+  uint64_t first_frame = 0;
+  uint64_t last_frame = 0;
+  uint32_t seed_index = 0;
+  bool full_geometry_match = false;
+  bool occupied = false;
 };
 
 enum class SemanticBatchRejection : uint32_t {
@@ -1389,6 +1417,24 @@ uint64_t g_vehicle_composed_matrix_routes_without_identity = 0;
 uint64_t g_vehicle_composed_matrix_tight_matches = 0;
 uint64_t g_vehicle_composed_matrix_correlation_count = 0;
 uint64_t g_vehicle_composed_matrix_correlation_overflow = 0;
+std::array<VehicleShadowGeometryIdentity, kShadowDepthBatchDrawCount>
+    g_vehicle_shadow_geometry_staging{};
+std::array<VehicleShadowGeometryIdentity, kVehicleShadowGeometrySeedCapacity>
+    g_vehicle_shadow_geometry_seeds{};
+std::array<VehicleShadowGeometryCorrelationEntry,
+           kVehicleShadowGeometryCorrelationCapacity>
+    g_vehicle_shadow_geometry_correlations{};
+uint64_t g_vehicle_shadow_geometry_epochs_committed = 0;
+uint64_t g_vehicle_shadow_geometry_staged_draws = 0;
+uint64_t g_vehicle_shadow_geometry_seed_count = 0;
+uint64_t g_vehicle_shadow_geometry_seed_duplicates = 0;
+uint64_t g_vehicle_shadow_geometry_seed_overflow = 0;
+uint64_t g_vehicle_shadow_geometry_color_draws_examined = 0;
+uint64_t g_vehicle_shadow_geometry_color_draws_matched = 0;
+uint64_t g_vehicle_shadow_geometry_full_matches = 0;
+uint64_t g_vehicle_shadow_geometry_partial_matches = 0;
+uint64_t g_vehicle_shadow_geometry_correlation_count = 0;
+uint64_t g_vehicle_shadow_geometry_correlation_overflow = 0;
 bool g_vehicle_title_provenance_requested = false;
 uint64_t g_title_packets_recorded = 0;
 uint64_t g_title_packets_matched = 0;
@@ -8099,6 +8145,7 @@ struct IsolatedDrawState {
   uint64_t shadow_replay_gate_rejections = 0;
   uint32_t prepared_title_lod_index = 0;
   rex::system::GraphicsDrawObservation prepared_sample;
+  SemanticPreparedDrawContract prepared_semantic_contract{};
   std::filesystem::path output_root;
   std::jthread artifact_writer;
   std::jthread reference_artifact_writer;
@@ -8131,6 +8178,7 @@ struct IsolatedDrawState {
   bool shadow_depth_mode = false;
   bool shadow_depth_prototype_mode = false;
   bool shadow_depth_batch_mode = false;
+  bool vehicle_shadow_geometry_correlation_mode = false;
   bool shadow_depth_publication_mode = false;
   bool shadow_depth_continuous_mode = false;
   bool shadow_depth_continuous_failed_closed = false;
@@ -8161,6 +8209,7 @@ struct IsolatedDrawState {
   uint64_t shadow_depth_continuous_max_publication_epochs = 0;
   uint64_t shadow_depth_continuous_epoch_limit = 0;
   uint32_t shadow_depth_batch_draws = 0;
+  uint32_t vehicle_shadow_geometry_staging_count = 0;
   bool shadow_depth_batch_active = false;
   bool shadow_depth_batch_backend_ready = false;
   bool shadow_depth_batch_capture_completed = false;
@@ -8689,6 +8738,25 @@ void ConfigureIsolatedDraw() {
   if (g_isolated_draw.shadow_depth_prototype_mode) {
     g_isolated_draw.shadow_depth_batch_mode = true;
   }
+  value = nullptr;
+  length = 0;
+  if (_dupenv_s(
+          &value, &length,
+          "PINYON_SHIFT_NATIVE_RENDERER_VEHICLE_SHADOW_GEOMETRY_CORRELATION") ==
+          0 &&
+      value && length > 1) {
+    const std::string setting(value);
+    g_isolated_draw.vehicle_shadow_geometry_correlation_mode =
+        setting == "true";
+    if (setting != "true" && setting != "false") {
+      g_isolated_draw.valid = false;
+    }
+  }
+  std::free(value);
+  if (g_isolated_draw.vehicle_shadow_geometry_correlation_mode &&
+      !g_isolated_draw.shadow_depth_batch_mode) {
+    g_isolated_draw.valid = false;
+  }
   if (g_isolated_draw.shadow_depth_mode) {
     g_isolated_draw.requested = true;
     if (signature_requested || g_isolated_draw.shadow_depth_batch_mode) {
@@ -8871,6 +8939,20 @@ void ConfigureIsolatedDraw() {
     }
   }
   std::free(value);
+  if (g_isolated_draw.vehicle_shadow_geometry_correlation_mode) {
+    pinyon_shift::diagnostics::RecordEvent(
+        "native_renderer.discovery.vehicle_shadow_geometry_config",
+        {{"status", g_isolated_draw.valid ? "armed"
+                                           : "blocked_invalid_configuration"},
+         {"shadow_depth_batch_required", "true"},
+         {"epoch_contract", "exact_consecutive_64_primary_12_secondary_4_tertiary"},
+         {"promotion_boundary", "backend_recorded_full_80_draw_epoch"},
+         {"color_match", "exact_full_or_index_plus_vertex_resource"},
+         {"guest_payload_capture", "false"},
+         {"native_draw", "false"},
+         {"xenos_authority", "true"},
+         {"suppression_allowed", "false"}});
+  }
 }
 
 void ConfigureVisibilityShadowReplay() {
@@ -14809,6 +14891,227 @@ SemanticPreparedDrawContract BuildSemanticPreparedDrawContract(
   return contract;
 }
 
+VehicleShadowGeometryIdentity BuildVehicleShadowGeometryIdentity(
+    const rex::system::GraphicsDrawObservation &observation,
+    const SemanticPreparedDrawContract &contract) {
+  VehicleShadowGeometryIdentity identity{
+      .geometry_resource_hash = contract.geometry_resource_hash,
+      .index_buffer_address = observation.index_buffer_address,
+      .index_buffer_length = observation.index_buffer_length,
+      .vertex_binding_count = std::min(
+          observation.vertex_binding_count,
+          rex::system::kGraphicsVertexBindingObservationLimit),
+      .occupied = contract.geometry_bounded,
+  };
+  for (uint32_t i = 0; i < identity.vertex_binding_count; ++i) {
+    identity.vertex_addresses[i] = observation.vertex_bindings[i].address;
+    identity.vertex_sizes[i] = observation.vertex_bindings[i].size;
+  }
+  return identity;
+}
+
+void ResetVehicleShadowGeometryStaging() {
+  g_vehicle_shadow_geometry_staging = {};
+  g_isolated_draw.vehicle_shadow_geometry_staging_count = 0;
+}
+
+void StageVehicleShadowGeometry(
+    const rex::system::GraphicsDrawObservation &observation,
+    const SemanticPreparedDrawContract &contract) {
+  if (!g_isolated_draw.vehicle_shadow_geometry_correlation_mode ||
+      g_isolated_draw.vehicle_shadow_geometry_staging_count >=
+          g_vehicle_shadow_geometry_staging.size()) {
+    return;
+  }
+  g_vehicle_shadow_geometry_staging
+      [g_isolated_draw.vehicle_shadow_geometry_staging_count++] =
+          BuildVehicleShadowGeometryIdentity(observation, contract);
+  ++g_vehicle_shadow_geometry_staged_draws;
+}
+
+bool SameVehicleShadowGeometryIdentity(
+    const VehicleShadowGeometryIdentity &left,
+    const VehicleShadowGeometryIdentity &right) {
+  if (!left.occupied || !right.occupied ||
+      left.geometry_resource_hash != right.geometry_resource_hash ||
+      left.index_buffer_address != right.index_buffer_address ||
+      left.index_buffer_length != right.index_buffer_length ||
+      left.vertex_binding_count != right.vertex_binding_count) {
+    return false;
+  }
+  for (uint32_t i = 0; i < left.vertex_binding_count; ++i) {
+    if (left.vertex_addresses[i] != right.vertex_addresses[i] ||
+        left.vertex_sizes[i] != right.vertex_sizes[i]) {
+      return false;
+    }
+  }
+  return true;
+}
+
+void CommitVehicleShadowGeometryEpoch() {
+  if (!g_isolated_draw.vehicle_shadow_geometry_correlation_mode ||
+      g_isolated_draw.vehicle_shadow_geometry_staging_count !=
+          kShadowDepthBatchDrawCount) {
+    ResetVehicleShadowGeometryStaging();
+    return;
+  }
+  ++g_vehicle_shadow_geometry_epochs_committed;
+  for (const VehicleShadowGeometryIdentity &candidate :
+       g_vehicle_shadow_geometry_staging) {
+    if (!candidate.occupied) {
+      continue;
+    }
+    bool duplicate = false;
+    for (size_t i = 0; i < g_vehicle_shadow_geometry_seed_count; ++i) {
+      if (SameVehicleShadowGeometryIdentity(
+              candidate, g_vehicle_shadow_geometry_seeds[i])) {
+        duplicate = true;
+        break;
+      }
+    }
+    if (duplicate) {
+      ++g_vehicle_shadow_geometry_seed_duplicates;
+      continue;
+    }
+    if (g_vehicle_shadow_geometry_seed_count >=
+        g_vehicle_shadow_geometry_seeds.size()) {
+      ++g_vehicle_shadow_geometry_seed_overflow;
+      continue;
+    }
+    g_vehicle_shadow_geometry_seeds[g_vehicle_shadow_geometry_seed_count++] =
+        candidate;
+  }
+  pinyon_shift::diagnostics::RecordEvent(
+      "native_renderer.discovery.vehicle_shadow_geometry_epoch",
+      {{"frame", std::to_string(g_isolated_draw.shadow_depth_batch_frame)},
+       {"draw_count", std::to_string(kShadowDepthBatchDrawCount)},
+       {"unique_geometry_seeds",
+        std::to_string(g_vehicle_shadow_geometry_seed_count)},
+       {"seed_duplicates",
+        std::to_string(g_vehicle_shadow_geometry_seed_duplicates)},
+       {"seed_overflow",
+        std::to_string(g_vehicle_shadow_geometry_seed_overflow)},
+       {"classification", "capture_proven_dynamic_vehicle_epoch"},
+       {"promotion_boundary", "backend_recorded_full_80_draw_epoch"},
+       {"guest_payload_capture", "false"},
+       {"native_draw", "false"},
+       {"xenos_authority", "true"},
+       {"suppression_allowed", "false"}});
+  ResetVehicleShadowGeometryStaging();
+}
+
+bool VehicleShadowGeometrySharesVertexResource(
+    const VehicleShadowGeometryIdentity &seed,
+    const VehicleShadowGeometryIdentity &candidate) {
+  for (uint32_t i = 0; i < seed.vertex_binding_count; ++i) {
+    for (uint32_t j = 0; j < candidate.vertex_binding_count; ++j) {
+      if (seed.vertex_addresses[i] &&
+          seed.vertex_addresses[i] == candidate.vertex_addresses[j] &&
+          seed.vertex_sizes[i] == candidate.vertex_sizes[j]) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+void ObserveVehicleShadowGeometryColorCorrelation(
+    const rex::system::GraphicsDrawObservation &observation,
+    bool samples_resolved_target,
+    const rex::system::GraphicsPreparedDrawObservation &prepared,
+    uint64_t prepared_signature,
+    const SemanticPreparedDrawContract &contract) {
+  if (!g_isolated_draw.vehicle_shadow_geometry_correlation_mode ||
+      !g_vehicle_shadow_geometry_seed_count || samples_resolved_target ||
+      !contract.geometry_bounded || !observation.indexed ||
+      !observation.rb_color_mask || !prepared.normalized_color_mask ||
+      !prepared.pixel_shader_hash || observation.viz_query_condition ||
+      (observation.pa_sc_viz_query & 1) || observation.vertex_memexport) {
+    return;
+  }
+  ++g_vehicle_shadow_geometry_color_draws_examined;
+  const VehicleShadowGeometryIdentity candidate =
+      BuildVehicleShadowGeometryIdentity(observation, contract);
+  size_t matched_seed = g_vehicle_shadow_geometry_seed_count;
+  bool full_geometry_match = false;
+  for (size_t i = 0; i < g_vehicle_shadow_geometry_seed_count; ++i) {
+    const VehicleShadowGeometryIdentity &seed =
+        g_vehicle_shadow_geometry_seeds[i];
+    if (SameVehicleShadowGeometryIdentity(seed, candidate)) {
+      matched_seed = i;
+      full_geometry_match = true;
+      break;
+    }
+    if (matched_seed == g_vehicle_shadow_geometry_seed_count &&
+        seed.index_buffer_address == candidate.index_buffer_address &&
+        seed.index_buffer_length == candidate.index_buffer_length &&
+        VehicleShadowGeometrySharesVertexResource(seed, candidate)) {
+      matched_seed = i;
+    }
+  }
+  if (matched_seed == g_vehicle_shadow_geometry_seed_count) {
+    return;
+  }
+  ++g_vehicle_shadow_geometry_color_draws_matched;
+  if (full_geometry_match) {
+    ++g_vehicle_shadow_geometry_full_matches;
+  } else {
+    ++g_vehicle_shadow_geometry_partial_matches;
+  }
+  VehicleShadowGeometryCorrelationEntry *available = nullptr;
+  for (VehicleShadowGeometryCorrelationEntry &entry :
+       g_vehicle_shadow_geometry_correlations) {
+    if (!entry.occupied) {
+      available = &entry;
+      break;
+    }
+    if (entry.prepared_signature == prepared_signature &&
+        entry.seed_index == matched_seed &&
+        entry.full_geometry_match == full_geometry_match) {
+      ++entry.draws;
+      entry.last_frame = observation.frame_sequence;
+      return;
+    }
+  }
+  if (!available) {
+    ++g_vehicle_shadow_geometry_correlation_overflow;
+    return;
+  }
+  *available = {
+      .prepared_signature = prepared_signature,
+      .template_key = contract.template_key,
+      .geometry_resource_hash = contract.geometry_resource_hash,
+      .texture_resource_hash = contract.texture_resource_hash,
+      .prepared_pipeline_hash = contract.prepared_pipeline_hash,
+      .draws = 1,
+      .first_frame = observation.frame_sequence,
+      .last_frame = observation.frame_sequence,
+      .seed_index = uint32_t(matched_seed),
+      .full_geometry_match = full_geometry_match,
+      .occupied = true,
+  };
+  ++g_vehicle_shadow_geometry_correlation_count;
+  pinyon_shift::diagnostics::RecordEvent(
+      "native_renderer.discovery.vehicle_shadow_geometry_correlation",
+      {{"prepared_signature", fmt::format("{:016X}", prepared_signature)},
+       {"template_key", fmt::format("{:016X}", contract.template_key)},
+       {"geometry_resource_hash",
+        fmt::format("{:016X}", contract.geometry_resource_hash)},
+       {"texture_resource_hash",
+        fmt::format("{:016X}", contract.texture_resource_hash)},
+       {"prepared_pipeline_hash",
+        fmt::format("{:016X}", contract.prepared_pipeline_hash)},
+       {"seed_index", std::to_string(matched_seed)},
+       {"match", full_geometry_match
+                     ? "exact_geometry_resource_set"
+                     : "exact_index_and_shared_vertex_resource"},
+       {"classification", "vehicle_color_geometry_correlation_candidate"},
+       {"guest_payload_capture", "false"},
+       {"native_draw", "false"},
+       {"xenos_authority", "true"},
+       {"suppression_allowed", "false"}});
+}
+
 void RecordStaticWorldPreparedLayout(
     const rex::system::GraphicsDrawObservation &observation,
     const StaticWorldDrawIdentity &identity,
@@ -19397,6 +19700,8 @@ void ObservePreparedDraw(
     CommitPassConsumer(sample, observation, g_pending_candidate);
     const uint64_t prepared_signature = CandidateSignature(
         sample, g_pending_candidate.samples_resolved_target, observation);
+    const SemanticPreparedDrawContract prepared_semantic_contract =
+        BuildSemanticPreparedDrawContract(sample, observation);
     RecordPreparedCommandBufferLineage(prepared_signature, sample);
     RecordTitleDrawProvenance(prepared_signature, true, 0, sample,
                               g_pending_candidate.title_origin,
@@ -19413,6 +19718,7 @@ void ObservePreparedDraw(
     g_isolated_draw.frame = sample.frame_sequence;
     g_isolated_draw.draw = sample.draw_sequence;
     g_isolated_draw.prepared_sample = sample;
+    g_isolated_draw.prepared_semantic_contract = prepared_semantic_contract;
     g_isolated_draw.prepared_shadow_depth_seed_eligible =
         IsExactShadowDepthIsolatedDraw(
             sample, g_pending_candidate.samples_resolved_target,
@@ -19545,6 +19851,9 @@ void ObservePreparedDraw(
         }
       }
     }
+    ObserveVehicleShadowGeometryColorCorrelation(
+        sample, g_pending_candidate.samples_resolved_target, observation,
+        prepared_signature, prepared_semantic_contract);
     if (g_isolated_draw.shadow_depth_mode ||
         g_isolated_draw.shadow_depth_batch_mode) {
       if (g_isolated_draw.prepared_shadow_depth_seed_eligible) {
@@ -20697,6 +21006,7 @@ void CompleteIsolatedShadowDepthBatch(
   if (!recorded) {
     g_isolated_draw.shadow_depth_batch_active = false;
     g_isolated_draw.shadow_depth_batch_backend_ready = false;
+    ResetVehicleShadowGeometryStaging();
     FailClosedContinuousShadowDepth("backend_replay_failure");
   }
   if (g_isolated_draw.shadow_depth_batch_draws !=
@@ -20708,6 +21018,9 @@ void CompleteIsolatedShadowDepthBatch(
     g_isolated_draw.shadow_depth_batch_last_completed_frame =
         g_isolated_draw.shadow_depth_batch_frame;
     g_isolated_draw.shadow_depth_batch_capture_completed = true;
+    CommitVehicleShadowGeometryEpoch();
+  } else {
+    ResetVehicleShadowGeometryStaging();
   }
   g_isolated_draw.shadow_depth_batch_active = false;
   pinyon_shift::diagnostics::RecordEvent(
@@ -21541,6 +21854,7 @@ void RequestIsolatedDraw(
         g_isolated_draw.shadow_depth_batch_active = false;
         g_isolated_draw.shadow_depth_batch_backend_ready = false;
         g_isolated_draw.shadow_depth_batch_draws = 0;
+        ResetVehicleShadowGeometryStaging();
         FailClosedContinuousShadowDepth("non_contiguous_epoch");
         if (g_isolated_draw.shadow_depth_continuous_failed_closed) {
           return;
@@ -21569,9 +21883,12 @@ void RequestIsolatedDraw(
       g_isolated_draw.shadow_depth_batch_backend_ready = false;
       g_isolated_draw.shadow_depth_batch_frame = g_isolated_draw.frame;
       g_isolated_draw.shadow_depth_batch_draws = 0;
+      ResetVehicleShadowGeometryStaging();
       ++g_isolated_draw.shadow_depth_batches_started;
     }
     ++g_isolated_draw.shadow_depth_batch_draws;
+    StageVehicleShadowGeometry(g_isolated_draw.prepared_sample,
+                               g_isolated_draw.prepared_semantic_contract);
     ++g_isolated_draw.shadow_depth_batch_requests;
     g_isolated_draw.shadow_depth_batch_last_draw = g_isolated_draw.draw;
     const bool completing_batch =
@@ -24995,6 +25312,54 @@ void UninstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system) {
          {"output_authority", "xenos"},
          {"draw_suppression", "false"},
        {"suppression_eligible", "false"}});
+  }
+  if (g_isolated_draw.vehicle_shadow_geometry_correlation_mode) {
+    const bool seed_accounting_complete =
+        g_vehicle_shadow_geometry_seed_count +
+                g_vehicle_shadow_geometry_seed_duplicates +
+                g_vehicle_shadow_geometry_seed_overflow ==
+            g_vehicle_shadow_geometry_epochs_committed *
+                kShadowDepthBatchDrawCount;
+    diagnostics::RecordEvent(
+        "native_renderer.discovery.vehicle_shadow_geometry_summary",
+        {{"status", g_vehicle_shadow_geometry_epochs_committed
+                        ? "qualified_epoch_observed"
+                        : "no_qualified_epoch"},
+         {"epochs_committed",
+          std::to_string(g_vehicle_shadow_geometry_epochs_committed)},
+         {"staged_draws",
+          std::to_string(g_vehicle_shadow_geometry_staged_draws)},
+         {"unique_geometry_seeds",
+          std::to_string(g_vehicle_shadow_geometry_seed_count)},
+         {"seed_duplicates",
+          std::to_string(g_vehicle_shadow_geometry_seed_duplicates)},
+         {"seed_overflow",
+          std::to_string(g_vehicle_shadow_geometry_seed_overflow)},
+         {"seed_capacity",
+          std::to_string(kVehicleShadowGeometrySeedCapacity)},
+         {"color_draws_examined",
+          std::to_string(g_vehicle_shadow_geometry_color_draws_examined)},
+         {"color_draws_matched",
+          std::to_string(g_vehicle_shadow_geometry_color_draws_matched)},
+         {"full_geometry_matches",
+          std::to_string(g_vehicle_shadow_geometry_full_matches)},
+         {"index_vertex_matches",
+          std::to_string(g_vehicle_shadow_geometry_partial_matches)},
+         {"correlations",
+          std::to_string(g_vehicle_shadow_geometry_correlation_count)},
+         {"correlation_overflow",
+          std::to_string(g_vehicle_shadow_geometry_correlation_overflow)},
+         {"correlation_capacity",
+          std::to_string(kVehicleShadowGeometryCorrelationCapacity)},
+         {"seed_accounting_complete",
+          seed_accounting_complete ? "true" : "false"},
+         {"epoch_contract", "exact_consecutive_64_primary_12_secondary_4_tertiary"},
+         {"classification", "measurement_only_candidate"},
+         {"object_identity_proven", "false"},
+         {"mesh_material_contract_proven", "false"},
+         {"native_draw", "false"},
+         {"xenos_authority", "true"},
+         {"suppression_allowed", "false"}});
   }
   if (g_isolated_draw.shadow_depth_batch_mode) {
     const uint64_t request_outcomes =

--- a/tools/capture-native-renderer-census.ps1
+++ b/tools/capture-native-renderer-census.ps1
@@ -18,6 +18,7 @@ param(
     [string]$IsolatedDrawDir,
     [switch]$ShadowDepthIsolated,
     [switch]$ShadowDepthBatch,
+    [switch]$VehicleShadowGeometryCorrelation,
     [switch]$PublishShadowDepth,
     [switch]$ContinuousShadowDepth,
     [ValidateRange(2, 120)]
@@ -110,6 +111,9 @@ if ($ShadowDepthIsolated -and -not $IsolatedDrawDir) {
 }
 if ($ShadowDepthBatch -and -not $IsolatedDrawDir) {
     throw 'ShadowDepthBatch requires IsolatedDrawDir.'
+}
+if ($VehicleShadowGeometryCorrelation -and -not $ShadowDepthBatch) {
+    throw 'VehicleShadowGeometryCorrelation requires ShadowDepthBatch.'
 }
 if ($PublishShadowDepth -and -not $ShadowDepthBatch) {
     throw 'PublishShadowDepth requires ShadowDepthBatch.'
@@ -230,6 +234,8 @@ $savedIsolatedDraw = $env:PINYON_SHIFT_NATIVE_RENDERER_ISOLATED_DRAW_SIGNATURE
 $savedIsolatedDrawDir = $env:PINYON_SHIFT_NATIVE_RENDERER_ISOLATED_DRAW_DIR
 $savedShadowDepthIsolated = $env:PINYON_SHIFT_NATIVE_RENDERER_SHADOW_DEPTH_ISOLATED
 $savedShadowDepthBatch = $env:PINYON_SHIFT_NATIVE_RENDERER_SHADOW_DEPTH_BATCH
+$savedVehicleShadowGeometryCorrelation =
+    $env:PINYON_SHIFT_NATIVE_RENDERER_VEHICLE_SHADOW_GEOMETRY_CORRELATION
 $savedShadowDepthPublication =
     $env:PINYON_SHIFT_NATIVE_RENDERER_SHADOW_DEPTH_PUBLICATION
 $savedShadowDepthContinuous =
@@ -278,6 +284,8 @@ try {
         if ($ShadowDepthIsolated) { 'true' } else { $null }
     $env:PINYON_SHIFT_NATIVE_RENDERER_SHADOW_DEPTH_BATCH =
         if ($ShadowDepthBatch) { 'true' } else { $null }
+    $env:PINYON_SHIFT_NATIVE_RENDERER_VEHICLE_SHADOW_GEOMETRY_CORRELATION =
+        if ($VehicleShadowGeometryCorrelation) { 'true' } else { $null }
     $env:PINYON_SHIFT_NATIVE_RENDERER_SHADOW_DEPTH_PUBLICATION =
         if ($PublishShadowDepth) { 'true' } else { $null }
     $env:PINYON_SHIFT_NATIVE_RENDERER_SHADOW_DEPTH_CONTINUOUS =
@@ -332,6 +340,8 @@ finally {
         $savedShadowDepthIsolated
     $env:PINYON_SHIFT_NATIVE_RENDERER_SHADOW_DEPTH_BATCH =
         $savedShadowDepthBatch
+    $env:PINYON_SHIFT_NATIVE_RENDERER_VEHICLE_SHADOW_GEOMETRY_CORRELATION =
+        $savedVehicleShadowGeometryCorrelation
     $env:PINYON_SHIFT_NATIVE_RENDERER_SHADOW_DEPTH_PUBLICATION =
         $savedShadowDepthPublication
     $env:PINYON_SHIFT_NATIVE_RENDERER_SHADOW_DEPTH_CONTINUOUS =

--- a/tools/summarize-native-renderer-vehicle-shadow-geometry.py
+++ b/tools/summarize-native-renderer-vehicle-shadow-geometry.py
@@ -1,0 +1,149 @@
+"""Summarize capture-proven vehicle shadow geometry/color correlations."""
+
+import argparse
+import json
+from pathlib import Path
+
+
+SCHEMA = "pinyon-shift.native-renderer-vehicle-shadow-geometry.v1"
+CONFIG_EVENT = "native_renderer.discovery.vehicle_shadow_geometry_config"
+EPOCH_EVENT = "native_renderer.discovery.vehicle_shadow_geometry_epoch"
+CORRELATION_EVENT = (
+    "native_renderer.discovery.vehicle_shadow_geometry_correlation"
+)
+SUMMARY_EVENT = "native_renderer.discovery.vehicle_shadow_geometry_summary"
+
+
+def require(condition, message):
+    if not condition:
+        raise ValueError(message)
+
+
+def integer(record, key):
+    try:
+        return int(record[key])
+    except (KeyError, TypeError, ValueError) as error:
+        raise ValueError(f"missing or invalid integer field: {key}") from error
+
+
+def load_events(path):
+    events = []
+    with path.open("r", encoding="utf-8") as source:
+        for line_number, line in enumerate(source, 1):
+            if not line.strip():
+                continue
+            try:
+                events.append(json.loads(line))
+            except json.JSONDecodeError as error:
+                raise ValueError(
+                    f"invalid JSONL at line {line_number}: {error}"
+                ) from error
+    return events
+
+
+def summarize(log_path):
+    events = load_events(log_path)
+    configs = [event for event in events if event.get("event") == CONFIG_EVENT]
+    epochs = [event for event in events if event.get("event") == EPOCH_EVENT]
+    correlations = [
+        event for event in events if event.get("event") == CORRELATION_EVENT
+    ]
+    summaries = [
+        event for event in events if event.get("event") == SUMMARY_EVENT
+    ]
+    require(len(configs) == 1, "expected exactly one correlation config event")
+    require(configs[0].get("status") == "armed", "correlation was not armed")
+    require(len(summaries) == 1, "expected exactly one correlation summary")
+    summary = summaries[0]
+    require(summary.get("status") == "qualified_epoch_observed", "no qualified epoch")
+    require(integer(summary, "epochs_committed") == len(epochs), "epoch accounting drift")
+    require(integer(summary, "epochs_committed") > 0, "no epoch was committed")
+    require(summary.get("seed_accounting_complete") == "true", "seed accounting drift")
+    require(integer(summary, "seed_overflow") == 0, "geometry seed table overflowed")
+    require(
+        integer(summary, "correlation_overflow") == 0,
+        "geometry correlation table overflowed",
+    )
+    require(
+        integer(summary, "correlations") == len(correlations),
+        "correlation event accounting drift",
+    )
+    require(
+        integer(summary, "color_draws_matched")
+        == integer(summary, "full_geometry_matches")
+        + integer(summary, "index_vertex_matches"),
+        "match accounting drift",
+    )
+    safety_events = [*configs, *epochs, *correlations, summary]
+    for event in safety_events:
+        require(event.get("native_draw") == "false", "native draw was enabled")
+        require(event.get("xenos_authority") == "true", "Xenos authority changed")
+        require(
+            event.get("suppression_allowed") == "false",
+            "suppression was allowed",
+        )
+    for event in epochs:
+        require(integer(event, "draw_count") == 80, "epoch draw count drift")
+        require(
+            event.get("promotion_boundary")
+            == "backend_recorded_full_80_draw_epoch",
+            "partial epoch was promoted",
+        )
+    for event in correlations:
+        require(
+            event.get("classification")
+            == "vehicle_color_geometry_correlation_candidate",
+            "correlation classification drift",
+        )
+        require(
+            event.get("match")
+            in {
+                "exact_geometry_resource_set",
+                "exact_index_and_shared_vertex_resource",
+            },
+            "unbounded correlation match",
+        )
+    return {
+        "schema": SCHEMA,
+        "source_log": str(log_path),
+        "totals": {
+            "epochs_committed": integer(summary, "epochs_committed"),
+            "unique_geometry_seeds": integer(summary, "unique_geometry_seeds"),
+            "color_draws_examined": integer(summary, "color_draws_examined"),
+            "color_draws_matched": integer(summary, "color_draws_matched"),
+            "full_geometry_matches": integer(summary, "full_geometry_matches"),
+            "index_vertex_matches": integer(summary, "index_vertex_matches"),
+            "correlations": len(correlations),
+        },
+        "epochs": epochs,
+        "correlations": correlations,
+        "qualification": {
+            "working_color_bridge_candidate": bool(correlations),
+            "object_identity_proven": False,
+            "mesh_material_contract_proven": False,
+            "native_admission_allowed": False,
+        },
+        "safety": {
+            "guest_payload_capture": False,
+            "native_draw": False,
+            "xenos_authority": True,
+            "suppression_allowed": False,
+        },
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("log", type=Path)
+    parser.add_argument("--output", type=Path, required=True)
+    arguments = parser.parse_args()
+    report = summarize(arguments.log)
+    arguments.output.parent.mkdir(parents=True, exist_ok=True)
+    arguments.output.write_text(
+        json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    print(json.dumps(report["totals"], sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/tests/test_native_renderer_vehicle_shadow_geometry.py
+++ b/tools/tests/test_native_renderer_vehicle_shadow_geometry.py
@@ -1,0 +1,125 @@
+import importlib.util
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+TOOL = ROOT / "tools/summarize-native-renderer-vehicle-shadow-geometry.py"
+SPEC = importlib.util.spec_from_file_location("vehicle_shadow_geometry", TOOL)
+assert SPEC and SPEC.loader
+MODULE = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = MODULE
+SPEC.loader.exec_module(MODULE)
+
+
+class VehicleShadowGeometryTests(unittest.TestCase):
+    def fixture(self):
+        safety = {
+            "native_draw": "false",
+            "xenos_authority": "true",
+            "suppression_allowed": "false",
+        }
+        return [
+            {
+                "event": MODULE.CONFIG_EVENT,
+                "status": "armed",
+                **safety,
+            },
+            {
+                "event": MODULE.EPOCH_EVENT,
+                "draw_count": "80",
+                "promotion_boundary": "backend_recorded_full_80_draw_epoch",
+                **safety,
+            },
+            {
+                "event": MODULE.CORRELATION_EVENT,
+                "classification": "vehicle_color_geometry_correlation_candidate",
+                "match": "exact_index_and_shared_vertex_resource",
+                **safety,
+            },
+            {
+                "event": MODULE.SUMMARY_EVENT,
+                "status": "qualified_epoch_observed",
+                "epochs_committed": "1",
+                "unique_geometry_seeds": "76",
+                "seed_overflow": "0",
+                "seed_accounting_complete": "true",
+                "color_draws_examined": "40",
+                "color_draws_matched": "3",
+                "full_geometry_matches": "1",
+                "index_vertex_matches": "2",
+                "correlations": "1",
+                "correlation_overflow": "0",
+                **safety,
+            },
+        ]
+
+    def summarize(self, events):
+        with tempfile.TemporaryDirectory(prefix="pinyon-vehicle-shadow-") as root:
+            log = Path(root) / "diagnostics.jsonl"
+            log.write_text(
+                "".join(json.dumps(event) + "\n" for event in events),
+                encoding="utf-8",
+            )
+            return MODULE.summarize(log)
+
+    def test_accepts_full_epoch_and_bounded_color_candidate(self):
+        report = self.summarize(self.fixture())
+        self.assertEqual(1, report["totals"]["epochs_committed"])
+        self.assertEqual(3, report["totals"]["color_draws_matched"])
+        self.assertTrue(
+            report["qualification"]["working_color_bridge_candidate"]
+        )
+        self.assertFalse(report["qualification"]["native_admission_allowed"])
+
+    def test_rejects_partial_epoch_promotion(self):
+        events = self.fixture()
+        events[1]["draw_count"] = "79"
+        with self.assertRaisesRegex(ValueError, "epoch draw count drift"):
+            self.summarize(events)
+
+    def test_rejects_match_accounting_drift(self):
+        events = self.fixture()
+        events[-1]["color_draws_matched"] = "4"
+        with self.assertRaisesRegex(ValueError, "match accounting drift"):
+            self.summarize(events)
+
+    def test_rejects_suppression(self):
+        events = self.fixture()
+        events[2]["suppression_allowed"] = "true"
+        with self.assertRaisesRegex(ValueError, "suppression was allowed"):
+            self.summarize(events)
+
+    def test_runtime_contract_is_default_off_and_full_epoch_gated(self):
+        source = (ROOT / "src/native_renderer/graphics_hooks.cpp").read_text(
+            encoding="utf-8"
+        )
+        capture = (ROOT / "tools/capture-native-renderer-census.ps1").read_text(
+            encoding="utf-8"
+        )
+        self.assertIn(
+            "PINYON_SHIFT_NATIVE_RENDERER_VEHICLE_SHADOW_GEOMETRY_CORRELATION",
+            source,
+        )
+        self.assertIn("CommitVehicleShadowGeometryEpoch", source)
+        self.assertIn(
+            "vehicle_shadow_geometry_staging_count !=\n"
+            "          kShadowDepthBatchDrawCount",
+            source,
+        )
+        self.assertIn('"native_renderer.discovery.vehicle_shadow_geometry_summary"', source)
+        self.assertIn("[switch]$VehicleShadowGeometryCorrelation", capture)
+        self.assertIn(
+            "VehicleShadowGeometryCorrelation requires ShadowDepthBatch",
+            capture,
+        )
+        self.assertIn('{"native_draw", "false"}', source)
+        self.assertIn('{"xenos_authority", "true"}', source)
+        self.assertIn('{"suppression_allowed", "false"}', source)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- stage bounded geometry identities from the exact 80-draw dynamic-vehicle shadow epoch
- promote seeds only after backend-confirmed full-epoch completion
- correlate later indexed color draws by exact geometry resources without native admission or suppression
- add a deterministic qualifier, tests, and C4 roadmap documentation

## Validation
- compiled `graphics_hooks.cpp` in the release configuration
- `python -m unittest discover -s tools/tests -p 'test_*.py'` (601 passed)