### PR TITLE
feat(renderer): admit exact track command candidates

### DIFF
--- a/docs/native-renderer/C1_C2_BATCH_QUALIFICATION.md
+++ b/docs/native-renderer/C1_C2_BATCH_QUALIFICATION.md
@@ -58,3 +58,11 @@ It also reached exact C2 presentation/transform scopes without reaching the
 assumed base-renderer handoff. Both results are diagnostic and cannot satisfy
 this gate; their focused corrections remain default-off and preserve Xenos as
 the sole output authority.
+
+The focused follow-up closed C1 command lineage through the prepared boundary:
+23,976 exact packets produced 36,266 prepared joins in clean session
+`20260901T004109Z-p33268`. It simultaneously proved the current C2 presentation
+population is dormant: all 78,312 exact preparations rejected with null
+resource and renderer. The full combined gate remains incomplete until a live
+C2 ingress is identified and both exact selectors produce swap-committed
+requests in one clean session.

--- a/docs/native-renderer/REPRIORITIZED_PLAN.md
+++ b/docs/native-renderer/REPRIORITIZED_PLAN.md
@@ -314,6 +314,16 @@ partitions joins with and without semantic origin. This is evidence-only: a
 command without a fresh semantic candidate is still not admitted to the
 continuous workset, and Xenos authority and suppression remain unchanged.
 
+Qualified command-lineage checkpoint: clean session
+`20260901T004109Z-p33268` proved 23,976 balanced exact scopes and packet joins
+reached 36,266 prepared draws with complete accounting and a normal shutdown.
+All 36,266 lacked an independent procedural semantic origin. The default-off
+C1 selector now treats the currently executing, exactly matched command as a
+fresh command candidate without fabricating a semantic record. Mechanical
+replay gates, the per-frame quota, private target, Xenos draws, fallback, and
+zero suppression remain unchanged; visual output qualification is deferred to
+the next meaningful batch.
+
 Implementation checkpoint: the exact model scope now inspects only its
 already-validated 64-byte child prefix and 248-byte type-21 descriptor for
 direct pointers to the seven RTTI-proved track model, mesh, submodel,
@@ -372,6 +382,15 @@ scope/owner faults, and null versus live offset-148 resources and offset-1608
 renderers, with bounded state/address samples. This directly explains the
 missing handoff on the next batched run and changes no guest state, call
 target, native selection, Xenos authority, or suppression decision.
+
+Preparation-outcome runtime result: the clean combined session observed
+78,464 helper returns. Every one of the 78,312 exact scopes rejected with both
+offset-148 resource and offset-1608 renderer null; the other 152 were safely
+classified as invalid presentation roots, with complete accounting and no
+handoff. This path is a dormant/unprepared population in the tested scene, not
+the live static-world draw ingress. C2 is reprioritized to identify the live
+deferred or alternate SimpleModel renderer population before reusing any owner
+or asset-field assumption from this path.
 
 ### C2. Static world buildings and props
 

--- a/docs/native-renderer/TERRAIN_ROAD_RENDER_PATH.md
+++ b/docs/native-renderer/TERRAIN_ROAD_RENDER_PATH.md
@@ -297,6 +297,16 @@ are not synthesized into visibility candidates and cannot enter the private
 continuous workset. A later batched run must prove the final hop before any C1
 admission work proceeds.
 
+The clean follow-up session proved that final hop: 23,976 exact scope/packet
+joins reached 36,266 prepared draws with zero accounting faults and a normal
+shutdown. All prepared joins were command-only and had no procedural semantic
+record. The default-off exact C1 selector therefore admits the currently
+executing matched command directly after its normal mechanical replay checks;
+it does not invent a receiver, visibility category, LOD, or resource identity.
+The private native target, full Xenos execution, fallback, and zero suppression
+remain unchanged. A later batched run must now prove coherent multi-draw output
+and visual terrain/road identity.
+
 ## Bounded track world-resource graph identity
 
 The balanced render-model scope now extends the passive join without adding a

--- a/src/native_renderer/graphics_hooks.cpp
+++ b/src/native_renderer/graphics_hooks.cpp
@@ -19752,6 +19752,8 @@ SemanticVisibilityPreparedAdmission RecordSemanticBatchOpportunity(
   }
   if (!origin.semantic_draw.valid) {
     return {
+        .track_render_model_scope = exact_track_command,
+        .track_command_lineage = exact_track_command,
         .static_world_origin = static_world_origin,
         .static_world_exact = static_world_exact,
     };
@@ -24115,6 +24117,11 @@ void RequestIsolatedDraw(
     const bool exact_static_world =
         g_continuous_world_workset.static_world_requested &&
         g_isolated_draw.prepared_static_world_exact;
+    const bool exact_track_world =
+        g_continuous_world_workset.track_world_requested &&
+        g_isolated_draw.prepared_track_render_model_scope &&
+        (g_isolated_draw.prepared_track_world_resource_shared_identity_mask ||
+         g_isolated_draw.prepared_track_command_lineage);
     if (g_continuous_world_workset.static_world_requested &&
         g_isolated_draw.prepared_static_world_origin &&
         !g_isolated_draw.prepared_static_world_exact) {
@@ -24122,21 +24129,18 @@ void RequestIsolatedDraw(
       return;
     }
     if (!g_isolated_draw.prepared_visibility_candidate_fresh &&
-        !qualified_retained_family && !exact_static_world) {
+        !qualified_retained_family && !exact_static_world &&
+        !exact_track_world) {
       ++g_continuous_world_workset.stale_or_unselected_rejections;
       return;
     }
     if (!qualified_retained_family &&
         !exact_static_world &&
+        !exact_track_world &&
         !g_isolated_draw.prepared_track_texture_provider) {
       ++g_continuous_world_workset.non_track_provider_rejections;
       return;
     }
-    const bool exact_track_world =
-        g_continuous_world_workset.track_world_requested &&
-        g_isolated_draw.prepared_track_render_model_scope &&
-        (g_isolated_draw.prepared_track_world_resource_shared_identity_mask ||
-         g_isolated_draw.prepared_track_command_lineage);
     if (g_continuous_world_workset.track_world_requested &&
         !qualified_retained_family && !exact_static_world &&
         !exact_track_world) {

--- a/tools/tests/test_native_renderer_continuous_world_workset.py
+++ b/tools/tests/test_native_renderer_continuous_world_workset.py
@@ -112,6 +112,10 @@ class ContinuousWorldWorksetTests(unittest.TestCase):
         self.assertIn("prepared_track_texture_provider", source)
         self.assertIn("prepared_track_render_model_scope", source)
         self.assertIn(
+            ".track_command_lineage = exact_track_command", source
+        )
+        self.assertIn("!exact_track_world &&", source)
+        self.assertIn(
             "prepared_track_world_resource_shared_identity_mask", source
         )
         self.assertIn("prepared_static_world_exact", source)


### PR DESCRIPTION
## Summary
- use the qualified active track command as a dedicated private-workset candidate when no procedural semantic record exists
- bypass only semantic freshness/provider filters for that exact command identity
- retain all mechanical replay gates, quotas, private output, Xenos draws, fallback, and zero suppression
- record the clean C1 qualification and decisive dormant C2 result

## Validation
- 32 focused Python tests passed
- incremental Release pinyon_shift build passed
- clean AppData session 20260901T004109Z-p33268: 23,976 exact packet joins to 36,266 prepared draws with complete accounting