### PR TITLE
feat(renderer): bridge vehicle constants at draw boundary

### DIFF
--- a/docs/native-renderer/REPRIORITIZED_PLAN.md
+++ b/docs/native-renderer/REPRIORITIZED_PLAN.md
@@ -59,8 +59,8 @@ Already landed or substantially qualified:
 - bounded visibility worksets with title visibility and LOD lineage;
 - exact native replay of an 80-draw dynamic shadow epoch with byte-identical
   D24S8 output and bounded multi-frame publication;
-- extensive vehicle provenance investigation, without a qualified semantic
-  vehicle rendering bridge yet; and
+- extensive vehicle provenance plus a qualified private draw-atomic semantic
+  constant bridge, without a visible semantic vehicle rendering path yet; and
 - post-processing topology census plus the mechanical presentation ingress.
 
 Phase A and B1-B5 are merged. The active B6 slice qualifies the first coherent
@@ -732,9 +732,21 @@ repeatable: 255 exact epochs, 7,650 correlated draws, and all 30 families were
 observed. Final register state matched 114,750 of 122,400 shader-used vectors
 (15 of 16 per draw), with no missing or split-component vectors and zero-frame
 age. The structural packet table retained 1,620 sources without overflow.
-The next focused slice identifies the one mismatched vector per draw and then
-publishes the first semantic vehicle-constant bridge from this proven final
-register boundary.
+The draw-atomic follow-up `20260831T203519Z-p39592` identifies register 254 as
+the sole mismatch: all four components differ on every one of 14,505 matched
+draws, with no mask variation, while the other 15 vectors remain exact. This
+proves a special-register path rather than observer timing drift.
+
+First semantic constant-bridge checkpoint: all 14,505 matched draws now publish
+a private current-draw snapshot into the bounded 30-family table with zero
+rejections and zero register-layout variations. Each family carries the same
+16 shader-used registers, 15 exact packet-lineage vectors, and one explicitly
+unresolved register-254 vector. The bridge exports hashes and counts only,
+draws nothing, publishes nothing, and cannot suppress Xenos. It is sufficient
+to advance the retained player-vehicle harness without attributing register
+254 to a guessed title producer. The next C4 slice joins player identity and
+mesh/material roles to this snapshot, then uses per-item replay fallback for
+unresolved or exceptional work.
 
 ### C5. Sky, atmosphere, and global lighting
 

--- a/docs/native-renderer/VEHICLE_SEMANTIC_CONSTANT_BRIDGE.md
+++ b/docs/native-renderer/VEHICLE_SEMANTIC_CONSTANT_BRIDGE.md
@@ -1,0 +1,51 @@
+# Vehicle semantic constant bridge
+
+Status: private draw-atomic bridge qualified; native publication remains off.
+
+## Purpose
+
+The retained 30-family vehicle pass already proves stable animated geometry
+and replay. This bridge gives each correlated color draw a current-draw vertex
+constant snapshot without guessing a title-side constant-buffer owner. It is
+an implementation boundary for later player identity, transform, wheel, and
+material work, not a claim that every register has semantic provenance.
+
+## Runtime contract
+
+- ReXGlue records compact final-write state for the 512 float-constant
+  registers inside the command processor.
+- Draw preparation compares that state with the exact shader-used register
+  values and records validity, split provenance, maximum age, and a component
+  mismatch mask.
+- A matched vehicle family copies its bounded prepared constant observation to
+  one private in-memory bridge slot for the current frame and draw.
+- The slot records register-layout and value hashes plus exact/unresolved
+  vector counts. Constant payloads never enter the public log or report.
+- Missing, overflowing, or uncorrelated draws are rejected. Xenos remains the
+  only output authority; no native draw, publication, or suppression follows
+  from this bridge.
+
+## Qualification
+
+The saved-profile run `20260831T203519Z-p39592` exited normally and produced:
+
+- 484 committed shadow epochs and 14,505 exact vehicle color correlations;
+- all 30 bounded vehicle families and 68 unique geometry seeds;
+- 14,505 bridge publications and zero bridge rejections;
+- a stable 16-register layout in every family with zero layout variations;
+- 217,575 exact vectors, zero missing vectors, zero split vectors, and a
+  maximum final-write age of zero frames; and
+- one unresolved vector per draw, always register 254 with mismatch mask `F`
+  and zero mask variations.
+
+Register 254 is therefore isolated as a special-register update outside the
+ordinary command-processor write route. It remains available as an opaque
+current-draw value in the private snapshot, but it is not packet-proven and
+must not receive transform or player semantics without independent evidence.
+
+## Next admission boundary
+
+The bridge may feed only private retained-vehicle work until exact player
+identity and mesh/material role joins are established. A later visible path
+must retain per-item Xenos fallback, reject stale or incomplete snapshots, and
+keep register 254 outside any provenance-dependent decision.

--- a/docs/native-renderer/VEHICLE_TYPED_CONSTANT_UPLOAD.md
+++ b/docs/native-renderer/VEHICLE_TYPED_CONSTANT_UPLOAD.md
@@ -131,6 +131,42 @@ the same producer shapes recur across all families. This proves the final
 register-write boundary and narrows the next slice to identifying the single
 per-draw mismatch before publishing a semantic constant bridge.
 
+## Draw-atomic provenance and semantic bridge
+
+ReXGlue patch `0105-graphics-draw-constant-write-provenance.patch` retains the
+last final-write state beside the command processor's live shader registers.
+At draw preparation, each observed float vector now carries only compact
+validation metadata: provenance validity, split-source state, maximum age, and
+a four-bit current-value mismatch mask. The native observer continues to use
+the bounded external packet table for source aggregation, but no longer relies
+on a cross-module timing assumption to decide whether the prepared value is
+the final value for that draw.
+
+Every exact vehicle-family match also publishes its full shader-used vertex
+constant observation into a private in-memory bridge slot. The slot is indexed
+by the already-bounded 30-family correlation table and retains the current
+draw's register layout, values, frame/draw sequence, and provenance counts.
+Only hashes and counts leave the process. The bridge is not a native draw,
+does not publish a render target, cannot suppress Xenos, and is rejected on
+missing or overflowing prepared observations.
+
+The AppData-backed `20260831T203519Z-p39592` qualification exited normally
+after 484 exact epochs and 14,505 correlated draws across all 30 families. It
+observed 232,080 vectors: 217,575 were exact with zero-frame age, zero were
+missing or split, and 14,505 were mismatched. Register-level evidence proves
+that registers 0, 1, 2, 3, 37-42, 58, 116, 126, 127, and 255 are exact on
+every draw. Register 254 alone mismatches on every draw; its component mask is
+always `F`, with zero mask variations. This is a genuine special-register
+update outside the ordinary final-write route, not an observer race.
+
+The private bridge accepted all 14,505 draws with zero rejections. Every
+family kept the same 16-register layout hash with zero layout variations and
+carried 15 exact packet-lineage vectors plus one explicitly unresolved vector.
+The values varied with animation on essentially every frame, as expected. This
+qualifies a working draw-atomic semantic constant snapshot for the retained
+vehicle harness while keeping register 254 unresolved and excluding it from
+any future packet-proven transform claim.
+
 ## Safety boundary
 
 - The hook is active only with the restart-gated vehicle correlation mode.

--- a/patches/rexglue/0105-graphics-draw-constant-write-provenance.patch
+++ b/patches/rexglue/0105-graphics-draw-constant-write-provenance.patch
@@ -1,0 +1,133 @@
+diff --git a/include/rex/system/interfaces/graphics.h b/include/rex/system/interfaces/graphics.h
+index 9340b58..211ca95 100644
+--- a/include/rex/system/interfaces/graphics.h
++++ b/include/rex/system/interfaces/graphics.h
+@@ -201,6 +201,10 @@ constexpr uint32_t kGraphicsVertexAttributeObservationLimit = 32;
+ struct GraphicsFloatConstantObservation {
+   uint32_t index = 0;
+   uint32_t values[4] = {};
++  uint32_t write_maximum_age_frames = 0;
++  uint32_t write_provenance_valid = 0;
++  uint32_t write_provenance_split = 0;
++  uint32_t write_value_mismatch_mask = 0;
+ };
+ 
+ constexpr uint32_t kGraphicsFloatConstantObservationLimit = 64;
+diff --git a/include/rex/graphics/command_processor.h b/include/rex/graphics/command_processor.h
+index dab6339..5d92677 100644
+--- a/include/rex/graphics/command_processor.h
++++ b/include/rex/graphics/command_processor.h
+@@ -288,6 +288,20 @@ class CommandProcessor {
+     uint32_t depth = 0;
+   };
+   ObservationCommandBufferContext observation_command_buffer_{};
++  struct ShaderConstantWriteState {
++    uint64_t frame_sequence = 0;
++    uint32_t packet_physical_address = UINT32_MAX;
++    uint32_t command_buffer_physical_address = UINT32_MAX;
++    uint32_t command_buffer_length_dwords = 0;
++    uint32_t command_buffer_parent_packet_physical_address = UINT32_MAX;
++    uint32_t command_buffer_root_physical_address = UINT32_MAX;
++    uint32_t command_buffer_depth = 0;
++    uint32_t packet = 0;
++    uint32_t value = 0;
++    bool valid = false;
++  };
++  std::array<ShaderConstantWriteState, 512 * 4>
++      shader_constant_write_state_{};
+ 
+   bool paused_ = false;
+ 
+diff --git a/src/graphics/command_processor.cpp b/src/graphics/command_processor.cpp
+index e67a5d5..ec9e2bf 100644
+--- a/src/graphics/command_processor.cpp
++++ b/src/graphics/command_processor.cpp
+@@ -377,6 +377,24 @@ void CommandProcessor::WriteRegister(uint32_t index, uint32_t value) {
+   const_cast<volatile uint32_t&>(regs.values[index]) = value;
+   if (index >= XE_GPU_REG_SHADER_CONSTANT_000_X &&
+       index < XE_GPU_REG_SHADER_CONSTANT_000_X + 512 * 4) {
++    ShaderConstantWriteState& write_state =
++        shader_constant_write_state_[index -
++                                     XE_GPU_REG_SHADER_CONSTANT_000_X];
++    write_state.frame_sequence = observation_frame_sequence_;
++    write_state.packet_physical_address =
++        observation_packet_physical_address_;
++    write_state.command_buffer_physical_address =
++        observation_command_buffer_.physical_address;
++    write_state.command_buffer_length_dwords =
++        observation_command_buffer_.length_dwords;
++    write_state.command_buffer_parent_packet_physical_address =
++        observation_command_buffer_.parent_packet_physical_address;
++    write_state.command_buffer_root_physical_address =
++        observation_command_buffer_.root_physical_address;
++    write_state.command_buffer_depth = observation_command_buffer_.depth;
++    write_state.packet = observation_packet_;
++    write_state.value = value;
++    write_state.valid = true;
+     auto observer = graphics_system_->shader_constant_write_observer();
+     if (observer) {
+       system::GraphicsShaderConstantWriteObservation observation;
+@@ -1734,6 +1752,63 @@ bool CommandProcessor::ExecutePacketType3Draw(memory::RingBuffer* reader, uint32
+               std::memcpy(output[output_index].values,
+                           &(*register_file_)[register_base + constant_index * 4],
+                           sizeof(output[output_index].values));
++              const uint32_t write_state_base =
++                  register_base - XE_GPU_REG_SHADER_CONSTANT_000_X +
++                  constant_index * 4;
++              const ShaderConstantWriteState& first_write_state =
++                  shader_constant_write_state_[write_state_base];
++              bool write_provenance_valid = first_write_state.valid;
++              bool write_provenance_split = false;
++              uint32_t write_value_mismatch_mask = 0;
++              uint64_t oldest_write_frame = first_write_state.frame_sequence;
++              const auto same_write_source = [](const auto& left,
++                                                const auto& right) {
++                return left.packet_physical_address ==
++                           right.packet_physical_address &&
++                       left.command_buffer_physical_address ==
++                           right.command_buffer_physical_address &&
++                       left.command_buffer_length_dwords ==
++                           right.command_buffer_length_dwords &&
++                       left.command_buffer_parent_packet_physical_address ==
++                           right.command_buffer_parent_packet_physical_address &&
++                       left.command_buffer_root_physical_address ==
++                           right.command_buffer_root_physical_address &&
++                       left.command_buffer_depth == right.command_buffer_depth &&
++                       left.packet == right.packet;
++              };
++              for (uint32_t component = 0; component < 4; ++component) {
++                const ShaderConstantWriteState& component_write_state =
++                    shader_constant_write_state_[write_state_base + component];
++                write_provenance_valid &= component_write_state.valid;
++                write_provenance_split |=
++                    component != 0 &&
++                    !same_write_source(first_write_state,
++                                       component_write_state);
++                if (component_write_state.valid) {
++                  oldest_write_frame =
++                      std::min(oldest_write_frame,
++                               component_write_state.frame_sequence);
++                  if (component_write_state.value !=
++                      output[output_index].values[component]) {
++                    write_value_mismatch_mask |= uint32_t(1) << component;
++                  }
++                }
++              }
++              auto& constant_output = output[output_index];
++              constant_output.write_provenance_valid =
++                  write_provenance_valid ? 1u : 0u;
++              constant_output.write_provenance_split =
++                  write_provenance_split ? 1u : 0u;
++              constant_output.write_value_mismatch_mask =
++                  write_value_mismatch_mask;
++              if (write_provenance_valid) {
++                constant_output.write_maximum_age_frames =
++                    observation_frame_sequence_ >= oldest_write_frame
++                        ? uint32_t(std::min<uint64_t>(
++                              observation_frame_sequence_ - oldest_write_frame,
++                              UINT32_MAX))
++                        : UINT32_MAX;
++              }
+               ++output_index;
+             }
+           }

--- a/src/native_renderer/graphics_hooks.cpp
+++ b/src/native_renderer/graphics_hooks.cpp
@@ -779,6 +779,23 @@ struct VehicleShaderConstantSourceEntry {
   bool occupied = false;
 };
 
+struct VehicleSemanticConstantBridgeEntry {
+  std::array<rex::system::GraphicsFloatConstantObservation,
+             rex::system::kGraphicsFloatConstantObservationLimit>
+      constants{};
+  uint64_t publications = 0;
+  uint64_t register_layout_hash = 0;
+  uint64_t value_hash = 0;
+  uint64_t register_layout_variations = 0;
+  uint64_t value_variations = 0;
+  uint64_t frame_sequence = 0;
+  uint64_t draw_sequence = 0;
+  uint32_t constant_count = 0;
+  uint32_t exact_packet_lineage_vectors = 0;
+  uint32_t unresolved_packet_lineage_vectors = 0;
+  bool occupied = false;
+};
+
 struct VehicleShadowColorRun {
   uint64_t frame = 0;
   uint64_t last_draw = 0;
@@ -1620,6 +1637,19 @@ std::array<VehicleShaderConstantComponentWrite,
 std::array<VehicleShaderConstantSourceEntry,
            kVehicleShaderConstantSourceCapacity>
     g_vehicle_shader_constant_sources{};
+std::array<VehicleSemanticConstantBridgeEntry,
+           kVehicleShadowGeometryCorrelationCapacity>
+    g_vehicle_semantic_constant_bridges{};
+std::array<uint64_t, kVehicleVertexShaderConstantComponentCount / 4>
+    g_vehicle_shader_constant_register_exact_vectors{};
+std::array<uint64_t, kVehicleVertexShaderConstantComponentCount / 4>
+    g_vehicle_shader_constant_register_missing_vectors{};
+std::array<uint64_t, kVehicleVertexShaderConstantComponentCount / 4>
+    g_vehicle_shader_constant_register_mismatched_vectors{};
+std::array<uint32_t, kVehicleVertexShaderConstantComponentCount / 4>
+    g_vehicle_shader_constant_register_first_mismatch_mask{};
+std::array<uint64_t, kVehicleVertexShaderConstantComponentCount / 4>
+    g_vehicle_shader_constant_register_mismatch_mask_variations{};
 std::mutex g_vehicle_shader_constant_mutex;
 uint64_t g_vehicle_shader_constant_write_observations = 0;
 uint64_t g_vehicle_vertex_shader_constant_write_observations = 0;
@@ -1628,6 +1658,10 @@ uint64_t g_vehicle_shader_constant_write_invalid_register = 0;
 uint64_t g_vehicle_shader_constant_write_sequence = 0;
 uint64_t g_vehicle_shader_constant_source_count = 0;
 uint64_t g_vehicle_shader_constant_source_overflow = 0;
+uint64_t g_vehicle_shader_constant_invalid_observed_vectors = 0;
+uint64_t g_vehicle_semantic_constant_bridge_publications = 0;
+uint64_t g_vehicle_semantic_constant_bridge_rejections = 0;
+uint64_t g_vehicle_semantic_constant_bridge_complete_lineage_publications = 0;
 uint64_t g_vehicle_shadow_geometry_mechanically_eligible_draws = 0;
 uint64_t g_vehicle_shadow_geometry_mechanically_rejected_draws = 0;
 std::array<uint64_t, 15> g_vehicle_shadow_geometry_rejection_reason_counts{};
@@ -15633,37 +15667,48 @@ void ObserveVehicleColorShaderConstantWrites(
     if (component_base + 4 >
         g_vehicle_shader_constant_components.size()) {
       ++entry.shader_constant_write_missing_vectors;
+      ++g_vehicle_shader_constant_invalid_observed_vectors;
       continue;
     }
     const VehicleShaderConstantComponentWrite *components =
         g_vehicle_shader_constant_components.data() + component_base;
-    bool missing = false;
-    bool mismatch = false;
-    bool coherent = true;
-    uint64_t maximum_age_frames = 0;
+    bool observer_provenance_valid = true;
+    bool observer_provenance_split = false;
     for (uint32_t component = 0; component < 4; ++component) {
-      missing |= !components[component].occupied;
-      mismatch |= components[component].occupied &&
-                  components[component].value != constant.values[component];
-      coherent &= component == 0 ||
-                  SameVehicleShaderConstantSource(components[0],
-                                                  components[component]);
-      if (components[component].occupied &&
-          observation.frame_sequence >= components[component].frame) {
-        maximum_age_frames = std::max(
-            maximum_age_frames,
-            observation.frame_sequence - components[component].frame);
-      }
+      observer_provenance_valid &= components[component].occupied;
+      observer_provenance_split |=
+          component != 0 &&
+          !SameVehicleShaderConstantSource(components[0],
+                                           components[component]);
     }
+    const bool missing = !constant.write_provenance_valid ||
+                         !observer_provenance_valid;
+    const bool mismatch = constant.write_value_mismatch_mask != 0;
+    const bool coherent = !constant.write_provenance_split &&
+                          !observer_provenance_split;
+    const uint64_t maximum_age_frames =
+        constant.write_maximum_age_frames;
     if (missing) {
       ++entry.shader_constant_write_missing_vectors;
+      ++g_vehicle_shader_constant_register_missing_vectors[constant.index];
       continue;
     }
     if (mismatch) {
       ++entry.shader_constant_write_mismatched_vectors;
+      ++g_vehicle_shader_constant_register_mismatched_vectors[constant.index];
+      uint32_t &first_mismatch_mask =
+          g_vehicle_shader_constant_register_first_mismatch_mask[constant.index];
+      if (!first_mismatch_mask) {
+        first_mismatch_mask = constant.write_value_mismatch_mask;
+      } else if (first_mismatch_mask !=
+                 constant.write_value_mismatch_mask) {
+        ++g_vehicle_shader_constant_register_mismatch_mask_variations
+              [constant.index];
+      }
       continue;
     }
     ++entry.shader_constant_write_exact_vectors;
+    ++g_vehicle_shader_constant_register_exact_vectors[constant.index];
     entry.shader_constant_write_maximum_age_frames =
         std::max(entry.shader_constant_write_maximum_age_frames,
                  maximum_age_frames);
@@ -15675,6 +15720,61 @@ void ObserveVehicleColorShaderConstantWrites(
     RecordVehicleShaderConstantSource(correlation_index, observation,
                                       components[0], maximum_age_frames);
   }
+}
+
+void PublishVehicleSemanticConstantBridge(
+    const rex::system::GraphicsDrawObservation &observation,
+    size_t correlation_index) {
+  if (correlation_index >= g_vehicle_semantic_constant_bridges.size() ||
+      observation.vertex_float_constant_overflow ||
+      !observation.vertex_float_constant_count ||
+      observation.vertex_float_constant_count >
+          rex::system::kGraphicsFloatConstantObservationLimit) {
+    ++g_vehicle_semantic_constant_bridge_rejections;
+    return;
+  }
+
+  const uint32_t constant_count = observation.vertex_float_constant_count;
+  uint64_t register_layout_hash = 0xCBF29CE484222325ull;
+  uint64_t value_hash = 0xCBF29CE484222325ull;
+  uint32_t exact_packet_lineage_vectors = 0;
+  for (uint32_t i = 0; i < constant_count; ++i) {
+    const auto &constant = observation.vertex_float_constants[i];
+    register_layout_hash = HashCombine(register_layout_hash, constant.index);
+    value_hash = HashCombine(value_hash, constant.index);
+    for (uint32_t value : constant.values) {
+      value_hash = HashCombine(value_hash, value);
+    }
+    exact_packet_lineage_vectors +=
+        constant.write_provenance_valid &&
+                !constant.write_provenance_split &&
+                !constant.write_value_mismatch_mask
+            ? 1u
+            : 0u;
+  }
+
+  VehicleSemanticConstantBridgeEntry &bridge =
+      g_vehicle_semantic_constant_bridges[correlation_index];
+  if (bridge.occupied) {
+    bridge.register_layout_variations +=
+        bridge.register_layout_hash != register_layout_hash;
+    bridge.value_variations += bridge.value_hash != value_hash;
+  }
+  std::copy_n(observation.vertex_float_constants, constant_count,
+              bridge.constants.begin());
+  bridge.publications += 1;
+  bridge.register_layout_hash = register_layout_hash;
+  bridge.value_hash = value_hash;
+  bridge.frame_sequence = observation.frame_sequence;
+  bridge.draw_sequence = observation.draw_sequence;
+  bridge.constant_count = constant_count;
+  bridge.exact_packet_lineage_vectors = exact_packet_lineage_vectors;
+  bridge.unresolved_packet_lineage_vectors =
+      constant_count - exact_packet_lineage_vectors;
+  bridge.occupied = true;
+  ++g_vehicle_semantic_constant_bridge_publications;
+  g_vehicle_semantic_constant_bridge_complete_lineage_publications +=
+      exact_packet_lineage_vectors == constant_count ? 1u : 0u;
 }
 
 VehicleConstantUploadSubsetResult MatchObservedVertexConstantSubset(
@@ -16105,6 +16205,7 @@ bool ObserveVehicleShadowGeometryColorCorrelation(
       ObserveVehicleColorTypedConstantUpload(observation, entry);
       ObserveVehicleColorShaderConstantWrites(observation, entry,
                                               correlation_index);
+      PublishVehicleSemanticConstantBridge(observation, correlation_index);
       if (matched_correlation_index) {
         *matched_correlation_index = correlation_index;
       }
@@ -16160,6 +16261,7 @@ bool ObserveVehicleShadowGeometryColorCorrelation(
   ObserveVehicleColorTypedConstantUpload(observation, *available);
   ObserveVehicleColorShaderConstantWrites(observation, *available,
                                           available_index);
+  PublishVehicleSemanticConstantBridge(observation, available_index);
   if (matched_correlation_index) {
     *matched_correlation_index = available_index;
   }
@@ -24461,6 +24563,14 @@ void ConfigureVehicleDiscovery(bool census_requested,
     std::fill(g_vehicle_shader_constant_sources.begin(),
               g_vehicle_shader_constant_sources.end(),
               VehicleShaderConstantSourceEntry{});
+    std::fill(g_vehicle_semantic_constant_bridges.begin(),
+              g_vehicle_semantic_constant_bridges.end(),
+              VehicleSemanticConstantBridgeEntry{});
+    g_vehicle_shader_constant_register_exact_vectors.fill(0);
+    g_vehicle_shader_constant_register_missing_vectors.fill(0);
+    g_vehicle_shader_constant_register_mismatched_vectors.fill(0);
+    g_vehicle_shader_constant_register_first_mismatch_mask.fill(0);
+    g_vehicle_shader_constant_register_mismatch_mask_variations.fill(0);
     g_vehicle_shader_constant_write_observations = 0;
     g_vehicle_vertex_shader_constant_write_observations = 0;
     g_vehicle_pixel_shader_constant_write_observations = 0;
@@ -24468,6 +24578,10 @@ void ConfigureVehicleDiscovery(bool census_requested,
     g_vehicle_shader_constant_write_sequence = 0;
     g_vehicle_shader_constant_source_count = 0;
     g_vehicle_shader_constant_source_overflow = 0;
+    g_vehicle_shader_constant_invalid_observed_vectors = 0;
+    g_vehicle_semantic_constant_bridge_publications = 0;
+    g_vehicle_semantic_constant_bridge_rejections = 0;
+    g_vehicle_semantic_constant_bridge_complete_lineage_publications = 0;
   }
   for (VehicleOwnerMethodStats &stats : g_vehicle_owner_method_stats) {
     stats.calls.store(0, std::memory_order_relaxed);
@@ -26983,6 +27097,8 @@ void UninstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system) {
       uint64_t shader_constant_source_count_for_family = 0;
       const size_t correlation_index = size_t(
           &entry - g_vehicle_shadow_geometry_correlations.data());
+      const VehicleSemanticConstantBridgeEntry &constant_bridge =
+          g_vehicle_semantic_constant_bridges[correlation_index];
       for (const VehicleShaderConstantSourceEntry &source :
            g_vehicle_shader_constant_sources) {
         shader_constant_source_count_for_family +=
@@ -27257,8 +27373,79 @@ void UninstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system) {
                     !entry.shader_constant_write_mismatched_vectors &&
                     !entry.shader_constant_write_split_vectors &&
                     shader_constant_source_count_for_family
-                ? "complete_exact_packet_lineage"
-                : "unresolved"},
+                 ? "complete_exact_packet_lineage"
+                 : "unresolved"},
+           {"semantic_constant_bridge_publications",
+            std::to_string(constant_bridge.publications)},
+           {"semantic_constant_bridge_constant_count",
+            std::to_string(constant_bridge.constant_count)},
+           {"semantic_constant_bridge_exact_packet_lineage_vectors",
+            std::to_string(
+                constant_bridge.exact_packet_lineage_vectors)},
+           {"semantic_constant_bridge_unresolved_packet_lineage_vectors",
+            std::to_string(
+                constant_bridge.unresolved_packet_lineage_vectors)},
+           {"semantic_constant_bridge_register_layout_hash",
+            fmt::format("{:016X}",
+                        constant_bridge.register_layout_hash)},
+           {"semantic_constant_bridge_register_layout_variations",
+            std::to_string(
+                constant_bridge.register_layout_variations)},
+           {"semantic_constant_bridge_value_variations",
+            std::to_string(constant_bridge.value_variations)},
+           {"semantic_constant_bridge_classification",
+            constant_bridge.occupied &&
+                    constant_bridge.publications == entry.draws &&
+                    !constant_bridge.register_layout_variations &&
+                    !constant_bridge.unresolved_packet_lineage_vectors
+                ? "complete_private_draw_atomic_snapshot"
+                : constant_bridge.occupied &&
+                          constant_bridge.publications == entry.draws &&
+                          !constant_bridge.register_layout_variations
+                      ? "private_draw_atomic_snapshot_with_unresolved_lineage"
+                      : "unresolved"},
+           {"guest_payload_capture", "false"},
+           {"native_draw", "false"},
+           {"xenos_authority", "true"},
+           {"suppression_allowed", "false"}});
+    }
+    uint64_t shader_constant_register_count = 0;
+    for (size_t register_index = 0;
+         register_index <
+         g_vehicle_shader_constant_register_exact_vectors.size();
+         ++register_index) {
+      const uint64_t exact_vectors =
+          g_vehicle_shader_constant_register_exact_vectors[register_index];
+      const uint64_t missing_vectors =
+          g_vehicle_shader_constant_register_missing_vectors[register_index];
+      const uint64_t mismatched_vectors =
+          g_vehicle_shader_constant_register_mismatched_vectors[register_index];
+      const uint64_t observed_vectors =
+          exact_vectors + missing_vectors + mismatched_vectors;
+      if (!observed_vectors) {
+        continue;
+      }
+      ++shader_constant_register_count;
+      diagnostics::RecordEvent(
+          "native_renderer.discovery.vehicle_shader_constant_register",
+          {{"register_index", std::to_string(register_index)},
+           {"observed_vectors", std::to_string(observed_vectors)},
+           {"exact_vectors", std::to_string(exact_vectors)},
+           {"missing_vectors", std::to_string(missing_vectors)},
+           {"mismatched_vectors", std::to_string(mismatched_vectors)},
+           {"first_mismatch_component_mask",
+            fmt::format("{:X}",
+                        g_vehicle_shader_constant_register_first_mismatch_mask
+                            [register_index])},
+           {"mismatch_component_mask_variations",
+            std::to_string(
+                g_vehicle_shader_constant_register_mismatch_mask_variations
+                    [register_index])},
+           {"classification",
+            mismatched_vectors
+                ? "current_register_value_mismatch"
+                : missing_vectors ? "current_register_value_missing"
+                                  : "exact_current_register_value"},
            {"guest_payload_capture", "false"},
            {"native_draw", "false"},
            {"xenos_authority", "true"},
@@ -27579,8 +27766,21 @@ void UninstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system) {
           std::to_string(g_vehicle_shader_constant_source_overflow)},
          {"shader_constant_source_capacity",
           std::to_string(kVehicleShaderConstantSourceCapacity)},
+         {"shader_constant_registers_observed",
+          std::to_string(shader_constant_register_count)},
+         {"shader_constant_invalid_observed_vectors",
+          std::to_string(g_vehicle_shader_constant_invalid_observed_vectors)},
          {"shader_constant_write_contract",
-          "exact_current_vertex_register_components_and_packet_lineage"},
+           "draw_atomic_current_vertex_register_components_and_packet_lineage"},
+          {"semantic_constant_bridge_publications",
+           std::to_string(g_vehicle_semantic_constant_bridge_publications)},
+          {"semantic_constant_bridge_rejections",
+           std::to_string(g_vehicle_semantic_constant_bridge_rejections)},
+          {"semantic_constant_bridge_complete_lineage_publications",
+           std::to_string(
+               g_vehicle_semantic_constant_bridge_complete_lineage_publications)},
+          {"semantic_constant_bridge_contract",
+           "private_draw_atomic_vertex_constant_snapshot"},
          {"material_topology_groups",
           std::to_string(material_topology_group_count)},
          {"material_topology_group_accounting_complete",

--- a/tools/summarize-native-renderer-vehicle-shadow-geometry.py
+++ b/tools/summarize-native-renderer-vehicle-shadow-geometry.py
@@ -5,7 +5,7 @@ import json
 from pathlib import Path
 
 
-SCHEMA = "pinyon-shift.native-renderer-vehicle-shadow-geometry.v13"
+SCHEMA = "pinyon-shift.native-renderer-vehicle-shadow-geometry.v15"
 CONFIG_EVENT = "native_renderer.discovery.vehicle_shadow_geometry_config"
 EPOCH_EVENT = "native_renderer.discovery.vehicle_shadow_geometry_epoch"
 CORRELATION_EVENT = (
@@ -14,6 +14,9 @@ CORRELATION_EVENT = (
 CANDIDATE_EVENT = "native_renderer.discovery.vehicle_shadow_geometry_candidate"
 SHADER_CONSTANT_SOURCE_EVENT = (
     "native_renderer.discovery.vehicle_shader_constant_source"
+)
+SHADER_CONSTANT_REGISTER_EVENT = (
+    "native_renderer.discovery.vehicle_shader_constant_register"
 )
 SUMMARY_EVENT = "native_renderer.discovery.vehicle_shadow_geometry_summary"
 CAPTURE_CONFIG_EVENT = (
@@ -108,6 +111,11 @@ def summarize(log_path):
         event
         for event in events
         if event.get("event") == SHADER_CONSTANT_SOURCE_EVENT
+    ]
+    shader_constant_registers = [
+        event
+        for event in events
+        if event.get("event") == SHADER_CONSTANT_REGISTER_EVENT
     ]
     summaries = [
         event for event in events if event.get("event") == SUMMARY_EVENT
@@ -427,15 +435,93 @@ def summarize(log_path):
         "shader constant source summary capacity drift",
     )
     require(
+        integer(summary, "shader_constant_registers_observed")
+        == len(shader_constant_registers),
+        "shader constant register event accounting drift",
+    )
+    register_observed_vectors = 0
+    register_exact_vectors = 0
+    register_missing_vectors = 0
+    register_mismatched_vectors = 0
+    for event in shader_constant_registers:
+        observed_vectors = integer(event, "observed_vectors")
+        exact_vectors = integer(event, "exact_vectors")
+        missing_vectors = integer(event, "missing_vectors")
+        mismatched_vectors = integer(event, "mismatched_vectors")
+        require(
+            exact_vectors + missing_vectors + mismatched_vectors
+            == observed_vectors,
+            "shader constant register outcome drift",
+        )
+        first_mismatch_mask = hexadecimal(
+            event, "first_mismatch_component_mask"
+        )
+        mismatch_mask_variations = integer(
+            event, "mismatch_component_mask_variations"
+        )
+        require(
+            (mismatched_vectors == 0 and first_mismatch_mask == 0)
+            or (
+                mismatched_vectors > 0
+                and 0 < first_mismatch_mask < 16
+                and mismatch_mask_variations < mismatched_vectors
+            ),
+            "shader constant register mismatch mask drift",
+        )
+        register_observed_vectors += observed_vectors
+        register_exact_vectors += exact_vectors
+        register_missing_vectors += missing_vectors
+        register_mismatched_vectors += mismatched_vectors
+    require(
+        register_observed_vectors
+        + integer(summary, "shader_constant_invalid_observed_vectors")
+        == shader_constant_write_observed_vectors,
+        "shader constant register observation total drift",
+    )
+    require(
+        register_exact_vectors == shader_constant_write_exact_vectors
+        and register_missing_vectors
+        + integer(summary, "shader_constant_invalid_observed_vectors")
+        == shader_constant_write_missing_vectors
+        and register_mismatched_vectors
+        == shader_constant_write_mismatched_vectors,
+        "shader constant register classification total drift",
+    )
+    require(
         summary.get("shader_constant_write_contract")
-        == "exact_current_vertex_register_components_and_packet_lineage",
+        == "draw_atomic_current_vertex_register_components_and_packet_lineage",
         "shader constant write summary contract drift",
+    )
+    semantic_bridge_publications = integer(
+        summary, "semantic_constant_bridge_publications"
+    )
+    semantic_bridge_rejections = integer(
+        summary, "semantic_constant_bridge_rejections"
+    )
+    semantic_bridge_complete_lineage_publications = integer(
+        summary, "semantic_constant_bridge_complete_lineage_publications"
+    )
+    require(
+        semantic_bridge_publications == integer(summary, "color_draws_matched")
+        and semantic_bridge_rejections == 0,
+        "semantic constant bridge publication accounting drift",
+    )
+    require(
+        semantic_bridge_complete_lineage_publications
+        <= semantic_bridge_publications,
+        "semantic constant bridge lineage accounting drift",
+    )
+    require(
+        summary.get("semantic_constant_bridge_contract")
+        == "private_draw_atomic_vertex_constant_snapshot",
+        "semantic constant bridge contract drift",
     )
     safety_events = [
         *configs,
         *epochs,
         *correlations,
         *candidates,
+        *shader_constant_registers,
         *shader_constant_sources,
         summary,
     ]
@@ -744,6 +830,48 @@ def summarize(log_path):
                 else "unresolved"
             ),
             "candidate shader constant classification drift",
+        )
+        bridge_publications = integer(
+            event, "semantic_constant_bridge_publications"
+        )
+        bridge_constant_count = integer(
+            event, "semantic_constant_bridge_constant_count"
+        )
+        bridge_exact_vectors = integer(
+            event, "semantic_constant_bridge_exact_packet_lineage_vectors"
+        )
+        bridge_unresolved_vectors = integer(
+            event,
+            "semantic_constant_bridge_unresolved_packet_lineage_vectors",
+        )
+        require(
+            bridge_publications == integer(event, "draws")
+            and 0 < bridge_constant_count <= 64,
+            "candidate semantic constant bridge publication drift",
+        )
+        require(
+            bridge_exact_vectors + bridge_unresolved_vectors
+            == bridge_constant_count,
+            "candidate semantic constant bridge vector drift",
+        )
+        require(
+            integer(event, "semantic_constant_bridge_register_layout_variations")
+            == 0,
+            "candidate semantic constant bridge layout drift",
+        )
+        require(
+            len(event.get("semantic_constant_bridge_register_layout_hash", ""))
+            == 16,
+            "candidate semantic constant bridge layout hash drift",
+        )
+        require(
+            event.get("semantic_constant_bridge_classification")
+            == (
+                "complete_private_draw_atomic_snapshot"
+                if bridge_unresolved_vectors == 0
+                else "private_draw_atomic_snapshot_with_unresolved_lineage"
+            ),
+            "candidate semantic constant bridge classification drift",
         )
         for key in (
             "prepared_signature",
@@ -1112,6 +1240,7 @@ def summarize(log_path):
             ),
             "source_count": len(shader_constant_sources),
             "sources": shader_constant_sources,
+            "registers": shader_constant_registers,
             "complete_lineage_families": sum(
                 event.get("shader_constant_write_classification")
                 == "complete_exact_packet_lineage"

--- a/tools/tests/test_native_renderer_vehicle_shadow_geometry.py
+++ b/tools/tests/test_native_renderer_vehicle_shadow_geometry.py
@@ -148,6 +148,26 @@ class VehicleShadowGeometryTests(unittest.TestCase):
                 "shader_constant_write_maximum_age_frames": "1",
                 "shader_constant_source_count": "1",
                 "shader_constant_write_classification": "complete_exact_packet_lineage",
+                "semantic_constant_bridge_publications": "3",
+                "semantic_constant_bridge_constant_count": "3",
+                "semantic_constant_bridge_exact_packet_lineage_vectors": "3",
+                "semantic_constant_bridge_unresolved_packet_lineage_vectors": "0",
+                "semantic_constant_bridge_register_layout_hash": "2" * 16,
+                "semantic_constant_bridge_register_layout_variations": "0",
+                "semantic_constant_bridge_value_variations": "2",
+                "semantic_constant_bridge_classification": "complete_private_draw_atomic_snapshot",
+                **safety,
+            },
+            {
+                "event": MODULE.SHADER_CONSTANT_REGISTER_EVENT,
+                "register_index": "120",
+                "observed_vectors": "9",
+                "exact_vectors": "9",
+                "missing_vectors": "0",
+                "mismatched_vectors": "0",
+                "first_mismatch_component_mask": "0",
+                "mismatch_component_mask_variations": "0",
+                "classification": "exact_current_register_value",
                 **safety,
             },
             {
@@ -332,7 +352,13 @@ class VehicleShadowGeometryTests(unittest.TestCase):
                 "shader_constant_sources": "1",
                 "shader_constant_source_overflow": "0",
                 "shader_constant_source_capacity": "4096",
-                "shader_constant_write_contract": "exact_current_vertex_register_components_and_packet_lineage",
+                "shader_constant_registers_observed": "1",
+                "shader_constant_invalid_observed_vectors": "0",
+                "shader_constant_write_contract": "draw_atomic_current_vertex_register_components_and_packet_lineage",
+                "semantic_constant_bridge_publications": "3",
+                "semantic_constant_bridge_rejections": "0",
+                "semantic_constant_bridge_complete_lineage_publications": "3",
+                "semantic_constant_bridge_contract": "private_draw_atomic_vertex_constant_snapshot",
                 "material_topology_groups": "1",
                 "material_topology_group_accounting_complete": "true",
                 "material_topology_contract": "shader_specialization_render_state_texture_layout",
@@ -442,6 +468,14 @@ class VehicleShadowGeometryTests(unittest.TestCase):
         self.assertEqual(
             1, report["shader_constant_register_writes"]["source_count"]
         )
+        self.assertEqual(
+            120,
+            int(
+                report["shader_constant_register_writes"]["registers"][0][
+                    "register_index"
+                ]
+            ),
+        )
 
     def test_rejects_partial_epoch_promotion(self):
         events = self.fixture()
@@ -529,19 +563,19 @@ class VehicleShadowGeometryTests(unittest.TestCase):
 
     def test_rejects_private_capture_authority_drift(self):
         events = self.fixture()
-        events[6]["output_authority"] = "native"
+        events[7]["output_authority"] = "native"
         with self.assertRaisesRegex(ValueError, "output authority"):
             self.summarize(events)
 
     def test_rejects_private_replay_accounting_drift(self):
         events = self.fixture()
-        events[7]["private_replay_recorded"] = "2"
+        events[8]["private_replay_recorded"] = "2"
         with self.assertRaisesRegex(ValueError, "private replay outcome drift"):
             self.summarize(events)
 
     def test_rejects_retained_frame_accounting_drift(self):
         events = self.fixture()
-        events[10]["frames_completed"] = "1"
+        events[11]["frames_completed"] = "1"
         with self.assertRaisesRegex(ValueError, "retained frame outcome drift"):
             self.summarize(events)
 
@@ -562,6 +596,10 @@ class VehicleShadowGeometryTests(unittest.TestCase):
         write_patch = (
             ROOT
             / "patches/rexglue/0104-graphics-shader-constant-write-observer.patch"
+        ).read_text(encoding="utf-8")
+        provenance_patch = (
+            ROOT
+            / "patches/rexglue/0105-graphics-draw-constant-write-provenance.patch"
         ).read_text(encoding="utf-8")
         self.assertIn(
             "PINYON_SHIFT_NATIVE_RENDERER_VEHICLE_SHADOW_GEOMETRY_CORRELATION",
@@ -613,6 +651,10 @@ class VehicleShadowGeometryTests(unittest.TestCase):
         self.assertIn("GraphicsShaderConstantWriteObservation", write_patch)
         self.assertIn("shader_constant_write_observer", write_patch)
         self.assertIn("observation_packet_ = packet", write_patch)
+        self.assertIn("ShaderConstantWriteState", provenance_patch)
+        self.assertIn("write_provenance_valid", provenance_patch)
+        self.assertIn("write_value_mismatch_mask", provenance_patch)
+        self.assertIn("PublishVehicleSemanticConstantBridge", source)
         self.assertIn("[switch]$VehicleShadowGeometryCorrelation", capture)
         self.assertIn("[switch]$CaptureVehicleShadowColor", capture)
         self.assertIn("[switch]$RetainVehicleShadowColorPass", capture)

--- a/tools/tests/test_release_contract.py
+++ b/tools/tests/test_release_contract.py
@@ -43,10 +43,10 @@ class ReleaseContractTests(unittest.TestCase):
 
     def test_rexglue_patches_have_stable_order_and_no_binary_payload(self):
         patches = sorted((ROOT / "patches/rexglue").glob("*.patch"))
-        self.assertEqual(len(patches), 104)
+        self.assertEqual(len(patches), 105)
         self.assertEqual(
             patches[-1].name,
-            "0104-graphics-shader-constant-write-observer.patch",
+            "0105-graphics-draw-constant-write-provenance.patch",
         )
         self.assertEqual(len(patches), len({path.name[:4] for path in patches}))
         for path in patches:


### PR DESCRIPTION
## Summary
- retain draw-atomic final-write provenance for shader-used float constants in ReXGlue
- publish bounded private semantic snapshots for all correlated vehicle families
- report per-register mismatch masks and isolate register 254 as the only unresolved special-register path
- document the v15 AppData qualification and update the reprioritized C4 checkpoint

## Qualification
- normal AppData-backed exit
- 484 committed epochs and 14,505 matched draws across all 30 families
- 14,505 bridge publications, zero rejections, zero layout variations
- 217,575 exact vectors; zero missing or split vectors; zero-frame maximum age
- register 254 alone mismatches with stable component mask F

## Tests
- python -m unittest tools.tests.test_native_renderer_vehicle_shadow_geometry (18 passed)
- clean 	ools/prepare-rexglue.ps1 application through patch 0105
- 	ools/build-preview.ps1 -Parallel 16 (patch count 105, successful)