### PR TITLE
test(renderer): add phase c qualification profile

### DIFF
--- a/docs/native-renderer/C1_C2_BATCH_QUALIFICATION.md
+++ b/docs/native-renderer/C1_C2_BATCH_QUALIFICATION.md
@@ -16,6 +16,22 @@ failures, and preserve its safety boundary. Track, static-world, and continuous
 output reports must prove a final shutdown summary; periodic checkpoints are
 useful for diagnosis but cannot satisfy this gate.
 
+Launch the combined profile with the installed AppData save:
+
+```powershell
+$stateRoot = Join-Path $env:LOCALAPPDATA `
+  'PinyonShift\source\0.1.0\.local\preview'
+./tools/capture-native-renderer-census.ps1 `
+  -StateRoot $stateRoot -PhaseCQualification -Json
+```
+
+The profile selects `open_world_day` unless a scene is supplied, enables the
+continuous exact track and static-world selectors together, and arms title
+draw provenance for the passive C4 player/material joins. It deliberately
+does not request the isolated per-resource vehicle readback: shadow-depth
+capture and the continuous workset are mutually exclusive, so conflating them
+would invalidate both gates.
+
 Run the four component qualifiers first, then join them:
 
 ```powershell

--- a/docs/native-renderer/REPRIORITIZED_PLAN.md
+++ b/docs/native-renderer/REPRIORITIZED_PLAN.md
@@ -283,6 +283,14 @@ clean final session. It proves neither manual visual acceptance nor race and
 streaming coverage. The contract and command are documented in
 [`C1_C2_BATCH_QUALIFICATION.md`](C1_C2_BATCH_QUALIFICATION.md).
 
+Phase C capture profile checkpoint: `-PhaseCQualification` now arms the exact
+C1 track-world selector, exact C2 static-world selector, continuous
+swap-committed workset, and passive C4 player/material provenance in one
+AppData-backed process. The incompatible isolated vehicle-resource readback
+stays in a later dedicated run. This gives the next manual session one clear
+purpose and prevents accidental combinations that would invalidate the
+continuous and shadow-depth gates.
+
 Next runtime checkpoint: the old typed-render-item evidence is now correctly
 classified by RTTI as the unified track render-model instance/model pair. A
 balanced passive scope at its accepted nested dispatch (`8240EC80`-`8240ECAC`)

--- a/tools/capture-native-renderer-census.ps1
+++ b/tools/capture-native-renderer-census.ps1
@@ -35,6 +35,7 @@ param(
     [switch]$ContinuousWorldWorkset,
     [switch]$ContinuousTrackWorld,
     [switch]$ContinuousStaticWorld,
+    [switch]$PhaseCQualification,
     [switch]$VehicleDrawCorrelation,
     [switch]$ShadowCasterProvenance,
     [ValidateSet(
@@ -58,6 +59,20 @@ param(
 
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
+
+# One long-lived profile for the pending C1/C2 runtime gates and passive C4
+# semantic/material joins. The isolated per-resource vehicle readback remains
+# a separate run because shadow-depth capture and the continuous workset are
+# intentionally mutually exclusive.
+if ($PhaseCQualification) {
+    if ($Scene -eq 'unmarked') {
+        $Scene = 'open_world_day'
+    }
+    $ContinuousWorldWorkset = $true
+    $ContinuousTrackWorld = $true
+    $ContinuousStaticWorld = $true
+    $VehicleDrawCorrelation = $true
+}
 
 if (-not $StateRoot) {
     $sourceRoot = Join-Path $env:LOCALAPPDATA 'PinyonShift\source'

--- a/tools/tests/test_native_renderer_phase_c_profile.py
+++ b/tools/tests/test_native_renderer_phase_c_profile.py
@@ -1,0 +1,36 @@
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+class NativeRendererPhaseCProfileTests(unittest.TestCase):
+    def test_profile_arms_compatible_phase_c_gates(self):
+        capture = (ROOT / "tools/capture-native-renderer-census.ps1").read_text(
+            encoding="utf-8"
+        )
+        self.assertIn("[switch]$PhaseCQualification", capture)
+        block = capture.split("if ($PhaseCQualification) {", 1)[1].split(
+            "if (-not $StateRoot)", 1
+        )[0]
+        self.assertIn("$Scene = 'open_world_day'", block)
+        self.assertIn("$ContinuousWorldWorkset = $true", block)
+        self.assertIn("$ContinuousTrackWorld = $true", block)
+        self.assertIn("$ContinuousStaticWorld = $true", block)
+        self.assertIn("$VehicleDrawCorrelation = $true", block)
+        self.assertNotIn("$ShadowDepthBatch = $true", block)
+        self.assertNotIn("$VehicleResourceContribution", block)
+
+    def test_documented_profile_uses_appdata_state_root(self):
+        document = (
+            ROOT / "docs/native-renderer/C1_C2_BATCH_QUALIFICATION.md"
+        ).read_text(encoding="utf-8")
+        self.assertIn("-PhaseCQualification -Json", document)
+        self.assertIn(".local\\preview", document)
+        self.assertIn("passive C4 player/material joins", document)
+        self.assertIn("mutually exclusive", document)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add one explicit AppData capture profile for compatible C1 track, C2 static-world, and passive C4 provenance gates
- select open-world day by default and arm exact continuous selectors plus vehicle draw correlation
- keep isolated vehicle resource capture separate because its shadow-depth mode is incompatible with the continuous workset

## Validation
- 16 focused Python tests passed
- PowerShell parser accepted capture-native-renderer-census.ps1

No build or gameplay run is required for this tooling-only slice.