### PR TITLE
feat(renderer): trace player vehicle semantic ingress

### DIFF
--- a/config/rexglue/analysis/main-xex.toml
+++ b/config/rexglue/analysis/main-xex.toml
@@ -798,6 +798,36 @@ address = 0x82BC5A3C
 name = "PinyonShiftTraceVehiclePose"
 registers = ["r1", "r30", "r31"]
 
+# C4 exact player/traffic semantic ingress. CMapEntityVehicleBase virtual slot
+# 11 is the retail one-instruction vehicle-ID getter at 0x82BBA010. Observe its
+# receiver before the load so the host can census only RTTI-locked vehicle
+# entity vtables and compare the exact ID with the existing pose identity. The
+# hook reads the already-live main vtable, ID, and exact type-name pointer only; it
+# does not scan an object, change guest state, publish native output, or permit
+# suppression.
+[[midasm_hook]]
+address = 0x82BBA010
+name = "PinyonShiftObserveVehicleMapEntity"
+registers = ["r3"]
+
+# The getter qualification found the exact local-player RTTI object but its
+# vehicle ID remained the unassigned 0xFFFFFFFF sentinel. Observe the shared
+# virtual setter immediately before its exact stw r4,12(r3) so the assigned ID
+# and receiver identity are retained without changing the store or guest state.
+[[midasm_hook]]
+address = 0x82CCF228
+name = "PinyonShiftObserveVehicleMapEntityIdAssignment"
+registers = ["r3", "r4"]
+
+# Retail initialization stores the completed 1,792-byte vehicle-map pool at
+# root offset 24 here. Its exact constructor embeds player_local at pool+32 and
+# retains root+4 at pool+16. Observe only those proved lineage addresses.
+[[midasm_hook]]
+address = 0x826291A8
+name = "PinyonShiftObserveVehiclePlayerPool"
+registers = ["r3", "r31"]
+after_instruction = true
+
 # NR-05E owner-vtable draw correlation. Runtime-qualified vtable 0x8213BA54
 # contains 19 nontrivial method bodies after trivial getters, null handlers,
 # and aliases are excluded. Entry hooks preserve r3 as the owner identity;

--- a/docs/native-renderer/REPRIORITIZED_PLAN.md
+++ b/docs/native-renderer/REPRIORITIZED_PLAN.md
@@ -60,7 +60,9 @@ Already landed or substantially qualified:
 - exact native replay of an 80-draw dynamic shadow epoch with byte-identical
   D24S8 output and bounded multi-frame publication;
 - extensive vehicle provenance plus a qualified private draw-atomic semantic
-  constant bridge, without a visible semantic vehicle rendering path yet; and
+  constant bridge; exact player-local RTTI is now proved, direct entity and
+  numeric-ID pose joins are closed negatively, and the exact owning
+  vehicle-map pool lineage is the final bounded follow-up; and
 - post-processing topology census plus the mechanical presentation ingress.
 
 Phase A and B1-B5 are merged. The active B6 slice qualifies the first coherent
@@ -747,6 +749,18 @@ to advance the retained player-vehicle harness without attributing register
 254 to a guessed title producer. The next C4 slice joins player identity and
 mesh/material roles to this snapshot, then uses per-item replay fallback for
 unresolved or exceptional work.
+
+Player/traffic semantic-ingress checkpoint: retail RTTI now locks distinct
+`player_local`, `ai`, `traffic`, and `player_remote` map-entity vtables. Shared
+slot 11 returns the exact vehicle ID at offset 12, while shared slot 3 returns
+the title-owned semantic type-name pointer at offset 16. A default-off passive
+hook on the getter admits only those exact vtables and retains bounded direct
+entity/source, entity/owner, and vehicle-ID/pose-slot correlations. The static
+proof and pending runtime gate are documented in
+[`VEHICLE_PLAYER_INGRESS.md`](VEHICLE_PLAYER_INGRESS.md). Runtime qualification
+is batched with the next meaningful C4 slice; until it proves one stable unique
+player-to-pose relationship, player attribution, mesh/material labels, native
+publication, and suppression remain closed.
 
 ### C5. Sky, atmosphere, and global lighting
 

--- a/docs/native-renderer/VEHICLE_PLAYER_INGRESS.md
+++ b/docs/native-renderer/VEHICLE_PLAYER_INGRESS.md
@@ -1,0 +1,102 @@
+# Vehicle player/traffic semantic ingress
+
+Status: implemented as a default-off, read-only C4 census. Static retail
+identity is proved. Two AppData qualifications found the exact local player,
+closed its direct entity/ID joins negatively, and selected the exact owning
+vehicle-map pool as the final bounded parent-lineage check.
+
+## Exact retail contract
+
+Retail RTTI exposes five related map-entity classes with independent primary
+vtables: `CMapEntityVehicleBase` (`8201D338`),
+`CMapEntityVehiclePlayerLocal` (`8201D380`), `CMapEntityVehicleAI`
+(`8201D3C8`), `CMapEntityVehicleFestivalTraffic` (`8201D430`), and
+`CMapEntityVehicleRemotePlayer` (`8201D4B0`). All have 13 virtual slots. The
+local-player, AI, traffic, and base tables share every target; the remote-player
+table differs only in its deleting destructor. The dynamic primary vtable is
+therefore the exact class discriminator.
+
+Two shared virtual methods establish the bounded object fields:
+
+- slot 11, `82BBA010`, returns the 32-bit vehicle ID at receiver offset 12;
+- slot 3, `82BBA1B8`, returns the pointer at receiver offset 16.
+
+The offset-16 values are title-owned class names immediately following their
+respective vtables: `vehicle_type`, `player_local`, `ai`, `traffic`, and
+`player_remote`. The base constructor `82558510` stores that pointer at offset
+16, while `82CCF228` assigns the vehicle ID at offset 12. AI constructor
+`82558698` independently proves the type-name and vtable installation pattern.
+
+The local-player creation edge is also exact. Constructor `82558620` calls the
+vehicle base constructor with type-name pointer `8201D3B4`, then installs the
+`8201D380` player-local vtable. Pool constructor `8255B238` embeds that object
+at pool offset 32, followed by six 64-byte AI objects beginning at offset 144.
+Initializer `82629088` allocates the 1,792-byte pool, passes root offset 4 as
+the pool's offset-16 context, and stores the completed pool at root offset 24.
+
+`discover-native-renderer-vehicle-player-ingress.py` locks the five RTTI
+descriptors, complete-object locators, vtables, all 13 targets, class-name
+pointers, and the getter/setter/constructor instruction contracts. It does not
+infer a player label from an address or render hash.
+
+## Runtime join
+
+A passive hook at the exact ID getter observes its already-live receiver. The
+host admits only the five statically locked primary vtables, then records the
+entity address, ID, and exact class-name pointer in a fixed 128-entry table.
+Unrecognized receivers remain separately accounted because the tiny getter can
+also be used with transient compatible objects.
+
+Every admitted entity is compared only with the existing exact vehicle-pose
+tuple at `82BC5A3C`. Nine exact relationships are retained independently in a
+fixed 256-entry table:
+
+- map entity address equals pose source;
+- map entity address equals pose owner; and
+- map vehicle ID equals pose active slot;
+- vehicle-map pool equals pose source or owner;
+- pool-owning root equals pose source or owner; and
+- pool context (`root+4`) equals pose source or owner.
+
+Each correlation retains the complete pose identity, relation, frame span, and
+observation count. This avoids repeating the rejected broad object scans and
+allows the offline qualifier to determine whether one relationship uniquely
+and stably selects a player-owned pose.
+
+## Safety and next gate
+
+The census reads only the receiver's main vtable, ID, and class-name pointer.
+It does not read a class-name payload at runtime, scan any object, export guest
+constants or assets, issue a native draw, publish a target, or suppress Xenos.
+Address-table overflow, type-name mismatch, identity drift, or an ambiguous
+player-to-pose relationship fails closed.
+
+The first 2026-08-31 AppData session observed 2,035,902 getter calls, including
+48,918 calls on the five locked vehicle classes and 3,156 calls on exactly one
+stable `player_local` object (`4066DB00`). All 23 admitted objects retained the
+unassigned ID sentinel `FFFFFFFF`; the player therefore made zero eligible
+pose comparisons because the first observer incorrectly gated all direct
+pointer comparisons on an assigned ID.
+
+The corrected Xenos-authoritative session then made 19,907 direct comparisons
+for the one exact `player_local` entity with zero entity/source or entity/owner
+matches. The setter had zero calls, confirming that this fixed descriptor pool
+does not receive live numeric IDs through the class API. A proposed creation
+edge was also rejected by runtime and corrected statically: `828FA310` installs
+`8207D380`, not `8201D380`. This is why high- and low-half address formation is
+now part of the locked constructor proof.
+
+The last bounded parent edge observes the exact pool installation at
+`826291A8`, derives the already-constructed player entity as pool plus 32, and
+retains only pool, root, and root-context addresses. The next batched AppData
+session tests their six direct source/owner relationships. A zero-hit or
+ambiguous result closes this descriptor-pool branch; it must not trigger
+another broad object scan.
+
+Only a proved relationship may label the already-qualified 30-family semantic
+constant bridge as the player vehicle. Mesh/material contribution labels and
+native admission remain separate gates. The qualification launch accidentally
+inherited the restart-gated `comparison_native` display selector; that affected
+only displayed diagnostic authority. Telemetry confirms the census changed no
+guest state, and future identity runs use Xenos output unless comparison is
+explicitly requested.

--- a/src/native_renderer/graphics_hooks.cpp
+++ b/src/native_renderer/graphics_hooks.cpp
@@ -117,6 +117,13 @@ constexpr uint64_t kVisibilityShadowReplayMaximumDrawsPerFrame = 1;
 constexpr uint64_t kContinuousWorldWorksetMaximumDrawsPerFrame = 64;
 constexpr size_t kVehicleIdentityCapacity = 64;
 constexpr size_t kVehicleIdentitySummaryLimit = kVehicleIdentityCapacity;
+constexpr size_t kVehicleMapEntityCapacity = 128;
+constexpr size_t kVehicleMapPoseCorrelationCapacity = 256;
+constexpr uint32_t kVehicleMapEntityBaseVtable = 0x8201D338;
+constexpr uint32_t kVehicleMapEntityPlayerLocalVtable = 0x8201D380;
+constexpr uint32_t kVehicleMapEntityAiVtable = 0x8201D3C8;
+constexpr uint32_t kVehicleMapEntityFestivalTrafficVtable = 0x8201D430;
+constexpr uint32_t kVehicleMapEntityRemotePlayerVtable = 0x8201D4B0;
 constexpr size_t kVehicleOwnerVtableMethodCount = 32;
 constexpr size_t kVehicleOwnerMethodCandidateCount = 19;
 constexpr size_t kVehicleOwnerMethodStackCapacity = 32;
@@ -1135,6 +1142,115 @@ struct VehicleIdentityEntry {
   bool valid = false;
 };
 
+struct VehicleMapEntityEntry {
+  uint64_t observations = 0;
+  uint64_t assignment_observations = 0;
+  uint64_t pool_observations = 0;
+  uint64_t first_frame = 0;
+  uint64_t last_frame = 0;
+  uint64_t vehicle_id_changes = 0;
+  uint64_t vtable_mismatches = 0;
+  uint64_t type_name_mismatches = 0;
+  uint64_t pool_manager_changes = 0;
+  uint64_t pool_root_changes = 0;
+  uint64_t pool_context_changes = 0;
+  uint64_t pose_comparisons = 0;
+  uint64_t pose_source_matches = 0;
+  uint64_t pose_owner_matches = 0;
+  uint64_t pose_slot_matches = 0;
+  uint32_t generation = 0;
+  uint32_t entity = 0;
+  uint32_t vtable = 0;
+  uint32_t vehicle_id = UINT32_MAX;
+  uint32_t type_name_address = 0;
+  uint32_t pool_manager = 0;
+  uint32_t pool_root = 0;
+  uint32_t pool_context = 0;
+  bool valid = false;
+};
+
+enum class VehicleMapPoseRelation : uint32_t {
+  kEntityIsPoseSource,
+  kEntityIsPoseOwner,
+  kVehicleIdIsPoseSlot,
+  kPoolManagerIsPoseSource,
+  kPoolManagerIsPoseOwner,
+  kPoolRootIsPoseSource,
+  kPoolRootIsPoseOwner,
+  kPoolContextIsPoseSource,
+  kPoolContextIsPoseOwner,
+};
+
+struct VehicleMapPoseCorrelationEntry {
+  uint64_t observations = 0;
+  uint64_t first_frame = 0;
+  uint64_t last_frame = 0;
+  uint32_t entity = 0;
+  uint32_t entity_vtable = 0;
+  uint32_t vehicle_id = UINT32_MAX;
+  uint32_t identity_generation = 0;
+  uint32_t identity_source = 0;
+  uint32_t identity_owner = 0;
+  uint32_t identity_slot = 0;
+  VehicleMapPoseRelation relation =
+      VehicleMapPoseRelation::kEntityIsPoseSource;
+  bool valid = false;
+};
+
+const char *VehicleMapEntityClassName(uint32_t vtable) {
+  switch (vtable) {
+  case kVehicleMapEntityBaseVtable:
+    return "base";
+  case kVehicleMapEntityPlayerLocalVtable:
+    return "player_local";
+  case kVehicleMapEntityAiVtable:
+    return "ai";
+  case kVehicleMapEntityFestivalTrafficVtable:
+    return "festival_traffic";
+  case kVehicleMapEntityRemotePlayerVtable:
+    return "remote_player";
+  default:
+    return "unrecognized";
+  }
+}
+
+uint32_t VehicleMapEntityExpectedTypeNameAddress(uint32_t vtable) {
+  switch (vtable) {
+  case kVehicleMapEntityBaseVtable:
+  case kVehicleMapEntityPlayerLocalVtable:
+  case kVehicleMapEntityAiVtable:
+  case kVehicleMapEntityFestivalTrafficVtable:
+  case kVehicleMapEntityRemotePlayerVtable:
+    return vtable + 13 * sizeof(uint32_t);
+  default:
+    return 0;
+  }
+}
+
+const char *VehicleMapPoseRelationName(VehicleMapPoseRelation relation) {
+  switch (relation) {
+  case VehicleMapPoseRelation::kEntityIsPoseSource:
+    return "entity_is_pose_source";
+  case VehicleMapPoseRelation::kEntityIsPoseOwner:
+    return "entity_is_pose_owner";
+  case VehicleMapPoseRelation::kVehicleIdIsPoseSlot:
+    return "vehicle_id_is_pose_slot";
+  case VehicleMapPoseRelation::kPoolManagerIsPoseSource:
+    return "pool_manager_is_pose_source";
+  case VehicleMapPoseRelation::kPoolManagerIsPoseOwner:
+    return "pool_manager_is_pose_owner";
+  case VehicleMapPoseRelation::kPoolRootIsPoseSource:
+    return "pool_root_is_pose_source";
+  case VehicleMapPoseRelation::kPoolRootIsPoseOwner:
+    return "pool_root_is_pose_owner";
+  case VehicleMapPoseRelation::kPoolContextIsPoseSource:
+    return "pool_context_is_pose_source";
+  case VehicleMapPoseRelation::kPoolContextIsPoseOwner:
+    return "pool_context_is_pose_owner";
+  }
+  return "unknown";
+}
+
 struct VehicleOwnerMethodCandidate {
   uint32_t method_address = 0;
   uint32_t exit_address = 0;
@@ -1482,6 +1598,11 @@ thread_local PendingVehicleDrawIdentityEvidence
 
 std::array<VehicleIdentityEntry, kVehicleIdentityCapacity>
     g_vehicle_identities{};
+std::array<VehicleMapEntityEntry, kVehicleMapEntityCapacity>
+    g_vehicle_map_entities{};
+std::array<VehicleMapPoseCorrelationEntry,
+           kVehicleMapPoseCorrelationCapacity>
+    g_vehicle_map_pose_correlations{};
 std::mutex g_vehicle_identity_mutex;
 std::atomic<bool> g_vehicle_discovery_installed{};
 std::atomic<rex::memory::Memory *> g_vehicle_discovery_memory{};
@@ -1490,6 +1611,22 @@ uint64_t g_vehicle_valid_observations = 0;
 uint64_t g_vehicle_invalid_observations = 0;
 uint64_t g_vehicle_identity_count = 0;
 uint64_t g_vehicle_identity_overflow = 0;
+uint64_t g_vehicle_map_entity_observations = 0;
+uint64_t g_vehicle_map_entity_valid_observations = 0;
+uint64_t g_vehicle_map_entity_unrecognized_observations = 0;
+uint64_t g_vehicle_map_entity_invalid_observations = 0;
+uint64_t g_vehicle_map_entity_assignment_observations = 0;
+uint64_t g_vehicle_map_entity_assignment_valid_observations = 0;
+uint64_t g_vehicle_map_entity_assignment_unrecognized_observations = 0;
+uint64_t g_vehicle_map_entity_assignment_invalid_observations = 0;
+uint64_t g_vehicle_map_entity_pool_observations = 0;
+uint64_t g_vehicle_map_entity_pool_valid_observations = 0;
+uint64_t g_vehicle_map_entity_pool_unrecognized_observations = 0;
+uint64_t g_vehicle_map_entity_pool_invalid_observations = 0;
+uint64_t g_vehicle_map_entity_count = 0;
+uint64_t g_vehicle_map_entity_overflow = 0;
+uint64_t g_vehicle_map_pose_correlation_count = 0;
+uint64_t g_vehicle_map_pose_correlation_overflow = 0;
 std::array<VehicleOwnerMethodStats, kVehicleOwnerMethodCandidateCount>
     g_vehicle_owner_method_stats{};
 std::atomic<uint64_t> g_vehicle_owner_method_stack_faults{};
@@ -24504,6 +24641,24 @@ void ConfigureVehicleDiscovery(bool census_requested,
     g_vehicle_identity_addresses = {};
     g_vehicle_identity_address_count = 0;
     g_vehicle_identity_address_overflow = 0;
+    g_vehicle_map_entities = {};
+    g_vehicle_map_entity_observations = 0;
+    g_vehicle_map_entity_valid_observations = 0;
+    g_vehicle_map_entity_unrecognized_observations = 0;
+    g_vehicle_map_entity_invalid_observations = 0;
+    g_vehicle_map_entity_assignment_observations = 0;
+    g_vehicle_map_entity_assignment_valid_observations = 0;
+    g_vehicle_map_entity_assignment_unrecognized_observations = 0;
+    g_vehicle_map_entity_assignment_invalid_observations = 0;
+    g_vehicle_map_entity_pool_observations = 0;
+    g_vehicle_map_entity_pool_valid_observations = 0;
+    g_vehicle_map_entity_pool_unrecognized_observations = 0;
+    g_vehicle_map_entity_pool_invalid_observations = 0;
+    g_vehicle_map_entity_count = 0;
+    g_vehicle_map_entity_overflow = 0;
+    g_vehicle_map_pose_correlations = {};
+    g_vehicle_map_pose_correlation_count = 0;
+    g_vehicle_map_pose_correlation_overflow = 0;
     g_vehicle_matrix_correlations = {};
     g_vehicle_matrix_caller_observations = 0;
     g_vehicle_matrix_caller_valid_observations = 0;
@@ -24661,6 +24816,18 @@ void ConfigureVehicleDiscovery(bool census_requested,
         std::to_string(kVehicleIdentitySummaryLimit)},
        {"classification", "unclassified_vehicle_pose_stream"},
        {"player_priority_admitted", "false"},
+       {"map_entity_hook", "82BBA010"},
+       {"map_entity_assignment_hook", "82CCF228"},
+       {"player_pool_hook", "826291A8"},
+       {"map_entity_contract",
+        "rtti_locked_main_vtable,vehicle_id_at_12,type_name_pointer_at_16"},
+       {"map_entity_capacity",
+        std::to_string(kVehicleMapEntityCapacity)},
+       {"map_entity_vtables",
+        "8201D338:base,8201D380:player_local,8201D3C8:ai,"
+        "8201D430:festival_traffic,8201D4B0:remote_player"},
+       {"map_entity_pose_join",
+        "exact_entity_to_source,entity_to_owner,vehicle_id_to_active_slot"},
        {"owner_vtable_method_count",
         std::to_string(kVehicleOwnerVtableMethodCount)},
        {"owner_method_candidates",
@@ -24776,6 +24943,39 @@ void EmitVehicleDiscoverySummary() {
       g_vehicle_composed_matrix_candidate_observations +
           g_vehicle_composed_matrix_routes_without_identity ==
       g_vehicle_composed_matrix_valid_pairs * 8;
+  const bool vehicle_map_entity_accounting_complete =
+      g_vehicle_map_entity_valid_observations +
+          g_vehicle_map_entity_unrecognized_observations +
+          g_vehicle_map_entity_invalid_observations ==
+      g_vehicle_map_entity_observations;
+  const bool vehicle_map_entity_assignment_accounting_complete =
+      g_vehicle_map_entity_assignment_valid_observations +
+          g_vehicle_map_entity_assignment_unrecognized_observations +
+          g_vehicle_map_entity_assignment_invalid_observations ==
+      g_vehicle_map_entity_assignment_observations;
+  const bool vehicle_map_entity_pool_accounting_complete =
+      g_vehicle_map_entity_pool_valid_observations +
+          g_vehicle_map_entity_pool_unrecognized_observations +
+          g_vehicle_map_entity_pool_invalid_observations ==
+      g_vehicle_map_entity_pool_observations;
+  uint64_t player_entity_count = 0;
+  uint64_t player_entity_observations = 0;
+  uint64_t player_pose_comparisons = 0;
+  uint64_t player_pose_source_matches = 0;
+  uint64_t player_pose_owner_matches = 0;
+  uint64_t player_pose_slot_matches = 0;
+  for (const VehicleMapEntityEntry &entry : g_vehicle_map_entities) {
+    if (!entry.valid ||
+        entry.vtable != kVehicleMapEntityPlayerLocalVtable) {
+      continue;
+    }
+    ++player_entity_count;
+    player_entity_observations += entry.observations;
+    player_pose_comparisons += entry.pose_comparisons;
+    player_pose_source_matches += entry.pose_source_matches;
+    player_pose_owner_matches += entry.pose_owner_matches;
+    player_pose_slot_matches += entry.pose_slot_matches;
+  }
   pinyon_shift::diagnostics::RecordEvent(
       "native_renderer.discovery.vehicle_pose_summary",
       {{"status", !g_vehicle_observations
@@ -25010,6 +25210,153 @@ void EmitVehicleDiscoverySummary() {
        {"native_draw", "false"},
        {"xenos_authority", "true"},
        {"suppression_allowed", "false"}});
+  pinyon_shift::diagnostics::RecordEvent(
+      "native_renderer.discovery.vehicle_map_entity_summary",
+      {{"status", !g_vehicle_map_entity_observations
+                      ? "not_observed"
+                      : (vehicle_map_entity_accounting_complete
+                             ? "complete"
+                             : "incomplete")},
+       {"hook", "82BBA010"},
+       {"assignment_hook", "82CCF228"},
+       {"observations", std::to_string(g_vehicle_map_entity_observations)},
+       {"valid_observations",
+        std::to_string(g_vehicle_map_entity_valid_observations)},
+       {"unrecognized_observations",
+        std::to_string(g_vehicle_map_entity_unrecognized_observations)},
+       {"invalid_observations",
+        std::to_string(g_vehicle_map_entity_invalid_observations)},
+       {"entities", std::to_string(g_vehicle_map_entity_count)},
+       {"capacity", std::to_string(kVehicleMapEntityCapacity)},
+       {"overflow", std::to_string(g_vehicle_map_entity_overflow)},
+       {"pose_correlations",
+        std::to_string(g_vehicle_map_pose_correlation_count)},
+       {"pose_correlation_capacity",
+        std::to_string(kVehicleMapPoseCorrelationCapacity)},
+       {"pose_correlation_overflow",
+        std::to_string(g_vehicle_map_pose_correlation_overflow)},
+       {"accounting_complete",
+        vehicle_map_entity_accounting_complete ? "true" : "false"},
+       {"assignment_observations",
+        std::to_string(g_vehicle_map_entity_assignment_observations)},
+       {"assignment_valid_observations",
+        std::to_string(g_vehicle_map_entity_assignment_valid_observations)},
+       {"assignment_unrecognized_observations",
+        std::to_string(
+            g_vehicle_map_entity_assignment_unrecognized_observations)},
+       {"assignment_invalid_observations",
+        std::to_string(g_vehicle_map_entity_assignment_invalid_observations)},
+       {"assignment_accounting_complete",
+        vehicle_map_entity_assignment_accounting_complete ? "true" : "false"},
+       {"pool_hook", "826291A8"},
+       {"pool_observations",
+        std::to_string(g_vehicle_map_entity_pool_observations)},
+       {"pool_valid_observations",
+        std::to_string(g_vehicle_map_entity_pool_valid_observations)},
+       {"pool_unrecognized_observations",
+        std::to_string(g_vehicle_map_entity_pool_unrecognized_observations)},
+       {"pool_invalid_observations",
+        std::to_string(g_vehicle_map_entity_pool_invalid_observations)},
+       {"pool_accounting_complete",
+        vehicle_map_entity_pool_accounting_complete ? "true" : "false"},
+       {"player_local_entities", std::to_string(player_entity_count)},
+       {"player_local_observations",
+        std::to_string(player_entity_observations)},
+       {"player_pose_comparisons",
+        std::to_string(player_pose_comparisons)},
+       {"player_pose_source_matches",
+        std::to_string(player_pose_source_matches)},
+       {"player_pose_owner_matches",
+        std::to_string(player_pose_owner_matches)},
+       {"player_pose_slot_matches",
+        std::to_string(player_pose_slot_matches)},
+       {"classification", "rtti_locked_vehicle_map_entity_census"},
+       {"player_pose_relation_candidate",
+        player_pose_comparisons &&
+                (player_pose_source_matches || player_pose_owner_matches ||
+                 player_pose_slot_matches)
+            ? "true"
+            : "false"},
+       {"player_vehicle_identity_proved", "false"},
+       {"guest_payload_read", "main_vtable,id,type_name_pointer"},
+       {"guest_state_changed", "false"},
+       {"native_draw", "false"},
+       {"xenos_authority", "true"},
+       {"suppression_allowed", "false"}});
+  for (const VehicleMapEntityEntry &entry : g_vehicle_map_entities) {
+    if (!entry.valid) {
+      continue;
+    }
+    const uint32_t expected_type_name =
+        VehicleMapEntityExpectedTypeNameAddress(entry.vtable);
+    pinyon_shift::diagnostics::RecordEvent(
+        "native_renderer.discovery.vehicle_map_entity",
+        {{"generation", fmt::format("{:08X}", entry.generation)},
+         {"entity", fmt::format("{:08X}", entry.entity)},
+         {"class", VehicleMapEntityClassName(entry.vtable)},
+         {"vtable", fmt::format("{:08X}", entry.vtable)},
+         {"vehicle_id", fmt::format("{:08X}", entry.vehicle_id)},
+         {"type_name_address",
+          fmt::format("{:08X}", entry.type_name_address)},
+         {"expected_type_name_address",
+          fmt::format("{:08X}", expected_type_name)},
+         {"observations", std::to_string(entry.observations)},
+         {"assignment_observations",
+          std::to_string(entry.assignment_observations)},
+         {"pool_observations", std::to_string(entry.pool_observations)},
+         {"pool_manager", fmt::format("{:08X}", entry.pool_manager)},
+         {"pool_root", fmt::format("{:08X}", entry.pool_root)},
+         {"pool_context", fmt::format("{:08X}", entry.pool_context)},
+         {"pool_manager_changes",
+          std::to_string(entry.pool_manager_changes)},
+         {"pool_root_changes", std::to_string(entry.pool_root_changes)},
+         {"pool_context_changes",
+          std::to_string(entry.pool_context_changes)},
+         {"first_frame", std::to_string(entry.first_frame)},
+         {"last_frame", std::to_string(entry.last_frame)},
+         {"vehicle_id_changes", std::to_string(entry.vehicle_id_changes)},
+         {"vtable_mismatches", std::to_string(entry.vtable_mismatches)},
+         {"type_name_mismatches",
+          std::to_string(entry.type_name_mismatches)},
+         {"pose_comparisons", std::to_string(entry.pose_comparisons)},
+         {"pose_source_matches",
+          std::to_string(entry.pose_source_matches)},
+         {"pose_owner_matches", std::to_string(entry.pose_owner_matches)},
+         {"pose_slot_matches", std::to_string(entry.pose_slot_matches)},
+         {"classification", "exact_vehicle_map_entity_identity"},
+         {"player_vehicle_identity_proved", "false"},
+         {"guest_state_changed", "false"},
+         {"native_draw", "false"},
+         {"xenos_authority", "true"},
+         {"suppression_allowed", "false"}});
+  }
+  for (const VehicleMapPoseCorrelationEntry &entry :
+       g_vehicle_map_pose_correlations) {
+    if (!entry.valid) {
+      continue;
+    }
+    pinyon_shift::diagnostics::RecordEvent(
+        "native_renderer.discovery.vehicle_map_pose_correlation",
+        {{"entity", fmt::format("{:08X}", entry.entity)},
+         {"entity_class", VehicleMapEntityClassName(entry.entity_vtable)},
+         {"entity_vtable", fmt::format("{:08X}", entry.entity_vtable)},
+         {"vehicle_id", fmt::format("{:08X}", entry.vehicle_id)},
+         {"relation", VehicleMapPoseRelationName(entry.relation)},
+         {"identity_generation",
+          fmt::format("{:08X}", entry.identity_generation)},
+         {"identity_source", fmt::format("{:08X}", entry.identity_source)},
+         {"identity_owner", fmt::format("{:08X}", entry.identity_owner)},
+         {"identity_slot", std::to_string(entry.identity_slot)},
+         {"observations", std::to_string(entry.observations)},
+         {"first_frame", std::to_string(entry.first_frame)},
+         {"last_frame", std::to_string(entry.last_frame)},
+         {"classification", "exact_map_entity_to_pose_relation_candidate"},
+         {"player_vehicle_identity_proved", "false"},
+         {"guest_state_changed", "false"},
+         {"native_draw", "false"},
+         {"xenos_authority", "true"},
+         {"suppression_allowed", "false"}});
+  }
   for (const VehicleRenderContextCalleeProfileEntry &entry :
        g_vehicle_render_context_callee_profiles) {
     if (!entry.valid) {
@@ -25528,6 +25875,197 @@ void ObserveVehicleOwnerIndirectCall(uint32_t method_address,
   ++g_vehicle_owner_indirect_target_count;
 }
 
+enum class VehicleMapObservationKind : uint32_t {
+  kGetter,
+  kIdAssignment,
+  kPlayerPool,
+};
+
+void ObserveVehicleMapEntityInternal(
+    uint32_t generation, uint32_t entity, uint32_t vtable,
+    uint32_t vehicle_id, uint32_t type_name_address,
+    VehicleMapObservationKind kind, uint32_t pool_manager = 0,
+    uint32_t pool_root = 0, uint32_t pool_context = 0) {
+  if (!g_vehicle_discovery_installed.load(std::memory_order_acquire)) {
+    return;
+  }
+  const uint32_t expected_type_name =
+      VehicleMapEntityExpectedTypeNameAddress(vtable);
+  std::scoped_lock lock(g_vehicle_identity_mutex);
+  if (!g_vehicle_discovery_installed.load(std::memory_order_acquire)) {
+    return;
+  }
+  uint64_t *observations = &g_vehicle_map_entity_observations;
+  uint64_t *valid_observations = &g_vehicle_map_entity_valid_observations;
+  uint64_t *unrecognized_observations =
+      &g_vehicle_map_entity_unrecognized_observations;
+  uint64_t *invalid_observations =
+      &g_vehicle_map_entity_invalid_observations;
+  if (kind == VehicleMapObservationKind::kIdAssignment) {
+    observations = &g_vehicle_map_entity_assignment_observations;
+    valid_observations = &g_vehicle_map_entity_assignment_valid_observations;
+    unrecognized_observations =
+        &g_vehicle_map_entity_assignment_unrecognized_observations;
+    invalid_observations =
+        &g_vehicle_map_entity_assignment_invalid_observations;
+  } else if (kind == VehicleMapObservationKind::kPlayerPool) {
+    observations = &g_vehicle_map_entity_pool_observations;
+    valid_observations = &g_vehicle_map_entity_pool_valid_observations;
+    unrecognized_observations =
+        &g_vehicle_map_entity_pool_unrecognized_observations;
+    invalid_observations = &g_vehicle_map_entity_pool_invalid_observations;
+  }
+  ++*observations;
+  if (!generation || !entity || (entity & 3) || !vtable || (vtable & 3)) {
+    ++*invalid_observations;
+    return;
+  }
+  if (!expected_type_name) {
+    ++*unrecognized_observations;
+    return;
+  }
+  ++*valid_observations;
+  VehicleMapEntityEntry *available = nullptr;
+  VehicleMapEntityEntry *matched = nullptr;
+  for (VehicleMapEntityEntry &entry : g_vehicle_map_entities) {
+    if (!entry.valid) {
+      if (!available) {
+        available = &entry;
+      }
+      continue;
+    }
+    if (entry.generation == generation && entry.entity == entity) {
+      matched = &entry;
+      break;
+    }
+  }
+  if (!matched) {
+    if (!available) {
+      ++g_vehicle_map_entity_overflow;
+      return;
+    }
+    matched = available;
+    matched->valid = true;
+    matched->generation = generation;
+    matched->entity = entity;
+    matched->vtable = vtable;
+    matched->vehicle_id = vehicle_id;
+    matched->type_name_address = type_name_address;
+    matched->first_frame = g_frame_sequence.load(std::memory_order_relaxed);
+    ++g_vehicle_map_entity_count;
+  } else {
+    if (matched->vehicle_id != vehicle_id) {
+      ++matched->vehicle_id_changes;
+    }
+    if (matched->vtable != vtable) {
+      ++matched->vtable_mismatches;
+    }
+    matched->vtable = vtable;
+    matched->vehicle_id = vehicle_id;
+    matched->type_name_address = type_name_address;
+  }
+  if (kind == VehicleMapObservationKind::kIdAssignment) {
+    ++matched->assignment_observations;
+  } else if (kind == VehicleMapObservationKind::kPlayerPool) {
+    if (matched->pool_observations) {
+      if (matched->pool_manager != pool_manager) {
+        ++matched->pool_manager_changes;
+      }
+      if (matched->pool_root != pool_root) {
+        ++matched->pool_root_changes;
+      }
+      if (matched->pool_context != pool_context) {
+        ++matched->pool_context_changes;
+      }
+    }
+    ++matched->pool_observations;
+    matched->pool_manager = pool_manager;
+    matched->pool_root = pool_root;
+    matched->pool_context = pool_context;
+  }
+  if (type_name_address != expected_type_name) {
+    ++matched->type_name_mismatches;
+  }
+  ++matched->observations;
+  matched->last_frame = g_frame_sequence.load(std::memory_order_relaxed);
+}
+
+void ObserveVehicleMapEntity(uint32_t generation, uint32_t entity,
+                             uint32_t vtable, uint32_t vehicle_id,
+                             uint32_t type_name_address) {
+  ObserveVehicleMapEntityInternal(generation, entity, vtable, vehicle_id,
+                                  type_name_address,
+                                  VehicleMapObservationKind::kGetter);
+}
+
+void ObserveVehicleMapEntityIdAssignment(uint32_t generation, uint32_t entity,
+                                         uint32_t vtable,
+                                         uint32_t assigned_vehicle_id,
+                                         uint32_t type_name_address) {
+  ObserveVehicleMapEntityInternal(generation, entity, vtable,
+                                  assigned_vehicle_id, type_name_address,
+                                  VehicleMapObservationKind::kIdAssignment);
+}
+
+void ObserveVehiclePlayerPool(uint32_t generation, uint32_t entity,
+                              uint32_t vtable, uint32_t vehicle_id,
+                              uint32_t type_name_address,
+                              uint32_t pool_manager, uint32_t pool_root,
+                              uint32_t pool_context) {
+  ObserveVehicleMapEntityInternal(
+      generation, entity, vtable, vehicle_id, type_name_address,
+      VehicleMapObservationKind::kPlayerPool, pool_manager, pool_root,
+      pool_context);
+}
+
+void RecordVehicleMapPoseCorrelationLocked(
+    const VehicleMapEntityEntry &entity,
+    const VehiclePoseObservation &observation,
+    VehicleMapPoseRelation relation) {
+  VehicleMapPoseCorrelationEntry *available = nullptr;
+  for (VehicleMapPoseCorrelationEntry &entry :
+       g_vehicle_map_pose_correlations) {
+    if (!entry.valid) {
+      if (!available) {
+        available = &entry;
+      }
+      continue;
+    }
+    if (entry.entity == entity.entity &&
+        entry.entity_vtable == entity.vtable &&
+        entry.vehicle_id == entity.vehicle_id &&
+        entry.identity_generation == observation.generation &&
+        entry.identity_source == observation.source &&
+        entry.identity_owner == observation.owner &&
+        entry.identity_slot == observation.slot &&
+        entry.relation == relation) {
+      ++entry.observations;
+      entry.last_frame = g_frame_sequence.load(std::memory_order_relaxed);
+      return;
+    }
+  }
+  if (!available) {
+    ++g_vehicle_map_pose_correlation_overflow;
+    return;
+  }
+  const uint64_t frame = g_frame_sequence.load(std::memory_order_relaxed);
+  *available = {
+      .observations = 1,
+      .first_frame = frame,
+      .last_frame = frame,
+      .entity = entity.entity,
+      .entity_vtable = entity.vtable,
+      .vehicle_id = entity.vehicle_id,
+      .identity_generation = observation.generation,
+      .identity_source = observation.source,
+      .identity_owner = observation.owner,
+      .identity_slot = observation.slot,
+      .relation = relation,
+      .valid = true,
+  };
+  ++g_vehicle_map_pose_correlation_count;
+}
+
 void ObserveVehiclePose(const VehiclePoseObservation &observation) {
   if (!g_vehicle_discovery_installed.load(std::memory_order_acquire)) {
     return;
@@ -25557,6 +26095,55 @@ void ObserveVehiclePose(const VehiclePoseObservation &observation) {
     return;
   }
   ++g_vehicle_valid_observations;
+  for (VehicleMapEntityEntry &entity : g_vehicle_map_entities) {
+    if (!entity.valid || entity.generation != observation.generation) {
+      continue;
+    }
+    ++entity.pose_comparisons;
+    if (entity.entity == observation.source) {
+      ++entity.pose_source_matches;
+      RecordVehicleMapPoseCorrelationLocked(
+          entity, observation, VehicleMapPoseRelation::kEntityIsPoseSource);
+    }
+    if (entity.entity == observation.owner) {
+      ++entity.pose_owner_matches;
+      RecordVehicleMapPoseCorrelationLocked(
+          entity, observation, VehicleMapPoseRelation::kEntityIsPoseOwner);
+    }
+    if (entity.vehicle_id != UINT32_MAX &&
+        entity.vehicle_id == observation.slot) {
+      ++entity.pose_slot_matches;
+      RecordVehicleMapPoseCorrelationLocked(
+          entity, observation,
+          VehicleMapPoseRelation::kVehicleIdIsPoseSlot);
+    }
+    if (entity.pool_observations &&
+        entity.pool_manager == observation.source) {
+      RecordVehicleMapPoseCorrelationLocked(
+          entity, observation,
+          VehicleMapPoseRelation::kPoolManagerIsPoseSource);
+    }
+    if (entity.pool_observations && entity.pool_manager == observation.owner) {
+      RecordVehicleMapPoseCorrelationLocked(
+          entity, observation, VehicleMapPoseRelation::kPoolManagerIsPoseOwner);
+    }
+    if (entity.pool_observations && entity.pool_root == observation.source) {
+      RecordVehicleMapPoseCorrelationLocked(
+          entity, observation, VehicleMapPoseRelation::kPoolRootIsPoseSource);
+    }
+    if (entity.pool_observations && entity.pool_root == observation.owner) {
+      RecordVehicleMapPoseCorrelationLocked(
+          entity, observation, VehicleMapPoseRelation::kPoolRootIsPoseOwner);
+    }
+    if (entity.pool_observations && entity.pool_context == observation.source) {
+      RecordVehicleMapPoseCorrelationLocked(
+          entity, observation, VehicleMapPoseRelation::kPoolContextIsPoseSource);
+    }
+    if (entity.pool_observations && entity.pool_context == observation.owner) {
+      RecordVehicleMapPoseCorrelationLocked(
+          entity, observation, VehicleMapPoseRelation::kPoolContextIsPoseOwner);
+    }
+  }
   VehicleIdentityEntry *available = nullptr;
   VehicleIdentityEntry *matched = nullptr;
   for (VehicleIdentityEntry &entry : g_vehicle_identities) {

--- a/src/native_renderer/graphics_hooks.h
+++ b/src/native_renderer/graphics_hooks.h
@@ -38,6 +38,18 @@ struct VehiclePoseObservation {
 };
 
 void ObserveVehiclePose(const VehiclePoseObservation& observation);
+void ObserveVehicleMapEntity(uint32_t generation, uint32_t entity,
+                             uint32_t vtable, uint32_t vehicle_id,
+                             uint32_t type_name_address);
+void ObserveVehicleMapEntityIdAssignment(uint32_t generation, uint32_t entity,
+                                         uint32_t vtable,
+                                         uint32_t assigned_vehicle_id,
+                                         uint32_t type_name_address);
+void ObserveVehiclePlayerPool(uint32_t generation, uint32_t entity,
+                              uint32_t vtable, uint32_t vehicle_id,
+                              uint32_t type_name_address,
+                              uint32_t pool_manager, uint32_t pool_root,
+                              uint32_t pool_context);
 void BeginVehicleOwnerMethod(uint32_t method_address, uint32_t owner_address);
 void EndVehicleOwnerMethod(uint32_t method_address);
 void ObserveVehicleOwnerIndirectCall(uint32_t method_address,

--- a/src/pinyon_shift_runtime_hooks.cpp
+++ b/src/pinyon_shift_runtime_hooks.cpp
@@ -563,6 +563,43 @@ void PinyonShiftTraceVehiclePose(PPCRegister& r1, PPCRegister& r30,
        {"forward_z", fmt::format("{}", effective.forward_z)}});
 }
 
+void PinyonShiftObserveVehicleMapEntity(PPCRegister& r3) {
+  if (!r3.u32) {
+    return;
+  }
+  pinyon_shift::native_renderer::ObserveVehicleMapEntity(
+      g_title_generation.load(std::memory_order_acquire), r3.u32,
+      LoadGuestU32(r3.u32), LoadGuestU32(r3.u32 + 12),
+      LoadGuestU32(r3.u32 + 16));
+}
+
+void PinyonShiftObserveVehicleMapEntityIdAssignment(PPCRegister& r3,
+                                                    PPCRegister& r4) {
+  if (!r3.u32) {
+    return;
+  }
+  pinyon_shift::native_renderer::ObserveVehicleMapEntityIdAssignment(
+      g_title_generation.load(std::memory_order_acquire), r3.u32,
+      LoadGuestU32(r3.u32), r4.u32, LoadGuestU32(r3.u32 + 16));
+}
+
+void PinyonShiftObserveVehiclePlayerPool(PPCRegister& r3, PPCRegister& r31) {
+  constexpr uint32_t kPlayerEntityOffset = 32;
+  constexpr uint32_t kPlayerTypeNameOffset = 16;
+  constexpr uint32_t kPoolContextOffset = 4;
+  if (!r3.u32 || !r31.u32 || (r3.u32 & 3) || (r31.u32 & 3) ||
+      r3.u32 > UINT32_MAX - kPlayerEntityOffset - kPlayerTypeNameOffset ||
+      r31.u32 > UINT32_MAX - kPoolContextOffset) {
+    return;
+  }
+  const uint32_t entity = r3.u32 + kPlayerEntityOffset;
+  pinyon_shift::native_renderer::ObserveVehiclePlayerPool(
+      g_title_generation.load(std::memory_order_acquire), entity,
+      LoadGuestU32(entity), LoadGuestU32(entity + 12),
+      LoadGuestU32(entity + kPlayerTypeNameOffset), r3.u32, r31.u32,
+      r31.u32 + kPoolContextOffset);
+}
+
 void PinyonShiftTraceBdz82AD8138(PPCRegister& ctr) {
   if (ctr.u32 == 1) {
     pinyon_shift::diagnostics::RecordEvent(

--- a/tools/discover-native-renderer-vehicle-player-ingress.py
+++ b/tools/discover-native-renderer-vehicle-player-ingress.py
@@ -1,0 +1,322 @@
+#!/usr/bin/env python3
+"""Lock the retail player/traffic map-entity semantic ingress."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import pathlib
+import re
+import sys
+
+
+SCHEMA = "pinyon-shift.native-renderer-vehicle-player-ingress.v1"
+IMAGE_BASE = 0x82000000
+FUNCTION_RE = re.compile(r"^DEFINE_REX_FUNC\(sub_([0-9A-F]{8})\) \{")
+INSTRUCTION_RE = re.compile(r"^\s*// (.+)$")
+GET_VEHICLE_ID = 0x82BBA010
+GET_TYPE_NAME = 0x82BBA1B8
+SET_VEHICLE_ID = 0x82CCF228
+BASE_CONSTRUCTOR = 0x82558510
+AI_CONSTRUCTOR = 0x82558698
+PLAYER_LOCAL_CONSTRUCTOR = 0x82558620
+VEHICLE_MAP_POOL_CONSTRUCTOR = 0x8255B238
+VEHICLE_MAP_POOL_INSTALLER = 0x82629088
+COMMON_METHODS = (
+    0x82559FE0,
+    0x82611B80,
+    0x82558590,
+    GET_TYPE_NAME,
+    0x82CD1900,
+    0x825585A0,
+    0x825585B8,
+    0x825585E0,
+    0x825585F8,
+    SET_VEHICLE_ID,
+    0x82CCF240,
+    GET_VEHICLE_ID,
+    0x82CCF260,
+)
+
+# name, type descriptor, complete-object locator, primary vtable,
+# title-owned type-name pointer, title-owned type name, slot-zero target.
+EXPECTED_TYPES = (
+    (
+        ".?AVCMapEntityVehicleBase@@",
+        0x83227960,
+        0x822E7924,
+        0x8201D338,
+        0x8201D36C,
+        "vehicle_type",
+        0x82559FE0,
+    ),
+    (
+        ".?AVCMapEntityVehiclePlayerLocal@@",
+        0x83227984,
+        0x822E7970,
+        0x8201D380,
+        0x8201D3B4,
+        "player_local",
+        0x82559FE0,
+    ),
+    (
+        ".?AVCMapEntityVehicleAI@@",
+        0x832279B0,
+        0x822E79C0,
+        0x8201D3C8,
+        0x8201D3FC,
+        "ai",
+        0x82559FE0,
+    ),
+    (
+        ".?AVCMapEntityVehicleFestivalTraffic@@",
+        0x83227A20,
+        0x822E7AA4,
+        0x8201D430,
+        0x8201D464,
+        "traffic",
+        0x82559FE0,
+    ),
+    (
+        ".?AVCMapEntityVehicleRemotePlayer@@",
+        0x83227A9C,
+        0x822E7B88,
+        0x8201D4B0,
+        0x8201D4E4,
+        "player_remote",
+        0x8255A7C8,
+    ),
+)
+
+
+def image_u32(image: bytes, address: int) -> int:
+    offset = address - IMAGE_BASE
+    if offset < 0 or offset + 4 > len(image):
+        raise ValueError(f"image address is out of range: {address:08X}")
+    return int.from_bytes(image[offset : offset + 4], "big")
+
+
+def image_string(image: bytes, address: int) -> str:
+    offset = address - IMAGE_BASE
+    if offset < 0 or offset >= len(image):
+        raise ValueError(f"image string is out of range: {address:08X}")
+    end = image.find(b"\0", offset, min(offset + 256, len(image)))
+    if end < 0:
+        raise ValueError(f"image string is unterminated: {address:08X}")
+    return image[offset:end].decode("ascii")
+
+
+def parse_function_sources(paths: list[pathlib.Path]) -> tuple[set[int], dict[int, list[str]]]:
+    functions: set[int] = set()
+    bodies: dict[int, list[str]] = {}
+    for path in sorted(paths, key=lambda item: item.as_posix()):
+        active = None
+        for line in path.read_text(encoding="utf-8").splitlines():
+            match = FUNCTION_RE.match(line)
+            if match:
+                active = int(match.group(1), 16)
+                functions.add(active)
+                bodies[active] = []
+                continue
+            instruction = INSTRUCTION_RE.match(line)
+            if active is not None and instruction:
+                bodies[active].append(instruction.group(1).strip())
+    return functions, bodies
+
+
+def require_ordered(body: list[str], expected: tuple[str, ...], label: str) -> None:
+    cursor = 0
+    for instruction in body:
+        if cursor < len(expected) and instruction == expected[cursor]:
+            cursor += 1
+    if cursor != len(expected):
+        raise ValueError(f"{label} instruction contract drifted")
+
+
+def build(functions: set[int], bodies: dict[int, list[str]], image: bytes) -> dict:
+    required_functions = {
+        target
+        for expected in EXPECTED_TYPES
+        for target in ((expected[6],) + COMMON_METHODS[1:])
+    } | {
+        BASE_CONSTRUCTOR,
+        AI_CONSTRUCTOR,
+        PLAYER_LOCAL_CONSTRUCTOR,
+        VEHICLE_MAP_POOL_CONSTRUCTOR,
+        VEHICLE_MAP_POOL_INSTALLER,
+    }
+    missing = sorted(required_functions - functions)
+    if missing:
+        raise ValueError(
+            "vehicle ingress functions are missing: "
+            + ",".join(f"{value:08X}" for value in missing)
+        )
+
+    require_ordered(
+        bodies.get(GET_VEHICLE_ID, []),
+        ("lwz r3,12(r3)", "blr"),
+        "vehicle ID getter",
+    )
+    require_ordered(
+        bodies.get(GET_TYPE_NAME, []),
+        ("lwz r3,16(r3)", "blr"),
+        "vehicle type-name getter",
+    )
+    require_ordered(
+        bodies.get(SET_VEHICLE_ID, []),
+        ("stw r4,12(r3)", "stfs f0,8(r3)", "blr"),
+        "vehicle ID setter",
+    )
+    require_ordered(
+        bodies.get(BASE_CONSTRUCTOR, []),
+        ("stw r30,16(r31)", "stw r9,0(r31)"),
+        "vehicle base constructor",
+    )
+    require_ordered(
+        bodies.get(AI_CONSTRUCTOR, []),
+        (
+            "addi r4,r11,-11268",
+            "bl 0x82558510",
+            "addi r11,r11,-11320",
+            "stw r11,0(r31)",
+        ),
+        "AI constructor",
+    )
+    require_ordered(
+        bodies.get(PLAYER_LOCAL_CONSTRUCTOR, []),
+        (
+            "lis r11,-32254",
+            "addi r4,r11,-11340",
+            "bl 0x82558510",
+            "lis r9,-32254",
+            "addi r9,r9,-11392",
+            "stw r9,0(r31)",
+        ),
+        "player-local constructor",
+    )
+    require_ordered(
+        bodies.get(VEHICLE_MAP_POOL_CONSTRUCTOR, []),
+        (
+            "stw r4,16(r3)",
+            "addi r3,r3,32",
+            "bl 0x82558620",
+            "addi r29,r31,144",
+            "li r30,6",
+            "bl 0x82558698",
+        ),
+        "vehicle-map pool constructor",
+    )
+    require_ordered(
+        bodies.get(VEHICLE_MAP_POOL_INSTALLER, []),
+        (
+            "li r3,1792",
+            "bl 0x82c0f6c0",
+            "lwz r4,4(r31)",
+            "bl 0x8255b238",
+            "stw r3,24(r31)",
+        ),
+        "vehicle-map pool installer",
+    )
+
+    types = []
+    for (
+        decorated_name,
+        type_descriptor,
+        locator,
+        vtable,
+        type_name_address,
+        type_name,
+        slot_zero,
+    ) in EXPECTED_TYPES:
+        if image_u32(image, locator + 12) != type_descriptor:
+            raise ValueError(f"{decorated_name} locator drifted")
+        if image_string(image, type_descriptor + 8) != decorated_name:
+            raise ValueError(f"{decorated_name} descriptor drifted")
+        observed_methods = tuple(image_u32(image, vtable + index * 4) for index in range(13))
+        expected_methods = (slot_zero,) + COMMON_METHODS[1:]
+        if observed_methods != expected_methods:
+            raise ValueError(f"{decorated_name} vtable drifted")
+        if image_string(image, type_name_address) != type_name:
+            raise ValueError(f"{decorated_name} type-name pointer drifted")
+        types.append(
+            {
+                "decorated_name": decorated_name,
+                "type_descriptor": f"{type_descriptor:08X}",
+                "complete_object_locator": f"{locator:08X}",
+                "primary_vtable": f"{vtable:08X}",
+                "slot_count": 13,
+                "type_name_address": f"{type_name_address:08X}",
+                "type_name": type_name,
+                "vehicle_id_offset": 12,
+                "type_name_pointer_offset": 16,
+                "methods": [f"{target:08X}" for target in observed_methods],
+            }
+        )
+
+    return {
+        "schema": SCHEMA,
+        "status": "complete",
+        "classification": "exact_vehicle_player_traffic_semantic_ingress",
+        "types": types,
+        "contracts": {
+            "vehicle_id_getter": f"{GET_VEHICLE_ID:08X}",
+            "vehicle_id_getter_behavior": "return_u32_at_receiver_plus_12",
+            "type_name_getter": f"{GET_TYPE_NAME:08X}",
+            "type_name_getter_behavior": "return_pointer_at_receiver_plus_16",
+            "vehicle_id_setter": f"{SET_VEHICLE_ID:08X}",
+            "base_constructor": f"{BASE_CONSTRUCTOR:08X}",
+            "ai_constructor": f"{AI_CONSTRUCTOR:08X}",
+            "player_local_constructor": f"{PLAYER_LOCAL_CONSTRUCTOR:08X}",
+            "vehicle_map_pool_constructor": f"{VEHICLE_MAP_POOL_CONSTRUCTOR:08X}",
+            "vehicle_map_pool_installer": f"{VEHICLE_MAP_POOL_INSTALLER:08X}",
+            "vehicle_map_pool_install_store": "826291A8",
+            "player_local_pool_offset": 32,
+            "pool_context_offset": 16,
+            "pool_root_pointer_offset": 24,
+            "runtime_join_required": True,
+        },
+        "summary": {
+            "type_count": len(types),
+            "player_local_type_count": sum(
+                item[5] == "player_local" for item in EXPECTED_TYPES
+            ),
+            "shared_method_count": 12,
+            "exact_player_discriminator_proved": True,
+            "player_pose_relation_proved": False,
+            "mesh_material_role_identity_proved": False,
+        },
+        "safety": {
+            "static_analysis_only": True,
+            "guest_payload_exported": False,
+            "native_admission": False,
+            "suppression_allowed": False,
+            "xenos_authority_required": True,
+        },
+    }
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("generated_root", type=pathlib.Path)
+    parser.add_argument("--image", required=True, type=pathlib.Path)
+    parser.add_argument("--output", required=True, type=pathlib.Path)
+    args = parser.parse_args(argv)
+    try:
+        paths = list(args.generated_root.glob("pinyon_shift_recomp.*.cpp"))
+        if not paths:
+            raise ValueError("no generated AOT C++ files found")
+        functions, bodies = parse_function_sources(paths)
+        document = build(functions, bodies, args.image.read_bytes())
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(
+            json.dumps(document, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        return 0
+    except (OSError, UnicodeDecodeError, ValueError) as error:
+        print(f"vehicle player ingress discovery failed: {error}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/summarize-native-renderer-vehicle-player-ingress.py
+++ b/tools/summarize-native-renderer-vehicle-player-ingress.py
@@ -1,0 +1,250 @@
+"""Summarize the exact player/traffic map-entity to pose census."""
+
+import argparse
+import json
+from pathlib import Path
+
+
+SCHEMA = "pinyon-shift.native-renderer-vehicle-player-ingress-runtime.v1"
+SUMMARY_EVENT = "native_renderer.discovery.vehicle_map_entity_summary"
+ENTITY_EVENT = "native_renderer.discovery.vehicle_map_entity"
+CORRELATION_EVENT = (
+    "native_renderer.discovery.vehicle_map_pose_correlation"
+)
+POSE_SUMMARY_EVENT = "native_renderer.discovery.vehicle_pose_summary"
+
+
+def require(condition, message):
+    if not condition:
+        raise ValueError(message)
+
+
+def integer(record, key):
+    try:
+        return int(record[key])
+    except (KeyError, TypeError, ValueError) as error:
+        raise ValueError(f"missing or invalid integer field: {key}") from error
+
+
+def optional_integer(record, key, default=0):
+    if key not in record:
+        return default
+    return integer(record, key)
+
+
+def load_events(path):
+    events = []
+    with path.open("r", encoding="utf-8") as source:
+        for line_number, line in enumerate(source, 1):
+            if not line.strip():
+                continue
+            try:
+                events.append(json.loads(line))
+            except json.JSONDecodeError as error:
+                raise ValueError(
+                    f"invalid JSONL at line {line_number}: {error}"
+                ) from error
+    return events
+
+
+def summarize(log_path):
+    events = load_events(log_path)
+    summaries = [event for event in events if event.get("event") == SUMMARY_EVENT]
+    pose_summaries = [
+        event for event in events if event.get("event") == POSE_SUMMARY_EVENT
+    ]
+    entities = [event for event in events if event.get("event") == ENTITY_EVENT]
+    correlations = [
+        event for event in events if event.get("event") == CORRELATION_EVENT
+    ]
+    require(len(summaries) == 1, "expected one map-entity summary")
+    require(len(pose_summaries) == 1, "expected one vehicle-pose summary")
+    summary = summaries[0]
+    pose_summary = pose_summaries[0]
+    require(summary.get("status") == "complete", "map-entity census incomplete")
+    require(summary.get("accounting_complete") == "true", "map-entity accounting drift")
+    require(integer(summary, "observations") > 0, "map entities were not observed")
+    require(integer(summary, "valid_observations") > 0, "no known vehicle entity observed")
+    require(integer(summary, "overflow") == 0, "map-entity table overflowed")
+    require(
+        integer(summary, "pose_correlation_overflow") == 0,
+        "map-to-pose correlation table overflowed",
+    )
+    require(
+        integer(summary, "entities") == len(entities),
+        "map-entity detail accounting drift",
+    )
+    require(
+        integer(summary, "pose_correlations") == len(correlations),
+        "map-to-pose detail accounting drift",
+    )
+    if optional_integer(summary, "assignment_observations"):
+        require(
+            summary.get("assignment_accounting_complete") == "true",
+            "map-entity assignment accounting drift",
+        )
+    if optional_integer(summary, "pool_observations"):
+        require(
+            summary.get("pool_accounting_complete") == "true",
+            "map-entity pool accounting drift",
+        )
+    require(pose_summary.get("status") == "complete", "vehicle-pose census incomplete")
+
+    for event in [summary, *entities, *correlations]:
+        require(event.get("xenos_authority") == "true", "Xenos authority changed")
+        require(event.get("suppression_allowed") == "false", "suppression was allowed")
+        require(event.get("native_draw") == "false", "native drawing was enabled")
+
+    player_entities = [event for event in entities if event.get("class") == "player_local"]
+    require(len(player_entities) == 1, "expected exactly one local-player entity")
+    player = player_entities[0]
+    require(player.get("vtable") == "8201D380", "player vtable drifted")
+    require(
+        player.get("type_name_address") == "8201D3B4"
+        and player.get("expected_type_name_address") == "8201D3B4",
+        "player type-name identity drifted",
+    )
+    require(integer(player, "observations") > 0, "player entity was not exercised")
+    require(integer(player, "vtable_mismatches") == 0, "player vtable changed")
+    require(integer(player, "type_name_mismatches") == 0, "player type-name changed")
+
+    player_correlations = [
+        event
+        for event in correlations
+        if event.get("entity") == player.get("entity")
+        and event.get("entity_class") == "player_local"
+    ]
+    direct_relations = {}
+    for relation in (
+        "entity_is_pose_source",
+        "entity_is_pose_owner",
+        "pool_manager_is_pose_source",
+        "pool_manager_is_pose_owner",
+        "pool_root_is_pose_source",
+        "pool_root_is_pose_owner",
+        "pool_context_is_pose_source",
+        "pool_context_is_pose_owner",
+    ):
+        rows = [event for event in player_correlations if event.get("relation") == relation]
+        identities = {
+            (
+                row.get("identity_generation"),
+                row.get("identity_source"),
+                row.get("identity_owner"),
+                row.get("identity_slot"),
+            )
+            for row in rows
+        }
+        if rows and len(identities) == 1:
+            direct_relations[relation] = rows[0]
+
+    direct_identities = {
+        (
+            row.get("identity_generation"),
+            row.get("identity_source"),
+            row.get("identity_owner"),
+            row.get("identity_slot"),
+        )
+        for row in direct_relations.values()
+    }
+    relation_proved = len(direct_identities) == 1
+    relation_priority = (
+        "entity_is_pose_owner",
+        "entity_is_pose_source",
+        "pool_manager_is_pose_owner",
+        "pool_manager_is_pose_source",
+        "pool_root_is_pose_owner",
+        "pool_root_is_pose_source",
+        "pool_context_is_pose_owner",
+        "pool_context_is_pose_source",
+    )
+    selected_relation = next(
+        (
+            relation
+            for relation in relation_priority
+            if relation_proved and relation in direct_relations
+        ),
+        "none",
+    )
+    selected = direct_relations.get(selected_relation)
+    slot_candidates = [
+        event
+        for event in player_correlations
+        if event.get("relation") == "vehicle_id_is_pose_slot"
+    ]
+    failures = []
+    if not relation_proved:
+        failures.append("no_unique_direct_player_pose_relation")
+    return {
+        "schema": SCHEMA,
+        "status": "qualified" if not failures else "bounded_negative_result",
+        "source_log": str(log_path),
+        "summary": {
+            "map_entity_observations": integer(summary, "observations"),
+            "known_vehicle_entity_observations": integer(summary, "valid_observations"),
+            "unrecognized_receiver_observations": integer(
+                summary, "unrecognized_observations"
+            ),
+            "entity_count": len(entities),
+            "player_entity": player.get("entity"),
+            "player_vehicle_id": player.get("vehicle_id"),
+            "player_vehicle_id_unassigned": player.get("vehicle_id")
+            == "FFFFFFFF",
+            "map_entity_assignment_observations": optional_integer(
+                summary, "assignment_observations"
+            ),
+            "map_entity_pool_observations": optional_integer(
+                summary, "pool_observations"
+            ),
+            "player_assignment_observations": optional_integer(
+                player, "assignment_observations"
+            ),
+            "player_pool_observations": optional_integer(
+                player, "pool_observations"
+            ),
+            "player_pose_comparisons": integer(player, "pose_comparisons"),
+            "direct_player_pose_relation": selected_relation,
+            "direct_player_pose_relations": sorted(direct_relations),
+            "slot_relation_candidate_count": len(slot_candidates),
+        },
+        "qualification": {
+            "exact_player_discriminator_proved": True,
+            "player_pose_relation_proved": relation_proved,
+            "selected_identity": (
+                {
+                    "generation": selected.get("identity_generation"),
+                    "source": selected.get("identity_source"),
+                    "owner": selected.get("identity_owner"),
+                    "slot": integer(selected, "identity_slot"),
+                }
+                if selected
+                else None
+            ),
+            "mesh_material_role_identity_proved": False,
+            "native_admission_allowed": False,
+            "suppression_allowed": False,
+        },
+        "failures": failures,
+    }
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("log", type=Path)
+    parser.add_argument("--output", required=True, type=Path)
+    args = parser.parse_args(argv)
+    try:
+        document = summarize(args.log)
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(
+            json.dumps(document, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        return 0
+    except (OSError, ValueError) as error:
+        print(f"vehicle player ingress summary failed: {error}")
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/tests/test_native_renderer_vehicle_player_ingress.py
+++ b/tools/tests/test_native_renderer_vehicle_player_ingress.py
@@ -1,0 +1,286 @@
+import importlib.util
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+ROOT = Path(__file__).resolve().parents[2]
+TOOL = ROOT / "tools" / "discover-native-renderer-vehicle-player-ingress.py"
+SPEC = importlib.util.spec_from_file_location("vehicle_player_ingress", TOOL)
+assert SPEC and SPEC.loader
+MODULE = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = MODULE
+SPEC.loader.exec_module(MODULE)
+
+SUMMARY_TOOL = (
+    ROOT / "tools" / "summarize-native-renderer-vehicle-player-ingress.py"
+)
+SUMMARY_SPEC = importlib.util.spec_from_file_location(
+    "vehicle_player_ingress_summary", SUMMARY_TOOL
+)
+assert SUMMARY_SPEC and SUMMARY_SPEC.loader
+SUMMARY_MODULE = importlib.util.module_from_spec(SUMMARY_SPEC)
+sys.modules[SUMMARY_SPEC.name] = SUMMARY_MODULE
+SUMMARY_SPEC.loader.exec_module(SUMMARY_MODULE)
+
+
+def fixture():
+    functions = {
+        target
+        for expected in MODULE.EXPECTED_TYPES
+        for target in ((expected[6],) + MODULE.COMMON_METHODS[1:])
+    } | {
+        MODULE.BASE_CONSTRUCTOR,
+        MODULE.AI_CONSTRUCTOR,
+        MODULE.PLAYER_LOCAL_CONSTRUCTOR,
+        MODULE.VEHICLE_MAP_POOL_CONSTRUCTOR,
+        MODULE.VEHICLE_MAP_POOL_INSTALLER,
+    }
+    bodies = {
+        MODULE.GET_VEHICLE_ID: ["lwz r3,12(r3)", "blr"],
+        MODULE.GET_TYPE_NAME: ["lwz r3,16(r3)", "blr"],
+        MODULE.SET_VEHICLE_ID: ["stw r4,12(r3)", "stfs f0,8(r3)", "blr"],
+        MODULE.BASE_CONSTRUCTOR: ["stw r30,16(r31)", "stw r9,0(r31)"],
+        MODULE.AI_CONSTRUCTOR: [
+            "addi r4,r11,-11268",
+            "bl 0x82558510",
+            "addi r11,r11,-11320",
+            "stw r11,0(r31)",
+        ],
+        MODULE.PLAYER_LOCAL_CONSTRUCTOR: [
+            "lis r11,-32254",
+            "addi r4,r11,-11340",
+            "bl 0x82558510",
+            "lis r9,-32254",
+            "addi r9,r9,-11392",
+            "stw r9,0(r31)",
+        ],
+        MODULE.VEHICLE_MAP_POOL_CONSTRUCTOR: [
+            "stw r4,16(r3)",
+            "addi r3,r3,32",
+            "bl 0x82558620",
+            "addi r29,r31,144",
+            "li r30,6",
+            "bl 0x82558698",
+        ],
+        MODULE.VEHICLE_MAP_POOL_INSTALLER: [
+            "li r3,1792",
+            "bl 0x82c0f6c0",
+            "lwz r4,4(r31)",
+            "bl 0x8255b238",
+            "stw r3,24(r31)",
+        ],
+    }
+    words = {}
+    strings = {}
+    for name, descriptor, locator, vtable, type_address, type_name, slot_zero in MODULE.EXPECTED_TYPES:
+        words[locator + 12] = descriptor
+        strings[descriptor + 8] = name
+        strings[type_address] = type_name
+        methods = (slot_zero,) + MODULE.COMMON_METHODS[1:]
+        for index, target in enumerate(methods):
+            words[vtable + index * 4] = target
+    return functions, bodies, words, strings
+
+
+class VehiclePlayerIngressTests(unittest.TestCase):
+    def test_locks_exact_player_and_traffic_semantic_types(self):
+        functions, bodies, words, strings = fixture()
+        with mock.patch.object(
+            MODULE, "image_u32", side_effect=lambda _image, address: words[address]
+        ), mock.patch.object(
+            MODULE, "image_string", side_effect=lambda _image, address: strings[address]
+        ):
+            document = MODULE.build(functions, bodies, b"")
+        self.assertEqual("complete", document["status"])
+        self.assertEqual(5, document["summary"]["type_count"])
+        self.assertTrue(document["summary"]["exact_player_discriminator_proved"])
+        self.assertFalse(document["summary"]["player_pose_relation_proved"])
+        self.assertEqual(
+            "player_local",
+            next(
+                item["type_name"]
+                for item in document["types"]
+                if item["primary_vtable"] == "8201D380"
+            ),
+        )
+
+    def test_rejects_vehicle_id_getter_drift(self):
+        functions, bodies, words, strings = fixture()
+        bodies[MODULE.GET_VEHICLE_ID] = ["lwz r3,16(r3)", "blr"]
+        with mock.patch.object(
+            MODULE, "image_u32", side_effect=lambda _image, address: words[address]
+        ), mock.patch.object(
+            MODULE, "image_string", side_effect=lambda _image, address: strings[address]
+        ):
+            with self.assertRaisesRegex(ValueError, "vehicle ID getter"):
+                MODULE.build(functions, bodies, b"")
+
+    def test_runtime_observer_is_passive_and_fail_closed(self):
+        hooks = (ROOT / "src/native_renderer/graphics_hooks.cpp").read_text(
+            encoding="utf-8"
+        )
+        runtime = (ROOT / "src/pinyon_shift_runtime_hooks.cpp").read_text(
+            encoding="utf-8"
+        )
+        config = (ROOT / "config/rexglue/analysis/main-xex.toml").read_text(
+            encoding="utf-8"
+        )
+        self.assertIn("ObserveVehicleMapEntity", hooks)
+        self.assertIn("vehicle_map_pose_correlation", hooks)
+        self.assertIn('player_vehicle_identity_proved", "false"', hooks)
+        self.assertIn("PinyonShiftObserveVehicleMapEntity", runtime)
+        self.assertIn("PinyonShiftObserveVehicleMapEntityIdAssignment", runtime)
+        self.assertIn("PinyonShiftObserveVehiclePlayerPool", runtime)
+        self.assertIn("UINT32_MAX - kPlayerEntityOffset", runtime)
+        self.assertIn("UINT32_MAX - kPoolContextOffset", runtime)
+        self.assertIn("address = 0x82BBA010", config)
+        self.assertIn('registers = ["r3"]', config)
+        self.assertIn("address = 0x82CCF228", config)
+        self.assertIn('registers = ["r3", "r4"]', config)
+        self.assertIn("address = 0x826291A8", config)
+        self.assertIn('registers = ["r3", "r31"]', config)
+
+    def test_runtime_qualifier_promotes_one_direct_player_pose_relation(self):
+        safety = {
+            "xenos_authority": "true",
+            "suppression_allowed": "false",
+            "native_draw": "false",
+        }
+        events = [
+            {
+                "event": SUMMARY_MODULE.SUMMARY_EVENT,
+                "status": "complete",
+                "accounting_complete": "true",
+                "observations": "50",
+                "valid_observations": "40",
+                "unrecognized_observations": "10",
+                "invalid_observations": "0",
+                "entities": "1",
+                "overflow": "0",
+                "pose_correlations": "1",
+                "pose_correlation_overflow": "0",
+                **safety,
+            },
+            {
+                "event": SUMMARY_MODULE.POSE_SUMMARY_EVENT,
+                "status": "complete",
+            },
+            {
+                "event": SUMMARY_MODULE.ENTITY_EVENT,
+                "entity": "40001000",
+                "class": "player_local",
+                "vtable": "8201D380",
+                "vehicle_id": "00000003",
+                "type_name_address": "8201D3B4",
+                "expected_type_name_address": "8201D3B4",
+                "observations": "40",
+                "vtable_mismatches": "0",
+                "type_name_mismatches": "0",
+                "pose_comparisons": "100",
+                **safety,
+            },
+            {
+                "event": SUMMARY_MODULE.CORRELATION_EVENT,
+                "entity": "40001000",
+                "entity_class": "player_local",
+                "relation": "entity_is_pose_owner",
+                "identity_generation": "00000001",
+                "identity_source": "40002000",
+                "identity_owner": "40001000",
+                "identity_slot": "3",
+                **safety,
+            },
+        ]
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "events.jsonl"
+            path.write_text(
+                "".join(json.dumps(event) + "\n" for event in events),
+                encoding="utf-8",
+            )
+            report = SUMMARY_MODULE.summarize(path)
+        self.assertEqual("qualified", report["status"])
+        self.assertTrue(report["qualification"]["player_pose_relation_proved"])
+        self.assertEqual(
+            "entity_is_pose_owner",
+            report["summary"]["direct_player_pose_relation"],
+        )
+
+    def test_runtime_qualifier_accepts_equivalent_exact_relations(self):
+        safety = {
+            "xenos_authority": "true",
+            "suppression_allowed": "false",
+            "native_draw": "false",
+        }
+        identity = {
+            "identity_generation": "00000001",
+            "identity_source": "40002000",
+            "identity_owner": "40001000",
+            "identity_slot": "3",
+        }
+        events = [
+            {
+                "event": SUMMARY_MODULE.SUMMARY_EVENT,
+                "status": "complete",
+                "accounting_complete": "true",
+                "observations": "50",
+                "valid_observations": "40",
+                "unrecognized_observations": "10",
+                "invalid_observations": "0",
+                "entities": "1",
+                "overflow": "0",
+                "pose_correlations": "2",
+                "pose_correlation_overflow": "0",
+                **safety,
+            },
+            {"event": SUMMARY_MODULE.POSE_SUMMARY_EVENT, "status": "complete"},
+            {
+                "event": SUMMARY_MODULE.ENTITY_EVENT,
+                "entity": "40001000",
+                "class": "player_local",
+                "vtable": "8201D380",
+                "vehicle_id": "FFFFFFFF",
+                "type_name_address": "8201D3B4",
+                "expected_type_name_address": "8201D3B4",
+                "observations": "40",
+                "vtable_mismatches": "0",
+                "type_name_mismatches": "0",
+                "pose_comparisons": "100",
+                **safety,
+            },
+            {
+                "event": SUMMARY_MODULE.CORRELATION_EVENT,
+                "entity": "40001000",
+                "entity_class": "player_local",
+                "relation": "entity_is_pose_owner",
+                **identity,
+                **safety,
+            },
+            {
+                "event": SUMMARY_MODULE.CORRELATION_EVENT,
+                "entity": "40001000",
+                "entity_class": "player_local",
+                "relation": "pool_manager_is_pose_owner",
+                **identity,
+                **safety,
+            },
+        ]
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "events.jsonl"
+            path.write_text(
+                "".join(json.dumps(event) + "\n" for event in events),
+                encoding="utf-8",
+            )
+            report = SUMMARY_MODULE.summarize(path)
+        self.assertEqual("qualified", report["status"])
+        self.assertEqual(
+            ["entity_is_pose_owner", "pool_manager_is_pose_owner"],
+            report["summary"]["direct_player_pose_relations"],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- lock the five retail vehicle map-entity RTTI/vtable contracts, including the exact `player_local` discriminator
- retain bounded getter, ID-assignment, and true vehicle-map pool lineage observations against the existing pose identity
- add static/runtime qualification tools and record the negative direct entity/ID joins without enabling native admission or suppression

## Safety
- Xenos remains authoritative
- observers are read-only, fixed-capacity, and fail closed
- no guest payload export, native draw, or suppression is introduced

## Validation
- `python -m unittest tools.tests.test_native_renderer_vehicle_player_ingress -v` (5 passed)
- Release incremental build of `pinyon_shift`
- `git diff --check`
- generated hook verified immediately after retail store `0x826291A8`
- AppData save SHA-256 unchanged by the aborted frontend-only run

The final pool/root-to-pose qualification is intentionally batched with the next meaningful manual open-world run; this PR only installs the passive evidence path.