### PR TITLE
fix(renderer): bridge exact track procedural receivers

### DIFF
--- a/config/rexglue/analysis/main-xex.toml
+++ b/config/rexglue/analysis/main-xex.toml
@@ -225,6 +225,16 @@ registers = ["r31"]
 address = 0x8240ECAC
 name = "PinyonShiftObserveTrackRenderModelDispatchExit"
 
+# The accepted track-render dispatch passes its exact CProceduralModels
+# receiver in r25 immediately before the render-state call. Persist that
+# address against the receiver's independently proved lifetime generation so
+# later semantic submissions retain exact track ownership even if their PM4
+# preparation crosses the balanced title scope.
+[[midasm_hook]]
+address = 0x82437040
+name = "PinyonShiftObserveTrackRenderModelProceduralReceiver"
+registers = ["r25"]
+
 # Phase C2 exact model-presentation owner scope. Retail RTTI proves slot 12 of
 # Presentation_Unified::CModelPresentation is 0x823F8DB8 and every path joins
 # at 0x823F8FA0. The nested SimpleModel renderer dispatch is accepted only when

--- a/docs/native-renderer/C1_C2_BATCH_QUALIFICATION.md
+++ b/docs/native-renderer/C1_C2_BATCH_QUALIFICATION.md
@@ -5,7 +5,8 @@ Status: implementation complete; first clean AppData batch pending
 The combined gate turns one exact runtime session into a single promotion
 decision. It joins four independently strict, payload-free reports:
 
-- unified track render-model and shared world-resource identity;
+- unified track render-model, generation-safe procedural-receiver handoff, and
+  shared world-resource identity;
 - complete SimpleModel presentation/resource/mesh lineage;
 - runtime transform classification against the title-authored spatial catalog;
   and

--- a/docs/native-renderer/REPRIORITIZED_PLAN.md
+++ b/docs/native-renderer/REPRIORITIZED_PLAN.md
@@ -332,6 +332,18 @@ accepts both `822432D4` and `82002464`; all resource, renderer, transform,
 metadata, prepared-layout, and lifecycle joins remain independently required.
 This fixes a type-family omission without weakening C2 admission.
 
+C1 receiver-handoff correction: that same clean session observed 110,023
+track-render scopes and 94,826 exact unified instance/model scopes, but zero
+procedural submissions inside them. The synchronous-scope join is therefore a
+disproved assumption, not a reason to gather more broad census data. Generated
+title code gives a stronger bounded edge: `82437040` moves the retained
+`CProceduralModels` receiver from `r25` to `r3` immediately before the semantic
+producer call at `82437044`. The passive runtime bridge now attaches the exact
+track owner tuple to the receiver's independently proved live generation and
+requires a later semantic submission from that same generation. Reuse clears
+the bridge; Xenos authority, native admission, and suppression remain unchanged
+until the next batched qualification proves the new edge.
+
 ### C2. Static world buildings and props
 
 - Expand opaque-world material and geometry coverage.

--- a/docs/native-renderer/TERRAIN_ROAD_RENDER_PATH.md
+++ b/docs/native-renderer/TERRAIN_ROAD_RENDER_PATH.md
@@ -258,17 +258,29 @@ flow shows that `8240EC80` is reached only after the instance, its child, and
 the child-owned 248-byte type-21 descriptor pass the title predicates. The
 nested render dispatch returns at `8240ECAC`.
 
-A balanced passive runtime scope now brackets those two addresses. It joins
-only procedural-model semantic submissions made synchronously inside the exact
-dynamic-type scope, carries the result to prepared candidates, and separately
-tests exact equality between the title descriptor/root/child identity and the
-procedural receiver, runtime object, bound resource, and provider identities.
-The payload-free qualifier distinguishes exact nested ownership from the
-stronger shared-object/resource proof rather than conflating them.
+A balanced passive runtime scope brackets those two addresses. The first
+combined Phase C session observed 110,023 scopes, including 94,826 exact
+dynamic-type scopes, but zero procedural submissions inside the scope. That
+clean negative result disproves the original synchronous-submission assumption;
+it is not an ownership failure in the title and cannot qualify C1.
 
-This instrumentation awaits the next batched AppData-backed run. Until then it
-does not prove the runtime join, terrain/road visual identity, or C1 admission.
-It changes no guest state, draw, output authority, or suppression decision.
+Static generated-code evidence supplies the missing handoff. Inside the exact
+track dispatch, `82437040` copies the retained `CProceduralModels` receiver from
+`r25` to `r3`, and `82437044` immediately calls the already-proved semantic
+producer `82417060`. A passive hook at the copy records the exact track root,
+child, descriptor, payload, and bounded world-resource mask against that
+receiver's independently generation-tracked live lifetime. Later submissions
+from the same live generation recover the owner without requiring PM4 work to
+remain on the title's balanced call stack. Re-publication clears the bridge, so
+an address reused by another receiver lifetime cannot inherit track identity.
+
+The payload-free qualifier now requires complete receiver-bridge accounting,
+at least one exact handoff, and at least one semantic submission from a bridged
+receiver. It still reports descriptor/root/child and world-resource equality
+separately rather than conflating them with the direct receiver proof. This
+instrumentation awaits the next batched AppData-backed run. Until then it does
+not prove terrain/road visual identity or C1 admission, and it changes no guest
+state, draw, output authority, or suppression decision.
 
 ## Bounded track world-resource graph identity
 

--- a/src/native_renderer/graphics_hooks.cpp
+++ b/src/native_renderer/graphics_hooks.cpp
@@ -1968,6 +1968,12 @@ struct SemanticReceiverLifecycleEntry {
   std::atomic<uint64_t> dispatches_without_preparation{};
   std::atomic<uint64_t> dispatches_without_visibility{};
   std::atomic<uint64_t> dispatches_without_render_state{};
+  std::atomic<uint32_t> track_render_bridge_generation{};
+  std::atomic<uint32_t> track_render_root_address{};
+  std::atomic<uint32_t> track_render_child_address{};
+  std::atomic<uint32_t> track_render_descriptor_address{};
+  std::atomic<uint32_t> track_render_descriptor_payload{};
+  std::atomic<uint32_t> track_world_resource_identity_mask{};
 };
 
 std::array<SemanticReceiverLifecycleEntry,
@@ -2371,6 +2377,7 @@ enum TrackRenderSharedIdentity : uint32_t {
   kTrackRenderSharedChildReceiver = 1u << 5,
   kTrackRenderSharedRootRuntimeObject = 1u << 6,
   kTrackRenderSharedChildRuntimeObject = 1u << 7,
+  kTrackRenderSharedProceduralReceiverBridge = 1u << 8,
 };
 
 enum TrackWorldResourceIdentity : uint32_t {
@@ -2401,6 +2408,7 @@ struct TrackWorldResourceGraphCacheEntry {
 
 struct TrackRenderModelDispatchScope {
   uint64_t submission_joins = 0;
+  uint64_t receiver_bridges = 0;
   uint32_t root_address = 0;
   uint32_t child_address = 0;
   uint32_t descriptor_address = 0;
@@ -2584,8 +2592,14 @@ std::atomic<uint64_t> g_track_render_model_scope_contract_mismatches{};
 std::atomic<uint64_t> g_track_render_model_scope_joined{};
 std::atomic<uint64_t> g_track_render_model_scope_unjoined{};
 std::atomic<uint64_t> g_track_render_model_submission_joins{};
+std::atomic<uint64_t> g_track_render_model_receiver_bridge_observations{};
+std::atomic<uint64_t> g_track_render_model_receiver_bridge_successes{};
+std::atomic<uint64_t> g_track_render_model_receiver_bridge_missing_scope{};
+std::atomic<uint64_t> g_track_render_model_receiver_bridge_unknown_receiver{};
+std::atomic<uint64_t>
+    g_track_render_model_receiver_bridge_submission_joins{};
 std::atomic<uint64_t> g_track_render_model_shared_identity_joins{};
-std::array<std::atomic<uint64_t>, 8>
+std::array<std::atomic<uint64_t>, 9>
     g_track_render_model_shared_identity_relations{};
 std::atomic<uint64_t> g_track_world_resource_graph_cache_hits{};
 std::atomic<uint64_t> g_track_world_resource_graph_cache_misses{};
@@ -3419,7 +3433,8 @@ void EndTrackRenderModelDispatch() {
     return;
   }
   if (g_track_render_model_scope.exact) {
-    if (g_track_render_model_scope.submission_joins) {
+    if (g_track_render_model_scope.submission_joins ||
+        g_track_render_model_scope.receiver_bridges) {
       ++g_track_render_model_scope_joined;
     } else {
       ++g_track_render_model_scope_unjoined;
@@ -6841,11 +6856,57 @@ void PublishSemanticReceiver(uint32_t address) {
                                               std::memory_order_relaxed);
   entry->dispatches_without_render_state.store(0,
                                                 std::memory_order_relaxed);
+  entry->track_render_bridge_generation.store(0,
+                                               std::memory_order_relaxed);
+  entry->track_render_root_address.store(0, std::memory_order_relaxed);
+  entry->track_render_child_address.store(0, std::memory_order_relaxed);
+  entry->track_render_descriptor_address.store(0,
+                                                std::memory_order_relaxed);
+  entry->track_render_descriptor_payload.store(0,
+                                                std::memory_order_relaxed);
+  entry->track_world_resource_identity_mask.store(
+      0, std::memory_order_relaxed);
   entry->generation.store(generation, std::memory_order_relaxed);
   entry->state.store(uint32_t(SemanticReceiverState::kLive),
                      std::memory_order_release);
   g_semantic_receiver_instances_published.fetch_add(
       1, std::memory_order_relaxed);
+}
+
+void ObserveTrackRenderModelProceduralReceiver(uint32_t receiver_address) {
+  ++g_track_render_model_receiver_bridge_observations;
+  TrackRenderModelDispatchScope &scope = g_track_render_model_scope;
+  if (!scope.active || !scope.exact) {
+    ++g_track_render_model_receiver_bridge_missing_scope;
+    return;
+  }
+  SemanticReceiverLifecycleEntry *entry =
+      FindSemanticReceiverLifecycle(receiver_address);
+  if (!entry || entry->state.load(std::memory_order_acquire) !=
+                    uint32_t(SemanticReceiverState::kLive)) {
+    ++g_track_render_model_receiver_bridge_unknown_receiver;
+    return;
+  }
+  const uint32_t generation =
+      entry->generation.load(std::memory_order_relaxed);
+  if (!generation) {
+    ++g_track_render_model_receiver_bridge_unknown_receiver;
+    return;
+  }
+  entry->track_render_root_address.store(scope.root_address,
+                                         std::memory_order_relaxed);
+  entry->track_render_child_address.store(scope.child_address,
+                                          std::memory_order_relaxed);
+  entry->track_render_descriptor_address.store(
+      scope.descriptor_address, std::memory_order_relaxed);
+  entry->track_render_descriptor_payload.store(
+      scope.descriptor_payload, std::memory_order_relaxed);
+  entry->track_world_resource_identity_mask.store(
+      scope.world_resource_identity_mask, std::memory_order_relaxed);
+  entry->track_render_bridge_generation.store(generation,
+                                               std::memory_order_release);
+  ++scope.receiver_bridges;
+  ++g_track_render_model_receiver_bridge_successes;
 }
 
 void BeginSemanticReceiverConstruction(uint32_t address) {
@@ -11630,64 +11691,103 @@ void RecordProceduralModelGeometrySubmission(
   key = key ? key : 1;
   const bool track_texture_provider =
       IsUnifiedTrackTextureProvider(pending.primary_provider);
-  const bool track_render_model_scope =
+  const bool live_track_render_model_scope =
       g_track_render_model_scope.active && g_track_render_model_scope.exact;
+  const bool track_render_receiver_bridge =
+      lifecycle->track_render_bridge_generation.load(
+          std::memory_order_acquire) == receiver_generation;
+  const bool track_render_model_scope =
+      live_track_render_model_scope || track_render_receiver_bridge;
   uint32_t track_render_shared_identity_mask = 0;
   uint32_t track_world_resource_identity_mask = 0;
   uint32_t track_world_resource_shared_identity_mask = 0;
   if (track_render_model_scope) {
     const TrackRenderModelDispatchScope &scope = g_track_render_model_scope;
+    const uint32_t track_root_address =
+        live_track_render_model_scope
+            ? scope.root_address
+            : lifecycle->track_render_root_address.load(
+                  std::memory_order_relaxed);
+    const uint32_t track_child_address =
+        live_track_render_model_scope
+            ? scope.child_address
+            : lifecycle->track_render_child_address.load(
+                  std::memory_order_relaxed);
+    const uint32_t track_descriptor_address =
+        live_track_render_model_scope
+            ? scope.descriptor_address
+            : lifecycle->track_render_descriptor_address.load(
+                  std::memory_order_relaxed);
+    const uint32_t track_descriptor_payload =
+        live_track_render_model_scope
+            ? scope.descriptor_payload
+            : lifecycle->track_render_descriptor_payload.load(
+                  std::memory_order_relaxed);
     track_render_shared_identity_mask |=
-        scope.descriptor_address == descriptor_address
+        track_descriptor_address == descriptor_address
             ? kTrackRenderSharedDescriptor
             : 0;
     track_render_shared_identity_mask |=
-        scope.descriptor_payload == pending.primary_bound_resource_object
+        track_descriptor_payload == pending.primary_bound_resource_object
             ? kTrackRenderSharedDescriptorPayloadBoundResource
             : 0;
     track_render_shared_identity_mask |=
-        scope.descriptor_payload == pending.primary_provider.provider_object
+        track_descriptor_payload == pending.primary_provider.provider_object
             ? kTrackRenderSharedDescriptorPayloadProvider
             : 0;
     track_render_shared_identity_mask |=
-        scope.descriptor_payload == runtime_submission_object
+        track_descriptor_payload == runtime_submission_object
             ? kTrackRenderSharedDescriptorPayloadRuntimeObject
             : 0;
     track_render_shared_identity_mask |=
-        scope.root_address == receiver_address ? kTrackRenderSharedRootReceiver
+        track_root_address == receiver_address ? kTrackRenderSharedRootReceiver
                                                : 0;
     track_render_shared_identity_mask |=
-        scope.child_address == receiver_address
+        track_child_address == receiver_address
             ? kTrackRenderSharedChildReceiver
             : 0;
     track_render_shared_identity_mask |=
-        scope.root_address == runtime_submission_object
+        track_root_address == runtime_submission_object
             ? kTrackRenderSharedRootRuntimeObject
             : 0;
     track_render_shared_identity_mask |=
-        scope.child_address == runtime_submission_object
+        track_child_address == runtime_submission_object
             ? kTrackRenderSharedChildRuntimeObject
             : 0;
+    if (track_render_receiver_bridge) {
+      track_render_shared_identity_mask |=
+          kTrackRenderSharedProceduralReceiverBridge;
+      ++g_track_render_model_receiver_bridge_submission_joins;
+    }
     track_world_resource_identity_mask =
-        scope.world_resource_identity_mask;
-    for (size_t index = 0; index < scope.world_resource_reference_count;
-         ++index) {
-      const TrackWorldResourceReference &reference =
-          scope.world_resource_references[index];
-      if (reference.address == receiver_address ||
-          reference.address == runtime_submission_object ||
-          reference.address == pending.primary_bound_resource_object ||
-          reference.address == pending.primary_provider.provider_object ||
-          (secondary_resource_present &&
-           (reference.address == pending.secondary_bound_resource_object ||
-            reference.address ==
-                pending.secondary_provider.provider_object))) {
-        track_world_resource_shared_identity_mask |= reference.identity;
+        live_track_render_model_scope
+            ? scope.world_resource_identity_mask
+            : lifecycle->track_world_resource_identity_mask.load(
+                  std::memory_order_relaxed);
+    if (live_track_render_model_scope) {
+      for (size_t index = 0; index < scope.world_resource_reference_count;
+           ++index) {
+        const TrackWorldResourceReference &reference =
+            scope.world_resource_references[index];
+        if (reference.address == receiver_address ||
+            reference.address == runtime_submission_object ||
+            reference.address == pending.primary_bound_resource_object ||
+            reference.address == pending.primary_provider.provider_object ||
+            (secondary_resource_present &&
+             (reference.address == pending.secondary_bound_resource_object ||
+              reference.address ==
+                  pending.secondary_provider.provider_object))) {
+          track_world_resource_shared_identity_mask |= reference.identity;
+        }
       }
     }
-    ++g_track_render_model_scope.submission_joins;
-    g_track_render_model_scope.shared_identity_mask |=
-        track_render_shared_identity_mask;
+    if (live_track_render_model_scope) {
+      ++g_track_render_model_scope.submission_joins;
+      g_track_render_model_scope.shared_identity_mask |=
+          track_render_shared_identity_mask;
+      g_track_render_model_scope.world_resource_shared_identity_mask |=
+          track_world_resource_shared_identity_mask;
+    }
     ++g_track_render_model_submission_joins;
     if (track_render_shared_identity_mask) {
       ++g_track_render_model_shared_identity_joins;
@@ -11699,8 +11799,6 @@ void RecordProceduralModelGeometrySubmission(
         }
       }
     }
-    g_track_render_model_scope.world_resource_shared_identity_mask |=
-        track_world_resource_shared_identity_mask;
     if (track_world_resource_shared_identity_mask) {
       ++g_track_world_resource_shared_identity_joins;
       for (size_t bit = 0;
@@ -12067,14 +12165,34 @@ void EmitTrackRenderModelRuntimeJoinEvent(const char *event_name,
   const uint64_t exit_without_entry =
       g_track_render_model_scope_exit_without_entry.load(
           std::memory_order_relaxed);
+  const uint64_t receiver_bridge_observations =
+      g_track_render_model_receiver_bridge_observations.load(
+          std::memory_order_relaxed);
+  const uint64_t receiver_bridge_successes =
+      g_track_render_model_receiver_bridge_successes.load(
+          std::memory_order_relaxed);
+  const uint64_t receiver_bridge_missing_scope =
+      g_track_render_model_receiver_bridge_missing_scope.load(
+          std::memory_order_relaxed);
+  const uint64_t receiver_bridge_unknown_receiver =
+      g_track_render_model_receiver_bridge_unknown_receiver.load(
+          std::memory_order_relaxed);
+  const uint64_t receiver_bridge_submission_joins =
+      g_track_render_model_receiver_bridge_submission_joins.load(
+          std::memory_order_relaxed);
   const bool accounting_complete =
       entries == exact + invalid_root + invalid_child + invalid_descriptor +
                      contract_mismatches &&
       exact == joined + unjoined && entries == exits && !overlaps &&
-      !exit_without_entry;
+      !exit_without_entry &&
+      receiver_bridge_observations ==
+          receiver_bridge_successes + receiver_bridge_missing_scope +
+              receiver_bridge_unknown_receiver;
   const bool qualification_complete =
       accounting_complete && exact && joined &&
       g_track_render_model_submission_joins.load(std::memory_order_relaxed) &&
+      receiver_bridge_successes && receiver_bridge_submission_joins &&
+      !receiver_bridge_missing_scope && !receiver_bridge_unknown_receiver &&
       !invalid_root && !invalid_child && !invalid_descriptor &&
       !contract_mismatches;
   pinyon_shift::diagnostics::RecordEvent(
@@ -12101,6 +12219,16 @@ void EmitTrackRenderModelRuntimeJoinEvent(const char *event_name,
        {"submission_joins",
         std::to_string(g_track_render_model_submission_joins.load(
             std::memory_order_relaxed))},
+       {"receiver_bridge_observations",
+        std::to_string(receiver_bridge_observations)},
+       {"receiver_bridge_successes",
+        std::to_string(receiver_bridge_successes)},
+       {"receiver_bridge_missing_scope",
+        std::to_string(receiver_bridge_missing_scope)},
+       {"receiver_bridge_unknown_receiver",
+        std::to_string(receiver_bridge_unknown_receiver)},
+       {"receiver_bridge_submission_joins",
+        std::to_string(receiver_bridge_submission_joins)},
        {"shared_identity_joins",
         std::to_string(g_track_render_model_shared_identity_joins.load(
             std::memory_order_relaxed))},
@@ -12127,6 +12255,9 @@ void EmitTrackRenderModelRuntimeJoinEvent(const char *event_name,
             std::memory_order_relaxed))},
        {"shared_child_runtime_object",
         std::to_string(g_track_render_model_shared_identity_relations[7].load(
+            std::memory_order_relaxed))},
+       {"shared_procedural_receiver_bridge",
+        std::to_string(g_track_render_model_shared_identity_relations[8].load(
             std::memory_order_relaxed))},
        {"world_resource_graph_scopes",
         std::to_string(g_track_world_resource_graph_scopes.load(
@@ -12202,7 +12333,7 @@ void EmitTrackRenderModelRuntimeJoinEvent(const char *event_name,
        {"qualification_complete",
         qualification_complete ? "true" : "false"},
        {"classification",
-        "exact_unified_track_render_model_nested_submission_join"},
+        "exact_unified_track_render_model_procedural_receiver_join"},
        {"guest_state_changed", "false"},
        {"control_flow_changed", "false"},
        {"native_admission", "false"},
@@ -27127,13 +27258,15 @@ void InstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system,
        {"entry_hook", "8240EC80"},
        {"exit_hook", "8240ECAC"},
        {"nested_dispatch", "82436468"},
+       {"procedural_receiver_bridge_hook", "82437040"},
        {"instance_vtable", "820019CC"},
        {"model_vtable", "82001D74"},
        {"instance_to_model", "root_plus_4"},
        {"model_to_descriptor", "child_plus_48_then_plus_128"},
        {"descriptor_type", "21"},
        {"descriptor_flag", "1"},
-       {"join", "synchronous_scope_to_procedural_model_submission"},
+       {"join",
+        "exact_track_dispatch_receiver_bridge_to_procedural_model_submission"},
        {"shared_identity",
         "descriptor_payload_or_object_address_exact_equality"},
        {"world_resource_vtables",
@@ -29453,6 +29586,11 @@ void PinyonShiftObserveTrackRenderModelDispatchEntry(PPCRegister &r31) {
 
 void PinyonShiftObserveTrackRenderModelDispatchExit() {
   EndTrackRenderModelDispatch();
+}
+
+void PinyonShiftObserveTrackRenderModelProceduralReceiver(
+    PPCRegister &r25) {
+  ObserveTrackRenderModelProceduralReceiver(r25.u32);
 }
 
 void PinyonShiftObserveStaticWorldRendererDispatchEntry(PPCRegister &r3,

--- a/tools/summarize-native-renderer-c1-c2-batch.py
+++ b/tools/summarize-native-renderer-c1-c2-batch.py
@@ -9,7 +9,7 @@ import sys
 
 SCHEMA = "pinyon-shift.native-renderer-c1-c2-batch.v1"
 INPUT_SCHEMAS = {
-    "track": "pinyon-shift.native-renderer-track-model-runtime-join.v2",
+    "track": "pinyon-shift.native-renderer-track-model-runtime-join.v3",
     "static_world": "pinyon-shift.native-renderer-static-world-runtime-join.v10",
     "classification": (
         "pinyon-shift.native-renderer-static-world-instance-classification.v1"
@@ -110,6 +110,7 @@ def build(reports):
 
     required_track = (
         "track_render_model_scope_to_submission_proved",
+        "procedural_receiver_bridge_proved",
         "track_world_resource_graph_identity_proved",
         "track_world_resource_to_submission_identity_proved",
     )

--- a/tools/summarize-native-renderer-track-model-runtime-join.py
+++ b/tools/summarize-native-renderer-track-model-runtime-join.py
@@ -7,7 +7,7 @@ import pathlib
 import sys
 
 
-SCHEMA = "pinyon-shift.native-renderer-track-model-runtime-join.v2"
+SCHEMA = "pinyon-shift.native-renderer-track-model-runtime-join.v3"
 CONFIG = "native_renderer.discovery.track_render_model_runtime_join_config"
 SUMMARY = "native_renderer.discovery.track_render_model_runtime_join_summary"
 CHECKPOINT = (
@@ -23,6 +23,7 @@ RELATIONS = (
     "shared_child_receiver",
     "shared_root_runtime_object",
     "shared_child_runtime_object",
+    "shared_procedural_receiver_bridge",
 )
 
 WORLD_RELATIONS = (
@@ -127,13 +128,17 @@ def build(events, requested_session=None, allow_checkpoint=False):
         "entry_hook": "8240EC80",
         "exit_hook": "8240ECAC",
         "nested_dispatch": "82436468",
+        "procedural_receiver_bridge_hook": "82437040",
         "instance_vtable": "820019CC",
         "model_vtable": "82001D74",
         "instance_to_model": "root_plus_4",
         "model_to_descriptor": "child_plus_48_then_plus_128",
         "descriptor_type": "21",
         "descriptor_flag": "1",
-        "join": "synchronous_scope_to_procedural_model_submission",
+        "join": (
+            "exact_track_dispatch_receiver_bridge_to_"
+            "procedural_model_submission"
+        ),
         "shared_identity": "descriptor_payload_or_object_address_exact_equality",
         "world_resource_vtables": (
             "820016B4,8200143C,82001474,82144CF8,82144D7C,82144DE0,"
@@ -175,7 +180,7 @@ def build(events, requested_session=None, allow_checkpoint=False):
             and summary.get("checkpoint_kind") != "periodic"
         )
         or summary.get("classification")
-        != "exact_unified_track_render_model_nested_submission_join"
+        != "exact_unified_track_render_model_procedural_receiver_join"
     ):
         raise ValueError("track-model runtime summary drifted")
     frame_sequence = (
@@ -197,6 +202,11 @@ def build(events, requested_session=None, allow_checkpoint=False):
         "joined_scopes",
         "unjoined_scopes",
         "submission_joins",
+        "receiver_bridge_observations",
+        "receiver_bridge_successes",
+        "receiver_bridge_missing_scope",
+        "receiver_bridge_unknown_receiver",
+        "receiver_bridge_submission_joins",
         "shared_identity_joins",
         "scope_overlaps",
         "exit_without_entry",
@@ -233,6 +243,25 @@ def build(events, requested_session=None, allow_checkpoint=False):
         failures.append("no exact unified track render-model scope was observed")
     if not totals["joined_scopes"] or not totals["submission_joins"]:
         failures.append("no exact scope joined a procedural-model submission")
+    if totals["receiver_bridge_observations"] != (
+        totals["receiver_bridge_successes"]
+        + totals["receiver_bridge_missing_scope"]
+        + totals["receiver_bridge_unknown_receiver"]
+    ):
+        failures.append("procedural-receiver bridge accounting drifted")
+    if not totals["receiver_bridge_successes"]:
+        failures.append("no exact procedural-receiver bridge was established")
+    if not totals["receiver_bridge_submission_joins"]:
+        failures.append("no bridged receiver joined a procedural submission")
+    if (
+        totals["receiver_bridge_submission_joins"]
+        > totals["submission_joins"]
+    ):
+        failures.append("receiver bridge joins exceed submission joins")
+    if totals["shared_procedural_receiver_bridge"] != totals[
+        "receiver_bridge_submission_joins"
+    ]:
+        failures.append("receiver bridge relation accounting drifted")
     for key in (
         "invalid_root",
         "invalid_child",
@@ -240,6 +269,8 @@ def build(events, requested_session=None, allow_checkpoint=False):
         "contract_mismatches",
         "scope_overlaps",
         "exit_without_entry",
+        "receiver_bridge_missing_scope",
+        "receiver_bridge_unknown_receiver",
     ):
         if totals[key]:
             failures.append(f"{key} is nonzero")
@@ -317,6 +348,7 @@ def build(events, requested_session=None, allow_checkpoint=False):
         },
         "qualification": {
             "track_render_model_scope_to_submission_proved": not failures,
+            "procedural_receiver_bridge_proved": not failures,
             "shared_object_or_resource_identity_proved": (
                 not failures and totals["shared_identity_joins"] > 0
             ),

--- a/tools/tests/test_native_renderer_c1_c2_batch.py
+++ b/tools/tests/test_native_renderer_c1_c2_batch.py
@@ -30,6 +30,7 @@ def fixture():
             "evidence": {"session_exit_proved": True},
             "qualification": {
                 "track_render_model_scope_to_submission_proved": True,
+                "procedural_receiver_bridge_proved": True,
                 "track_world_resource_graph_identity_proved": True,
                 "track_world_resource_to_submission_identity_proved": True,
             },

--- a/tools/tests/test_native_renderer_track_model_runtime_join.py
+++ b/tools/tests/test_native_renderer_track_model_runtime_join.py
@@ -33,13 +33,17 @@ def fixture(shared=3):
         entry_hook="8240EC80",
         exit_hook="8240ECAC",
         nested_dispatch="82436468",
+        procedural_receiver_bridge_hook="82437040",
         instance_vtable="820019CC",
         model_vtable="82001D74",
         instance_to_model="root_plus_4",
         model_to_descriptor="child_plus_48_then_plus_128",
         descriptor_type="21",
         descriptor_flag="1",
-        join="synchronous_scope_to_procedural_model_submission",
+        join=(
+            "exact_track_dispatch_receiver_bridge_to_"
+            "procedural_model_submission"
+        ),
         shared_identity="descriptor_payload_or_object_address_exact_equality",
         world_resource_vtables=(
             "820016B4,8200143C,82001474,82144CF8,82144D7C,82144DE0,"
@@ -63,6 +67,7 @@ def fixture(shared=3):
     shared_world_relations = {
         key: "0" for key in MODULE.SHARED_WORLD_RELATIONS
     }
+    relations["shared_procedural_receiver_bridge"] = "3"
     if shared:
         relations["shared_descriptor_payload_bound_resource"] = str(shared)
         world_relations["world_track_mesh"] = "6"
@@ -82,7 +87,12 @@ def fixture(shared=3):
         joined_scopes="8",
         unjoined_scopes="2",
         submission_joins="12",
-        shared_identity_joins=str(shared),
+        receiver_bridge_observations="3",
+        receiver_bridge_successes="3",
+        receiver_bridge_missing_scope="0",
+        receiver_bridge_unknown_receiver="0",
+        receiver_bridge_submission_joins="3",
+        shared_identity_joins="3",
         world_resource_graph_scopes="6" if shared else "0",
         world_resource_graph_cache_hits="8",
         world_resource_graph_cache_misses="2",
@@ -93,7 +103,9 @@ def fixture(shared=3):
         exit_without_entry="0",
         accounting_complete="true",
         qualification_complete="true",
-        classification="exact_unified_track_render_model_nested_submission_join",
+        classification=(
+            "exact_unified_track_render_model_procedural_receiver_join"
+        ),
         **relations,
         **world_relations,
         **shared_world_relations,
@@ -112,6 +124,9 @@ class TrackModelRuntimeJoinTests(unittest.TestCase):
             ]
         )
         self.assertTrue(
+            document["qualification"]["procedural_receiver_bridge_proved"]
+        )
+        self.assertTrue(
             document["qualification"][
                 "shared_object_or_resource_identity_proved"
             ]
@@ -122,10 +137,10 @@ class TrackModelRuntimeJoinTests(unittest.TestCase):
             ]
         )
 
-    def test_qualifies_scope_without_claiming_shared_identity(self):
+    def test_qualifies_scope_without_claiming_world_identity(self):
         document = MODULE.build(fixture(shared=0))
         self.assertEqual("complete", document["status"])
-        self.assertFalse(
+        self.assertTrue(
             document["qualification"][
                 "shared_object_or_resource_identity_proved"
             ]
@@ -197,6 +212,7 @@ class TrackModelRuntimeJoinTests(unittest.TestCase):
             joined_scopes="0",
             unjoined_scopes="10",
             submission_joins="0",
+            receiver_bridge_submission_joins="0",
             shared_identity_joins="0",
             shared_descriptor_payload_bound_resource="0",
             world_resource_graph_scopes="0",
@@ -224,6 +240,35 @@ class TrackModelRuntimeJoinTests(unittest.TestCase):
         self.assertEqual("incomplete", document["status"])
         self.assertIn("scope_overlaps is nonzero", document["failures"])
 
+    def test_rejects_receiver_bridge_fault(self):
+        events = copy.deepcopy(fixture())
+        events[-1].update(
+            status="incomplete",
+            qualification_complete="false",
+            receiver_bridge_successes="2",
+            receiver_bridge_unknown_receiver="1",
+        )
+        document = MODULE.build(events)
+        self.assertEqual("incomplete", document["status"])
+        self.assertIn(
+            "receiver_bridge_unknown_receiver is nonzero",
+            document["failures"],
+        )
+
+    def test_rejects_receiver_bridge_relation_drift(self):
+        events = copy.deepcopy(fixture())
+        events[-1].update(
+            status="incomplete",
+            qualification_complete="false",
+            shared_procedural_receiver_bridge="2",
+        )
+        document = MODULE.build(events)
+        self.assertEqual("incomplete", document["status"])
+        self.assertIn(
+            "receiver bridge relation accounting drifted",
+            document["failures"],
+        )
+
     def test_source_contract_has_exact_balanced_hooks(self):
         hooks = (ROOT / "src/native_renderer/graphics_hooks.cpp").read_text(
             encoding="utf-8"
@@ -243,6 +288,13 @@ class TrackModelRuntimeJoinTests(unittest.TestCase):
         )
         self.assertIn("address = 0x8240EC80", analysis)
         self.assertIn("address = 0x8240ECAC", analysis)
+        self.assertIn("address = 0x82437040", analysis)
+        self.assertIn(
+            "PinyonShiftObserveTrackRenderModelProceduralReceiver", hooks
+        )
+        self.assertIn(
+            "PinyonShiftObserveTrackRenderModelProceduralReceiver", analysis
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- replace the disproved synchronous C1 scope join with the exact title-authored CProceduralModels receiver handoff
- persist track owner identity on the receiver's independently generation-tracked lifecycle
- require complete receiver-bridge accounting in both the C1 qualifier and the combined C1/C2 gate

## Safety
- Xenos remains authoritative
- native admission and suppression remain disabled by this evidence slice
- no save or AppData mutation

## Validation
- 638 Python tests pass
- repository release preview build passes, including hook-aware code generation