### PR TITLE
docs(renderer): qualify vehicle transform and material census

### DIFF
--- a/docs/native-renderer/REPRIORITIZED_PLAN.md
+++ b/docs/native-renderer/REPRIORITIZED_PLAN.md
@@ -661,6 +661,24 @@ publication, or suppression. Runtime evidence is combined with the pending
 transform census; the contract is documented in
 [`VEHICLE_MATERIAL_TOPOLOGY.md`](VEHICLE_MATERIAL_TOPOLOGY.md).
 
+Combined transform/material result: the clean merged-`dev` build loaded the
+AppData save and exited normally with no error or fatal log entries. The
+retained full-vehicle diagnostic again completed 120/120 frames and all 3,600
+draws, including 3,480 retained-target reuses, with zero failures. Across
+18,360 correlated draws, the constant census completed 18,360 scans and
+18,207,360 comparisons but found no stable world-position carrier in the raw
+vertex constants; the nearest squared position delta was still about 753,399.
+Forward matches were close but ambiguous. The v8 report therefore correctly
+keeps the shared-transform and object-identity gates closed.
+
+The material census reconciled all 30 families into one stable mechanical
+topology while every family varied its hashed material parameters. C4 is now
+re-prioritized around the typed constant/material upload and bind edges: first
+recover the exact player transform carrier and semantic player discriminator,
+then label body, glass, wheel, light, and livery contributions within the
+shared topology. More broad raw-constant or hash-only scans are deferred. The
+retained private pass remains the stable geometry/output harness throughout.
+
 ### C5. Sky, atmosphere, and global lighting
 
 - Replace the qualified sky/global-light families.

--- a/docs/native-renderer/VEHICLE_COLOR_CONSTANT_IDENTITY.md
+++ b/docs/native-renderer/VEHICLE_COLOR_CONSTANT_IDENTITY.md
@@ -1,8 +1,8 @@
 # Vehicle color constant identity census
 
-Status: implemented as a default-off, measurement-only extension of the
-qualified vehicle shadow/color correlation; runtime evidence is batched with
-the next C4 AppData session.
+Status: qualified as a default-off, measurement-only extension of the vehicle
+shadow/color correlation. The raw constant scan is closed as an identity path;
+the next step is the typed upload/bind edge.
 
 ## Purpose
 
@@ -59,3 +59,22 @@ Qualify it with the existing retained-pass batch command in
 vehicle report requires full scan/outcome accounting and exposes
 `complete_shared_vehicle_transform_candidate` without changing
 `object_identity_proven` or `native_admission_allowed`.
+
+## AppData qualification result
+
+The clean combined C4 session examined 18,360 exact correlated draws across all
+30 families. It completed 18,360 constant scans, inspected 293,760 finite
+three-component vectors, and performed 18,207,360 tight identity comparisons
+with no stale-pose or non-finite-vector gaps.
+
+No family produced a stable world-position candidate. Every position outcome
+was a miss, and the closest observed squared delta was still roughly 753,399,
+far outside the `0.25` bound. Forward vectors were near the title-owned pose
+but ambiguous rather than uniquely identifying one owner. Therefore
+`complete_shared_vehicle_transform_candidate` correctly remains false.
+
+This is a useful negative result: the correlated vertex constants are not a
+direct world-position carrier under the tested convention. Repeating or
+widening the raw scan is not justified. C4 should instead observe the typed
+constant upload/bind boundary that produces the prepared color pipeline, then
+join that typed transform carrier back to the 30 exact families.

--- a/docs/native-renderer/VEHICLE_MATERIAL_TOPOLOGY.md
+++ b/docs/native-renderer/VEHICLE_MATERIAL_TOPOLOGY.md
@@ -1,7 +1,7 @@
 # Vehicle material topology census
 
-Status: implemented as payload-free metadata in the default-off C4 correlation
-mode; runtime evidence is batched with the transform-constant census.
+Status: qualified as payload-free metadata in the default-off C4 correlation
+mode. The mechanical topology is closed; semantic material labels remain open.
 
 ## Boundary
 
@@ -43,3 +43,18 @@ publication or suppression.
 - Every original Xenos draw executes unchanged.
 - The output is metadata only and cannot establish player identity, complete
   material coverage, or native admission.
+
+## AppData qualification result
+
+The clean combined C4 session reconciled all 30 exact families into one
+mechanical material-topology group. All 30 families changed their hashed pixel
+parameters over the session, while the shared shader specialization, prepared
+render state, and texture layout remained stable. The report passed exact
+family/group accounting without exporting material values or assets.
+
+The single group means shader/topology hashes cannot separate body, glass,
+wheels, lights, or livery. Those distinctions are parameter- or title-semantic
+driven inside the shared mechanical contract. The next material slice should
+join the bounded families to the typed title material/upload edge and use
+visual contribution evidence for labels; it should not invent semantics from
+the common topology key.


### PR DESCRIPTION
## Summary
- record the combined C4 AppData qualification on merged dev
- close raw vertex-constant scanning as a world-position identity path
- establish typed upload/bind observation as the next C4 implementation route
- record the shared 30-family material topology and semantic follow-up boundary

## Validation
- clean Release preview build (102 ReXGlue patches)
- AppData-backed gameplay run exited normally with no error/fatal entries
- v8 vehicle qualifier: 18,360 correlated draws, 120/120 retained frames, exact topology accounting
- git diff --check