### PR TITLE
fix(renderer): observe prepared track command lineage

### DIFF
--- a/docs/native-renderer/C1_C2_BATCH_QUALIFICATION.md
+++ b/docs/native-renderer/C1_C2_BATCH_QUALIFICATION.md
@@ -1,6 +1,6 @@
 # Combined C1/C2 qualification gate
 
-Status: implementation complete; first clean AppData batch pending
+Status: implementation complete; first clean AppData batch incomplete
 
 The combined gate turns one exact runtime session into a single promotion
 decision. It joins four independently strict, payload-free reports:
@@ -51,3 +51,10 @@ family promotion, or suppression. Those remain the next gates.
 
 This report never reads or modifies the AppData save and cannot enable runtime
 behavior. It only joins existing payload-free evidence.
+
+The first clean combined run reached exact C1 scope, context, and indirect
+packet identity but exposed an observer-ordering gap at the prepared boundary.
+It also reached exact C2 presentation/transform scopes without reaching the
+assumed base-renderer handoff. Both results are diagnostic and cannot satisfy
+this gate; their focused corrections remain default-off and preserve Xenos as
+the sole output authority.

--- a/docs/native-renderer/REPRIORITIZED_PLAN.md
+++ b/docs/native-renderer/REPRIORITIZED_PLAN.md
@@ -304,6 +304,16 @@ does not persist identity on a shared receiver, and treats non-track calls as
 normal exclusions. The next batched run must prove context, packet, and
 prepared-draw joins before C1 can advance. No suppression is enabled.
 
+Clean command-lineage checkpoint: the AppData-backed Phase C run observed
+80,790 exact scopes, context bridges, and command-packet joins with zero scope
+or packet accounting faults. Prepared-draw joins remained zero because their
+observer returned before consulting active command lineage whenever the title
+draw lacked an independent procedural semantic record. The observer now counts
+exact active command lineage before that semantic-only early return and
+partitions joins with and without semantic origin. This is evidence-only: a
+command without a fresh semantic candidate is still not admitted to the
+continuous workset, and Xenos authority and suppression remain unchanged.
+
 Implementation checkpoint: the exact model scope now inspects only its
 already-validated 64-byte child prefix and 248-byte type-21 descriptor for
 direct pointers to the seven RTTI-proved track model, mesh, submodel,
@@ -345,6 +355,15 @@ virtual handoff at `823F8F1C`, including owner/resource equality, renderer
 vtable, dispatch target, and the offset-148 resource vtable. This will separate
 a deferred-renderer route from incorrect field assumptions before C2 lineage
 is widened.
+
+Latest Phase C checkpoint: a longer clean festival session produced 238,592
+exact balanced presentation scopes and transforms, but again no renderer
+handoff. Every offset-148 resource-vtable and bounded asset-metadata read
+failed, while the slot-12 handoff hook remained untouched. This proves the
+accepted wrapper path does not execute the assumed base method body in this
+scene. The next C2 slice must resolve the wrapper's actual dispatch target or
+lazy resource initialization point before widening lineage; it must not treat
+the stale offset-148 assumption as runtime identity.
 
 ### C2. Static world buildings and props
 

--- a/docs/native-renderer/TERRAIN_ROAD_RENDER_PATH.md
+++ b/docs/native-renderer/TERRAIN_ROAD_RENDER_PATH.md
@@ -278,6 +278,25 @@ run. Until then it does not prove terrain/road visual identity or C1 family
 promotion. It changes no guest state, Xenos draw, output authority, or
 suppression decision.
 
+### First clean command-lineage result
+
+The combined Phase C run closed the first two runtime hops exactly: 80,790
+balanced unified track scopes produced 80,790 accepted `824365B0` context
+bridges and 80,790 matched indirect packets, with no invalid roots, descriptor
+faults, overlaps, or unmatched accepted scopes. The prepared counter was still
+zero even though 2,600,588 prepared indirect draws completed in the same
+process.
+
+That zero exposed observer ordering rather than missing command provenance.
+Prepared semantic processing returned immediately when a title draw had no
+procedural semantic record, before it queried the already-matched active
+indirect command buffer. Exact command-lineage accounting now runs before that
+semantic-only early return and separately counts prepared joins with and
+without a procedural semantic origin. The latter remain evidence only: they
+are not synthesized into visibility candidates and cannot enter the private
+continuous workset. A later batched run must prove the final hop before any C1
+admission work proceeds.
+
 ## Bounded track world-resource graph identity
 
 The balanced render-model scope now extends the passive join without adding a

--- a/src/native_renderer/graphics_hooks.cpp
+++ b/src/native_renderer/graphics_hooks.cpp
@@ -2605,6 +2605,10 @@ std::atomic<uint64_t> g_track_render_model_context_observations{};
 std::atomic<uint64_t> g_track_render_model_context_bridges{};
 std::atomic<uint64_t> g_track_render_model_packet_joins{};
 std::atomic<uint64_t> g_track_render_model_prepared_draw_joins{};
+std::atomic<uint64_t>
+    g_track_render_model_prepared_draw_joins_with_semantic_origin{};
+std::atomic<uint64_t>
+    g_track_render_model_prepared_draw_joins_without_semantic_origin{};
 std::atomic<uint64_t> g_track_render_model_shared_identity_joins{};
 std::array<std::atomic<uint64_t>, 9>
     g_track_render_model_shared_identity_relations{};
@@ -12282,6 +12286,14 @@ void EmitTrackRenderModelRuntimeJoinEvent(const char *event_name,
        {"command_prepared_draw_joins",
         std::to_string(g_track_render_model_prepared_draw_joins.load(
             std::memory_order_relaxed))},
+       {"command_prepared_draw_joins_with_semantic_origin",
+        std::to_string(
+            g_track_render_model_prepared_draw_joins_with_semantic_origin.load(
+                std::memory_order_relaxed))},
+       {"command_prepared_draw_joins_without_semantic_origin",
+        std::to_string(
+            g_track_render_model_prepared_draw_joins_without_semantic_origin
+                .load(std::memory_order_relaxed))},
        {"shared_identity_joins",
         std::to_string(g_track_render_model_shared_identity_joins.load(
             std::memory_order_relaxed))},
@@ -19587,6 +19599,21 @@ SemanticVisibilityPreparedAdmission RecordSemanticBatchOpportunity(
       origin.static_world_draw.asset_metadata_valid &&
       origin.static_world_draw.transform_valid &&
       origin.static_world_draw.mesh_semantics_valid;
+  const ActiveTitleIndirectBuffer *active =
+      CurrentTitleIndirectBuffer(observation);
+  const bool exact_track_command =
+      active && active->constructor_origin.owner.producer.context
+                    .track_command_lineage;
+  if (exact_track_command) {
+    g_track_render_model_prepared_draw_joins.fetch_add(
+        1, std::memory_order_relaxed);
+    (origin.semantic_draw.valid
+         ? g_track_render_model_prepared_draw_joins_with_semantic_origin
+         : g_track_render_model_prepared_draw_joins_without_semantic_origin)
+        .fetch_add(1, std::memory_order_relaxed);
+    g_track_render_model_shared_identity_relations[8].fetch_add(
+        1, std::memory_order_relaxed);
+  }
   if (!origin.semantic_draw.valid) {
     return {
         .static_world_origin = static_world_origin,
@@ -19594,10 +19621,7 @@ SemanticVisibilityPreparedAdmission RecordSemanticBatchOpportunity(
     };
   }
   SemanticDrawIdentity identity = origin.semantic_draw;
-  const ActiveTitleIndirectBuffer *active =
-      CurrentTitleIndirectBuffer(observation);
-  if (active && active->constructor_origin.owner.producer.context
-                    .track_command_lineage) {
+  if (exact_track_command) {
     const auto &track_context =
         active->constructor_origin.owner.producer.context;
     identity.track_render_model_scope = true;
@@ -19606,10 +19630,6 @@ SemanticVisibilityPreparedAdmission RecordSemanticBatchOpportunity(
         kTrackRenderSharedCommandLineage;
     identity.track_world_resource_identity_mask |=
         track_context.track_world_resource_identity_mask;
-    g_track_render_model_prepared_draw_joins.fetch_add(
-        1, std::memory_order_relaxed);
-    g_track_render_model_shared_identity_relations[8].fetch_add(
-        1, std::memory_order_relaxed);
   }
   const SemanticPreparedDrawContract contract =
       BuildSemanticPreparedDrawContract(observation, prepared);

--- a/tools/summarize-native-renderer-track-model-runtime-join.py
+++ b/tools/summarize-native-renderer-track-model-runtime-join.py
@@ -217,7 +217,20 @@ def build(events, requested_session=None, allow_checkpoint=False):
         *SHARED_WORLD_RELATIONS,
     )
     totals = {key: integer(summary, key) for key in keys}
+    prepared_partition_keys = (
+        "command_prepared_draw_joins_with_semantic_origin",
+        "command_prepared_draw_joins_without_semantic_origin",
+    )
+    prepared_partition_present = all(
+        key in summary for key in prepared_partition_keys
+    )
+    for key in prepared_partition_keys:
+        totals[key] = integer(summary, key) if key in summary else 0
     failures = []
+    if any(key in summary for key in prepared_partition_keys) and not (
+        prepared_partition_present
+    ):
+        failures.append("prepared command semantic-origin partition is incomplete")
     classified = (
         totals["exact_scopes"]
         + totals["invalid_root"]
@@ -245,6 +258,11 @@ def build(events, requested_session=None, allow_checkpoint=False):
         failures.append("no exact track command packet was observed")
     if not totals["command_prepared_draw_joins"]:
         failures.append("no exact track command reached a prepared draw")
+    if prepared_partition_present and totals["command_prepared_draw_joins"] != (
+        totals["command_prepared_draw_joins_with_semantic_origin"]
+        + totals["command_prepared_draw_joins_without_semantic_origin"]
+    ):
+        failures.append("prepared command semantic-origin accounting drifted")
     if totals["shared_command_lineage"] != totals["command_prepared_draw_joins"]:
         failures.append("prepared command-lineage relation accounting drifted")
     for key in (

--- a/tools/tests/test_native_renderer_track_model_runtime_join.py
+++ b/tools/tests/test_native_renderer_track_model_runtime_join.py
@@ -88,6 +88,8 @@ def fixture(shared=3):
         command_context_bridges="8",
         command_packet_joins="16",
         command_prepared_draw_joins="24",
+        command_prepared_draw_joins_with_semantic_origin="9",
+        command_prepared_draw_joins_without_semantic_origin="15",
         shared_identity_joins=str(shared),
         world_resource_graph_scopes="6" if shared else "0",
         world_resource_graph_cache_hits="8",
@@ -157,6 +159,8 @@ class TrackModelRuntimeJoinTests(unittest.TestCase):
         events[-1].update(
             status="incomplete",
             command_prepared_draw_joins="0",
+            command_prepared_draw_joins_with_semantic_origin="0",
+            command_prepared_draw_joins_without_semantic_origin="0",
             shared_command_lineage="0",
             qualification_complete="false",
         )
@@ -165,6 +169,22 @@ class TrackModelRuntimeJoinTests(unittest.TestCase):
             "no exact track command reached a prepared draw",
             document["failures"],
         )
+
+    def test_rejects_prepared_command_semantic_origin_drift(self):
+        events = copy.deepcopy(fixture())
+        events[-1]["command_prepared_draw_joins_without_semantic_origin"] = "14"
+        document = MODULE.build(events)
+        self.assertIn(
+            "prepared command semantic-origin accounting drifted",
+            document["failures"],
+        )
+
+    def test_accepts_legacy_summary_without_prepared_origin_partition(self):
+        events = copy.deepcopy(fixture())
+        events[-1].pop("command_prepared_draw_joins_with_semantic_origin")
+        events[-1].pop("command_prepared_draw_joins_without_semantic_origin")
+        document = MODULE.build(events)
+        self.assertEqual("complete", document["status"])
 
     def test_latest_checkpoint_is_diagnostic_not_admission_evidence(self):
         events = fixture()


### PR DESCRIPTION
## Summary
- observe exact track command lineage before semantic-only filtering
- partition prepared joins with and without procedural semantic origin
- preserve fail-closed visibility admission, Xenos authority, and historical report compatibility
- record the clean Phase C evidence in the native-renderer backlog

## Validation
- python -m pytest tools/tests -q (640 passed)
- incremental Release pinyon_shift build passed
- previous AppData report remains analyzable and correctly incomplete at the prepared boundary