### PR TITLE
feat(renderer): trace vehicle material bindings

### DIFF
--- a/config/rexglue/analysis/main-xex.toml
+++ b/config/rexglue/analysis/main-xex.toml
@@ -367,6 +367,16 @@ address = 0x82435E78
 name = "PinyonShiftObserveVehicleTypedConstantUpload"
 registers = ["r3", "r4", "r5", "r6", "lr"]
 
+# Exact title-owned tire/wheel material binding. 82549670 receives the car
+# material root in r3, its root+1056 destination binding in r4, the UI-load
+# flag in r5, and the normal/SLOD selector in r6. The passive census hashes
+# only the MSVC asset-key string at root+1712 and retains exact draw-argument
+# address joins; it never exports a path or changes the bind.
+[[midasm_hook]]
+address = 0x82549670
+name = "PinyonShiftObserveVehicleMaterialBinding"
+registers = ["r3", "r4", "r5", "r6"]
+
 [[midasm_hook]]
 address = 0x8243646C
 name = "PinyonShiftObserveVehicleRenderContextDispatcherEntry"

--- a/docs/native-renderer/REPRIORITIZED_PLAN.md
+++ b/docs/native-renderer/REPRIORITIZED_PLAN.md
@@ -776,6 +776,16 @@ qualifies the first isolated resource result and joins it to an independent
 title-owned asset/material discriminator before
 assigning body, glass, wheel, light, livery, or exceptional-work labels.
 
+Asset/material discriminator checkpoint: retail construction now proves the
+exact title-owned tire/wheel shader-settings path builder and its root-plus-1056
+binding object. A passive bounded hook hashes only the model-owned asset key,
+retains Normal/SLOD and UI flags, and records exact title draw-argument joins.
+The static proof and pending runtime gate are documented in
+[`VEHICLE_ASSET_MATERIAL_BINDING.md`](VEHICLE_ASSET_MATERIAL_BINDING.md).
+This narrows one independent semantic family without guessing from shared
+shader topology; per-resource role labels remain closed until the next batched
+visual-contribution run agrees with this title-owned evidence.
+
 ### C5. Sky, atmosphere, and global lighting
 
 - Replace the qualified sky/global-light families.

--- a/docs/native-renderer/VEHICLE_ASSET_MATERIAL_BINDING.md
+++ b/docs/native-renderer/VEHICLE_ASSET_MATERIAL_BINDING.md
@@ -1,0 +1,56 @@
+# Vehicle asset/material binding
+
+Status: exact static title-owned tire/wheel discriminator proved; passive
+runtime census implemented and awaiting the next batched gameplay run.
+
+## Exact edge
+
+Retail function `82543558` constructs the car-specific tire/wheel shader
+settings path. It selects the shared Normal or SLOD tire settings, appends the
+title's `game:\media\Wheels\` root, the model-owned MSVC string at offset
+1712, and the `ShaderSettings` suffix. Function `82549670` binds that result to
+the destination object and optionally loads its UI settings.
+
+The car-resource constructor `824D11B0` calls this binding function twice. At
+both sites, `r3` is the car material root and `r4` is exactly root plus 1056.
+The retail image independently identifies the related
+`CCarMaterialSettingsResourceType`, `CCarModelResourceType`,
+`CCarMaterialSettingsResource`, and `CCarModelResource` RTTI/vtable surfaces.
+`discover-native-renderer-vehicle-asset-material.py` locks all of these
+relationships and fails if any instruction, string, type, locator, vtable, or
+call count drifts.
+
+## Passive runtime join
+
+The census hook at `82549670` records only:
+
+- the root and exact root-plus-1056 binding addresses;
+- a length and hash of the model-owned asset key at root plus 1712;
+- the UI-load and Normal/SLOD flags; and
+- exact backend signatures if either retained address later appears directly
+  in title draw provenance.
+
+The bounded table has 128 binding rows and 16 backend signatures per row.
+Every observation is accounted as a valid exact relation, an invalid owner
+relation, or an asset-key read fault. No path text or asset bytes are logged.
+
+## What this proves
+
+This is the independent title-owned discriminator required by the resource
+contribution work, but only for the tire/wheel shader-settings family. It does
+not yet assign one of the 15 geometry resources to body paint, glass, wheels,
+lights, livery, or exceptional work. That requires the next batched run to
+join a binding/backend signature with an isolated visual contribution (or to
+show that a narrower downstream bind edge is still needed).
+
+Xenos remains authoritative. The hook cannot alter guest state, publish a
+native draw, admit a resource, or enable suppression.
+
+## Reproduction
+
+```powershell
+python tools/discover-native-renderer-vehicle-asset-material.py `
+  .local/generated/default `
+  --image C:\path\to\default-image.bin `
+  --output .local/qualification/native-renderer-vehicle-asset-material.json
+```

--- a/docs/native-renderer/VEHICLE_RESOURCE_CONTRIBUTIONS.md
+++ b/docs/native-renderer/VEHICLE_RESOURCE_CONTRIBUTIONS.md
@@ -39,6 +39,13 @@ details, but those names remain hypotheses until an independent title-owned
 asset/material discriminator agrees. Player identity, native publication, and
 suppression remain closed.
 
+The first independent discriminator is now implemented at the exact retail
+tire/wheel shader-settings binding. See
+[`VEHICLE_ASSET_MATERIAL_BINDING.md`](VEHICLE_ASSET_MATERIAL_BINDING.md). It
+provides a title-owned family seed and an exact backend-signature join when
+the binding addresses appear in draw provenance, but it does not by itself
+label any geometry contribution.
+
 ## Private resource capture
 
 `-VehicleResourceContribution <geometry_resource_hash>` targets one qualified

--- a/src/native_renderer/graphics_hooks.cpp
+++ b/src/native_renderer/graphics_hooks.cpp
@@ -155,6 +155,12 @@ constexpr size_t kVehicleVertexShaderConstantComponentCount = 256 * 4;
 constexpr size_t kVehicleShaderConstantSourceCapacity = 4096;
 constexpr size_t kVehicleShadowGeometrySeedCapacity = 256;
 constexpr size_t kVehicleShadowGeometryCorrelationCapacity = 1024;
+constexpr uint32_t kVehicleMaterialBindingHook = 0x82549670;
+constexpr uint32_t kVehicleMaterialBindingObjectOffset = 1056;
+constexpr uint32_t kVehicleMaterialAssetKeyOffset = 1712;
+constexpr uint32_t kVehicleMaterialAssetKeyMaximumBytes = 512;
+constexpr size_t kVehicleMaterialBindingCapacity = 128;
+constexpr size_t kVehicleMaterialBackendSignatureCapacity = 16;
 constexpr uint64_t kVehicleColorConstantMaximumIdentityAgeFrames = 1;
 constexpr uint64_t kVehicleShadowColorPrivateReplayLimit = 300;
 constexpr uint32_t kVehicleShadowColorRetainedFamilyCount = 30;
@@ -1593,6 +1599,22 @@ struct PendingVehicleDrawIdentityEvidence {
   bool valid = false;
 };
 
+struct VehicleMaterialBindingEntry {
+  uint32_t root_address = 0;
+  uint32_t binding_address = 0;
+  uint32_t asset_key_length = 0;
+  uint32_t flags = 0;
+  uint64_t asset_key_hash = 0;
+  uint64_t observations = 0;
+  uint64_t root_draw_probe_matches = 0;
+  uint64_t binding_draw_probe_matches = 0;
+  std::array<uint64_t, kVehicleMaterialBackendSignatureCapacity>
+      backend_signatures{};
+  uint32_t backend_signature_count = 0;
+  uint64_t backend_signature_overflow = 0;
+  bool valid = false;
+};
+
 thread_local PendingVehicleDrawIdentityEvidence
     g_pending_vehicle_draw_identity_evidence;
 
@@ -1627,6 +1649,15 @@ uint64_t g_vehicle_map_entity_count = 0;
 uint64_t g_vehicle_map_entity_overflow = 0;
 uint64_t g_vehicle_map_pose_correlation_count = 0;
 uint64_t g_vehicle_map_pose_correlation_overflow = 0;
+std::array<VehicleMaterialBindingEntry, kVehicleMaterialBindingCapacity>
+    g_vehicle_material_bindings{};
+std::mutex g_vehicle_material_binding_mutex;
+uint64_t g_vehicle_material_binding_observations = 0;
+uint64_t g_vehicle_material_binding_valid_observations = 0;
+uint64_t g_vehicle_material_binding_invalid_relation = 0;
+uint64_t g_vehicle_material_binding_asset_read_faults = 0;
+uint64_t g_vehicle_material_binding_count = 0;
+uint64_t g_vehicle_material_binding_overflow = 0;
 std::array<VehicleOwnerMethodStats, kVehicleOwnerMethodCandidateCount>
     g_vehicle_owner_method_stats{};
 std::atomic<uint64_t> g_vehicle_owner_method_stack_faults{};
@@ -3450,6 +3481,113 @@ bool LoadMappedGuestU8(rex::memory::Memory *memory, uint32_t address,
   }
   value = *memory->TranslateVirtual<uint8_t *>(address);
   return true;
+}
+
+bool ReadVehicleMaterialAssetKey(rex::memory::Memory *memory,
+                                 uint32_t root_address,
+                                 uint64_t &asset_key_hash,
+                                 uint32_t &asset_key_length) {
+  if (!memory || !root_address ||
+      root_address > UINT32_MAX - kVehicleMaterialAssetKeyOffset -
+                         kMsvcStringCapacityOffset - sizeof(uint32_t)) {
+    return false;
+  }
+  const uint32_t string_address =
+      root_address + kVehicleMaterialAssetKeyOffset;
+  uint32_t string_capacity = 0;
+  if (!LoadMappedGuestU32(memory, string_address + kMsvcStringSizeOffset,
+                          asset_key_length) ||
+      !LoadMappedGuestU32(memory,
+                          string_address + kMsvcStringCapacityOffset,
+                          string_capacity) ||
+      !asset_key_length ||
+      asset_key_length > kVehicleMaterialAssetKeyMaximumBytes ||
+      string_capacity < asset_key_length) {
+    return false;
+  }
+  uint32_t data_address = string_address;
+  if (string_capacity >= kMsvcStringInlineCapacity &&
+      !LoadMappedGuestU32(memory, string_address, data_address)) {
+    return false;
+  }
+  if (!IsReadableVehicleGuestRange(memory, data_address, asset_key_length)) {
+    return false;
+  }
+  size_t host_region_length = 0;
+  rex::memory::PageAccess host_access = rex::memory::PageAccess::kNoAccess;
+  const uint8_t *data =
+      memory->TranslateVirtual<const uint8_t *>(data_address);
+  if (!rex::memory::QueryProtect(const_cast<uint8_t *>(data),
+                                 host_region_length, host_access) ||
+      host_region_length < asset_key_length ||
+      host_access == rex::memory::PageAccess::kNoAccess) {
+    return false;
+  }
+  uint64_t hash = UINT64_C(0xCBF29CE484222325);
+  for (uint32_t index = 0; index < asset_key_length; ++index) {
+    hash ^= data[index];
+    hash *= UINT64_C(0x100000001B3);
+  }
+  asset_key_hash = hash ? hash : 1;
+  return true;
+}
+
+void ObserveVehicleMaterialBinding(uint32_t root_address,
+                                   uint32_t binding_address,
+                                   uint32_t load_ui,
+                                   uint32_t slod) {
+  if (!g_vehicle_discovery_installed.load(std::memory_order_acquire)) {
+    return;
+  }
+  std::scoped_lock lock(g_vehicle_material_binding_mutex);
+  ++g_vehicle_material_binding_observations;
+  if (!root_address ||
+      root_address > UINT32_MAX - kVehicleMaterialBindingObjectOffset ||
+      binding_address !=
+          root_address + kVehicleMaterialBindingObjectOffset) {
+    ++g_vehicle_material_binding_invalid_relation;
+    return;
+  }
+  rex::memory::Memory *memory =
+      g_vehicle_discovery_memory.load(std::memory_order_acquire);
+  uint64_t asset_key_hash = 0;
+  uint32_t asset_key_length = 0;
+  if (!ReadVehicleMaterialAssetKey(memory, root_address, asset_key_hash,
+                                   asset_key_length)) {
+    ++g_vehicle_material_binding_asset_read_faults;
+    return;
+  }
+  ++g_vehicle_material_binding_valid_observations;
+  const uint32_t flags = (load_ui ? 1u : 0u) | (slod ? 2u : 0u);
+  VehicleMaterialBindingEntry *available = nullptr;
+  for (VehicleMaterialBindingEntry &entry : g_vehicle_material_bindings) {
+    if (!entry.valid) {
+      if (!available) {
+        available = &entry;
+      }
+      continue;
+    }
+    if (entry.root_address == root_address &&
+        entry.binding_address == binding_address &&
+        entry.asset_key_hash == asset_key_hash && entry.flags == flags) {
+      ++entry.observations;
+      return;
+    }
+  }
+  if (!available) {
+    ++g_vehicle_material_binding_overflow;
+    return;
+  }
+  *available = {
+      .root_address = root_address,
+      .binding_address = binding_address,
+      .asset_key_length = asset_key_length,
+      .flags = flags,
+      .asset_key_hash = asset_key_hash,
+      .observations = 1,
+      .valid = true,
+  };
+  ++g_vehicle_material_binding_count;
 }
 
 enum class StaticWorldAssetMetadataResult {
@@ -5457,6 +5595,37 @@ void ObserveVehicleDrawArgumentCorrelations(
     }
     if (!probe.value) {
       continue;
+    }
+    {
+      std::scoped_lock material_lock(g_vehicle_material_binding_mutex);
+      for (VehicleMaterialBindingEntry &entry :
+           g_vehicle_material_bindings) {
+        if (!entry.valid ||
+            (probe.value != entry.root_address &&
+             probe.value != entry.binding_address)) {
+          continue;
+        }
+        entry.root_draw_probe_matches +=
+            probe.value == entry.root_address ? 1 : 0;
+        entry.binding_draw_probe_matches +=
+            probe.value == entry.binding_address ? 1 : 0;
+        bool known_signature = false;
+        for (size_t signature_index = 0;
+             signature_index < entry.backend_signature_count;
+             ++signature_index) {
+          known_signature |=
+              entry.backend_signatures[signature_index] == backend_signature;
+        }
+        if (!known_signature) {
+          if (entry.backend_signature_count <
+              entry.backend_signatures.size()) {
+            entry.backend_signatures[entry.backend_signature_count++] =
+                backend_signature;
+          } else {
+            ++entry.backend_signature_overflow;
+          }
+        }
+      }
     }
     size_t address_index =
         (probe.value >> 4) % kVehicleIdentityAddressCapacity;
@@ -24928,6 +25097,16 @@ void ConfigureVehicleDiscovery(bool census_requested,
     g_vehicle_composed_matrix_correlation_overflow = 0;
   }
   {
+    std::scoped_lock lock(g_vehicle_material_binding_mutex);
+    g_vehicle_material_bindings = {};
+    g_vehicle_material_binding_observations = 0;
+    g_vehicle_material_binding_valid_observations = 0;
+    g_vehicle_material_binding_invalid_relation = 0;
+    g_vehicle_material_binding_asset_read_faults = 0;
+    g_vehicle_material_binding_count = 0;
+    g_vehicle_material_binding_overflow = 0;
+  }
+  {
     std::scoped_lock lock(g_vehicle_constant_upload_mutex);
     std::fill(g_vehicle_constant_uploads.begin(),
               g_vehicle_constant_uploads.end(),
@@ -25058,6 +25237,12 @@ void ConfigureVehicleDiscovery(bool census_requested,
         "8201D430:festival_traffic,8201D4B0:remote_player"},
        {"map_entity_pose_join",
         "exact_entity_to_source,entity_to_owner,vehicle_id_to_active_slot"},
+       {"material_binding_hook",
+        fmt::format("{:08X}", kVehicleMaterialBindingHook)},
+       {"material_binding_contract",
+        "entry_r3_root,entry_r4_root_plus_1056,asset_key_at_root_plus_1712"},
+       {"material_binding_capacity",
+        std::to_string(kVehicleMaterialBindingCapacity)},
        {"owner_vtable_method_count",
         std::to_string(kVehicleOwnerVtableMethodCount)},
        {"owner_method_candidates",
@@ -25143,7 +25328,8 @@ void EmitVehicleDiscoverySummary() {
   }
   std::scoped_lock lock(g_vehicle_identity_mutex,
                         g_vehicle_owner_indirect_mutex,
-                        g_vehicle_draw_correlation_mutex);
+                        g_vehicle_draw_correlation_mutex,
+                        g_vehicle_material_binding_mutex);
   const bool accounting_complete =
       g_vehicle_valid_observations + g_vehicle_invalid_observations ==
       g_vehicle_observations;
@@ -25188,6 +25374,11 @@ void EmitVehicleDiscoverySummary() {
           g_vehicle_map_entity_pool_unrecognized_observations +
           g_vehicle_map_entity_pool_invalid_observations ==
       g_vehicle_map_entity_pool_observations;
+  const bool vehicle_material_binding_accounting_complete =
+      g_vehicle_material_binding_valid_observations +
+          g_vehicle_material_binding_invalid_relation +
+          g_vehicle_material_binding_asset_read_faults ==
+      g_vehicle_material_binding_observations;
   uint64_t player_entity_count = 0;
   uint64_t player_entity_observations = 0;
   uint64_t player_pose_comparisons = 0;
@@ -25440,6 +25631,80 @@ void EmitVehicleDiscoverySummary() {
        {"native_draw", "false"},
        {"xenos_authority", "true"},
        {"suppression_allowed", "false"}});
+  pinyon_shift::diagnostics::RecordEvent(
+      "native_renderer.discovery.vehicle_material_binding_summary",
+      {{"status", !g_vehicle_material_binding_observations
+                      ? "not_observed"
+                      : (vehicle_material_binding_accounting_complete
+                             ? "complete"
+                             : "incomplete")},
+       {"hook", fmt::format("{:08X}", kVehicleMaterialBindingHook)},
+       {"observations",
+        std::to_string(g_vehicle_material_binding_observations)},
+       {"valid_observations",
+        std::to_string(g_vehicle_material_binding_valid_observations)},
+       {"invalid_relation",
+        std::to_string(g_vehicle_material_binding_invalid_relation)},
+       {"asset_read_faults",
+        std::to_string(g_vehicle_material_binding_asset_read_faults)},
+       {"bindings", std::to_string(g_vehicle_material_binding_count)},
+       {"capacity", std::to_string(kVehicleMaterialBindingCapacity)},
+       {"overflow", std::to_string(g_vehicle_material_binding_overflow)},
+       {"accounting_complete",
+        vehicle_material_binding_accounting_complete ? "true" : "false"},
+       {"title_semantic", "tire_wheel_shader_settings"},
+       {"binding_contract", "root_plus_1056"},
+       {"asset_key_contract", "root_plus_1712_msvc_string_hash"},
+       {"draw_join", "exact_title_draw_argument_address"},
+       {"semantic_mesh_material_roles_proved", "false"},
+       {"guest_payload_exported", "false"},
+       {"guest_state_changed", "false"},
+       {"native_draw", "false"},
+       {"xenos_authority", "true"},
+       {"suppression_allowed", "false"}});
+  for (const VehicleMaterialBindingEntry &entry :
+       g_vehicle_material_bindings) {
+    if (!entry.valid) {
+      continue;
+    }
+    std::string backend_signatures;
+    for (size_t index = 0; index < entry.backend_signature_count; ++index) {
+      if (!backend_signatures.empty()) {
+        backend_signatures += ',';
+      }
+      backend_signatures +=
+          fmt::format("{:016X}", entry.backend_signatures[index]);
+    }
+    pinyon_shift::diagnostics::RecordEvent(
+        "native_renderer.discovery.vehicle_material_binding",
+        {{"root_address", fmt::format("{:08X}", entry.root_address)},
+         {"binding_address",
+          fmt::format("{:08X}", entry.binding_address)},
+         {"asset_key_hash",
+          fmt::format("{:016X}", entry.asset_key_hash)},
+         {"asset_key_length", std::to_string(entry.asset_key_length)},
+         {"load_ui", entry.flags & 1 ? "true" : "false"},
+         {"slod", entry.flags & 2 ? "true" : "false"},
+         {"observations", std::to_string(entry.observations)},
+         {"root_draw_probe_matches",
+          std::to_string(entry.root_draw_probe_matches)},
+         {"binding_draw_probe_matches",
+          std::to_string(entry.binding_draw_probe_matches)},
+         {"backend_signatures", backend_signatures},
+         {"backend_signature_count",
+          std::to_string(entry.backend_signature_count)},
+         {"backend_signature_capacity",
+          std::to_string(kVehicleMaterialBackendSignatureCapacity)},
+         {"backend_signature_overflow",
+          std::to_string(entry.backend_signature_overflow)},
+         {"classification", "exact_tire_wheel_material_binding_seed"},
+         {"semantic_mesh_material_roles_proved", "false"},
+         {"guest_payload_exported", "false"},
+         {"guest_state_changed", "false"},
+         {"native_draw", "false"},
+         {"xenos_authority", "true"},
+         {"suppression_allowed", "false"}});
+  }
   pinyon_shift::diagnostics::RecordEvent(
       "native_renderer.discovery.vehicle_map_entity_summary",
       {{"status", !g_vehicle_map_entity_observations
@@ -29274,6 +29539,11 @@ void PinyonShiftObserveStaticWorldResourceRefreshResetExit(
 void PinyonShiftObserveVehicleComposedMatrix(PPCRegister &r5,
                                              PPCRegister &r22) {
   ObserveVehicleComposedMatrix(r22.u32, r5.u32);
+}
+
+void PinyonShiftObserveVehicleMaterialBinding(
+    PPCRegister &r3, PPCRegister &r4, PPCRegister &r5, PPCRegister &r6) {
+  ObserveVehicleMaterialBinding(r3.u32, r4.u32, r5.u32, r6.u32);
 }
 
 void PinyonShiftObserveVehicleTypedConstantUpload(

--- a/tools/discover-native-renderer-vehicle-asset-material.py
+++ b/tools/discover-native-renderer-vehicle-asset-material.py
@@ -1,0 +1,248 @@
+#!/usr/bin/env python3
+"""Lock the title-owned vehicle tire/wheel asset-material binding edge."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import pathlib
+import re
+import sys
+
+
+SCHEMA = "pinyon-shift.native-renderer-vehicle-asset-material.v1"
+IMAGE_BASE = 0x82000000
+FUNCTION_RE = re.compile(r"^DEFINE_REX_FUNC\(sub_([0-9A-F]{8})\) \{")
+INSTRUCTION_RE = re.compile(r"^\s*// (.+)$")
+PATH_BUILDER = 0x82543558
+BINDING_FUNCTION = 0x82549670
+CAR_RESOURCE_CONSTRUCTOR = 0x824D11B0
+EXPECTED_TYPES = (
+    (
+        ".?AVCCarMaterialSettingsResourceType@@",
+        0x8322C978,
+        0x822EC784,
+        0x82020B4C,
+        9,
+    ),
+    (
+        ".?AVCCarModelResourceType@@",
+        0x8322CD44,
+        0x822ECC3C,
+        0x82020CB8,
+        9,
+    ),
+    (
+        ".?AVCCarMaterialSettingsResource@@",
+        0x832B41D0,
+        0x8235E0B4,
+        0x8223FEDC,
+        23,
+    ),
+    (
+        ".?AVCCarModelResource@@",
+        0x832B43A0,
+        0x8235E470,
+        0x82240B54,
+        23,
+    ),
+)
+EXPECTED_STRINGS = (
+    (0x8201A254, ";game:\\media\\cars\\shared\\ShaderSettings\\Tire\\ui.xml"),
+    (0x8201A288, "\\ShaderSettings\\Tire\\"),
+    (0x8201A2C0, "game:\\media\\Wheels\\"),
+    (0x8201A2D4, "game:\\media\\cars\\shared\\ShaderSettings\\Tire\\Slod.xml;"),
+    (0x8201A30C, "game:\\media\\cars\\shared\\ShaderSettings\\Tire\\Normal.xml;"),
+    (0x82021CEC, "CarMaterialSettings Resources"),
+    (0x82021D8C, "CarModel Resources"),
+)
+
+
+def image_u32(image: bytes, address: int) -> int:
+    offset = address - IMAGE_BASE
+    if offset < 0 or offset + 4 > len(image):
+        raise ValueError(f"image address is out of range: {address:08X}")
+    return int.from_bytes(image[offset : offset + 4], "big")
+
+
+def image_string(image: bytes, address: int) -> str:
+    offset = address - IMAGE_BASE
+    if offset < 0 or offset >= len(image):
+        raise ValueError(f"image string is out of range: {address:08X}")
+    end = image.find(b"\0", offset, min(offset + 512, len(image)))
+    if end < 0:
+        raise ValueError(f"image string is unterminated: {address:08X}")
+    return image[offset:end].decode("ascii")
+
+
+def parse_sources(paths: list[pathlib.Path]) -> tuple[set[int], dict[int, list[str]]]:
+    functions: set[int] = set()
+    bodies: dict[int, list[str]] = {}
+    for path in sorted(paths, key=lambda item: item.as_posix()):
+        active = None
+        for line in path.read_text(encoding="utf-8").splitlines():
+            match = FUNCTION_RE.match(line)
+            if match:
+                active = int(match.group(1), 16)
+                functions.add(active)
+                bodies[active] = []
+                continue
+            instruction = INSTRUCTION_RE.match(line)
+            if active is not None and instruction:
+                bodies[active].append(instruction.group(1).strip())
+    return functions, bodies
+
+
+def require_ordered(body: list[str], expected: tuple[str, ...], label: str) -> None:
+    cursor = 0
+    for instruction in body:
+        if cursor < len(expected) and instruction == expected[cursor]:
+            cursor += 1
+    if cursor != len(expected):
+        raise ValueError(f"{label} instruction contract drifted")
+
+
+def build(functions: set[int], bodies: dict[int, list[str]], image: bytes) -> dict:
+    missing = sorted(
+        {PATH_BUILDER, BINDING_FUNCTION, CAR_RESOURCE_CONSTRUCTOR} - functions
+    )
+    if missing:
+        raise ValueError(
+            "vehicle asset-material functions are missing: "
+            + ",".join(f"{value:08X}" for value in missing)
+        )
+    for address, expected in EXPECTED_STRINGS:
+        if image_string(image, address) != expected:
+            raise ValueError(f"title string drifted at {address:08X}")
+
+    require_ordered(
+        bodies[PATH_BUILDER],
+        (
+            "mr r29,r3",
+            "mr r31,r4",
+            "mr r30,r5",
+            "addi r5,r11,-23796",
+            "addi r5,r11,-23852",
+            "addi r5,r11,-23872",
+            "addi r5,r31,1712",
+            "addi r31,r11,-23880",
+            "addi r5,r11,-23896",
+            "addi r5,r11,-23904",
+            "addi r4,r1,80",
+            "bl 0x82450f48",
+            "mr r3,r29",
+        ),
+        "tire/wheel path builder",
+    )
+    require_ordered(
+        bodies[BINDING_FUNCTION],
+        (
+            "mr r31,r4",
+            "mr r30,r5",
+            "mr r4,r3",
+            "mr r5,r6",
+            "bl 0x82543558",
+            "mr r3,r31",
+            "bl 0x82480fc0",
+            "mr r3,r31",
+            "bl 0x825434a0",
+        ),
+        "vehicle material binding",
+    )
+    constructor = bodies[CAR_RESOURCE_CONSTRUCTOR]
+    if constructor.count("bl 0x82549670") != 2:
+        raise ValueError("car resource binding call count drifted")
+    require_ordered(
+        constructor,
+        (
+            "addi r4,r31,1056",
+            "mr r3,r31",
+            "bl 0x82549670",
+            "addi r29,r31,1056",
+            "mr r4,r29",
+            "mr r3,r31",
+            "bl 0x82549670",
+        ),
+        "car resource owner relation",
+    )
+
+    types = []
+    for name, descriptor, locator, vtable, slot_count in EXPECTED_TYPES:
+        if image_string(image, descriptor + 8) != name:
+            raise ValueError(f"{name} type descriptor drifted")
+        if image_u32(image, locator + 12) != descriptor:
+            raise ValueError(f"{name} complete-object locator drifted")
+        if any(
+            image_u32(image, vtable + index * 4) not in functions
+            for index in range(slot_count)
+        ):
+            raise ValueError(f"{name} vtable drifted")
+        types.append(
+            {
+                "decorated_name": name,
+                "type_descriptor": f"{descriptor:08X}",
+                "complete_object_locator": f"{locator:08X}",
+                "primary_vtable": f"{vtable:08X}",
+                "slot_count": slot_count,
+            }
+        )
+
+    return {
+        "schema": SCHEMA,
+        "status": "complete",
+        "classification": "exact_title_owned_vehicle_asset_material_binding",
+        "types": types,
+        "contracts": {
+            "path_builder": f"{PATH_BUILDER:08X}",
+            "binding_function": f"{BINDING_FUNCTION:08X}",
+            "car_resource_constructor": f"{CAR_RESOURCE_CONSTRUCTOR:08X}",
+            "binding_object_offset": 1056,
+            "asset_key_offset": 1712,
+            "binding_call_count": 2,
+            "title_semantic": "tire_wheel_shader_settings",
+            "runtime_hook": "82549670:r3_root,r4_binding,r5_load_ui,r6_slod",
+            "draw_join": "exact_title_draw_argument_address",
+        },
+        "summary": {
+            "resource_type_count": len(types),
+            "title_owned_asset_material_discriminator_proved": True,
+            "tire_wheel_material_family_proved": True,
+            "semantic_mesh_material_roles_proved": False,
+            "geometry_resource_join_proved": False,
+            "runtime_qualification_required": True,
+        },
+        "safety": {
+            "static_analysis_only": True,
+            "guest_payload_exported": False,
+            "native_admission": False,
+            "suppression_allowed": False,
+            "xenos_authority_required": True,
+        },
+    }
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("generated_root", type=pathlib.Path)
+    parser.add_argument("--image", required=True, type=pathlib.Path)
+    parser.add_argument("--output", required=True, type=pathlib.Path)
+    args = parser.parse_args(argv)
+    try:
+        paths = list(args.generated_root.glob("pinyon_shift_recomp.*.cpp"))
+        if not paths:
+            raise ValueError("no generated AOT C++ files found")
+        functions, bodies = parse_sources(paths)
+        document = build(functions, bodies, args.image.read_bytes())
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(
+            json.dumps(document, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        return 0
+    except (OSError, UnicodeDecodeError, ValueError) as error:
+        print(f"vehicle asset-material discovery failed: {error}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/tests/test_native_renderer_vehicle_asset_material.py
+++ b/tools/tests/test_native_renderer_vehicle_asset_material.py
@@ -1,0 +1,122 @@
+import importlib.util
+import sys
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+TOOL = ROOT / "tools" / "discover-native-renderer-vehicle-asset-material.py"
+SPEC = importlib.util.spec_from_file_location("vehicle_asset_material", TOOL)
+assert SPEC and SPEC.loader
+MODULE = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = MODULE
+SPEC.loader.exec_module(MODULE)
+
+
+def store_u32(image, address, value):
+    offset = address - MODULE.IMAGE_BASE
+    image[offset : offset + 4] = value.to_bytes(4, "big")
+
+
+def store_string(image, address, value):
+    offset = address - MODULE.IMAGE_BASE
+    encoded = value.encode("ascii") + b"\0"
+    image[offset : offset + len(encoded)] = encoded
+
+
+def fixture():
+    image = bytearray(0x01400000)
+    functions = {
+        MODULE.PATH_BUILDER,
+        MODULE.BINDING_FUNCTION,
+        MODULE.CAR_RESOURCE_CONSTRUCTOR,
+        0x82450F48,
+    }
+    for address, value in MODULE.EXPECTED_STRINGS:
+        store_string(image, address, value)
+    for name, descriptor, locator, vtable, slot_count in MODULE.EXPECTED_TYPES:
+        store_string(image, descriptor + 8, name)
+        store_u32(image, locator + 12, descriptor)
+        for index in range(slot_count):
+            store_u32(image, vtable + index * 4, 0x82450F48)
+    bodies = {
+        MODULE.PATH_BUILDER: [
+            "mr r29,r3",
+            "mr r31,r4",
+            "mr r30,r5",
+            "addi r5,r11,-23796",
+            "addi r5,r11,-23852",
+            "addi r5,r11,-23872",
+            "addi r5,r31,1712",
+            "addi r31,r11,-23880",
+            "addi r5,r11,-23896",
+            "addi r5,r11,-23904",
+            "addi r4,r1,80",
+            "bl 0x82450f48",
+            "mr r3,r29",
+        ],
+        MODULE.BINDING_FUNCTION: [
+            "mr r31,r4",
+            "mr r30,r5",
+            "mr r4,r3",
+            "mr r5,r6",
+            "bl 0x82543558",
+            "mr r3,r31",
+            "bl 0x82480fc0",
+            "mr r3,r31",
+            "bl 0x825434a0",
+        ],
+        MODULE.CAR_RESOURCE_CONSTRUCTOR: [
+            "addi r4,r31,1056",
+            "mr r3,r31",
+            "bl 0x82549670",
+            "addi r29,r31,1056",
+            "mr r4,r29",
+            "mr r3,r31",
+            "bl 0x82549670",
+        ],
+    }
+    return functions, bodies, bytes(image)
+
+
+class VehicleAssetMaterialTests(unittest.TestCase):
+    def test_locks_title_owned_binding(self):
+        report = MODULE.build(*fixture())
+        self.assertEqual("complete", report["status"])
+        self.assertTrue(
+            report["summary"][
+                "title_owned_asset_material_discriminator_proved"
+            ]
+        )
+        self.assertEqual(
+            "tire_wheel_shader_settings",
+            report["contracts"]["title_semantic"],
+        )
+        self.assertFalse(
+            report["summary"]["semantic_mesh_material_roles_proved"]
+        )
+
+    def test_rejects_owner_offset_drift(self):
+        functions, bodies, image = fixture()
+        bodies[MODULE.CAR_RESOURCE_CONSTRUCTOR][0] = "addi r4,r31,1052"
+        with self.assertRaisesRegex(ValueError, "owner relation"):
+            MODULE.build(functions, bodies, image)
+
+    def test_runtime_hook_is_passive_and_exact(self):
+        config = (ROOT / "config/rexglue/analysis/main-xex.toml").read_text(
+            encoding="utf-8"
+        )
+        source = (ROOT / "src/native_renderer/graphics_hooks.cpp").read_text(
+            encoding="utf-8"
+        )
+        self.assertIn("address = 0x82549670", config)
+        self.assertIn("PinyonShiftObserveVehicleMaterialBinding", config)
+        self.assertIn("kVehicleMaterialBindingObjectOffset = 1056", source)
+        self.assertIn("kVehicleMaterialAssetKeyOffset = 1712", source)
+        self.assertIn("guest_payload_exported", source)
+        self.assertIn('{"xenos_authority", "true"}', source)
+        self.assertIn('{"suppression_allowed", "false"}', source)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- lock the exact retail tire/wheel shader-settings path builder, resource RTTI, and root-plus-1056 binding edge
- add a bounded passive runtime census that hashes the model-owned asset key and joins exact binding addresses to backend signatures
- document the remaining visual-contribution/runtime gate without changing Xenos authority

## Validation
- python -m unittest discover -s tools/tests (629 passed)
- tools/build-preview.ps1 -Parallel 16 (Release build passed)
- static retail-image contract generated successfully

No AppData gameplay run was performed for this slice; runtime qualification remains batched with the next meaningful C4 checkpoint.