### PR TITLE
fix(renderer): join only shader-used upload vectors

### DIFF
--- a/docs/native-renderer/REPRIORITIZED_PLAN.md
+++ b/docs/native-renderer/REPRIORITIZED_PLAN.md
@@ -682,15 +682,18 @@ retained private pass remains the stable geometry/output harness throughout.
 Typed constant-upload implementation checkpoint: the exact generic title
 writer at `82435E78` now feeds a bounded 8,192-entry recent-upload ledger. Each
 entry retains its destination register range, title source/destination
-addresses, exact caller return address, and semantic payload hash without
+addresses, exact caller return address, and per-vector semantic hashes without
 exporting constant values. Every
 exact vehicle color family joins its observed vertex registers to uploads no
-more than one frame old by exact range and hash. The v9 qualifier requires
+more than one frame old. The first AppData run strictly accounted 2,419,537
+writer observations and 16,230 vehicle draw scans, but the whole-range rule
+produced zero matches because prepared observations contain only constants
+referenced by the active shader. The rule is rejected and replaced by an exact
+shader-used subset join. The v10 qualifier requires
 complete upload/outcome accounting and recognizes a 30-family bridge only
-when every family matches on every draw with a stable caller and register
-range. Runtime
-proof is deliberately batched with the next substantial C4 slice; the contract
-is documented in
+when every family matches on every draw with a stable caller, upload range, and
+consumed subset size. Runtime proof remains batched with the next substantial
+C4 slice; the corrected contract and first-run evidence are documented in
 [`VEHICLE_TYPED_CONSTANT_UPLOAD.md`](VEHICLE_TYPED_CONSTANT_UPLOAD.md).
 
 ### C5. Sky, atmosphere, and global lighting

--- a/docs/native-renderer/VEHICLE_TYPED_CONSTANT_UPLOAD.md
+++ b/docs/native-renderer/VEHICLE_TYPED_CONSTANT_UPLOAD.md
@@ -1,8 +1,8 @@
 # Vehicle typed constant-upload join
 
-Status: implemented as a default-off, payload-free extension of the C4 vehicle
-correlation mode; runtime qualification is deferred to the next batched
-AppData session.
+Status: the first default-off AppData qualification rejected the whole-range
+join; an exact shader-used-vector join is implemented for the next batched
+qualification.
 
 ## Proven title boundary
 
@@ -18,7 +18,7 @@ entry retains only:
 - the exact caller return address supplied by the guest link register;
 - destination buffer and source addresses;
 - destination register range; and
-- a semantic hash of that exact range and payload.
+- one semantic hash for each vector in that range.
 
 No constant value is logged or written to the offline report. Invalid source
 or register ranges are counted and rejected before the source is read. The
@@ -27,22 +27,41 @@ overwrites explicitly.
 
 ## Draw join
 
-Each exact shadow-correlated vehicle color draw tests its observed vertex
-constants against uploads no more than one frame old. A match requires every
-register in the uploaded range to exist in the prepared draw and the semantic
-payload hash to agree exactly. The newest exact upload wins when repeated
-writes carry the same range and values.
+Each exact shadow-correlated vehicle color draw tests its shader-used vertex
+constants against uploads no more than one frame old. A match requires at
+least one used register to overlap the upload range and every overlapping
+vector hash to agree exactly. Unused vectors in the title upload are not
+invented as shader inputs. The candidate with the most exact used-vector
+matches wins, with newest sequence breaking a tie.
 
-Per-family accounting records exact matches, misses, caller and register/count
-stability, and source/destination address variation. The v9 qualifier
-recognizes a stable typed-upload candidate only when every draw in a family
-matches and its caller and register range never change. A complete bridge
-candidate requires all 30 families to satisfy that rule.
+Per-family accounting records exact draw and used-vector matches, misses,
+caller, register/range and used-count stability, and source/destination address
+variation. The v10 qualifier recognizes a stable candidate only when every
+draw in a family matches and its caller, upload range, and consumed subset
+size never change. A complete bridge candidate requires all 30 families to
+satisfy that rule.
 
 ReXGlue patch `0103-codegen-midasm-link-register-argument.patch` exposes the
 guest link register as an optional read-only mid-assembly hook argument. This
 avoids 82 duplicated callsite hooks while retaining the exact `bl` return
 address for offline title-function resolution.
+
+## First runtime result and correction
+
+The AppData-backed `20260831T181527Z-p45996` run exited normally with no error,
+fatal, validation, or device-removal signature. It committed 541 exact vehicle
+epochs and 16,230 full-resource matches across all 30 families. The writer
+hook strictly accounted 2,419,537 observations: 594,688 valid uploads,
+1,824,849 rejected register ranges, and zero invalid source ranges.
+
+The whole-range join produced zero matches across all 16,230 draw scans. That
+rejects its admission rule, not the generic writer: ReXGlue reports only
+constants actually referenced by the active shader, so requiring every vector
+in a broader title upload to appear in the prepared observation was
+structurally impossible whenever the shader consumed a subset. The v10 join
+therefore compares only the exact shader-used intersection while retaining the
+same one-frame freshness, caller provenance, payload-free output, and Xenos
+authority.
 
 This proves which typed writes feed the prepared vehicle draws. It does not by
 itself convert reference-space constants to a world transform or label a
@@ -55,4 +74,5 @@ ranges and title callers should receive the next semantic discriminator.
 - The ledger is fixed-size and retains hashes, not payloads.
 - Every authoritative Xenos upload and draw executes unchanged.
 - No native publication or draw suppression depends on this evidence.
-- Missing, stale, invalid, or incomplete ranges remain unresolved.
+- Missing, stale, invalid, non-overlapping, or hash-mismatched ranges remain
+  unresolved.

--- a/src/native_renderer/graphics_hooks.cpp
+++ b/src/native_renderer/graphics_hooks.cpp
@@ -657,8 +657,10 @@ struct VehicleShadowGeometryCorrelationEntry {
   uint64_t typed_upload_scans = 0;
   uint64_t typed_upload_exact_matches = 0;
   uint64_t typed_upload_misses = 0;
+  uint64_t typed_upload_exact_used_vectors = 0;
   uint64_t typed_upload_start_register_variations = 0;
   uint64_t typed_upload_vector_count_variations = 0;
+  uint64_t typed_upload_used_vector_count_variations = 0;
   uint64_t typed_upload_source_address_variations = 0;
   uint64_t typed_upload_buffer_address_variations = 0;
   uint64_t typed_upload_caller_variations = 0;
@@ -686,6 +688,7 @@ struct VehicleShadowGeometryCorrelationEntry {
   int32_t constant_forward_sign = 0;
   uint32_t typed_upload_start_register = 0;
   uint32_t typed_upload_vector_count = 0;
+  uint32_t typed_upload_used_vector_count = 0;
   uint32_t typed_upload_source_address = 0;
   uint32_t typed_upload_buffer_address = 0;
   uint32_t typed_upload_caller_return_address = 0;
@@ -699,12 +702,14 @@ struct VehicleShadowGeometryCorrelationEntry {
 struct VehicleConstantUploadEntry {
   uint64_t frame = 0;
   uint64_t sequence = 0;
-  uint64_t payload_hash = 0;
   uint32_t buffer_address = 0;
   uint32_t source_address = 0;
   uint32_t start_register = 0;
   uint32_t vector_count = 0;
   uint32_t caller_return_address = 0;
+  std::array<uint64_t,
+             rex::system::kGraphicsFloatConstantObservationLimit>
+      vector_hashes{};
   bool occupied = false;
 };
 
@@ -9146,7 +9151,7 @@ void ConfigureIsolatedDraw() {
          {"color_match", "exact_full_or_index_plus_vertex_resource"},
          {"typed_constant_upload_hook", "82435E78:r3,r4,r5,r6,lr"},
          {"typed_constant_upload_contract",
-          "exact_register_range_and_payload_hash"},
+          "exact_shader_used_vertex_subset_hash"},
          {"typed_constant_upload_capacity",
           std::to_string(kVehicleConstantUploadCapacity)},
          {"typed_constant_upload_maximum_age_frames",
@@ -15329,20 +15334,27 @@ void ObserveVehicleTypedConstantUpload(uint32_t buffer_address,
     words[i] = LoadSemanticGuestU32(memory,
                                     source_address + i * sizeof(uint32_t));
   }
+  std::array<uint64_t,
+             rex::system::kGraphicsFloatConstantObservationLimit>
+      vector_hashes{};
+  for (uint32_t vector_offset = 0; vector_offset < vector_count;
+       ++vector_offset) {
+    vector_hashes[vector_offset] = VehicleConstantPayloadHash(
+        uint32_t(start_register_64) + vector_offset, 1,
+        std::span(words.data() + vector_offset * 4, 4));
+  }
   VehicleConstantUploadEntry &entry =
       g_vehicle_constant_uploads[g_vehicle_constant_upload_cursor];
   g_vehicle_constant_upload_overwrites += entry.occupied ? 1u : 0u;
   entry = {
       .frame = g_frame_sequence.load(std::memory_order_relaxed),
       .sequence = ++g_vehicle_constant_upload_sequence,
-      .payload_hash = VehicleConstantPayloadHash(
-          uint32_t(start_register_64), vector_count,
-          std::span(words.data(), word_count)),
       .buffer_address = buffer_address,
       .source_address = source_address,
       .start_register = uint32_t(start_register_64),
       .vector_count = vector_count,
       .caller_return_address = caller_return_address,
+      .vector_hashes = vector_hashes,
       .occupied = true,
   };
   g_vehicle_constant_upload_cursor =
@@ -15351,41 +15363,35 @@ void ObserveVehicleTypedConstantUpload(uint32_t buffer_address,
   ++g_vehicle_constant_upload_valid;
 }
 
-bool HashObservedVertexConstantRange(
+bool MatchObservedVertexConstantSubset(
     const rex::system::GraphicsDrawObservation &observation,
-    uint32_t start_register, uint32_t vector_count, uint64_t *payload_hash) {
-  if (!payload_hash) {
+    const VehicleConstantUploadEntry &upload,
+    uint32_t *matched_vector_count) {
+  if (!matched_vector_count) {
     return false;
   }
-  std::array<uint32_t,
-             rex::system::kGraphicsFloatConstantObservationLimit * 4>
-      words{};
+  *matched_vector_count = 0;
   const uint32_t observed_count = std::min(
       observation.vertex_float_constant_count,
       rex::system::kGraphicsFloatConstantObservationLimit);
-  for (uint32_t vector_offset = 0; vector_offset < vector_count;
-       ++vector_offset) {
-    const uint32_t target_register = start_register + vector_offset;
-    const rex::system::GraphicsFloatConstantObservation *matched = nullptr;
-    for (uint32_t observed_offset = 0; observed_offset < observed_count;
-         ++observed_offset) {
-      const auto &candidate =
-          observation.vertex_float_constants[observed_offset];
-      if (candidate.index == target_register) {
-        matched = &candidate;
-        break;
-      }
+  for (uint32_t observed_offset = 0; observed_offset < observed_count;
+       ++observed_offset) {
+    const auto &constant =
+        observation.vertex_float_constants[observed_offset];
+    if (constant.index < upload.start_register ||
+        constant.index >= upload.start_register + upload.vector_count) {
+      continue;
     }
-    if (!matched) {
+    const uint32_t vector_offset = constant.index - upload.start_register;
+    const uint64_t observed_hash = VehicleConstantPayloadHash(
+        constant.index, 1,
+        std::span(constant.values, std::size(constant.values)));
+    if (observed_hash != upload.vector_hashes[vector_offset]) {
       return false;
     }
-    std::copy(std::begin(matched->values), std::end(matched->values),
-              words.begin() + vector_offset * 4);
+    ++*matched_vector_count;
   }
-  *payload_hash = VehicleConstantPayloadHash(
-      start_register, vector_count,
-      std::span(words.data(), vector_count * 4));
-  return true;
+  return *matched_vector_count != 0;
 }
 
 void ObserveVehicleColorTypedConstantUpload(
@@ -15393,6 +15399,7 @@ void ObserveVehicleColorTypedConstantUpload(
     VehicleShadowGeometryCorrelationEntry &entry) {
   ++entry.typed_upload_scans;
   VehicleConstantUploadEntry best{};
+  uint32_t best_matched_vector_count = 0;
   {
     std::scoped_lock lock(g_vehicle_constant_upload_mutex);
     for (const VehicleConstantUploadEntry &upload :
@@ -15402,15 +15409,17 @@ void ObserveVehicleColorTypedConstantUpload(
               kVehicleConstantUploadMaximumAgeFrames) {
         continue;
       }
-      uint64_t observed_hash = 0;
-      if (!HashObservedVertexConstantRange(
-              observation, upload.start_register, upload.vector_count,
-              &observed_hash) ||
-          observed_hash != upload.payload_hash) {
+      uint32_t matched_vector_count = 0;
+      if (!MatchObservedVertexConstantSubset(
+              observation, upload, &matched_vector_count)) {
         continue;
       }
-      if (!best.occupied || upload.sequence > best.sequence) {
+      if (!best.occupied ||
+          matched_vector_count > best_matched_vector_count ||
+          (matched_vector_count == best_matched_vector_count &&
+           upload.sequence > best.sequence)) {
         best = upload;
+        best_matched_vector_count = matched_vector_count;
       }
     }
   }
@@ -15419,11 +15428,14 @@ void ObserveVehicleColorTypedConstantUpload(
     return;
   }
   ++entry.typed_upload_exact_matches;
+  entry.typed_upload_exact_used_vectors += best_matched_vector_count;
   if (entry.typed_upload_identity_valid) {
     entry.typed_upload_start_register_variations +=
         entry.typed_upload_start_register != best.start_register;
     entry.typed_upload_vector_count_variations +=
         entry.typed_upload_vector_count != best.vector_count;
+    entry.typed_upload_used_vector_count_variations +=
+        entry.typed_upload_used_vector_count != best_matched_vector_count;
     entry.typed_upload_source_address_variations +=
         entry.typed_upload_source_address != best.source_address;
     entry.typed_upload_buffer_address_variations +=
@@ -15434,6 +15446,7 @@ void ObserveVehicleColorTypedConstantUpload(
   }
   entry.typed_upload_start_register = best.start_register;
   entry.typed_upload_vector_count = best.vector_count;
+  entry.typed_upload_used_vector_count = best_matched_vector_count;
   entry.typed_upload_source_address = best.source_address;
   entry.typed_upload_buffer_address = best.buffer_address;
   entry.typed_upload_caller_return_address = best.caller_return_address;
@@ -26520,6 +26533,7 @@ void UninstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system) {
     uint64_t typed_upload_scans = 0;
     uint64_t typed_upload_exact_matches = 0;
     uint64_t typed_upload_misses = 0;
+    uint64_t typed_upload_exact_used_vectors = 0;
     std::array<uint64_t, kVehicleShadowGeometryCorrelationCapacity>
         material_topology_keys{};
     size_t material_topology_group_count = 0;
@@ -26544,6 +26558,8 @@ void UninstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system) {
       typed_upload_scans += entry.typed_upload_scans;
       typed_upload_exact_matches += entry.typed_upload_exact_matches;
       typed_upload_misses += entry.typed_upload_misses;
+      typed_upload_exact_used_vectors +=
+          entry.typed_upload_exact_used_vectors;
       bool material_topology_seen = false;
       for (size_t material_index = 0;
            material_index < material_topology_group_count;
@@ -26728,11 +26744,16 @@ void UninstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system) {
             std::to_string(entry.typed_upload_exact_matches)},
            {"typed_upload_misses",
             std::to_string(entry.typed_upload_misses)},
+           {"typed_upload_exact_used_vectors",
+            std::to_string(entry.typed_upload_exact_used_vectors)},
            {"typed_upload_start_register_variations",
             std::to_string(
                 entry.typed_upload_start_register_variations)},
            {"typed_upload_vector_count_variations",
             std::to_string(entry.typed_upload_vector_count_variations)},
+           {"typed_upload_used_vector_count_variations",
+            std::to_string(
+                entry.typed_upload_used_vector_count_variations)},
            {"typed_upload_source_address_variations",
             std::to_string(
                 entry.typed_upload_source_address_variations)},
@@ -26748,6 +26769,10 @@ void UninstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system) {
            {"typed_upload_vector_count",
             entry.typed_upload_identity_valid
                 ? std::to_string(entry.typed_upload_vector_count)
+                : "unknown"},
+           {"typed_upload_used_vector_count",
+            entry.typed_upload_identity_valid
+                ? std::to_string(entry.typed_upload_used_vector_count)
                 : "unknown"},
            {"typed_upload_source_address",
             entry.typed_upload_identity_valid
@@ -26767,8 +26792,9 @@ void UninstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system) {
                     !entry.typed_upload_misses &&
                     !entry.typed_upload_start_register_variations &&
                     !entry.typed_upload_vector_count_variations &&
+                    !entry.typed_upload_used_vector_count_variations &&
                     !entry.typed_upload_caller_variations
-                ? "stable_exact_typed_upload_candidate"
+                ? "stable_exact_used_vertex_subset_candidate"
                 : "unresolved"},
            {"guest_payload_capture", "false"},
            {"native_draw", "false"},
@@ -26942,6 +26968,8 @@ void UninstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system) {
          {"typed_upload_exact_matches",
           std::to_string(typed_upload_exact_matches)},
          {"typed_upload_misses", std::to_string(typed_upload_misses)},
+         {"typed_upload_exact_used_vectors",
+          std::to_string(typed_upload_exact_used_vectors)},
          {"typed_upload_outcome_accounting_complete",
           typed_upload_exact_matches + typed_upload_misses ==
                   typed_upload_scans
@@ -26950,7 +26978,7 @@ void UninstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system) {
          {"typed_upload_maximum_age_frames",
           std::to_string(kVehicleConstantUploadMaximumAgeFrames)},
          {"typed_upload_contract",
-          "82435E78_exact_vertex_register_range_and_payload_hash"},
+          "82435E78_exact_shader_used_vertex_subset_hash"},
          {"material_topology_groups",
           std::to_string(material_topology_group_count)},
          {"material_topology_group_accounting_complete",

--- a/tools/summarize-native-renderer-vehicle-shadow-geometry.py
+++ b/tools/summarize-native-renderer-vehicle-shadow-geometry.py
@@ -5,7 +5,7 @@ import json
 from pathlib import Path
 
 
-SCHEMA = "pinyon-shift.native-renderer-vehicle-shadow-geometry.v9"
+SCHEMA = "pinyon-shift.native-renderer-vehicle-shadow-geometry.v10"
 CONFIG_EVENT = "native_renderer.discovery.vehicle_shadow_geometry_config"
 EPOCH_EVENT = "native_renderer.discovery.vehicle_shadow_geometry_epoch"
 CORRELATION_EVENT = (
@@ -131,7 +131,7 @@ def summarize(log_path):
     )
     require(
         configs[0].get("typed_constant_upload_contract")
-        == "exact_register_range_and_payload_hash",
+        == "exact_shader_used_vertex_subset_hash",
         "typed constant upload contract drift",
     )
     require(
@@ -267,6 +267,9 @@ def summarize(log_path):
         summary, "typed_upload_exact_matches"
     )
     typed_upload_misses = integer(summary, "typed_upload_misses")
+    typed_upload_exact_used_vectors = integer(
+        summary, "typed_upload_exact_used_vectors"
+    )
     require(
         typed_upload_scans == integer(summary, "color_draws_matched"),
         "typed upload scan accounting drift",
@@ -279,6 +282,10 @@ def summarize(log_path):
         typed_upload_exact_matches + typed_upload_misses
         == typed_upload_scans,
         "typed upload outcome drift",
+    )
+    require(
+        typed_upload_exact_used_vectors >= typed_upload_exact_matches,
+        "typed upload used-vector accounting drift",
     )
     require(
         integer(summary, "typed_upload_valid")
@@ -297,7 +304,7 @@ def summarize(log_path):
     )
     require(
         summary.get("typed_upload_contract")
-        == "82435E78_exact_vertex_register_range_and_payload_hash",
+        == "82435E78_exact_shader_used_vertex_subset_hash",
         "typed upload summary contract drift",
     )
     safety_events = [*configs, *epochs, *correlations, *candidates, summary]
@@ -487,14 +494,19 @@ def summarize(log_path):
         stable_typed_upload_candidate = (
             family_typed_upload_matches == integer(event, "draws")
             and family_typed_upload_misses == 0
+            and integer(event, "typed_upload_exact_used_vectors")
+            >= family_typed_upload_matches
             and integer(event, "typed_upload_start_register_variations") == 0
             and integer(event, "typed_upload_vector_count_variations") == 0
+            and integer(
+                event, "typed_upload_used_vector_count_variations"
+            ) == 0
             and integer(event, "typed_upload_caller_variations") == 0
         )
         require(
             event.get("typed_upload_classification")
             == (
-                "stable_exact_typed_upload_candidate"
+                "stable_exact_used_vertex_subset_candidate"
                 if stable_typed_upload_candidate
                 else "unresolved"
             ),
@@ -508,6 +520,11 @@ def summarize(log_path):
             require(
                 0 < integer(event, "typed_upload_vector_count") <= 64,
                 "candidate typed upload vector count drift",
+            )
+            require(
+                0 < integer(event, "typed_upload_used_vector_count")
+                <= integer(event, "typed_upload_vector_count"),
+                "candidate typed upload used vector count drift",
             )
             hexadecimal(event, "typed_upload_source_address")
             hexadecimal(event, "typed_upload_buffer_address")
@@ -716,7 +733,7 @@ def summarize(log_path):
         event
         for event in candidates
         if event.get("typed_upload_classification")
-        == "stable_exact_typed_upload_candidate"
+        == "stable_exact_used_vertex_subset_candidate"
     ]
     complete_typed_upload_bridge_candidate = (
         len(candidates) == 30
@@ -814,6 +831,7 @@ def summarize(log_path):
             "scans": typed_upload_scans,
             "exact_matches": typed_upload_exact_matches,
             "misses": typed_upload_misses,
+            "exact_used_vectors": typed_upload_exact_used_vectors,
             "stable_candidate_families": len(
                 stable_typed_upload_candidates
             ),

--- a/tools/tests/test_native_renderer_vehicle_shadow_geometry.py
+++ b/tools/tests/test_native_renderer_vehicle_shadow_geometry.py
@@ -27,7 +27,7 @@ class VehicleShadowGeometryTests(unittest.TestCase):
                 "event": MODULE.CONFIG_EVENT,
                 "status": "armed",
                 "typed_constant_upload_hook": "82435E78:r3,r4,r5,r6,lr",
-                "typed_constant_upload_contract": "exact_register_range_and_payload_hash",
+                "typed_constant_upload_contract": "exact_shader_used_vertex_subset_hash",
                 "typed_constant_upload_capacity": "8192",
                 "typed_constant_upload_maximum_age_frames": "1",
                 **safety,
@@ -115,17 +115,20 @@ class VehicleShadowGeometryTests(unittest.TestCase):
                 "typed_upload_scans": "3",
                 "typed_upload_exact_matches": "3",
                 "typed_upload_misses": "0",
+                "typed_upload_exact_used_vectors": "9",
                 "typed_upload_start_register_variations": "0",
                 "typed_upload_vector_count_variations": "0",
+                "typed_upload_used_vector_count_variations": "0",
                 "typed_upload_source_address_variations": "2",
                 "typed_upload_buffer_address_variations": "0",
                 "typed_upload_caller_variations": "0",
                 "typed_upload_start_register": "208",
                 "typed_upload_vector_count": "4",
+                "typed_upload_used_vector_count": "3",
                 "typed_upload_source_address": "7FFF1000",
                 "typed_upload_buffer_address": "50001000",
                 "typed_upload_caller_return_address": "8240EB60",
-                "typed_upload_classification": "stable_exact_typed_upload_candidate",
+                "typed_upload_classification": "stable_exact_used_vertex_subset_candidate",
                 **safety,
             },
             {
@@ -255,9 +258,10 @@ class VehicleShadowGeometryTests(unittest.TestCase):
                 "typed_upload_scans": "3",
                 "typed_upload_exact_matches": "3",
                 "typed_upload_misses": "0",
+                "typed_upload_exact_used_vectors": "9",
                 "typed_upload_outcome_accounting_complete": "true",
                 "typed_upload_maximum_age_frames": "1",
-                "typed_upload_contract": "82435E78_exact_vertex_register_range_and_payload_hash",
+                "typed_upload_contract": "82435E78_exact_shader_used_vertex_subset_hash",
                 "material_topology_groups": "1",
                 "material_topology_group_accounting_complete": "true",
                 "material_topology_contract": "shader_specialization_render_state_texture_layout",
@@ -335,6 +339,9 @@ class VehicleShadowGeometryTests(unittest.TestCase):
             ],
         )
         self.assertEqual(3, report["typed_constant_upload"]["exact_matches"])
+        self.assertEqual(
+            9, report["typed_constant_upload"]["exact_used_vectors"]
+        )
         self.assertEqual(
             1, report["typed_constant_upload"]["stable_candidate_families"]
         )
@@ -478,6 +485,11 @@ class VehicleShadowGeometryTests(unittest.TestCase):
         self.assertIn("ObserveVehicleColorConstantIdentity", source)
         self.assertIn("ObserveVehicleTypedConstantUpload", source)
         self.assertIn("ObserveVehicleColorTypedConstantUpload", source)
+        self.assertIn("MatchObservedVertexConstantSubset", source)
+        self.assertNotIn("HashObservedVertexConstantRange", source)
+        self.assertIn(
+            '"82435E78_exact_shader_used_vertex_subset_hash"', source
+        )
         self.assertIn("constant_position_accounting_complete", source)
         self.assertIn("typed_upload_outcome_accounting_complete", source)
         self.assertIn(


### PR DESCRIPTION
## Summary
- record payload-free per-vector hashes for typed title uploads
- join only the exact upload subset referenced by the active vehicle shader
- retain one-frame freshness and stable caller/range/subset qualification
- document the first AppData rejection and the corrected v10 contract

## Evidence
- first run: 541 exact epochs, 16,230 vehicle draw scans, 2,419,537 strictly accounted upload observations, zero whole-range matches
- 613 repository tests
- incremental Release build with 103 ReXGlue patches
- git diff --check