### PR TITLE
feat(renderer): trace typed uploads per vertex register

### DIFF
--- a/docs/native-renderer/REPRIORITIZED_PLAN.md
+++ b/docs/native-renderer/REPRIORITIZED_PLAN.md
@@ -706,6 +706,15 @@ no-overlap, hash-mismatch, or exact outcomes and records each family's observed
 register envelope without exporting values. This selects the next exact
 contract before any semantic caller bridge, native admission, or suppression.
 
+The short v11 run `20260831T190405Z-p11884` completed that partition across
+11,880 draws and 8,331,453 fresh candidates. It found 1,330,751 real register
+overlaps and the same observed `0..255` register envelope in all 30 families;
+therefore neither freshness nor register space explains the failed join. The
+v12 contract reconstructs exact last-writer provenance per shader-used
+register, allowing later writes to replace unrelated vectors from a broader
+upload without erasing exact matches. It still requires exact index/hash
+equality for every credited register and changes no draw authority.
+
 ### C5. Sky, atmosphere, and global lighting
 
 - Replace the qualified sky/global-light families.

--- a/docs/native-renderer/VEHICLE_TYPED_CONSTANT_UPLOAD.md
+++ b/docs/native-renderer/VEHICLE_TYPED_CONSTANT_UPLOAD.md
@@ -1,8 +1,8 @@
 # Vehicle typed constant-upload join
 
-Status: both the whole-range and shader-used-subset joins are rejected. The
-next bounded run will partition each fresh candidate as no register overlap,
-hash mismatch, or exact subset and report only register envelopes and counts.
+Status: whole-range and all-overlapping-vector joins are rejected. The v11
+partition proved fresh register overlap and selected an exact per-register
+last-writer join for the next batched qualification.
 
 ## Proven title boundary
 
@@ -76,9 +76,19 @@ draw scans. This rejects the second join rule without weakening the proven
 writer coverage. A narrow diagnostic now records the observed shader register
 envelope and partitions every fresh upload candidate into no-overlap,
 hash-mismatch, or exact-subset outcomes. It does not export constant values.
-The v11 qualifier requires complete candidate accounting. That single
-partition will distinguish register-space/freshness drift from a payload-
-representation mismatch before another join rule is proposed.
+The v11 qualifier requires complete candidate accounting. The short
+AppData-backed `20260831T190405Z-p11884` run then reproduced all 30 families
+across 11,880 exact geometry matches. It classified 8,331,453 fresh upload
+candidates: 7,000,702 had no used-register overlap and 1,330,751 overlapped
+but failed the all-vector rule. Every family observed shader registers 0
+through 255, proving that freshness and register space are not the blocker.
+
+The v12 join now credits each shader-used register independently when its
+index and semantic hash match exactly. Later writes may legitimately replace
+other registers from the same broader title upload, so those unrelated
+mismatches no longer erase exact provenance. The contributing upload with the
+most exact registers wins, with newest sequence as the tie-breaker. Payload
+values remain in memory only and Xenos remains authoritative.
 
 The generic writer boundary and caller provenance are proved, but neither
 runtime join has yet proved which writes feed the prepared vehicle draws. No

--- a/src/native_renderer/graphics_hooks.cpp
+++ b/src/native_renderer/graphics_hooks.cpp
@@ -9164,7 +9164,7 @@ void ConfigureIsolatedDraw() {
          {"color_match", "exact_full_or_index_plus_vertex_resource"},
          {"typed_constant_upload_hook", "82435E78:r3,r4,r5,r6,lr"},
          {"typed_constant_upload_contract",
-          "exact_shader_used_vertex_subset_hash"},
+          "exact_shader_used_vertex_register_hash"},
          {"typed_constant_upload_capacity",
           std::to_string(kVehicleConstantUploadCapacity)},
          {"typed_constant_upload_maximum_age_frames",
@@ -15384,6 +15384,7 @@ VehicleConstantUploadSubsetResult MatchObservedVertexConstantSubset(
     return VehicleConstantUploadSubsetResult::kNoOverlap;
   }
   *matched_vector_count = 0;
+  uint32_t mismatched_vector_count = 0;
   const uint32_t observed_count = std::min(
       observation.vertex_float_constant_count,
       rex::system::kGraphicsFloatConstantObservationLimit);
@@ -15400,13 +15401,16 @@ VehicleConstantUploadSubsetResult MatchObservedVertexConstantSubset(
         constant.index, 1,
         std::span(constant.values, std::size(constant.values)));
     if (observed_hash != upload.vector_hashes[vector_offset]) {
-      return VehicleConstantUploadSubsetResult::kHashMismatch;
+      ++mismatched_vector_count;
+      continue;
     }
     ++*matched_vector_count;
   }
   return *matched_vector_count
              ? VehicleConstantUploadSubsetResult::kExact
-             : VehicleConstantUploadSubsetResult::kNoOverlap;
+             : (mismatched_vector_count
+                    ? VehicleConstantUploadSubsetResult::kHashMismatch
+                    : VehicleConstantUploadSubsetResult::kNoOverlap);
 }
 
 void ObserveVehicleColorTypedConstantUpload(
@@ -26864,7 +26868,7 @@ void UninstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system) {
                     !entry.typed_upload_vector_count_variations &&
                     !entry.typed_upload_used_vector_count_variations &&
                     !entry.typed_upload_caller_variations
-                ? "stable_exact_used_vertex_subset_candidate"
+                ? "stable_exact_vertex_register_candidate"
                 : "unresolved"},
            {"guest_payload_capture", "false"},
            {"native_draw", "false"},
@@ -27063,7 +27067,7 @@ void UninstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system) {
          {"typed_upload_maximum_age_frames",
           std::to_string(kVehicleConstantUploadMaximumAgeFrames)},
          {"typed_upload_contract",
-          "82435E78_exact_shader_used_vertex_subset_hash"},
+          "82435E78_exact_shader_used_vertex_register_hash"},
          {"material_topology_groups",
           std::to_string(material_topology_group_count)},
          {"material_topology_group_accounting_complete",

--- a/tools/summarize-native-renderer-vehicle-shadow-geometry.py
+++ b/tools/summarize-native-renderer-vehicle-shadow-geometry.py
@@ -5,7 +5,7 @@ import json
 from pathlib import Path
 
 
-SCHEMA = "pinyon-shift.native-renderer-vehicle-shadow-geometry.v11"
+SCHEMA = "pinyon-shift.native-renderer-vehicle-shadow-geometry.v12"
 CONFIG_EVENT = "native_renderer.discovery.vehicle_shadow_geometry_config"
 EPOCH_EVENT = "native_renderer.discovery.vehicle_shadow_geometry_epoch"
 CORRELATION_EVENT = (
@@ -131,7 +131,7 @@ def summarize(log_path):
     )
     require(
         configs[0].get("typed_constant_upload_contract")
-        == "exact_shader_used_vertex_subset_hash",
+        == "exact_shader_used_vertex_register_hash",
         "typed constant upload contract drift",
     )
     require(
@@ -327,7 +327,7 @@ def summarize(log_path):
     )
     require(
         summary.get("typed_upload_contract")
-        == "82435E78_exact_shader_used_vertex_subset_hash",
+        == "82435E78_exact_shader_used_vertex_register_hash",
         "typed upload summary contract drift",
     )
     safety_events = [*configs, *epochs, *correlations, *candidates, summary]
@@ -558,7 +558,7 @@ def summarize(log_path):
         require(
             event.get("typed_upload_classification")
             == (
-                "stable_exact_used_vertex_subset_candidate"
+                "stable_exact_vertex_register_candidate"
                 if stable_typed_upload_candidate
                 else "unresolved"
             ),
@@ -785,7 +785,7 @@ def summarize(log_path):
         event
         for event in candidates
         if event.get("typed_upload_classification")
-        == "stable_exact_used_vertex_subset_candidate"
+        == "stable_exact_vertex_register_candidate"
     ]
     complete_typed_upload_bridge_candidate = (
         len(candidates) == 30

--- a/tools/tests/test_native_renderer_vehicle_shadow_geometry.py
+++ b/tools/tests/test_native_renderer_vehicle_shadow_geometry.py
@@ -27,7 +27,7 @@ class VehicleShadowGeometryTests(unittest.TestCase):
                 "event": MODULE.CONFIG_EVENT,
                 "status": "armed",
                 "typed_constant_upload_hook": "82435E78:r3,r4,r5,r6,lr",
-                "typed_constant_upload_contract": "exact_shader_used_vertex_subset_hash",
+                "typed_constant_upload_contract": "exact_shader_used_vertex_register_hash",
                 "typed_constant_upload_capacity": "8192",
                 "typed_constant_upload_maximum_age_frames": "1",
                 **safety,
@@ -134,7 +134,7 @@ class VehicleShadowGeometryTests(unittest.TestCase):
                 "typed_upload_caller_return_address": "8240EB60",
                 "typed_upload_observed_register_min": "208",
                 "typed_upload_observed_register_max": "211",
-                "typed_upload_classification": "stable_exact_used_vertex_subset_candidate",
+                "typed_upload_classification": "stable_exact_vertex_register_candidate",
                 **safety,
             },
             {
@@ -272,7 +272,7 @@ class VehicleShadowGeometryTests(unittest.TestCase):
                 "typed_upload_exact_used_vectors": "9",
                 "typed_upload_outcome_accounting_complete": "true",
                 "typed_upload_maximum_age_frames": "1",
-                "typed_upload_contract": "82435E78_exact_shader_used_vertex_subset_hash",
+                "typed_upload_contract": "82435E78_exact_shader_used_vertex_register_hash",
                 "material_topology_groups": "1",
                 "material_topology_group_accounting_complete": "true",
                 "material_topology_contract": "shader_specialization_render_state_texture_layout",
@@ -515,12 +515,13 @@ class VehicleShadowGeometryTests(unittest.TestCase):
         self.assertIn("ObserveVehicleTypedConstantUpload", source)
         self.assertIn("ObserveVehicleColorTypedConstantUpload", source)
         self.assertIn("MatchObservedVertexConstantSubset", source)
+        self.assertIn("mismatched_vector_count", source)
         self.assertNotIn("HashObservedVertexConstantRange", source)
         self.assertNotIn("g_vehicle_constant_uploads = {};", source)
         self.assertIn("g_vehicle_constant_uploads.begin()", source)
         self.assertIn("VehicleConstantUploadEntry{}", source)
         self.assertIn(
-            '"82435E78_exact_shader_used_vertex_subset_hash"', source
+            '"82435E78_exact_shader_used_vertex_register_hash"', source
         )
         self.assertIn("constant_position_accounting_complete", source)
         self.assertIn("typed_upload_outcome_accounting_complete", source)


### PR DESCRIPTION
## Summary
- reconstruct exact typed-upload provenance per shader-used vertex register
- allow later writes to unrelated vectors without erasing exact provenance
- advance the qualifier to v12 and document the decisive v11 runtime partition

## Validation
- 554 native-renderer tests
- 614 repository tests
- full Release build
- git diff --check