### PR TITLE
feat(renderer): correlate vehicle constants to live poses

### DIFF
--- a/docs/native-renderer/REPRIORITIZED_PLAN.md
+++ b/docs/native-renderer/REPRIORITIZED_PLAN.md
@@ -638,6 +638,18 @@ frame-wide retention mechanism. The result remains an isolated unlit
 diagnostic; exact player identity, transforms, material completeness, hybrid
 publication, traffic coverage, and per-item fallback remain open C4 work.
 
+Transform-identity implementation checkpoint: every exact correlated color
+draw now compares its already-bounded vertex constants with title-owned vehicle
+positions and both forward signs no more than one frame old. Per-family
+accounting distinguishes unique, ambiguous, and missing matches and requires a
+stable constant register and identity across every observation. The offline
+gate recognizes a complete shared vehicle-transform candidate only when all 30
+families consistently name the same generation, owner, and slot. No constant
+payload is exported, and the result cannot label the instance as the player,
+publish native output, or suppress Xenos. Runtime evidence is batched with the
+next C4 AppData session; the contract is documented in
+[`VEHICLE_COLOR_CONSTANT_IDENTITY.md`](VEHICLE_COLOR_CONSTANT_IDENTITY.md).
+
 ### C5. Sky, atmosphere, and global lighting
 
 - Replace the qualified sky/global-light families.

--- a/docs/native-renderer/VEHICLE_COLOR_CONSTANT_IDENTITY.md
+++ b/docs/native-renderer/VEHICLE_COLOR_CONSTANT_IDENTITY.md
@@ -1,0 +1,61 @@
+# Vehicle color constant identity census
+
+Status: implemented as a default-off, measurement-only extension of the
+qualified vehicle shadow/color correlation; runtime evidence is batched with
+the next C4 AppData session.
+
+## Purpose
+
+The retained color pass proves that 30 exact geometry families can form one
+coherent vehicle contribution. It does not connect that contribution to one of
+the title-owned live vehicle identities or expose the render transform used by
+the color shaders.
+
+The next bounded join compares only the already-observed vertex float
+constants of each correlated color draw with the latest title-owned vehicle
+poses. It tests every finite three-component constant vector against:
+
+- the position of every vehicle identity no more than one frame old; and
+- both signs of every fresh vehicle forward vector.
+
+Position and forward use the same tight squared-delta limits as the earlier
+typed matrix census: `0.25` and `0.04`, respectively. The observer never reads
+new guest memory and does not persist constant values.
+
+## Evidence contract
+
+Every correlated draw produces exactly one position outcome and one forward
+outcome:
+
+- `unique` means exactly one constant-register/identity pair passed the tight
+  threshold;
+- `ambiguous` means more than one pair passed; and
+- `miss` means none passed, including the explicit no-fresh-pose case.
+
+Each of the 30 exact color families retains its last unique identity and
+constant register plus identity/register variation counts. A family is a
+stable tight position candidate only when every observation is unique and the
+identity and register never change. The offline qualifier promotes a complete
+shared vehicle-transform candidate only when all 30 families meet that rule
+and name the same title generation, owner, and slot.
+
+That result would prove a vehicle-instance transform bridge, not that the
+instance is the human player's car. A separate title-semantic discriminator is
+still required before applying the player label. Ambiguous or missing results
+select the next typed constant-upload investigation rather than widening
+heuristic object scans.
+
+## Safety boundary
+
+- The census is active only with the existing default-off shadow geometry
+  correlation mode.
+- Constant payloads are neither logged nor written to reports.
+- No native draw, publication, or suppression decision depends on a match.
+- Every authoritative Xenos draw remains present.
+- Missing, stale, non-finite, or ambiguous evidence cannot establish identity.
+
+Qualify it with the existing retained-pass batch command in
+[`VEHICLE_RETAINED_COLOR_PASS.md`](VEHICLE_RETAINED_COLOR_PASS.md). The v7
+vehicle report requires full scan/outcome accounting and exposes
+`complete_shared_vehicle_transform_candidate` without changing
+`object_identity_proven` or `native_admission_allowed`.

--- a/src/native_renderer/graphics_hooks.cpp
+++ b/src/native_renderer/graphics_hooks.cpp
@@ -141,6 +141,7 @@ constexpr uint32_t kVehicleComposedMatrixCallee = 0x82435E78;
 constexpr size_t kVehicleComposedMatrixCorrelationCapacity = 1024;
 constexpr size_t kVehicleShadowGeometrySeedCapacity = 256;
 constexpr size_t kVehicleShadowGeometryCorrelationCapacity = 1024;
+constexpr uint64_t kVehicleColorConstantMaximumIdentityAgeFrames = 1;
 constexpr uint64_t kVehicleShadowColorPrivateReplayLimit = 300;
 constexpr uint32_t kVehicleShadowColorRetainedFamilyCount = 30;
 constexpr uint64_t kVehicleShadowColorRetainedPassLimit = 120;
@@ -629,6 +630,22 @@ struct VehicleShadowGeometryCorrelationEntry {
   uint64_t private_capture_eligible_draws = 0;
   uint64_t private_capture_rejected_draws = 0;
   uint64_t private_capture_rejection_mask_switches = 0;
+  uint64_t constant_identity_scans = 0;
+  uint64_t constant_identity_missing_fresh_pose = 0;
+  uint64_t constant_position_unique_matches = 0;
+  uint64_t constant_position_ambiguous_matches = 0;
+  uint64_t constant_position_misses = 0;
+  uint64_t constant_position_identity_variations = 0;
+  uint64_t constant_position_register_variations = 0;
+  uint64_t constant_forward_unique_matches = 0;
+  uint64_t constant_forward_ambiguous_matches = 0;
+  uint64_t constant_forward_misses = 0;
+  uint64_t constant_forward_identity_variations = 0;
+  uint64_t constant_forward_register_variations = 0;
+  double closest_position_delta_squared =
+      std::numeric_limits<double>::infinity();
+  double closest_forward_delta_squared =
+      std::numeric_limits<double>::infinity();
   uint32_t seed_index = 0;
   uint32_t first_rejection_mask = 0;
   uint32_t last_rejection_mask = 0;
@@ -638,7 +655,18 @@ struct VehicleShadowGeometryCorrelationEntry {
   uint32_t last_private_capture_rejection_mask = 0;
   uint32_t private_capture_rejection_mask_or = 0;
   uint32_t private_capture_rejection_mask_and = 0;
+  uint32_t constant_position_identity_generation = 0;
+  uint32_t constant_position_identity_owner = 0;
+  uint32_t constant_position_identity_slot = 0;
+  uint32_t constant_position_register = 0;
+  uint32_t constant_forward_identity_generation = 0;
+  uint32_t constant_forward_identity_owner = 0;
+  uint32_t constant_forward_identity_slot = 0;
+  uint32_t constant_forward_register = 0;
+  int32_t constant_forward_sign = 0;
   bool full_geometry_match = false;
+  bool constant_position_identity_valid = false;
+  bool constant_forward_identity_valid = false;
   bool occupied = false;
 };
 
@@ -1464,6 +1492,9 @@ uint64_t g_vehicle_shadow_geometry_full_matches = 0;
 uint64_t g_vehicle_shadow_geometry_partial_matches = 0;
 uint64_t g_vehicle_shadow_geometry_correlation_count = 0;
 uint64_t g_vehicle_shadow_geometry_correlation_overflow = 0;
+uint64_t g_vehicle_color_constant_vectors_scanned = 0;
+uint64_t g_vehicle_color_constant_non_finite_vectors = 0;
+uint64_t g_vehicle_color_constant_identity_comparisons = 0;
 uint64_t g_vehicle_shadow_geometry_mechanically_eligible_draws = 0;
 uint64_t g_vehicle_shadow_geometry_mechanically_rejected_draws = 0;
 std::array<uint64_t, 15> g_vehicle_shadow_geometry_rejection_reason_counts{};
@@ -15162,6 +15193,180 @@ bool VehicleShadowGeometrySharesVertexResource(
   return false;
 }
 
+void ObserveVehicleColorConstantIdentity(
+    const rex::system::GraphicsDrawObservation &observation,
+    VehicleShadowGeometryCorrelationEntry &entry) {
+  struct PoseCandidate {
+    uint64_t last_frame = 0;
+    uint32_t generation = 0;
+    uint32_t owner = 0;
+    uint32_t slot = 0;
+    float x = 0.0f;
+    float y = 0.0f;
+    float z = 0.0f;
+    float forward_x = 0.0f;
+    float forward_y = 0.0f;
+    float forward_z = 0.0f;
+  };
+  struct Match {
+    double delta_squared = std::numeric_limits<double>::infinity();
+    uint32_t generation = 0;
+    uint32_t owner = 0;
+    uint32_t slot = 0;
+    uint32_t constant_register = 0;
+    int32_t forward_sign = 0;
+  };
+
+  std::array<PoseCandidate, kVehicleIdentityCapacity> poses{};
+  size_t pose_count = 0;
+  {
+    std::scoped_lock lock(g_vehicle_identity_mutex);
+    for (const VehicleIdentityEntry &identity : g_vehicle_identities) {
+      if (!identity.valid || observation.frame_sequence < identity.last_frame ||
+          observation.frame_sequence - identity.last_frame >
+              kVehicleColorConstantMaximumIdentityAgeFrames) {
+        continue;
+      }
+      poses[pose_count++] = {
+          .last_frame = identity.last_frame,
+          .generation = identity.generation,
+          .owner = identity.owner,
+          .slot = identity.slot,
+          .x = identity.last_x,
+          .y = identity.last_y,
+          .z = identity.last_z,
+          .forward_x = identity.last_forward_x,
+          .forward_y = identity.last_forward_y,
+          .forward_z = identity.last_forward_z,
+      };
+    }
+  }
+
+  ++entry.constant_identity_scans;
+  if (!pose_count) {
+    ++entry.constant_identity_missing_fresh_pose;
+    ++entry.constant_position_misses;
+    ++entry.constant_forward_misses;
+    return;
+  }
+
+  Match best_position{};
+  Match best_forward{};
+  uint64_t tight_position_matches = 0;
+  uint64_t tight_forward_matches = 0;
+  const uint32_t constant_count = std::min(
+      observation.vertex_float_constant_count,
+      rex::system::kGraphicsFloatConstantObservationLimit);
+  for (uint32_t constant_offset = 0; constant_offset < constant_count;
+       ++constant_offset) {
+    const auto &constant =
+        observation.vertex_float_constants[constant_offset];
+    const float x = std::bit_cast<float>(constant.values[0]);
+    const float y = std::bit_cast<float>(constant.values[1]);
+    const float z = std::bit_cast<float>(constant.values[2]);
+    if (!std::isfinite(x) || !std::isfinite(y) || !std::isfinite(z)) {
+      ++g_vehicle_color_constant_non_finite_vectors;
+      continue;
+    }
+    ++g_vehicle_color_constant_vectors_scanned;
+    for (const PoseCandidate &pose : std::span(poses.data(), pose_count)) {
+      const double position_dx = double(x) - pose.x;
+      const double position_dy = double(y) - pose.y;
+      const double position_dz = double(z) - pose.z;
+      const double position_delta_squared =
+          position_dx * position_dx + position_dy * position_dy +
+          position_dz * position_dz;
+      ++g_vehicle_color_constant_identity_comparisons;
+      if (position_delta_squared < best_position.delta_squared) {
+        best_position = {
+            .delta_squared = position_delta_squared,
+            .generation = pose.generation,
+            .owner = pose.owner,
+            .slot = pose.slot,
+            .constant_register = constant.index,
+        };
+      }
+      tight_position_matches +=
+          position_delta_squared <=
+          kVehicleMatrixPositionDeltaSquaredThreshold;
+
+      for (int32_t sign : {1, -1}) {
+        const double forward_dx = double(x) - sign * pose.forward_x;
+        const double forward_dy = double(y) - sign * pose.forward_y;
+        const double forward_dz = double(z) - sign * pose.forward_z;
+        const double forward_delta_squared =
+            forward_dx * forward_dx + forward_dy * forward_dy +
+            forward_dz * forward_dz;
+        ++g_vehicle_color_constant_identity_comparisons;
+        if (forward_delta_squared < best_forward.delta_squared) {
+          best_forward = {
+              .delta_squared = forward_delta_squared,
+              .generation = pose.generation,
+              .owner = pose.owner,
+              .slot = pose.slot,
+              .constant_register = constant.index,
+              .forward_sign = sign,
+          };
+        }
+        tight_forward_matches +=
+            forward_delta_squared <=
+            kVehicleMatrixForwardDeltaSquaredThreshold;
+      }
+    }
+  }
+
+  entry.closest_position_delta_squared = std::min(
+      entry.closest_position_delta_squared, best_position.delta_squared);
+  entry.closest_forward_delta_squared = std::min(
+      entry.closest_forward_delta_squared, best_forward.delta_squared);
+  if (tight_position_matches == 1) {
+    ++entry.constant_position_unique_matches;
+    if (entry.constant_position_identity_valid) {
+      entry.constant_position_identity_variations +=
+          entry.constant_position_identity_generation !=
+              best_position.generation ||
+          entry.constant_position_identity_owner != best_position.owner ||
+          entry.constant_position_identity_slot != best_position.slot;
+      entry.constant_position_register_variations +=
+          entry.constant_position_register !=
+          best_position.constant_register;
+    }
+    entry.constant_position_identity_generation = best_position.generation;
+    entry.constant_position_identity_owner = best_position.owner;
+    entry.constant_position_identity_slot = best_position.slot;
+    entry.constant_position_register = best_position.constant_register;
+    entry.constant_position_identity_valid = true;
+  } else if (tight_position_matches) {
+    ++entry.constant_position_ambiguous_matches;
+  } else {
+    ++entry.constant_position_misses;
+  }
+
+  if (tight_forward_matches == 1) {
+    ++entry.constant_forward_unique_matches;
+    if (entry.constant_forward_identity_valid) {
+      entry.constant_forward_identity_variations +=
+          entry.constant_forward_identity_generation !=
+              best_forward.generation ||
+          entry.constant_forward_identity_owner != best_forward.owner ||
+          entry.constant_forward_identity_slot != best_forward.slot;
+      entry.constant_forward_register_variations +=
+          entry.constant_forward_register != best_forward.constant_register ||
+          entry.constant_forward_sign != best_forward.forward_sign;
+    }
+    entry.constant_forward_identity_generation = best_forward.generation;
+    entry.constant_forward_identity_owner = best_forward.owner;
+    entry.constant_forward_identity_slot = best_forward.slot;
+    entry.constant_forward_register = best_forward.constant_register;
+    entry.constant_forward_sign = best_forward.forward_sign;
+    entry.constant_forward_identity_valid = true;
+  } else if (tight_forward_matches) {
+    ++entry.constant_forward_ambiguous_matches;
+  } else {
+    ++entry.constant_forward_misses;
+  }
+}
+
 bool ObserveVehicleShadowGeometryColorCorrelation(
     const rex::system::GraphicsDrawObservation &observation,
     bool samples_resolved_target,
@@ -15280,6 +15485,7 @@ bool ObserveVehicleShadowGeometryColorCorrelation(
       }
       ++entry.draws;
       entry.last_frame = observation.frame_sequence;
+      ObserveVehicleColorConstantIdentity(observation, entry);
       if (matched_correlation_index) {
         *matched_correlation_index = correlation_index;
       }
@@ -15324,6 +15530,7 @@ bool ObserveVehicleShadowGeometryColorCorrelation(
       .full_geometry_match = full_geometry_match,
       .occupied = true,
   };
+  ObserveVehicleColorConstantIdentity(observation, *available);
   if (matched_correlation_index) {
     *matched_correlation_index = available_index;
   }
@@ -26018,11 +26225,32 @@ void UninstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system) {
   }
   if (g_isolated_draw.vehicle_shadow_geometry_correlation_mode) {
     FinalizeVehicleShadowColorRun();
+    uint64_t constant_identity_scans = 0;
+    uint64_t constant_identity_missing_fresh_pose = 0;
+    uint64_t constant_position_unique_matches = 0;
+    uint64_t constant_position_ambiguous_matches = 0;
+    uint64_t constant_position_misses = 0;
+    uint64_t constant_forward_unique_matches = 0;
+    uint64_t constant_forward_ambiguous_matches = 0;
+    uint64_t constant_forward_misses = 0;
     for (const VehicleShadowGeometryCorrelationEntry &entry :
          g_vehicle_shadow_geometry_correlations) {
       if (!entry.occupied) {
         continue;
       }
+      constant_identity_scans += entry.constant_identity_scans;
+      constant_identity_missing_fresh_pose +=
+          entry.constant_identity_missing_fresh_pose;
+      constant_position_unique_matches +=
+          entry.constant_position_unique_matches;
+      constant_position_ambiguous_matches +=
+          entry.constant_position_ambiguous_matches;
+      constant_position_misses += entry.constant_position_misses;
+      constant_forward_unique_matches +=
+          entry.constant_forward_unique_matches;
+      constant_forward_ambiguous_matches +=
+          entry.constant_forward_ambiguous_matches;
+      constant_forward_misses += entry.constant_forward_misses;
       diagnostics::RecordEvent(
           "native_renderer.discovery.vehicle_shadow_geometry_candidate",
           {{"prepared_signature",
@@ -26089,6 +26317,88 @@ void UninstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system) {
                 entry.private_capture_rejection_mask_switches)},
            {"private_capture_admission_contract",
             "vehicle_color_private_replay_v1"},
+           {"constant_identity_scans",
+            std::to_string(entry.constant_identity_scans)},
+           {"constant_identity_missing_fresh_pose",
+            std::to_string(entry.constant_identity_missing_fresh_pose)},
+           {"constant_position_unique_matches",
+            std::to_string(entry.constant_position_unique_matches)},
+           {"constant_position_ambiguous_matches",
+            std::to_string(entry.constant_position_ambiguous_matches)},
+           {"constant_position_misses",
+            std::to_string(entry.constant_position_misses)},
+           {"constant_position_identity_variations",
+            std::to_string(entry.constant_position_identity_variations)},
+           {"constant_position_register_variations",
+            std::to_string(entry.constant_position_register_variations)},
+           {"constant_position_identity_generation",
+            entry.constant_position_identity_valid
+                ? fmt::format("{:08X}",
+                              entry.constant_position_identity_generation)
+                : "unknown"},
+           {"constant_position_identity_owner",
+            entry.constant_position_identity_valid
+                ? fmt::format("{:08X}",
+                              entry.constant_position_identity_owner)
+                : "unknown"},
+           {"constant_position_identity_slot",
+            entry.constant_position_identity_valid
+                ? std::to_string(entry.constant_position_identity_slot)
+                : "unknown"},
+           {"constant_position_register",
+            entry.constant_position_identity_valid
+                ? std::to_string(entry.constant_position_register)
+                : "unknown"},
+           {"closest_position_delta_squared",
+            std::isfinite(entry.closest_position_delta_squared)
+                ? fmt::format("{:.9g}",
+                              entry.closest_position_delta_squared)
+                : "unknown"},
+           {"constant_forward_unique_matches",
+            std::to_string(entry.constant_forward_unique_matches)},
+           {"constant_forward_ambiguous_matches",
+            std::to_string(entry.constant_forward_ambiguous_matches)},
+           {"constant_forward_misses",
+            std::to_string(entry.constant_forward_misses)},
+           {"constant_forward_identity_variations",
+            std::to_string(entry.constant_forward_identity_variations)},
+           {"constant_forward_register_variations",
+            std::to_string(entry.constant_forward_register_variations)},
+           {"constant_forward_identity_generation",
+            entry.constant_forward_identity_valid
+                ? fmt::format("{:08X}",
+                              entry.constant_forward_identity_generation)
+                : "unknown"},
+           {"constant_forward_identity_owner",
+            entry.constant_forward_identity_valid
+                ? fmt::format("{:08X}",
+                              entry.constant_forward_identity_owner)
+                : "unknown"},
+           {"constant_forward_identity_slot",
+            entry.constant_forward_identity_valid
+                ? std::to_string(entry.constant_forward_identity_slot)
+                : "unknown"},
+           {"constant_forward_register",
+            entry.constant_forward_identity_valid
+                ? std::to_string(entry.constant_forward_register)
+                : "unknown"},
+           {"constant_forward_sign",
+            entry.constant_forward_identity_valid
+                ? std::to_string(entry.constant_forward_sign)
+                : "unknown"},
+           {"closest_forward_delta_squared",
+            std::isfinite(entry.closest_forward_delta_squared)
+                ? fmt::format("{:.9g}",
+                              entry.closest_forward_delta_squared)
+                : "unknown"},
+           {"constant_identity_classification",
+            entry.constant_position_unique_matches == entry.draws &&
+                    !entry.constant_position_ambiguous_matches &&
+                    !entry.constant_position_misses &&
+                    !entry.constant_position_identity_variations &&
+                    !entry.constant_position_register_variations
+                ? "stable_tight_position_candidate"
+                : "unresolved"},
            {"guest_payload_capture", "false"},
            {"native_draw", "false"},
            {"xenos_authority", "true"},
@@ -26207,6 +26517,43 @@ void UninstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system) {
                   g_vehicle_shadow_geometry_color_draws_matched
               ? "true"
               : "false"},
+         {"constant_identity_scans", std::to_string(constant_identity_scans)},
+         {"constant_identity_missing_fresh_pose",
+          std::to_string(constant_identity_missing_fresh_pose)},
+         {"constant_vectors_scanned",
+          std::to_string(g_vehicle_color_constant_vectors_scanned)},
+         {"constant_non_finite_vectors",
+          std::to_string(g_vehicle_color_constant_non_finite_vectors)},
+         {"constant_identity_comparisons",
+          std::to_string(g_vehicle_color_constant_identity_comparisons)},
+         {"constant_position_unique_matches",
+          std::to_string(constant_position_unique_matches)},
+         {"constant_position_ambiguous_matches",
+          std::to_string(constant_position_ambiguous_matches)},
+         {"constant_position_misses",
+          std::to_string(constant_position_misses)},
+         {"constant_position_accounting_complete",
+          constant_position_unique_matches +
+                      constant_position_ambiguous_matches +
+                      constant_position_misses ==
+                  constant_identity_scans
+              ? "true"
+              : "false"},
+         {"constant_forward_unique_matches",
+          std::to_string(constant_forward_unique_matches)},
+         {"constant_forward_ambiguous_matches",
+          std::to_string(constant_forward_ambiguous_matches)},
+         {"constant_forward_misses",
+          std::to_string(constant_forward_misses)},
+         {"constant_forward_accounting_complete",
+          constant_forward_unique_matches +
+                      constant_forward_ambiguous_matches +
+                      constant_forward_misses ==
+                  constant_identity_scans
+              ? "true"
+              : "false"},
+         {"constant_identity_maximum_pose_age_frames",
+          std::to_string(kVehicleColorConstantMaximumIdentityAgeFrames)},
          {"seed_accounting_complete",
           seed_accounting_complete ? "true" : "false"},
          {"epoch_contract", "exact_consecutive_64_primary_12_secondary_4_tertiary"},

--- a/tools/summarize-native-renderer-vehicle-shadow-geometry.py
+++ b/tools/summarize-native-renderer-vehicle-shadow-geometry.py
@@ -5,7 +5,7 @@ import json
 from pathlib import Path
 
 
-SCHEMA = "pinyon-shift.native-renderer-vehicle-shadow-geometry.v6"
+SCHEMA = "pinyon-shift.native-renderer-vehicle-shadow-geometry.v7"
 CONFIG_EVENT = "native_renderer.discovery.vehicle_shadow_geometry_config"
 EPOCH_EVENT = "native_renderer.discovery.vehicle_shadow_geometry_epoch"
 CORRELATION_EVENT = (
@@ -67,6 +67,13 @@ def hexadecimal(record, key):
         return int(record[key], 16)
     except (KeyError, TypeError, ValueError) as error:
         raise ValueError(f"missing or invalid hexadecimal field: {key}") from error
+
+
+def decimal(record, key):
+    try:
+        return float(record[key])
+    except (KeyError, TypeError, ValueError) as error:
+        raise ValueError(f"missing or invalid decimal field: {key}") from error
 
 
 def load_events(path):
@@ -192,6 +199,37 @@ def summarize(log_path):
     )
     sequence_hash = summary.get("first_full_family_sequence_hash", "")
     require(len(sequence_hash) == 16, "invalid full-family sequence hash")
+    constant_identity_scans = integer(summary, "constant_identity_scans")
+    require(
+        constant_identity_scans == integer(summary, "color_draws_matched"),
+        "constant identity scan accounting drift",
+    )
+    require(
+        summary.get("constant_position_accounting_complete") == "true",
+        "constant position accounting drift",
+    )
+    require(
+        integer(summary, "constant_position_unique_matches")
+        + integer(summary, "constant_position_ambiguous_matches")
+        + integer(summary, "constant_position_misses")
+        == constant_identity_scans,
+        "constant position outcome drift",
+    )
+    require(
+        summary.get("constant_forward_accounting_complete") == "true",
+        "constant forward accounting drift",
+    )
+    require(
+        integer(summary, "constant_forward_unique_matches")
+        + integer(summary, "constant_forward_ambiguous_matches")
+        + integer(summary, "constant_forward_misses")
+        == constant_identity_scans,
+        "constant forward outcome drift",
+    )
+    require(
+        integer(summary, "constant_identity_maximum_pose_age_frames") == 1,
+        "constant identity freshness drift",
+    )
     safety_events = [*configs, *epochs, *correlations, *candidates, summary]
     for event in safety_events:
         require(event.get("native_draw") == "false", "native draw was enabled")
@@ -293,6 +331,64 @@ def summarize(log_path):
             not private_eligible_draws or private_mask_and == 0,
             "candidate private eligible draw retained a stable rejection",
         )
+        constant_scans = integer(event, "constant_identity_scans")
+        require(
+            constant_scans == integer(event, "draws"),
+            "candidate constant scan accounting drift",
+        )
+        require(
+            integer(event, "constant_position_unique_matches")
+            + integer(event, "constant_position_ambiguous_matches")
+            + integer(event, "constant_position_misses")
+            == constant_scans,
+            "candidate constant position accounting drift",
+        )
+        require(
+            integer(event, "constant_forward_unique_matches")
+            + integer(event, "constant_forward_ambiguous_matches")
+            + integer(event, "constant_forward_misses")
+            == constant_scans,
+            "candidate constant forward accounting drift",
+        )
+        stable_position_candidate = (
+            integer(event, "constant_position_unique_matches")
+            == integer(event, "draws")
+            and integer(event, "constant_position_ambiguous_matches") == 0
+            and integer(event, "constant_position_misses") == 0
+            and integer(event, "constant_position_identity_variations") == 0
+            and integer(event, "constant_position_register_variations") == 0
+        )
+        require(
+            event.get("constant_identity_classification")
+            == (
+                "stable_tight_position_candidate"
+                if stable_position_candidate
+                else "unresolved"
+            ),
+            "candidate constant identity classification drift",
+        )
+        if integer(event, "constant_position_unique_matches"):
+            hexadecimal(event, "constant_position_identity_generation")
+            hexadecimal(event, "constant_position_identity_owner")
+            integer(event, "constant_position_identity_slot")
+            integer(event, "constant_position_register")
+            require(
+                decimal(event, "closest_position_delta_squared") <= 0.25,
+                "candidate position threshold drift",
+            )
+        if integer(event, "constant_forward_unique_matches"):
+            hexadecimal(event, "constant_forward_identity_generation")
+            hexadecimal(event, "constant_forward_identity_owner")
+            integer(event, "constant_forward_identity_slot")
+            integer(event, "constant_forward_register")
+            require(
+                integer(event, "constant_forward_sign") in {-1, 1},
+                "candidate forward sign drift",
+            )
+            require(
+                decimal(event, "closest_forward_delta_squared") <= 0.04,
+                "candidate forward threshold drift",
+            )
         for key in (
             "prepared_signature",
             "template_key",
@@ -462,6 +558,25 @@ def summarize(log_path):
             "result": retained_results[0] if retained_results else None,
             "summary": retained_summary,
         }
+    stable_position_candidates = [
+        event
+        for event in candidates
+        if event.get("constant_identity_classification")
+        == "stable_tight_position_candidate"
+    ]
+    stable_position_identities = {
+        (
+            event.get("constant_position_identity_generation"),
+            event.get("constant_position_identity_owner"),
+            event.get("constant_position_identity_slot"),
+        )
+        for event in stable_position_candidates
+    }
+    complete_shared_vehicle_transform_candidate = (
+        len(candidates) == 30
+        and len(stable_position_candidates) == len(candidates)
+        and len(stable_position_identities) == 1
+    )
     return {
         "schema": SCHEMA,
         "source_log": str(log_path),
@@ -498,6 +613,32 @@ def summarize(log_path):
         "epochs": epochs,
         "correlations": correlations,
         "candidate_families": candidates,
+        "constant_identity": {
+            "scans": constant_identity_scans,
+            "missing_fresh_pose": integer(
+                summary, "constant_identity_missing_fresh_pose"
+            ),
+            "vectors_scanned": integer(summary, "constant_vectors_scanned"),
+            "non_finite_vectors": integer(
+                summary, "constant_non_finite_vectors"
+            ),
+            "identity_comparisons": integer(
+                summary, "constant_identity_comparisons"
+            ),
+            "stable_position_candidate_families": len(
+                stable_position_candidates
+            ),
+            "stable_position_identities": [
+                {
+                    "generation": generation,
+                    "owner": owner,
+                    "slot": slot,
+                }
+                for generation, owner, slot in sorted(
+                    stable_position_identities
+                )
+            ],
+        },
         "private_color_capture": capture,
         "private_retained_color_pass": retained,
         "qualification": {
@@ -520,6 +661,9 @@ def summarize(log_path):
                 and integer(retained["summary"], "requests")
                 == integer(retained["summary"], "recorded")
                 and retained["summary"].get("capture_recorded") == "true"
+            ),
+            "complete_shared_vehicle_transform_candidate": (
+                complete_shared_vehicle_transform_candidate
             ),
             "object_identity_proven": False,
             "mesh_material_contract_proven": False,

--- a/tools/tests/test_native_renderer_vehicle_shadow_geometry.py
+++ b/tools/tests/test_native_renderer_vehicle_shadow_geometry.py
@@ -71,6 +71,30 @@ class VehicleShadowGeometryTests(unittest.TestCase):
                 "private_capture_rejection_mask_or": "00000000",
                 "private_capture_rejection_mask_and": "00000000",
                 "private_capture_rejection_mask_switches": "0",
+                "constant_identity_scans": "3",
+                "constant_identity_missing_fresh_pose": "0",
+                "constant_position_unique_matches": "3",
+                "constant_position_ambiguous_matches": "0",
+                "constant_position_misses": "0",
+                "constant_position_identity_variations": "0",
+                "constant_position_register_variations": "0",
+                "constant_position_identity_generation": "00000001",
+                "constant_position_identity_owner": "40123450",
+                "constant_position_identity_slot": "2",
+                "constant_position_register": "208",
+                "closest_position_delta_squared": "0.01",
+                "constant_forward_unique_matches": "0",
+                "constant_forward_ambiguous_matches": "3",
+                "constant_forward_misses": "0",
+                "constant_forward_identity_variations": "0",
+                "constant_forward_register_variations": "0",
+                "constant_forward_identity_generation": "unknown",
+                "constant_forward_identity_owner": "unknown",
+                "constant_forward_identity_slot": "unknown",
+                "constant_forward_register": "unknown",
+                "constant_forward_sign": "unknown",
+                "closest_forward_delta_squared": "0.01",
+                "constant_identity_classification": "stable_tight_position_candidate",
                 **safety,
             },
             {
@@ -177,6 +201,20 @@ class VehicleShadowGeometryTests(unittest.TestCase):
                 "first_full_family_sequence_hash": "9" * 16,
                 "full_family_sequence_variants": "0",
                 "color_run_accounting_complete": "true",
+                "constant_identity_scans": "3",
+                "constant_identity_missing_fresh_pose": "0",
+                "constant_vectors_scanned": "96",
+                "constant_non_finite_vectors": "0",
+                "constant_identity_comparisons": "8928",
+                "constant_position_unique_matches": "3",
+                "constant_position_ambiguous_matches": "0",
+                "constant_position_misses": "0",
+                "constant_position_accounting_complete": "true",
+                "constant_forward_unique_matches": "0",
+                "constant_forward_ambiguous_matches": "3",
+                "constant_forward_misses": "0",
+                "constant_forward_accounting_complete": "true",
+                "constant_identity_maximum_pose_age_frames": "1",
                 "reject_resolved_input": "0",
                 "reject_unsupported_geometry": "0",
                 "reject_empty_draw": "0",
@@ -231,6 +269,15 @@ class VehicleShadowGeometryTests(unittest.TestCase):
             int(report["private_retained_color_pass"]["summary"]["frames_completed"]),
         )
         self.assertEqual(3, report["color_run_topology"]["maximum_run_length"])
+        self.assertEqual(
+            1,
+            report["constant_identity"]["stable_position_candidate_families"],
+        )
+        self.assertFalse(
+            report["qualification"][
+                "complete_shared_vehicle_transform_candidate"
+            ]
+        )
 
     def test_rejects_partial_epoch_promotion(self):
         events = self.fixture()
@@ -284,6 +331,18 @@ class VehicleShadowGeometryTests(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "color run draw accounting drift"):
             self.summarize(events)
 
+    def test_rejects_constant_identity_scan_accounting_drift(self):
+        events = self.fixture()
+        events[-1]["constant_identity_scans"] = "2"
+        with self.assertRaisesRegex(ValueError, "constant identity scan"):
+            self.summarize(events)
+
+    def test_rejects_constant_identity_classification_drift(self):
+        events = self.fixture()
+        events[3]["constant_identity_classification"] = "unresolved"
+        with self.assertRaisesRegex(ValueError, "constant identity classification"):
+            self.summarize(events)
+
     def test_rejects_private_capture_authority_drift(self):
         events = self.fixture()
         events[5]["output_authority"] = "native"
@@ -330,6 +389,8 @@ class VehicleShadowGeometryTests(unittest.TestCase):
             '"native_renderer.discovery.vehicle_shadow_color_retained_summary"',
             source,
         )
+        self.assertIn("ObserveVehicleColorConstantIdentity", source)
+        self.assertIn("constant_position_accounting_complete", source)
         self.assertIn("[switch]$VehicleShadowGeometryCorrelation", capture)
         self.assertIn("[switch]$CaptureVehicleShadowColor", capture)
         self.assertIn("[switch]$RetainVehicleShadowColorPass", capture)


### PR DESCRIPTION
## Summary
- compare bounded correlated vehicle vertex constants with one-frame-fresh title vehicle poses
- classify per-family position/forward evidence as unique, ambiguous, or missing without logging payloads
- add a v7 offline gate for a complete shared 30-family transform candidate

## Safety
- default-off specialized census only
- Xenos remains authoritative
- no native publication or suppression
- no player label is inferred from vehicle-instance evidence

## Validation
- 551 native-renderer tests
- Release target compilation
- git diff --check

Runtime qualification is intentionally batched with the next C4 material-coverage slice.