### PR TITLE
test(renderer): qualify vehicle material bindings

### DIFF
--- a/docs/native-renderer/REPRIORITIZED_PLAN.md
+++ b/docs/native-renderer/REPRIORITIZED_PLAN.md
@@ -786,6 +786,14 @@ This narrows one independent semantic family without guessing from shared
 shader topology; per-resource role labels remain closed until the next batched
 visual-contribution run agrees with this title-owned evidence.
 
+Runtime material-join checkpoint: a strict payload-free qualifier now maps
+the binding census's exact backend signatures onto the 15-resource partition.
+It produces a unique tire/wheel contribution candidate or one of two bounded
+negative results (no direct draw join or an ambiguous multi-resource join).
+Visual-role proof remains independently closed until isolated output agrees,
+so this tooling can be exercised in the combined Phase C session without
+weakening native admission or Xenos fallback.
+
 ### C5. Sky, atmosphere, and global lighting
 
 - Replace the qualified sky/global-light families.

--- a/docs/native-renderer/VEHICLE_ASSET_MATERIAL_BINDING.md
+++ b/docs/native-renderer/VEHICLE_ASSET_MATERIAL_BINDING.md
@@ -46,6 +46,25 @@ show that a narrower downstream bind edge is still needed).
 Xenos remains authoritative. The hook cannot alter guest state, publish a
 native draw, admit a resource, or enable suppression.
 
+## Runtime decision
+
+`summarize-native-renderer-vehicle-material-bindings.py` consumes the final
+JSONL census and the qualified 15-resource contribution report. It validates
+strict hook accounting and safety, then maps exact backend draw signatures to
+each contribution's two prepared variants.
+
+The result is intentionally three-way:
+
+- `qualified` only when every observed binding signature maps to one unique
+  geometry resource;
+- `bounded_negative_result/no_direct_binding_to_draw_join` when neither
+  retained address reaches draw provenance; or
+- `bounded_negative_result/binding_to_geometry_join_not_unique` when the edge
+  is real but does not isolate one contribution.
+
+Even a unique join remains a tire/wheel candidate until its isolated visual
+capture agrees. The qualifier cannot promote, publish, or suppress it.
+
 ## Reproduction
 
 ```powershell
@@ -53,4 +72,11 @@ python tools/discover-native-renderer-vehicle-asset-material.py `
   .local/generated/default `
   --image C:\path\to\default-image.bin `
   --output .local/qualification/native-renderer-vehicle-asset-material.json
+
+python tools/summarize-native-renderer-vehicle-material-bindings.py `
+  .local/logs/pinyon_shift.jsonl `
+  --contributions `
+    .local/qualification/native-renderer-vehicle-resource-contributions-v1.json `
+  --output `
+    .local/qualification/native-renderer-vehicle-material-bindings.json
 ```

--- a/tools/summarize-native-renderer-vehicle-material-bindings.py
+++ b/tools/summarize-native-renderer-vehicle-material-bindings.py
@@ -1,0 +1,281 @@
+#!/usr/bin/env python3
+"""Join title-owned vehicle material bindings to geometry contributions."""
+
+import argparse
+import json
+from pathlib import Path
+
+
+SCHEMA = "pinyon-shift.native-renderer-vehicle-material-bindings.v1"
+CONTRIBUTION_SCHEMA = "pinyon-shift.native-renderer-vehicle-contributions.v1"
+SUMMARY_EVENT = "native_renderer.discovery.vehicle_material_binding_summary"
+DETAIL_EVENT = "native_renderer.discovery.vehicle_material_binding"
+
+
+def require(condition, message):
+    if not condition:
+        raise ValueError(message)
+
+
+def integer(record, key):
+    try:
+        return int(record[key])
+    except (KeyError, TypeError, ValueError) as error:
+        raise ValueError(f"missing or invalid integer field: {key}") from error
+
+
+def hexadecimal(value, width, label):
+    value = str(value).upper()
+    require(
+        len(value) == width
+        and all(character in "0123456789ABCDEF" for character in value),
+        f"missing or invalid hexadecimal field: {label}",
+    )
+    return value
+
+
+def load_json(path):
+    with path.open("r", encoding="utf-8") as source:
+        return json.load(source)
+
+
+def load_events(path):
+    events = []
+    with path.open("r", encoding="utf-8") as source:
+        for line_number, line in enumerate(source, 1):
+            if not line.strip():
+                continue
+            try:
+                events.append(json.loads(line))
+            except json.JSONDecodeError as error:
+                raise ValueError(
+                    f"invalid JSONL at line {line_number}: {error}"
+                ) from error
+    return events
+
+
+def parse_signatures(record):
+    values = [
+        value
+        for value in str(record.get("backend_signatures", "")).split(",")
+        if value
+    ]
+    signatures = {
+        hexadecimal(value, 16, "backend_signatures") for value in values
+    }
+    require(
+        integer(record, "backend_signature_count") == len(signatures),
+        "backend signature detail accounting drift",
+    )
+    return signatures
+
+
+def summarize(log_path, contribution_path):
+    events = load_events(log_path)
+    summaries = [event for event in events if event.get("event") == SUMMARY_EVENT]
+    details = [event for event in events if event.get("event") == DETAIL_EVENT]
+    require(len(summaries) == 1, "expected one material-binding summary")
+    summary = summaries[0]
+    require(
+        summary.get("status") == "complete",
+        "material-binding census incomplete",
+    )
+    require(
+        summary.get("accounting_complete") == "true",
+        "binding accounting drift",
+    )
+    require(summary.get("hook") == "82549670", "material-binding hook drifted")
+    require(
+        summary.get("title_semantic") == "tire_wheel_shader_settings",
+        "title material semantic drifted",
+    )
+    require(
+        integer(summary, "observations") > 0,
+        "material binding was not observed",
+    )
+    require(integer(summary, "valid_observations") > 0, "no valid binding observed")
+    require(integer(summary, "invalid_relation") == 0, "binding relation drifted")
+    require(integer(summary, "asset_read_faults") == 0, "asset-key read faulted")
+    require(integer(summary, "overflow") == 0, "binding table overflowed")
+    require(
+        integer(summary, "bindings") == len(details),
+        "binding detail accounting drift",
+    )
+    require(summary.get("xenos_authority") == "true", "Xenos authority changed")
+    require(summary.get("suppression_allowed") == "false", "suppression was allowed")
+    require(summary.get("native_draw") == "false", "native drawing was enabled")
+    require(
+        summary.get("guest_payload_exported") == "false",
+        "guest payload was exported",
+    )
+
+    contributions = load_json(contribution_path)
+    require(
+        contributions.get("schema") == CONTRIBUTION_SCHEMA,
+        "unsupported contribution schema",
+    )
+    require(
+        contributions.get("status") == "qualified",
+        "contribution partition incomplete",
+    )
+    require(
+        contributions.get("qualification", {}).get(
+            "exact_resource_contribution_partition_proved"
+        )
+        is True,
+        "exact contribution partition was not proved",
+    )
+    require(
+        contributions.get("safety", {}).get("source_xenos_authority") is True,
+        "contribution source changed Xenos authority",
+    )
+
+    signature_to_contribution = {}
+    for contribution in contributions.get("contributions", []):
+        geometry_resource_hash = hexadecimal(
+            contribution.get("geometry_resource_hash"),
+            16,
+            "geometry_resource_hash",
+        )
+        signatures = {
+            hexadecimal(value, 16, "prepared_signatures")
+            for value in contribution.get("prepared_signatures", [])
+        }
+        require(len(signatures) == 2, "contribution variant count drifted")
+        for signature in signatures:
+            require(
+                signature not in signature_to_contribution,
+                "prepared signature maps to multiple contributions",
+            )
+            signature_to_contribution[signature] = geometry_resource_hash
+
+    all_binding_signatures = set()
+    binding_rows = []
+    detail_observations = 0
+    for detail in details:
+        require(
+            detail.get("classification")
+            == "exact_tire_wheel_material_binding_seed",
+            "binding classification drifted",
+        )
+        require(detail.get("xenos_authority") == "true", "Xenos authority changed")
+        require(
+            detail.get("suppression_allowed") == "false",
+            "suppression was allowed",
+        )
+        require(detail.get("native_draw") == "false", "native drawing was enabled")
+        require(
+            detail.get("guest_payload_exported") == "false",
+            "guest payload was exported",
+        )
+        require(integer(detail, "asset_key_length") > 0, "asset key was empty")
+        require(
+            integer(detail, "backend_signature_overflow") == 0,
+            "binding signature table overflowed",
+        )
+        detail_observations += integer(detail, "observations")
+        signatures = parse_signatures(detail)
+        all_binding_signatures.update(signatures)
+        matches = sorted(
+            {
+                signature_to_contribution[signature]
+                for signature in signatures
+                if signature in signature_to_contribution
+            }
+        )
+        binding_rows.append(
+            {
+                "asset_key_hash": hexadecimal(
+                    detail.get("asset_key_hash"), 16, "asset_key_hash"
+                ),
+                "asset_key_length": integer(detail, "asset_key_length"),
+                "load_ui": detail.get("load_ui") == "true",
+                "slod": detail.get("slod") == "true",
+                "observations": integer(detail, "observations"),
+                "root_draw_probe_matches": integer(
+                    detail, "root_draw_probe_matches"
+                ),
+                "binding_draw_probe_matches": integer(
+                    detail, "binding_draw_probe_matches"
+                ),
+                "backend_signatures": sorted(signatures),
+                "matched_geometry_resources": matches,
+            }
+        )
+
+    require(
+        detail_observations == integer(summary, "valid_observations"),
+        "binding observation detail accounting drift",
+    )
+
+    matched_resources = sorted(
+        {
+            signature_to_contribution[signature]
+            for signature in all_binding_signatures
+            if signature in signature_to_contribution
+        }
+    )
+    unmatched_signatures = sorted(
+        signature
+        for signature in all_binding_signatures
+        if signature not in signature_to_contribution
+    )
+    unique_join = len(matched_resources) == 1 and not unmatched_signatures
+    failures = []
+    if not all_binding_signatures:
+        failures.append("no_direct_binding_to_draw_join")
+    elif not unique_join:
+        failures.append("binding_to_geometry_join_not_unique")
+
+    return {
+        "schema": SCHEMA,
+        "status": "qualified" if unique_join else "bounded_negative_result",
+        "source_log": str(log_path),
+        "source_contributions": str(contribution_path),
+        "summary": {
+            "binding_count": len(binding_rows),
+            "backend_signature_count": len(all_binding_signatures),
+            "matched_geometry_resource_count": len(matched_resources),
+            "unmatched_backend_signature_count": len(unmatched_signatures),
+        },
+        "bindings": binding_rows,
+        "matched_geometry_resources": matched_resources,
+        "unmatched_backend_signatures": unmatched_signatures,
+        "qualification": {
+            "title_owned_tire_wheel_discriminator_proved": True,
+            "unique_geometry_resource_join_proved": unique_join,
+            "tire_wheel_visual_role_proved": False,
+            "native_admission_allowed": False,
+            "suppression_allowed": False,
+        },
+        "safety": {
+            "xenos_authority": True,
+            "guest_payload_exported": False,
+            "native_draw": False,
+            "suppression_allowed": False,
+        },
+        "failures": failures,
+    }
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("log", type=Path)
+    parser.add_argument("--contributions", required=True, type=Path)
+    parser.add_argument("--output", required=True, type=Path)
+    args = parser.parse_args(argv)
+    try:
+        document = summarize(args.log, args.contributions)
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(
+            json.dumps(document, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        return 0
+    except (OSError, ValueError) as error:
+        print(f"vehicle material-binding summary failed: {error}")
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/tests/test_native_renderer_vehicle_material_bindings.py
+++ b/tools/tests/test_native_renderer_vehicle_material_bindings.py
@@ -1,0 +1,146 @@
+import importlib.util
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+TOOL = ROOT / "tools" / "summarize-native-renderer-vehicle-material-bindings.py"
+SPEC = importlib.util.spec_from_file_location("vehicle_material_bindings", TOOL)
+assert SPEC and SPEC.loader
+MODULE = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = MODULE
+SPEC.loader.exec_module(MODULE)
+
+
+def summary():
+    return {
+        "event": MODULE.SUMMARY_EVENT,
+        "status": "complete",
+        "hook": "82549670",
+        "observations": "2",
+        "valid_observations": "2",
+        "invalid_relation": "0",
+        "asset_read_faults": "0",
+        "bindings": "1",
+        "capacity": "128",
+        "overflow": "0",
+        "accounting_complete": "true",
+        "title_semantic": "tire_wheel_shader_settings",
+        "guest_payload_exported": "false",
+        "native_draw": "false",
+        "xenos_authority": "true",
+        "suppression_allowed": "false",
+    }
+
+
+def detail(signatures="1111111111111111,2222222222222222"):
+    count = len([value for value in signatures.split(",") if value])
+    return {
+        "event": MODULE.DETAIL_EVENT,
+        "asset_key_hash": "AAAAAAAAAAAAAAAA",
+        "asset_key_length": "12",
+        "load_ui": "true",
+        "slod": "false",
+        "observations": "2",
+        "root_draw_probe_matches": str(count),
+        "binding_draw_probe_matches": "0",
+        "backend_signatures": signatures,
+        "backend_signature_count": str(count),
+        "backend_signature_capacity": "16",
+        "backend_signature_overflow": "0",
+        "classification": "exact_tire_wheel_material_binding_seed",
+        "guest_payload_exported": "false",
+        "native_draw": "false",
+        "xenos_authority": "true",
+        "suppression_allowed": "false",
+    }
+
+
+def contributions():
+    return {
+        "schema": MODULE.CONTRIBUTION_SCHEMA,
+        "status": "qualified",
+        "contributions": [
+            {
+                "geometry_resource_hash": "AAAAAAAAAAAAAAAA",
+                "prepared_signatures": [
+                    "1111111111111111",
+                    "2222222222222222",
+                ],
+            },
+            {
+                "geometry_resource_hash": "BBBBBBBBBBBBBBBB",
+                "prepared_signatures": [
+                    "3333333333333333",
+                    "4444444444444444",
+                ],
+            },
+        ],
+        "qualification": {
+            "exact_resource_contribution_partition_proved": True,
+        },
+        "safety": {
+            "source_xenos_authority": True,
+        },
+    }
+
+
+def summarize(events, contribution_document=None):
+    with tempfile.TemporaryDirectory() as directory:
+        root = Path(directory)
+        log_path = root / "events.jsonl"
+        contribution_path = root / "contributions.json"
+        log_path.write_text(
+            "".join(json.dumps(event) + "\n" for event in events),
+            encoding="utf-8",
+        )
+        contribution_path.write_text(
+            json.dumps(contribution_document or contributions()),
+            encoding="utf-8",
+        )
+        return MODULE.summarize(log_path, contribution_path)
+
+
+class VehicleMaterialBindingTests(unittest.TestCase):
+    def test_qualifies_unique_two_variant_join(self):
+        report = summarize([summary(), detail()])
+        self.assertEqual("qualified", report["status"])
+        self.assertEqual(
+            ["AAAAAAAAAAAAAAAA"], report["matched_geometry_resources"]
+        )
+        self.assertTrue(
+            report["qualification"]["unique_geometry_resource_join_proved"]
+        )
+        self.assertFalse(
+            report["qualification"]["tire_wheel_visual_role_proved"]
+        )
+
+    def test_reports_no_direct_draw_join(self):
+        report = summarize([summary(), detail("")])
+        self.assertEqual("bounded_negative_result", report["status"])
+        self.assertEqual(
+            ["no_direct_binding_to_draw_join"], report["failures"]
+        )
+
+    def test_rejects_ambiguous_contribution_join(self):
+        report = summarize(
+            [summary(), detail("1111111111111111,3333333333333333")]
+        )
+        self.assertEqual("bounded_negative_result", report["status"])
+        self.assertEqual(2, len(report["matched_geometry_resources"]))
+        self.assertEqual(
+            ["binding_to_geometry_join_not_unique"], report["failures"]
+        )
+
+    def test_rejects_changed_authority(self):
+        row = detail()
+        row["xenos_authority"] = "false"
+        with self.assertRaisesRegex(ValueError, "Xenos authority"):
+            summarize([summary(), row])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- join passive tire/wheel binding signatures to the exact 15-resource vehicle contribution partition
- fail closed on accounting, safety, signature ambiguity, or missing direct draw joins
- preserve visual-role admission as a separate isolated-output gate

## Validation
- python -m unittest tools.tests.test_native_renderer_vehicle_material_bindings (4 passed)

This slice is tooling-only and intentionally does not trigger another full build or AppData run.