### PR TITLE
feat(renderer): census vehicle replay rejections

### DIFF
--- a/docs/native-renderer/REPRIORITIZED_PLAN.md
+++ b/docs/native-renderer/REPRIORITIZED_PLAN.md
@@ -544,6 +544,24 @@ same long session, never publishes the private target, preserves the original
 Xenos draw, and cannot suppress. This is intended to produce the first direct
 C4 image pair without requiring a second gameplay run.
 
+Batched ingress result: the first AppData qualification committed one exact
+80-draw epoch with 68 unique geometry seeds and no overflow. Across 1,929
+loaded-game frames it found 57,870 exact full-resource color matches in 30
+bounded families; every family changed its parameter hash on every subsequent
+frame. This confirms a stable animated vehicle color ingress, while still not
+proving object identity or a complete material contract. No private color
+capture request was issued because none of the correlated draws passed the
+existing isolated-draw mechanical gate.
+
+Replay-gate diagnostic checkpoint: each matched draw now records the exact
+mechanical rejection mask before capture selection. Bounded family aggregates
+retain eligible/rejected draw counts, first/last/OR/AND masks, and mask-switch
+counts; the final summary emits per-reason draw totals and strict accounting.
+This does not relax admission, publish a native target, capture guest payload,
+or allow suppression. The next batched run will identify the smallest missing
+geometry, texture, pipeline, or render-target contract before any native
+vehicle implementation is admitted.
+
 ### C5. Sky, atmosphere, and global lighting
 
 - Replace the qualified sky/global-light families.

--- a/docs/native-renderer/VEHICLE_INSTANCE_SEMANTIC_SEED.md
+++ b/docs/native-renderer/VEHICLE_INSTANCE_SEMANTIC_SEED.md
@@ -488,3 +488,19 @@ shadow-depth artifacts. The authoritative Xenos draw still executes, the
 private target is never published, and no suppression is permitted. A usable
 pair gives the first direct visual checkpoint for the C4 ingress; failure or
 absence remains a bounded diagnostic result.
+
+The first loaded-game qualification committed one exact epoch with 68 unique
+seeds and zero overflow. It observed 57,870 exact full-resource matches across
+1,929 frames and 30 bounded families. Every family exhibited per-frame
+parameter variation, which confirms that the bridge tracks animated vehicle
+geometry rather than a static title artifact. The private color request count
+remained zero: the correlation succeeded, but every matched draw failed at
+least one existing isolated-draw mechanical requirement.
+
+The observer therefore retains the gate and adds bounded rejection evidence.
+For each family it reports eligible and rejected draw counts, first and last
+rejection masks, their union and intersection, and mask switches. The session
+summary reports the count for every `isolated_draw_v1` rejection bit and proves
+that eligible plus rejected draws equals all correlated draws. This is still
+measurement-only: no guest payload is exported, no native color target is
+published, every Xenos draw executes, and suppression remains impossible.

--- a/src/native_renderer/graphics_hooks.cpp
+++ b/src/native_renderer/graphics_hooks.cpp
@@ -620,7 +620,14 @@ struct VehicleShadowGeometryCorrelationEntry {
   uint64_t parameter_switches = 0;
   uint64_t first_frame = 0;
   uint64_t last_frame = 0;
+  uint64_t mechanically_eligible_draws = 0;
+  uint64_t mechanically_rejected_draws = 0;
+  uint64_t rejection_mask_switches = 0;
   uint32_t seed_index = 0;
+  uint32_t first_rejection_mask = 0;
+  uint32_t last_rejection_mask = 0;
+  uint32_t rejection_mask_or = 0;
+  uint32_t rejection_mask_and = 0;
   bool full_geometry_match = false;
   bool occupied = false;
 };
@@ -1439,6 +1446,9 @@ uint64_t g_vehicle_shadow_geometry_full_matches = 0;
 uint64_t g_vehicle_shadow_geometry_partial_matches = 0;
 uint64_t g_vehicle_shadow_geometry_correlation_count = 0;
 uint64_t g_vehicle_shadow_geometry_correlation_overflow = 0;
+uint64_t g_vehicle_shadow_geometry_mechanically_eligible_draws = 0;
+uint64_t g_vehicle_shadow_geometry_mechanically_rejected_draws = 0;
+std::array<uint64_t, 15> g_vehicle_shadow_geometry_rejection_reason_counts{};
 bool g_vehicle_title_provenance_requested = false;
 uint64_t g_title_packets_recorded = 0;
 uint64_t g_title_packets_matched = 0;
@@ -15062,7 +15072,8 @@ bool ObserveVehicleShadowGeometryColorCorrelation(
     bool samples_resolved_target,
     const rex::system::GraphicsPreparedDrawObservation &prepared,
     uint64_t prepared_signature,
-    const SemanticPreparedDrawContract &contract) {
+    const SemanticPreparedDrawContract &contract,
+    uint32_t mechanical_rejection_mask) {
   if (!g_isolated_draw.vehicle_shadow_geometry_correlation_mode ||
       !g_vehicle_shadow_geometry_seed_count || samples_resolved_target ||
       !contract.geometry_bounded || !observation.indexed ||
@@ -15100,6 +15111,17 @@ bool ObserveVehicleShadowGeometryColorCorrelation(
   } else {
     ++g_vehicle_shadow_geometry_partial_matches;
   }
+  if (mechanical_rejection_mask) {
+    ++g_vehicle_shadow_geometry_mechanically_rejected_draws;
+  } else {
+    ++g_vehicle_shadow_geometry_mechanically_eligible_draws;
+  }
+  for (size_t bit = 0;
+       bit < g_vehicle_shadow_geometry_rejection_reason_counts.size(); ++bit) {
+    if (mechanical_rejection_mask & (uint32_t(1) << bit)) {
+      ++g_vehicle_shadow_geometry_rejection_reason_counts[bit];
+    }
+  }
   VehicleShadowGeometryCorrelationEntry *available = nullptr;
   for (VehicleShadowGeometryCorrelationEntry &entry :
        g_vehicle_shadow_geometry_correlations) {
@@ -15119,6 +15141,17 @@ bool ObserveVehicleShadowGeometryColorCorrelation(
       if (entry.last_parameter_hash != parameter_hash) {
         ++entry.parameter_switches;
         entry.last_parameter_hash = parameter_hash;
+      }
+      if (entry.last_rejection_mask != mechanical_rejection_mask) {
+        ++entry.rejection_mask_switches;
+        entry.last_rejection_mask = mechanical_rejection_mask;
+      }
+      entry.rejection_mask_or |= mechanical_rejection_mask;
+      entry.rejection_mask_and &= mechanical_rejection_mask;
+      if (mechanical_rejection_mask) {
+        ++entry.mechanically_rejected_draws;
+      } else {
+        ++entry.mechanically_eligible_draws;
       }
       ++entry.draws;
       entry.last_frame = observation.frame_sequence;
@@ -15141,7 +15174,13 @@ bool ObserveVehicleShadowGeometryColorCorrelation(
       .draws = 1,
       .first_frame = observation.frame_sequence,
       .last_frame = observation.frame_sequence,
+      .mechanically_eligible_draws = mechanical_rejection_mask ? 0u : 1u,
+      .mechanically_rejected_draws = mechanical_rejection_mask ? 1u : 0u,
       .seed_index = uint32_t(matched_seed),
+      .first_rejection_mask = mechanical_rejection_mask,
+      .last_rejection_mask = mechanical_rejection_mask,
+      .rejection_mask_or = mechanical_rejection_mask,
+      .rejection_mask_and = mechanical_rejection_mask,
       .full_geometry_match = full_geometry_match,
       .occupied = true,
   };
@@ -15158,6 +15197,10 @@ bool ObserveVehicleShadowGeometryColorCorrelation(
         fmt::format("{:016X}", contract.texture_resource_hash)},
        {"prepared_pipeline_hash",
         fmt::format("{:016X}", contract.prepared_pipeline_hash)},
+       {"mechanical_rejection_mask",
+        fmt::format("{:08X}", mechanical_rejection_mask)},
+       {"mechanically_eligible",
+        mechanical_rejection_mask ? "false" : "true"},
        {"seed_index", std::to_string(matched_seed)},
        {"match", full_geometry_match
                      ? "exact_geometry_resource_set"
@@ -19910,16 +19953,19 @@ void ObservePreparedDraw(
         }
       }
     }
+    const uint32_t vehicle_shadow_color_rejection_mask =
+        IsolatedDrawMechanicalRejectionMask(
+            sample, g_pending_candidate.samples_resolved_target,
+            observation);
     const bool vehicle_shadow_geometry_color_match =
         ObserveVehicleShadowGeometryColorCorrelation(
         sample, g_pending_candidate.samples_resolved_target, observation,
-        prepared_signature, prepared_semantic_contract);
+        prepared_signature, prepared_semantic_contract,
+        vehicle_shadow_color_rejection_mask);
     if (g_isolated_draw.vehicle_shadow_color_capture_mode &&
         !g_isolated_draw.vehicle_shadow_color_capture_completed &&
         vehicle_shadow_geometry_color_match &&
-        IsIsolatedDrawEligible(
-            sample, g_pending_candidate.samples_resolved_target,
-            observation)) {
+        !vehicle_shadow_color_rejection_mask) {
       g_isolated_draw.prepared_vehicle_shadow_color_replay_eligible = true;
       g_isolated_draw.vehicle_shadow_color_capture_pending = true;
     }
@@ -25477,6 +25523,21 @@ void UninstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system) {
             "bounded_vehicle_color_geometry_candidate_family"},
            {"pose_variation_observed",
             entry.parameter_switches ? "true" : "false"},
+           {"mechanically_eligible_draws",
+            std::to_string(entry.mechanically_eligible_draws)},
+           {"mechanically_rejected_draws",
+            std::to_string(entry.mechanically_rejected_draws)},
+           {"first_rejection_mask",
+            fmt::format("{:08X}", entry.first_rejection_mask)},
+           {"last_rejection_mask",
+            fmt::format("{:08X}", entry.last_rejection_mask)},
+           {"rejection_mask_or",
+            fmt::format("{:08X}", entry.rejection_mask_or)},
+           {"rejection_mask_and",
+            fmt::format("{:08X}", entry.rejection_mask_and)},
+           {"rejection_mask_switches",
+            std::to_string(entry.rejection_mask_switches)},
+           {"mechanical_admission_contract", "isolated_draw_v1"},
            {"guest_payload_capture", "false"},
            {"native_draw", "false"},
            {"xenos_authority", "true"},
@@ -25519,6 +25580,48 @@ void UninstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system) {
           std::to_string(g_vehicle_shadow_geometry_correlation_overflow)},
          {"correlation_capacity",
           std::to_string(kVehicleShadowGeometryCorrelationCapacity)},
+         {"mechanically_eligible_draws",
+          std::to_string(
+              g_vehicle_shadow_geometry_mechanically_eligible_draws)},
+         {"mechanically_rejected_draws",
+          std::to_string(
+              g_vehicle_shadow_geometry_mechanically_rejected_draws)},
+         {"reject_resolved_input",
+          std::to_string(g_vehicle_shadow_geometry_rejection_reason_counts[0])},
+         {"reject_unsupported_geometry",
+          std::to_string(g_vehicle_shadow_geometry_rejection_reason_counts[1])},
+         {"reject_empty_draw",
+          std::to_string(g_vehicle_shadow_geometry_rejection_reason_counts[2])},
+         {"reject_vertex_binding_count",
+          std::to_string(g_vehicle_shadow_geometry_rejection_reason_counts[3])},
+         {"reject_vertex_binding_overflow",
+          std::to_string(g_vehicle_shadow_geometry_rejection_reason_counts[4])},
+         {"reject_vertex_attribute_overflow",
+          std::to_string(g_vehicle_shadow_geometry_rejection_reason_counts[5])},
+         {"reject_vertex_constant_overflow",
+          std::to_string(g_vehicle_shadow_geometry_rejection_reason_counts[6])},
+         {"reject_pixel_constant_overflow",
+          std::to_string(g_vehicle_shadow_geometry_rejection_reason_counts[7])},
+         {"reject_texture_state_overflow",
+          std::to_string(g_vehicle_shadow_geometry_rejection_reason_counts[8])},
+         {"reject_memexport",
+          std::to_string(g_vehicle_shadow_geometry_rejection_reason_counts[9])},
+         {"reject_query",
+          std::to_string(g_vehicle_shadow_geometry_rejection_reason_counts[10])},
+         {"reject_texture_count",
+          std::to_string(g_vehicle_shadow_geometry_rejection_reason_counts[11])},
+         {"reject_texture_layout",
+          std::to_string(g_vehicle_shadow_geometry_rejection_reason_counts[12])},
+         {"reject_prepared_pipeline",
+          std::to_string(g_vehicle_shadow_geometry_rejection_reason_counts[13])},
+         {"reject_render_targets",
+          std::to_string(g_vehicle_shadow_geometry_rejection_reason_counts[14])},
+         {"mechanical_rejection_accounting_complete",
+          g_vehicle_shadow_geometry_mechanically_eligible_draws +
+                      g_vehicle_shadow_geometry_mechanically_rejected_draws ==
+                  g_vehicle_shadow_geometry_color_draws_matched
+              ? "true"
+              : "false"},
          {"seed_accounting_complete",
           seed_accounting_complete ? "true" : "false"},
          {"epoch_contract", "exact_consecutive_64_primary_12_secondary_4_tertiary"},

--- a/tools/summarize-native-renderer-vehicle-shadow-geometry.py
+++ b/tools/summarize-native-renderer-vehicle-shadow-geometry.py
@@ -5,7 +5,7 @@ import json
 from pathlib import Path
 
 
-SCHEMA = "pinyon-shift.native-renderer-vehicle-shadow-geometry.v1"
+SCHEMA = "pinyon-shift.native-renderer-vehicle-shadow-geometry.v2"
 CONFIG_EVENT = "native_renderer.discovery.vehicle_shadow_geometry_config"
 EPOCH_EVENT = "native_renderer.discovery.vehicle_shadow_geometry_epoch"
 CORRELATION_EVENT = (
@@ -22,6 +22,23 @@ CAPTURE_RESULT_EVENT = (
 CAPTURE_SUMMARY_EVENT = (
     "native_renderer.discovery.vehicle_shadow_color_capture_summary"
 )
+REJECTION_REASON_FIELDS = (
+    "reject_resolved_input",
+    "reject_unsupported_geometry",
+    "reject_empty_draw",
+    "reject_vertex_binding_count",
+    "reject_vertex_binding_overflow",
+    "reject_vertex_attribute_overflow",
+    "reject_vertex_constant_overflow",
+    "reject_pixel_constant_overflow",
+    "reject_texture_state_overflow",
+    "reject_memexport",
+    "reject_query",
+    "reject_texture_count",
+    "reject_texture_layout",
+    "reject_prepared_pipeline",
+    "reject_render_targets",
+)
 
 
 def require(condition, message):
@@ -34,6 +51,13 @@ def integer(record, key):
         return int(record[key])
     except (KeyError, TypeError, ValueError) as error:
         raise ValueError(f"missing or invalid integer field: {key}") from error
+
+
+def hexadecimal(record, key):
+    try:
+        return int(record[key], 16)
+    except (KeyError, TypeError, ValueError) as error:
+        raise ValueError(f"missing or invalid hexadecimal field: {key}") from error
 
 
 def load_events(path):
@@ -100,6 +124,21 @@ def summarize(log_path):
         + integer(summary, "index_vertex_matches"),
         "match accounting drift",
     )
+    require(
+        summary.get("mechanical_rejection_accounting_complete") == "true",
+        "mechanical rejection accounting drift",
+    )
+    mechanically_eligible_draws = integer(
+        summary, "mechanically_eligible_draws"
+    )
+    mechanically_rejected_draws = integer(
+        summary, "mechanically_rejected_draws"
+    )
+    require(
+        mechanically_eligible_draws + mechanically_rejected_draws
+        == integer(summary, "color_draws_matched"),
+        "mechanical eligibility accounting drift",
+    )
     safety_events = [*configs, *epochs, *correlations, *candidates, summary]
     for event in safety_events:
         require(event.get("native_draw") == "false", "native draw was enabled")
@@ -144,6 +183,23 @@ def summarize(log_path):
             event.get("pose_variation_observed")
             == ("true" if integer(event, "parameter_switches") else "false"),
             "pose variation accounting drift",
+        )
+        eligible_draws = integer(event, "mechanically_eligible_draws")
+        rejected_draws = integer(event, "mechanically_rejected_draws")
+        require(
+            eligible_draws + rejected_draws == integer(event, "draws"),
+            "candidate mechanical eligibility accounting drift",
+        )
+        first_mask = hexadecimal(event, "first_rejection_mask")
+        last_mask = hexadecimal(event, "last_rejection_mask")
+        mask_or = hexadecimal(event, "rejection_mask_or")
+        mask_and = hexadecimal(event, "rejection_mask_and")
+        require(first_mask & mask_or == first_mask, "candidate first mask drift")
+        require(last_mask & mask_or == last_mask, "candidate last mask drift")
+        require(mask_and & mask_or == mask_and, "candidate mask bounds drift")
+        require(
+            not eligible_draws or mask_and == 0,
+            "candidate eligible draw retained a stable rejection",
         )
         for key in (
             "prepared_signature",
@@ -204,7 +260,13 @@ def summarize(log_path):
             "color_draws_matched": integer(summary, "color_draws_matched"),
             "full_geometry_matches": integer(summary, "full_geometry_matches"),
             "index_vertex_matches": integer(summary, "index_vertex_matches"),
+            "mechanically_eligible_draws": mechanically_eligible_draws,
+            "mechanically_rejected_draws": mechanically_rejected_draws,
             "correlations": len(correlations),
+        },
+        "mechanical_rejections": {
+            key.removeprefix("reject_"): integer(summary, key)
+            for key in REJECTION_REASON_FIELDS
         },
         "epochs": epochs,
         "correlations": correlations,

--- a/tools/tests/test_native_renderer_vehicle_shadow_geometry.py
+++ b/tools/tests/test_native_renderer_vehicle_shadow_geometry.py
@@ -57,6 +57,13 @@ class VehicleShadowGeometryTests(unittest.TestCase):
                 "first_frame": "10",
                 "last_frame": "12",
                 "pose_variation_observed": "true",
+                "mechanically_eligible_draws": "1",
+                "mechanically_rejected_draws": "2",
+                "first_rejection_mask": "00002000",
+                "last_rejection_mask": "00000000",
+                "rejection_mask_or": "00002000",
+                "rejection_mask_and": "00000000",
+                "rejection_mask_switches": "1",
                 **safety,
             },
             {
@@ -101,6 +108,24 @@ class VehicleShadowGeometryTests(unittest.TestCase):
                 "index_vertex_matches": "2",
                 "correlations": "1",
                 "correlation_overflow": "0",
+                "mechanically_eligible_draws": "1",
+                "mechanically_rejected_draws": "2",
+                "mechanical_rejection_accounting_complete": "true",
+                "reject_resolved_input": "0",
+                "reject_unsupported_geometry": "0",
+                "reject_empty_draw": "0",
+                "reject_vertex_binding_count": "0",
+                "reject_vertex_binding_overflow": "0",
+                "reject_vertex_attribute_overflow": "0",
+                "reject_vertex_constant_overflow": "0",
+                "reject_pixel_constant_overflow": "0",
+                "reject_texture_state_overflow": "0",
+                "reject_memexport": "0",
+                "reject_query": "0",
+                "reject_texture_count": "0",
+                "reject_texture_layout": "0",
+                "reject_prepared_pipeline": "2",
+                "reject_render_targets": "0",
                 **safety,
             },
         ]
@@ -130,6 +155,7 @@ class VehicleShadowGeometryTests(unittest.TestCase):
         self.assertTrue(
             report["qualification"]["private_color_capture_recorded"]
         )
+        self.assertEqual(2, report["mechanical_rejections"]["prepared_pipeline"])
 
     def test_rejects_partial_epoch_promotion(self):
         events = self.fixture()
@@ -153,6 +179,20 @@ class VehicleShadowGeometryTests(unittest.TestCase):
         events = self.fixture()
         events[3]["pose_variation_observed"] = "false"
         with self.assertRaisesRegex(ValueError, "pose variation accounting drift"):
+            self.summarize(events)
+
+    def test_rejects_mechanical_eligibility_accounting_drift(self):
+        events = self.fixture()
+        events[3]["mechanically_rejected_draws"] = "1"
+        with self.assertRaisesRegex(
+            ValueError, "candidate mechanical eligibility accounting drift"
+        ):
+            self.summarize(events)
+
+    def test_rejects_candidate_mask_bounds_drift(self):
+        events = self.fixture()
+        events[3]["rejection_mask_or"] = "00000000"
+        with self.assertRaisesRegex(ValueError, "candidate first mask drift"):
             self.summarize(events)
 
     def test_rejects_private_capture_authority_drift(self):


### PR DESCRIPTION
Records exact isolated-draw rejection evidence for every capture-proven vehicle color match, aggregates mask stability per bounded family, and exposes strict per-reason accounting in the v2 qualifier. Xenos remains authoritative; native admission, publication, and suppression are unchanged. Tests: Release pinyon_shift target compiled; 9 focused unit tests passed; diff check clean.