### PR TITLE
build(renderer): preserve typed upload caller provenance

### DIFF
--- a/config/rexglue/analysis/main-xex.toml
+++ b/config/rexglue/analysis/main-xex.toml
@@ -365,7 +365,7 @@ registers = ["r5", "r22"]
 [[midasm_hook]]
 address = 0x82435E78
 name = "PinyonShiftObserveVehicleTypedConstantUpload"
-registers = ["r3", "r4", "r5", "r6"]
+registers = ["r3", "r4", "r5", "r6", "lr"]
 
 [[midasm_hook]]
 address = 0x8243646C

--- a/docs/native-renderer/REPRIORITIZED_PLAN.md
+++ b/docs/native-renderer/REPRIORITIZED_PLAN.md
@@ -682,11 +682,13 @@ retained private pass remains the stable geometry/output harness throughout.
 Typed constant-upload implementation checkpoint: the exact generic title
 writer at `82435E78` now feeds a bounded 8,192-entry recent-upload ledger. Each
 entry retains its destination register range, title source/destination
-addresses, and semantic payload hash without exporting constant values. Every
+addresses, exact caller return address, and semantic payload hash without
+exporting constant values. Every
 exact vehicle color family joins its observed vertex registers to uploads no
 more than one frame old by exact range and hash. The v9 qualifier requires
 complete upload/outcome accounting and recognizes a 30-family bridge only
-when every family matches on every draw with a stable register range. Runtime
+when every family matches on every draw with a stable caller and register
+range. Runtime
 proof is deliberately batched with the next substantial C4 slice; the contract
 is documented in
 [`VEHICLE_TYPED_CONSTANT_UPLOAD.md`](VEHICLE_TYPED_CONSTANT_UPLOAD.md).

--- a/docs/native-renderer/VEHICLE_TYPED_CONSTANT_UPLOAD.md
+++ b/docs/native-renderer/VEHICLE_TYPED_CONSTANT_UPLOAD.md
@@ -15,6 +15,7 @@ A read-only entry hook now records a bounded recent-upload ledger. Each valid
 entry retains only:
 
 - the frame and monotonic observation sequence;
+- the exact caller return address supplied by the guest link register;
 - destination buffer and source addresses;
 - destination register range; and
 - a semantic hash of that exact range and payload.
@@ -32,11 +33,16 @@ register in the uploaded range to exist in the prepared draw and the semantic
 payload hash to agree exactly. The newest exact upload wins when repeated
 writes carry the same range and values.
 
-Per-family accounting records exact matches, misses, register/count stability,
-and source/destination address variation. The v9 qualifier recognizes a stable
-typed-upload candidate only when every draw in a family matches and its
-register range never changes. A complete bridge candidate requires all 30
-families to satisfy that rule.
+Per-family accounting records exact matches, misses, caller and register/count
+stability, and source/destination address variation. The v9 qualifier
+recognizes a stable typed-upload candidate only when every draw in a family
+matches and its caller and register range never change. A complete bridge
+candidate requires all 30 families to satisfy that rule.
+
+ReXGlue patch `0103-codegen-midasm-link-register-argument.patch` exposes the
+guest link register as an optional read-only mid-assembly hook argument. This
+avoids 82 duplicated callsite hooks while retaining the exact `bl` return
+address for offline title-function resolution.
 
 This proves which typed writes feed the prepared vehicle draws. It does not by
 itself convert reference-space constants to a world transform or label a

--- a/patches/rexglue/0103-codegen-midasm-link-register-argument.patch
+++ b/patches/rexglue/0103-codegen-midasm-link-register-argument.patch
@@ -1,0 +1,28 @@
+diff --git a/src/codegen/builders/context.cpp b/src/codegen/builders/context.cpp
+--- a/src/codegen/builders/context.cpp
++++ b/src/codegen/builders/context.cpp
+@@ -416,6 +416,10 @@ void BuilderContext::call_midasm_hook(uint32_t address) {
+       case 'x':
+         out += xer();
+         break;
++      case 'l':
++        if (reg == "lr")
++          out += "ctx.lr";
++        break;
+       case 'r':
+         if (reg == "reserved")
+           out += reserved();
+diff --git a/src/codegen/function_graph.cpp b/src/codegen/function_graph.cpp
+--- a/src/codegen/function_graph.cpp
++++ b/src/codegen/function_graph.cpp
+@@ -466,6 +466,10 @@ void FunctionGraph::EmitFunctions(const std::filesystem::path& outputDir) {
+             case 'x':
+               emit_print(out, "PPCXERRegister& xer");
+               break;
++            case 'l':
++              if (reg == "lr")
++                emit_print(out, "uint64_t& lr");
++              break;
+             case 'r':
+               emit_print(out, "PPCRegister& {}", reg);
+               break;

--- a/src/native_renderer/graphics_hooks.cpp
+++ b/src/native_renderer/graphics_hooks.cpp
@@ -661,6 +661,7 @@ struct VehicleShadowGeometryCorrelationEntry {
   uint64_t typed_upload_vector_count_variations = 0;
   uint64_t typed_upload_source_address_variations = 0;
   uint64_t typed_upload_buffer_address_variations = 0;
+  uint64_t typed_upload_caller_variations = 0;
   double closest_position_delta_squared =
       std::numeric_limits<double>::infinity();
   double closest_forward_delta_squared =
@@ -687,6 +688,7 @@ struct VehicleShadowGeometryCorrelationEntry {
   uint32_t typed_upload_vector_count = 0;
   uint32_t typed_upload_source_address = 0;
   uint32_t typed_upload_buffer_address = 0;
+  uint32_t typed_upload_caller_return_address = 0;
   bool full_geometry_match = false;
   bool constant_position_identity_valid = false;
   bool constant_forward_identity_valid = false;
@@ -702,6 +704,7 @@ struct VehicleConstantUploadEntry {
   uint32_t source_address = 0;
   uint32_t start_register = 0;
   uint32_t vector_count = 0;
+  uint32_t caller_return_address = 0;
   bool occupied = false;
 };
 
@@ -9141,7 +9144,7 @@ void ConfigureIsolatedDraw() {
          {"epoch_contract", "exact_consecutive_64_primary_12_secondary_4_tertiary"},
          {"promotion_boundary", "backend_recorded_full_80_draw_epoch"},
          {"color_match", "exact_full_or_index_plus_vertex_resource"},
-         {"typed_constant_upload_hook", "82435E78:r3,r4,r5,r6"},
+         {"typed_constant_upload_hook", "82435E78:r3,r4,r5,r6,lr"},
          {"typed_constant_upload_contract",
           "exact_register_range_and_payload_hash"},
          {"typed_constant_upload_capacity",
@@ -15292,7 +15295,8 @@ uint64_t VehicleConstantPayloadHash(uint32_t start_register,
 void ObserveVehicleTypedConstantUpload(uint32_t buffer_address,
                                        uint32_t register_offset,
                                        uint32_t source_address,
-                                       uint32_t vector_count) {
+                                       uint32_t vector_count,
+                                       uint32_t caller_return_address) {
   if (!g_vehicle_discovery_installed.load(std::memory_order_acquire) ||
       !g_isolated_draw.vehicle_shadow_geometry_correlation_mode) {
     return;
@@ -15338,6 +15342,7 @@ void ObserveVehicleTypedConstantUpload(uint32_t buffer_address,
       .source_address = source_address,
       .start_register = uint32_t(start_register_64),
       .vector_count = vector_count,
+      .caller_return_address = caller_return_address,
       .occupied = true,
   };
   g_vehicle_constant_upload_cursor =
@@ -15423,11 +15428,15 @@ void ObserveVehicleColorTypedConstantUpload(
         entry.typed_upload_source_address != best.source_address;
     entry.typed_upload_buffer_address_variations +=
         entry.typed_upload_buffer_address != best.buffer_address;
+    entry.typed_upload_caller_variations +=
+        entry.typed_upload_caller_return_address !=
+        best.caller_return_address;
   }
   entry.typed_upload_start_register = best.start_register;
   entry.typed_upload_vector_count = best.vector_count;
   entry.typed_upload_source_address = best.source_address;
   entry.typed_upload_buffer_address = best.buffer_address;
+  entry.typed_upload_caller_return_address = best.caller_return_address;
   entry.typed_upload_identity_valid = true;
 }
 
@@ -26730,6 +26739,8 @@ void UninstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system) {
            {"typed_upload_buffer_address_variations",
             std::to_string(
                 entry.typed_upload_buffer_address_variations)},
+           {"typed_upload_caller_variations",
+            std::to_string(entry.typed_upload_caller_variations)},
            {"typed_upload_start_register",
             entry.typed_upload_identity_valid
                 ? std::to_string(entry.typed_upload_start_register)
@@ -26746,11 +26757,17 @@ void UninstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system) {
             entry.typed_upload_identity_valid
                 ? fmt::format("{:08X}", entry.typed_upload_buffer_address)
                 : "unknown"},
+           {"typed_upload_caller_return_address",
+            entry.typed_upload_identity_valid
+                ? fmt::format("{:08X}",
+                              entry.typed_upload_caller_return_address)
+                : "unknown"},
            {"typed_upload_classification",
             entry.typed_upload_exact_matches == entry.draws &&
                     !entry.typed_upload_misses &&
                     !entry.typed_upload_start_register_variations &&
-                    !entry.typed_upload_vector_count_variations
+                    !entry.typed_upload_vector_count_variations &&
+                    !entry.typed_upload_caller_variations
                 ? "stable_exact_typed_upload_candidate"
                 : "unresolved"},
            {"guest_payload_capture", "false"},
@@ -27563,8 +27580,10 @@ void PinyonShiftObserveVehicleComposedMatrix(PPCRegister &r5,
 }
 
 void PinyonShiftObserveVehicleTypedConstantUpload(
-    PPCRegister &r3, PPCRegister &r4, PPCRegister &r5, PPCRegister &r6) {
-  ObserveVehicleTypedConstantUpload(r3.u32, r4.u32, r5.u32, r6.u32);
+    PPCRegister &r3, PPCRegister &r4, PPCRegister &r5, PPCRegister &r6,
+    uint64_t &lr) {
+  ObserveVehicleTypedConstantUpload(r3.u32, r4.u32, r5.u32, r6.u32,
+                                    uint32_t(lr));
 }
 
 void PinyonShiftObserveVehicleRenderContextDispatcherEntry(

--- a/tools/summarize-native-renderer-vehicle-shadow-geometry.py
+++ b/tools/summarize-native-renderer-vehicle-shadow-geometry.py
@@ -126,7 +126,7 @@ def summarize(log_path):
     require(configs[0].get("status") == "armed", "correlation was not armed")
     require(
         configs[0].get("typed_constant_upload_hook")
-        == "82435E78:r3,r4,r5,r6",
+        == "82435E78:r3,r4,r5,r6,lr",
         "typed constant upload hook drift",
     )
     require(
@@ -489,6 +489,7 @@ def summarize(log_path):
             and family_typed_upload_misses == 0
             and integer(event, "typed_upload_start_register_variations") == 0
             and integer(event, "typed_upload_vector_count_variations") == 0
+            and integer(event, "typed_upload_caller_variations") == 0
         )
         require(
             event.get("typed_upload_classification")
@@ -510,6 +511,7 @@ def summarize(log_path):
             )
             hexadecimal(event, "typed_upload_source_address")
             hexadecimal(event, "typed_upload_buffer_address")
+            hexadecimal(event, "typed_upload_caller_return_address")
         for key in (
             "prepared_signature",
             "template_key",
@@ -720,6 +722,13 @@ def summarize(log_path):
         len(candidates) == 30
         and len(stable_typed_upload_candidates) == len(candidates)
     )
+    typed_upload_callers = sorted(
+        {
+            event["typed_upload_caller_return_address"]
+            for event in candidates
+            if integer(event, "typed_upload_exact_matches")
+        }
+    )
     material_groups = {}
     for event in candidates:
         material_groups.setdefault(event["material_topology_key"], []).append(
@@ -808,6 +817,7 @@ def summarize(log_path):
             "stable_candidate_families": len(
                 stable_typed_upload_candidates
             ),
+            "caller_return_addresses": typed_upload_callers,
         },
         "material_topology": {
             "group_count": material_topology_groups,

--- a/tools/tests/test_native_renderer_vehicle_shadow_geometry.py
+++ b/tools/tests/test_native_renderer_vehicle_shadow_geometry.py
@@ -26,7 +26,7 @@ class VehicleShadowGeometryTests(unittest.TestCase):
             {
                 "event": MODULE.CONFIG_EVENT,
                 "status": "armed",
-                "typed_constant_upload_hook": "82435E78:r3,r4,r5,r6",
+                "typed_constant_upload_hook": "82435E78:r3,r4,r5,r6,lr",
                 "typed_constant_upload_contract": "exact_register_range_and_payload_hash",
                 "typed_constant_upload_capacity": "8192",
                 "typed_constant_upload_maximum_age_frames": "1",
@@ -119,10 +119,12 @@ class VehicleShadowGeometryTests(unittest.TestCase):
                 "typed_upload_vector_count_variations": "0",
                 "typed_upload_source_address_variations": "2",
                 "typed_upload_buffer_address_variations": "0",
+                "typed_upload_caller_variations": "0",
                 "typed_upload_start_register": "208",
                 "typed_upload_vector_count": "4",
                 "typed_upload_source_address": "7FFF1000",
                 "typed_upload_buffer_address": "50001000",
+                "typed_upload_caller_return_address": "8240EB60",
                 "typed_upload_classification": "stable_exact_typed_upload_candidate",
                 **safety,
             },
@@ -336,6 +338,10 @@ class VehicleShadowGeometryTests(unittest.TestCase):
         self.assertEqual(
             1, report["typed_constant_upload"]["stable_candidate_families"]
         )
+        self.assertEqual(
+            ["8240EB60"],
+            report["typed_constant_upload"]["caller_return_addresses"],
+        )
         self.assertFalse(
             report["qualification"]["complete_typed_upload_bridge_candidate"]
         )
@@ -441,6 +447,13 @@ class VehicleShadowGeometryTests(unittest.TestCase):
         capture = (ROOT / "tools/capture-native-renderer-census.ps1").read_text(
             encoding="utf-8"
         )
+        analysis = (
+            ROOT / "config/rexglue/analysis/main-xex.toml"
+        ).read_text(encoding="utf-8")
+        lr_patch = (
+            ROOT
+            / "patches/rexglue/0103-codegen-midasm-link-register-argument.patch"
+        ).read_text(encoding="utf-8")
         self.assertIn(
             "PINYON_SHIFT_NATIVE_RENDERER_VEHICLE_SHADOW_GEOMETRY_CORRELATION",
             source,
@@ -467,6 +480,12 @@ class VehicleShadowGeometryTests(unittest.TestCase):
         self.assertIn("ObserveVehicleColorTypedConstantUpload", source)
         self.assertIn("constant_position_accounting_complete", source)
         self.assertIn("typed_upload_outcome_accounting_complete", source)
+        self.assertIn(
+            'registers = ["r3", "r4", "r5", "r6", "lr"]', analysis
+        )
+        self.assertIn('if (reg == "lr")', lr_patch)
+        self.assertIn('out += "ctx.lr"', lr_patch)
+        self.assertIn('emit_print(out, "uint64_t& lr")', lr_patch)
         self.assertIn("[switch]$VehicleShadowGeometryCorrelation", capture)
         self.assertIn("[switch]$CaptureVehicleShadowColor", capture)
         self.assertIn("[switch]$RetainVehicleShadowColorPass", capture)

--- a/tools/tests/test_release_contract.py
+++ b/tools/tests/test_release_contract.py
@@ -43,10 +43,10 @@ class ReleaseContractTests(unittest.TestCase):
 
     def test_rexglue_patches_have_stable_order_and_no_binary_payload(self):
         patches = sorted((ROOT / "patches/rexglue").glob("*.patch"))
-        self.assertEqual(len(patches), 102)
+        self.assertEqual(len(patches), 103)
         self.assertEqual(
             patches[-1].name,
-            "0102-d3d12-track-retained-preview-logical-extent.patch",
+            "0103-codegen-midasm-link-register-argument.patch",
         )
         self.assertEqual(len(patches), len({path.name[:4] for path in patches}))
         for path in patches:


### PR DESCRIPTION
## Summary
- expose the guest link register as an optional ReXGlue mid-assembly hook argument
- retain exact typed-upload caller return addresses without 82 duplicated callsite hooks
- require caller stability in the vehicle-family typed-upload qualifier

## Validation
- 553 native-renderer tests
- full Release build with all 103 ReXGlue patches
- generated hook invocation verified to pass ctx.lr
- git diff --check