### PR TITLE
feat(renderer): join vehicle draws to typed constant uploads

### DIFF
--- a/config/rexglue/analysis/main-xex.toml
+++ b/config/rexglue/analysis/main-xex.toml
@@ -358,6 +358,15 @@ address = 0x8240EB5C
 name = "PinyonShiftObserveVehicleComposedMatrix"
 registers = ["r5", "r22"]
 
+# Observe the exact generic constant-buffer writer before it copies the source
+# vectors. The bounded C4 ledger retains only a semantic payload hash and the
+# typed destination range so prepared vehicle draws can prove their upload
+# source without exporting constant values.
+[[midasm_hook]]
+address = 0x82435E78
+name = "PinyonShiftObserveVehicleTypedConstantUpload"
+registers = ["r3", "r4", "r5", "r6"]
+
 [[midasm_hook]]
 address = 0x8243646C
 name = "PinyonShiftObserveVehicleRenderContextDispatcherEntry"

--- a/docs/native-renderer/REPRIORITIZED_PLAN.md
+++ b/docs/native-renderer/REPRIORITIZED_PLAN.md
@@ -679,6 +679,18 @@ then label body, glass, wheel, light, and livery contributions within the
 shared topology. More broad raw-constant or hash-only scans are deferred. The
 retained private pass remains the stable geometry/output harness throughout.
 
+Typed constant-upload implementation checkpoint: the exact generic title
+writer at `82435E78` now feeds a bounded 8,192-entry recent-upload ledger. Each
+entry retains its destination register range, title source/destination
+addresses, and semantic payload hash without exporting constant values. Every
+exact vehicle color family joins its observed vertex registers to uploads no
+more than one frame old by exact range and hash. The v9 qualifier requires
+complete upload/outcome accounting and recognizes a 30-family bridge only
+when every family matches on every draw with a stable register range. Runtime
+proof is deliberately batched with the next substantial C4 slice; the contract
+is documented in
+[`VEHICLE_TYPED_CONSTANT_UPLOAD.md`](VEHICLE_TYPED_CONSTANT_UPLOAD.md).
+
 ### C5. Sky, atmosphere, and global lighting
 
 - Replace the qualified sky/global-light families.

--- a/docs/native-renderer/VEHICLE_COLOR_CONSTANT_IDENTITY.md
+++ b/docs/native-renderer/VEHICLE_COLOR_CONSTANT_IDENTITY.md
@@ -78,3 +78,7 @@ direct world-position carrier under the tested convention. Repeating or
 widening the raw scan is not justified. C4 should instead observe the typed
 constant upload/bind boundary that produces the prepared color pipeline, then
 join that typed transform carrier back to the 30 exact families.
+
+That bounded join is implemented in
+[`VEHICLE_TYPED_CONSTANT_UPLOAD.md`](VEHICLE_TYPED_CONSTANT_UPLOAD.md). Its
+runtime evidence remains deferred to the next combined C4 qualification.

--- a/docs/native-renderer/VEHICLE_TYPED_CONSTANT_UPLOAD.md
+++ b/docs/native-renderer/VEHICLE_TYPED_CONSTANT_UPLOAD.md
@@ -1,0 +1,52 @@
+# Vehicle typed constant-upload join
+
+Status: implemented as a default-off, payload-free extension of the C4 vehicle
+correlation mode; runtime qualification is deferred to the next batched
+AppData session.
+
+## Proven title boundary
+
+Title function `82435E78` is the generic float-constant writer. At entry it
+receives the destination buffer in `r3`, a register offset in `r4`, the source
+vectors in `r5`, and the vector count in `r6`. It copies those vectors into
+registers beginning at `r4 + 120` and then marks the destination buffer dirty.
+
+A read-only entry hook now records a bounded recent-upload ledger. Each valid
+entry retains only:
+
+- the frame and monotonic observation sequence;
+- destination buffer and source addresses;
+- destination register range; and
+- a semantic hash of that exact range and payload.
+
+No constant value is logged or written to the offline report. Invalid source
+or register ranges are counted and rejected before the source is read. The
+fixed 8,192-entry ring covers two representative heavy frames and reports
+overwrites explicitly.
+
+## Draw join
+
+Each exact shadow-correlated vehicle color draw tests its observed vertex
+constants against uploads no more than one frame old. A match requires every
+register in the uploaded range to exist in the prepared draw and the semantic
+payload hash to agree exactly. The newest exact upload wins when repeated
+writes carry the same range and values.
+
+Per-family accounting records exact matches, misses, register/count stability,
+and source/destination address variation. The v9 qualifier recognizes a stable
+typed-upload candidate only when every draw in a family matches and its
+register range never changes. A complete bridge candidate requires all 30
+families to satisfy that rule.
+
+This proves which typed writes feed the prepared vehicle draws. It does not by
+itself convert reference-space constants to a world transform or label a
+vehicle as the player. The runtime result will determine which exact register
+ranges and title callers should receive the next semantic discriminator.
+
+## Safety boundary
+
+- The hook is active only with the restart-gated vehicle correlation mode.
+- The ledger is fixed-size and retains hashes, not payloads.
+- Every authoritative Xenos upload and draw executes unchanged.
+- No native publication or draw suppression depends on this evidence.
+- Missing, stale, invalid, or incomplete ranges remain unresolved.

--- a/src/native_renderer/graphics_hooks.cpp
+++ b/src/native_renderer/graphics_hooks.cpp
@@ -139,6 +139,10 @@ constexpr size_t kVehicleTypedDescriptorCorrelationCapacity = 512;
 constexpr uint32_t kVehicleComposedMatrixHook = 0x8240EB5C;
 constexpr uint32_t kVehicleComposedMatrixCallee = 0x82435E78;
 constexpr size_t kVehicleComposedMatrixCorrelationCapacity = 1024;
+constexpr uint32_t kVehicleConstantUploadHook = 0x82435E78;
+constexpr uint32_t kVehicleConstantUploadRegisterBias = 120;
+constexpr size_t kVehicleConstantUploadCapacity = 8192;
+constexpr uint64_t kVehicleConstantUploadMaximumAgeFrames = 1;
 constexpr size_t kVehicleShadowGeometrySeedCapacity = 256;
 constexpr size_t kVehicleShadowGeometryCorrelationCapacity = 1024;
 constexpr uint64_t kVehicleColorConstantMaximumIdentityAgeFrames = 1;
@@ -650,6 +654,13 @@ struct VehicleShadowGeometryCorrelationEntry {
   uint64_t constant_forward_misses = 0;
   uint64_t constant_forward_identity_variations = 0;
   uint64_t constant_forward_register_variations = 0;
+  uint64_t typed_upload_scans = 0;
+  uint64_t typed_upload_exact_matches = 0;
+  uint64_t typed_upload_misses = 0;
+  uint64_t typed_upload_start_register_variations = 0;
+  uint64_t typed_upload_vector_count_variations = 0;
+  uint64_t typed_upload_source_address_variations = 0;
+  uint64_t typed_upload_buffer_address_variations = 0;
   double closest_position_delta_squared =
       std::numeric_limits<double>::infinity();
   double closest_forward_delta_squared =
@@ -672,9 +683,25 @@ struct VehicleShadowGeometryCorrelationEntry {
   uint32_t constant_forward_identity_slot = 0;
   uint32_t constant_forward_register = 0;
   int32_t constant_forward_sign = 0;
+  uint32_t typed_upload_start_register = 0;
+  uint32_t typed_upload_vector_count = 0;
+  uint32_t typed_upload_source_address = 0;
+  uint32_t typed_upload_buffer_address = 0;
   bool full_geometry_match = false;
   bool constant_position_identity_valid = false;
   bool constant_forward_identity_valid = false;
+  bool typed_upload_identity_valid = false;
+  bool occupied = false;
+};
+
+struct VehicleConstantUploadEntry {
+  uint64_t frame = 0;
+  uint64_t sequence = 0;
+  uint64_t payload_hash = 0;
+  uint32_t buffer_address = 0;
+  uint32_t source_address = 0;
+  uint32_t start_register = 0;
+  uint32_t vector_count = 0;
   bool occupied = false;
 };
 
@@ -1503,6 +1530,16 @@ uint64_t g_vehicle_shadow_geometry_correlation_overflow = 0;
 uint64_t g_vehicle_color_constant_vectors_scanned = 0;
 uint64_t g_vehicle_color_constant_non_finite_vectors = 0;
 uint64_t g_vehicle_color_constant_identity_comparisons = 0;
+std::array<VehicleConstantUploadEntry, kVehicleConstantUploadCapacity>
+    g_vehicle_constant_uploads{};
+std::mutex g_vehicle_constant_upload_mutex;
+uint64_t g_vehicle_constant_upload_observations = 0;
+uint64_t g_vehicle_constant_upload_valid = 0;
+uint64_t g_vehicle_constant_upload_invalid_register_range = 0;
+uint64_t g_vehicle_constant_upload_invalid_source_range = 0;
+uint64_t g_vehicle_constant_upload_overwrites = 0;
+uint64_t g_vehicle_constant_upload_sequence = 0;
+size_t g_vehicle_constant_upload_cursor = 0;
 uint64_t g_vehicle_shadow_geometry_mechanically_eligible_draws = 0;
 uint64_t g_vehicle_shadow_geometry_mechanically_rejected_draws = 0;
 std::array<uint64_t, 15> g_vehicle_shadow_geometry_rejection_reason_counts{};
@@ -9104,6 +9141,13 @@ void ConfigureIsolatedDraw() {
          {"epoch_contract", "exact_consecutive_64_primary_12_secondary_4_tertiary"},
          {"promotion_boundary", "backend_recorded_full_80_draw_epoch"},
          {"color_match", "exact_full_or_index_plus_vertex_resource"},
+         {"typed_constant_upload_hook", "82435E78:r3,r4,r5,r6"},
+         {"typed_constant_upload_contract",
+          "exact_register_range_and_payload_hash"},
+         {"typed_constant_upload_capacity",
+          std::to_string(kVehicleConstantUploadCapacity)},
+         {"typed_constant_upload_maximum_age_frames",
+          std::to_string(kVehicleConstantUploadMaximumAgeFrames)},
          {"guest_payload_capture", "false"},
          {"native_draw", "false"},
          {"xenos_authority", "true"},
@@ -15233,6 +15277,160 @@ uint64_t VehicleColorMaterialParameterHash(
   return hash ? hash : 1;
 }
 
+uint64_t VehicleConstantPayloadHash(uint32_t start_register,
+                                    uint32_t vector_count,
+                                    std::span<const uint32_t> words) {
+  uint64_t hash = UINT64_C(0xCBF29CE484222325);
+  hash = HashCombine(hash, start_register);
+  hash = HashCombine(hash, vector_count);
+  for (uint32_t word : words) {
+    hash = HashCombine(hash, word);
+  }
+  return hash ? hash : 1;
+}
+
+void ObserveVehicleTypedConstantUpload(uint32_t buffer_address,
+                                       uint32_t register_offset,
+                                       uint32_t source_address,
+                                       uint32_t vector_count) {
+  if (!g_vehicle_discovery_installed.load(std::memory_order_acquire) ||
+      !g_isolated_draw.vehicle_shadow_geometry_correlation_mode) {
+    return;
+  }
+  std::scoped_lock lock(g_vehicle_constant_upload_mutex);
+  ++g_vehicle_constant_upload_observations;
+  const uint64_t start_register_64 =
+      uint64_t(register_offset) + kVehicleConstantUploadRegisterBias;
+  if (!vector_count ||
+      vector_count > rex::system::kGraphicsFloatConstantObservationLimit ||
+      start_register_64 > UINT32_MAX ||
+      start_register_64 + vector_count > 256) {
+    ++g_vehicle_constant_upload_invalid_register_range;
+    return;
+  }
+  const uint64_t byte_count = uint64_t(vector_count) * 4 * sizeof(uint32_t);
+  rex::memory::Memory *memory =
+      g_vehicle_discovery_memory.load(std::memory_order_acquire);
+  if (byte_count > UINT32_MAX ||
+      !IsReadableVehicleGuestRange(memory, source_address,
+                                   uint32_t(byte_count))) {
+    ++g_vehicle_constant_upload_invalid_source_range;
+    return;
+  }
+  std::array<uint32_t,
+             rex::system::kGraphicsFloatConstantObservationLimit * 4>
+      words{};
+  const uint32_t word_count = vector_count * 4;
+  for (uint32_t i = 0; i < word_count; ++i) {
+    words[i] = LoadSemanticGuestU32(memory,
+                                    source_address + i * sizeof(uint32_t));
+  }
+  VehicleConstantUploadEntry &entry =
+      g_vehicle_constant_uploads[g_vehicle_constant_upload_cursor];
+  g_vehicle_constant_upload_overwrites += entry.occupied ? 1u : 0u;
+  entry = {
+      .frame = g_frame_sequence.load(std::memory_order_relaxed),
+      .sequence = ++g_vehicle_constant_upload_sequence,
+      .payload_hash = VehicleConstantPayloadHash(
+          uint32_t(start_register_64), vector_count,
+          std::span(words.data(), word_count)),
+      .buffer_address = buffer_address,
+      .source_address = source_address,
+      .start_register = uint32_t(start_register_64),
+      .vector_count = vector_count,
+      .occupied = true,
+  };
+  g_vehicle_constant_upload_cursor =
+      (g_vehicle_constant_upload_cursor + 1) %
+      g_vehicle_constant_uploads.size();
+  ++g_vehicle_constant_upload_valid;
+}
+
+bool HashObservedVertexConstantRange(
+    const rex::system::GraphicsDrawObservation &observation,
+    uint32_t start_register, uint32_t vector_count, uint64_t *payload_hash) {
+  if (!payload_hash) {
+    return false;
+  }
+  std::array<uint32_t,
+             rex::system::kGraphicsFloatConstantObservationLimit * 4>
+      words{};
+  const uint32_t observed_count = std::min(
+      observation.vertex_float_constant_count,
+      rex::system::kGraphicsFloatConstantObservationLimit);
+  for (uint32_t vector_offset = 0; vector_offset < vector_count;
+       ++vector_offset) {
+    const uint32_t target_register = start_register + vector_offset;
+    const rex::system::GraphicsFloatConstantObservation *matched = nullptr;
+    for (uint32_t observed_offset = 0; observed_offset < observed_count;
+         ++observed_offset) {
+      const auto &candidate =
+          observation.vertex_float_constants[observed_offset];
+      if (candidate.index == target_register) {
+        matched = &candidate;
+        break;
+      }
+    }
+    if (!matched) {
+      return false;
+    }
+    std::copy(std::begin(matched->values), std::end(matched->values),
+              words.begin() + vector_offset * 4);
+  }
+  *payload_hash = VehicleConstantPayloadHash(
+      start_register, vector_count,
+      std::span(words.data(), vector_count * 4));
+  return true;
+}
+
+void ObserveVehicleColorTypedConstantUpload(
+    const rex::system::GraphicsDrawObservation &observation,
+    VehicleShadowGeometryCorrelationEntry &entry) {
+  ++entry.typed_upload_scans;
+  VehicleConstantUploadEntry best{};
+  {
+    std::scoped_lock lock(g_vehicle_constant_upload_mutex);
+    for (const VehicleConstantUploadEntry &upload :
+         g_vehicle_constant_uploads) {
+      if (!upload.occupied || observation.frame_sequence < upload.frame ||
+          observation.frame_sequence - upload.frame >
+              kVehicleConstantUploadMaximumAgeFrames) {
+        continue;
+      }
+      uint64_t observed_hash = 0;
+      if (!HashObservedVertexConstantRange(
+              observation, upload.start_register, upload.vector_count,
+              &observed_hash) ||
+          observed_hash != upload.payload_hash) {
+        continue;
+      }
+      if (!best.occupied || upload.sequence > best.sequence) {
+        best = upload;
+      }
+    }
+  }
+  if (!best.occupied) {
+    ++entry.typed_upload_misses;
+    return;
+  }
+  ++entry.typed_upload_exact_matches;
+  if (entry.typed_upload_identity_valid) {
+    entry.typed_upload_start_register_variations +=
+        entry.typed_upload_start_register != best.start_register;
+    entry.typed_upload_vector_count_variations +=
+        entry.typed_upload_vector_count != best.vector_count;
+    entry.typed_upload_source_address_variations +=
+        entry.typed_upload_source_address != best.source_address;
+    entry.typed_upload_buffer_address_variations +=
+        entry.typed_upload_buffer_address != best.buffer_address;
+  }
+  entry.typed_upload_start_register = best.start_register;
+  entry.typed_upload_vector_count = best.vector_count;
+  entry.typed_upload_source_address = best.source_address;
+  entry.typed_upload_buffer_address = best.buffer_address;
+  entry.typed_upload_identity_valid = true;
+}
+
 void ObserveVehicleColorConstantIdentity(
     const rex::system::GraphicsDrawObservation &observation,
     VehicleShadowGeometryCorrelationEntry &entry) {
@@ -15535,6 +15733,7 @@ bool ObserveVehicleShadowGeometryColorCorrelation(
       ++entry.draws;
       entry.last_frame = observation.frame_sequence;
       ObserveVehicleColorConstantIdentity(observation, entry);
+      ObserveVehicleColorTypedConstantUpload(observation, entry);
       if (matched_correlation_index) {
         *matched_correlation_index = correlation_index;
       }
@@ -15587,6 +15786,7 @@ bool ObserveVehicleShadowGeometryColorCorrelation(
       .occupied = true,
   };
   ObserveVehicleColorConstantIdentity(observation, *available);
+  ObserveVehicleColorTypedConstantUpload(observation, *available);
   if (matched_correlation_index) {
     *matched_correlation_index = available_index;
   }
@@ -23867,6 +24067,17 @@ void ConfigureVehicleDiscovery(bool census_requested,
     g_vehicle_composed_matrix_correlation_count = 0;
     g_vehicle_composed_matrix_correlation_overflow = 0;
   }
+  {
+    std::scoped_lock lock(g_vehicle_constant_upload_mutex);
+    g_vehicle_constant_uploads = {};
+    g_vehicle_constant_upload_observations = 0;
+    g_vehicle_constant_upload_valid = 0;
+    g_vehicle_constant_upload_invalid_register_range = 0;
+    g_vehicle_constant_upload_invalid_source_range = 0;
+    g_vehicle_constant_upload_overwrites = 0;
+    g_vehicle_constant_upload_sequence = 0;
+    g_vehicle_constant_upload_cursor = 0;
+  }
   for (VehicleOwnerMethodStats &stats : g_vehicle_owner_method_stats) {
     stats.calls.store(0, std::memory_order_relaxed);
     stats.matched_owner_calls.store(0, std::memory_order_relaxed);
@@ -26297,6 +26508,9 @@ void UninstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system) {
     uint64_t constant_forward_unique_matches = 0;
     uint64_t constant_forward_ambiguous_matches = 0;
     uint64_t constant_forward_misses = 0;
+    uint64_t typed_upload_scans = 0;
+    uint64_t typed_upload_exact_matches = 0;
+    uint64_t typed_upload_misses = 0;
     std::array<uint64_t, kVehicleShadowGeometryCorrelationCapacity>
         material_topology_keys{};
     size_t material_topology_group_count = 0;
@@ -26318,6 +26532,9 @@ void UninstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system) {
       constant_forward_ambiguous_matches +=
           entry.constant_forward_ambiguous_matches;
       constant_forward_misses += entry.constant_forward_misses;
+      typed_upload_scans += entry.typed_upload_scans;
+      typed_upload_exact_matches += entry.typed_upload_exact_matches;
+      typed_upload_misses += entry.typed_upload_misses;
       bool material_topology_seen = false;
       for (size_t material_index = 0;
            material_index < material_topology_group_count;
@@ -26496,6 +26713,46 @@ void UninstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system) {
                     !entry.constant_position_register_variations
                 ? "stable_tight_position_candidate"
                 : "unresolved"},
+           {"typed_upload_scans",
+            std::to_string(entry.typed_upload_scans)},
+           {"typed_upload_exact_matches",
+            std::to_string(entry.typed_upload_exact_matches)},
+           {"typed_upload_misses",
+            std::to_string(entry.typed_upload_misses)},
+           {"typed_upload_start_register_variations",
+            std::to_string(
+                entry.typed_upload_start_register_variations)},
+           {"typed_upload_vector_count_variations",
+            std::to_string(entry.typed_upload_vector_count_variations)},
+           {"typed_upload_source_address_variations",
+            std::to_string(
+                entry.typed_upload_source_address_variations)},
+           {"typed_upload_buffer_address_variations",
+            std::to_string(
+                entry.typed_upload_buffer_address_variations)},
+           {"typed_upload_start_register",
+            entry.typed_upload_identity_valid
+                ? std::to_string(entry.typed_upload_start_register)
+                : "unknown"},
+           {"typed_upload_vector_count",
+            entry.typed_upload_identity_valid
+                ? std::to_string(entry.typed_upload_vector_count)
+                : "unknown"},
+           {"typed_upload_source_address",
+            entry.typed_upload_identity_valid
+                ? fmt::format("{:08X}", entry.typed_upload_source_address)
+                : "unknown"},
+           {"typed_upload_buffer_address",
+            entry.typed_upload_identity_valid
+                ? fmt::format("{:08X}", entry.typed_upload_buffer_address)
+                : "unknown"},
+           {"typed_upload_classification",
+            entry.typed_upload_exact_matches == entry.draws &&
+                    !entry.typed_upload_misses &&
+                    !entry.typed_upload_start_register_variations &&
+                    !entry.typed_upload_vector_count_variations
+                ? "stable_exact_typed_upload_candidate"
+                : "unresolved"},
            {"guest_payload_capture", "false"},
            {"native_draw", "false"},
            {"xenos_authority", "true"},
@@ -26651,6 +26908,32 @@ void UninstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system) {
               : "false"},
          {"constant_identity_maximum_pose_age_frames",
           std::to_string(kVehicleColorConstantMaximumIdentityAgeFrames)},
+         {"typed_upload_observations",
+          std::to_string(g_vehicle_constant_upload_observations)},
+         {"typed_upload_valid",
+          std::to_string(g_vehicle_constant_upload_valid)},
+         {"typed_upload_invalid_register_range",
+          std::to_string(
+              g_vehicle_constant_upload_invalid_register_range)},
+         {"typed_upload_invalid_source_range",
+          std::to_string(g_vehicle_constant_upload_invalid_source_range)},
+         {"typed_upload_overwrites",
+          std::to_string(g_vehicle_constant_upload_overwrites)},
+         {"typed_upload_capacity",
+          std::to_string(kVehicleConstantUploadCapacity)},
+         {"typed_upload_scans", std::to_string(typed_upload_scans)},
+         {"typed_upload_exact_matches",
+          std::to_string(typed_upload_exact_matches)},
+         {"typed_upload_misses", std::to_string(typed_upload_misses)},
+         {"typed_upload_outcome_accounting_complete",
+          typed_upload_exact_matches + typed_upload_misses ==
+                  typed_upload_scans
+              ? "true"
+              : "false"},
+         {"typed_upload_maximum_age_frames",
+          std::to_string(kVehicleConstantUploadMaximumAgeFrames)},
+         {"typed_upload_contract",
+          "82435E78_exact_vertex_register_range_and_payload_hash"},
          {"material_topology_groups",
           std::to_string(material_topology_group_count)},
          {"material_topology_group_accounting_complete",
@@ -27277,6 +27560,11 @@ void PinyonShiftObserveStaticWorldResourceRefreshResetExit(
 void PinyonShiftObserveVehicleComposedMatrix(PPCRegister &r5,
                                              PPCRegister &r22) {
   ObserveVehicleComposedMatrix(r22.u32, r5.u32);
+}
+
+void PinyonShiftObserveVehicleTypedConstantUpload(
+    PPCRegister &r3, PPCRegister &r4, PPCRegister &r5, PPCRegister &r6) {
+  ObserveVehicleTypedConstantUpload(r3.u32, r4.u32, r5.u32, r6.u32);
 }
 
 void PinyonShiftObserveVehicleRenderContextDispatcherEntry(

--- a/tools/summarize-native-renderer-vehicle-shadow-geometry.py
+++ b/tools/summarize-native-renderer-vehicle-shadow-geometry.py
@@ -5,7 +5,7 @@ import json
 from pathlib import Path
 
 
-SCHEMA = "pinyon-shift.native-renderer-vehicle-shadow-geometry.v8"
+SCHEMA = "pinyon-shift.native-renderer-vehicle-shadow-geometry.v9"
 CONFIG_EVENT = "native_renderer.discovery.vehicle_shadow_geometry_config"
 EPOCH_EVENT = "native_renderer.discovery.vehicle_shadow_geometry_epoch"
 CORRELATION_EVENT = (
@@ -124,6 +124,24 @@ def summarize(log_path):
     ]
     require(len(configs) == 1, "expected exactly one correlation config event")
     require(configs[0].get("status") == "armed", "correlation was not armed")
+    require(
+        configs[0].get("typed_constant_upload_hook")
+        == "82435E78:r3,r4,r5,r6",
+        "typed constant upload hook drift",
+    )
+    require(
+        configs[0].get("typed_constant_upload_contract")
+        == "exact_register_range_and_payload_hash",
+        "typed constant upload contract drift",
+    )
+    require(
+        integer(configs[0], "typed_constant_upload_capacity") == 8192,
+        "typed constant upload capacity drift",
+    )
+    require(
+        integer(configs[0], "typed_constant_upload_maximum_age_frames") == 1,
+        "typed constant upload freshness drift",
+    )
     require(len(summaries) == 1, "expected exactly one correlation summary")
     summary = summaries[0]
     require(summary.get("status") == "qualified_epoch_observed", "no qualified epoch")
@@ -243,6 +261,44 @@ def summarize(log_path):
         summary.get("material_topology_contract")
         == "shader_specialization_render_state_texture_layout",
         "material topology contract drift",
+    )
+    typed_upload_scans = integer(summary, "typed_upload_scans")
+    typed_upload_exact_matches = integer(
+        summary, "typed_upload_exact_matches"
+    )
+    typed_upload_misses = integer(summary, "typed_upload_misses")
+    require(
+        typed_upload_scans == integer(summary, "color_draws_matched"),
+        "typed upload scan accounting drift",
+    )
+    require(
+        summary.get("typed_upload_outcome_accounting_complete") == "true",
+        "typed upload outcome accounting drift",
+    )
+    require(
+        typed_upload_exact_matches + typed_upload_misses
+        == typed_upload_scans,
+        "typed upload outcome drift",
+    )
+    require(
+        integer(summary, "typed_upload_valid")
+        + integer(summary, "typed_upload_invalid_register_range")
+        + integer(summary, "typed_upload_invalid_source_range")
+        == integer(summary, "typed_upload_observations"),
+        "typed upload observation accounting drift",
+    )
+    require(
+        integer(summary, "typed_upload_capacity") == 8192,
+        "typed upload summary capacity drift",
+    )
+    require(
+        integer(summary, "typed_upload_maximum_age_frames") == 1,
+        "typed upload summary freshness drift",
+    )
+    require(
+        summary.get("typed_upload_contract")
+        == "82435E78_exact_vertex_register_range_and_payload_hash",
+        "typed upload summary contract drift",
     )
     safety_events = [*configs, *epochs, *correlations, *candidates, summary]
     for event in safety_events:
@@ -414,6 +470,46 @@ def summarize(log_path):
                 decimal(event, "closest_forward_delta_squared") <= 0.04,
                 "candidate forward threshold drift",
             )
+        family_typed_upload_scans = integer(event, "typed_upload_scans")
+        family_typed_upload_matches = integer(
+            event, "typed_upload_exact_matches"
+        )
+        family_typed_upload_misses = integer(event, "typed_upload_misses")
+        require(
+            family_typed_upload_scans == integer(event, "draws"),
+            "candidate typed upload scan accounting drift",
+        )
+        require(
+            family_typed_upload_matches + family_typed_upload_misses
+            == family_typed_upload_scans,
+            "candidate typed upload outcome drift",
+        )
+        stable_typed_upload_candidate = (
+            family_typed_upload_matches == integer(event, "draws")
+            and family_typed_upload_misses == 0
+            and integer(event, "typed_upload_start_register_variations") == 0
+            and integer(event, "typed_upload_vector_count_variations") == 0
+        )
+        require(
+            event.get("typed_upload_classification")
+            == (
+                "stable_exact_typed_upload_candidate"
+                if stable_typed_upload_candidate
+                else "unresolved"
+            ),
+            "candidate typed upload classification drift",
+        )
+        if family_typed_upload_matches:
+            require(
+                0 <= integer(event, "typed_upload_start_register") < 256,
+                "candidate typed upload register drift",
+            )
+            require(
+                0 < integer(event, "typed_upload_vector_count") <= 64,
+                "candidate typed upload vector count drift",
+            )
+            hexadecimal(event, "typed_upload_source_address")
+            hexadecimal(event, "typed_upload_buffer_address")
         for key in (
             "prepared_signature",
             "template_key",
@@ -614,6 +710,16 @@ def summarize(log_path):
         and len(stable_position_candidates) == len(candidates)
         and len(stable_position_identities) == 1
     )
+    stable_typed_upload_candidates = [
+        event
+        for event in candidates
+        if event.get("typed_upload_classification")
+        == "stable_exact_typed_upload_candidate"
+    ]
+    complete_typed_upload_bridge_candidate = (
+        len(candidates) == 30
+        and len(stable_typed_upload_candidates) == len(candidates)
+    )
     material_groups = {}
     for event in candidates:
         material_groups.setdefault(event["material_topology_key"], []).append(
@@ -685,6 +791,24 @@ def summarize(log_path):
                 )
             ],
         },
+        "typed_constant_upload": {
+            "observations": integer(summary, "typed_upload_observations"),
+            "valid": integer(summary, "typed_upload_valid"),
+            "invalid_register_range": integer(
+                summary, "typed_upload_invalid_register_range"
+            ),
+            "invalid_source_range": integer(
+                summary, "typed_upload_invalid_source_range"
+            ),
+            "overwrites": integer(summary, "typed_upload_overwrites"),
+            "capacity": integer(summary, "typed_upload_capacity"),
+            "scans": typed_upload_scans,
+            "exact_matches": typed_upload_exact_matches,
+            "misses": typed_upload_misses,
+            "stable_candidate_families": len(
+                stable_typed_upload_candidates
+            ),
+        },
         "material_topology": {
             "group_count": material_topology_groups,
             "groups": [
@@ -725,6 +849,9 @@ def summarize(log_path):
             ),
             "complete_shared_vehicle_transform_candidate": (
                 complete_shared_vehicle_transform_candidate
+            ),
+            "complete_typed_upload_bridge_candidate": (
+                complete_typed_upload_bridge_candidate
             ),
             "object_identity_proven": False,
             "mesh_material_contract_proven": False,

--- a/tools/tests/test_native_renderer_vehicle_shadow_geometry.py
+++ b/tools/tests/test_native_renderer_vehicle_shadow_geometry.py
@@ -26,6 +26,10 @@ class VehicleShadowGeometryTests(unittest.TestCase):
             {
                 "event": MODULE.CONFIG_EVENT,
                 "status": "armed",
+                "typed_constant_upload_hook": "82435E78:r3,r4,r5,r6",
+                "typed_constant_upload_contract": "exact_register_range_and_payload_hash",
+                "typed_constant_upload_capacity": "8192",
+                "typed_constant_upload_maximum_age_frames": "1",
                 **safety,
             },
             {
@@ -108,6 +112,18 @@ class VehicleShadowGeometryTests(unittest.TestCase):
                 "constant_forward_sign": "unknown",
                 "closest_forward_delta_squared": "0.01",
                 "constant_identity_classification": "stable_tight_position_candidate",
+                "typed_upload_scans": "3",
+                "typed_upload_exact_matches": "3",
+                "typed_upload_misses": "0",
+                "typed_upload_start_register_variations": "0",
+                "typed_upload_vector_count_variations": "0",
+                "typed_upload_source_address_variations": "2",
+                "typed_upload_buffer_address_variations": "0",
+                "typed_upload_start_register": "208",
+                "typed_upload_vector_count": "4",
+                "typed_upload_source_address": "7FFF1000",
+                "typed_upload_buffer_address": "50001000",
+                "typed_upload_classification": "stable_exact_typed_upload_candidate",
                 **safety,
             },
             {
@@ -228,6 +244,18 @@ class VehicleShadowGeometryTests(unittest.TestCase):
                 "constant_forward_misses": "0",
                 "constant_forward_accounting_complete": "true",
                 "constant_identity_maximum_pose_age_frames": "1",
+                "typed_upload_observations": "4",
+                "typed_upload_valid": "3",
+                "typed_upload_invalid_register_range": "1",
+                "typed_upload_invalid_source_range": "0",
+                "typed_upload_overwrites": "0",
+                "typed_upload_capacity": "8192",
+                "typed_upload_scans": "3",
+                "typed_upload_exact_matches": "3",
+                "typed_upload_misses": "0",
+                "typed_upload_outcome_accounting_complete": "true",
+                "typed_upload_maximum_age_frames": "1",
+                "typed_upload_contract": "82435E78_exact_vertex_register_range_and_payload_hash",
                 "material_topology_groups": "1",
                 "material_topology_group_accounting_complete": "true",
                 "material_topology_contract": "shader_specialization_render_state_texture_layout",
@@ -304,6 +332,13 @@ class VehicleShadowGeometryTests(unittest.TestCase):
                 "families_with_parameter_variation"
             ],
         )
+        self.assertEqual(3, report["typed_constant_upload"]["exact_matches"])
+        self.assertEqual(
+            1, report["typed_constant_upload"]["stable_candidate_families"]
+        )
+        self.assertFalse(
+            report["qualification"]["complete_typed_upload_bridge_candidate"]
+        )
 
     def test_rejects_partial_epoch_promotion(self):
         events = self.fixture()
@@ -375,6 +410,12 @@ class VehicleShadowGeometryTests(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "material topology"):
             self.summarize(events)
 
+    def test_rejects_typed_upload_outcome_drift(self):
+        events = self.fixture()
+        events[-1]["typed_upload_exact_matches"] = "2"
+        with self.assertRaisesRegex(ValueError, "typed upload outcome drift"):
+            self.summarize(events)
+
     def test_rejects_private_capture_authority_drift(self):
         events = self.fixture()
         events[5]["output_authority"] = "native"
@@ -422,7 +463,10 @@ class VehicleShadowGeometryTests(unittest.TestCase):
             source,
         )
         self.assertIn("ObserveVehicleColorConstantIdentity", source)
+        self.assertIn("ObserveVehicleTypedConstantUpload", source)
+        self.assertIn("ObserveVehicleColorTypedConstantUpload", source)
         self.assertIn("constant_position_accounting_complete", source)
+        self.assertIn("typed_upload_outcome_accounting_complete", source)
         self.assertIn("[switch]$VehicleShadowGeometryCorrelation", capture)
         self.assertIn("[switch]$CaptureVehicleShadowColor", capture)
         self.assertIn("[switch]$RetainVehicleShadowColorPass", capture)


### PR DESCRIPTION
## Summary
- hook the proven generic title constant writer at 82435E78
- retain a bounded two-heavy-frame ledger of register ranges and semantic hashes
- join exact vehicle families to fresh vertex uploads without logging payloads
- add v9 qualification and per-family stability accounting
- document the next C4 semantic boundary

## Validation
- 553 native-renderer tests pass
- incremental Release build succeeds after regenerated hook
- git diff --check

## Runtime boundary
- no new AppData run in this PR; qualification is intentionally batched with the next substantial C4 slice
- Xenos remains authoritative; no publication or suppression