### PR TITLE
feat(renderer): retain full vehicle color pass

### DIFF
--- a/docs/native-renderer/REPRIORITIZED_PLAN.md
+++ b/docs/native-renderer/REPRIORITIZED_PLAN.md
@@ -627,8 +627,16 @@ reuses the private target for the remaining 29 in guest order, releases and
 optionally reads back only the complete frame, and repeats for at most 120
 frames. Missing, extra, non-monotonic, unsupported, or failed work disables the
 path for the process. It never publishes, suppresses, or changes Xenos output
-authority. Runtime and visual proof are deferred to the next batched AppData
-checkpoint.
+authority.
+
+Retained-pass result: the clean AppData run completed all 120 bounded frames
+and recorded all 3,600 requested draws, including 3,480 retained-target reuses,
+with zero failures, unsupported replays, errors, or suppression. Its one
+readback contains a coherent multi-submesh rear view with body, bumper,
+glazing, wheels, and lower geometry in the same native target. This closes the
+frame-wide retention mechanism. The result remains an isolated unlit
+diagnostic; exact player identity, transforms, material completeness, hybrid
+publication, traffic coverage, and per-item fallback remain open C4 work.
 
 ### C5. Sky, atmosphere, and global lighting
 

--- a/docs/native-renderer/REPRIORITIZED_PLAN.md
+++ b/docs/native-renderer/REPRIORITIZED_PLAN.md
@@ -612,6 +612,24 @@ bounded family table, and the ordered signature hash of those full-family
 runs. It remains measurement-only. A stable full-family sequence is the gate
 for assembling the 30 proven submeshes into one retained private vehicle pass.
 
+Topology result: the clean AppData run observed all 30 families exactly once
+per frame for 187 consecutive frames (5,610 matches), but unrelated guest work
+partitions them into 2,992 consecutive runs whose maximum length is five. A
+single consecutive 30-draw pass therefore does not exist. The retained-pass
+gate is corrected to the stronger frame-wide contract already implied by the
+per-family summaries: all 30 exact families, once each in original guest draw
+order, may accumulate across unrelated Xenos draws in one private target.
+
+Retained-pass implementation checkpoint: the default-off qualification mode
+starts only after the one-family native/Xenos capture succeeds and the exact
+correlation table contains 30 families. It retains the first matching draw,
+reuses the private target for the remaining 29 in guest order, releases and
+optionally reads back only the complete frame, and repeats for at most 120
+frames. Missing, extra, non-monotonic, unsupported, or failed work disables the
+path for the process. It never publishes, suppresses, or changes Xenos output
+authority. Runtime and visual proof are deferred to the next batched AppData
+checkpoint.
+
 ### C5. Sky, atmosphere, and global lighting
 
 - Replace the qualified sky/global-light families.

--- a/docs/native-renderer/VEHICLE_RETAINED_COLOR_PASS.md
+++ b/docs/native-renderer/VEHICLE_RETAINED_COLOR_PASS.md
@@ -1,0 +1,76 @@
+# Vehicle retained color pass
+
+Status: implemented behind a default-off qualification switch; runtime proof
+pending.
+
+## Evidence boundary
+
+The qualified dynamic-shadow epoch correlates 30 bounded color families by
+exact geometry-resource identity. In the 2026-08-31 topology run, every family
+appeared exactly once in every frame from 8,822 through 9,008. The 5,610
+matches were split into 2,992 consecutive runs, with a maximum run length of
+five, because unrelated guest draws occur between vehicle submeshes.
+
+This rules out a consecutive 30-draw replay. It supports a frame-wide retained
+pass that preserves the relative guest order of the 30 correlated draws while
+leaving all intervening guest work on Xenos.
+
+## Admission contract
+
+The retained pass is armed only when all of these conditions hold:
+
+- the exact 80-draw vehicle shadow epoch was recorded successfully;
+- the one-family private native/Xenos color capture succeeded;
+- the correlation table contains exactly 30 families and did not overflow;
+- the current draw is an exact correlated family accepted by the private
+  vehicle replay gate; and
+- the process has not encountered a prior retained-pass failure.
+
+Each accepted frame must contain exactly 30 matches in monotonically
+increasing guest draw order. The first draw creates and retains a private color
+target, the middle 28 reuse it, and the final draw reuses and releases it. The
+first complete target can be read back below `.local`; later frames remain
+private. The path is bounded to 120 frames per process.
+
+Any missing or extra family, non-monotonic ordering, target-creation failure,
+or unsupported replay fails the experiment closed for the rest of the
+process. Xenos draws remain intact in every case.
+
+## Safety and non-claims
+
+- The target is never published to the guest or final presentation path.
+- No guest draw, resolve, query, or side effect is suppressed.
+- Xenos remains the only output authority.
+- No guest payload is included in diagnostics or public reports.
+- Correlated shadow geometry does not yet prove player/traffic object identity,
+  wheels, livery, glass, every material, or semantic full-vehicle coverage.
+
+## Batched qualification
+
+Build once, then launch the AppData save with:
+
+```powershell
+.\tools\capture-native-renderer-census.ps1 `
+  -StateRoot $stateRoot `
+  -Scene open_world_day `
+  -ShadowDepthBatch `
+  -VehicleShadowGeometryCorrelation `
+  -CaptureVehicleShadowColor `
+  -RetainVehicleShadowColorPass `
+  -IsolatedDrawDir .local\qualification\vehicle-retained-color
+```
+
+The v6 vehicle qualifier must report:
+
+- 120 started and completed frames, zero failed frames;
+- 3,600 requests and 3,600 recorded outcomes;
+- 3,480 retained-target reuse requests;
+- one complete native retained-pass readback;
+- no target failures, unsupported replays, errors, crashes, publication, or
+  suppression; and
+- a clean normal exit.
+
+Visual acceptance is a recognizable multi-submesh vehicle contribution rather
+than the previously captured single rear-body slice. It remains a private
+prototype until object identity, remaining vehicle material families, hybrid
+publication, and per-item fallback are qualified.

--- a/docs/native-renderer/VEHICLE_RETAINED_COLOR_PASS.md
+++ b/docs/native-renderer/VEHICLE_RETAINED_COLOR_PASS.md
@@ -1,7 +1,7 @@
 # Vehicle retained color pass
 
-Status: implemented behind a default-off qualification switch; runtime proof
-pending.
+Status: privately qualified behind a default-off switch; native publication
+remains disabled.
 
 ## Evidence boundary
 
@@ -74,3 +74,19 @@ Visual acceptance is a recognizable multi-submesh vehicle contribution rather
 than the previously captured single rear-body slice. It remains a private
 prototype until object identity, remaining vehicle material families, hybrid
 publication, and per-item fallback are qualified.
+
+## Qualification result
+
+The clean AppData-backed session `20260831T164716Z-p35116` completed normally
+with the retained mode enabled. It recorded all 3,600 requested draws across
+120 complete frames, including 3,480 retained-target reuses, with zero failed
+frames, target failures, unsupported replays, errors, or suppression. The
+session observed 9,600 exact color correlations and produced one complete
+retained readback.
+
+The readback is a coherent multi-submesh rear view: body panels, bumper,
+glazing, wheels, and lower geometry coexist in one native target. This is a
+material improvement over the single rear-body slice. The diagnostic remains
+unlit and isolated, with flat gray/black material regions and no scene
+composition, so it proves frame-wide geometry retention rather than material,
+lighting, object-identity, or final-frame parity.

--- a/src/native_renderer/graphics_hooks.cpp
+++ b/src/native_renderer/graphics_hooks.cpp
@@ -142,6 +142,8 @@ constexpr size_t kVehicleComposedMatrixCorrelationCapacity = 1024;
 constexpr size_t kVehicleShadowGeometrySeedCapacity = 256;
 constexpr size_t kVehicleShadowGeometryCorrelationCapacity = 1024;
 constexpr uint64_t kVehicleShadowColorPrivateReplayLimit = 300;
+constexpr uint32_t kVehicleShadowColorRetainedFamilyCount = 30;
+constexpr uint64_t kVehicleShadowColorRetainedPassLimit = 120;
 constexpr size_t kShadowCasterProvenanceSampleCapacity = 4096;
 constexpr uint64_t kShadowCasterMaximumVehicleIdentityAgeFrames = 1;
 constexpr size_t kSemanticInstanceCapacity = 4096;
@@ -8184,6 +8186,7 @@ struct IsolatedDrawState {
   uint64_t shadow_replay_unsupported = 0;
   uint64_t shadow_replay_gate_rejections = 0;
   uint32_t prepared_title_lod_index = 0;
+  uint32_t prepared_vehicle_shadow_color_family_index = UINT32_MAX;
   rex::system::GraphicsDrawObservation prepared_sample;
   SemanticPreparedDrawContract prepared_semantic_contract{};
   std::filesystem::path output_root;
@@ -8193,6 +8196,7 @@ struct IsolatedDrawState {
   std::jthread reference_depth_artifact_writer;
   std::jthread seed_depth_artifact_writer;
   std::jthread reference_seed_depth_artifact_writer;
+  std::jthread vehicle_retained_artifact_writer;
   bool requested = false;
   bool readback_requested = false;
   bool completed = false;
@@ -8220,10 +8224,13 @@ struct IsolatedDrawState {
   bool shadow_depth_batch_mode = false;
   bool vehicle_shadow_geometry_correlation_mode = false;
   bool vehicle_shadow_color_capture_mode = false;
+  bool vehicle_shadow_color_retained_pass_mode = false;
   bool prepared_vehicle_shadow_color_replay_eligible = false;
   bool vehicle_shadow_color_capture_pending = false;
   bool vehicle_shadow_color_capture_completed = false;
   bool vehicle_shadow_color_private_replay_failed_closed = false;
+  bool vehicle_shadow_color_retained_pass_failed_closed = false;
+  bool vehicle_shadow_color_retained_capture_completed = false;
   bool shadow_depth_publication_mode = false;
   bool shadow_depth_continuous_mode = false;
   bool shadow_depth_continuous_failed_closed = false;
@@ -8260,6 +8267,24 @@ struct IsolatedDrawState {
   uint64_t vehicle_shadow_color_private_replay_frame_quota_yields = 0;
   uint64_t vehicle_shadow_color_private_replay_limit_yields = 0;
   uint64_t vehicle_shadow_color_private_replay_last_frame = UINT64_MAX;
+  uint64_t vehicle_shadow_color_retained_current_frame = UINT64_MAX;
+  uint64_t vehicle_shadow_color_retained_skip_frame = UINT64_MAX;
+  uint64_t vehicle_shadow_color_retained_last_draw = 0;
+  uint64_t vehicle_shadow_color_retained_requests = 0;
+  uint64_t vehicle_shadow_color_retained_recorded = 0;
+  uint64_t vehicle_shadow_color_retained_target_failures = 0;
+  uint64_t vehicle_shadow_color_retained_unsupported = 0;
+  uint64_t vehicle_shadow_color_retained_reused_target_requests = 0;
+  uint64_t vehicle_shadow_color_retained_frames_started = 0;
+  uint64_t vehicle_shadow_color_retained_frames_completed = 0;
+  uint64_t vehicle_shadow_color_retained_frames_failed = 0;
+  uint64_t vehicle_shadow_color_retained_limit_yields = 0;
+  uint32_t vehicle_shadow_color_retained_current_requests = 0;
+  uint32_t vehicle_shadow_color_retained_current_outcomes = 0;
+  uint32_t vehicle_shadow_color_retained_current_recorded = 0;
+  uint32_t vehicle_shadow_color_retained_current_family_mask = 0;
+  bool vehicle_shadow_color_retained_current_failed = false;
+  bool vehicle_shadow_color_retained_current_accounted = false;
   uint64_t shadow_depth_continuous_last_publication_frame = UINT64_MAX;
   uint64_t shadow_depth_continuous_publication_epochs = 0;
   uint64_t shadow_depth_continuous_max_publication_epochs = 0;
@@ -8830,6 +8855,25 @@ void ConfigureIsolatedDraw() {
       !g_isolated_draw.vehicle_shadow_geometry_correlation_mode) {
     g_isolated_draw.valid = false;
   }
+  value = nullptr;
+  length = 0;
+  if (_dupenv_s(
+          &value, &length,
+          "PINYON_SHIFT_NATIVE_RENDERER_VEHICLE_SHADOW_COLOR_RETAINED_PASS") ==
+          0 &&
+      value && length > 1) {
+    const std::string setting(value);
+    g_isolated_draw.vehicle_shadow_color_retained_pass_mode =
+        setting == "true";
+    if (setting != "true" && setting != "false") {
+      g_isolated_draw.valid = false;
+    }
+  }
+  std::free(value);
+  if (g_isolated_draw.vehicle_shadow_color_retained_pass_mode &&
+      !g_isolated_draw.vehicle_shadow_color_capture_mode) {
+    g_isolated_draw.valid = false;
+  }
   if (g_isolated_draw.shadow_depth_mode) {
     g_isolated_draw.requested = true;
     if (signature_requested || g_isolated_draw.shadow_depth_batch_mode) {
@@ -9035,6 +9079,23 @@ void ConfigureIsolatedDraw() {
          {"activation_boundary", "backend_recorded_full_80_draw_epoch"},
          {"readback", "native_and_xenos_color"},
          {"native_draw", "private_capture_only"},
+         {"xenos_draw", "preserved"},
+         {"output_authority", "xenos"},
+         {"suppression_allowed", "false"}});
+  }
+  if (g_isolated_draw.vehicle_shadow_color_retained_pass_mode) {
+    pinyon_shift::diagnostics::RecordEvent(
+        "native_renderer.discovery.vehicle_shadow_color_retained_config",
+        {{"status", g_isolated_draw.valid ? "armed"
+                                           : "blocked_invalid_configuration"},
+         {"selection", "all_30_exact_correlated_families_in_guest_order"},
+         {"activation_boundary", "single_family_private_capture_recorded"},
+         {"frame_contract", "exactly_one_draw_per_family_per_frame"},
+         {"target_lifecycle", "retain_first_reuse_middle_release_last"},
+         {"pass_limit",
+          std::to_string(kVehicleShadowColorRetainedPassLimit)},
+         {"readback", "first_complete_native_retained_pass"},
+         {"native_draw", "private_retained_pass_only"},
          {"xenos_draw", "preserved"},
          {"output_authority", "xenos"},
          {"suppression_allowed", "false"}});
@@ -15108,7 +15169,11 @@ bool ObserveVehicleShadowGeometryColorCorrelation(
     uint64_t prepared_signature,
     const SemanticPreparedDrawContract &contract,
     uint32_t mechanical_rejection_mask,
-    uint32_t private_capture_rejection_mask) {
+    uint32_t private_capture_rejection_mask,
+    size_t *matched_correlation_index) {
+  if (matched_correlation_index) {
+    *matched_correlation_index = kVehicleShadowGeometryCorrelationCapacity;
+  }
   if (!g_isolated_draw.vehicle_shadow_geometry_correlation_mode ||
       !g_vehicle_shadow_geometry_seed_count || samples_resolved_target ||
       !contract.geometry_bounded || !observation.indexed ||
@@ -15163,10 +15228,15 @@ bool ObserveVehicleShadowGeometryColorCorrelation(
     ++g_vehicle_shadow_color_private_capture_eligible_draws;
   }
   VehicleShadowGeometryCorrelationEntry *available = nullptr;
-  for (VehicleShadowGeometryCorrelationEntry &entry :
-       g_vehicle_shadow_geometry_correlations) {
+  size_t available_index = kVehicleShadowGeometryCorrelationCapacity;
+  for (size_t correlation_index = 0;
+       correlation_index < g_vehicle_shadow_geometry_correlations.size();
+       ++correlation_index) {
+    VehicleShadowGeometryCorrelationEntry &entry =
+        g_vehicle_shadow_geometry_correlations[correlation_index];
     if (!entry.occupied) {
       available = &entry;
+      available_index = correlation_index;
       break;
     }
     if (entry.prepared_signature == prepared_signature &&
@@ -15210,6 +15280,9 @@ bool ObserveVehicleShadowGeometryColorCorrelation(
       }
       ++entry.draws;
       entry.last_frame = observation.frame_sequence;
+      if (matched_correlation_index) {
+        *matched_correlation_index = correlation_index;
+      }
       return true;
     }
   }
@@ -15251,6 +15324,9 @@ bool ObserveVehicleShadowGeometryColorCorrelation(
       .full_geometry_match = full_geometry_match,
       .occupied = true,
   };
+  if (matched_correlation_index) {
+    *matched_correlation_index = available_index;
+  }
   ++g_vehicle_shadow_geometry_correlation_count;
   pinyon_shift::diagnostics::RecordEvent(
       "native_renderer.discovery.vehicle_shadow_geometry_correlation",
@@ -15297,7 +15373,8 @@ void FinalizeVehicleShadowColorRun() {
   if (g_vehicle_shadow_color_run.length > 1) {
     ++g_vehicle_shadow_color_multi_draw_runs;
   }
-  if (g_vehicle_shadow_geometry_correlation_count &&
+  if (g_vehicle_shadow_geometry_correlation_count ==
+          kVehicleShadowColorRetainedFamilyCount &&
       g_vehicle_shadow_color_run.length ==
           g_vehicle_shadow_geometry_correlation_count) {
     ++g_vehicle_shadow_color_full_family_runs;
@@ -19939,6 +20016,7 @@ void ObservePreparedDraw(
   g_isolated_draw.prepared_shadow_depth_batch_family =
       ShadowDepthBatchFamily::kNone;
   g_isolated_draw.prepared_vehicle_shadow_color_replay_eligible = false;
+  g_isolated_draw.prepared_vehicle_shadow_color_family_index = UINT32_MAX;
   g_consumer_family_marker.current_match = false;
   if (!g_pending_candidate.valid) {
     ++g_candidate_prepared_without_observation_count;
@@ -20110,12 +20188,15 @@ void ObservePreparedDraw(
         VehicleShadowColorPrivateCaptureRejectionMask(
             sample, g_pending_candidate.samples_resolved_target,
             observation);
+    size_t vehicle_shadow_color_family_index =
+        kVehicleShadowGeometryCorrelationCapacity;
     const bool vehicle_shadow_geometry_color_match =
         ObserveVehicleShadowGeometryColorCorrelation(
         sample, g_pending_candidate.samples_resolved_target, observation,
         prepared_signature, prepared_semantic_contract,
         vehicle_shadow_color_rejection_mask,
-        vehicle_shadow_color_private_capture_rejection_mask);
+        vehicle_shadow_color_private_capture_rejection_mask,
+        &vehicle_shadow_color_family_index);
     ObserveVehicleShadowColorRun(vehicle_shadow_geometry_color_match,
                                  sample.frame_sequence,
                                  sample.draw_sequence,
@@ -20124,6 +20205,8 @@ void ObservePreparedDraw(
         vehicle_shadow_geometry_color_match &&
         !vehicle_shadow_color_private_capture_rejection_mask) {
       g_isolated_draw.prepared_vehicle_shadow_color_replay_eligible = true;
+      g_isolated_draw.prepared_vehicle_shadow_color_family_index =
+          uint32_t(vehicle_shadow_color_family_index);
       if (!g_isolated_draw.vehicle_shadow_color_capture_completed) {
         g_isolated_draw.vehicle_shadow_color_capture_pending = true;
       }
@@ -20959,6 +21042,15 @@ void CompleteIsolatedReferenceReadback(
       g_isolated_draw.reference_artifact_writer);
 }
 
+void CompleteVehicleShadowColorRetainedReadback(
+    const rex::system::GraphicsIsolatedDrawReadback &readback) {
+  std::filesystem::path retained_root = g_isolated_draw.output_root;
+  retained_root += L".vehicle.retained.native";
+  CompleteIsolatedReadbackArtifact(
+      readback, "native_vehicle_retained", retained_root,
+      g_isolated_draw.vehicle_retained_artifact_writer);
+}
+
 void CompleteIsolatedDepthReadbackArtifact(
     const rex::system::GraphicsIsolatedDrawReadback &readback,
     const char *capture_role, const std::filesystem::path &artifact_root,
@@ -21268,6 +21360,110 @@ void CompleteVehicleShadowColorPrivateReplay(
        {"draw", std::to_string(g_isolated_draw.draw)},
        {"fallback", "authoritative_xenos_draw"},
        {"native_draw", "false"},
+       {"xenos_draw", "preserved"},
+       {"output_authority", "xenos"},
+       {"suppression_allowed", "false"}});
+}
+
+void FailClosedVehicleShadowColorRetainedPass(const char *reason) {
+  if (g_isolated_draw.vehicle_shadow_color_retained_pass_failed_closed) {
+    return;
+  }
+  g_isolated_draw.vehicle_shadow_color_retained_pass_failed_closed = true;
+  pinyon_shift::diagnostics::RecordEvent(
+      "native_renderer.discovery.vehicle_shadow_color_retained_failure",
+      {{"status", "failed_closed"},
+       {"reason", reason},
+       {"frame",
+        std::to_string(
+            g_isolated_draw.vehicle_shadow_color_retained_current_frame)},
+       {"last_draw",
+        std::to_string(
+            g_isolated_draw.vehicle_shadow_color_retained_last_draw)},
+       {"requests",
+        std::to_string(
+            g_isolated_draw.vehicle_shadow_color_retained_current_requests)},
+       {"outcomes",
+        std::to_string(
+            g_isolated_draw.vehicle_shadow_color_retained_current_outcomes)},
+       {"recorded",
+        std::to_string(
+            g_isolated_draw.vehicle_shadow_color_retained_current_recorded)},
+       {"family_mask",
+        fmt::format(
+            "{:08X}",
+            g_isolated_draw.vehicle_shadow_color_retained_current_family_mask)},
+       {"expected_draws",
+        std::to_string(kVehicleShadowColorRetainedFamilyCount)},
+       {"fallback", "authoritative_xenos_draws"},
+       {"native_draw", "false"},
+       {"xenos_draw", "preserved"},
+       {"output_authority", "xenos"},
+       {"suppression_allowed", "false"}});
+}
+
+void CompleteVehicleShadowColorRetainedPass(
+    const rex::system::GraphicsIsolatedDrawResult &result) {
+  ++g_isolated_draw.vehicle_shadow_color_retained_current_outcomes;
+  const bool recorded =
+      result.status == rex::system::GraphicsIsolatedDrawStatus::kRecorded;
+  if (recorded) {
+    ++g_isolated_draw.vehicle_shadow_color_retained_recorded;
+    ++g_isolated_draw.vehicle_shadow_color_retained_current_recorded;
+  } else {
+    g_isolated_draw.vehicle_shadow_color_retained_current_failed = true;
+    if (result.status == rex::system::
+                             GraphicsIsolatedDrawStatus::
+                                 kTargetCreationFailed) {
+      ++g_isolated_draw.vehicle_shadow_color_retained_target_failures;
+    } else {
+      ++g_isolated_draw.vehicle_shadow_color_retained_unsupported;
+    }
+  }
+  if (g_isolated_draw.vehicle_shadow_color_retained_current_failed) {
+    if (!g_isolated_draw.vehicle_shadow_color_retained_current_accounted) {
+      g_isolated_draw.vehicle_shadow_color_retained_current_accounted = true;
+      ++g_isolated_draw.vehicle_shadow_color_retained_frames_failed;
+    }
+    FailClosedVehicleShadowColorRetainedPass("backend_replay_failure");
+    return;
+  }
+  if (g_isolated_draw.vehicle_shadow_color_retained_current_requests !=
+          kVehicleShadowColorRetainedFamilyCount ||
+      g_isolated_draw.vehicle_shadow_color_retained_current_outcomes !=
+          kVehicleShadowColorRetainedFamilyCount ||
+      g_isolated_draw.vehicle_shadow_color_retained_current_accounted) {
+    return;
+  }
+  g_isolated_draw.vehicle_shadow_color_retained_current_accounted = true;
+  if (g_isolated_draw.vehicle_shadow_color_retained_current_recorded !=
+      kVehicleShadowColorRetainedFamilyCount) {
+    ++g_isolated_draw.vehicle_shadow_color_retained_frames_failed;
+    FailClosedVehicleShadowColorRetainedPass("incomplete_recording");
+    return;
+  }
+  ++g_isolated_draw.vehicle_shadow_color_retained_frames_completed;
+  if (g_isolated_draw.vehicle_shadow_color_retained_capture_completed) {
+    return;
+  }
+  g_isolated_draw.vehicle_shadow_color_retained_capture_completed = true;
+  pinyon_shift::diagnostics::RecordEvent(
+      "native_renderer.discovery.vehicle_shadow_color_retained_result",
+      {{"status", "recorded_complete_private_vehicle_pass"},
+       {"frame",
+        std::to_string(
+            g_isolated_draw.vehicle_shadow_color_retained_current_frame)},
+       {"last_draw",
+        std::to_string(
+            g_isolated_draw.vehicle_shadow_color_retained_last_draw)},
+       {"draw_count",
+        std::to_string(kVehicleShadowColorRetainedFamilyCount)},
+       {"target_width", std::to_string(result.target_width)},
+       {"target_height", std::to_string(result.target_height)},
+       {"readback", g_isolated_draw.readback_requested
+                        ? "native_retained_vehicle_color"
+                        : "disabled"},
+       {"native_draw", "private_retained_pass_only"},
        {"xenos_draw", "preserved"},
        {"output_authority", "xenos"},
        {"suppression_allowed", "false"}});
@@ -22183,6 +22379,126 @@ void RequestIsolatedDraw(
     if (g_isolated_draw.shadow_depth_batch_capture_completed &&
         g_isolated_draw.vehicle_shadow_color_capture_mode &&
         g_isolated_draw.vehicle_shadow_color_capture_recorded &&
+        g_isolated_draw.vehicle_shadow_color_retained_pass_mode &&
+        !g_isolated_draw.vehicle_shadow_color_retained_pass_failed_closed &&
+        g_isolated_draw.prepared_vehicle_shadow_color_replay_eligible) {
+      const uint64_t frame = g_isolated_draw.frame;
+      if (frame <= g_isolated_draw.captured_frame) {
+        return;
+      }
+      if (g_vehicle_shadow_geometry_correlation_count !=
+          kVehicleShadowColorRetainedFamilyCount) {
+        FailClosedVehicleShadowColorRetainedPass(
+            "unexpected_correlation_family_count");
+        return;
+      }
+      if (g_isolated_draw.vehicle_shadow_color_retained_skip_frame == frame) {
+        return;
+      }
+      if (g_isolated_draw.vehicle_shadow_color_retained_current_frame !=
+          frame) {
+        if (g_isolated_draw.vehicle_shadow_color_retained_current_frame !=
+                UINT64_MAX &&
+            !g_isolated_draw
+                 .vehicle_shadow_color_retained_current_accounted) {
+          if (g_isolated_draw
+                  .vehicle_shadow_color_retained_current_requests !=
+              kVehicleShadowColorRetainedFamilyCount) {
+            ++g_isolated_draw.vehicle_shadow_color_retained_frames_failed;
+            g_isolated_draw
+                .vehicle_shadow_color_retained_current_accounted = true;
+            FailClosedVehicleShadowColorRetainedPass(
+                "incomplete_family_frame");
+          } else {
+            g_isolated_draw.vehicle_shadow_color_retained_skip_frame = frame;
+          }
+          return;
+        }
+        if (g_isolated_draw.vehicle_shadow_color_retained_frames_started >=
+            kVehicleShadowColorRetainedPassLimit) {
+          ++g_isolated_draw.vehicle_shadow_color_retained_limit_yields;
+          return;
+        }
+        g_isolated_draw.vehicle_shadow_color_retained_current_frame = frame;
+        g_isolated_draw.vehicle_shadow_color_retained_last_draw = 0;
+        g_isolated_draw.vehicle_shadow_color_retained_current_requests = 0;
+        g_isolated_draw.vehicle_shadow_color_retained_current_outcomes = 0;
+        g_isolated_draw.vehicle_shadow_color_retained_current_recorded = 0;
+        g_isolated_draw.vehicle_shadow_color_retained_current_family_mask = 0;
+        g_isolated_draw.vehicle_shadow_color_retained_current_failed = false;
+        g_isolated_draw.vehicle_shadow_color_retained_current_accounted =
+            false;
+        ++g_isolated_draw.vehicle_shadow_color_retained_frames_started;
+      }
+      if (g_isolated_draw.vehicle_shadow_color_retained_current_requests >=
+          kVehicleShadowColorRetainedFamilyCount) {
+        FailClosedVehicleShadowColorRetainedPass("extra_family_draw");
+        return;
+      }
+      if (g_isolated_draw.vehicle_shadow_color_retained_last_draw &&
+          g_isolated_draw.draw <=
+              g_isolated_draw.vehicle_shadow_color_retained_last_draw) {
+        FailClosedVehicleShadowColorRetainedPass("non_monotonic_draw_order");
+        return;
+      }
+      const uint32_t family_index =
+          g_isolated_draw.prepared_vehicle_shadow_color_family_index;
+      if (family_index >= kVehicleShadowColorRetainedFamilyCount) {
+        FailClosedVehicleShadowColorRetainedPass("invalid_family_index");
+        return;
+      }
+      const uint32_t family_bit = uint32_t(1) << family_index;
+      if (g_isolated_draw.vehicle_shadow_color_retained_current_family_mask &
+          family_bit) {
+        FailClosedVehicleShadowColorRetainedPass("duplicate_family_draw");
+        return;
+      }
+      g_isolated_draw.vehicle_shadow_color_retained_current_family_mask |=
+          family_bit;
+      ++g_isolated_draw.vehicle_shadow_color_retained_current_requests;
+      ++g_isolated_draw.vehicle_shadow_color_retained_requests;
+      g_isolated_draw.vehicle_shadow_color_retained_last_draw =
+          g_isolated_draw.draw;
+      const bool first_draw =
+          g_isolated_draw.vehicle_shadow_color_retained_current_requests == 1;
+      const bool completing_pass =
+          g_isolated_draw.vehicle_shadow_color_retained_current_requests ==
+          kVehicleShadowColorRetainedFamilyCount;
+      if (completing_pass &&
+          g_isolated_draw.vehicle_shadow_color_retained_current_family_mask !=
+              ((uint32_t(1) << kVehicleShadowColorRetainedFamilyCount) - 1)) {
+        FailClosedVehicleShadowColorRetainedPass("incomplete_family_set");
+        return;
+      }
+      if (!first_draw) {
+        ++g_isolated_draw
+              .vehicle_shadow_color_retained_reused_target_requests;
+      }
+      if (completing_pass) {
+        g_isolated_draw.captured_signature =
+            g_isolated_draw.prepared_signature;
+        g_isolated_draw.captured_frame = frame;
+        g_isolated_draw.captured_draw = g_isolated_draw.draw;
+      }
+      request.requested = true;
+      request.retain_target = !completing_pass;
+      request.reuse_target = !first_draw;
+      request.frame_sequence = frame;
+      request.reference_marker_requested = true;
+      request.completion = &CompleteVehicleShadowColorRetainedPass;
+      const bool capture_pass =
+          completing_pass && g_isolated_draw.readback_requested &&
+          !g_isolated_draw.vehicle_shadow_color_retained_capture_completed;
+      request.readback_requested = capture_pass;
+      request.readback_completion =
+          capture_pass ? &CompleteVehicleShadowColorRetainedReadback
+                       : nullptr;
+      return;
+    }
+    if (g_isolated_draw.shadow_depth_batch_capture_completed &&
+        g_isolated_draw.vehicle_shadow_color_capture_mode &&
+        g_isolated_draw.vehicle_shadow_color_capture_recorded &&
+        !g_isolated_draw.vehicle_shadow_color_retained_pass_mode &&
         !g_isolated_draw.vehicle_shadow_color_private_replay_failed_closed &&
         g_isolated_draw.prepared_vehicle_shadow_color_replay_eligible &&
         g_isolated_draw.prepared_signature ==
@@ -25974,6 +26290,77 @@ void UninstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system) {
          {"native_draw",
           g_isolated_draw.vehicle_shadow_color_capture_recorded
               ? "private_capture_only"
+              : "false"},
+         {"xenos_draw", "preserved"},
+         {"output_authority", "xenos"},
+         {"suppression_allowed", "false"}});
+  }
+  if (g_isolated_draw.vehicle_shadow_color_retained_pass_mode) {
+    const uint64_t retained_outcomes =
+        g_isolated_draw.vehicle_shadow_color_retained_recorded +
+        g_isolated_draw.vehicle_shadow_color_retained_target_failures +
+        g_isolated_draw.vehicle_shadow_color_retained_unsupported;
+    diagnostics::RecordEvent(
+        "native_renderer.discovery.vehicle_shadow_color_retained_summary",
+        {{"status",
+          g_isolated_draw.vehicle_shadow_color_retained_pass_failed_closed
+              ? "failed_closed"
+              : (g_isolated_draw
+                             .vehicle_shadow_color_retained_frames_completed
+                         ? "bounded_retained_pass_stable"
+                         : "not_observed")},
+         {"requests",
+          std::to_string(
+              g_isolated_draw.vehicle_shadow_color_retained_requests)},
+         {"recorded",
+          std::to_string(
+              g_isolated_draw.vehicle_shadow_color_retained_recorded)},
+         {"target_creation_failures",
+          std::to_string(
+              g_isolated_draw.vehicle_shadow_color_retained_target_failures)},
+         {"unsupported",
+          std::to_string(
+              g_isolated_draw.vehicle_shadow_color_retained_unsupported)},
+         {"request_accounting_complete",
+          retained_outcomes ==
+                  g_isolated_draw.vehicle_shadow_color_retained_requests
+              ? "true"
+              : "false"},
+         {"reused_target_requests",
+          std::to_string(g_isolated_draw
+                             .vehicle_shadow_color_retained_reused_target_requests)},
+         {"frames_started",
+          std::to_string(
+              g_isolated_draw.vehicle_shadow_color_retained_frames_started)},
+         {"frames_completed",
+          std::to_string(
+              g_isolated_draw.vehicle_shadow_color_retained_frames_completed)},
+         {"frames_failed",
+          std::to_string(
+              g_isolated_draw.vehicle_shadow_color_retained_frames_failed)},
+         {"frame_accounting_complete",
+          g_isolated_draw.vehicle_shadow_color_retained_frames_completed +
+                      g_isolated_draw.vehicle_shadow_color_retained_frames_failed ==
+                  g_isolated_draw.vehicle_shadow_color_retained_frames_started
+              ? "true"
+              : "false"},
+         {"draws_per_frame",
+          std::to_string(kVehicleShadowColorRetainedFamilyCount)},
+         {"pass_limit",
+          std::to_string(kVehicleShadowColorRetainedPassLimit)},
+         {"limit_yields",
+          std::to_string(
+              g_isolated_draw.vehicle_shadow_color_retained_limit_yields)},
+         {"capture_recorded",
+          g_isolated_draw.vehicle_shadow_color_retained_capture_completed
+              ? "true"
+              : "false"},
+         {"selection", "all_30_exact_correlated_families_in_guest_order"},
+         {"target_lifecycle", "retain_first_reuse_middle_release_last"},
+         {"readback", "first_complete_native_retained_pass"},
+         {"native_draw",
+          g_isolated_draw.vehicle_shadow_color_retained_frames_completed
+              ? "private_retained_pass_only"
               : "false"},
          {"xenos_draw", "preserved"},
          {"output_authority", "xenos"},

--- a/tools/capture-native-renderer-census.ps1
+++ b/tools/capture-native-renderer-census.ps1
@@ -20,6 +20,7 @@ param(
     [switch]$ShadowDepthBatch,
     [switch]$VehicleShadowGeometryCorrelation,
     [switch]$CaptureVehicleShadowColor,
+    [switch]$RetainVehicleShadowColorPass,
     [switch]$PublishShadowDepth,
     [switch]$ContinuousShadowDepth,
     [ValidateRange(2, 120)]
@@ -118,6 +119,9 @@ if ($VehicleShadowGeometryCorrelation -and -not $ShadowDepthBatch) {
 }
 if ($CaptureVehicleShadowColor -and -not $VehicleShadowGeometryCorrelation) {
     throw 'CaptureVehicleShadowColor requires VehicleShadowGeometryCorrelation.'
+}
+if ($RetainVehicleShadowColorPass -and -not $CaptureVehicleShadowColor) {
+    throw 'RetainVehicleShadowColorPass requires CaptureVehicleShadowColor.'
 }
 if ($PublishShadowDepth -and -not $ShadowDepthBatch) {
     throw 'PublishShadowDepth requires ShadowDepthBatch.'
@@ -242,6 +246,8 @@ $savedVehicleShadowGeometryCorrelation =
     $env:PINYON_SHIFT_NATIVE_RENDERER_VEHICLE_SHADOW_GEOMETRY_CORRELATION
 $savedVehicleShadowColorCapture =
     $env:PINYON_SHIFT_NATIVE_RENDERER_VEHICLE_SHADOW_COLOR_CAPTURE
+$savedVehicleShadowColorRetainedPass =
+    $env:PINYON_SHIFT_NATIVE_RENDERER_VEHICLE_SHADOW_COLOR_RETAINED_PASS
 $savedShadowDepthPublication =
     $env:PINYON_SHIFT_NATIVE_RENDERER_SHADOW_DEPTH_PUBLICATION
 $savedShadowDepthContinuous =
@@ -294,6 +300,8 @@ try {
         if ($VehicleShadowGeometryCorrelation) { 'true' } else { $null }
     $env:PINYON_SHIFT_NATIVE_RENDERER_VEHICLE_SHADOW_COLOR_CAPTURE =
         if ($CaptureVehicleShadowColor) { 'true' } else { $null }
+    $env:PINYON_SHIFT_NATIVE_RENDERER_VEHICLE_SHADOW_COLOR_RETAINED_PASS =
+        if ($RetainVehicleShadowColorPass) { 'true' } else { $null }
     $env:PINYON_SHIFT_NATIVE_RENDERER_SHADOW_DEPTH_PUBLICATION =
         if ($PublishShadowDepth) { 'true' } else { $null }
     $env:PINYON_SHIFT_NATIVE_RENDERER_SHADOW_DEPTH_CONTINUOUS =
@@ -352,6 +360,8 @@ finally {
         $savedVehicleShadowGeometryCorrelation
     $env:PINYON_SHIFT_NATIVE_RENDERER_VEHICLE_SHADOW_COLOR_CAPTURE =
         $savedVehicleShadowColorCapture
+    $env:PINYON_SHIFT_NATIVE_RENDERER_VEHICLE_SHADOW_COLOR_RETAINED_PASS =
+        $savedVehicleShadowColorRetainedPass
     $env:PINYON_SHIFT_NATIVE_RENDERER_SHADOW_DEPTH_PUBLICATION =
         $savedShadowDepthPublication
     $env:PINYON_SHIFT_NATIVE_RENDERER_SHADOW_DEPTH_CONTINUOUS =

--- a/tools/summarize-native-renderer-vehicle-shadow-geometry.py
+++ b/tools/summarize-native-renderer-vehicle-shadow-geometry.py
@@ -5,7 +5,7 @@ import json
 from pathlib import Path
 
 
-SCHEMA = "pinyon-shift.native-renderer-vehicle-shadow-geometry.v5"
+SCHEMA = "pinyon-shift.native-renderer-vehicle-shadow-geometry.v6"
 CONFIG_EVENT = "native_renderer.discovery.vehicle_shadow_geometry_config"
 EPOCH_EVENT = "native_renderer.discovery.vehicle_shadow_geometry_epoch"
 CORRELATION_EVENT = (
@@ -21,6 +21,15 @@ CAPTURE_RESULT_EVENT = (
 )
 CAPTURE_SUMMARY_EVENT = (
     "native_renderer.discovery.vehicle_shadow_color_capture_summary"
+)
+RETAINED_CONFIG_EVENT = (
+    "native_renderer.discovery.vehicle_shadow_color_retained_config"
+)
+RETAINED_RESULT_EVENT = (
+    "native_renderer.discovery.vehicle_shadow_color_retained_result"
+)
+RETAINED_SUMMARY_EVENT = (
+    "native_renderer.discovery.vehicle_shadow_color_retained_summary"
 )
 REJECTION_REASON_FIELDS = (
     "reject_resolved_input",
@@ -96,6 +105,15 @@ def summarize(log_path):
     ]
     capture_summaries = [
         event for event in events if event.get("event") == CAPTURE_SUMMARY_EVENT
+    ]
+    retained_configs = [
+        event for event in events if event.get("event") == RETAINED_CONFIG_EVENT
+    ]
+    retained_results = [
+        event for event in events if event.get("event") == RETAINED_RESULT_EVENT
+    ]
+    retained_summaries = [
+        event for event in events if event.get("event") == RETAINED_SUMMARY_EVENT
     ]
     require(len(configs) == 1, "expected exactly one correlation config event")
     require(configs[0].get("status") == "armed", "correlation was not armed")
@@ -354,6 +372,96 @@ def summarize(log_path):
             "result": capture_results[0] if capture_results else None,
             "summary": capture_summary,
         }
+    retained = None
+    if retained_configs or retained_results or retained_summaries:
+        require(len(retained_configs) == 1, "expected one retained pass config")
+        require(
+            retained_configs[0].get("status") == "armed",
+            "retained pass was not armed",
+        )
+        require(len(retained_summaries) == 1, "expected one retained pass summary")
+        retained_summary = retained_summaries[0]
+        require(
+            retained_summary.get("request_accounting_complete") == "true",
+            "retained pass request accounting drift",
+        )
+        retained_requests = integer(retained_summary, "requests")
+        retained_recorded = integer(retained_summary, "recorded")
+        retained_failures = integer(
+            retained_summary, "target_creation_failures"
+        ) + integer(retained_summary, "unsupported")
+        require(
+            retained_requests == retained_recorded + retained_failures,
+            "retained pass outcome drift",
+        )
+        frames_started = integer(retained_summary, "frames_started")
+        frames_completed = integer(retained_summary, "frames_completed")
+        frames_failed = integer(retained_summary, "frames_failed")
+        draws_per_frame = integer(retained_summary, "draws_per_frame")
+        pass_limit = integer(retained_summary, "pass_limit")
+        require(draws_per_frame == 30, "retained family count drift")
+        require(frames_started <= pass_limit, "retained pass limit drift")
+        require(
+            retained_summary.get("frame_accounting_complete") == "true",
+            "retained frame accounting drift",
+        )
+        require(
+            frames_started == frames_completed + frames_failed,
+            "retained frame outcome drift",
+        )
+        require(
+            retained_requests <= frames_started * draws_per_frame,
+            "retained request frame bound drift",
+        )
+        reused_target_requests = integer(
+            retained_summary, "reused_target_requests"
+        )
+        require(
+            reused_target_requests <= retained_requests,
+            "retained target reuse bound drift",
+        )
+        if not retained_failures and frames_completed == frames_started:
+            require(
+                retained_requests == frames_completed * draws_per_frame,
+                "retained complete-frame request drift",
+            )
+            require(
+                reused_target_requests
+                == frames_completed * (draws_per_frame - 1),
+                "retained target lifecycle drift",
+            )
+        require(
+            not retained_failures
+            or retained_summary.get("status") == "failed_closed",
+            "retained pass did not fail closed",
+        )
+        capture_recorded = retained_summary.get("capture_recorded") == "true"
+        require(
+            len(retained_results) == (1 if capture_recorded else 0),
+            "retained capture result drift",
+        )
+        for event in [*retained_configs, *retained_results, retained_summary]:
+            require(
+                event.get("xenos_draw") == "preserved"
+                and event.get("output_authority") == "xenos"
+                and event.get("suppression_allowed") == "false",
+                "retained pass changed output authority",
+            )
+        if retained_results:
+            require(
+                retained_results[0].get("status")
+                == "recorded_complete_private_vehicle_pass",
+                "retained pass result drift",
+            )
+            require(
+                integer(retained_results[0], "draw_count") == draws_per_frame,
+                "retained result draw count drift",
+            )
+        retained = {
+            "config": retained_configs[0],
+            "result": retained_results[0] if retained_results else None,
+            "summary": retained_summary,
+        }
     return {
         "schema": SCHEMA,
         "source_log": str(log_path),
@@ -391,6 +499,7 @@ def summarize(log_path):
         "correlations": correlations,
         "candidate_families": candidates,
         "private_color_capture": capture,
+        "private_retained_color_pass": retained,
         "qualification": {
             "working_color_bridge_candidate": bool(correlations),
             "private_color_capture_recorded": bool(
@@ -402,6 +511,15 @@ def summarize(log_path):
                 and integer(capture["summary"], "private_replay_requests")
                 and integer(capture["summary"], "private_replay_requests")
                 == integer(capture["summary"], "private_replay_recorded")
+            ),
+            "private_retained_color_pass_stable": bool(
+                retained
+                and integer(retained["summary"], "frames_completed")
+                == integer(retained["summary"], "pass_limit")
+                and integer(retained["summary"], "frames_failed") == 0
+                and integer(retained["summary"], "requests")
+                == integer(retained["summary"], "recorded")
+                and retained["summary"].get("capture_recorded") == "true"
             ),
             "object_identity_proven": False,
             "mesh_material_contract_proven": False,

--- a/tools/tests/test_native_renderer_vehicle_shadow_geometry.py
+++ b/tools/tests/test_native_renderer_vehicle_shadow_geometry.py
@@ -112,6 +112,45 @@ class VehicleShadowGeometryTests(unittest.TestCase):
                 "suppression_allowed": "false",
             },
             {
+                "event": MODULE.RETAINED_CONFIG_EVENT,
+                "status": "armed",
+                "native_draw": "private_retained_pass_only",
+                "xenos_draw": "preserved",
+                "output_authority": "xenos",
+                "suppression_allowed": "false",
+            },
+            {
+                "event": MODULE.RETAINED_RESULT_EVENT,
+                "status": "recorded_complete_private_vehicle_pass",
+                "draw_count": "30",
+                "native_draw": "private_retained_pass_only",
+                "xenos_draw": "preserved",
+                "output_authority": "xenos",
+                "suppression_allowed": "false",
+            },
+            {
+                "event": MODULE.RETAINED_SUMMARY_EVENT,
+                "status": "bounded_retained_pass_stable",
+                "requests": "60",
+                "recorded": "60",
+                "target_creation_failures": "0",
+                "unsupported": "0",
+                "request_accounting_complete": "true",
+                "reused_target_requests": "58",
+                "frames_started": "2",
+                "frames_completed": "2",
+                "frames_failed": "0",
+                "frame_accounting_complete": "true",
+                "draws_per_frame": "30",
+                "pass_limit": "2",
+                "limit_yields": "1",
+                "capture_recorded": "true",
+                "native_draw": "private_retained_pass_only",
+                "xenos_draw": "preserved",
+                "output_authority": "xenos",
+                "suppression_allowed": "false",
+            },
+            {
                 "event": MODULE.SUMMARY_EVENT,
                 "status": "qualified_epoch_observed",
                 "epochs_committed": "1",
@@ -184,6 +223,13 @@ class VehicleShadowGeometryTests(unittest.TestCase):
         )
         self.assertEqual(2, report["mechanical_rejections"]["prepared_pipeline"])
         self.assertTrue(report["qualification"]["private_color_replay_stable"])
+        self.assertTrue(
+            report["qualification"]["private_retained_color_pass_stable"]
+        )
+        self.assertEqual(
+            2,
+            int(report["private_retained_color_pass"]["summary"]["frames_completed"]),
+        )
         self.assertEqual(3, report["color_run_topology"]["maximum_run_length"])
 
     def test_rejects_partial_epoch_promotion(self):
@@ -250,6 +296,12 @@ class VehicleShadowGeometryTests(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "private replay outcome drift"):
             self.summarize(events)
 
+    def test_rejects_retained_frame_accounting_drift(self):
+        events = self.fixture()
+        events[9]["frames_completed"] = "1"
+        with self.assertRaisesRegex(ValueError, "retained frame outcome drift"):
+            self.summarize(events)
+
     def test_runtime_contract_is_default_off_and_full_epoch_gated(self):
         source = (ROOT / "src/native_renderer/graphics_hooks.cpp").read_text(
             encoding="utf-8"
@@ -274,14 +326,23 @@ class VehicleShadowGeometryTests(unittest.TestCase):
             '"native_renderer.discovery.vehicle_shadow_color_capture_summary"',
             source,
         )
+        self.assertIn(
+            '"native_renderer.discovery.vehicle_shadow_color_retained_summary"',
+            source,
+        )
         self.assertIn("[switch]$VehicleShadowGeometryCorrelation", capture)
         self.assertIn("[switch]$CaptureVehicleShadowColor", capture)
+        self.assertIn("[switch]$RetainVehicleShadowColorPass", capture)
         self.assertIn(
             "VehicleShadowGeometryCorrelation requires ShadowDepthBatch",
             capture,
         )
         self.assertIn(
             "CaptureVehicleShadowColor requires VehicleShadowGeometryCorrelation",
+            capture,
+        )
+        self.assertIn(
+            "RetainVehicleShadowColorPass requires CaptureVehicleShadowColor",
             capture,
         )
         self.assertIn('{"native_draw", "false"}', source)


### PR DESCRIPTION
## Summary
- accumulate all 30 exact correlated vehicle color families into one private retained target per frame
- enforce bounded, ordered, fail-closed admission while preserving Xenos authority
- qualify 120 complete AppData-backed frames and document the coherent multi-submesh readback

## Validation
- 549 native-renderer tests
- Release target compilation
- clean 102-patch preview build
- AppData session 20260831T164716Z-p35116: 3,600/3,600 recorded, 3,480 reuses, zero failures/errors, normal exit
- git diff --check