### PR TITLE
feat(renderer): trace shader constants to command packets

### DIFF
--- a/docs/native-renderer/REPRIORITIZED_PLAN.md
+++ b/docs/native-renderer/REPRIORITIZED_PLAN.md
@@ -715,6 +715,27 @@ register, allowing later writes to replace unrelated vectors from a broader
 upload without erasing exact matches. It still requires exact index/hash
 equality for every credited register and changes no draw authority.
 
+Per-register qualification result: the corrected AppData run
+`20260831T191732Z-p39892` completed 308 exact epochs and 9,210 correlated draws
+across all 30 families, but found zero exact typed-writer register matches.
+This closes the generic title writer route. The next bounded slice observes the
+command processor's final shader-register writes instead, retaining exact
+packet and command-buffer lineage for current vertex-constant components. A
+fixed 4,096-source table aggregates source identity by family, packet header,
+packet offset, and nesting depth while retaining dynamic buffer length and
+physical-address variation as evidence. Strict component/source accounting
+selects the semantic command-buffer producer before player identity,
+publication, or suppression can advance.
+
+Command-stream qualification `20260831T200117Z-p31000` is bounded and
+repeatable: 255 exact epochs, 7,650 correlated draws, and all 30 families were
+observed. Final register state matched 114,750 of 122,400 shader-used vectors
+(15 of 16 per draw), with no missing or split-component vectors and zero-frame
+age. The structural packet table retained 1,620 sources without overflow.
+The next focused slice identifies the one mismatched vector per draw and then
+publishes the first semantic vehicle-constant bridge from this proven final
+register boundary.
+
 ### C5. Sky, atmosphere, and global lighting
 
 - Replace the qualified sky/global-light families.

--- a/docs/native-renderer/VEHICLE_TYPED_CONSTANT_UPLOAD.md
+++ b/docs/native-renderer/VEHICLE_TYPED_CONSTANT_UPLOAD.md
@@ -1,8 +1,9 @@
 # Vehicle typed constant-upload join
 
-Status: whole-range and all-overlapping-vector joins are rejected. The v11
-partition proved fresh register overlap and selected an exact per-register
-last-writer join for the next batched qualification.
+Status: the title-side upload joins are rejected. The v12 per-register run
+proved that the generic CPU writer is not the final source of the prepared
+vehicle constants. Work continues at the command processor's authoritative
+shader-register write boundary.
 
 ## Proven title boundary
 
@@ -90,10 +91,45 @@ mismatches no longer erase exact provenance. The contributing upload with the
 most exact registers wins, with newest sequence as the tie-breaker. Payload
 values remain in memory only and Xenos remains authoritative.
 
-The generic writer boundary and caller provenance are proved, but neither
-runtime join has yet proved which writes feed the prepared vehicle draws. No
-transform or player label may depend on this evidence until the diagnostic
-partition selects an exact register-space and payload contract.
+## Per-register result and command-stream boundary
+
+The AppData-backed `20260831T191732Z-p39892` run exited normally after 308
+qualified vehicle epochs and 9,210 exact color correlations across all 30
+families. It strictly accounted 1,363,934 typed-writer observations and
+6,111,555 fresh candidates. Of those candidates, 960,532 overlapped a used
+register but none matched even one register's exact current value. The v12
+last-writer rule therefore also produced zero matches.
+
+This rejects `82435E78` as the semantic provenance boundary for the prepared
+draws. It does not invalidate the function's static constant-buffer contract;
+it proves that later GPU command construction or register writes replace the
+values before the correlated draw reaches the command processor.
+
+ReXGlue now exposes a read-only observer at the final shader-register write.
+For each float-constant component it reports the already-endian-correct value,
+packet address/header, and complete current/parent/root command-buffer lineage.
+The native observer retains only the current 256 vertex-register components and
+a bounded 4,096-entry packet-source table. Correlated draws compare their
+shader-used values with that authoritative current state and aggregate source
+identity by packet header, normalized packet offset, and nesting depth. Dynamic
+buffer length and physical addresses remain variation evidence rather than
+source identity. No constant payload is exported.
+
+The generic writer boundary and caller provenance remain useful negative
+evidence, but no transform or player label may depend on them. The command-
+stream census must first prove complete exact component coverage without table
+overflow and identify bounded packet-lineage sources for all 30 families.
+
+The corrected command-stream qualification
+`20260831T200117Z-p31000` completed normally with 255 exact epochs and 7,650
+correlated draws across all 30 vehicle families. Of 122,400 shader-used vertex
+vectors, 114,750 (15 per draw) matched the final command-processor register
+state exactly, with zero missing or split-component vectors and a maximum age
+of zero frames. Exactly one vector per draw remained mismatched. Structural
+source aggregation retained 1,620 packet-lineage entries without overflow;
+the same producer shapes recur across all families. This proves the final
+register-write boundary and narrows the next slice to identifying the single
+per-draw mismatch before publishing a semantic constant bridge.
 
 ## Safety boundary
 

--- a/patches/rexglue/0104-graphics-shader-constant-write-observer.patch
+++ b/patches/rexglue/0104-graphics-shader-constant-write-observer.patch
@@ -1,0 +1,121 @@
+diff --git a/include/rex/graphics/command_processor.h b/include/rex/graphics/command_processor.h
+index 8234329..dab6339 100644
+--- a/include/rex/graphics/command_processor.h
++++ b/include/rex/graphics/command_processor.h
+@@ -279,6 +279,7 @@ class CommandProcessor {
+   uint64_t observation_draw_sequence_ = 0;
+   uint64_t observation_copy_sequence_ = 0;
+   uint32_t observation_packet_physical_address_ = UINT32_MAX;
++  uint32_t observation_packet_ = 0;
+   struct ObservationCommandBufferContext {
+     uint32_t physical_address = UINT32_MAX;
+     uint32_t length_dwords = 0;
+diff --git a/include/rex/graphics/graphics_system.h b/include/rex/graphics/graphics_system.h
+index 3ae6a8b..ddfc1ee 100644
+--- a/include/rex/graphics/graphics_system.h
++++ b/include/rex/graphics/graphics_system.h
+@@ -76,6 +76,15 @@ class GraphicsSystem : public system::IGraphicsSystem {
+   system::GraphicsDrawObserver draw_observer() const {
+     return draw_observer_.load(std::memory_order_acquire);
+   }
++  void SetShaderConstantWriteObserver(
++      system::GraphicsShaderConstantWriteObserver observer) override {
++    shader_constant_write_observer_.store(observer,
++                                          std::memory_order_release);
++  }
++  system::GraphicsShaderConstantWriteObserver
++  shader_constant_write_observer() const {
++    return shader_constant_write_observer_.load(std::memory_order_acquire);
++  }
+   void SetIndirectBufferObserver(
+       system::GraphicsIndirectBufferObserver observer) override {
+     indirect_buffer_observer_.store(observer, std::memory_order_release);
+@@ -203,6 +212,8 @@ class GraphicsSystem : public system::IGraphicsSystem {
+   std::unique_ptr<::rex::ui::Presenter> presenter_;
+ 
+   std::atomic<system::GraphicsDrawObserver> draw_observer_{nullptr};
++  std::atomic<system::GraphicsShaderConstantWriteObserver>
++      shader_constant_write_observer_{nullptr};
+   std::atomic<system::GraphicsIndirectBufferObserver>
+       indirect_buffer_observer_{nullptr};
+   std::atomic<system::GraphicsCopyObserver> copy_observer_{nullptr};
+diff --git a/include/rex/system/interfaces/graphics.h b/include/rex/system/interfaces/graphics.h
+index 812e5ae..9340b58 100644
+--- a/include/rex/system/interfaces/graphics.h
++++ b/include/rex/system/interfaces/graphics.h
+@@ -303,6 +303,22 @@ struct GraphicsDrawObservation {
+ 
+ using GraphicsDrawObserver = void (*)(const GraphicsDrawObservation& observation);
+ 
++struct GraphicsShaderConstantWriteObservation {
++  uint64_t frame_sequence = 0;
++  uint32_t packet_physical_address = UINT32_MAX;
++  uint32_t command_buffer_physical_address = UINT32_MAX;
++  uint32_t command_buffer_length_dwords = 0;
++  uint32_t command_buffer_parent_packet_physical_address = UINT32_MAX;
++  uint32_t command_buffer_root_physical_address = UINT32_MAX;
++  uint32_t command_buffer_depth = 0;
++  uint32_t packet = 0;
++  uint32_t register_index = 0;
++  uint32_t value = 0;
++};
++
++using GraphicsShaderConstantWriteObserver = void (*)(
++    const GraphicsShaderConstantWriteObservation& observation);
++
+ struct GraphicsIndirectBufferObservation {
+   uint32_t packet_physical_address = UINT32_MAX;
+   uint32_t parent_buffer_physical_address = UINT32_MAX;
+@@ -598,6 +614,10 @@ class IGraphicsSystem {
+   virtual void SetDrawObserver(GraphicsDrawObserver observer) {
+     (void)observer;
+   }
++  virtual void SetShaderConstantWriteObserver(
++      GraphicsShaderConstantWriteObserver observer) {
++    (void)observer;
++  }
+   virtual void SetIndirectBufferObserver(
+       GraphicsIndirectBufferObserver observer) {
+     (void)observer;
+diff --git a/src/graphics/command_processor.cpp b/src/graphics/command_processor.cpp
+index 02416cd..e67a5d5 100644
+--- a/src/graphics/command_processor.cpp
++++ b/src/graphics/command_processor.cpp
+@@ -375,6 +375,29 @@ void CommandProcessor::WriteRegister(uint32_t index, uint32_t value) {
+ 
+   // Volatile for the WAIT_REG_MEM loop.
+   const_cast<volatile uint32_t&>(regs.values[index]) = value;
++  if (index >= XE_GPU_REG_SHADER_CONSTANT_000_X &&
++      index < XE_GPU_REG_SHADER_CONSTANT_000_X + 512 * 4) {
++    auto observer = graphics_system_->shader_constant_write_observer();
++    if (observer) {
++      system::GraphicsShaderConstantWriteObservation observation;
++      observation.frame_sequence = observation_frame_sequence_;
++      observation.packet_physical_address =
++          observation_packet_physical_address_;
++      observation.command_buffer_physical_address =
++          observation_command_buffer_.physical_address;
++      observation.command_buffer_length_dwords =
++          observation_command_buffer_.length_dwords;
++      observation.command_buffer_parent_packet_physical_address =
++          observation_command_buffer_.parent_packet_physical_address;
++      observation.command_buffer_root_physical_address =
++          observation_command_buffer_.root_physical_address;
++      observation.command_buffer_depth = observation_command_buffer_.depth;
++      observation.packet = observation_packet_;
++      observation.register_index = index;
++      observation.value = value;
++      observer(observation);
++    }
++  }
+   if (!regs.GetRegisterInfo(index)) {
+     REXGPU_DEBUG("GPU: Write to unknown register ({:04X} = {:08X})", index, value);
+   }
+@@ -720,6 +743,7 @@ bool CommandProcessor::ExecutePacket(memory::RingBuffer* reader) {
+           ? uint32_t(physical_offset)
+           : UINT32_MAX;
+   const uint32_t packet = reader->ReadAndSwap<uint32_t>();
++  observation_packet_ = packet;
+   const uint32_t packet_type = packet >> 30;
+   if (packet == 0) {
+     return true;

--- a/src/native_renderer/graphics_hooks.cpp
+++ b/src/native_renderer/graphics_hooks.cpp
@@ -143,6 +143,9 @@ constexpr uint32_t kVehicleConstantUploadHook = 0x82435E78;
 constexpr uint32_t kVehicleConstantUploadRegisterBias = 120;
 constexpr size_t kVehicleConstantUploadCapacity = 8192;
 constexpr uint64_t kVehicleConstantUploadMaximumAgeFrames = 1;
+constexpr uint32_t kVehicleVertexShaderConstantRegisterBase = 0x4000;
+constexpr size_t kVehicleVertexShaderConstantComponentCount = 256 * 4;
+constexpr size_t kVehicleShaderConstantSourceCapacity = 4096;
 constexpr size_t kVehicleShadowGeometrySeedCapacity = 256;
 constexpr size_t kVehicleShadowGeometryCorrelationCapacity = 1024;
 constexpr uint64_t kVehicleColorConstantMaximumIdentityAgeFrames = 1;
@@ -668,6 +671,14 @@ struct VehicleShadowGeometryCorrelationEntry {
   uint64_t typed_upload_source_address_variations = 0;
   uint64_t typed_upload_buffer_address_variations = 0;
   uint64_t typed_upload_caller_variations = 0;
+  uint64_t shader_constant_write_scans = 0;
+  uint64_t shader_constant_write_observed_vectors = 0;
+  uint64_t shader_constant_write_exact_vectors = 0;
+  uint64_t shader_constant_write_missing_vectors = 0;
+  uint64_t shader_constant_write_mismatched_vectors = 0;
+  uint64_t shader_constant_write_coherent_vectors = 0;
+  uint64_t shader_constant_write_split_vectors = 0;
+  uint64_t shader_constant_write_maximum_age_frames = 0;
   double closest_position_delta_squared =
       std::numeric_limits<double>::infinity();
   double closest_forward_delta_squared =
@@ -724,6 +735,48 @@ enum class VehicleConstantUploadSubsetResult : uint32_t {
   kNoOverlap = 0,
   kHashMismatch,
   kExact,
+};
+
+struct VehicleShaderConstantComponentWrite {
+  uint64_t frame = 0;
+  uint64_t sequence = 0;
+  uint32_t packet_physical_address = UINT32_MAX;
+  uint32_t command_buffer_physical_address = UINT32_MAX;
+  uint32_t command_buffer_length_dwords = 0;
+  uint32_t command_buffer_parent_packet_physical_address = UINT32_MAX;
+  uint32_t command_buffer_root_physical_address = UINT32_MAX;
+  uint32_t command_buffer_depth = 0;
+  uint32_t packet = 0;
+  uint32_t value = 0;
+  bool occupied = false;
+};
+
+struct VehicleShaderConstantSourceEntry {
+  uint64_t key = 0;
+  uint64_t vectors = 0;
+  uint64_t draws = 0;
+  uint64_t last_draw_sequence = 0;
+  uint64_t maximum_age_frames = 0;
+  uint64_t packet_address_variations = 0;
+  uint64_t command_buffer_length_variations = 0;
+  uint64_t command_buffer_address_variations = 0;
+  uint64_t parent_packet_address_variations = 0;
+  uint64_t root_buffer_address_variations = 0;
+  uint32_t correlation_index = 0;
+  uint32_t packet = 0;
+  uint32_t packet_offset_dwords = UINT32_MAX;
+  uint32_t command_buffer_depth = 0;
+  uint32_t first_command_buffer_length_dwords = 0;
+  uint32_t last_command_buffer_length_dwords = 0;
+  uint32_t first_packet_physical_address = UINT32_MAX;
+  uint32_t last_packet_physical_address = UINT32_MAX;
+  uint32_t first_command_buffer_physical_address = UINT32_MAX;
+  uint32_t last_command_buffer_physical_address = UINT32_MAX;
+  uint32_t first_parent_packet_physical_address = UINT32_MAX;
+  uint32_t last_parent_packet_physical_address = UINT32_MAX;
+  uint32_t first_root_buffer_physical_address = UINT32_MAX;
+  uint32_t last_root_buffer_physical_address = UINT32_MAX;
+  bool occupied = false;
 };
 
 struct VehicleShadowColorRun {
@@ -1561,6 +1614,20 @@ uint64_t g_vehicle_constant_upload_invalid_source_range = 0;
 uint64_t g_vehicle_constant_upload_overwrites = 0;
 uint64_t g_vehicle_constant_upload_sequence = 0;
 size_t g_vehicle_constant_upload_cursor = 0;
+std::array<VehicleShaderConstantComponentWrite,
+           kVehicleVertexShaderConstantComponentCount>
+    g_vehicle_shader_constant_components{};
+std::array<VehicleShaderConstantSourceEntry,
+           kVehicleShaderConstantSourceCapacity>
+    g_vehicle_shader_constant_sources{};
+std::mutex g_vehicle_shader_constant_mutex;
+uint64_t g_vehicle_shader_constant_write_observations = 0;
+uint64_t g_vehicle_vertex_shader_constant_write_observations = 0;
+uint64_t g_vehicle_pixel_shader_constant_write_observations = 0;
+uint64_t g_vehicle_shader_constant_write_invalid_register = 0;
+uint64_t g_vehicle_shader_constant_write_sequence = 0;
+uint64_t g_vehicle_shader_constant_source_count = 0;
+uint64_t g_vehicle_shader_constant_source_overflow = 0;
 uint64_t g_vehicle_shadow_geometry_mechanically_eligible_draws = 0;
 uint64_t g_vehicle_shadow_geometry_mechanically_rejected_draws = 0;
 std::array<uint64_t, 15> g_vehicle_shadow_geometry_rejection_reason_counts{};
@@ -9169,6 +9236,12 @@ void ConfigureIsolatedDraw() {
           std::to_string(kVehicleConstantUploadCapacity)},
          {"typed_constant_upload_maximum_age_frames",
           std::to_string(kVehicleConstantUploadMaximumAgeFrames)},
+         {"shader_constant_write_observer",
+          "command_processor_final_shader_register_write"},
+         {"shader_constant_write_contract",
+          "exact_current_vertex_register_components_and_packet_lineage"},
+         {"shader_constant_source_capacity",
+          std::to_string(kVehicleShaderConstantSourceCapacity)},
          {"guest_payload_capture", "false"},
          {"native_draw", "false"},
          {"xenos_authority", "true"},
@@ -15376,6 +15449,234 @@ void ObserveVehicleTypedConstantUpload(uint32_t buffer_address,
   ++g_vehicle_constant_upload_valid;
 }
 
+void ObserveVehicleShaderConstantWrite(
+    const rex::system::GraphicsShaderConstantWriteObservation &observation) {
+  if (!g_vehicle_discovery_installed.load(std::memory_order_acquire) ||
+      !g_isolated_draw.vehicle_shadow_geometry_correlation_mode) {
+    return;
+  }
+  std::scoped_lock lock(g_vehicle_shader_constant_mutex);
+  ++g_vehicle_shader_constant_write_observations;
+  if (observation.register_index <
+      kVehicleVertexShaderConstantRegisterBase) {
+    ++g_vehicle_shader_constant_write_invalid_register;
+    return;
+  }
+  const uint32_t component_index =
+      observation.register_index - kVehicleVertexShaderConstantRegisterBase;
+  if (component_index >= 512 * 4) {
+    ++g_vehicle_shader_constant_write_invalid_register;
+    return;
+  }
+  if (component_index >= kVehicleVertexShaderConstantComponentCount) {
+    ++g_vehicle_pixel_shader_constant_write_observations;
+    return;
+  }
+  ++g_vehicle_vertex_shader_constant_write_observations;
+  g_vehicle_shader_constant_components[component_index] = {
+      .frame = observation.frame_sequence,
+      .sequence = ++g_vehicle_shader_constant_write_sequence,
+      .packet_physical_address = observation.packet_physical_address,
+      .command_buffer_physical_address =
+          observation.command_buffer_physical_address,
+      .command_buffer_length_dwords =
+          observation.command_buffer_length_dwords,
+      .command_buffer_parent_packet_physical_address =
+          observation.command_buffer_parent_packet_physical_address,
+      .command_buffer_root_physical_address =
+          observation.command_buffer_root_physical_address,
+      .command_buffer_depth = observation.command_buffer_depth,
+      .packet = observation.packet,
+      .value = observation.value,
+      .occupied = true,
+  };
+}
+
+bool SameVehicleShaderConstantSource(
+    const VehicleShaderConstantComponentWrite &left,
+    const VehicleShaderConstantComponentWrite &right) {
+  return left.packet_physical_address == right.packet_physical_address &&
+         left.command_buffer_physical_address ==
+             right.command_buffer_physical_address &&
+         left.command_buffer_length_dwords ==
+             right.command_buffer_length_dwords &&
+         left.command_buffer_parent_packet_physical_address ==
+             right.command_buffer_parent_packet_physical_address &&
+         left.command_buffer_root_physical_address ==
+             right.command_buffer_root_physical_address &&
+         left.command_buffer_depth == right.command_buffer_depth &&
+         left.packet == right.packet;
+}
+
+void RecordVehicleShaderConstantSource(
+    size_t correlation_index,
+    const rex::system::GraphicsDrawObservation &observation,
+    const VehicleShaderConstantComponentWrite &write,
+    uint64_t age_frames) {
+  uint32_t packet_offset_dwords = UINT32_MAX;
+  if (write.packet_physical_address != UINT32_MAX &&
+      write.command_buffer_physical_address != UINT32_MAX &&
+      write.packet_physical_address >=
+          write.command_buffer_physical_address &&
+      !((write.packet_physical_address -
+         write.command_buffer_physical_address) & 3)) {
+    packet_offset_dwords =
+        (write.packet_physical_address -
+         write.command_buffer_physical_address) /
+        sizeof(uint32_t);
+  }
+  uint64_t key = UINT64_C(0xCBF29CE484222325);
+  for (uint64_t value :
+       {uint64_t(correlation_index), uint64_t(write.packet),
+        uint64_t(packet_offset_dwords),
+        uint64_t(write.command_buffer_depth)}) {
+    key = HashCombine(key, value);
+  }
+  key = key ? key : 1;
+  for (size_t probe = 0; probe < g_vehicle_shader_constant_sources.size();
+       ++probe) {
+    VehicleShaderConstantSourceEntry &source =
+        g_vehicle_shader_constant_sources[
+            (key + probe) % g_vehicle_shader_constant_sources.size()];
+    if (!source.occupied) {
+      source = {
+          .key = key,
+          .vectors = 1,
+          .draws = 1,
+          .last_draw_sequence = observation.draw_sequence,
+          .maximum_age_frames = age_frames,
+          .correlation_index = uint32_t(correlation_index),
+          .packet = write.packet,
+          .packet_offset_dwords = packet_offset_dwords,
+          .command_buffer_depth = write.command_buffer_depth,
+          .first_command_buffer_length_dwords =
+              write.command_buffer_length_dwords,
+          .last_command_buffer_length_dwords =
+              write.command_buffer_length_dwords,
+          .first_packet_physical_address = write.packet_physical_address,
+          .last_packet_physical_address = write.packet_physical_address,
+          .first_command_buffer_physical_address =
+              write.command_buffer_physical_address,
+          .last_command_buffer_physical_address =
+              write.command_buffer_physical_address,
+          .first_parent_packet_physical_address =
+              write.command_buffer_parent_packet_physical_address,
+          .last_parent_packet_physical_address =
+              write.command_buffer_parent_packet_physical_address,
+          .first_root_buffer_physical_address =
+              write.command_buffer_root_physical_address,
+          .last_root_buffer_physical_address =
+              write.command_buffer_root_physical_address,
+          .occupied = true,
+      };
+      ++g_vehicle_shader_constant_source_count;
+      return;
+    }
+    if (source.key != key ||
+        source.correlation_index != correlation_index ||
+        source.packet != write.packet ||
+        source.packet_offset_dwords != packet_offset_dwords ||
+        source.command_buffer_depth != write.command_buffer_depth) {
+      continue;
+    }
+    ++source.vectors;
+    if (source.last_draw_sequence != observation.draw_sequence) {
+      ++source.draws;
+      source.last_draw_sequence = observation.draw_sequence;
+    }
+    source.maximum_age_frames =
+        std::max(source.maximum_age_frames, age_frames);
+    source.packet_address_variations +=
+        source.last_packet_physical_address !=
+        write.packet_physical_address;
+    source.command_buffer_length_variations +=
+        source.last_command_buffer_length_dwords !=
+        write.command_buffer_length_dwords;
+    source.command_buffer_address_variations +=
+        source.last_command_buffer_physical_address !=
+        write.command_buffer_physical_address;
+    source.parent_packet_address_variations +=
+        source.last_parent_packet_physical_address !=
+        write.command_buffer_parent_packet_physical_address;
+    source.root_buffer_address_variations +=
+        source.last_root_buffer_physical_address !=
+        write.command_buffer_root_physical_address;
+    source.last_packet_physical_address = write.packet_physical_address;
+    source.last_command_buffer_length_dwords =
+        write.command_buffer_length_dwords;
+    source.last_command_buffer_physical_address =
+        write.command_buffer_physical_address;
+    source.last_parent_packet_physical_address =
+        write.command_buffer_parent_packet_physical_address;
+    source.last_root_buffer_physical_address =
+        write.command_buffer_root_physical_address;
+    return;
+  }
+  ++g_vehicle_shader_constant_source_overflow;
+}
+
+void ObserveVehicleColorShaderConstantWrites(
+    const rex::system::GraphicsDrawObservation &observation,
+    VehicleShadowGeometryCorrelationEntry &entry,
+    size_t correlation_index) {
+  ++entry.shader_constant_write_scans;
+  const uint32_t observed_count = std::min(
+      observation.vertex_float_constant_count,
+      rex::system::kGraphicsFloatConstantObservationLimit);
+  entry.shader_constant_write_observed_vectors += observed_count;
+  std::scoped_lock lock(g_vehicle_shader_constant_mutex);
+  for (uint32_t observed_offset = 0; observed_offset < observed_count;
+       ++observed_offset) {
+    const auto &constant =
+        observation.vertex_float_constants[observed_offset];
+    const uint32_t component_base = constant.index * 4;
+    if (component_base + 4 >
+        g_vehicle_shader_constant_components.size()) {
+      ++entry.shader_constant_write_missing_vectors;
+      continue;
+    }
+    const VehicleShaderConstantComponentWrite *components =
+        g_vehicle_shader_constant_components.data() + component_base;
+    bool missing = false;
+    bool mismatch = false;
+    bool coherent = true;
+    uint64_t maximum_age_frames = 0;
+    for (uint32_t component = 0; component < 4; ++component) {
+      missing |= !components[component].occupied;
+      mismatch |= components[component].occupied &&
+                  components[component].value != constant.values[component];
+      coherent &= component == 0 ||
+                  SameVehicleShaderConstantSource(components[0],
+                                                  components[component]);
+      if (components[component].occupied &&
+          observation.frame_sequence >= components[component].frame) {
+        maximum_age_frames = std::max(
+            maximum_age_frames,
+            observation.frame_sequence - components[component].frame);
+      }
+    }
+    if (missing) {
+      ++entry.shader_constant_write_missing_vectors;
+      continue;
+    }
+    if (mismatch) {
+      ++entry.shader_constant_write_mismatched_vectors;
+      continue;
+    }
+    ++entry.shader_constant_write_exact_vectors;
+    entry.shader_constant_write_maximum_age_frames =
+        std::max(entry.shader_constant_write_maximum_age_frames,
+                 maximum_age_frames);
+    if (!coherent) {
+      ++entry.shader_constant_write_split_vectors;
+      continue;
+    }
+    ++entry.shader_constant_write_coherent_vectors;
+    RecordVehicleShaderConstantSource(correlation_index, observation,
+                                      components[0], maximum_age_frames);
+  }
+}
+
 VehicleConstantUploadSubsetResult MatchObservedVertexConstantSubset(
     const rex::system::GraphicsDrawObservation &observation,
     const VehicleConstantUploadEntry &upload,
@@ -15802,6 +16103,8 @@ bool ObserveVehicleShadowGeometryColorCorrelation(
       entry.last_frame = observation.frame_sequence;
       ObserveVehicleColorConstantIdentity(observation, entry);
       ObserveVehicleColorTypedConstantUpload(observation, entry);
+      ObserveVehicleColorShaderConstantWrites(observation, entry,
+                                              correlation_index);
       if (matched_correlation_index) {
         *matched_correlation_index = correlation_index;
       }
@@ -15855,6 +16158,8 @@ bool ObserveVehicleShadowGeometryColorCorrelation(
   };
   ObserveVehicleColorConstantIdentity(observation, *available);
   ObserveVehicleColorTypedConstantUpload(observation, *available);
+  ObserveVehicleColorShaderConstantWrites(observation, *available,
+                                          available_index);
   if (matched_correlation_index) {
     *matched_correlation_index = available_index;
   }
@@ -24148,6 +24453,22 @@ void ConfigureVehicleDiscovery(bool census_requested,
     g_vehicle_constant_upload_sequence = 0;
     g_vehicle_constant_upload_cursor = 0;
   }
+  {
+    std::scoped_lock lock(g_vehicle_shader_constant_mutex);
+    std::fill(g_vehicle_shader_constant_components.begin(),
+              g_vehicle_shader_constant_components.end(),
+              VehicleShaderConstantComponentWrite{});
+    std::fill(g_vehicle_shader_constant_sources.begin(),
+              g_vehicle_shader_constant_sources.end(),
+              VehicleShaderConstantSourceEntry{});
+    g_vehicle_shader_constant_write_observations = 0;
+    g_vehicle_vertex_shader_constant_write_observations = 0;
+    g_vehicle_pixel_shader_constant_write_observations = 0;
+    g_vehicle_shader_constant_write_invalid_register = 0;
+    g_vehicle_shader_constant_write_sequence = 0;
+    g_vehicle_shader_constant_source_count = 0;
+    g_vehicle_shader_constant_source_overflow = 0;
+  }
   for (VehicleOwnerMethodStats &stats : g_vehicle_owner_method_stats) {
     stats.calls.store(0, std::memory_order_relaxed);
     stats.matched_owner_calls.store(0, std::memory_order_relaxed);
@@ -25307,6 +25628,8 @@ void InstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system,
   }
   g_graphics_census_installed = true;
   graphics_system->SetDrawObserver(&ObserveDraw);
+  graphics_system->SetShaderConstantWriteObserver(
+      &ObserveVehicleShaderConstantWrite);
   graphics_system->SetIndirectBufferObserver(&ObserveIndirectBuffer);
   graphics_system->SetCopyObserver(&ObserveCopy);
   graphics_system->SetPreparedDrawObserver(&ObservePreparedDraw);
@@ -26034,6 +26357,7 @@ void InstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system,
 void UninstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system) {
   if (graphics_system) {
     graphics_system->SetDrawObserver(nullptr);
+    graphics_system->SetShaderConstantWriteObserver(nullptr);
     graphics_system->SetIndirectBufferObserver(nullptr);
     graphics_system->SetCopyObserver(nullptr);
     graphics_system->SetPreparedDrawObserver(nullptr);
@@ -26586,6 +26910,14 @@ void UninstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system) {
     uint64_t typed_upload_exact_matches = 0;
     uint64_t typed_upload_misses = 0;
     uint64_t typed_upload_exact_used_vectors = 0;
+    uint64_t shader_constant_write_scans = 0;
+    uint64_t shader_constant_write_observed_vectors = 0;
+    uint64_t shader_constant_write_exact_vectors = 0;
+    uint64_t shader_constant_write_missing_vectors = 0;
+    uint64_t shader_constant_write_mismatched_vectors = 0;
+    uint64_t shader_constant_write_coherent_vectors = 0;
+    uint64_t shader_constant_write_split_vectors = 0;
+    uint64_t shader_constant_write_maximum_age_frames = 0;
     std::array<uint64_t, kVehicleShadowGeometryCorrelationCapacity>
         material_topology_keys{};
     size_t material_topology_group_count = 0;
@@ -26618,6 +26950,22 @@ void UninstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system) {
       typed_upload_misses += entry.typed_upload_misses;
       typed_upload_exact_used_vectors +=
           entry.typed_upload_exact_used_vectors;
+      shader_constant_write_scans += entry.shader_constant_write_scans;
+      shader_constant_write_observed_vectors +=
+          entry.shader_constant_write_observed_vectors;
+      shader_constant_write_exact_vectors +=
+          entry.shader_constant_write_exact_vectors;
+      shader_constant_write_missing_vectors +=
+          entry.shader_constant_write_missing_vectors;
+      shader_constant_write_mismatched_vectors +=
+          entry.shader_constant_write_mismatched_vectors;
+      shader_constant_write_coherent_vectors +=
+          entry.shader_constant_write_coherent_vectors;
+      shader_constant_write_split_vectors +=
+          entry.shader_constant_write_split_vectors;
+      shader_constant_write_maximum_age_frames = std::max(
+          shader_constant_write_maximum_age_frames,
+          entry.shader_constant_write_maximum_age_frames);
       bool material_topology_seen = false;
       for (size_t material_index = 0;
            material_index < material_topology_group_count;
@@ -26631,6 +26979,15 @@ void UninstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system) {
       if (!material_topology_seen) {
         material_topology_keys[material_topology_group_count++] =
             entry.material_topology_key;
+      }
+      uint64_t shader_constant_source_count_for_family = 0;
+      const size_t correlation_index = size_t(
+          &entry - g_vehicle_shadow_geometry_correlations.data());
+      for (const VehicleShaderConstantSourceEntry &source :
+           g_vehicle_shader_constant_sources) {
+        shader_constant_source_count_for_family +=
+            source.occupied &&
+            source.correlation_index == correlation_index;
       }
       diagnostics::RecordEvent(
           "native_renderer.discovery.vehicle_shadow_geometry_candidate",
@@ -26870,6 +27227,107 @@ void UninstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system) {
                     !entry.typed_upload_caller_variations
                 ? "stable_exact_vertex_register_candidate"
                 : "unresolved"},
+           {"shader_constant_write_scans",
+            std::to_string(entry.shader_constant_write_scans)},
+           {"shader_constant_write_observed_vectors",
+            std::to_string(
+                entry.shader_constant_write_observed_vectors)},
+           {"shader_constant_write_exact_vectors",
+            std::to_string(entry.shader_constant_write_exact_vectors)},
+           {"shader_constant_write_missing_vectors",
+            std::to_string(
+                entry.shader_constant_write_missing_vectors)},
+           {"shader_constant_write_mismatched_vectors",
+            std::to_string(
+                entry.shader_constant_write_mismatched_vectors)},
+           {"shader_constant_write_coherent_vectors",
+            std::to_string(
+                entry.shader_constant_write_coherent_vectors)},
+           {"shader_constant_write_split_vectors",
+            std::to_string(entry.shader_constant_write_split_vectors)},
+           {"shader_constant_write_maximum_age_frames",
+            std::to_string(
+                entry.shader_constant_write_maximum_age_frames)},
+           {"shader_constant_source_count",
+            std::to_string(shader_constant_source_count_for_family)},
+           {"shader_constant_write_classification",
+            entry.shader_constant_write_exact_vectors ==
+                        entry.shader_constant_write_observed_vectors &&
+                    !entry.shader_constant_write_missing_vectors &&
+                    !entry.shader_constant_write_mismatched_vectors &&
+                    !entry.shader_constant_write_split_vectors &&
+                    shader_constant_source_count_for_family
+                ? "complete_exact_packet_lineage"
+                : "unresolved"},
+           {"guest_payload_capture", "false"},
+           {"native_draw", "false"},
+           {"xenos_authority", "true"},
+           {"suppression_allowed", "false"}});
+    }
+    for (const VehicleShaderConstantSourceEntry &source :
+         g_vehicle_shader_constant_sources) {
+      if (!source.occupied ||
+          source.correlation_index >=
+              g_vehicle_shadow_geometry_correlations.size() ||
+          !g_vehicle_shadow_geometry_correlations[source.correlation_index]
+               .occupied) {
+        continue;
+      }
+      const VehicleShadowGeometryCorrelationEntry &family =
+          g_vehicle_shadow_geometry_correlations[source.correlation_index];
+      diagnostics::RecordEvent(
+          "native_renderer.discovery.vehicle_shader_constant_source",
+          {{"prepared_signature",
+            fmt::format("{:016X}", family.prepared_signature)},
+           {"packet", fmt::format("{:08X}", source.packet)},
+           {"opcode", std::to_string((source.packet >> 8) & 0x7F)},
+           {"packet_offset_dwords",
+            source.packet_offset_dwords == UINT32_MAX
+                ? "unknown"
+                : std::to_string(source.packet_offset_dwords)},
+           {"first_command_buffer_length_dwords",
+            std::to_string(source.first_command_buffer_length_dwords)},
+           {"last_command_buffer_length_dwords",
+            std::to_string(source.last_command_buffer_length_dwords)},
+           {"command_buffer_length_variations",
+            std::to_string(source.command_buffer_length_variations)},
+           {"command_buffer_depth",
+            std::to_string(source.command_buffer_depth)},
+           {"vectors", std::to_string(source.vectors)},
+           {"draws", std::to_string(source.draws)},
+           {"maximum_age_frames",
+            std::to_string(source.maximum_age_frames)},
+           {"first_packet_physical_address",
+            fmt::format("{:08X}", source.first_packet_physical_address)},
+           {"last_packet_physical_address",
+            fmt::format("{:08X}", source.last_packet_physical_address)},
+           {"packet_address_variations",
+            std::to_string(source.packet_address_variations)},
+           {"first_command_buffer_physical_address",
+            fmt::format("{:08X}",
+                        source.first_command_buffer_physical_address)},
+           {"last_command_buffer_physical_address",
+            fmt::format("{:08X}",
+                        source.last_command_buffer_physical_address)},
+           {"command_buffer_address_variations",
+            std::to_string(source.command_buffer_address_variations)},
+           {"first_parent_packet_physical_address",
+            fmt::format("{:08X}",
+                        source.first_parent_packet_physical_address)},
+           {"last_parent_packet_physical_address",
+            fmt::format("{:08X}",
+                        source.last_parent_packet_physical_address)},
+           {"parent_packet_address_variations",
+            std::to_string(source.parent_packet_address_variations)},
+           {"first_root_buffer_physical_address",
+            fmt::format("{:08X}",
+                        source.first_root_buffer_physical_address)},
+           {"last_root_buffer_physical_address",
+            fmt::format("{:08X}",
+                        source.last_root_buffer_physical_address)},
+           {"root_buffer_address_variations",
+            std::to_string(source.root_buffer_address_variations)},
+           {"classification", "exact_current_vertex_register_source"},
            {"guest_payload_capture", "false"},
            {"native_draw", "false"},
            {"xenos_authority", "true"},
@@ -27068,6 +27526,61 @@ void UninstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system) {
           std::to_string(kVehicleConstantUploadMaximumAgeFrames)},
          {"typed_upload_contract",
           "82435E78_exact_shader_used_vertex_register_hash"},
+         {"shader_constant_write_observations",
+          std::to_string(g_vehicle_shader_constant_write_observations)},
+         {"vertex_shader_constant_write_observations",
+          std::to_string(
+              g_vehicle_vertex_shader_constant_write_observations)},
+         {"pixel_shader_constant_write_observations",
+          std::to_string(
+              g_vehicle_pixel_shader_constant_write_observations)},
+         {"shader_constant_write_invalid_register",
+          std::to_string(
+              g_vehicle_shader_constant_write_invalid_register)},
+         {"shader_constant_write_observation_accounting_complete",
+          g_vehicle_vertex_shader_constant_write_observations +
+                      g_vehicle_pixel_shader_constant_write_observations +
+                      g_vehicle_shader_constant_write_invalid_register ==
+                  g_vehicle_shader_constant_write_observations
+              ? "true"
+              : "false"},
+         {"shader_constant_write_scans",
+          std::to_string(shader_constant_write_scans)},
+         {"shader_constant_write_observed_vectors",
+          std::to_string(shader_constant_write_observed_vectors)},
+         {"shader_constant_write_exact_vectors",
+          std::to_string(shader_constant_write_exact_vectors)},
+         {"shader_constant_write_missing_vectors",
+          std::to_string(shader_constant_write_missing_vectors)},
+         {"shader_constant_write_mismatched_vectors",
+          std::to_string(shader_constant_write_mismatched_vectors)},
+         {"shader_constant_write_vector_accounting_complete",
+          shader_constant_write_exact_vectors +
+                      shader_constant_write_missing_vectors +
+                      shader_constant_write_mismatched_vectors ==
+                  shader_constant_write_observed_vectors
+              ? "true"
+              : "false"},
+         {"shader_constant_write_coherent_vectors",
+          std::to_string(shader_constant_write_coherent_vectors)},
+         {"shader_constant_write_split_vectors",
+          std::to_string(shader_constant_write_split_vectors)},
+         {"shader_constant_write_source_accounting_complete",
+          shader_constant_write_coherent_vectors +
+                      shader_constant_write_split_vectors ==
+                  shader_constant_write_exact_vectors
+              ? "true"
+              : "false"},
+         {"shader_constant_write_maximum_age_frames",
+          std::to_string(shader_constant_write_maximum_age_frames)},
+         {"shader_constant_sources",
+          std::to_string(g_vehicle_shader_constant_source_count)},
+         {"shader_constant_source_overflow",
+          std::to_string(g_vehicle_shader_constant_source_overflow)},
+         {"shader_constant_source_capacity",
+          std::to_string(kVehicleShaderConstantSourceCapacity)},
+         {"shader_constant_write_contract",
+          "exact_current_vertex_register_components_and_packet_lineage"},
          {"material_topology_groups",
           std::to_string(material_topology_group_count)},
          {"material_topology_group_accounting_complete",

--- a/tools/summarize-native-renderer-vehicle-shadow-geometry.py
+++ b/tools/summarize-native-renderer-vehicle-shadow-geometry.py
@@ -5,13 +5,16 @@ import json
 from pathlib import Path
 
 
-SCHEMA = "pinyon-shift.native-renderer-vehicle-shadow-geometry.v12"
+SCHEMA = "pinyon-shift.native-renderer-vehicle-shadow-geometry.v13"
 CONFIG_EVENT = "native_renderer.discovery.vehicle_shadow_geometry_config"
 EPOCH_EVENT = "native_renderer.discovery.vehicle_shadow_geometry_epoch"
 CORRELATION_EVENT = (
     "native_renderer.discovery.vehicle_shadow_geometry_correlation"
 )
 CANDIDATE_EVENT = "native_renderer.discovery.vehicle_shadow_geometry_candidate"
+SHADER_CONSTANT_SOURCE_EVENT = (
+    "native_renderer.discovery.vehicle_shader_constant_source"
+)
 SUMMARY_EVENT = "native_renderer.discovery.vehicle_shadow_geometry_summary"
 CAPTURE_CONFIG_EVENT = (
     "native_renderer.discovery.vehicle_shadow_color_capture_config"
@@ -101,6 +104,11 @@ def summarize(log_path):
     candidates = [
         event for event in events if event.get("event") == CANDIDATE_EVENT
     ]
+    shader_constant_sources = [
+        event
+        for event in events
+        if event.get("event") == SHADER_CONSTANT_SOURCE_EVENT
+    ]
     summaries = [
         event for event in events if event.get("event") == SUMMARY_EVENT
     ]
@@ -141,6 +149,20 @@ def summarize(log_path):
     require(
         integer(configs[0], "typed_constant_upload_maximum_age_frames") == 1,
         "typed constant upload freshness drift",
+    )
+    require(
+        configs[0].get("shader_constant_write_observer")
+        == "command_processor_final_shader_register_write",
+        "shader constant write observer drift",
+    )
+    require(
+        configs[0].get("shader_constant_write_contract")
+        == "exact_current_vertex_register_components_and_packet_lineage",
+        "shader constant write contract drift",
+    )
+    require(
+        integer(configs[0], "shader_constant_source_capacity") == 4096,
+        "shader constant source capacity drift",
     )
     require(len(summaries) == 1, "expected exactly one correlation summary")
     summary = summaries[0]
@@ -330,7 +352,93 @@ def summarize(log_path):
         == "82435E78_exact_shader_used_vertex_register_hash",
         "typed upload summary contract drift",
     )
-    safety_events = [*configs, *epochs, *correlations, *candidates, summary]
+    shader_constant_write_scans = integer(
+        summary, "shader_constant_write_scans"
+    )
+    shader_constant_write_observed_vectors = integer(
+        summary, "shader_constant_write_observed_vectors"
+    )
+    shader_constant_write_exact_vectors = integer(
+        summary, "shader_constant_write_exact_vectors"
+    )
+    shader_constant_write_missing_vectors = integer(
+        summary, "shader_constant_write_missing_vectors"
+    )
+    shader_constant_write_mismatched_vectors = integer(
+        summary, "shader_constant_write_mismatched_vectors"
+    )
+    shader_constant_write_coherent_vectors = integer(
+        summary, "shader_constant_write_coherent_vectors"
+    )
+    shader_constant_write_split_vectors = integer(
+        summary, "shader_constant_write_split_vectors"
+    )
+    require(
+        summary.get("shader_constant_write_observation_accounting_complete")
+        == "true",
+        "shader constant write observation accounting drift",
+    )
+    require(
+        integer(summary, "vertex_shader_constant_write_observations")
+        + integer(summary, "pixel_shader_constant_write_observations")
+        + integer(summary, "shader_constant_write_invalid_register")
+        == integer(summary, "shader_constant_write_observations"),
+        "shader constant write observation outcome drift",
+    )
+    require(
+        shader_constant_write_scans
+        == integer(summary, "color_draws_matched"),
+        "shader constant write scan accounting drift",
+    )
+    require(
+        summary.get("shader_constant_write_vector_accounting_complete")
+        == "true",
+        "shader constant write vector accounting drift",
+    )
+    require(
+        shader_constant_write_exact_vectors
+        + shader_constant_write_missing_vectors
+        + shader_constant_write_mismatched_vectors
+        == shader_constant_write_observed_vectors,
+        "shader constant write vector outcome drift",
+    )
+    require(
+        summary.get("shader_constant_write_source_accounting_complete")
+        == "true",
+        "shader constant write source accounting drift",
+    )
+    require(
+        shader_constant_write_coherent_vectors
+        + shader_constant_write_split_vectors
+        == shader_constant_write_exact_vectors,
+        "shader constant write source outcome drift",
+    )
+    require(
+        integer(summary, "shader_constant_sources")
+        == len(shader_constant_sources),
+        "shader constant source event accounting drift",
+    )
+    require(
+        integer(summary, "shader_constant_source_overflow") == 0,
+        "shader constant source table overflowed",
+    )
+    require(
+        integer(summary, "shader_constant_source_capacity") == 4096,
+        "shader constant source summary capacity drift",
+    )
+    require(
+        summary.get("shader_constant_write_contract")
+        == "exact_current_vertex_register_components_and_packet_lineage",
+        "shader constant write summary contract drift",
+    )
+    safety_events = [
+        *configs,
+        *epochs,
+        *correlations,
+        *candidates,
+        *shader_constant_sources,
+        summary,
+    ]
     for event in safety_events:
         require(event.get("native_draw") == "false", "native draw was enabled")
         require(event.get("xenos_authority") == "true", "Xenos authority changed")
@@ -581,6 +689,62 @@ def summarize(log_path):
             hexadecimal(event, "typed_upload_source_address")
             hexadecimal(event, "typed_upload_buffer_address")
             hexadecimal(event, "typed_upload_caller_return_address")
+        family_shader_constant_scans = integer(
+            event, "shader_constant_write_scans"
+        )
+        family_shader_constant_observed = integer(
+            event, "shader_constant_write_observed_vectors"
+        )
+        family_shader_constant_exact = integer(
+            event, "shader_constant_write_exact_vectors"
+        )
+        family_shader_constant_missing = integer(
+            event, "shader_constant_write_missing_vectors"
+        )
+        family_shader_constant_mismatched = integer(
+            event, "shader_constant_write_mismatched_vectors"
+        )
+        family_shader_constant_coherent = integer(
+            event, "shader_constant_write_coherent_vectors"
+        )
+        family_shader_constant_split = integer(
+            event, "shader_constant_write_split_vectors"
+        )
+        family_shader_constant_sources = integer(
+            event, "shader_constant_source_count"
+        )
+        require(
+            family_shader_constant_scans == integer(event, "draws"),
+            "candidate shader constant scan accounting drift",
+        )
+        require(
+            family_shader_constant_exact
+            + family_shader_constant_missing
+            + family_shader_constant_mismatched
+            == family_shader_constant_observed,
+            "candidate shader constant vector outcome drift",
+        )
+        require(
+            family_shader_constant_coherent + family_shader_constant_split
+            == family_shader_constant_exact,
+            "candidate shader constant source outcome drift",
+        )
+        complete_shader_constant_lineage = (
+            family_shader_constant_exact == family_shader_constant_observed
+            and family_shader_constant_missing == 0
+            and family_shader_constant_mismatched == 0
+            and family_shader_constant_split == 0
+            and family_shader_constant_sources > 0
+        )
+        require(
+            event.get("shader_constant_write_classification")
+            == (
+                "complete_exact_packet_lineage"
+                if complete_shader_constant_lineage
+                else "unresolved"
+            ),
+            "candidate shader constant classification drift",
+        )
         for key in (
             "prepared_signature",
             "template_key",
@@ -604,6 +768,34 @@ def summarize(log_path):
             <= integer(event, "draws") - 1,
             "candidate material parameter switch drift",
         )
+    candidate_signatures = {
+        event["prepared_signature"] for event in candidates
+    }
+    for event in shader_constant_sources:
+        require(
+            event.get("classification")
+            == "exact_current_vertex_register_source",
+            "shader constant source classification drift",
+        )
+        require(
+            event.get("prepared_signature") in candidate_signatures,
+            "shader constant source family drift",
+        )
+        require(integer(event, "vectors") > 0, "empty shader constant source")
+        require(integer(event, "draws") > 0, "unused shader constant source")
+        require(0 <= integer(event, "opcode") <= 0x7F, "invalid packet opcode")
+        hexadecimal(event, "packet")
+        for key in (
+            "first_packet_physical_address",
+            "last_packet_physical_address",
+            "first_command_buffer_physical_address",
+            "last_command_buffer_physical_address",
+            "first_parent_packet_physical_address",
+            "last_parent_packet_physical_address",
+            "first_root_buffer_physical_address",
+            "last_root_buffer_physical_address",
+        ):
+            hexadecimal(event, key)
     capture = None
     if capture_configs or capture_results or capture_summaries:
         require(len(capture_configs) == 1, "expected one color capture config")
@@ -895,6 +1087,37 @@ def summarize(log_path):
             ),
             "caller_return_addresses": typed_upload_callers,
         },
+        "shader_constant_register_writes": {
+            "observations": integer(
+                summary, "shader_constant_write_observations"
+            ),
+            "vertex_observations": integer(
+                summary, "vertex_shader_constant_write_observations"
+            ),
+            "pixel_observations": integer(
+                summary, "pixel_shader_constant_write_observations"
+            ),
+            "invalid_register": integer(
+                summary, "shader_constant_write_invalid_register"
+            ),
+            "scans": shader_constant_write_scans,
+            "observed_vectors": shader_constant_write_observed_vectors,
+            "exact_vectors": shader_constant_write_exact_vectors,
+            "missing_vectors": shader_constant_write_missing_vectors,
+            "mismatched_vectors": shader_constant_write_mismatched_vectors,
+            "coherent_vectors": shader_constant_write_coherent_vectors,
+            "split_vectors": shader_constant_write_split_vectors,
+            "maximum_age_frames": integer(
+                summary, "shader_constant_write_maximum_age_frames"
+            ),
+            "source_count": len(shader_constant_sources),
+            "sources": shader_constant_sources,
+            "complete_lineage_families": sum(
+                event.get("shader_constant_write_classification")
+                == "complete_exact_packet_lineage"
+                for event in candidates
+            ),
+        },
         "material_topology": {
             "group_count": material_topology_groups,
             "groups": [
@@ -938,6 +1161,14 @@ def summarize(log_path):
             ),
             "complete_typed_upload_bridge_candidate": (
                 complete_typed_upload_bridge_candidate
+            ),
+            "complete_shader_constant_packet_lineage_candidate": (
+                len(candidates) == 30
+                and all(
+                    event.get("shader_constant_write_classification")
+                    == "complete_exact_packet_lineage"
+                    for event in candidates
+                )
             ),
             "object_identity_proven": False,
             "mesh_material_contract_proven": False,

--- a/tools/tests/test_native_renderer_vehicle_shadow_geometry.py
+++ b/tools/tests/test_native_renderer_vehicle_shadow_geometry.py
@@ -30,6 +30,9 @@ class VehicleShadowGeometryTests(unittest.TestCase):
                 "typed_constant_upload_contract": "exact_shader_used_vertex_register_hash",
                 "typed_constant_upload_capacity": "8192",
                 "typed_constant_upload_maximum_age_frames": "1",
+                "shader_constant_write_observer": "command_processor_final_shader_register_write",
+                "shader_constant_write_contract": "exact_current_vertex_register_components_and_packet_lineage",
+                "shader_constant_source_capacity": "4096",
                 **safety,
             },
             {
@@ -135,6 +138,44 @@ class VehicleShadowGeometryTests(unittest.TestCase):
                 "typed_upload_observed_register_min": "208",
                 "typed_upload_observed_register_max": "211",
                 "typed_upload_classification": "stable_exact_vertex_register_candidate",
+                "shader_constant_write_scans": "3",
+                "shader_constant_write_observed_vectors": "9",
+                "shader_constant_write_exact_vectors": "9",
+                "shader_constant_write_missing_vectors": "0",
+                "shader_constant_write_mismatched_vectors": "0",
+                "shader_constant_write_coherent_vectors": "9",
+                "shader_constant_write_split_vectors": "0",
+                "shader_constant_write_maximum_age_frames": "1",
+                "shader_constant_source_count": "1",
+                "shader_constant_write_classification": "complete_exact_packet_lineage",
+                **safety,
+            },
+            {
+                "event": MODULE.SHADER_CONSTANT_SOURCE_EVENT,
+                "prepared_signature": "1" * 16,
+                "packet": "C0032D00",
+                "opcode": "45",
+                "packet_offset_dwords": "12",
+                "first_command_buffer_length_dwords": "128",
+                "last_command_buffer_length_dwords": "128",
+                "command_buffer_length_variations": "0",
+                "command_buffer_depth": "1",
+                "vectors": "9",
+                "draws": "3",
+                "maximum_age_frames": "1",
+                "first_packet_physical_address": "00100030",
+                "last_packet_physical_address": "00100030",
+                "packet_address_variations": "0",
+                "first_command_buffer_physical_address": "00100000",
+                "last_command_buffer_physical_address": "00100000",
+                "command_buffer_address_variations": "0",
+                "first_parent_packet_physical_address": "00001000",
+                "last_parent_packet_physical_address": "00001000",
+                "parent_packet_address_variations": "0",
+                "first_root_buffer_physical_address": "00100000",
+                "last_root_buffer_physical_address": "00100000",
+                "root_buffer_address_variations": "0",
+                "classification": "exact_current_vertex_register_source",
                 **safety,
             },
             {
@@ -273,6 +314,25 @@ class VehicleShadowGeometryTests(unittest.TestCase):
                 "typed_upload_outcome_accounting_complete": "true",
                 "typed_upload_maximum_age_frames": "1",
                 "typed_upload_contract": "82435E78_exact_shader_used_vertex_register_hash",
+                "shader_constant_write_observations": "20",
+                "vertex_shader_constant_write_observations": "12",
+                "pixel_shader_constant_write_observations": "8",
+                "shader_constant_write_invalid_register": "0",
+                "shader_constant_write_observation_accounting_complete": "true",
+                "shader_constant_write_scans": "3",
+                "shader_constant_write_observed_vectors": "9",
+                "shader_constant_write_exact_vectors": "9",
+                "shader_constant_write_missing_vectors": "0",
+                "shader_constant_write_mismatched_vectors": "0",
+                "shader_constant_write_vector_accounting_complete": "true",
+                "shader_constant_write_coherent_vectors": "9",
+                "shader_constant_write_split_vectors": "0",
+                "shader_constant_write_source_accounting_complete": "true",
+                "shader_constant_write_maximum_age_frames": "1",
+                "shader_constant_sources": "1",
+                "shader_constant_source_overflow": "0",
+                "shader_constant_source_capacity": "4096",
+                "shader_constant_write_contract": "exact_current_vertex_register_components_and_packet_lineage",
                 "material_topology_groups": "1",
                 "material_topology_group_accounting_complete": "true",
                 "material_topology_contract": "shader_specialization_render_state_texture_layout",
@@ -373,6 +433,15 @@ class VehicleShadowGeometryTests(unittest.TestCase):
         self.assertFalse(
             report["qualification"]["complete_typed_upload_bridge_candidate"]
         )
+        self.assertEqual(
+            1,
+            report["shader_constant_register_writes"][
+                "complete_lineage_families"
+            ],
+        )
+        self.assertEqual(
+            1, report["shader_constant_register_writes"]["source_count"]
+        )
 
     def test_rejects_partial_epoch_promotion(self):
         events = self.fixture()
@@ -460,19 +529,19 @@ class VehicleShadowGeometryTests(unittest.TestCase):
 
     def test_rejects_private_capture_authority_drift(self):
         events = self.fixture()
-        events[5]["output_authority"] = "native"
+        events[6]["output_authority"] = "native"
         with self.assertRaisesRegex(ValueError, "output authority"):
             self.summarize(events)
 
     def test_rejects_private_replay_accounting_drift(self):
         events = self.fixture()
-        events[6]["private_replay_recorded"] = "2"
+        events[7]["private_replay_recorded"] = "2"
         with self.assertRaisesRegex(ValueError, "private replay outcome drift"):
             self.summarize(events)
 
     def test_rejects_retained_frame_accounting_drift(self):
         events = self.fixture()
-        events[9]["frames_completed"] = "1"
+        events[10]["frames_completed"] = "1"
         with self.assertRaisesRegex(ValueError, "retained frame outcome drift"):
             self.summarize(events)
 
@@ -489,6 +558,10 @@ class VehicleShadowGeometryTests(unittest.TestCase):
         lr_patch = (
             ROOT
             / "patches/rexglue/0103-codegen-midasm-link-register-argument.patch"
+        ).read_text(encoding="utf-8")
+        write_patch = (
+            ROOT
+            / "patches/rexglue/0104-graphics-shader-constant-write-observer.patch"
         ).read_text(encoding="utf-8")
         self.assertIn(
             "PINYON_SHIFT_NATIVE_RENDERER_VEHICLE_SHADOW_GEOMETRY_CORRELATION",
@@ -514,6 +587,12 @@ class VehicleShadowGeometryTests(unittest.TestCase):
         self.assertIn("ObserveVehicleColorConstantIdentity", source)
         self.assertIn("ObserveVehicleTypedConstantUpload", source)
         self.assertIn("ObserveVehicleColorTypedConstantUpload", source)
+        self.assertIn("ObserveVehicleShaderConstantWrite", source)
+        self.assertIn("ObserveVehicleColorShaderConstantWrites", source)
+        self.assertIn(
+            '"native_renderer.discovery.vehicle_shader_constant_source"',
+            source,
+        )
         self.assertIn("MatchObservedVertexConstantSubset", source)
         self.assertIn("mismatched_vector_count", source)
         self.assertNotIn("HashObservedVertexConstantRange", source)
@@ -531,6 +610,9 @@ class VehicleShadowGeometryTests(unittest.TestCase):
         self.assertIn('if (reg == "lr")', lr_patch)
         self.assertIn('out += "ctx.lr"', lr_patch)
         self.assertIn('emit_print(out, "uint64_t& lr")', lr_patch)
+        self.assertIn("GraphicsShaderConstantWriteObservation", write_patch)
+        self.assertIn("shader_constant_write_observer", write_patch)
+        self.assertIn("observation_packet_ = packet", write_patch)
         self.assertIn("[switch]$VehicleShadowGeometryCorrelation", capture)
         self.assertIn("[switch]$CaptureVehicleShadowColor", capture)
         self.assertIn("[switch]$RetainVehicleShadowColorPass", capture)

--- a/tools/tests/test_release_contract.py
+++ b/tools/tests/test_release_contract.py
@@ -43,10 +43,10 @@ class ReleaseContractTests(unittest.TestCase):
 
     def test_rexglue_patches_have_stable_order_and_no_binary_payload(self):
         patches = sorted((ROOT / "patches/rexglue").glob("*.patch"))
-        self.assertEqual(len(patches), 103)
+        self.assertEqual(len(patches), 104)
         self.assertEqual(
             patches[-1].name,
-            "0103-codegen-midasm-link-register-argument.patch",
+            "0104-graphics-shader-constant-write-observer.patch",
         )
         self.assertEqual(len(patches), len({path.name[:4] for path in patches}))
         for path in patches:


### PR DESCRIPTION
## Summary
- expose a read-only ReXGlue observer for final shader-register writes
- correlate vehicle constants with exact packet and command-buffer lineage
- add bounded structural source accounting, strict reports, tests, and roadmap evidence

## Validation
- clean preview build (ReXGlue patch set materialized from scratch)
- 614 unit tests
- AppData qualification 20260831T200117Z-p31000: normal exit, 255 epochs, 7,650 correlated draws, all 30 families, 114,750/122,400 exact vectors, zero missing/split vectors, 1,620 sources, zero overflow

## Safety
- measurement only; native draws remain disabled
- Xenos authority remains enabled
- no constant payload is logged
- AppData save was only used by the launched preview and was not modified by tooling