### PR TITLE
feat(renderer): qualify vehicle replay stability

### DIFF
--- a/docs/native-renderer/REPRIORITIZED_PLAN.md
+++ b/docs/native-renderer/REPRIORITIZED_PLAN.md
@@ -579,6 +579,23 @@ input and a shader that samples no textures. Generic isolated-draw admission is
 unchanged. This exception remains correlation-gated, private, one-shot,
 non-publishing, Xenos-authoritative, and unable to suppress.
 
+First visual result: the next AppData session privately replayed exact family
+`436C58CA13690625` at frame 2,633, draw 4,358 into a 2560x1024 target. The
+cropped native and Xenos images contain the same rear vehicle body/bumper
+submesh, and their full raw source hashes are identical
+(`F30FFA26CCF670DD`). All 7,320 correlated draws in that session passed the
+private vehicle gate, while generic admission remained closed. This proves one
+working animated vehicle color slice, not a complete car or material system.
+
+Private stability checkpoint: after the one-shot image pair succeeds, the same
+exact prepared signature may now replay privately at most once per frame for a
+hard limit of 300 draws. It performs no further readbacks, never publishes,
+never suppresses, and stops all later private requests on the first backend
+failure. Final accounting distinguishes recorded draws, target failures,
+unsupported state, per-frame quota yields, and limit yields. Long-session
+success is required before considering visible native publication of this
+submesh.
+
 ### C5. Sky, atmosphere, and global lighting
 
 - Replace the qualified sky/global-light families.

--- a/docs/native-renderer/VEHICLE_INSTANCE_SEMANTIC_SEED.md
+++ b/docs/native-renderer/VEHICLE_INSTANCE_SEMANTIC_SEED.md
@@ -520,3 +520,20 @@ mandatory. The generic gate is untouched, and this private exception is
 reachable only after the backend-confirmed 80-draw epoch and exact geometry
 correlation. It cannot publish or suppress, and the authoritative Xenos draw
 still executes.
+
+The first admitted session recorded family `436C58CA13690625` at frame 2,633,
+draw 4,358 into a private 2560x1024 color target. Native and authoritative
+Xenos readbacks both show the same rear body/bumper submesh and have the exact
+same full source hash, `F30FFA26CCF670DD`. The session accounted for 7,320
+private-eligible correlations, one successful capture request, zero target or
+unsupported failures, and a normal process exit. This is the first working C4
+rendering slice, but it is still a submesh-level bridge rather than player-car
+identity or full vehicle coverage.
+
+Following a successful one-shot pair, the exact captured prepared signature is
+eligible for a bounded private stability run. The backend duplicates at most
+one matching draw per frame, stops at 300 requests, performs no additional
+readback, and fails closed on the first target or unsupported result. The
+authoritative Xenos draw remains present on every request. This measures
+animation-time replay stability before any native vehicle target can be
+published or any Xenos draw can be considered for suppression.

--- a/src/native_renderer/graphics_hooks.cpp
+++ b/src/native_renderer/graphics_hooks.cpp
@@ -141,6 +141,7 @@ constexpr uint32_t kVehicleComposedMatrixCallee = 0x82435E78;
 constexpr size_t kVehicleComposedMatrixCorrelationCapacity = 1024;
 constexpr size_t kVehicleShadowGeometrySeedCapacity = 256;
 constexpr size_t kVehicleShadowGeometryCorrelationCapacity = 1024;
+constexpr uint64_t kVehicleShadowColorPrivateReplayLimit = 300;
 constexpr size_t kShadowCasterProvenanceSampleCapacity = 4096;
 constexpr uint64_t kShadowCasterMaximumVehicleIdentityAgeFrames = 1;
 constexpr size_t kSemanticInstanceCapacity = 4096;
@@ -8206,6 +8207,7 @@ struct IsolatedDrawState {
   bool prepared_vehicle_shadow_color_replay_eligible = false;
   bool vehicle_shadow_color_capture_pending = false;
   bool vehicle_shadow_color_capture_completed = false;
+  bool vehicle_shadow_color_private_replay_failed_closed = false;
   bool shadow_depth_publication_mode = false;
   bool shadow_depth_continuous_mode = false;
   bool shadow_depth_continuous_failed_closed = false;
@@ -8235,6 +8237,13 @@ struct IsolatedDrawState {
   uint64_t vehicle_shadow_color_capture_recorded = 0;
   uint64_t vehicle_shadow_color_capture_target_failures = 0;
   uint64_t vehicle_shadow_color_capture_unsupported = 0;
+  uint64_t vehicle_shadow_color_private_replay_requests = 0;
+  uint64_t vehicle_shadow_color_private_replay_recorded = 0;
+  uint64_t vehicle_shadow_color_private_replay_target_failures = 0;
+  uint64_t vehicle_shadow_color_private_replay_unsupported = 0;
+  uint64_t vehicle_shadow_color_private_replay_frame_quota_yields = 0;
+  uint64_t vehicle_shadow_color_private_replay_limit_yields = 0;
+  uint64_t vehicle_shadow_color_private_replay_last_frame = UINT64_MAX;
   uint64_t shadow_depth_continuous_last_publication_frame = UINT64_MAX;
   uint64_t shadow_depth_continuous_publication_epochs = 0;
   uint64_t shadow_depth_continuous_max_publication_epochs = 0;
@@ -20037,11 +20046,12 @@ void ObservePreparedDraw(
         vehicle_shadow_color_rejection_mask,
         vehicle_shadow_color_private_capture_rejection_mask);
     if (g_isolated_draw.vehicle_shadow_color_capture_mode &&
-        !g_isolated_draw.vehicle_shadow_color_capture_completed &&
         vehicle_shadow_geometry_color_match &&
         !vehicle_shadow_color_private_capture_rejection_mask) {
       g_isolated_draw.prepared_vehicle_shadow_color_replay_eligible = true;
-      g_isolated_draw.vehicle_shadow_color_capture_pending = true;
+      if (!g_isolated_draw.vehicle_shadow_color_capture_completed) {
+        g_isolated_draw.vehicle_shadow_color_capture_pending = true;
+      }
     }
     if (g_isolated_draw.shadow_depth_mode ||
         g_isolated_draw.shadow_depth_batch_mode) {
@@ -21161,6 +21171,33 @@ void CompleteVehicleShadowColorCapture(
        {"suppression_allowed", "false"}});
 }
 
+void CompleteVehicleShadowColorPrivateReplay(
+    const rex::system::GraphicsIsolatedDrawResult &result) {
+  if (result.status == rex::system::GraphicsIsolatedDrawStatus::kRecorded) {
+    ++g_isolated_draw.vehicle_shadow_color_private_replay_recorded;
+    return;
+  }
+  g_isolated_draw.vehicle_shadow_color_private_replay_failed_closed = true;
+  if (result.status ==
+      rex::system::GraphicsIsolatedDrawStatus::kTargetCreationFailed) {
+    ++g_isolated_draw.vehicle_shadow_color_private_replay_target_failures;
+  } else {
+    ++g_isolated_draw.vehicle_shadow_color_private_replay_unsupported;
+  }
+  pinyon_shift::diagnostics::RecordEvent(
+      "native_renderer.discovery.vehicle_shadow_color_private_replay_failure",
+      {{"status", "failed_closed"},
+       {"signature",
+        fmt::format("{:016X}", g_isolated_draw.captured_signature)},
+       {"frame", std::to_string(g_isolated_draw.frame)},
+       {"draw", std::to_string(g_isolated_draw.draw)},
+       {"fallback", "authoritative_xenos_draw"},
+       {"native_draw", "false"},
+       {"xenos_draw", "preserved"},
+       {"output_authority", "xenos"},
+       {"suppression_allowed", "false"}});
+}
+
 void CompleteIsolatedShadowDepth(
     const rex::system::GraphicsIsolatedDrawResult &result) {
   CompleteIsolatedDraw(result);
@@ -22066,6 +22103,33 @@ void RequestIsolatedDraw(
           g_isolated_draw.readback_requested
               ? &CompleteIsolatedReferenceReadback
               : nullptr;
+      return;
+    }
+    if (g_isolated_draw.shadow_depth_batch_capture_completed &&
+        g_isolated_draw.vehicle_shadow_color_capture_mode &&
+        g_isolated_draw.vehicle_shadow_color_capture_recorded &&
+        !g_isolated_draw.vehicle_shadow_color_private_replay_failed_closed &&
+        g_isolated_draw.prepared_vehicle_shadow_color_replay_eligible &&
+        g_isolated_draw.prepared_signature ==
+            g_isolated_draw.captured_signature) {
+      if (g_isolated_draw.vehicle_shadow_color_private_replay_requests >=
+          kVehicleShadowColorPrivateReplayLimit) {
+        ++g_isolated_draw.vehicle_shadow_color_private_replay_limit_yields;
+        return;
+      }
+      if (g_isolated_draw.vehicle_shadow_color_private_replay_last_frame ==
+          g_isolated_draw.frame) {
+        ++g_isolated_draw
+              .vehicle_shadow_color_private_replay_frame_quota_yields;
+        return;
+      }
+      g_isolated_draw.vehicle_shadow_color_private_replay_last_frame =
+          g_isolated_draw.frame;
+      ++g_isolated_draw.vehicle_shadow_color_private_replay_requests;
+      request.requested = true;
+      request.frame_sequence = g_isolated_draw.frame;
+      request.reference_marker_requested = true;
+      request.completion = &CompleteVehicleShadowColorPrivateReplay;
       return;
     }
     if ((g_isolated_draw.shadow_depth_batch_capture_completed &&
@@ -25746,6 +25810,11 @@ void UninstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system) {
         g_isolated_draw.vehicle_shadow_color_capture_recorded +
         g_isolated_draw.vehicle_shadow_color_capture_target_failures +
         g_isolated_draw.vehicle_shadow_color_capture_unsupported;
+    const uint64_t private_replay_outcomes =
+        g_isolated_draw.vehicle_shadow_color_private_replay_recorded +
+        g_isolated_draw
+            .vehicle_shadow_color_private_replay_target_failures +
+        g_isolated_draw.vehicle_shadow_color_private_replay_unsupported;
     diagnostics::RecordEvent(
         "native_renderer.discovery.vehicle_shadow_color_capture_summary",
         {{"status", g_isolated_draw.vehicle_shadow_color_capture_recorded
@@ -25770,6 +25839,40 @@ void UninstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system) {
                   g_isolated_draw.vehicle_shadow_color_capture_requests
               ? "true"
               : "false"},
+         {"private_replay_status",
+          g_isolated_draw.vehicle_shadow_color_private_replay_failed_closed
+              ? "failed_closed"
+              : (g_isolated_draw
+                             .vehicle_shadow_color_private_replay_requests
+                         ? "bounded_stability_observed"
+                         : "not_observed")},
+         {"private_replay_requests",
+          std::to_string(
+              g_isolated_draw.vehicle_shadow_color_private_replay_requests)},
+         {"private_replay_recorded",
+          std::to_string(
+              g_isolated_draw.vehicle_shadow_color_private_replay_recorded)},
+         {"private_replay_target_creation_failures",
+          std::to_string(g_isolated_draw
+                             .vehicle_shadow_color_private_replay_target_failures)},
+         {"private_replay_unsupported",
+          std::to_string(
+              g_isolated_draw.vehicle_shadow_color_private_replay_unsupported)},
+         {"private_replay_frame_quota_yields",
+          std::to_string(g_isolated_draw
+                             .vehicle_shadow_color_private_replay_frame_quota_yields)},
+         {"private_replay_limit_yields",
+          std::to_string(
+              g_isolated_draw.vehicle_shadow_color_private_replay_limit_yields)},
+         {"private_replay_limit",
+          std::to_string(kVehicleShadowColorPrivateReplayLimit)},
+         {"private_replay_accounting_complete",
+          private_replay_outcomes ==
+                  g_isolated_draw.vehicle_shadow_color_private_replay_requests
+              ? "true"
+              : "false"},
+         {"private_replay_selection",
+          "exact_first_captured_signature_one_draw_per_frame"},
          {"selection", "first_mechanically_replayable_correlated_color_draw"},
          {"readback", "native_and_xenos_color"},
          {"native_draw",

--- a/tools/summarize-native-renderer-vehicle-shadow-geometry.py
+++ b/tools/summarize-native-renderer-vehicle-shadow-geometry.py
@@ -5,7 +5,7 @@ import json
 from pathlib import Path
 
 
-SCHEMA = "pinyon-shift.native-renderer-vehicle-shadow-geometry.v3"
+SCHEMA = "pinyon-shift.native-renderer-vehicle-shadow-geometry.v4"
 CONFIG_EVENT = "native_renderer.discovery.vehicle_shadow_geometry_config"
 EPOCH_EVENT = "native_renderer.discovery.vehicle_shadow_geometry_epoch"
 CORRELATION_EVENT = (
@@ -282,6 +282,36 @@ def summarize(log_path):
         require(recorded in {0, 1}, "color capture result bound drift")
         require(len(capture_results) == requests, "color capture result drift")
         require(recorded <= requests, "recorded capture exceeds requests")
+        require(
+            capture_summary.get("private_replay_accounting_complete") == "true",
+            "private replay accounting drift",
+        )
+        private_replay_requests = integer(
+            capture_summary, "private_replay_requests"
+        )
+        private_replay_recorded = integer(
+            capture_summary, "private_replay_recorded"
+        )
+        private_replay_failures = integer(
+            capture_summary, "private_replay_target_creation_failures"
+        ) + integer(capture_summary, "private_replay_unsupported")
+        private_replay_limit = integer(
+            capture_summary, "private_replay_limit"
+        )
+        require(
+            private_replay_requests
+            == private_replay_recorded + private_replay_failures,
+            "private replay outcome drift",
+        )
+        require(
+            private_replay_requests <= private_replay_limit,
+            "private replay request bound drift",
+        )
+        require(
+            not private_replay_failures
+            or capture_summary.get("private_replay_status") == "failed_closed",
+            "private replay did not fail closed",
+        )
         for event in [*capture_configs, *capture_results, capture_summary]:
             require(
                 event.get("xenos_draw") == "preserved"
@@ -333,6 +363,12 @@ def summarize(log_path):
             "private_color_capture_recorded": bool(
                 capture
                 and integer(capture["summary"], "recorded") == 1
+            ),
+            "private_color_replay_stable": bool(
+                capture
+                and integer(capture["summary"], "private_replay_requests")
+                and integer(capture["summary"], "private_replay_requests")
+                == integer(capture["summary"], "private_replay_recorded")
             ),
             "object_identity_proven": False,
             "mesh_material_contract_proven": False,

--- a/tools/tests/test_native_renderer_vehicle_shadow_geometry.py
+++ b/tools/tests/test_native_renderer_vehicle_shadow_geometry.py
@@ -97,6 +97,15 @@ class VehicleShadowGeometryTests(unittest.TestCase):
                 "target_creation_failures": "0",
                 "unsupported": "0",
                 "request_accounting_complete": "true",
+                "private_replay_status": "bounded_stability_observed",
+                "private_replay_requests": "3",
+                "private_replay_recorded": "3",
+                "private_replay_target_creation_failures": "0",
+                "private_replay_unsupported": "0",
+                "private_replay_frame_quota_yields": "0",
+                "private_replay_limit_yields": "0",
+                "private_replay_limit": "300",
+                "private_replay_accounting_complete": "true",
                 "native_draw": "private_capture_only",
                 "xenos_draw": "preserved",
                 "output_authority": "xenos",
@@ -166,6 +175,7 @@ class VehicleShadowGeometryTests(unittest.TestCase):
             report["qualification"]["private_color_capture_recorded"]
         )
         self.assertEqual(2, report["mechanical_rejections"]["prepared_pipeline"])
+        self.assertTrue(report["qualification"]["private_color_replay_stable"])
 
     def test_rejects_partial_epoch_promotion(self):
         events = self.fixture()
@@ -217,6 +227,12 @@ class VehicleShadowGeometryTests(unittest.TestCase):
         events = self.fixture()
         events[5]["output_authority"] = "native"
         with self.assertRaisesRegex(ValueError, "output authority"):
+            self.summarize(events)
+
+    def test_rejects_private_replay_accounting_drift(self):
+        events = self.fixture()
+        events[6]["private_replay_recorded"] = "2"
+        with self.assertRaisesRegex(ValueError, "private replay outcome drift"):
             self.summarize(events)
 
     def test_runtime_contract_is_default_off_and_full_epoch_gated(self):


### PR DESCRIPTION
Extends the pixel-identical vehicle color checkpoint into a bounded private stability run for the exact captured signature. Requests are limited to one per frame and 300 total, stop permanently on the first backend failure, perform no extra readbacks, and never publish or suppress. Adds strict v4 qualifier accounting and documents the first exact native/Xenos vehicle submesh pair. Tests: Release pinyon_shift target compiled; 11 focused tests passed; diff check clean.