### PR TITLE
feat(native-renderer): census vehicle color families

### DIFF
--- a/docs/native-renderer/REPRIORITIZED_PLAN.md
+++ b/docs/native-renderer/REPRIORITIZED_PLAN.md
@@ -529,6 +529,14 @@ and cannot suppress. The next batched gameplay run determines whether this
 produces a working player-vehicle color ingress before transform, wheel,
 livery, traffic, and full material contracts are added.
 
+Color-family hardening checkpoint: correlated draws are now partitioned by
+exact draw arguments, geometry, texture resources, prepared pipeline, and the
+committed shadow seed rather than by a loose shader family. Stable aggregate
+records retain draw/frame coverage and parameter-switch counts, so animated
+pose candidates can be identified without exporting constant payloads and
+different submeshes or liveries cannot silently collapse together. Runtime
+qualification remains part of the next batched gameplay run.
+
 ### C5. Sky, atmosphere, and global lighting
 
 - Replace the qualified sky/global-light families.

--- a/docs/native-renderer/VEHICLE_INSTANCE_SEMANTIC_SEED.md
+++ b/docs/native-renderer/VEHICLE_INSTANCE_SEMANTIC_SEED.md
@@ -449,6 +449,14 @@ texture hash form a bounded candidate table for the player-vehicle color
 bridge. This is a cross-pass resource correlation, not yet object identity:
 transform, wheel, livery, traffic, and complete material semantics remain open.
 
+Candidate aggregation is deliberately stable across animated constants. A
+family is partitioned by the exact shadow seed, prepared signature, draw
+arguments, geometry resources, texture resources, and prepared pipeline. The
+final report retains draw/frame coverage and first/last parameter hashes plus
+parameter-switch counts. This prevents different submeshes or liveries from
+collapsing together while exposing likely pose-bearing families without
+exporting the constant payload itself.
+
 The mode captures no guest payload, submits no native color draw, preserves all
 Xenos draws, and cannot suppress anything. Qualify it in a representative
 driving session with:

--- a/src/native_renderer/graphics_hooks.cpp
+++ b/src/native_renderer/graphics_hooks.cpp
@@ -610,10 +610,14 @@ struct VehicleShadowGeometryIdentity {
 struct VehicleShadowGeometryCorrelationEntry {
   uint64_t prepared_signature = 0;
   uint64_t template_key = 0;
+  uint64_t draw_argument_hash = 0;
   uint64_t geometry_resource_hash = 0;
   uint64_t texture_resource_hash = 0;
   uint64_t prepared_pipeline_hash = 0;
+  uint64_t first_parameter_hash = 0;
+  uint64_t last_parameter_hash = 0;
   uint64_t draws = 0;
+  uint64_t parameter_switches = 0;
   uint64_t first_frame = 0;
   uint64_t last_frame = 0;
   uint32_t seed_index = 0;
@@ -15067,7 +15071,17 @@ void ObserveVehicleShadowGeometryColorCorrelation(
     }
     if (entry.prepared_signature == prepared_signature &&
         entry.seed_index == matched_seed &&
-        entry.full_geometry_match == full_geometry_match) {
+        entry.full_geometry_match == full_geometry_match &&
+        entry.draw_argument_hash == contract.draw_argument_hash &&
+        entry.geometry_resource_hash == contract.geometry_resource_hash &&
+        entry.texture_resource_hash == contract.texture_resource_hash &&
+        entry.prepared_pipeline_hash == contract.prepared_pipeline_hash) {
+      const uint64_t parameter_hash =
+          SemanticInstanceParameterHash(observation);
+      if (entry.last_parameter_hash != parameter_hash) {
+        ++entry.parameter_switches;
+        entry.last_parameter_hash = parameter_hash;
+      }
       ++entry.draws;
       entry.last_frame = observation.frame_sequence;
       return;
@@ -15080,9 +15094,12 @@ void ObserveVehicleShadowGeometryColorCorrelation(
   *available = {
       .prepared_signature = prepared_signature,
       .template_key = contract.template_key,
+      .draw_argument_hash = contract.draw_argument_hash,
       .geometry_resource_hash = contract.geometry_resource_hash,
       .texture_resource_hash = contract.texture_resource_hash,
       .prepared_pipeline_hash = contract.prepared_pipeline_hash,
+      .first_parameter_hash = SemanticInstanceParameterHash(observation),
+      .last_parameter_hash = SemanticInstanceParameterHash(observation),
       .draws = 1,
       .first_frame = observation.frame_sequence,
       .last_frame = observation.frame_sequence,
@@ -15095,6 +15112,8 @@ void ObserveVehicleShadowGeometryColorCorrelation(
       "native_renderer.discovery.vehicle_shadow_geometry_correlation",
       {{"prepared_signature", fmt::format("{:016X}", prepared_signature)},
        {"template_key", fmt::format("{:016X}", contract.template_key)},
+       {"draw_argument_hash",
+        fmt::format("{:016X}", contract.draw_argument_hash)},
        {"geometry_resource_hash",
         fmt::format("{:016X}", contract.geometry_resource_hash)},
        {"texture_resource_hash",
@@ -25314,6 +25333,46 @@ void UninstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system) {
        {"suppression_eligible", "false"}});
   }
   if (g_isolated_draw.vehicle_shadow_geometry_correlation_mode) {
+    for (const VehicleShadowGeometryCorrelationEntry &entry :
+         g_vehicle_shadow_geometry_correlations) {
+      if (!entry.occupied) {
+        continue;
+      }
+      diagnostics::RecordEvent(
+          "native_renderer.discovery.vehicle_shadow_geometry_candidate",
+          {{"prepared_signature",
+            fmt::format("{:016X}", entry.prepared_signature)},
+           {"template_key", fmt::format("{:016X}", entry.template_key)},
+           {"draw_argument_hash",
+            fmt::format("{:016X}", entry.draw_argument_hash)},
+           {"geometry_resource_hash",
+            fmt::format("{:016X}", entry.geometry_resource_hash)},
+           {"texture_resource_hash",
+            fmt::format("{:016X}", entry.texture_resource_hash)},
+           {"prepared_pipeline_hash",
+            fmt::format("{:016X}", entry.prepared_pipeline_hash)},
+           {"first_parameter_hash",
+            fmt::format("{:016X}", entry.first_parameter_hash)},
+           {"last_parameter_hash",
+            fmt::format("{:016X}", entry.last_parameter_hash)},
+           {"draws", std::to_string(entry.draws)},
+           {"parameter_switches",
+            std::to_string(entry.parameter_switches)},
+           {"first_frame", std::to_string(entry.first_frame)},
+           {"last_frame", std::to_string(entry.last_frame)},
+           {"seed_index", std::to_string(entry.seed_index)},
+           {"match", entry.full_geometry_match
+                         ? "exact_geometry_resource_set"
+                         : "exact_index_and_shared_vertex_resource"},
+           {"classification",
+            "bounded_vehicle_color_geometry_candidate_family"},
+           {"pose_variation_observed",
+            entry.parameter_switches ? "true" : "false"},
+           {"guest_payload_capture", "false"},
+           {"native_draw", "false"},
+           {"xenos_authority", "true"},
+           {"suppression_allowed", "false"}});
+    }
     const bool seed_accounting_complete =
         g_vehicle_shadow_geometry_seed_count +
                 g_vehicle_shadow_geometry_seed_duplicates +

--- a/tools/summarize-native-renderer-vehicle-shadow-geometry.py
+++ b/tools/summarize-native-renderer-vehicle-shadow-geometry.py
@@ -11,6 +11,7 @@ EPOCH_EVENT = "native_renderer.discovery.vehicle_shadow_geometry_epoch"
 CORRELATION_EVENT = (
     "native_renderer.discovery.vehicle_shadow_geometry_correlation"
 )
+CANDIDATE_EVENT = "native_renderer.discovery.vehicle_shadow_geometry_candidate"
 SUMMARY_EVENT = "native_renderer.discovery.vehicle_shadow_geometry_summary"
 
 
@@ -48,6 +49,9 @@ def summarize(log_path):
     correlations = [
         event for event in events if event.get("event") == CORRELATION_EVENT
     ]
+    candidates = [
+        event for event in events if event.get("event") == CANDIDATE_EVENT
+    ]
     summaries = [
         event for event in events if event.get("event") == SUMMARY_EVENT
     ]
@@ -69,12 +73,16 @@ def summarize(log_path):
         "correlation event accounting drift",
     )
     require(
+        integer(summary, "correlations") == len(candidates),
+        "candidate family accounting drift",
+    )
+    require(
         integer(summary, "color_draws_matched")
         == integer(summary, "full_geometry_matches")
         + integer(summary, "index_vertex_matches"),
         "match accounting drift",
     )
-    safety_events = [*configs, *epochs, *correlations, summary]
+    safety_events = [*configs, *epochs, *correlations, *candidates, summary]
     for event in safety_events:
         require(event.get("native_draw") == "false", "native draw was enabled")
         require(event.get("xenos_authority") == "true", "Xenos authority changed")
@@ -103,6 +111,33 @@ def summarize(log_path):
             },
             "unbounded correlation match",
         )
+    for event in candidates:
+        require(
+            event.get("classification")
+            == "bounded_vehicle_color_geometry_candidate_family",
+            "candidate family classification drift",
+        )
+        require(integer(event, "draws") > 0, "empty candidate family")
+        require(
+            integer(event, "last_frame") >= integer(event, "first_frame"),
+            "candidate frame range drift",
+        )
+        require(
+            event.get("pose_variation_observed")
+            == ("true" if integer(event, "parameter_switches") else "false"),
+            "pose variation accounting drift",
+        )
+        for key in (
+            "prepared_signature",
+            "template_key",
+            "draw_argument_hash",
+            "geometry_resource_hash",
+            "texture_resource_hash",
+            "prepared_pipeline_hash",
+            "first_parameter_hash",
+            "last_parameter_hash",
+        ):
+            require(len(event.get(key, "")) == 16, f"invalid candidate hash: {key}")
     return {
         "schema": SCHEMA,
         "source_log": str(log_path),
@@ -117,6 +152,7 @@ def summarize(log_path):
         },
         "epochs": epochs,
         "correlations": correlations,
+        "candidate_families": candidates,
         "qualification": {
             "working_color_bridge_candidate": bool(correlations),
             "object_identity_proven": False,

--- a/tools/tests/test_native_renderer_vehicle_shadow_geometry.py
+++ b/tools/tests/test_native_renderer_vehicle_shadow_geometry.py
@@ -41,6 +41,25 @@ class VehicleShadowGeometryTests(unittest.TestCase):
                 **safety,
             },
             {
+                "event": MODULE.CANDIDATE_EVENT,
+                "classification": "bounded_vehicle_color_geometry_candidate_family",
+                "match": "exact_index_and_shared_vertex_resource",
+                "prepared_signature": "1" * 16,
+                "template_key": "2" * 16,
+                "draw_argument_hash": "3" * 16,
+                "geometry_resource_hash": "4" * 16,
+                "texture_resource_hash": "5" * 16,
+                "prepared_pipeline_hash": "6" * 16,
+                "first_parameter_hash": "7" * 16,
+                "last_parameter_hash": "8" * 16,
+                "draws": "3",
+                "parameter_switches": "2",
+                "first_frame": "10",
+                "last_frame": "12",
+                "pose_variation_observed": "true",
+                **safety,
+            },
+            {
                 "event": MODULE.SUMMARY_EVENT,
                 "status": "qualified_epoch_observed",
                 "epochs_committed": "1",
@@ -73,6 +92,7 @@ class VehicleShadowGeometryTests(unittest.TestCase):
         self.assertTrue(
             report["qualification"]["working_color_bridge_candidate"]
         )
+        self.assertEqual(1, len(report["candidate_families"]))
         self.assertFalse(report["qualification"]["native_admission_allowed"])
 
     def test_rejects_partial_epoch_promotion(self):
@@ -93,6 +113,12 @@ class VehicleShadowGeometryTests(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "suppression was allowed"):
             self.summarize(events)
 
+    def test_rejects_pose_variation_accounting_drift(self):
+        events = self.fixture()
+        events[3]["pose_variation_observed"] = "false"
+        with self.assertRaisesRegex(ValueError, "pose variation accounting drift"):
+            self.summarize(events)
+
     def test_runtime_contract_is_default_off_and_full_epoch_gated(self):
         source = (ROOT / "src/native_renderer/graphics_hooks.cpp").read_text(
             encoding="utf-8"
@@ -111,6 +137,7 @@ class VehicleShadowGeometryTests(unittest.TestCase):
             source,
         )
         self.assertIn('"native_renderer.discovery.vehicle_shadow_geometry_summary"', source)
+        self.assertIn('"native_renderer.discovery.vehicle_shadow_geometry_candidate"', source)
         self.assertIn("[switch]$VehicleShadowGeometryCorrelation", capture)
         self.assertIn(
             "VehicleShadowGeometryCorrelation requires ShadowDepthBatch",


### PR DESCRIPTION
## Summary
- partition shadow/color candidates by exact draw, geometry, texture, and pipeline identity
- keep animated constants out of the stable family key
- emit bounded final family coverage and parameter-switch counts
- preserve measurement-only Xenos authority and update the C4 roadmap

## Validation
- compiled `graphics_hooks.cpp` in the release configuration
- `python -m unittest discover -s tools/tests -p 'test_*.py'` (602 passed)