### PR TITLE
feat(renderer): capture isolated vehicle contributions

### DIFF
--- a/docs/native-renderer/REPRIORITIZED_PLAN.md
+++ b/docs/native-renderer/REPRIORITIZED_PLAN.md
@@ -769,8 +769,11 @@ offline fail-closed partition is documented in
 [`VEHICLE_RESOURCE_CONTRIBUTIONS.md`](VEHICLE_RESOURCE_CONTRIBUTIONS.md). C4
 role attribution now targets those 15 exact resources; prepared signatures
 alone cannot carry a semantic label because two resources reuse one signature
-pair. The next batched slice records isolated per-contribution output evidence
-and joins it to an independent title-owned asset/material discriminator before
+pair. A default-off private capture now retains the two exact variants for one
+selected resource, releases after the second, and reads back only that bounded
+contribution while preserving both Xenos draws. The next batched gameplay run
+qualifies the first isolated resource result and joins it to an independent
+title-owned asset/material discriminator before
 assigning body, glass, wheel, light, livery, or exceptional-work labels.
 
 ### C5. Sky, atmosphere, and global lighting

--- a/docs/native-renderer/VEHICLE_RESOURCE_CONTRIBUTIONS.md
+++ b/docs/native-renderer/VEHICLE_RESOURCE_CONTRIBUTIONS.md
@@ -1,8 +1,9 @@
 # Vehicle resource contributions
 
 Status: exact offline C4 partition qualified from the existing v15 semantic
-constant-bridge report. No semantic body/glass/wheel/light/livery label is
-assigned yet.
+constant-bridge report. A default-off private two-variant resource capture is
+implemented for the next batched run. No semantic
+body/glass/wheel/light/livery label is assigned yet.
 
 ## Result
 
@@ -38,10 +39,37 @@ details, but those names remain hypotheses until an independent title-owned
 asset/material discriminator agrees. Player identity, native publication, and
 suppression remain closed.
 
+## Private resource capture
+
+`-VehicleResourceContribution <geometry_resource_hash>` targets one qualified
+resource in the existing shadow/color correlation mode. After all 30 prepared
+families and the single-draw replay gate are established, it requires exactly
+two correlation entries for the requested resource in one frame. The first
+variant creates and retains the private target; the second reuses, releases,
+and reads it back. Any variant-count, frame-order, duplicate-family, target, or
+backend-result mismatch fails closed for the process.
+
+The capture never replaces the game target and never suppresses either guest
+draw. Its artifact is written below the requested `.local` isolated-draw root
+with the selected resource hash in the directory name. One target resource is
+captured per run so evidence cannot be mislabeled by overlapping asynchronous
+readbacks. The next gameplay run should start with a visually large resource,
+then use the result to decide whether the remaining 14 captures can be batched
+without weakening artifact identity.
+
 ## Reproduction
 
 ```powershell
 python tools/summarize-native-renderer-vehicle-contributions.py `
   .local/qualification/native-renderer-vehicle-c4-semantic-constant-bridge-v15-20260831.json `
   --output .local/qualification/native-renderer-vehicle-resource-contributions-v1.json
+
+$stateRoot = Join-Path $env:LOCALAPPDATA `
+  'PinyonShift\source\0.1.0\.local\preview'
+./tools/capture-native-renderer-census.ps1 -StateRoot $stateRoot `
+  -Scene open_world_day -ShadowDepthBatch `
+  -VehicleShadowGeometryCorrelation -CaptureVehicleShadowColor `
+  -VehicleResourceContribution D77EBD5592D13A1D `
+  -IsolatedDrawDir .local/qualification/vehicle-resource-d77ebd `
+  -VehicleDrawCorrelation -Json
 ```

--- a/src/native_renderer/graphics_hooks.cpp
+++ b/src/native_renderer/graphics_hooks.cpp
@@ -8532,6 +8532,7 @@ struct IsolatedDrawState {
   std::jthread seed_depth_artifact_writer;
   std::jthread reference_seed_depth_artifact_writer;
   std::jthread vehicle_retained_artifact_writer;
+  std::jthread vehicle_contribution_artifact_writer;
   bool requested = false;
   bool readback_requested = false;
   bool completed = false;
@@ -8560,12 +8561,15 @@ struct IsolatedDrawState {
   bool vehicle_shadow_geometry_correlation_mode = false;
   bool vehicle_shadow_color_capture_mode = false;
   bool vehicle_shadow_color_retained_pass_mode = false;
+  bool vehicle_resource_contribution_capture_mode = false;
   bool prepared_vehicle_shadow_color_replay_eligible = false;
   bool vehicle_shadow_color_capture_pending = false;
   bool vehicle_shadow_color_capture_completed = false;
   bool vehicle_shadow_color_private_replay_failed_closed = false;
   bool vehicle_shadow_color_retained_pass_failed_closed = false;
   bool vehicle_shadow_color_retained_capture_completed = false;
+  bool vehicle_resource_contribution_failed_closed = false;
+  bool vehicle_resource_contribution_capture_completed = false;
   bool shadow_depth_publication_mode = false;
   bool shadow_depth_continuous_mode = false;
   bool shadow_depth_continuous_failed_closed = false;
@@ -8614,6 +8618,17 @@ struct IsolatedDrawState {
   uint64_t vehicle_shadow_color_retained_frames_completed = 0;
   uint64_t vehicle_shadow_color_retained_frames_failed = 0;
   uint64_t vehicle_shadow_color_retained_limit_yields = 0;
+  uint64_t vehicle_resource_contribution_hash = 0;
+  uint64_t vehicle_resource_contribution_frame = UINT64_MAX;
+  uint64_t vehicle_resource_contribution_last_draw = 0;
+  uint64_t vehicle_resource_contribution_requests = 0;
+  uint64_t vehicle_resource_contribution_recorded = 0;
+  uint64_t vehicle_resource_contribution_target_failures = 0;
+  uint64_t vehicle_resource_contribution_unsupported = 0;
+  uint32_t vehicle_resource_contribution_current_requests = 0;
+  uint32_t vehicle_resource_contribution_current_outcomes = 0;
+  uint32_t vehicle_resource_contribution_current_recorded = 0;
+  uint32_t vehicle_resource_contribution_family_mask = 0;
   uint32_t vehicle_shadow_color_retained_current_requests = 0;
   uint32_t vehicle_shadow_color_retained_current_outcomes = 0;
   uint32_t vehicle_shadow_color_retained_current_recorded = 0;
@@ -9209,6 +9224,16 @@ void ConfigureIsolatedDraw() {
       !g_isolated_draw.vehicle_shadow_color_capture_mode) {
     g_isolated_draw.valid = false;
   }
+  ConfigureSignatureScan(
+      "PINYON_SHIFT_NATIVE_RENDERER_VEHICLE_RESOURCE_CONTRIBUTION",
+      g_isolated_draw.vehicle_resource_contribution_hash,
+      g_isolated_draw.vehicle_resource_contribution_capture_mode,
+      g_isolated_draw.valid);
+  if (g_isolated_draw.vehicle_resource_contribution_capture_mode &&
+      (!g_isolated_draw.vehicle_shadow_color_capture_mode ||
+       g_isolated_draw.vehicle_shadow_color_retained_pass_mode)) {
+    g_isolated_draw.valid = false;
+  }
   if (g_isolated_draw.shadow_depth_mode) {
     g_isolated_draw.requested = true;
     if (signature_requested || g_isolated_draw.shadow_depth_batch_mode) {
@@ -9444,6 +9469,22 @@ void ConfigureIsolatedDraw() {
           std::to_string(kVehicleShadowColorRetainedPassLimit)},
          {"readback", "first_complete_native_retained_pass"},
          {"native_draw", "private_retained_pass_only"},
+         {"xenos_draw", "preserved"},
+         {"output_authority", "xenos"},
+         {"suppression_allowed", "false"}});
+  }
+  if (g_isolated_draw.vehicle_resource_contribution_capture_mode) {
+    pinyon_shift::diagnostics::RecordEvent(
+        "native_renderer.discovery.vehicle_resource_contribution_config",
+        {{"status", g_isolated_draw.valid ? "armed"
+                                           : "blocked_invalid_configuration"},
+         {"geometry_resource_hash",
+          fmt::format("{:016X}",
+                      g_isolated_draw.vehicle_resource_contribution_hash)},
+         {"selection", "two_exact_prepared_variants_for_one_geometry_resource"},
+         {"target_lifecycle", "retain_first_release_second"},
+         {"readback", "complete_private_resource_contribution"},
+         {"native_draw", "private_resource_contribution_only"},
          {"xenos_draw", "preserved"},
          {"output_authority", "xenos"},
          {"suppression_allowed", "false"}});
@@ -22134,6 +22175,18 @@ void CompleteVehicleShadowColorRetainedReadback(
       g_isolated_draw.vehicle_retained_artifact_writer);
 }
 
+void CompleteVehicleResourceContributionReadback(
+    const rex::system::GraphicsIsolatedDrawReadback &readback) {
+  std::filesystem::path contribution_root = g_isolated_draw.output_root;
+  contribution_root += L".vehicle.contribution.";
+  contribution_root += fmt::format(
+      "{:016X}", g_isolated_draw.vehicle_resource_contribution_hash);
+  contribution_root += L".native";
+  CompleteIsolatedReadbackArtifact(
+      readback, "native_vehicle_resource_contribution", contribution_root,
+      g_isolated_draw.vehicle_contribution_artifact_writer);
+}
+
 void CompleteIsolatedDepthReadbackArtifact(
     const rex::system::GraphicsIsolatedDrawReadback &readback,
     const char *capture_role, const std::filesystem::path &artifact_root,
@@ -22443,6 +22496,90 @@ void CompleteVehicleShadowColorPrivateReplay(
        {"draw", std::to_string(g_isolated_draw.draw)},
        {"fallback", "authoritative_xenos_draw"},
        {"native_draw", "false"},
+       {"xenos_draw", "preserved"},
+       {"output_authority", "xenos"},
+       {"suppression_allowed", "false"}});
+}
+
+void FailClosedVehicleResourceContribution(const char *reason) {
+  if (g_isolated_draw.vehicle_resource_contribution_failed_closed) {
+    return;
+  }
+  g_isolated_draw.vehicle_resource_contribution_failed_closed = true;
+  pinyon_shift::diagnostics::RecordEvent(
+      "native_renderer.discovery.vehicle_resource_contribution_failure",
+      {{"status", "failed_closed"},
+       {"reason", reason},
+       {"geometry_resource_hash",
+        fmt::format("{:016X}",
+                    g_isolated_draw.vehicle_resource_contribution_hash)},
+       {"frame",
+        std::to_string(g_isolated_draw.vehicle_resource_contribution_frame)},
+       {"last_draw",
+        std::to_string(g_isolated_draw.vehicle_resource_contribution_last_draw)},
+       {"requests",
+        std::to_string(
+            g_isolated_draw.vehicle_resource_contribution_current_requests)},
+       {"outcomes",
+        std::to_string(
+            g_isolated_draw.vehicle_resource_contribution_current_outcomes)},
+       {"recorded",
+        std::to_string(
+            g_isolated_draw.vehicle_resource_contribution_current_recorded)},
+       {"family_mask",
+        fmt::format("{:08X}",
+                    g_isolated_draw.vehicle_resource_contribution_family_mask)},
+       {"fallback", "authoritative_xenos_draws"},
+       {"native_draw", "false"},
+       {"xenos_draw", "preserved"},
+       {"output_authority", "xenos"},
+       {"suppression_allowed", "false"}});
+}
+
+void CompleteVehicleResourceContribution(
+    const rex::system::GraphicsIsolatedDrawResult &result) {
+  ++g_isolated_draw.vehicle_resource_contribution_current_outcomes;
+  const bool recorded =
+      result.status == rex::system::GraphicsIsolatedDrawStatus::kRecorded;
+  if (recorded) {
+    ++g_isolated_draw.vehicle_resource_contribution_recorded;
+    ++g_isolated_draw.vehicle_resource_contribution_current_recorded;
+  } else {
+    if (result.status == rex::system::
+                             GraphicsIsolatedDrawStatus::
+                                 kTargetCreationFailed) {
+      ++g_isolated_draw.vehicle_resource_contribution_target_failures;
+    } else {
+      ++g_isolated_draw.vehicle_resource_contribution_unsupported;
+    }
+    FailClosedVehicleResourceContribution("backend_replay_failure");
+    return;
+  }
+  if (g_isolated_draw.vehicle_resource_contribution_current_requests != 2 ||
+      g_isolated_draw.vehicle_resource_contribution_current_outcomes != 2 ||
+      g_isolated_draw.vehicle_resource_contribution_capture_completed) {
+    return;
+  }
+  if (g_isolated_draw.vehicle_resource_contribution_current_recorded != 2) {
+    FailClosedVehicleResourceContribution("incomplete_recording");
+    return;
+  }
+  g_isolated_draw.vehicle_resource_contribution_capture_completed = true;
+  pinyon_shift::diagnostics::RecordEvent(
+      "native_renderer.discovery.vehicle_resource_contribution_result",
+      {{"status", "recorded_complete_private_resource_contribution"},
+       {"geometry_resource_hash",
+        fmt::format("{:016X}",
+                    g_isolated_draw.vehicle_resource_contribution_hash)},
+       {"frame",
+        std::to_string(g_isolated_draw.vehicle_resource_contribution_frame)},
+       {"last_draw",
+        std::to_string(g_isolated_draw.vehicle_resource_contribution_last_draw)},
+       {"draw_count", "2"},
+       {"target_width", std::to_string(result.target_width)},
+       {"target_height", std::to_string(result.target_height)},
+       {"readback", "native_resource_contribution"},
+       {"native_draw", "private_resource_contribution_only"},
        {"xenos_draw", "preserved"},
        {"output_authority", "xenos"},
        {"suppression_allowed", "false"}});
@@ -23456,6 +23593,99 @@ void RequestIsolatedDraw(
       request.reference_readback_completion =
           g_isolated_draw.readback_requested
               ? &CompleteIsolatedReferenceReadback
+              : nullptr;
+      return;
+    }
+    if (g_isolated_draw.shadow_depth_batch_capture_completed &&
+        g_isolated_draw.vehicle_shadow_color_capture_mode &&
+        g_isolated_draw.vehicle_shadow_color_capture_recorded &&
+        g_isolated_draw.vehicle_resource_contribution_capture_mode &&
+        !g_isolated_draw.vehicle_resource_contribution_failed_closed &&
+        !g_isolated_draw.vehicle_resource_contribution_capture_completed &&
+        g_isolated_draw.prepared_vehicle_shadow_color_replay_eligible) {
+      if (g_vehicle_shadow_geometry_correlation_count !=
+          kVehicleShadowColorRetainedFamilyCount) {
+        return;
+      }
+      const uint32_t family_index =
+          g_isolated_draw.prepared_vehicle_shadow_color_family_index;
+      if (family_index >= kVehicleShadowColorRetainedFamilyCount) {
+        FailClosedVehicleResourceContribution("invalid_family_index");
+        return;
+      }
+      const VehicleShadowGeometryCorrelationEntry &family =
+          g_vehicle_shadow_geometry_correlations[family_index];
+      if (!family.occupied ||
+          family.geometry_resource_hash !=
+              g_isolated_draw.vehicle_resource_contribution_hash) {
+        return;
+      }
+      uint32_t resource_variant_count = 0;
+      for (const VehicleShadowGeometryCorrelationEntry &entry :
+           g_vehicle_shadow_geometry_correlations) {
+        resource_variant_count +=
+            entry.occupied &&
+            entry.geometry_resource_hash ==
+                g_isolated_draw.vehicle_resource_contribution_hash;
+      }
+      if (resource_variant_count != 2) {
+        FailClosedVehicleResourceContribution("unexpected_variant_count");
+        return;
+      }
+      const uint64_t frame = g_isolated_draw.frame;
+      if (g_isolated_draw.vehicle_resource_contribution_frame != frame) {
+        if (g_isolated_draw.vehicle_resource_contribution_frame != UINT64_MAX &&
+            g_isolated_draw.vehicle_resource_contribution_current_requests) {
+          FailClosedVehicleResourceContribution("incomplete_resource_frame");
+          return;
+        }
+        g_isolated_draw.vehicle_resource_contribution_frame = frame;
+        g_isolated_draw.vehicle_resource_contribution_last_draw = 0;
+        g_isolated_draw.vehicle_resource_contribution_current_requests = 0;
+        g_isolated_draw.vehicle_resource_contribution_current_outcomes = 0;
+        g_isolated_draw.vehicle_resource_contribution_current_recorded = 0;
+        g_isolated_draw.vehicle_resource_contribution_family_mask = 0;
+      }
+      if (g_isolated_draw.vehicle_resource_contribution_current_requests >= 2) {
+        FailClosedVehicleResourceContribution("extra_resource_variant");
+        return;
+      }
+      if (g_isolated_draw.vehicle_resource_contribution_last_draw &&
+          g_isolated_draw.draw <=
+              g_isolated_draw.vehicle_resource_contribution_last_draw) {
+        FailClosedVehicleResourceContribution("non_monotonic_draw_order");
+        return;
+      }
+      const uint32_t family_bit = uint32_t(1) << family_index;
+      if (g_isolated_draw.vehicle_resource_contribution_family_mask &
+          family_bit) {
+        FailClosedVehicleResourceContribution("duplicate_resource_variant");
+        return;
+      }
+      g_isolated_draw.vehicle_resource_contribution_family_mask |= family_bit;
+      ++g_isolated_draw.vehicle_resource_contribution_current_requests;
+      ++g_isolated_draw.vehicle_resource_contribution_requests;
+      g_isolated_draw.vehicle_resource_contribution_last_draw =
+          g_isolated_draw.draw;
+      const bool completing_contribution =
+          g_isolated_draw.vehicle_resource_contribution_current_requests == 2;
+      if (completing_contribution) {
+        g_isolated_draw.captured_signature =
+            g_isolated_draw.prepared_signature;
+        g_isolated_draw.captured_frame = frame;
+        g_isolated_draw.captured_draw = g_isolated_draw.draw;
+      }
+      request.requested = true;
+      request.retain_target = !completing_contribution;
+      request.reuse_target = completing_contribution;
+      request.frame_sequence = frame;
+      request.reference_marker_requested = true;
+      request.completion = &CompleteVehicleResourceContribution;
+      request.readback_requested =
+          completing_contribution && g_isolated_draw.readback_requested;
+      request.readback_completion =
+          request.readback_requested
+              ? &CompleteVehicleResourceContributionReadback
               : nullptr;
       return;
     }
@@ -28461,6 +28691,56 @@ void UninstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system) {
          {"native_draw",
           g_isolated_draw.vehicle_shadow_color_capture_recorded
               ? "private_capture_only"
+              : "false"},
+         {"xenos_draw", "preserved"},
+         {"output_authority", "xenos"},
+         {"suppression_allowed", "false"}});
+  }
+  if (g_isolated_draw.vehicle_resource_contribution_capture_mode) {
+    const uint64_t contribution_outcomes =
+        g_isolated_draw.vehicle_resource_contribution_recorded +
+        g_isolated_draw.vehicle_resource_contribution_target_failures +
+        g_isolated_draw.vehicle_resource_contribution_unsupported;
+    diagnostics::RecordEvent(
+        "native_renderer.discovery.vehicle_resource_contribution_summary",
+        {{"status",
+          g_isolated_draw.vehicle_resource_contribution_failed_closed
+              ? "failed_closed"
+              : (g_isolated_draw
+                         .vehicle_resource_contribution_capture_completed
+                     ? "bounded_resource_contribution_recorded"
+                     : "not_observed")},
+         {"geometry_resource_hash",
+          fmt::format("{:016X}",
+                      g_isolated_draw.vehicle_resource_contribution_hash)},
+         {"requests",
+          std::to_string(
+              g_isolated_draw.vehicle_resource_contribution_requests)},
+         {"recorded",
+          std::to_string(
+              g_isolated_draw.vehicle_resource_contribution_recorded)},
+         {"target_creation_failures",
+          std::to_string(
+              g_isolated_draw.vehicle_resource_contribution_target_failures)},
+         {"unsupported",
+          std::to_string(
+              g_isolated_draw.vehicle_resource_contribution_unsupported)},
+         {"request_accounting_complete",
+          contribution_outcomes ==
+                  g_isolated_draw.vehicle_resource_contribution_requests
+              ? "true"
+              : "false"},
+         {"expected_variants", "2"},
+         {"capture_recorded",
+          g_isolated_draw.vehicle_resource_contribution_capture_completed
+              ? "true"
+              : "false"},
+         {"selection", "two_exact_prepared_variants_for_one_geometry_resource"},
+         {"target_lifecycle", "retain_first_release_second"},
+         {"readback", "complete_private_resource_contribution"},
+         {"native_draw",
+          g_isolated_draw.vehicle_resource_contribution_capture_completed
+              ? "private_resource_contribution_only"
               : "false"},
          {"xenos_draw", "preserved"},
          {"output_authority", "xenos"},

--- a/tools/capture-native-renderer-census.ps1
+++ b/tools/capture-native-renderer-census.ps1
@@ -21,6 +21,8 @@ param(
     [switch]$VehicleShadowGeometryCorrelation,
     [switch]$CaptureVehicleShadowColor,
     [switch]$RetainVehicleShadowColorPass,
+    [ValidatePattern('^[0-9A-Fa-f]{16}$')]
+    [string]$VehicleResourceContribution,
     [switch]$PublishShadowDepth,
     [switch]$ContinuousShadowDepth,
     [ValidateRange(2, 120)]
@@ -122,6 +124,12 @@ if ($CaptureVehicleShadowColor -and -not $VehicleShadowGeometryCorrelation) {
 }
 if ($RetainVehicleShadowColorPass -and -not $CaptureVehicleShadowColor) {
     throw 'RetainVehicleShadowColorPass requires CaptureVehicleShadowColor.'
+}
+if ($VehicleResourceContribution -and -not $CaptureVehicleShadowColor) {
+    throw 'VehicleResourceContribution requires CaptureVehicleShadowColor.'
+}
+if ($VehicleResourceContribution -and $RetainVehicleShadowColorPass) {
+    throw 'VehicleResourceContribution and RetainVehicleShadowColorPass are mutually exclusive.'
 }
 if ($PublishShadowDepth -and -not $ShadowDepthBatch) {
     throw 'PublishShadowDepth requires ShadowDepthBatch.'
@@ -248,6 +256,8 @@ $savedVehicleShadowColorCapture =
     $env:PINYON_SHIFT_NATIVE_RENDERER_VEHICLE_SHADOW_COLOR_CAPTURE
 $savedVehicleShadowColorRetainedPass =
     $env:PINYON_SHIFT_NATIVE_RENDERER_VEHICLE_SHADOW_COLOR_RETAINED_PASS
+$savedVehicleResourceContribution =
+    $env:PINYON_SHIFT_NATIVE_RENDERER_VEHICLE_RESOURCE_CONTRIBUTION
 $savedShadowDepthPublication =
     $env:PINYON_SHIFT_NATIVE_RENDERER_SHADOW_DEPTH_PUBLICATION
 $savedShadowDepthContinuous =
@@ -302,6 +312,8 @@ try {
         if ($CaptureVehicleShadowColor) { 'true' } else { $null }
     $env:PINYON_SHIFT_NATIVE_RENDERER_VEHICLE_SHADOW_COLOR_RETAINED_PASS =
         if ($RetainVehicleShadowColorPass) { 'true' } else { $null }
+    $env:PINYON_SHIFT_NATIVE_RENDERER_VEHICLE_RESOURCE_CONTRIBUTION =
+        $VehicleResourceContribution
     $env:PINYON_SHIFT_NATIVE_RENDERER_SHADOW_DEPTH_PUBLICATION =
         if ($PublishShadowDepth) { 'true' } else { $null }
     $env:PINYON_SHIFT_NATIVE_RENDERER_SHADOW_DEPTH_CONTINUOUS =
@@ -362,6 +374,8 @@ finally {
         $savedVehicleShadowColorCapture
     $env:PINYON_SHIFT_NATIVE_RENDERER_VEHICLE_SHADOW_COLOR_RETAINED_PASS =
         $savedVehicleShadowColorRetainedPass
+    $env:PINYON_SHIFT_NATIVE_RENDERER_VEHICLE_RESOURCE_CONTRIBUTION =
+        $savedVehicleResourceContribution
     $env:PINYON_SHIFT_NATIVE_RENDERER_SHADOW_DEPTH_PUBLICATION =
         $savedShadowDepthPublication
     $env:PINYON_SHIFT_NATIVE_RENDERER_SHADOW_DEPTH_CONTINUOUS =

--- a/tools/tests/test_native_renderer_vehicle_contributions.py
+++ b/tools/tests/test_native_renderer_vehicle_contributions.py
@@ -134,6 +134,24 @@ class VehicleContributionTests(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "Xenos authority"):
             summarize(document)
 
+    def test_private_capture_is_targeted_and_preserves_xenos(self):
+        hooks = (ROOT / "src/native_renderer/graphics_hooks.cpp").read_text(
+            encoding="utf-8"
+        )
+        capture = (ROOT / "tools/capture-native-renderer-census.ps1").read_text(
+            encoding="utf-8"
+        )
+        self.assertIn("VEHICLE_RESOURCE_CONTRIBUTION", hooks)
+        self.assertIn("CompleteVehicleResourceContributionReadback", hooks)
+        self.assertIn("retain_first_release_second", hooks)
+        self.assertIn('"xenos_draw", "preserved"', hooks)
+        self.assertIn('"suppression_allowed", "false"', hooks)
+        self.assertIn("[string]$VehicleResourceContribution", capture)
+        self.assertIn(
+            "VehicleResourceContribution and RetainVehicleShadowColorPass",
+            capture,
+        )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- target one of the 15 qualified vehicle geometry resources by exact hash
- retain its first prepared variant, reuse/release on the second, and read back the bounded private contribution
- fail closed on variant count, frame ordering, duplicate identity, target creation, or backend replay drift
- expose the mode through the AppData-safe census launcher

## Safety
- both original Xenos draws remain preserved
- output authority remains Xenos
- no native publication or suppression is allowed
- one resource is captured per run to keep asynchronous artifact identity exact

## Validation
- `python -m unittest discover -s tools/tests -p 'test_*.py'` (626 passed)
- Release `pinyon_shift` build
- PowerShell parameter parsing verified
- `git diff --check`

Runtime visual qualification is intentionally batched with the next meaningful open-world run.