### PR TITLE
feat(native-renderer): capture vehicle color candidate

### DIFF
--- a/docs/native-renderer/REPRIORITIZED_PLAN.md
+++ b/docs/native-renderer/REPRIORITIZED_PLAN.md
@@ -537,6 +537,13 @@ pose candidates can be identified without exporting constant payloads and
 different submeshes or liveries cannot silently collapse together. Runtime
 qualification remains part of the next batched gameplay run.
 
+Same-session visual checkpoint: an independent opt-in now privately replays
+the first mechanically eligible correlated color family after the full shadow
+epoch has been committed. It captures native and Xenos color targets in the
+same long session, never publishes the private target, preserves the original
+Xenos draw, and cannot suppress. This is intended to produce the first direct
+C4 image pair without requiring a second gameplay run.
+
 ### C5. Sky, atmosphere, and global lighting
 
 - Replace the qualified sky/global-light families.

--- a/docs/native-renderer/VEHICLE_INSTANCE_SEMANTIC_SEED.md
+++ b/docs/native-renderer/VEHICLE_INSTANCE_SEMANTIC_SEED.md
@@ -467,6 +467,7 @@ driving session with:
   -Scene open_world_day `
   -ShadowDepthBatch `
   -VehicleShadowGeometryCorrelation `
+  -CaptureVehicleShadowColor `
   -IsolatedDrawDir .local\qualification\vehicle-shadow-geometry
 
 python .\tools\summarize-native-renderer-vehicle-shadow-geometry.py `
@@ -478,3 +479,12 @@ The qualifier requires a backend-confirmed full epoch, exact seed and
 correlation accounting, zero table overflow, unchanged Xenos authority, and no
 native draw or suppression. A non-empty correlation set is only a working C4
 color-ingress candidate; it is not native admission.
+
+The optional capture switch avoids a second long gameplay session. After the
+backend-confirmed shadow epoch, the first correlated color draw that also
+passes the existing isolated-replay mechanical gate is replayed once into a
+private native target. Native and Xenos color readbacks are written beside the
+shadow-depth artifacts. The authoritative Xenos draw still executes, the
+private target is never published, and no suppression is permitted. A usable
+pair gives the first direct visual checkpoint for the C4 ingress; failure or
+absence remains a bounded diagnostic result.

--- a/src/native_renderer/graphics_hooks.cpp
+++ b/src/native_renderer/graphics_hooks.cpp
@@ -8183,6 +8183,10 @@ struct IsolatedDrawState {
   bool shadow_depth_prototype_mode = false;
   bool shadow_depth_batch_mode = false;
   bool vehicle_shadow_geometry_correlation_mode = false;
+  bool vehicle_shadow_color_capture_mode = false;
+  bool prepared_vehicle_shadow_color_replay_eligible = false;
+  bool vehicle_shadow_color_capture_pending = false;
+  bool vehicle_shadow_color_capture_completed = false;
   bool shadow_depth_publication_mode = false;
   bool shadow_depth_continuous_mode = false;
   bool shadow_depth_continuous_failed_closed = false;
@@ -8208,6 +8212,10 @@ struct IsolatedDrawState {
   uint64_t shadow_depth_publication_attempts = 0;
   uint64_t shadow_depth_publications = 0;
   uint64_t shadow_depth_publication_failures = 0;
+  uint64_t vehicle_shadow_color_capture_requests = 0;
+  uint64_t vehicle_shadow_color_capture_recorded = 0;
+  uint64_t vehicle_shadow_color_capture_target_failures = 0;
+  uint64_t vehicle_shadow_color_capture_unsupported = 0;
   uint64_t shadow_depth_continuous_last_publication_frame = UINT64_MAX;
   uint64_t shadow_depth_continuous_publication_epochs = 0;
   uint64_t shadow_depth_continuous_max_publication_epochs = 0;
@@ -8761,6 +8769,23 @@ void ConfigureIsolatedDraw() {
       !g_isolated_draw.shadow_depth_batch_mode) {
     g_isolated_draw.valid = false;
   }
+  value = nullptr;
+  length = 0;
+  if (_dupenv_s(
+          &value, &length,
+          "PINYON_SHIFT_NATIVE_RENDERER_VEHICLE_SHADOW_COLOR_CAPTURE") == 0 &&
+      value && length > 1) {
+    const std::string setting(value);
+    g_isolated_draw.vehicle_shadow_color_capture_mode = setting == "true";
+    if (setting != "true" && setting != "false") {
+      g_isolated_draw.valid = false;
+    }
+  }
+  std::free(value);
+  if (g_isolated_draw.vehicle_shadow_color_capture_mode &&
+      !g_isolated_draw.vehicle_shadow_geometry_correlation_mode) {
+    g_isolated_draw.valid = false;
+  }
   if (g_isolated_draw.shadow_depth_mode) {
     g_isolated_draw.requested = true;
     if (signature_requested || g_isolated_draw.shadow_depth_batch_mode) {
@@ -8955,6 +8980,19 @@ void ConfigureIsolatedDraw() {
          {"guest_payload_capture", "false"},
          {"native_draw", "false"},
          {"xenos_authority", "true"},
+         {"suppression_allowed", "false"}});
+  }
+  if (g_isolated_draw.vehicle_shadow_color_capture_mode) {
+    pinyon_shift::diagnostics::RecordEvent(
+        "native_renderer.discovery.vehicle_shadow_color_capture_config",
+        {{"status", g_isolated_draw.valid ? "armed"
+                                           : "blocked_invalid_configuration"},
+         {"selection", "first_mechanically_replayable_correlated_color_draw"},
+         {"activation_boundary", "backend_recorded_full_80_draw_epoch"},
+         {"readback", "native_and_xenos_color"},
+         {"native_draw", "private_capture_only"},
+         {"xenos_draw", "preserved"},
+         {"output_authority", "xenos"},
          {"suppression_allowed", "false"}});
   }
 }
@@ -15019,7 +15057,7 @@ bool VehicleShadowGeometrySharesVertexResource(
   return false;
 }
 
-void ObserveVehicleShadowGeometryColorCorrelation(
+bool ObserveVehicleShadowGeometryColorCorrelation(
     const rex::system::GraphicsDrawObservation &observation,
     bool samples_resolved_target,
     const rex::system::GraphicsPreparedDrawObservation &prepared,
@@ -15031,7 +15069,7 @@ void ObserveVehicleShadowGeometryColorCorrelation(
       !observation.rb_color_mask || !prepared.normalized_color_mask ||
       !prepared.pixel_shader_hash || observation.viz_query_condition ||
       (observation.pa_sc_viz_query & 1) || observation.vertex_memexport) {
-    return;
+    return false;
   }
   ++g_vehicle_shadow_geometry_color_draws_examined;
   const VehicleShadowGeometryIdentity candidate =
@@ -15054,7 +15092,7 @@ void ObserveVehicleShadowGeometryColorCorrelation(
     }
   }
   if (matched_seed == g_vehicle_shadow_geometry_seed_count) {
-    return;
+    return false;
   }
   ++g_vehicle_shadow_geometry_color_draws_matched;
   if (full_geometry_match) {
@@ -15084,12 +15122,12 @@ void ObserveVehicleShadowGeometryColorCorrelation(
       }
       ++entry.draws;
       entry.last_frame = observation.frame_sequence;
-      return;
+      return true;
     }
   }
   if (!available) {
     ++g_vehicle_shadow_geometry_correlation_overflow;
-    return;
+    return true;
   }
   *available = {
       .prepared_signature = prepared_signature,
@@ -15129,6 +15167,7 @@ void ObserveVehicleShadowGeometryColorCorrelation(
        {"native_draw", "false"},
        {"xenos_authority", "true"},
        {"suppression_allowed", "false"}});
+  return true;
 }
 
 void RecordStaticWorldPreparedLayout(
@@ -19707,6 +19746,7 @@ void ObservePreparedDraw(
   g_isolated_draw.prepared_shadow_depth_batch_member = false;
   g_isolated_draw.prepared_shadow_depth_batch_family =
       ShadowDepthBatchFamily::kNone;
+  g_isolated_draw.prepared_vehicle_shadow_color_replay_eligible = false;
   g_consumer_family_marker.current_match = false;
   if (!g_pending_candidate.valid) {
     ++g_candidate_prepared_without_observation_count;
@@ -19870,9 +19910,19 @@ void ObservePreparedDraw(
         }
       }
     }
-    ObserveVehicleShadowGeometryColorCorrelation(
+    const bool vehicle_shadow_geometry_color_match =
+        ObserveVehicleShadowGeometryColorCorrelation(
         sample, g_pending_candidate.samples_resolved_target, observation,
         prepared_signature, prepared_semantic_contract);
+    if (g_isolated_draw.vehicle_shadow_color_capture_mode &&
+        !g_isolated_draw.vehicle_shadow_color_capture_completed &&
+        vehicle_shadow_geometry_color_match &&
+        IsIsolatedDrawEligible(
+            sample, g_pending_candidate.samples_resolved_target,
+            observation)) {
+      g_isolated_draw.prepared_vehicle_shadow_color_replay_eligible = true;
+      g_isolated_draw.vehicle_shadow_color_capture_pending = true;
+    }
     if (g_isolated_draw.shadow_depth_mode ||
         g_isolated_draw.shadow_depth_batch_mode) {
       if (g_isolated_draw.prepared_shadow_depth_seed_eligible) {
@@ -20960,6 +21010,37 @@ void CompleteIsolatedDraw(
        {"suppression_eligible", "false"}});
 }
 
+void CompleteVehicleShadowColorCapture(
+    const rex::system::GraphicsIsolatedDrawResult &result) {
+  CompleteIsolatedDraw(result);
+  const bool recorded =
+      result.status == rex::system::GraphicsIsolatedDrawStatus::kRecorded;
+  if (recorded) {
+    ++g_isolated_draw.vehicle_shadow_color_capture_recorded;
+  } else if (result.status == rex::system::
+                                  GraphicsIsolatedDrawStatus::
+                                      kTargetCreationFailed) {
+    ++g_isolated_draw.vehicle_shadow_color_capture_target_failures;
+  } else {
+    ++g_isolated_draw.vehicle_shadow_color_capture_unsupported;
+  }
+  pinyon_shift::diagnostics::RecordEvent(
+      "native_renderer.discovery.vehicle_shadow_color_capture_result",
+      {{"status", recorded ? "recorded_private_color_candidate"
+                              : "failed_closed"},
+       {"signature",
+        fmt::format("{:016X}", g_isolated_draw.captured_signature)},
+       {"frame", std::to_string(g_isolated_draw.captured_frame)},
+       {"draw", std::to_string(g_isolated_draw.captured_draw)},
+       {"target_width", std::to_string(result.target_width)},
+       {"target_height", std::to_string(result.target_height)},
+       {"readback", "native_and_xenos_color"},
+       {"native_draw", recorded ? "private_capture_only" : "false"},
+       {"xenos_draw", "preserved"},
+       {"output_authority", "xenos"},
+       {"suppression_allowed", "false"}});
+}
+
 void CompleteIsolatedShadowDepth(
     const rex::system::GraphicsIsolatedDrawResult &result) {
   CompleteIsolatedDraw(result);
@@ -21839,6 +21920,34 @@ void RequestIsolatedDraw(
     // Qualification mode is one-shot. Continuous mode admits later exact
     // epochs, but the first ordering, replay, or publication failure disables
     // every later native request for the process and leaves Xenos authoritative.
+    if (g_isolated_draw.shadow_depth_batch_capture_completed &&
+        g_isolated_draw.vehicle_shadow_color_capture_mode &&
+        g_isolated_draw.vehicle_shadow_color_capture_pending &&
+        g_isolated_draw.prepared_vehicle_shadow_color_replay_eligible &&
+        !g_isolated_draw.vehicle_shadow_color_capture_completed) {
+      g_isolated_draw.vehicle_shadow_color_capture_completed = true;
+      g_isolated_draw.vehicle_shadow_color_capture_pending = false;
+      ++g_isolated_draw.vehicle_shadow_color_capture_requests;
+      g_isolated_draw.captured_signature =
+          g_isolated_draw.prepared_signature;
+      g_isolated_draw.captured_frame = g_isolated_draw.frame;
+      g_isolated_draw.captured_draw = g_isolated_draw.draw;
+      request.requested = true;
+      request.frame_sequence = g_isolated_draw.frame;
+      request.readback_requested = g_isolated_draw.readback_requested;
+      request.reference_readback_requested =
+          g_isolated_draw.readback_requested;
+      request.reference_marker_requested = true;
+      request.completion = &CompleteVehicleShadowColorCapture;
+      request.readback_completion = g_isolated_draw.readback_requested
+                                        ? &CompleteIsolatedDrawReadback
+                                        : nullptr;
+      request.reference_readback_completion =
+          g_isolated_draw.readback_requested
+              ? &CompleteIsolatedReferenceReadback
+              : nullptr;
+      return;
+    }
     if ((g_isolated_draw.shadow_depth_batch_capture_completed &&
          !g_isolated_draw.shadow_depth_continuous_mode) ||
         g_isolated_draw.shadow_depth_continuous_failed_closed ||
@@ -25418,6 +25527,45 @@ void UninstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system) {
          {"mesh_material_contract_proven", "false"},
          {"native_draw", "false"},
          {"xenos_authority", "true"},
+         {"suppression_allowed", "false"}});
+  }
+  if (g_isolated_draw.vehicle_shadow_color_capture_mode) {
+    const uint64_t capture_outcomes =
+        g_isolated_draw.vehicle_shadow_color_capture_recorded +
+        g_isolated_draw.vehicle_shadow_color_capture_target_failures +
+        g_isolated_draw.vehicle_shadow_color_capture_unsupported;
+    diagnostics::RecordEvent(
+        "native_renderer.discovery.vehicle_shadow_color_capture_summary",
+        {{"status", g_isolated_draw.vehicle_shadow_color_capture_recorded
+                        ? "recorded_private_color_candidate"
+                        : (g_isolated_draw.vehicle_shadow_color_capture_requests
+                               ? "failed_closed"
+                               : "not_observed")},
+         {"requests",
+          std::to_string(
+              g_isolated_draw.vehicle_shadow_color_capture_requests)},
+         {"recorded",
+          std::to_string(
+              g_isolated_draw.vehicle_shadow_color_capture_recorded)},
+         {"target_creation_failures",
+          std::to_string(
+              g_isolated_draw.vehicle_shadow_color_capture_target_failures)},
+         {"unsupported",
+          std::to_string(
+              g_isolated_draw.vehicle_shadow_color_capture_unsupported)},
+         {"request_accounting_complete",
+          capture_outcomes ==
+                  g_isolated_draw.vehicle_shadow_color_capture_requests
+              ? "true"
+              : "false"},
+         {"selection", "first_mechanically_replayable_correlated_color_draw"},
+         {"readback", "native_and_xenos_color"},
+         {"native_draw",
+          g_isolated_draw.vehicle_shadow_color_capture_recorded
+              ? "private_capture_only"
+              : "false"},
+         {"xenos_draw", "preserved"},
+         {"output_authority", "xenos"},
          {"suppression_allowed", "false"}});
   }
   if (g_isolated_draw.shadow_depth_batch_mode) {

--- a/tools/capture-native-renderer-census.ps1
+++ b/tools/capture-native-renderer-census.ps1
@@ -19,6 +19,7 @@ param(
     [switch]$ShadowDepthIsolated,
     [switch]$ShadowDepthBatch,
     [switch]$VehicleShadowGeometryCorrelation,
+    [switch]$CaptureVehicleShadowColor,
     [switch]$PublishShadowDepth,
     [switch]$ContinuousShadowDepth,
     [ValidateRange(2, 120)]
@@ -114,6 +115,9 @@ if ($ShadowDepthBatch -and -not $IsolatedDrawDir) {
 }
 if ($VehicleShadowGeometryCorrelation -and -not $ShadowDepthBatch) {
     throw 'VehicleShadowGeometryCorrelation requires ShadowDepthBatch.'
+}
+if ($CaptureVehicleShadowColor -and -not $VehicleShadowGeometryCorrelation) {
+    throw 'CaptureVehicleShadowColor requires VehicleShadowGeometryCorrelation.'
 }
 if ($PublishShadowDepth -and -not $ShadowDepthBatch) {
     throw 'PublishShadowDepth requires ShadowDepthBatch.'
@@ -236,6 +240,8 @@ $savedShadowDepthIsolated = $env:PINYON_SHIFT_NATIVE_RENDERER_SHADOW_DEPTH_ISOLA
 $savedShadowDepthBatch = $env:PINYON_SHIFT_NATIVE_RENDERER_SHADOW_DEPTH_BATCH
 $savedVehicleShadowGeometryCorrelation =
     $env:PINYON_SHIFT_NATIVE_RENDERER_VEHICLE_SHADOW_GEOMETRY_CORRELATION
+$savedVehicleShadowColorCapture =
+    $env:PINYON_SHIFT_NATIVE_RENDERER_VEHICLE_SHADOW_COLOR_CAPTURE
 $savedShadowDepthPublication =
     $env:PINYON_SHIFT_NATIVE_RENDERER_SHADOW_DEPTH_PUBLICATION
 $savedShadowDepthContinuous =
@@ -286,6 +292,8 @@ try {
         if ($ShadowDepthBatch) { 'true' } else { $null }
     $env:PINYON_SHIFT_NATIVE_RENDERER_VEHICLE_SHADOW_GEOMETRY_CORRELATION =
         if ($VehicleShadowGeometryCorrelation) { 'true' } else { $null }
+    $env:PINYON_SHIFT_NATIVE_RENDERER_VEHICLE_SHADOW_COLOR_CAPTURE =
+        if ($CaptureVehicleShadowColor) { 'true' } else { $null }
     $env:PINYON_SHIFT_NATIVE_RENDERER_SHADOW_DEPTH_PUBLICATION =
         if ($PublishShadowDepth) { 'true' } else { $null }
     $env:PINYON_SHIFT_NATIVE_RENDERER_SHADOW_DEPTH_CONTINUOUS =
@@ -342,6 +350,8 @@ finally {
         $savedShadowDepthBatch
     $env:PINYON_SHIFT_NATIVE_RENDERER_VEHICLE_SHADOW_GEOMETRY_CORRELATION =
         $savedVehicleShadowGeometryCorrelation
+    $env:PINYON_SHIFT_NATIVE_RENDERER_VEHICLE_SHADOW_COLOR_CAPTURE =
+        $savedVehicleShadowColorCapture
     $env:PINYON_SHIFT_NATIVE_RENDERER_SHADOW_DEPTH_PUBLICATION =
         $savedShadowDepthPublication
     $env:PINYON_SHIFT_NATIVE_RENDERER_SHADOW_DEPTH_CONTINUOUS =

--- a/tools/summarize-native-renderer-vehicle-shadow-geometry.py
+++ b/tools/summarize-native-renderer-vehicle-shadow-geometry.py
@@ -13,6 +13,15 @@ CORRELATION_EVENT = (
 )
 CANDIDATE_EVENT = "native_renderer.discovery.vehicle_shadow_geometry_candidate"
 SUMMARY_EVENT = "native_renderer.discovery.vehicle_shadow_geometry_summary"
+CAPTURE_CONFIG_EVENT = (
+    "native_renderer.discovery.vehicle_shadow_color_capture_config"
+)
+CAPTURE_RESULT_EVENT = (
+    "native_renderer.discovery.vehicle_shadow_color_capture_result"
+)
+CAPTURE_SUMMARY_EVENT = (
+    "native_renderer.discovery.vehicle_shadow_color_capture_summary"
+)
 
 
 def require(condition, message):
@@ -54,6 +63,15 @@ def summarize(log_path):
     ]
     summaries = [
         event for event in events if event.get("event") == SUMMARY_EVENT
+    ]
+    capture_configs = [
+        event for event in events if event.get("event") == CAPTURE_CONFIG_EVENT
+    ]
+    capture_results = [
+        event for event in events if event.get("event") == CAPTURE_RESULT_EVENT
+    ]
+    capture_summaries = [
+        event for event in events if event.get("event") == CAPTURE_SUMMARY_EVENT
     ]
     require(len(configs) == 1, "expected exactly one correlation config event")
     require(configs[0].get("status") == "armed", "correlation was not armed")
@@ -138,6 +156,44 @@ def summarize(log_path):
             "last_parameter_hash",
         ):
             require(len(event.get(key, "")) == 16, f"invalid candidate hash: {key}")
+    capture = None
+    if capture_configs or capture_results or capture_summaries:
+        require(len(capture_configs) == 1, "expected one color capture config")
+        require(capture_configs[0].get("status") == "armed", "color capture was not armed")
+        require(len(capture_summaries) == 1, "expected one color capture summary")
+        capture_summary = capture_summaries[0]
+        require(
+            capture_summary.get("request_accounting_complete") == "true",
+            "color capture accounting drift",
+        )
+        requests = integer(capture_summary, "requests")
+        recorded = integer(capture_summary, "recorded")
+        require(requests in {0, 1}, "color capture request bound drift")
+        require(recorded in {0, 1}, "color capture result bound drift")
+        require(len(capture_results) == requests, "color capture result drift")
+        require(recorded <= requests, "recorded capture exceeds requests")
+        for event in [*capture_configs, *capture_results, capture_summary]:
+            require(
+                event.get("xenos_draw") == "preserved"
+                and event.get("output_authority") == "xenos"
+                and event.get("suppression_allowed") == "false",
+                "color capture changed output authority",
+            )
+        if recorded:
+            require(
+                capture_results[0].get("status")
+                == "recorded_private_color_candidate",
+                "private color capture result drift",
+            )
+            require(
+                capture_results[0].get("native_draw") == "private_capture_only",
+                "color capture escaped private replay",
+            )
+        capture = {
+            "config": capture_configs[0],
+            "result": capture_results[0] if capture_results else None,
+            "summary": capture_summary,
+        }
     return {
         "schema": SCHEMA,
         "source_log": str(log_path),
@@ -153,8 +209,13 @@ def summarize(log_path):
         "epochs": epochs,
         "correlations": correlations,
         "candidate_families": candidates,
+        "private_color_capture": capture,
         "qualification": {
             "working_color_bridge_candidate": bool(correlations),
+            "private_color_capture_recorded": bool(
+                capture
+                and integer(capture["summary"], "recorded") == 1
+            ),
             "object_identity_proven": False,
             "mesh_material_contract_proven": False,
             "native_admission_allowed": False,

--- a/tools/tests/test_native_renderer_vehicle_shadow_geometry.py
+++ b/tools/tests/test_native_renderer_vehicle_shadow_geometry.py
@@ -60,6 +60,35 @@ class VehicleShadowGeometryTests(unittest.TestCase):
                 **safety,
             },
             {
+                "event": MODULE.CAPTURE_CONFIG_EVENT,
+                "status": "armed",
+                "native_draw": "private_capture_only",
+                "xenos_draw": "preserved",
+                "output_authority": "xenos",
+                "suppression_allowed": "false",
+            },
+            {
+                "event": MODULE.CAPTURE_RESULT_EVENT,
+                "status": "recorded_private_color_candidate",
+                "native_draw": "private_capture_only",
+                "xenos_draw": "preserved",
+                "output_authority": "xenos",
+                "suppression_allowed": "false",
+            },
+            {
+                "event": MODULE.CAPTURE_SUMMARY_EVENT,
+                "status": "recorded_private_color_candidate",
+                "requests": "1",
+                "recorded": "1",
+                "target_creation_failures": "0",
+                "unsupported": "0",
+                "request_accounting_complete": "true",
+                "native_draw": "private_capture_only",
+                "xenos_draw": "preserved",
+                "output_authority": "xenos",
+                "suppression_allowed": "false",
+            },
+            {
                 "event": MODULE.SUMMARY_EVENT,
                 "status": "qualified_epoch_observed",
                 "epochs_committed": "1",
@@ -93,7 +122,14 @@ class VehicleShadowGeometryTests(unittest.TestCase):
             report["qualification"]["working_color_bridge_candidate"]
         )
         self.assertEqual(1, len(report["candidate_families"]))
+        self.assertEqual(
+            "recorded_private_color_candidate",
+            report["private_color_capture"]["result"]["status"],
+        )
         self.assertFalse(report["qualification"]["native_admission_allowed"])
+        self.assertTrue(
+            report["qualification"]["private_color_capture_recorded"]
+        )
 
     def test_rejects_partial_epoch_promotion(self):
         events = self.fixture()
@@ -119,6 +155,12 @@ class VehicleShadowGeometryTests(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "pose variation accounting drift"):
             self.summarize(events)
 
+    def test_rejects_private_capture_authority_drift(self):
+        events = self.fixture()
+        events[5]["output_authority"] = "native"
+        with self.assertRaisesRegex(ValueError, "output authority"):
+            self.summarize(events)
+
     def test_runtime_contract_is_default_off_and_full_epoch_gated(self):
         source = (ROOT / "src/native_renderer/graphics_hooks.cpp").read_text(
             encoding="utf-8"
@@ -138,9 +180,19 @@ class VehicleShadowGeometryTests(unittest.TestCase):
         )
         self.assertIn('"native_renderer.discovery.vehicle_shadow_geometry_summary"', source)
         self.assertIn('"native_renderer.discovery.vehicle_shadow_geometry_candidate"', source)
+        self.assertIn("CompleteVehicleShadowColorCapture", source)
+        self.assertIn(
+            '"native_renderer.discovery.vehicle_shadow_color_capture_summary"',
+            source,
+        )
         self.assertIn("[switch]$VehicleShadowGeometryCorrelation", capture)
+        self.assertIn("[switch]$CaptureVehicleShadowColor", capture)
         self.assertIn(
             "VehicleShadowGeometryCorrelation requires ShadowDepthBatch",
+            capture,
+        )
+        self.assertIn(
+            "CaptureVehicleShadowColor requires VehicleShadowGeometryCorrelation",
             capture,
         )
         self.assertIn('{"native_draw", "false"}', source)


### PR DESCRIPTION
## Summary
- add an independent opt-in for same-session vehicle color capture
- wait for the backend-confirmed 80-draw vehicle shadow epoch
- privately replay the first mechanically eligible correlated color draw
- capture native and Xenos color readbacks without publication or suppression
- extend the deterministic qualifier and C4 roadmap

## Validation
- compiled `graphics_hooks.cpp` in the release configuration
- `python -m unittest discover -s tools/tests -p 'test_*.py'` (603 passed)