### PR TITLE
feat(renderer): census vehicle color run topology

### DIFF
--- a/docs/native-renderer/REPRIORITIZED_PLAN.md
+++ b/docs/native-renderer/REPRIORITIZED_PLAN.md
@@ -596,6 +596,22 @@ unsupported state, per-frame quota yields, and limit yields. Long-session
 success is required before considering visible native publication of this
 submesh.
 
+Private stability result: the AppData qualification reached the complete
+300-request bound with 300 recorded replays, zero target failures, zero
+unsupported states, and no per-frame quota misses. A further 168 matching
+frames were correctly declined after the limit. The session observed 14,070
+exact correlations, exited normally, and logged no error or crash. The exact
+submesh is therefore stable in private animated replay, but native admission
+remains closed because player identity and complete vehicle coverage are not
+yet proven.
+
+Full-vehicle topology checkpoint: matched color draws are now grouped into
+exact consecutive prepared-draw runs. The census records run count, matched
+draw accounting, multi-draw runs, maximum length, runs covering the complete
+bounded family table, and the ordered signature hash of those full-family
+runs. It remains measurement-only. A stable full-family sequence is the gate
+for assembling the 30 proven submeshes into one retained private vehicle pass.
+
 ### C5. Sky, atmosphere, and global lighting
 
 - Replace the qualified sky/global-light families.

--- a/docs/native-renderer/VEHICLE_INSTANCE_SEMANTIC_SEED.md
+++ b/docs/native-renderer/VEHICLE_INSTANCE_SEMANTIC_SEED.md
@@ -537,3 +537,20 @@ readback, and fails closed on the first target or unsupported result. The
 authoritative Xenos draw remains present on every request. This measures
 animation-time replay stability before any native vehicle target can be
 published or any Xenos draw can be considered for suppression.
+
+The bounded stability session completed all 300 requested private replays with
+300 recorded results, zero target failures, zero unsupported results, and zero
+same-frame quota yields. It then rejected 168 later matches at the hard limit.
+Across the session, 14,070 exact geometry correlations were private-eligible;
+the process exited normally with no error or crash evidence. This establishes
+animated backend stability for the captured submesh only. Object identity and
+complete vehicle material coverage remain open, so publication and suppression
+stay disabled.
+
+The next observer treats every exact color correlation as a member of a
+consecutive prepared-draw run. A run continues only on the same frame and the
+immediately following draw sequence. Final accounting records total run draws,
+maximum run length, multi-draw runs, runs whose length equals the complete
+bounded family table, and the ordered prepared-signature hash of those full
+runs. No native request is added. A stable full-family sequence is required
+before the 30 submesh families can share one retained private vehicle target.

--- a/src/native_renderer/graphics_hooks.cpp
+++ b/src/native_renderer/graphics_hooks.cpp
@@ -640,6 +640,14 @@ struct VehicleShadowGeometryCorrelationEntry {
   bool occupied = false;
 };
 
+struct VehicleShadowColorRun {
+  uint64_t frame = 0;
+  uint64_t last_draw = 0;
+  uint64_t length = 0;
+  uint64_t sequence_hash = 0;
+  bool valid = false;
+};
+
 enum class SemanticBatchRejection : uint32_t {
   kNone = 0,
   kMissingTitleResource = 1,
@@ -1459,6 +1467,14 @@ uint64_t g_vehicle_shadow_geometry_mechanically_rejected_draws = 0;
 std::array<uint64_t, 15> g_vehicle_shadow_geometry_rejection_reason_counts{};
 uint64_t g_vehicle_shadow_color_private_capture_eligible_draws = 0;
 uint64_t g_vehicle_shadow_color_private_capture_rejected_draws = 0;
+VehicleShadowColorRun g_vehicle_shadow_color_run{};
+uint64_t g_vehicle_shadow_color_runs = 0;
+uint64_t g_vehicle_shadow_color_run_draws = 0;
+uint64_t g_vehicle_shadow_color_multi_draw_runs = 0;
+uint64_t g_vehicle_shadow_color_maximum_run_length = 0;
+uint64_t g_vehicle_shadow_color_full_family_runs = 0;
+uint64_t g_vehicle_shadow_color_first_full_family_sequence_hash = 0;
+uint64_t g_vehicle_shadow_color_full_family_sequence_variants = 0;
 bool g_vehicle_title_provenance_requested = false;
 uint64_t g_title_packets_recorded = 0;
 uint64_t g_title_packets_matched = 0;
@@ -15268,6 +15284,61 @@ bool ObserveVehicleShadowGeometryColorCorrelation(
   return true;
 }
 
+void FinalizeVehicleShadowColorRun() {
+  if (!g_vehicle_shadow_color_run.valid) {
+    return;
+  }
+  ++g_vehicle_shadow_color_runs;
+  g_vehicle_shadow_color_run_draws +=
+      g_vehicle_shadow_color_run.length;
+  g_vehicle_shadow_color_maximum_run_length =
+      std::max(g_vehicle_shadow_color_maximum_run_length,
+               g_vehicle_shadow_color_run.length);
+  if (g_vehicle_shadow_color_run.length > 1) {
+    ++g_vehicle_shadow_color_multi_draw_runs;
+  }
+  if (g_vehicle_shadow_geometry_correlation_count &&
+      g_vehicle_shadow_color_run.length ==
+          g_vehicle_shadow_geometry_correlation_count) {
+    ++g_vehicle_shadow_color_full_family_runs;
+    if (!g_vehicle_shadow_color_first_full_family_sequence_hash) {
+      g_vehicle_shadow_color_first_full_family_sequence_hash =
+          g_vehicle_shadow_color_run.sequence_hash;
+    } else if (g_vehicle_shadow_color_first_full_family_sequence_hash !=
+               g_vehicle_shadow_color_run.sequence_hash) {
+      ++g_vehicle_shadow_color_full_family_sequence_variants;
+    }
+  }
+  g_vehicle_shadow_color_run = {};
+}
+
+void ObserveVehicleShadowColorRun(bool matched, uint64_t frame,
+                                  uint64_t draw,
+                                  uint64_t prepared_signature) {
+  if (!matched) {
+    FinalizeVehicleShadowColorRun();
+    return;
+  }
+  if (g_vehicle_shadow_color_run.valid &&
+      g_vehicle_shadow_color_run.frame == frame &&
+      draw == g_vehicle_shadow_color_run.last_draw + 1) {
+    ++g_vehicle_shadow_color_run.length;
+    g_vehicle_shadow_color_run.last_draw = draw;
+    g_vehicle_shadow_color_run.sequence_hash = HashCombine(
+        g_vehicle_shadow_color_run.sequence_hash, prepared_signature);
+    return;
+  }
+  FinalizeVehicleShadowColorRun();
+  g_vehicle_shadow_color_run = {
+      .frame = frame,
+      .last_draw = draw,
+      .length = 1,
+      .sequence_hash =
+          HashCombine(UINT64_C(0xCBF29CE484222325), prepared_signature),
+      .valid = true,
+  };
+}
+
 void RecordStaticWorldPreparedLayout(
     const rex::system::GraphicsDrawObservation &observation,
     const StaticWorldDrawIdentity &identity,
@@ -20045,6 +20116,10 @@ void ObservePreparedDraw(
         prepared_signature, prepared_semantic_contract,
         vehicle_shadow_color_rejection_mask,
         vehicle_shadow_color_private_capture_rejection_mask);
+    ObserveVehicleShadowColorRun(vehicle_shadow_geometry_color_match,
+                                 sample.frame_sequence,
+                                 sample.draw_sequence,
+                                 prepared_signature);
     if (g_isolated_draw.vehicle_shadow_color_capture_mode &&
         vehicle_shadow_geometry_color_match &&
         !vehicle_shadow_color_private_capture_rejection_mask) {
@@ -25626,6 +25701,7 @@ void UninstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system) {
        {"suppression_eligible", "false"}});
   }
   if (g_isolated_draw.vehicle_shadow_geometry_correlation_mode) {
+    FinalizeVehicleShadowColorRun();
     for (const VehicleShadowGeometryCorrelationEntry &entry :
          g_vehicle_shadow_geometry_correlations) {
       if (!entry.occupied) {
@@ -25795,6 +25871,26 @@ void UninstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system) {
               : "false"},
          {"private_capture_admission_contract",
           "vehicle_color_private_replay_v1"},
+         {"color_runs", std::to_string(g_vehicle_shadow_color_runs)},
+         {"color_run_draws",
+          std::to_string(g_vehicle_shadow_color_run_draws)},
+         {"multi_draw_color_runs",
+          std::to_string(g_vehicle_shadow_color_multi_draw_runs)},
+         {"maximum_color_run_length",
+          std::to_string(g_vehicle_shadow_color_maximum_run_length)},
+         {"full_family_color_runs",
+          std::to_string(g_vehicle_shadow_color_full_family_runs)},
+         {"first_full_family_sequence_hash",
+          fmt::format("{:016X}",
+                      g_vehicle_shadow_color_first_full_family_sequence_hash)},
+         {"full_family_sequence_variants",
+          std::to_string(
+              g_vehicle_shadow_color_full_family_sequence_variants)},
+         {"color_run_accounting_complete",
+          g_vehicle_shadow_color_run_draws ==
+                  g_vehicle_shadow_geometry_color_draws_matched
+              ? "true"
+              : "false"},
          {"seed_accounting_complete",
           seed_accounting_complete ? "true" : "false"},
          {"epoch_contract", "exact_consecutive_64_primary_12_secondary_4_tertiary"},

--- a/tools/summarize-native-renderer-vehicle-shadow-geometry.py
+++ b/tools/summarize-native-renderer-vehicle-shadow-geometry.py
@@ -5,7 +5,7 @@ import json
 from pathlib import Path
 
 
-SCHEMA = "pinyon-shift.native-renderer-vehicle-shadow-geometry.v4"
+SCHEMA = "pinyon-shift.native-renderer-vehicle-shadow-geometry.v5"
 CONFIG_EVENT = "native_renderer.discovery.vehicle_shadow_geometry_config"
 EPOCH_EVENT = "native_renderer.discovery.vehicle_shadow_geometry_epoch"
 CORRELATION_EVENT = (
@@ -154,6 +154,26 @@ def summarize(log_path):
         == integer(summary, "color_draws_matched"),
         "private capture eligibility accounting drift",
     )
+    require(
+        summary.get("color_run_accounting_complete") == "true",
+        "color run accounting drift",
+    )
+    color_runs = integer(summary, "color_runs")
+    color_run_draws = integer(summary, "color_run_draws")
+    require(
+        color_run_draws == integer(summary, "color_draws_matched"),
+        "color run draw accounting drift",
+    )
+    require(
+        integer(summary, "multi_draw_color_runs") <= color_runs,
+        "multi-draw color run accounting drift",
+    )
+    require(
+        integer(summary, "full_family_color_runs") <= color_runs,
+        "full-family color run accounting drift",
+    )
+    sequence_hash = summary.get("first_full_family_sequence_hash", "")
+    require(len(sequence_hash) == 16, "invalid full-family sequence hash")
     safety_events = [*configs, *epochs, *correlations, *candidates, summary]
     for event in safety_events:
         require(event.get("native_draw") == "false", "native draw was enabled")
@@ -353,6 +373,19 @@ def summarize(log_path):
         "mechanical_rejections": {
             key.removeprefix("reject_"): integer(summary, key)
             for key in REJECTION_REASON_FIELDS
+        },
+        "color_run_topology": {
+            "runs": color_runs,
+            "draws": color_run_draws,
+            "multi_draw_runs": integer(summary, "multi_draw_color_runs"),
+            "maximum_run_length": integer(
+                summary, "maximum_color_run_length"
+            ),
+            "full_family_runs": integer(summary, "full_family_color_runs"),
+            "first_full_family_sequence_hash": sequence_hash,
+            "full_family_sequence_variants": integer(
+                summary, "full_family_sequence_variants"
+            ),
         },
         "epochs": epochs,
         "correlations": correlations,

--- a/tools/tests/test_native_renderer_vehicle_shadow_geometry.py
+++ b/tools/tests/test_native_renderer_vehicle_shadow_geometry.py
@@ -130,6 +130,14 @@ class VehicleShadowGeometryTests(unittest.TestCase):
                 "private_capture_eligible_draws": "3",
                 "private_capture_rejected_draws": "0",
                 "private_capture_rejection_accounting_complete": "true",
+                "color_runs": "1",
+                "color_run_draws": "3",
+                "multi_draw_color_runs": "1",
+                "maximum_color_run_length": "3",
+                "full_family_color_runs": "1",
+                "first_full_family_sequence_hash": "9" * 16,
+                "full_family_sequence_variants": "0",
+                "color_run_accounting_complete": "true",
                 "reject_resolved_input": "0",
                 "reject_unsupported_geometry": "0",
                 "reject_empty_draw": "0",
@@ -176,6 +184,7 @@ class VehicleShadowGeometryTests(unittest.TestCase):
         )
         self.assertEqual(2, report["mechanical_rejections"]["prepared_pipeline"])
         self.assertTrue(report["qualification"]["private_color_replay_stable"])
+        self.assertEqual(3, report["color_run_topology"]["maximum_run_length"])
 
     def test_rejects_partial_epoch_promotion(self):
         events = self.fixture()
@@ -221,6 +230,12 @@ class VehicleShadowGeometryTests(unittest.TestCase):
         with self.assertRaisesRegex(
             ValueError, "candidate private capture accounting drift"
         ):
+            self.summarize(events)
+
+    def test_rejects_color_run_accounting_drift(self):
+        events = self.fixture()
+        events[-1]["color_run_draws"] = "2"
+        with self.assertRaisesRegex(ValueError, "color run draw accounting drift"):
             self.summarize(events)
 
     def test_rejects_private_capture_authority_drift(self):


### PR DESCRIPTION
Adds bounded consecutive-run topology accounting for all capture-proven vehicle color families. It records matched-run length, full-family coverage, and ordered signature stability to gate a retained full-vehicle private pass. No native request, publication, suppression, or guest payload capture is added. Also records the clean 300/300 private stability result. Tests: Release pinyon_shift target compiled; 12 focused tests passed; diff check clean.