### PR TITLE
feat(renderer): classify typed upload join misses

### DIFF
--- a/docs/native-renderer/REPRIORITIZED_PLAN.md
+++ b/docs/native-renderer/REPRIORITIZED_PLAN.md
@@ -696,6 +696,16 @@ consumed subset size. Runtime proof remains batched with the next substantial
 C4 slice; the corrected contract and first-run evidence are documented in
 [`VEHICLE_TYPED_CONSTANT_UPLOAD.md`](VEHICLE_TYPED_CONSTANT_UPLOAD.md).
 
+Shader-used subset qualification result: the AppData-backed
+`20260831T184645Z-p11956` run exited normally and strictly accounted 2,245,612
+writer observations, including 469,815 valid uploads and zero invalid source
+ranges. It reproduced all 30 families across 15,750 exact geometry matches but
+the subset rule still produced zero upload matches. The join is therefore not
+promoted. The next bounded slice partitions every fresh candidate into
+no-overlap, hash-mismatch, or exact outcomes and records each family's observed
+register envelope without exporting values. This selects the next exact
+contract before any semantic caller bridge, native admission, or suppression.
+
 ### C5. Sky, atmosphere, and global lighting
 
 - Replace the qualified sky/global-light families.

--- a/docs/native-renderer/VEHICLE_TYPED_CONSTANT_UPLOAD.md
+++ b/docs/native-renderer/VEHICLE_TYPED_CONSTANT_UPLOAD.md
@@ -1,8 +1,8 @@
 # Vehicle typed constant-upload join
 
-Status: the first default-off AppData qualification rejected the whole-range
-join; an exact shader-used-vector join is implemented for the next batched
-qualification.
+Status: both the whole-range and shader-used-subset joins are rejected. The
+next bounded run will partition each fresh candidate as no register overlap,
+hash mismatch, or exact subset and report only register envelopes and counts.
 
 ## Proven title boundary
 
@@ -63,10 +63,27 @@ therefore compares only the exact shader-used intersection while retaining the
 same one-frame freshness, caller provenance, payload-free output, and Xenos
 authority.
 
-This proves which typed writes feed the prepared vehicle draws. It does not by
-itself convert reference-space constants to a world transform or label a
-vehicle as the player. The runtime result will determine which exact register
-ranges and title callers should receive the next semantic discriminator.
+## Shader-used subset runtime result
+
+The AppData-backed `20260831T184645Z-p11956` run exited normally after the
+expanded ledger reset was changed to avoid a multi-megabyte stack temporary.
+It committed 525 exact epochs and 15,750 full-resource matches across all 30
+families. The writer strictly accounted 2,245,612 observations: 469,815 valid
+uploads, 1,775,797 rejected register ranges, and zero invalid source ranges.
+
+The v10 shader-used subset rule also produced zero matches across all 15,750
+draw scans. This rejects the second join rule without weakening the proven
+writer coverage. A narrow diagnostic now records the observed shader register
+envelope and partitions every fresh upload candidate into no-overlap,
+hash-mismatch, or exact-subset outcomes. It does not export constant values.
+The v11 qualifier requires complete candidate accounting. That single
+partition will distinguish register-space/freshness drift from a payload-
+representation mismatch before another join rule is proposed.
+
+The generic writer boundary and caller provenance are proved, but neither
+runtime join has yet proved which writes feed the prepared vehicle draws. No
+transform or player label may depend on this evidence until the diagnostic
+partition selects an exact register-space and payload contract.
 
 ## Safety boundary
 

--- a/src/native_renderer/graphics_hooks.cpp
+++ b/src/native_renderer/graphics_hooks.cpp
@@ -655,6 +655,10 @@ struct VehicleShadowGeometryCorrelationEntry {
   uint64_t constant_forward_identity_variations = 0;
   uint64_t constant_forward_register_variations = 0;
   uint64_t typed_upload_scans = 0;
+  uint64_t typed_upload_fresh_candidates = 0;
+  uint64_t typed_upload_no_overlap_candidates = 0;
+  uint64_t typed_upload_hash_mismatch_candidates = 0;
+  uint64_t typed_upload_exact_candidates = 0;
   uint64_t typed_upload_exact_matches = 0;
   uint64_t typed_upload_misses = 0;
   uint64_t typed_upload_exact_used_vectors = 0;
@@ -692,10 +696,13 @@ struct VehicleShadowGeometryCorrelationEntry {
   uint32_t typed_upload_source_address = 0;
   uint32_t typed_upload_buffer_address = 0;
   uint32_t typed_upload_caller_return_address = 0;
+  uint32_t typed_upload_observed_register_min = 0;
+  uint32_t typed_upload_observed_register_max = 0;
   bool full_geometry_match = false;
   bool constant_position_identity_valid = false;
   bool constant_forward_identity_valid = false;
   bool typed_upload_identity_valid = false;
+  bool typed_upload_observed_register_range_valid = false;
   bool occupied = false;
 };
 
@@ -711,6 +718,12 @@ struct VehicleConstantUploadEntry {
              rex::system::kGraphicsFloatConstantObservationLimit>
       vector_hashes{};
   bool occupied = false;
+};
+
+enum class VehicleConstantUploadSubsetResult : uint32_t {
+  kNoOverlap = 0,
+  kHashMismatch,
+  kExact,
 };
 
 struct VehicleShadowColorRun {
@@ -15363,12 +15376,12 @@ void ObserveVehicleTypedConstantUpload(uint32_t buffer_address,
   ++g_vehicle_constant_upload_valid;
 }
 
-bool MatchObservedVertexConstantSubset(
+VehicleConstantUploadSubsetResult MatchObservedVertexConstantSubset(
     const rex::system::GraphicsDrawObservation &observation,
     const VehicleConstantUploadEntry &upload,
     uint32_t *matched_vector_count) {
   if (!matched_vector_count) {
-    return false;
+    return VehicleConstantUploadSubsetResult::kNoOverlap;
   }
   *matched_vector_count = 0;
   const uint32_t observed_count = std::min(
@@ -15387,17 +15400,37 @@ bool MatchObservedVertexConstantSubset(
         constant.index, 1,
         std::span(constant.values, std::size(constant.values)));
     if (observed_hash != upload.vector_hashes[vector_offset]) {
-      return false;
+      return VehicleConstantUploadSubsetResult::kHashMismatch;
     }
     ++*matched_vector_count;
   }
-  return *matched_vector_count != 0;
+  return *matched_vector_count
+             ? VehicleConstantUploadSubsetResult::kExact
+             : VehicleConstantUploadSubsetResult::kNoOverlap;
 }
 
 void ObserveVehicleColorTypedConstantUpload(
     const rex::system::GraphicsDrawObservation &observation,
     VehicleShadowGeometryCorrelationEntry &entry) {
   ++entry.typed_upload_scans;
+  const uint32_t observed_count = std::min(
+      observation.vertex_float_constant_count,
+      rex::system::kGraphicsFloatConstantObservationLimit);
+  for (uint32_t observed_offset = 0; observed_offset < observed_count;
+       ++observed_offset) {
+    const uint32_t observed_register =
+        observation.vertex_float_constants[observed_offset].index;
+    if (!entry.typed_upload_observed_register_range_valid) {
+      entry.typed_upload_observed_register_min = observed_register;
+      entry.typed_upload_observed_register_max = observed_register;
+      entry.typed_upload_observed_register_range_valid = true;
+    } else {
+      entry.typed_upload_observed_register_min = std::min(
+          entry.typed_upload_observed_register_min, observed_register);
+      entry.typed_upload_observed_register_max = std::max(
+          entry.typed_upload_observed_register_max, observed_register);
+    }
+  }
   VehicleConstantUploadEntry best{};
   uint32_t best_matched_vector_count = 0;
   {
@@ -15409,11 +15442,20 @@ void ObserveVehicleColorTypedConstantUpload(
               kVehicleConstantUploadMaximumAgeFrames) {
         continue;
       }
+      ++entry.typed_upload_fresh_candidates;
       uint32_t matched_vector_count = 0;
-      if (!MatchObservedVertexConstantSubset(
-              observation, upload, &matched_vector_count)) {
+      const VehicleConstantUploadSubsetResult subset_result =
+          MatchObservedVertexConstantSubset(
+              observation, upload, &matched_vector_count);
+      if (subset_result == VehicleConstantUploadSubsetResult::kNoOverlap) {
+        ++entry.typed_upload_no_overlap_candidates;
         continue;
       }
+      if (subset_result == VehicleConstantUploadSubsetResult::kHashMismatch) {
+        ++entry.typed_upload_hash_mismatch_candidates;
+        continue;
+      }
+      ++entry.typed_upload_exact_candidates;
       if (!best.occupied ||
           matched_vector_count > best_matched_vector_count ||
           (matched_vector_count == best_matched_vector_count &&
@@ -26533,6 +26575,10 @@ void UninstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system) {
     uint64_t constant_forward_ambiguous_matches = 0;
     uint64_t constant_forward_misses = 0;
     uint64_t typed_upload_scans = 0;
+    uint64_t typed_upload_fresh_candidates = 0;
+    uint64_t typed_upload_no_overlap_candidates = 0;
+    uint64_t typed_upload_hash_mismatch_candidates = 0;
+    uint64_t typed_upload_exact_candidates = 0;
     uint64_t typed_upload_exact_matches = 0;
     uint64_t typed_upload_misses = 0;
     uint64_t typed_upload_exact_used_vectors = 0;
@@ -26558,6 +26604,12 @@ void UninstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system) {
           entry.constant_forward_ambiguous_matches;
       constant_forward_misses += entry.constant_forward_misses;
       typed_upload_scans += entry.typed_upload_scans;
+      typed_upload_fresh_candidates += entry.typed_upload_fresh_candidates;
+      typed_upload_no_overlap_candidates +=
+          entry.typed_upload_no_overlap_candidates;
+      typed_upload_hash_mismatch_candidates +=
+          entry.typed_upload_hash_mismatch_candidates;
+      typed_upload_exact_candidates += entry.typed_upload_exact_candidates;
       typed_upload_exact_matches += entry.typed_upload_exact_matches;
       typed_upload_misses += entry.typed_upload_misses;
       typed_upload_exact_used_vectors +=
@@ -26742,6 +26794,14 @@ void UninstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system) {
                 : "unresolved"},
            {"typed_upload_scans",
             std::to_string(entry.typed_upload_scans)},
+           {"typed_upload_fresh_candidates",
+            std::to_string(entry.typed_upload_fresh_candidates)},
+           {"typed_upload_no_overlap_candidates",
+            std::to_string(entry.typed_upload_no_overlap_candidates)},
+           {"typed_upload_hash_mismatch_candidates",
+            std::to_string(entry.typed_upload_hash_mismatch_candidates)},
+           {"typed_upload_exact_candidates",
+            std::to_string(entry.typed_upload_exact_candidates)},
            {"typed_upload_exact_matches",
             std::to_string(entry.typed_upload_exact_matches)},
            {"typed_upload_misses",
@@ -26788,6 +26848,14 @@ void UninstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system) {
             entry.typed_upload_identity_valid
                 ? fmt::format("{:08X}",
                               entry.typed_upload_caller_return_address)
+                : "unknown"},
+           {"typed_upload_observed_register_min",
+            entry.typed_upload_observed_register_range_valid
+                ? std::to_string(entry.typed_upload_observed_register_min)
+                : "unknown"},
+           {"typed_upload_observed_register_max",
+            entry.typed_upload_observed_register_range_valid
+                ? std::to_string(entry.typed_upload_observed_register_max)
                 : "unknown"},
            {"typed_upload_classification",
             entry.typed_upload_exact_matches == entry.draws &&
@@ -26967,6 +27035,21 @@ void UninstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system) {
          {"typed_upload_capacity",
           std::to_string(kVehicleConstantUploadCapacity)},
          {"typed_upload_scans", std::to_string(typed_upload_scans)},
+         {"typed_upload_fresh_candidates",
+          std::to_string(typed_upload_fresh_candidates)},
+         {"typed_upload_no_overlap_candidates",
+          std::to_string(typed_upload_no_overlap_candidates)},
+         {"typed_upload_hash_mismatch_candidates",
+          std::to_string(typed_upload_hash_mismatch_candidates)},
+         {"typed_upload_exact_candidates",
+          std::to_string(typed_upload_exact_candidates)},
+         {"typed_upload_candidate_accounting_complete",
+          typed_upload_no_overlap_candidates +
+                      typed_upload_hash_mismatch_candidates +
+                      typed_upload_exact_candidates ==
+                  typed_upload_fresh_candidates
+              ? "true"
+              : "false"},
          {"typed_upload_exact_matches",
           std::to_string(typed_upload_exact_matches)},
          {"typed_upload_misses", std::to_string(typed_upload_misses)},

--- a/tools/summarize-native-renderer-vehicle-shadow-geometry.py
+++ b/tools/summarize-native-renderer-vehicle-shadow-geometry.py
@@ -5,7 +5,7 @@ import json
 from pathlib import Path
 
 
-SCHEMA = "pinyon-shift.native-renderer-vehicle-shadow-geometry.v10"
+SCHEMA = "pinyon-shift.native-renderer-vehicle-shadow-geometry.v11"
 CONFIG_EVENT = "native_renderer.discovery.vehicle_shadow_geometry_config"
 EPOCH_EVENT = "native_renderer.discovery.vehicle_shadow_geometry_epoch"
 CORRELATION_EVENT = (
@@ -270,6 +270,18 @@ def summarize(log_path):
     typed_upload_exact_used_vectors = integer(
         summary, "typed_upload_exact_used_vectors"
     )
+    typed_upload_fresh_candidates = integer(
+        summary, "typed_upload_fresh_candidates"
+    )
+    typed_upload_no_overlap_candidates = integer(
+        summary, "typed_upload_no_overlap_candidates"
+    )
+    typed_upload_hash_mismatch_candidates = integer(
+        summary, "typed_upload_hash_mismatch_candidates"
+    )
+    typed_upload_exact_candidates = integer(
+        summary, "typed_upload_exact_candidates"
+    )
     require(
         typed_upload_scans == integer(summary, "color_draws_matched"),
         "typed upload scan accounting drift",
@@ -286,6 +298,17 @@ def summarize(log_path):
     require(
         typed_upload_exact_used_vectors >= typed_upload_exact_matches,
         "typed upload used-vector accounting drift",
+    )
+    require(
+        summary.get("typed_upload_candidate_accounting_complete") == "true",
+        "typed upload candidate accounting drift",
+    )
+    require(
+        typed_upload_no_overlap_candidates
+        + typed_upload_hash_mismatch_candidates
+        + typed_upload_exact_candidates
+        == typed_upload_fresh_candidates,
+        "typed upload candidate outcome drift",
     )
     require(
         integer(summary, "typed_upload_valid")
@@ -482,6 +505,18 @@ def summarize(log_path):
             event, "typed_upload_exact_matches"
         )
         family_typed_upload_misses = integer(event, "typed_upload_misses")
+        family_typed_upload_fresh_candidates = integer(
+            event, "typed_upload_fresh_candidates"
+        )
+        family_typed_upload_no_overlap_candidates = integer(
+            event, "typed_upload_no_overlap_candidates"
+        )
+        family_typed_upload_hash_mismatch_candidates = integer(
+            event, "typed_upload_hash_mismatch_candidates"
+        )
+        family_typed_upload_exact_candidates = integer(
+            event, "typed_upload_exact_candidates"
+        )
         require(
             family_typed_upload_scans == integer(event, "draws"),
             "candidate typed upload scan accounting drift",
@@ -490,6 +525,23 @@ def summarize(log_path):
             family_typed_upload_matches + family_typed_upload_misses
             == family_typed_upload_scans,
             "candidate typed upload outcome drift",
+        )
+        require(
+            family_typed_upload_no_overlap_candidates
+            + family_typed_upload_hash_mismatch_candidates
+            + family_typed_upload_exact_candidates
+            == family_typed_upload_fresh_candidates,
+            "candidate typed upload candidate outcome drift",
+        )
+        observed_register_min = integer(
+            event, "typed_upload_observed_register_min"
+        )
+        observed_register_max = integer(
+            event, "typed_upload_observed_register_max"
+        )
+        require(
+            0 <= observed_register_min <= observed_register_max < 256,
+            "candidate typed upload observed register range drift",
         )
         stable_typed_upload_candidate = (
             family_typed_upload_matches == integer(event, "draws")
@@ -832,6 +884,12 @@ def summarize(log_path):
             "exact_matches": typed_upload_exact_matches,
             "misses": typed_upload_misses,
             "exact_used_vectors": typed_upload_exact_used_vectors,
+            "fresh_candidates": typed_upload_fresh_candidates,
+            "no_overlap_candidates": typed_upload_no_overlap_candidates,
+            "hash_mismatch_candidates": (
+                typed_upload_hash_mismatch_candidates
+            ),
+            "exact_candidates": typed_upload_exact_candidates,
             "stable_candidate_families": len(
                 stable_typed_upload_candidates
             ),

--- a/tools/tests/test_native_renderer_vehicle_shadow_geometry.py
+++ b/tools/tests/test_native_renderer_vehicle_shadow_geometry.py
@@ -113,6 +113,10 @@ class VehicleShadowGeometryTests(unittest.TestCase):
                 "closest_forward_delta_squared": "0.01",
                 "constant_identity_classification": "stable_tight_position_candidate",
                 "typed_upload_scans": "3",
+                "typed_upload_fresh_candidates": "12",
+                "typed_upload_no_overlap_candidates": "6",
+                "typed_upload_hash_mismatch_candidates": "3",
+                "typed_upload_exact_candidates": "3",
                 "typed_upload_exact_matches": "3",
                 "typed_upload_misses": "0",
                 "typed_upload_exact_used_vectors": "9",
@@ -128,6 +132,8 @@ class VehicleShadowGeometryTests(unittest.TestCase):
                 "typed_upload_source_address": "7FFF1000",
                 "typed_upload_buffer_address": "50001000",
                 "typed_upload_caller_return_address": "8240EB60",
+                "typed_upload_observed_register_min": "208",
+                "typed_upload_observed_register_max": "211",
                 "typed_upload_classification": "stable_exact_used_vertex_subset_candidate",
                 **safety,
             },
@@ -256,6 +262,11 @@ class VehicleShadowGeometryTests(unittest.TestCase):
                 "typed_upload_overwrites": "0",
                 "typed_upload_capacity": "8192",
                 "typed_upload_scans": "3",
+                "typed_upload_fresh_candidates": "12",
+                "typed_upload_no_overlap_candidates": "6",
+                "typed_upload_hash_mismatch_candidates": "3",
+                "typed_upload_exact_candidates": "3",
+                "typed_upload_candidate_accounting_complete": "true",
                 "typed_upload_exact_matches": "3",
                 "typed_upload_misses": "0",
                 "typed_upload_exact_used_vectors": "9",
@@ -339,6 +350,16 @@ class VehicleShadowGeometryTests(unittest.TestCase):
             ],
         )
         self.assertEqual(3, report["typed_constant_upload"]["exact_matches"])
+        self.assertEqual(
+            12, report["typed_constant_upload"]["fresh_candidates"]
+        )
+        self.assertEqual(
+            6, report["typed_constant_upload"]["no_overlap_candidates"]
+        )
+        self.assertEqual(
+            3,
+            report["typed_constant_upload"]["hash_mismatch_candidates"],
+        )
         self.assertEqual(
             9, report["typed_constant_upload"]["exact_used_vectors"]
         )
@@ -427,6 +448,14 @@ class VehicleShadowGeometryTests(unittest.TestCase):
         events = self.fixture()
         events[-1]["typed_upload_exact_matches"] = "2"
         with self.assertRaisesRegex(ValueError, "typed upload outcome drift"):
+            self.summarize(events)
+
+    def test_rejects_typed_upload_candidate_accounting_drift(self):
+        events = self.fixture()
+        events[-1]["typed_upload_no_overlap_candidates"] = "5"
+        with self.assertRaisesRegex(
+            ValueError, "typed upload candidate outcome drift"
+        ):
             self.summarize(events)
 
     def test_rejects_private_capture_authority_drift(self):


### PR DESCRIPTION
## Summary
- partition fresh typed-upload candidates into no-overlap, hash-mismatch, and exact outcomes
- report per-family shader register envelopes without exporting constant values
- record the zero-match v10 AppData evidence and advance the qualifier to v11

## Validation
- 554 native-renderer tests
- 614 repository tests
- full Release build
- git diff --check