### PR TITLE
fix(renderer): accept refcounted static world owners

### DIFF
--- a/docs/native-renderer/REPRIORITIZED_PLAN.md
+++ b/docs/native-renderer/REPRIORITIZED_PLAN.md
@@ -323,6 +323,15 @@ does not prove clean shutdown or permit native admission; the unique final
 summary remains authoritative. This removes an observability dead end without
 weakening the pending C1 gate.
 
+Failed-batch correction: the first combined Phase C session exposed that the
+static presentation runtime gate accepted only the base `CModelPresentation`
+primary vtable even though the existing complete RTTI census also proves the
+thread-safe ref-counted complete object's primary vtable at the same object
+offset and with the same inherited slot-12 draw target. The exact owner gate now
+accepts both `822432D4` and `82002464`; all resource, renderer, transform,
+metadata, prepared-layout, and lifecycle joins remain independently required.
+This fixes a type-family omission without weakening C2 admission.
+
 ### C2. Static world buildings and props
 
 - Expand opaque-world material and geometry coverage.

--- a/docs/native-renderer/STATIC_WORLD_OWNER.md
+++ b/docs/native-renderer/STATIC_WORLD_OWNER.md
@@ -16,7 +16,9 @@ semantics.
 
 Retail RTTI, vtables, and generated AOT instructions prove:
 
-- `Presentation_Unified::CModelPresentation` uses primary vtable `822432D4`;
+- `Presentation_Unified::CModelPresentation` uses primary vtable `822432D4`,
+  while its proved thread-safe ref-counted complete object uses primary vtable
+  `82002464`; both inherit slot 12 target `823F8DB8` at object offset zero;
 - its slot 12 is method `823F8DB8`, with one balanced exit at `823F8FA0`;
 - the owner stores its exact `CSimpleModelResource` reference at offset 148,
   state at offset 144, and renderer at offset 1608;

--- a/src/native_renderer/graphics_hooks.cpp
+++ b/src/native_renderer/graphics_hooks.cpp
@@ -221,6 +221,7 @@ constexpr uint32_t kSimpleModelResourceEffectRecordsOffset = 124;
 constexpr uint32_t kSimpleModelResourceEffectCountOffset = 128;
 constexpr uint32_t kSimpleModelResourceTextureVectorOffset = 288;
 constexpr uint32_t kModelPresentationVtable = 0x822432D4;
+constexpr uint32_t kRefCountedModelPresentationVtable = 0x82002464;
 constexpr uint32_t kModelPresentationNameOffset = 16;
 constexpr uint32_t kModelPresentationTransformOffset = 80;
 constexpr uint32_t kModelPresentationTransformWordCount = 16;
@@ -4354,7 +4355,8 @@ void BeginStaticWorldPresentationDispatch(uint32_t presentation_address) {
     ++g_static_world_presentation_invalid_root;
     return;
   }
-  if (vtable != kModelPresentationVtable) {
+  if (vtable != kModelPresentationVtable &&
+      vtable != kRefCountedModelPresentationVtable) {
     ++g_static_world_presentation_vtable_mismatches;
     return;
   }
@@ -27193,6 +27195,7 @@ void InstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system,
        {"simple_member_draw_hooks", "82C4DC54,82C4DC58"},
        {"presentation_class", "Presentation_Unified::CModelPresentation"},
        {"presentation_vtable", "822432D4"},
+       {"presentation_refcounted_vtable", "82002464"},
        {"presentation_draw_slot", "12"},
        {"presentation_draw_hooks", "823F8DB8,823F8FA0"},
        {"presentation_resource_field", "presentation_plus_148"},

--- a/tools/discover-native-renderer-static-world-owner.py
+++ b/tools/discover-native-renderer-static-world-owner.py
@@ -13,6 +13,7 @@ import sys
 SCHEMA = "pinyon-shift.native-renderer-static-world-owner.v2"
 IMAGE_BASE = 0x82000000
 PRESENTATION_VTABLE = 0x822432D4
+REFCOUNTED_PRESENTATION_VTABLE = 0x82002464
 PRESENTATION_SLOT_COUNT = 18
 FUNCTION_RE = re.compile(r"^DEFINE_REX_FUNC\(sub_([0-9A-F]{8})\) \{")
 LABEL_RE = re.compile(r"^loc_([0-9A-F]{8}):")
@@ -96,6 +97,12 @@ def build(functions: dict[int, dict[int, str]], image: bytes) -> dict:
         raise ValueError("CModelPresentation draw slot drifted")
     if slots[7] != PRESENTATION_INITIALIZE:
         raise ValueError("CModelPresentation initialize slot drifted")
+    refcounted_slots = [
+        image_u32(image, REFCOUNTED_PRESENTATION_VTABLE + index * 4)
+        for index in range(PRESENTATION_SLOT_COUNT)
+    ]
+    if refcounted_slots[PRESENTATION_DRAW_SLOT] != PRESENTATION_DRAW:
+        raise ValueError("ref-counted CModelPresentation draw slot drifted")
     renderer_slots = [
         image_u32(image, RENDERER_VTABLE + index * 4) for index in range(17)
     ]
@@ -236,6 +243,9 @@ def build(functions: dict[int, dict[int, str]], image: bytes) -> dict:
         "presentation": {
             "class": "Presentation_Unified::CModelPresentation",
             "vtable": f"{PRESENTATION_VTABLE:08X}",
+            "refcounted_primary_vtable": (
+                f"{REFCOUNTED_PRESENTATION_VTABLE:08X}"
+            ),
             "constructor": f"{PRESENTATION_CONSTRUCTOR:08X}",
             "destructor": f"{PRESENTATION_DESTRUCTOR:08X}",
             "deleting_destructor_slot": 0,

--- a/tools/summarize-native-renderer-static-world-runtime-join.py
+++ b/tools/summarize-native-renderer-static-world-runtime-join.py
@@ -391,6 +391,7 @@ def validate_static_owner(document):
     expected_presentation = {
         "class": "Presentation_Unified::CModelPresentation",
         "vtable": "822432D4",
+        "refcounted_primary_vtable": "82002464",
         "constructor": "82DE9840",
         "destructor": "82DEA218",
         "deleting_destructor_slot": 0,
@@ -709,6 +710,7 @@ def build(
         "simple_member_draw_hooks": "82C4DC54,82C4DC58",
         "presentation_class": "Presentation_Unified::CModelPresentation",
         "presentation_vtable": "822432D4",
+        "presentation_refcounted_vtable": "82002464",
         "presentation_draw_slot": "12",
         "presentation_draw_hooks": "823F8DB8,823F8FA0",
         "presentation_resource_field": "presentation_plus_148",

--- a/tools/tests/test_native_renderer_static_world_owner.py
+++ b/tools/tests/test_native_renderer_static_world_owner.py
@@ -17,6 +17,8 @@ SPEC.loader.exec_module(MODULE)
 def fixture():
     highest = max(
         MODULE.PRESENTATION_VTABLE + MODULE.PRESENTATION_SLOT_COUNT * 4,
+        MODULE.REFCOUNTED_PRESENTATION_VTABLE
+        + MODULE.PRESENTATION_SLOT_COUNT * 4,
         MODULE.RENDERER_VTABLE + 17 * 4,
     )
     image = bytearray(highest - MODULE.IMAGE_BASE)
@@ -24,12 +26,17 @@ def fixture():
     presentation_slots[0] = MODULE.PRESENTATION_DELETING_DESTRUCTOR
     presentation_slots[7] = MODULE.PRESENTATION_INITIALIZE
     presentation_slots[12] = MODULE.PRESENTATION_DRAW
+    refcounted_presentation_slots = list(presentation_slots)
     renderer_slots = [0x82900000 + index * 4 for index in range(17)]
     renderer_slots[0] = 0x82C4C838
     renderer_slots[6] = MODULE.RENDERER_TRANSFORM
     renderer_slots[12] = 0x82C4CCC8
     for base, slots in (
         (MODULE.PRESENTATION_VTABLE, presentation_slots),
+        (
+            MODULE.REFCOUNTED_PRESENTATION_VTABLE,
+            refcounted_presentation_slots,
+        ),
         (MODULE.RENDERER_VTABLE, renderer_slots),
     ):
         for index, target in enumerate(slots):
@@ -164,6 +171,18 @@ class StaticWorldOwnerTests(unittest.TestCase):
         offset = MODULE.PRESENTATION_VTABLE + 12 * 4 - MODULE.IMAGE_BASE
         corrupted[offset : offset + 4] = (0x823F8DBC).to_bytes(4, "big")
         with self.assertRaisesRegex(ValueError, "draw slot drifted"):
+            MODULE.build(functions, bytes(corrupted))
+
+    def test_rejects_refcounted_presentation_draw_slot_drift(self):
+        functions, image = fixture()
+        corrupted = bytearray(image)
+        offset = (
+            MODULE.REFCOUNTED_PRESENTATION_VTABLE
+            + 12 * 4
+            - MODULE.IMAGE_BASE
+        )
+        corrupted[offset : offset + 4] = (0x823F8DBC).to_bytes(4, "big")
+        with self.assertRaisesRegex(ValueError, "ref-counted.*draw slot drifted"):
             MODULE.build(functions, bytes(corrupted))
 
     def test_rejects_renderer_field_drift(self):

--- a/tools/tests/test_native_renderer_static_world_runtime_join.py
+++ b/tools/tests/test_native_renderer_static_world_runtime_join.py
@@ -245,6 +245,7 @@ def static_owner():
         "presentation": {
             "class": "Presentation_Unified::CModelPresentation",
             "vtable": "822432D4",
+            "refcounted_primary_vtable": "82002464",
             "constructor": "82DE9840",
             "destructor": "82DEA218",
             "deleting_destructor_slot": 0,
@@ -476,6 +477,7 @@ def fixture():
             "simple_member_draw_hooks": "82C4DC54,82C4DC58",
             "presentation_class": "Presentation_Unified::CModelPresentation",
             "presentation_vtable": "822432D4",
+            "presentation_refcounted_vtable": "82002464",
             "presentation_draw_slot": "12",
             "presentation_draw_hooks": "823F8DB8,823F8FA0",
             "presentation_resource_field": "presentation_plus_148",
@@ -1221,6 +1223,7 @@ class StaticWorldRuntimeJoinTests(unittest.TestCase):
         self.assertIn("address = 0x823F8DB8", analysis)
         self.assertIn("address = 0x823F8FA0", analysis)
         self.assertIn("kModelPresentationNameOffset = 16", hooks)
+        self.assertIn("kRefCountedModelPresentationVtable = 0x82002464", hooks)
         self.assertIn("kModelPresentationTransformOffset = 80", hooks)
         self.assertIn("ReadStaticWorldPresentationTransform", hooks)
         self.assertIn("static_world_transform_words", hooks)


### PR DESCRIPTION
## Summary
- accept both RTTI-proved primary CModelPresentation vtables at the exact static-world owner boundary
- keep renderer, resource, transform, metadata, mesh, lifecycle, and prepared-draw gates unchanged
- extend the static owner proof, runtime qualifier contract, tests, and reprioritized roadmap with the failed-batch correction

## Evidence
The combined Phase C run recorded 338,944 presentation entries, including 290,688 vtable mismatches. The existing complete RTTI census proves the missing primary surface at 0x82002464 and proves that its slot 12 resolves to the same 0x823F8DB8 draw method at object offset zero.

## Tests
- python -m unittest discover -s tools/tests -p 'test_*.py' (636 passed)
- incremental win-amd64-release build