### PR TITLE
fix(renderer): classify exact track replay eligibility

### DIFF
--- a/docs/native-renderer/REPRIORITIZED_PLAN.md
+++ b/docs/native-renderer/REPRIORITIZED_PLAN.md
@@ -400,6 +400,22 @@ the target vtable and dispatch at `82BA61DC` with complete fail-closed
 accounting. This is the next batched C2 lead; it changes no queue, callback,
 draw, output authority, or suppression state.
 
+Combined runtime result: clean AppData session `20260901T005806Z-p31580`
+preserved a visually normal festival frame and exited normally. C1 proved
+17,373 balanced exact scopes and 26,209 prepared command-lineage joins, all
+without an independent procedural semantic origin. The workset still emitted
+zero exact track requests while completing 156 older retained-family frames;
+the existing counter could not distinguish replay-mechanical rejection from a
+selector bug. The workset now partitions exact command candidates into
+mechanically eligible and rejected outcomes and reports all 15 rejection bits.
+This is the next batched C1 gate and does not widen replay support.
+
+The same session observed zero deferred-task publications, callbacks, or
+handoffs. The proved deferred slot-12 route is therefore dormant in this
+festival population, just like the synchronous presentation population. C2
+must move to a live SimpleModel construction/registration or draw-producing
+call edge rather than adding more assumptions to either dormant path.
+
 ### C2. Static world buildings and props
 
 - Expand opaque-world material and geometry coverage.

--- a/src/native_renderer/graphics_hooks.cpp
+++ b/src/native_renderer/graphics_hooks.cpp
@@ -9248,6 +9248,10 @@ struct ContinuousWorldWorksetState {
   uint64_t stale_or_unselected_rejections = 0;
   uint64_t non_track_provider_rejections = 0;
   uint64_t track_world_identity_exclusions = 0;
+  uint64_t track_world_candidates = 0;
+  uint64_t track_world_mechanically_eligible = 0;
+  uint64_t track_world_mechanically_rejected = 0;
+  std::array<uint64_t, 15> track_world_mechanical_rejection_reasons{};
   uint64_t track_world_requests = 0;
   uint64_t static_world_lineage_rejections = 0;
   uint64_t static_world_requests = 0;
@@ -23969,6 +23973,37 @@ void EmitContinuousWorldWorksetEvent(const char *event_name,
        {"track_world_identity_exclusions",
         std::to_string(
             g_continuous_world_workset.track_world_identity_exclusions)},
+       {"track_world_candidates",
+        std::to_string(g_continuous_world_workset.track_world_candidates)},
+       {"track_world_mechanically_eligible",
+        std::to_string(
+            g_continuous_world_workset.track_world_mechanically_eligible)},
+       {"track_world_mechanically_rejected",
+        std::to_string(
+            g_continuous_world_workset.track_world_mechanically_rejected)},
+       {"track_world_mechanical_rejection_reasons",
+        fmt::format(
+            "resolved_input={};unsupported_geometry={};empty_draw={};"
+            "vertex_binding_count={};vertex_binding_overflow={};"
+            "vertex_attribute_overflow={};vertex_constant_overflow={};"
+            "pixel_constant_overflow={};texture_state_overflow={};"
+            "memexport={};query={};texture_count={};texture_layout={};"
+            "prepared_pipeline={};render_targets={}",
+            g_continuous_world_workset.track_world_mechanical_rejection_reasons[0],
+            g_continuous_world_workset.track_world_mechanical_rejection_reasons[1],
+            g_continuous_world_workset.track_world_mechanical_rejection_reasons[2],
+            g_continuous_world_workset.track_world_mechanical_rejection_reasons[3],
+            g_continuous_world_workset.track_world_mechanical_rejection_reasons[4],
+            g_continuous_world_workset.track_world_mechanical_rejection_reasons[5],
+            g_continuous_world_workset.track_world_mechanical_rejection_reasons[6],
+            g_continuous_world_workset.track_world_mechanical_rejection_reasons[7],
+            g_continuous_world_workset.track_world_mechanical_rejection_reasons[8],
+            g_continuous_world_workset.track_world_mechanical_rejection_reasons[9],
+            g_continuous_world_workset.track_world_mechanical_rejection_reasons[10],
+            g_continuous_world_workset.track_world_mechanical_rejection_reasons[11],
+            g_continuous_world_workset.track_world_mechanical_rejection_reasons[12],
+            g_continuous_world_workset.track_world_mechanical_rejection_reasons[13],
+            g_continuous_world_workset.track_world_mechanical_rejection_reasons[14])},
        {"track_world_requests",
         std::to_string(g_continuous_world_workset.track_world_requests)},
        {"static_world_lineage_rejections",
@@ -24350,10 +24385,6 @@ void RequestIsolatedDraw(
       !g_isolated_draw.shadow_depth_batch_active) {
     BeginContinuousWorldWorksetFrame(g_isolated_draw.frame);
     ++g_continuous_world_workset.prepared_observations;
-    if (!g_isolated_draw.prepared_candidate_eligible) {
-      ++g_continuous_world_workset.mechanical_rejections;
-      return;
-    }
     const bool qualified_retained_family =
         g_isolated_draw.prepared_signature == kSkyHorizonFollowerSignature;
     const bool exact_static_world =
@@ -24364,6 +24395,29 @@ void RequestIsolatedDraw(
         g_isolated_draw.prepared_track_render_model_scope &&
         (g_isolated_draw.prepared_track_world_resource_shared_identity_mask ||
          g_isolated_draw.prepared_track_command_lineage);
+    if (exact_track_world) {
+      ++g_continuous_world_workset.track_world_candidates;
+      const uint32_t rejection_mask =
+          g_isolated_draw.prepared_candidate_rejection_mask;
+      if (rejection_mask) {
+        ++g_continuous_world_workset.track_world_mechanically_rejected;
+        for (size_t bit = 0;
+             bit < g_continuous_world_workset
+                       .track_world_mechanical_rejection_reasons.size();
+             ++bit) {
+          if (rejection_mask & (uint32_t(1) << bit)) {
+            ++g_continuous_world_workset
+                  .track_world_mechanical_rejection_reasons[bit];
+          }
+        }
+      } else {
+        ++g_continuous_world_workset.track_world_mechanically_eligible;
+      }
+    }
+    if (!g_isolated_draw.prepared_candidate_eligible) {
+      ++g_continuous_world_workset.mechanical_rejections;
+      return;
+    }
     if (g_continuous_world_workset.static_world_requested &&
         g_isolated_draw.prepared_static_world_origin &&
         !g_isolated_draw.prepared_static_world_exact) {

--- a/tools/summarize-native-renderer-continuous-world-workset.py
+++ b/tools/summarize-native-renderer-continuous-world-workset.py
@@ -7,7 +7,7 @@ import pathlib
 import sys
 
 
-SCHEMA = "pinyon-shift.native-renderer-continuous-world-workset.v6"
+SCHEMA = "pinyon-shift.native-renderer-continuous-world-workset.v7"
 SELECTION = (
     "fresh_track_texture_provider_visibility_or_qualified_"
     "sky_horizon_or_optional_exact_track_or_static_world_and_mechanical"
@@ -174,6 +174,17 @@ def build(events, requested_session=None, allow_checkpoint=False):
         "maximum_draws_per_frame",
     )
     totals = {key: integer(summary, key) for key in keys}
+    track_eligibility_present = "track_world_candidates" in summary
+    if track_eligibility_present:
+        for key in (
+            "track_world_candidates",
+            "track_world_mechanically_eligible",
+            "track_world_mechanically_rejected",
+        ):
+            totals[key] = integer(summary, key)
+        totals["track_world_mechanical_rejection_reasons"] = summary.get(
+            "track_world_mechanical_rejection_reasons", ""
+        )
     output_frames = [
         event for event in selected if event.get("event") == OUTPUT_FRAME
     ]
@@ -227,6 +238,17 @@ def build(events, requested_session=None, allow_checkpoint=False):
         failures.append("no track-provider visibility request was observed")
     if track_world_requested and not totals["track_world_requests"]:
         failures.append("no exact track-world request was observed")
+    if track_eligibility_present and totals["track_world_candidates"] != (
+        totals["track_world_mechanically_eligible"]
+        + totals["track_world_mechanically_rejected"]
+    ):
+        failures.append("track-world mechanical eligibility accounting drifted")
+    if (
+        track_eligibility_present
+        and totals["track_world_requests"]
+        > totals["track_world_mechanically_eligible"]
+    ):
+        failures.append("track-world requests exceed mechanically eligible candidates")
     if not track_world_requested and (
         totals["track_world_requests"]
         or totals["track_world_identity_exclusions"]

--- a/tools/tests/test_native_renderer_continuous_world_workset.py
+++ b/tools/tests/test_native_renderer_continuous_world_workset.py
@@ -51,6 +51,17 @@ def fixture():
         stale_or_unselected_rejections="3",
         non_track_provider_rejections="2",
         track_world_identity_exclusions="1",
+        track_world_candidates="7",
+        track_world_mechanically_eligible="3",
+        track_world_mechanically_rejected="4",
+        track_world_mechanical_rejection_reasons=(
+            "resolved_input=0;unsupported_geometry=4;empty_draw=0;"
+            "vertex_binding_count=0;vertex_binding_overflow=0;"
+            "vertex_attribute_overflow=0;vertex_constant_overflow=0;"
+            "pixel_constant_overflow=0;texture_state_overflow=0;memexport=0;"
+            "query=0;texture_count=0;texture_layout=0;prepared_pipeline=0;"
+            "render_targets=0"
+        ),
         track_world_requests="3",
         static_world_lineage_rejections="0",
         static_world_requests="3",
@@ -111,6 +122,8 @@ class ContinuousWorldWorksetTests(unittest.TestCase):
         self.assertIn("qualified_retained_family_requests", source)
         self.assertIn("prepared_track_texture_provider", source)
         self.assertIn("prepared_track_render_model_scope", source)
+        self.assertIn("track_world_mechanically_rejected", source)
+        self.assertIn("track_world_mechanical_rejection_reasons", source)
         self.assertIn(
             ".track_command_lineage = exact_track_command", source
         )
@@ -250,6 +263,28 @@ class ContinuousWorldWorksetTests(unittest.TestCase):
         self.assertIn(
             "no exact track-world request was observed", document["failures"]
         )
+
+    def test_rejects_track_world_eligibility_accounting_drift(self):
+        events = fixture()
+        events[-1]["track_world_mechanically_rejected"] = "3"
+        document = MODULE.build(events)
+        self.assertEqual("incomplete", document["status"])
+        self.assertIn(
+            "track-world mechanical eligibility accounting drifted",
+            document["failures"],
+        )
+
+    def test_accepts_legacy_summary_without_eligibility_partition(self):
+        events = fixture()
+        for key in (
+            "track_world_candidates",
+            "track_world_mechanically_eligible",
+            "track_world_mechanically_rejected",
+            "track_world_mechanical_rejection_reasons",
+        ):
+            events[-1].pop(key)
+        document = MODULE.build(events)
+        self.assertEqual("complete", document["status"])
 
     def test_keeps_exact_track_world_selection_optional(self):
         events = fixture()


### PR DESCRIPTION
## Summary\n- partition exact track command candidates before the mechanical replay gate\n- export all 15 rejection-reason counters with backward-compatible v7 analysis\n- record the clean combined C1/C2 runtime result and retire the dormant deferred C2 lead\n\n## Safety\n- does not widen replay support or selection\n- preserves Xenos draws and renderer authority\n- enables no suppression\n\n## Tests\n- python -m unittest tools.tests.test_native_renderer_continuous_world_workset tools.tests.test_native_renderer_c1_c2_batch (21 passed)\n- incremental Release build passed