### PR TITLE
feat(renderer): census vehicle material topology

### DIFF
--- a/docs/native-renderer/REPRIORITIZED_PLAN.md
+++ b/docs/native-renderer/REPRIORITIZED_PLAN.md
@@ -650,6 +650,17 @@ publish native output, or suppress Xenos. Runtime evidence is batched with the
 next C4 AppData session; the contract is documented in
 [`VEHICLE_COLOR_CONSTANT_IDENTITY.md`](VEHICLE_COLOR_CONSTANT_IDENTITY.md).
 
+Material-topology implementation checkpoint: the same 30 exact families now
+carry a geometry-independent key over shader identity and specialization,
+prepared render state, and texture layout. Pixel-float parameter changes are
+counted through hashes without exporting their values. The v8 report groups
+every family by that key, providing the bounded mechanical topology needed to
+target body, glass, wheel, light, livery, and exceptional-material follow-ups.
+Hashes do not receive semantic labels and cannot establish completeness,
+publication, or suppression. Runtime evidence is combined with the pending
+transform census; the contract is documented in
+[`VEHICLE_MATERIAL_TOPOLOGY.md`](VEHICLE_MATERIAL_TOPOLOGY.md).
+
 ### C5. Sky, atmosphere, and global lighting
 
 - Replace the qualified sky/global-light families.

--- a/docs/native-renderer/VEHICLE_MATERIAL_TOPOLOGY.md
+++ b/docs/native-renderer/VEHICLE_MATERIAL_TOPOLOGY.md
@@ -1,0 +1,45 @@
+# Vehicle material topology census
+
+Status: implemented as payload-free metadata in the default-off C4 correlation
+mode; runtime evidence is batched with the transform-constant census.
+
+## Boundary
+
+The coherent retained target proves multi-submesh geometry, but its flat
+diagnostic output does not identify body paint, glazing, wheels, lights,
+livery, or exceptional materials. Before adding semantic material handlers,
+the 30 exact vehicle color families need a topology that is independent of
+their geometry resources and animated vertex parameters.
+
+Each family now records a material-topology key derived from:
+
+- vertex and pixel shader identity and specialization;
+- prepared render state and render-target contract; and
+- texture fetch and texture-layout state.
+
+Geometry resources, draw arguments, and raw constant values are excluded from
+the topology key. A separate hash tracks pixel-float parameter changes over
+time without retaining or exporting their values. The report groups all exact
+families by the topology key and counts which families vary their material
+parameters.
+
+## Interpretation
+
+The topology answers how many mechanically distinct shader/material contracts
+the retained vehicle uses and which exact geometry families share each one. It
+does not assign semantic names from hashes. Visual contribution evidence or a
+typed title material edge is still required before labeling a group as paint,
+glass, wheel, light, livery, or another vehicle material.
+
+The v8 offline qualifier requires the group count to reconcile exactly with
+the 30 candidate-family records. Any shader, render-state, texture-layout, or
+accounting drift fails the report. The topology cannot enable native
+publication or suppression.
+
+## Safety
+
+- The mode remains restart-gated and default-off.
+- No constant payload, texture payload, or game asset is written to the log.
+- Every original Xenos draw executes unchanged.
+- The output is metadata only and cannot establish player identity, complete
+  material coverage, or native admission.

--- a/src/native_renderer/graphics_hooks.cpp
+++ b/src/native_renderer/graphics_hooks.cpp
@@ -614,6 +614,14 @@ struct VehicleShadowGeometryIdentity {
 struct VehicleShadowGeometryCorrelationEntry {
   uint64_t prepared_signature = 0;
   uint64_t template_key = 0;
+  uint64_t material_topology_key = 0;
+  uint64_t vertex_shader_hash = 0;
+  uint64_t pixel_shader_hash = 0;
+  uint64_t render_state_hash = 0;
+  uint64_t texture_layout_hash = 0;
+  uint64_t first_material_parameter_hash = 0;
+  uint64_t last_material_parameter_hash = 0;
+  uint64_t material_parameter_switches = 0;
   uint64_t draw_argument_hash = 0;
   uint64_t geometry_resource_hash = 0;
   uint64_t texture_resource_hash = 0;
@@ -15193,6 +15201,38 @@ bool VehicleShadowGeometrySharesVertexResource(
   return false;
 }
 
+uint64_t VehicleColorMaterialTopologyKey(
+    const SemanticPreparedDrawContract &contract) {
+  uint64_t hash = UINT64_C(0xCBF29CE484222325);
+  for (uint64_t value :
+       {contract.render_state_hash, contract.batch_texture_layout_hash,
+        contract.vertex_shader_hash, contract.pixel_shader_hash,
+        contract.vertex_specialization_mask,
+        contract.pixel_specialization_mask,
+        uint64_t(contract.texture_fetch_mask),
+        uint64_t(contract.texture_layout_valid_mask),
+        uint64_t(contract.texture_state_count)}) {
+    hash = HashCombine(hash, value);
+  }
+  return hash ? hash : 1;
+}
+
+uint64_t VehicleColorMaterialParameterHash(
+    const rex::system::GraphicsDrawObservation &observation) {
+  uint64_t hash = UINT64_C(0xCBF29CE484222325);
+  const uint32_t count = std::min(
+      observation.pixel_float_constant_count,
+      rex::system::kGraphicsFloatConstantObservationLimit);
+  for (uint32_t i = 0; i < count; ++i) {
+    const auto &constant = observation.pixel_float_constants[i];
+    hash = HashCombine(hash, constant.index);
+    for (uint32_t value : constant.values) {
+      hash = HashCombine(hash, value);
+    }
+  }
+  return hash ? hash : 1;
+}
+
 void ObserveVehicleColorConstantIdentity(
     const rex::system::GraphicsDrawObservation &observation,
     VehicleShadowGeometryCorrelationEntry &entry) {
@@ -15432,6 +15472,10 @@ bool ObserveVehicleShadowGeometryColorCorrelation(
   } else {
     ++g_vehicle_shadow_color_private_capture_eligible_draws;
   }
+  const uint64_t material_topology_key =
+      VehicleColorMaterialTopologyKey(contract);
+  const uint64_t material_parameter_hash =
+      VehicleColorMaterialParameterHash(observation);
   VehicleShadowGeometryCorrelationEntry *available = nullptr;
   size_t available_index = kVehicleShadowGeometryCorrelationCapacity;
   for (size_t correlation_index = 0;
@@ -15447,6 +15491,7 @@ bool ObserveVehicleShadowGeometryColorCorrelation(
     if (entry.prepared_signature == prepared_signature &&
         entry.seed_index == matched_seed &&
         entry.full_geometry_match == full_geometry_match &&
+        entry.material_topology_key == material_topology_key &&
         entry.draw_argument_hash == contract.draw_argument_hash &&
         entry.geometry_resource_hash == contract.geometry_resource_hash &&
         entry.texture_resource_hash == contract.texture_resource_hash &&
@@ -15456,6 +15501,10 @@ bool ObserveVehicleShadowGeometryColorCorrelation(
       if (entry.last_parameter_hash != parameter_hash) {
         ++entry.parameter_switches;
         entry.last_parameter_hash = parameter_hash;
+      }
+      if (entry.last_material_parameter_hash != material_parameter_hash) {
+        ++entry.material_parameter_switches;
+        entry.last_material_parameter_hash = material_parameter_hash;
       }
       if (entry.last_rejection_mask != mechanical_rejection_mask) {
         ++entry.rejection_mask_switches;
@@ -15499,6 +15548,13 @@ bool ObserveVehicleShadowGeometryColorCorrelation(
   *available = {
       .prepared_signature = prepared_signature,
       .template_key = contract.template_key,
+      .material_topology_key = material_topology_key,
+      .vertex_shader_hash = contract.vertex_shader_hash,
+      .pixel_shader_hash = contract.pixel_shader_hash,
+      .render_state_hash = contract.render_state_hash,
+      .texture_layout_hash = contract.texture_layout_hash,
+      .first_material_parameter_hash = material_parameter_hash,
+      .last_material_parameter_hash = material_parameter_hash,
       .draw_argument_hash = contract.draw_argument_hash,
       .geometry_resource_hash = contract.geometry_resource_hash,
       .texture_resource_hash = contract.texture_resource_hash,
@@ -15538,7 +15594,15 @@ bool ObserveVehicleShadowGeometryColorCorrelation(
   pinyon_shift::diagnostics::RecordEvent(
       "native_renderer.discovery.vehicle_shadow_geometry_correlation",
       {{"prepared_signature", fmt::format("{:016X}", prepared_signature)},
-       {"template_key", fmt::format("{:016X}", contract.template_key)},
+      {"template_key", fmt::format("{:016X}", contract.template_key)},
+       {"material_topology_key",
+        fmt::format("{:016X}", material_topology_key)},
+       {"vertex_shader", fmt::format("{:016X}", contract.vertex_shader_hash)},
+       {"pixel_shader", fmt::format("{:016X}", contract.pixel_shader_hash)},
+       {"render_state_hash",
+        fmt::format("{:016X}", contract.render_state_hash)},
+       {"texture_layout_hash",
+        fmt::format("{:016X}", contract.texture_layout_hash)},
        {"draw_argument_hash",
         fmt::format("{:016X}", contract.draw_argument_hash)},
        {"geometry_resource_hash",
@@ -26233,6 +26297,9 @@ void UninstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system) {
     uint64_t constant_forward_unique_matches = 0;
     uint64_t constant_forward_ambiguous_matches = 0;
     uint64_t constant_forward_misses = 0;
+    std::array<uint64_t, kVehicleShadowGeometryCorrelationCapacity>
+        material_topology_keys{};
+    size_t material_topology_group_count = 0;
     for (const VehicleShadowGeometryCorrelationEntry &entry :
          g_vehicle_shadow_geometry_correlations) {
       if (!entry.occupied) {
@@ -26251,11 +26318,41 @@ void UninstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system) {
       constant_forward_ambiguous_matches +=
           entry.constant_forward_ambiguous_matches;
       constant_forward_misses += entry.constant_forward_misses;
+      bool material_topology_seen = false;
+      for (size_t material_index = 0;
+           material_index < material_topology_group_count;
+           ++material_index) {
+        if (material_topology_keys[material_index] ==
+            entry.material_topology_key) {
+          material_topology_seen = true;
+          break;
+        }
+      }
+      if (!material_topology_seen) {
+        material_topology_keys[material_topology_group_count++] =
+            entry.material_topology_key;
+      }
       diagnostics::RecordEvent(
           "native_renderer.discovery.vehicle_shadow_geometry_candidate",
           {{"prepared_signature",
             fmt::format("{:016X}", entry.prepared_signature)},
            {"template_key", fmt::format("{:016X}", entry.template_key)},
+           {"material_topology_key",
+            fmt::format("{:016X}", entry.material_topology_key)},
+           {"vertex_shader",
+            fmt::format("{:016X}", entry.vertex_shader_hash)},
+           {"pixel_shader",
+            fmt::format("{:016X}", entry.pixel_shader_hash)},
+           {"render_state_hash",
+            fmt::format("{:016X}", entry.render_state_hash)},
+           {"texture_layout_hash",
+            fmt::format("{:016X}", entry.texture_layout_hash)},
+           {"first_material_parameter_hash",
+            fmt::format("{:016X}", entry.first_material_parameter_hash)},
+           {"last_material_parameter_hash",
+            fmt::format("{:016X}", entry.last_material_parameter_hash)},
+           {"material_parameter_switches",
+            std::to_string(entry.material_parameter_switches)},
            {"draw_argument_hash",
             fmt::format("{:016X}", entry.draw_argument_hash)},
            {"geometry_resource_hash",
@@ -26554,6 +26651,16 @@ void UninstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system) {
               : "false"},
          {"constant_identity_maximum_pose_age_frames",
           std::to_string(kVehicleColorConstantMaximumIdentityAgeFrames)},
+         {"material_topology_groups",
+          std::to_string(material_topology_group_count)},
+         {"material_topology_group_accounting_complete",
+          material_topology_group_count > 0 &&
+                  material_topology_group_count <=
+                      g_vehicle_shadow_geometry_correlation_count
+              ? "true"
+              : "false"},
+         {"material_topology_contract",
+          "shader_specialization_render_state_texture_layout"},
          {"seed_accounting_complete",
           seed_accounting_complete ? "true" : "false"},
          {"epoch_contract", "exact_consecutive_64_primary_12_secondary_4_tertiary"},

--- a/tools/summarize-native-renderer-vehicle-shadow-geometry.py
+++ b/tools/summarize-native-renderer-vehicle-shadow-geometry.py
@@ -5,7 +5,7 @@ import json
 from pathlib import Path
 
 
-SCHEMA = "pinyon-shift.native-renderer-vehicle-shadow-geometry.v7"
+SCHEMA = "pinyon-shift.native-renderer-vehicle-shadow-geometry.v8"
 CONFIG_EVENT = "native_renderer.discovery.vehicle_shadow_geometry_config"
 EPOCH_EVENT = "native_renderer.discovery.vehicle_shadow_geometry_epoch"
 CORRELATION_EVENT = (
@@ -230,6 +230,20 @@ def summarize(log_path):
         integer(summary, "constant_identity_maximum_pose_age_frames") == 1,
         "constant identity freshness drift",
     )
+    require(
+        summary.get("material_topology_group_accounting_complete") == "true",
+        "material topology group accounting drift",
+    )
+    material_topology_groups = integer(summary, "material_topology_groups")
+    require(
+        0 < material_topology_groups <= len(candidates),
+        "material topology group bounds drift",
+    )
+    require(
+        summary.get("material_topology_contract")
+        == "shader_specialization_render_state_texture_layout",
+        "material topology contract drift",
+    )
     safety_events = [*configs, *epochs, *correlations, *candidates, summary]
     for event in safety_events:
         require(event.get("native_draw") == "false", "native draw was enabled")
@@ -259,6 +273,17 @@ def summarize(log_path):
             },
             "unbounded correlation match",
         )
+        for key in (
+            "material_topology_key",
+            "vertex_shader",
+            "pixel_shader",
+            "render_state_hash",
+            "texture_layout_hash",
+        ):
+            require(
+                len(event.get(key, "")) == 16,
+                f"invalid correlation material hash: {key}",
+            )
     for event in candidates:
         require(
             event.get("classification")
@@ -392,6 +417,13 @@ def summarize(log_path):
         for key in (
             "prepared_signature",
             "template_key",
+            "material_topology_key",
+            "vertex_shader",
+            "pixel_shader",
+            "render_state_hash",
+            "texture_layout_hash",
+            "first_material_parameter_hash",
+            "last_material_parameter_hash",
             "draw_argument_hash",
             "geometry_resource_hash",
             "texture_resource_hash",
@@ -400,6 +432,11 @@ def summarize(log_path):
             "last_parameter_hash",
         ):
             require(len(event.get(key, "")) == 16, f"invalid candidate hash: {key}")
+        require(
+            integer(event, "material_parameter_switches")
+            <= integer(event, "draws") - 1,
+            "candidate material parameter switch drift",
+        )
     capture = None
     if capture_configs or capture_results or capture_summaries:
         require(len(capture_configs) == 1, "expected one color capture config")
@@ -577,6 +614,15 @@ def summarize(log_path):
         and len(stable_position_candidates) == len(candidates)
         and len(stable_position_identities) == 1
     )
+    material_groups = {}
+    for event in candidates:
+        material_groups.setdefault(event["material_topology_key"], []).append(
+            event["prepared_signature"]
+        )
+    require(
+        len(material_groups) == material_topology_groups,
+        "material topology candidate accounting drift",
+    )
     return {
         "schema": SCHEMA,
         "source_log": str(log_path),
@@ -638,6 +684,21 @@ def summarize(log_path):
                     stable_position_identities
                 )
             ],
+        },
+        "material_topology": {
+            "group_count": material_topology_groups,
+            "groups": [
+                {
+                    "material_topology_key": key,
+                    "family_count": len(signatures),
+                    "prepared_signatures": signatures,
+                }
+                for key, signatures in sorted(material_groups.items())
+            ],
+            "families_with_parameter_variation": sum(
+                integer(event, "material_parameter_switches") > 0
+                for event in candidates
+            ),
         },
         "private_color_capture": capture,
         "private_retained_color_pass": retained,

--- a/tools/tests/test_native_renderer_vehicle_shadow_geometry.py
+++ b/tools/tests/test_native_renderer_vehicle_shadow_geometry.py
@@ -38,6 +38,11 @@ class VehicleShadowGeometryTests(unittest.TestCase):
                 "event": MODULE.CORRELATION_EVENT,
                 "classification": "vehicle_color_geometry_correlation_candidate",
                 "match": "exact_index_and_shared_vertex_resource",
+                "material_topology_key": "A" * 16,
+                "vertex_shader": "B" * 16,
+                "pixel_shader": "C" * 16,
+                "render_state_hash": "D" * 16,
+                "texture_layout_hash": "E" * 16,
                 **safety,
             },
             {
@@ -46,6 +51,14 @@ class VehicleShadowGeometryTests(unittest.TestCase):
                 "match": "exact_index_and_shared_vertex_resource",
                 "prepared_signature": "1" * 16,
                 "template_key": "2" * 16,
+                "material_topology_key": "A" * 16,
+                "vertex_shader": "B" * 16,
+                "pixel_shader": "C" * 16,
+                "render_state_hash": "D" * 16,
+                "texture_layout_hash": "E" * 16,
+                "first_material_parameter_hash": "F" * 16,
+                "last_material_parameter_hash": "0" * 16,
+                "material_parameter_switches": "2",
                 "draw_argument_hash": "3" * 16,
                 "geometry_resource_hash": "4" * 16,
                 "texture_resource_hash": "5" * 16,
@@ -215,6 +228,9 @@ class VehicleShadowGeometryTests(unittest.TestCase):
                 "constant_forward_misses": "0",
                 "constant_forward_accounting_complete": "true",
                 "constant_identity_maximum_pose_age_frames": "1",
+                "material_topology_groups": "1",
+                "material_topology_group_accounting_complete": "true",
+                "material_topology_contract": "shader_specialization_render_state_texture_layout",
                 "reject_resolved_input": "0",
                 "reject_unsupported_geometry": "0",
                 "reject_empty_draw": "0",
@@ -277,6 +293,16 @@ class VehicleShadowGeometryTests(unittest.TestCase):
             report["qualification"][
                 "complete_shared_vehicle_transform_candidate"
             ]
+        )
+        self.assertEqual(1, report["material_topology"]["group_count"])
+        self.assertEqual(
+            1, report["material_topology"]["groups"][0]["family_count"]
+        )
+        self.assertEqual(
+            1,
+            report["material_topology"][
+                "families_with_parameter_variation"
+            ],
         )
 
     def test_rejects_partial_epoch_promotion(self):
@@ -341,6 +367,12 @@ class VehicleShadowGeometryTests(unittest.TestCase):
         events = self.fixture()
         events[3]["constant_identity_classification"] = "unresolved"
         with self.assertRaisesRegex(ValueError, "constant identity classification"):
+            self.summarize(events)
+
+    def test_rejects_material_topology_group_accounting_drift(self):
+        events = self.fixture()
+        events[-1]["material_topology_groups"] = "2"
+        with self.assertRaisesRegex(ValueError, "material topology"):
             self.summarize(events)
 
     def test_rejects_private_capture_authority_drift(self):


### PR DESCRIPTION
## Summary
- derive a geometry-independent topology key for all exact retained vehicle families
- group shader, specialization, render-state, and texture-layout contracts
- track pixel-parameter variation through hashes without exporting payloads

## Safety
- default-off C4 correlation mode only
- metadata only; no semantic material labels
- Xenos remains authoritative with no publication or suppression

## Validation
- 552 native-renderer tests
- Release target compilation
- git diff --check

Runtime evidence is batched with the transform-constant census after merge.