### PR TITLE
fix(renderer): avoid typed upload ledger stack overflow

### DIFF
--- a/src/native_renderer/graphics_hooks.cpp
+++ b/src/native_renderer/graphics_hooks.cpp
@@ -24091,7 +24091,9 @@ void ConfigureVehicleDiscovery(bool census_requested,
   }
   {
     std::scoped_lock lock(g_vehicle_constant_upload_mutex);
-    g_vehicle_constant_uploads = {};
+    std::fill(g_vehicle_constant_uploads.begin(),
+              g_vehicle_constant_uploads.end(),
+              VehicleConstantUploadEntry{});
     g_vehicle_constant_upload_observations = 0;
     g_vehicle_constant_upload_valid = 0;
     g_vehicle_constant_upload_invalid_register_range = 0;

--- a/tools/tests/test_native_renderer_vehicle_shadow_geometry.py
+++ b/tools/tests/test_native_renderer_vehicle_shadow_geometry.py
@@ -487,6 +487,9 @@ class VehicleShadowGeometryTests(unittest.TestCase):
         self.assertIn("ObserveVehicleColorTypedConstantUpload", source)
         self.assertIn("MatchObservedVertexConstantSubset", source)
         self.assertNotIn("HashObservedVertexConstantRange", source)
+        self.assertNotIn("g_vehicle_constant_uploads = {};", source)
+        self.assertIn("g_vehicle_constant_uploads.begin()", source)
+        self.assertIn("VehicleConstantUploadEntry{}", source)
         self.assertIn(
             '"82435E78_exact_shader_used_vertex_subset_hash"', source
         )


### PR DESCRIPTION
## Summary
- reset the expanded typed-upload ledger element-by-element
- avoid a multi-megabyte stack temporary during census installation
- cover the safe reset shape in the native renderer contract test

## Validation
- 553 native-renderer tests
- 613 repository tests
- incremental Release build
- git diff --check