### PR TITLE
feat(renderer): partition vehicle resource contributions

### DIFF
--- a/docs/native-renderer/REPRIORITIZED_PLAN.md
+++ b/docs/native-renderer/REPRIORITIZED_PLAN.md
@@ -762,6 +762,17 @@ is batched with the next meaningful C4 slice; until it proves one stable unique
 player-to-pose relationship, player attribution, mesh/material labels, native
 publication, and suppression remain closed.
 
+Resource-contribution checkpoint: the existing 30 retained prepared-signature
+families reduce exactly to 15 geometry-resource contributions, each with two
+distinct prepared variants and otherwise identical mechanical state. The
+offline fail-closed partition is documented in
+[`VEHICLE_RESOURCE_CONTRIBUTIONS.md`](VEHICLE_RESOURCE_CONTRIBUTIONS.md). C4
+role attribution now targets those 15 exact resources; prepared signatures
+alone cannot carry a semantic label because two resources reuse one signature
+pair. The next batched slice records isolated per-contribution output evidence
+and joins it to an independent title-owned asset/material discriminator before
+assigning body, glass, wheel, light, livery, or exceptional-work labels.
+
 ### C5. Sky, atmosphere, and global lighting
 
 - Replace the qualified sky/global-light families.

--- a/docs/native-renderer/VEHICLE_RESOURCE_CONTRIBUTIONS.md
+++ b/docs/native-renderer/VEHICLE_RESOURCE_CONTRIBUTIONS.md
@@ -1,0 +1,47 @@
+# Vehicle resource contributions
+
+Status: exact offline C4 partition qualified from the existing v15 semantic
+constant-bridge report. No semantic body/glass/wheel/light/livery label is
+assigned yet.
+
+## Result
+
+The retained vehicle harness previously exposed 30 prepared-signature
+families. Those are not 30 independent geometry contributions. Grouping by the
+already-retained exact `geometry_resource_hash` produces 15 resource
+contributions, each exercised through exactly two prepared-signature variants.
+
+Within every pair, seed index, draw arguments, shaders, prepared pipeline,
+render state, template, texture layout/resource, and material-topology key are
+identical. Only the prepared signature and its dynamic parameter payload vary.
+The source run exercised every variant for 483 or 484 frames and published the
+private draw-atomic semantic constant snapshot on every draw.
+
+`summarize-native-renderer-vehicle-contributions.py` locks this mechanical
+partition and emits one unclassified row per exact geometry resource. It fails
+closed if a resource does not have exactly two distinct variants, any stable
+mechanical field drifts within a pair, publication accounting is incomplete,
+or the source report changes Xenos authority or safety policy.
+
+## Why this changes C4
+
+Mesh/material role work now has a 15-item geometry-resource frontier rather
+than a 30-family prepared-state frontier. A semantic role must be attached to
+the exact resource contribution, while its two prepared variants remain
+separate render work. Shared prepared signatures cannot supply a role: two
+different resource contributions reuse the same signature pair.
+
+The next bounded step is per-contribution isolated output evidence using the
+existing retained private target. Coverage, depth, and color contribution may
+mechanically distinguish opaque exterior, glazing, wheels, lights, and small
+details, but those names remain hypotheses until an independent title-owned
+asset/material discriminator agrees. Player identity, native publication, and
+suppression remain closed.
+
+## Reproduction
+
+```powershell
+python tools/summarize-native-renderer-vehicle-contributions.py `
+  .local/qualification/native-renderer-vehicle-c4-semantic-constant-bridge-v15-20260831.json `
+  --output .local/qualification/native-renderer-vehicle-resource-contributions-v1.json
+```

--- a/tools/summarize-native-renderer-vehicle-contributions.py
+++ b/tools/summarize-native-renderer-vehicle-contributions.py
@@ -1,0 +1,206 @@
+#!/usr/bin/env python3
+"""Partition the retained vehicle families into exact resource contributions."""
+
+import argparse
+import collections
+import json
+from pathlib import Path
+
+
+SCHEMA = "pinyon-shift.native-renderer-vehicle-contributions.v1"
+INPUT_SCHEMA = "pinyon-shift.native-renderer-vehicle-shadow-geometry.v15"
+EXPECTED_FAMILY_COUNT = 30
+EXPECTED_VARIANTS_PER_CONTRIBUTION = 2
+STABLE_FIELDS = (
+    "seed_index",
+    "draw_argument_hash",
+    "material_topology_key",
+    "pixel_shader",
+    "prepared_pipeline_hash",
+    "render_state_hash",
+    "template_key",
+    "texture_layout_hash",
+    "texture_resource_hash",
+    "vertex_shader",
+)
+
+
+def require(condition, message):
+    if not condition:
+        raise ValueError(message)
+
+
+def integer(record, key):
+    try:
+        return int(record[key])
+    except (KeyError, TypeError, ValueError) as error:
+        raise ValueError(f"missing or invalid integer field: {key}") from error
+
+
+def hexadecimal(record, key, width):
+    value = str(record.get(key, "")).upper()
+    require(
+        len(value) == width and all(character in "0123456789ABCDEF" for character in value),
+        f"missing or invalid hexadecimal field: {key}",
+    )
+    return value
+
+
+def load(path):
+    with path.open("r", encoding="utf-8") as source:
+        return json.load(source)
+
+
+def stable_key(family):
+    return tuple(str(family.get(field, "")) for field in STABLE_FIELDS)
+
+
+def summarize(path):
+    source = load(path)
+    require(source.get("schema") == INPUT_SCHEMA, "unsupported source schema")
+    safety = source.get("safety", {})
+    require(safety.get("xenos_authority") is True, "Xenos authority changed")
+    require(safety.get("native_draw") is False, "native drawing was enabled")
+    require(
+        safety.get("suppression_allowed") is False,
+        "suppression was allowed",
+    )
+    require(
+        safety.get("guest_payload_capture") is False,
+        "guest payload capture was enabled",
+    )
+    qualification = source.get("qualification", {})
+    require(
+        qualification.get("working_color_bridge_candidate") is True,
+        "semantic constant bridge is not complete",
+    )
+    require(
+        qualification.get("native_admission_allowed") is False,
+        "source report unexpectedly allows native admission",
+    )
+
+    families = source.get("candidate_families")
+    require(isinstance(families, list), "candidate family table is missing")
+    require(
+        len(families) == EXPECTED_FAMILY_COUNT,
+        f"expected {EXPECTED_FAMILY_COUNT} candidate families",
+    )
+    require(
+        integer(source.get("totals", {}), "correlations") == len(families),
+        "candidate family accounting drift",
+    )
+
+    groups = collections.defaultdict(list)
+    for family in families:
+        geometry = hexadecimal(family, "geometry_resource_hash", 16)
+        hexadecimal(family, "prepared_signature", 16)
+        require(integer(family, "draws") > 0, "candidate family was not exercised")
+        require(
+            integer(family, "semantic_constant_bridge_publications")
+            == integer(family, "draws"),
+            "semantic bridge publication accounting drift",
+        )
+        groups[geometry].append(family)
+
+    contributions = []
+    failures = []
+    ordered_groups = sorted(
+        groups.items(), key=lambda item: (integer(item[1][0], "seed_index"), item[0])
+    )
+    for geometry, variants in ordered_groups:
+        signatures = sorted(
+            hexadecimal(variant, "prepared_signature", 16) for variant in variants
+        )
+        keys = {stable_key(variant) for variant in variants}
+        draw_counts = {integer(variant, "draws") for variant in variants}
+        publication_counts = {
+            integer(variant, "semantic_constant_bridge_publications")
+            for variant in variants
+        }
+        local_failures = []
+        if len(variants) != EXPECTED_VARIANTS_PER_CONTRIBUTION:
+            local_failures.append("variant_count")
+        if len(set(signatures)) != EXPECTED_VARIANTS_PER_CONTRIBUTION:
+            local_failures.append("prepared_signature_count")
+        if len(keys) != 1:
+            local_failures.append("mechanical_contract_drift")
+        if draw_counts and max(draw_counts) - min(draw_counts) > 1:
+            local_failures.append("draw_count_drift")
+        failures.extend(f"{geometry}:{failure}" for failure in local_failures)
+        representative = variants[0]
+        contributions.append(
+            {
+                "contribution_index": len(contributions),
+                "geometry_resource_hash": geometry,
+                "seed_index": integer(representative, "seed_index"),
+                "variant_count": len(variants),
+                "prepared_signatures": signatures,
+                "draws_per_variant": sorted(draw_counts),
+                "semantic_bridge_publications_per_variant": sorted(
+                    publication_counts
+                ),
+                "draw_argument_hash": hexadecimal(
+                    representative, "draw_argument_hash", 16
+                ),
+                "template_key": hexadecimal(representative, "template_key", 16),
+                "mechanical_contract_stable": len(keys) == 1,
+                "semantic_role": "unclassified",
+                "semantic_label_proved": False,
+            }
+        )
+
+    complete = not failures
+    return {
+        "schema": SCHEMA,
+        "status": "qualified" if complete else "incomplete",
+        "source_report": str(path),
+        "summary": {
+            "candidate_family_count": len(families),
+            "resource_contribution_count": len(contributions),
+            "variants_per_complete_contribution": EXPECTED_VARIANTS_PER_CONTRIBUTION,
+            "complete_resource_contributions": sum(
+                contribution["variant_count"] == EXPECTED_VARIANTS_PER_CONTRIBUTION
+                and contribution["mechanical_contract_stable"]
+                for contribution in contributions
+            ),
+            "family_to_contribution_reduction": len(families) - len(contributions),
+        },
+        "contributions": contributions,
+        "qualification": {
+            "exact_resource_contribution_partition_proved": complete,
+            "semantic_mesh_material_roles_proved": False,
+            "player_vehicle_identity_proved": False,
+            "native_admission_allowed": False,
+            "suppression_allowed": False,
+        },
+        "safety": {
+            "source_xenos_authority": True,
+            "guest_payload_exported": False,
+            "native_draw": False,
+            "suppression_allowed": False,
+        },
+        "failures": failures,
+    }
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("report", type=Path)
+    parser.add_argument("--output", required=True, type=Path)
+    args = parser.parse_args(argv)
+    try:
+        document = summarize(args.report)
+        require(document["status"] == "qualified", "contribution partition incomplete")
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(
+            json.dumps(document, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        return 0
+    except (OSError, ValueError) as error:
+        print(f"vehicle contribution summary failed: {error}")
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/tests/test_native_renderer_vehicle_contributions.py
+++ b/tools/tests/test_native_renderer_vehicle_contributions.py
@@ -1,0 +1,139 @@
+import importlib.util
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+TOOL = ROOT / "tools" / "summarize-native-renderer-vehicle-contributions.py"
+SPEC = importlib.util.spec_from_file_location("vehicle_contributions", TOOL)
+assert SPEC and SPEC.loader
+MODULE = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = MODULE
+SPEC.loader.exec_module(MODULE)
+
+
+def family(contribution, variant):
+    token = f"{contribution + 1:016X}"
+    signature = f"{0x100 + contribution * 2 + variant:016X}"
+    return {
+        "seed_index": contribution,
+        "geometry_resource_hash": token,
+        "prepared_signature": signature,
+        "draw_argument_hash": f"{0x200 + contribution:016X}",
+        "material_topology_key": "0000000000000300",
+        "pixel_shader": "0000000000000400",
+        "prepared_pipeline_hash": "0000000000000500",
+        "render_state_hash": "0000000000000600",
+        "template_key": f"{0x700 + contribution:016X}",
+        "texture_layout_hash": "0000000000000800",
+        "texture_resource_hash": "0000000000000900",
+        "vertex_shader": "0000000000000A00",
+        "draws": 20,
+        "semantic_constant_bridge_publications": 20,
+    }
+
+
+def fixture():
+    families = [
+        family(contribution, variant)
+        for contribution in range(15)
+        for variant in range(2)
+    ]
+    return {
+        "schema": MODULE.INPUT_SCHEMA,
+        "safety": {
+            "xenos_authority": True,
+            "native_draw": False,
+            "suppression_allowed": False,
+            "guest_payload_capture": False,
+        },
+        "qualification": {
+            "working_color_bridge_candidate": True,
+            "native_admission_allowed": False,
+        },
+        "totals": {"correlations": len(families)},
+        "candidate_families": families,
+    }
+
+
+def summarize(document):
+    with tempfile.TemporaryDirectory() as directory:
+        path = Path(directory) / "report.json"
+        path.write_text(json.dumps(document), encoding="utf-8")
+        return MODULE.summarize(path)
+
+
+class VehicleContributionTests(unittest.TestCase):
+    def test_partitions_thirty_families_into_fifteen_resources(self):
+        report = summarize(fixture())
+        self.assertEqual("qualified", report["status"])
+        self.assertEqual(30, report["summary"]["candidate_family_count"])
+        self.assertEqual(15, report["summary"]["resource_contribution_count"])
+        self.assertEqual(15, report["summary"]["complete_resource_contributions"])
+        self.assertTrue(
+            report["qualification"][
+                "exact_resource_contribution_partition_proved"
+            ]
+        )
+        self.assertFalse(
+            report["qualification"]["semantic_mesh_material_roles_proved"]
+        )
+        self.assertTrue(
+            all(
+                row["semantic_role"] == "unclassified"
+                and not row["semantic_label_proved"]
+                for row in report["contributions"]
+            )
+        )
+
+    def test_rejects_missing_pass_variant(self):
+        document = fixture()
+        document["candidate_families"][-1]["geometry_resource_hash"] = (
+            "FFFFFFFFFFFFFFFF"
+        )
+        report = summarize(document)
+        self.assertEqual("incomplete", report["status"])
+        self.assertTrue(any("variant_count" in row for row in report["failures"]))
+
+    def test_rejects_mechanical_drift_within_resource(self):
+        document = fixture()
+        document["candidate_families"][1]["template_key"] = "FFFFFFFFFFFFFFFF"
+        report = summarize(document)
+        self.assertEqual("incomplete", report["status"])
+        self.assertTrue(
+            any("mechanical_contract_drift" in row for row in report["failures"])
+        )
+
+    def test_accepts_one_trailing_partial_frame(self):
+        document = fixture()
+        document["candidate_families"][1]["draws"] = 19
+        document["candidate_families"][1][
+            "semantic_constant_bridge_publications"
+        ] = 19
+        report = summarize(document)
+        self.assertEqual("qualified", report["status"])
+
+    def test_rejects_multi_frame_draw_count_drift(self):
+        document = fixture()
+        document["candidate_families"][1]["draws"] = 18
+        document["candidate_families"][1][
+            "semantic_constant_bridge_publications"
+        ] = 18
+        report = summarize(document)
+        self.assertEqual("incomplete", report["status"])
+        self.assertTrue(
+            any("draw_count_drift" in row for row in report["failures"])
+        )
+
+    def test_rejects_changed_authority(self):
+        document = fixture()
+        document["safety"]["xenos_authority"] = False
+        with self.assertRaisesRegex(ValueError, "Xenos authority"):
+            summarize(document)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- partition the 30 retained vehicle prepared families into 15 exact geometry-resource contributions
- prove two mechanically stable prepared variants per resource from the existing v15 report
- keep every body/glass/wheel/light/livery label unclassified until independent title-owned evidence exists

## Validation
- `python -m unittest tools.tests.test_native_renderer_vehicle_contributions -v` (6 passed)
- real v15 semantic-constant-bridge report qualified 15/15 contributions
- `git diff --check`

This is offline qualification only. It does not draw, publish, suppress Xenos, or export guest payloads.