### PR TITLE
feat(renderer): admit private vehicle color replay

### DIFF
--- a/docs/native-renderer/REPRIORITIZED_PLAN.md
+++ b/docs/native-renderer/REPRIORITIZED_PLAN.md
@@ -562,6 +562,23 @@ or allow suppression. The next batched run will identify the smallest missing
 geometry, texture, pipeline, or render-target contract before any native
 vehicle implementation is admitted.
 
+Replay-gate result: a clean AppData session reproduced all 30 families across
+25,200 exact matches. Every draw retained the same `00000808` generic mask:
+three-stream vertex input and zero sampled textures. All other rejection
+reasons were zero, and every family kept the same mask across 840 animated
+frames. Backend inspection confirms that private replay restores and duplicates
+the already-prepared guest pipeline, bindings, and texture state; the one-stream
+and at-least-one-texture rules belong to payload snapshot serialization rather
+than backend replay.
+
+Private vehicle capture therefore uses a narrower admission contract. It still
+requires bounded geometry, no overflows, supported indexed input, complete
+prepared pipeline and render targets, no query, memexport, or resolved input,
+and at most four valid textures. It additionally permits bounded multi-stream
+input and a shader that samples no textures. Generic isolated-draw admission is
+unchanged. This exception remains correlation-gated, private, one-shot,
+non-publishing, Xenos-authoritative, and unable to suppress.
+
 ### C5. Sky, atmosphere, and global lighting
 
 - Replace the qualified sky/global-light families.

--- a/docs/native-renderer/VEHICLE_INSTANCE_SEMANTIC_SEED.md
+++ b/docs/native-renderer/VEHICLE_INSTANCE_SEMANTIC_SEED.md
@@ -504,3 +504,19 @@ summary reports the count for every `isolated_draw_v1` rejection bit and proves
 that eligible plus rejected draws equals all correlated draws. This is still
 measurement-only: no guest payload is exported, no native color target is
 published, every Xenos draw executes, and suppression remains impossible.
+
+The follow-up AppData qualification observed 25,200 exact matches over 840
+animated frames. All 30 families retained the same `00000808` generic mask
+with no switches: multiple vertex streams and zero textures. Every other
+mechanical rejection counter was zero. The D3D12 private replay path restores
+the already-prepared guest state before duplicating the current indexed draw;
+it does not depend on the one-stream, textured payload snapshot serializer.
+
+`vehicle_color_private_replay_v1` consequently clears only those two generic
+rejection bits when vertex streams remain within the observation bound, no
+binding or texture overflow occurred, and at most four valid texture resources
+are present (including zero). All other `isolated_draw_v1` requirements remain
+mandatory. The generic gate is untouched, and this private exception is
+reachable only after the backend-confirmed 80-draw epoch and exact geometry
+correlation. It cannot publish or suppress, and the authoritative Xenos draw
+still executes.

--- a/src/native_renderer/graphics_hooks.cpp
+++ b/src/native_renderer/graphics_hooks.cpp
@@ -623,11 +623,18 @@ struct VehicleShadowGeometryCorrelationEntry {
   uint64_t mechanically_eligible_draws = 0;
   uint64_t mechanically_rejected_draws = 0;
   uint64_t rejection_mask_switches = 0;
+  uint64_t private_capture_eligible_draws = 0;
+  uint64_t private_capture_rejected_draws = 0;
+  uint64_t private_capture_rejection_mask_switches = 0;
   uint32_t seed_index = 0;
   uint32_t first_rejection_mask = 0;
   uint32_t last_rejection_mask = 0;
   uint32_t rejection_mask_or = 0;
   uint32_t rejection_mask_and = 0;
+  uint32_t first_private_capture_rejection_mask = 0;
+  uint32_t last_private_capture_rejection_mask = 0;
+  uint32_t private_capture_rejection_mask_or = 0;
+  uint32_t private_capture_rejection_mask_and = 0;
   bool full_geometry_match = false;
   bool occupied = false;
 };
@@ -1449,6 +1456,8 @@ uint64_t g_vehicle_shadow_geometry_correlation_overflow = 0;
 uint64_t g_vehicle_shadow_geometry_mechanically_eligible_draws = 0;
 uint64_t g_vehicle_shadow_geometry_mechanically_rejected_draws = 0;
 std::array<uint64_t, 15> g_vehicle_shadow_geometry_rejection_reason_counts{};
+uint64_t g_vehicle_shadow_color_private_capture_eligible_draws = 0;
+uint64_t g_vehicle_shadow_color_private_capture_rejected_draws = 0;
 bool g_vehicle_title_provenance_requested = false;
 uint64_t g_title_packets_recorded = 0;
 uint64_t g_title_packets_matched = 0;
@@ -15073,7 +15082,8 @@ bool ObserveVehicleShadowGeometryColorCorrelation(
     const rex::system::GraphicsPreparedDrawObservation &prepared,
     uint64_t prepared_signature,
     const SemanticPreparedDrawContract &contract,
-    uint32_t mechanical_rejection_mask) {
+    uint32_t mechanical_rejection_mask,
+    uint32_t private_capture_rejection_mask) {
   if (!g_isolated_draw.vehicle_shadow_geometry_correlation_mode ||
       !g_vehicle_shadow_geometry_seed_count || samples_resolved_target ||
       !contract.geometry_bounded || !observation.indexed ||
@@ -15122,6 +15132,11 @@ bool ObserveVehicleShadowGeometryColorCorrelation(
       ++g_vehicle_shadow_geometry_rejection_reason_counts[bit];
     }
   }
+  if (private_capture_rejection_mask) {
+    ++g_vehicle_shadow_color_private_capture_rejected_draws;
+  } else {
+    ++g_vehicle_shadow_color_private_capture_eligible_draws;
+  }
   VehicleShadowGeometryCorrelationEntry *available = nullptr;
   for (VehicleShadowGeometryCorrelationEntry &entry :
        g_vehicle_shadow_geometry_correlations) {
@@ -15153,6 +15168,21 @@ bool ObserveVehicleShadowGeometryColorCorrelation(
       } else {
         ++entry.mechanically_eligible_draws;
       }
+      if (entry.last_private_capture_rejection_mask !=
+          private_capture_rejection_mask) {
+        ++entry.private_capture_rejection_mask_switches;
+        entry.last_private_capture_rejection_mask =
+            private_capture_rejection_mask;
+      }
+      entry.private_capture_rejection_mask_or |=
+          private_capture_rejection_mask;
+      entry.private_capture_rejection_mask_and &=
+          private_capture_rejection_mask;
+      if (private_capture_rejection_mask) {
+        ++entry.private_capture_rejected_draws;
+      } else {
+        ++entry.private_capture_eligible_draws;
+      }
       ++entry.draws;
       entry.last_frame = observation.frame_sequence;
       return true;
@@ -15176,11 +15206,23 @@ bool ObserveVehicleShadowGeometryColorCorrelation(
       .last_frame = observation.frame_sequence,
       .mechanically_eligible_draws = mechanical_rejection_mask ? 0u : 1u,
       .mechanically_rejected_draws = mechanical_rejection_mask ? 1u : 0u,
+      .private_capture_eligible_draws =
+          private_capture_rejection_mask ? 0u : 1u,
+      .private_capture_rejected_draws =
+          private_capture_rejection_mask ? 1u : 0u,
       .seed_index = uint32_t(matched_seed),
       .first_rejection_mask = mechanical_rejection_mask,
       .last_rejection_mask = mechanical_rejection_mask,
       .rejection_mask_or = mechanical_rejection_mask,
       .rejection_mask_and = mechanical_rejection_mask,
+      .first_private_capture_rejection_mask =
+          private_capture_rejection_mask,
+      .last_private_capture_rejection_mask =
+          private_capture_rejection_mask,
+      .private_capture_rejection_mask_or =
+          private_capture_rejection_mask,
+      .private_capture_rejection_mask_and =
+          private_capture_rejection_mask,
       .full_geometry_match = full_geometry_match,
       .occupied = true,
   };
@@ -15201,6 +15243,10 @@ bool ObserveVehicleShadowGeometryColorCorrelation(
         fmt::format("{:08X}", mechanical_rejection_mask)},
        {"mechanically_eligible",
         mechanical_rejection_mask ? "false" : "true"},
+       {"private_capture_rejection_mask",
+        fmt::format("{:08X}", private_capture_rejection_mask)},
+       {"private_capture_eligible",
+        private_capture_rejection_mask ? "false" : "true"},
        {"seed_index", std::to_string(matched_seed)},
        {"match", full_geometry_match
                      ? "exact_geometry_resource_set"
@@ -16377,6 +16423,29 @@ bool IsIsolatedDrawEligible(
     const rex::system::GraphicsPreparedDrawObservation &prepared) {
   return !IsolatedDrawMechanicalRejectionMask(
       observation, samples_resolved_target, prepared);
+}
+
+uint32_t VehicleShadowColorPrivateCaptureRejectionMask(
+    const rex::system::GraphicsDrawObservation &observation,
+    bool samples_resolved_target,
+    const rex::system::GraphicsPreparedDrawObservation &prepared) {
+  uint32_t mask = IsolatedDrawMechanicalRejectionMask(
+      observation, samples_resolved_target, prepared);
+  // The generic isolated-draw gate is also used by payload snapshots, which
+  // currently serialize one vertex stream and at least one texture. Vehicle
+  // color capture duplicates the already-prepared backend draw directly, so
+  // it can retain bounded multi-stream input and a shader with no textures.
+  if (observation.vertex_binding_count >= 1 &&
+      observation.vertex_binding_count <=
+          rex::system::kGraphicsVertexBindingObservationLimit &&
+      !observation.vertex_binding_overflow) {
+    mask &= ~kIsolatedRejectVertexBindingCount;
+  }
+  if (std::popcount(observation.texture_fetch_mask) <= 4 &&
+      !observation.texture_state_overflow) {
+    mask &= ~kIsolatedRejectTextureCount;
+  }
+  return mask;
 }
 
 bool IsShadowDepthBatchMechanicalDraw(
@@ -19957,15 +20026,20 @@ void ObservePreparedDraw(
         IsolatedDrawMechanicalRejectionMask(
             sample, g_pending_candidate.samples_resolved_target,
             observation);
+    const uint32_t vehicle_shadow_color_private_capture_rejection_mask =
+        VehicleShadowColorPrivateCaptureRejectionMask(
+            sample, g_pending_candidate.samples_resolved_target,
+            observation);
     const bool vehicle_shadow_geometry_color_match =
         ObserveVehicleShadowGeometryColorCorrelation(
         sample, g_pending_candidate.samples_resolved_target, observation,
         prepared_signature, prepared_semantic_contract,
-        vehicle_shadow_color_rejection_mask);
+        vehicle_shadow_color_rejection_mask,
+        vehicle_shadow_color_private_capture_rejection_mask);
     if (g_isolated_draw.vehicle_shadow_color_capture_mode &&
         !g_isolated_draw.vehicle_shadow_color_capture_completed &&
         vehicle_shadow_geometry_color_match &&
-        !vehicle_shadow_color_rejection_mask) {
+        !vehicle_shadow_color_private_capture_rejection_mask) {
       g_isolated_draw.prepared_vehicle_shadow_color_replay_eligible = true;
       g_isolated_draw.vehicle_shadow_color_capture_pending = true;
     }
@@ -25538,6 +25612,27 @@ void UninstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system) {
            {"rejection_mask_switches",
             std::to_string(entry.rejection_mask_switches)},
            {"mechanical_admission_contract", "isolated_draw_v1"},
+           {"private_capture_eligible_draws",
+            std::to_string(entry.private_capture_eligible_draws)},
+           {"private_capture_rejected_draws",
+            std::to_string(entry.private_capture_rejected_draws)},
+           {"first_private_capture_rejection_mask",
+            fmt::format("{:08X}",
+                        entry.first_private_capture_rejection_mask)},
+           {"last_private_capture_rejection_mask",
+            fmt::format("{:08X}",
+                        entry.last_private_capture_rejection_mask)},
+           {"private_capture_rejection_mask_or",
+            fmt::format("{:08X}",
+                        entry.private_capture_rejection_mask_or)},
+           {"private_capture_rejection_mask_and",
+            fmt::format("{:08X}",
+                        entry.private_capture_rejection_mask_and)},
+           {"private_capture_rejection_mask_switches",
+            std::to_string(
+                entry.private_capture_rejection_mask_switches)},
+           {"private_capture_admission_contract",
+            "vehicle_color_private_replay_v1"},
            {"guest_payload_capture", "false"},
            {"native_draw", "false"},
            {"xenos_authority", "true"},
@@ -25622,6 +25717,20 @@ void UninstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system) {
                   g_vehicle_shadow_geometry_color_draws_matched
               ? "true"
               : "false"},
+         {"private_capture_eligible_draws",
+          std::to_string(
+              g_vehicle_shadow_color_private_capture_eligible_draws)},
+         {"private_capture_rejected_draws",
+          std::to_string(
+              g_vehicle_shadow_color_private_capture_rejected_draws)},
+         {"private_capture_rejection_accounting_complete",
+          g_vehicle_shadow_color_private_capture_eligible_draws +
+                      g_vehicle_shadow_color_private_capture_rejected_draws ==
+                  g_vehicle_shadow_geometry_color_draws_matched
+              ? "true"
+              : "false"},
+         {"private_capture_admission_contract",
+          "vehicle_color_private_replay_v1"},
          {"seed_accounting_complete",
           seed_accounting_complete ? "true" : "false"},
          {"epoch_contract", "exact_consecutive_64_primary_12_secondary_4_tertiary"},

--- a/tools/summarize-native-renderer-vehicle-shadow-geometry.py
+++ b/tools/summarize-native-renderer-vehicle-shadow-geometry.py
@@ -5,7 +5,7 @@ import json
 from pathlib import Path
 
 
-SCHEMA = "pinyon-shift.native-renderer-vehicle-shadow-geometry.v2"
+SCHEMA = "pinyon-shift.native-renderer-vehicle-shadow-geometry.v3"
 CONFIG_EVENT = "native_renderer.discovery.vehicle_shadow_geometry_config"
 EPOCH_EVENT = "native_renderer.discovery.vehicle_shadow_geometry_epoch"
 CORRELATION_EVENT = (
@@ -139,6 +139,21 @@ def summarize(log_path):
         == integer(summary, "color_draws_matched"),
         "mechanical eligibility accounting drift",
     )
+    require(
+        summary.get("private_capture_rejection_accounting_complete") == "true",
+        "private capture rejection accounting drift",
+    )
+    private_capture_eligible_draws = integer(
+        summary, "private_capture_eligible_draws"
+    )
+    private_capture_rejected_draws = integer(
+        summary, "private_capture_rejected_draws"
+    )
+    require(
+        private_capture_eligible_draws + private_capture_rejected_draws
+        == integer(summary, "color_draws_matched"),
+        "private capture eligibility accounting drift",
+    )
     safety_events = [*configs, *epochs, *correlations, *candidates, summary]
     for event in safety_events:
         require(event.get("native_draw") == "false", "native draw was enabled")
@@ -201,6 +216,45 @@ def summarize(log_path):
             not eligible_draws or mask_and == 0,
             "candidate eligible draw retained a stable rejection",
         )
+        private_eligible_draws = integer(
+            event, "private_capture_eligible_draws"
+        )
+        private_rejected_draws = integer(
+            event, "private_capture_rejected_draws"
+        )
+        require(
+            private_eligible_draws + private_rejected_draws
+            == integer(event, "draws"),
+            "candidate private capture accounting drift",
+        )
+        private_first_mask = hexadecimal(
+            event, "first_private_capture_rejection_mask"
+        )
+        private_last_mask = hexadecimal(
+            event, "last_private_capture_rejection_mask"
+        )
+        private_mask_or = hexadecimal(
+            event, "private_capture_rejection_mask_or"
+        )
+        private_mask_and = hexadecimal(
+            event, "private_capture_rejection_mask_and"
+        )
+        require(
+            private_first_mask & private_mask_or == private_first_mask,
+            "candidate private first mask drift",
+        )
+        require(
+            private_last_mask & private_mask_or == private_last_mask,
+            "candidate private last mask drift",
+        )
+        require(
+            private_mask_and & private_mask_or == private_mask_and,
+            "candidate private mask bounds drift",
+        )
+        require(
+            not private_eligible_draws or private_mask_and == 0,
+            "candidate private eligible draw retained a stable rejection",
+        )
         for key in (
             "prepared_signature",
             "template_key",
@@ -262,6 +316,8 @@ def summarize(log_path):
             "index_vertex_matches": integer(summary, "index_vertex_matches"),
             "mechanically_eligible_draws": mechanically_eligible_draws,
             "mechanically_rejected_draws": mechanically_rejected_draws,
+            "private_capture_eligible_draws": private_capture_eligible_draws,
+            "private_capture_rejected_draws": private_capture_rejected_draws,
             "correlations": len(correlations),
         },
         "mechanical_rejections": {

--- a/tools/tests/test_native_renderer_vehicle_shadow_geometry.py
+++ b/tools/tests/test_native_renderer_vehicle_shadow_geometry.py
@@ -64,6 +64,13 @@ class VehicleShadowGeometryTests(unittest.TestCase):
                 "rejection_mask_or": "00002000",
                 "rejection_mask_and": "00000000",
                 "rejection_mask_switches": "1",
+                "private_capture_eligible_draws": "3",
+                "private_capture_rejected_draws": "0",
+                "first_private_capture_rejection_mask": "00000000",
+                "last_private_capture_rejection_mask": "00000000",
+                "private_capture_rejection_mask_or": "00000000",
+                "private_capture_rejection_mask_and": "00000000",
+                "private_capture_rejection_mask_switches": "0",
                 **safety,
             },
             {
@@ -111,6 +118,9 @@ class VehicleShadowGeometryTests(unittest.TestCase):
                 "mechanically_eligible_draws": "1",
                 "mechanically_rejected_draws": "2",
                 "mechanical_rejection_accounting_complete": "true",
+                "private_capture_eligible_draws": "3",
+                "private_capture_rejected_draws": "0",
+                "private_capture_rejection_accounting_complete": "true",
                 "reject_resolved_input": "0",
                 "reject_unsupported_geometry": "0",
                 "reject_empty_draw": "0",
@@ -193,6 +203,14 @@ class VehicleShadowGeometryTests(unittest.TestCase):
         events = self.fixture()
         events[3]["rejection_mask_or"] = "00000000"
         with self.assertRaisesRegex(ValueError, "candidate first mask drift"):
+            self.summarize(events)
+
+    def test_rejects_private_capture_accounting_drift(self):
+        events = self.fixture()
+        events[3]["private_capture_eligible_draws"] = "2"
+        with self.assertRaisesRegex(
+            ValueError, "candidate private capture accounting drift"
+        ):
             self.summarize(events)
 
     def test_rejects_private_capture_authority_drift(self):


### PR DESCRIPTION
Adds a vehicle-only private replay admission contract for the stable 0x00000808 correlation family: bounded multi-stream vertex input and zero-texture shaders. The generic isolated gate is unchanged. The path remains one-shot, private, non-publishing, non-suppressing, and Xenos-authoritative. Adds v3 qualifier accounting for generic and private admission. Tests: Release pinyon_shift target compiled; 10 focused tests passed; diff check clean.