### PR TITLE
feat(renderer): census live world graph pointees

### DIFF
--- a/docs/native-renderer/REPRIORITIZED_PLAN.md
+++ b/docs/native-renderer/REPRIORITIZED_PLAN.md
@@ -416,6 +416,16 @@ festival population, just like the synchronous presentation population. C2
 must move to a live SimpleModel construction/registration or draw-producing
 call edge rather than adding more assumptions to either dormant path.
 
+Live-world pointee census checkpoint: on each cache miss, the exact C1 child
+and type-21 descriptor now supply at most 16 unique mapped roots apiece to a
+one-level, 16-word prefix census. Direct and nested RTTI matches are counted
+separately for the seven proved track-world types and the immediate/deferred
+SimpleModel renderer, resource, model, submodel, mesh, and presentation types.
+Nested results are diagnostic only: they are not copied into command identity,
+native selection, or suppression. The next combined run can therefore tell us
+whether C2's live static objects sit behind the already-live command graph
+without widening either renderer contract or doing another broad draw census.
+
 ### C2. Static world buildings and props
 
 - Expand opaque-world material and geometry coverage.

--- a/src/native_renderer/graphics_hooks.cpp
+++ b/src/native_renderer/graphics_hooks.cpp
@@ -244,6 +244,8 @@ constexpr uint32_t kTrackPvsZoneObjectVtable = 0x82144DE0;
 constexpr uint32_t kTrackPvsZoneResourceVtable = 0x82144E64;
 constexpr size_t kTrackWorldResourceIdentityCapacity = 16;
 constexpr size_t kTrackWorldResourceGraphCacheCapacity = 1024;
+constexpr size_t kTrackWorldPointeePrefixWords = 16;
+constexpr size_t kTrackWorldPointeeIdentityCount = 14;
 constexpr uint64_t kSkyHorizonAnchorSignature = UINT64_C(0x747837906D0BF484);
 constexpr uint64_t kSkyHorizonFollowerSignature = UINT64_C(0x1D253A52B55C9FB3);
 constexpr uint64_t kShadowDepthVertexShader = UINT64_C(0x4E1DA281CC3D7EDB);
@@ -2638,6 +2640,14 @@ std::array<std::atomic<uint64_t>, 7>
     g_track_world_resource_identity_relations{};
 std::array<std::atomic<uint64_t>, 7>
     g_track_world_resource_shared_identity_relations{};
+std::atomic<uint64_t> g_track_world_pointee_graph_samples{};
+std::atomic<uint64_t> g_track_world_pointee_direct_hits{};
+std::atomic<uint64_t> g_track_world_pointee_nested_hits{};
+std::atomic<uint64_t> g_track_world_pointee_host_unmapped_rejections{};
+std::array<std::atomic<uint64_t>, kTrackWorldPointeeIdentityCount>
+    g_track_world_pointee_direct_identity_relations{};
+std::array<std::atomic<uint64_t>, kTrackWorldPointeeIdentityCount>
+    g_track_world_pointee_nested_identity_relations{};
 std::atomic<uint64_t> g_static_world_scope_entries{};
 std::atomic<uint64_t> g_static_world_scope_exits{};
 std::atomic<uint64_t> g_static_world_scope_overlaps{};
@@ -3342,6 +3352,116 @@ uint32_t ClassifyTrackWorldResourceVtable(uint32_t vtable) {
   }
 }
 
+size_t ClassifyTrackWorldPointeeVtable(uint32_t vtable) {
+  switch (vtable) {
+  case kTrackModelVtable:
+    return 0;
+  case kTrackMeshVtable:
+    return 1;
+  case kTrackSubModelVtable:
+    return 2;
+  case kTrackProceduralGeometryObjectVtable:
+    return 3;
+  case kTrackProceduralGeometryResourceVtable:
+    return 4;
+  case kTrackPvsZoneObjectVtable:
+    return 5;
+  case kTrackPvsZoneResourceVtable:
+    return 6;
+  case kSimpleModelRendererVtable:
+    return 7;
+  case kSimpleModelResourceVtable:
+    return 8;
+  case kSimpleModelVtable:
+    return 9;
+  case kSimpleSubModelVtable:
+    return 10;
+  case kSimpleMeshVtable:
+    return 11;
+  case kDeferredSimpleModelRendererVtable:
+    return 12;
+  case kModelPresentationVtable:
+  case kRefCountedModelPresentationVtable:
+    return 13;
+  default:
+    return kTrackWorldPointeeIdentityCount;
+  }
+}
+
+bool TryReadTrackWorldPointeeVtable(rex::memory::Memory *memory,
+                                    uint32_t address, uint32_t &vtable) {
+  if (!address || (address & 3) ||
+      !IsReadableVehicleGuestRange(memory, address, sizeof(uint32_t))) {
+    return false;
+  }
+  size_t host_region_length = 0;
+  rex::memory::PageAccess host_access = rex::memory::PageAccess::kNoAccess;
+  void *host_address = memory->TranslateVirtual<void *>(address);
+  if (!rex::memory::QueryProtect(host_address, host_region_length,
+                                 host_access) ||
+      host_access == rex::memory::PageAccess::kNoAccess) {
+    ++g_track_world_pointee_host_unmapped_rejections;
+    return false;
+  }
+  vtable = static_cast<uint32_t>(
+      *memory->TranslateVirtual<rex::be_u32 *>(address));
+  return true;
+}
+
+template <size_t N>
+void CensusTrackWorldPointees(rex::memory::Memory *memory,
+                              const std::array<uint32_t, N> &words) {
+  ++g_track_world_pointee_graph_samples;
+  std::array<uint32_t, kTrackWorldResourceIdentityCapacity> roots{};
+  size_t root_count = 0;
+  for (uint32_t address : words) {
+    uint32_t vtable = 0;
+    if (!TryReadTrackWorldPointeeVtable(memory, address, vtable)) {
+      continue;
+    }
+    const size_t identity = ClassifyTrackWorldPointeeVtable(vtable);
+    if (identity != kTrackWorldPointeeIdentityCount) {
+      ++g_track_world_pointee_direct_hits;
+      ++g_track_world_pointee_direct_identity_relations[identity];
+    }
+    if (root_count >= roots.size() ||
+        std::find(roots.begin(), roots.begin() + root_count, address) !=
+            roots.begin() + root_count) {
+      continue;
+    }
+    roots[root_count++] = address;
+  }
+  for (size_t root_index = 0; root_index < root_count; ++root_index) {
+    const uint32_t root = roots[root_index];
+    if (root > UINT32_MAX -
+                   uint32_t((kTrackWorldPointeePrefixWords - 1) *
+                            sizeof(uint32_t))) {
+      continue;
+    }
+    for (size_t word_index = 0; word_index < kTrackWorldPointeePrefixWords;
+         ++word_index) {
+      const uint32_t field_address =
+          root + uint32_t(word_index * sizeof(uint32_t));
+      uint32_t nested_address = 0;
+      if (!TryReadTrackWorldPointeeVtable(memory, field_address,
+                                         nested_address)) {
+        continue;
+      }
+      uint32_t nested_vtable = 0;
+      if (!TryReadTrackWorldPointeeVtable(memory, nested_address,
+                                         nested_vtable)) {
+        continue;
+      }
+      const size_t identity = ClassifyTrackWorldPointeeVtable(nested_vtable);
+      if (identity == kTrackWorldPointeeIdentityCount) {
+        continue;
+      }
+      ++g_track_world_pointee_nested_hits;
+      ++g_track_world_pointee_nested_identity_relations[identity];
+    }
+  }
+}
+
 void AddTrackWorldResourceReference(
     TrackWorldResourceGraphCacheEntry &entry, uint32_t address,
     uint32_t identity) {
@@ -3424,6 +3544,8 @@ void PopulateTrackWorldResourceGraph(
     };
     ScanTrackWorldResourcePointers(memory, child_words, entry);
     ScanTrackWorldResourcePointers(memory, descriptor_words, entry);
+    CensusTrackWorldPointees(memory, child_words);
+    CensusTrackWorldPointees(memory, descriptor_words);
   }
   TrackRenderModelDispatchScope &scope = g_track_render_model_scope;
   scope.world_resource_identity_mask = entry.identity_mask;
@@ -12555,6 +12677,61 @@ void EmitTrackRenderModelRuntimeJoinEvent(const char *event_name,
         std::to_string(
             g_track_world_resource_graph_host_unmapped_rejections.load(
                 std::memory_order_relaxed))},
+       {"world_pointee_graph_samples",
+        std::to_string(g_track_world_pointee_graph_samples.load(
+            std::memory_order_relaxed))},
+       {"world_pointee_direct_hits",
+        std::to_string(g_track_world_pointee_direct_hits.load(
+            std::memory_order_relaxed))},
+       {"world_pointee_nested_hits",
+        std::to_string(g_track_world_pointee_nested_hits.load(
+            std::memory_order_relaxed))},
+       {"world_pointee_host_unmapped_rejections",
+        std::to_string(
+            g_track_world_pointee_host_unmapped_rejections.load(
+                std::memory_order_relaxed))},
+       {"world_pointee_direct_relations",
+        fmt::format(
+            "track_model={};track_mesh={};track_submodel={};"
+            "procedural_object={};procedural_resource={};pvs_object={};"
+            "pvs_resource={};simple_renderer={};simple_resource={};"
+            "simple_model={};simple_submodel={};simple_mesh={};"
+            "deferred_renderer={};model_presentation={}",
+            g_track_world_pointee_direct_identity_relations[0].load(),
+            g_track_world_pointee_direct_identity_relations[1].load(),
+            g_track_world_pointee_direct_identity_relations[2].load(),
+            g_track_world_pointee_direct_identity_relations[3].load(),
+            g_track_world_pointee_direct_identity_relations[4].load(),
+            g_track_world_pointee_direct_identity_relations[5].load(),
+            g_track_world_pointee_direct_identity_relations[6].load(),
+            g_track_world_pointee_direct_identity_relations[7].load(),
+            g_track_world_pointee_direct_identity_relations[8].load(),
+            g_track_world_pointee_direct_identity_relations[9].load(),
+            g_track_world_pointee_direct_identity_relations[10].load(),
+            g_track_world_pointee_direct_identity_relations[11].load(),
+            g_track_world_pointee_direct_identity_relations[12].load(),
+            g_track_world_pointee_direct_identity_relations[13].load())},
+       {"world_pointee_nested_relations",
+        fmt::format(
+            "track_model={};track_mesh={};track_submodel={};"
+            "procedural_object={};procedural_resource={};pvs_object={};"
+            "pvs_resource={};simple_renderer={};simple_resource={};"
+            "simple_model={};simple_submodel={};simple_mesh={};"
+            "deferred_renderer={};model_presentation={}",
+            g_track_world_pointee_nested_identity_relations[0].load(),
+            g_track_world_pointee_nested_identity_relations[1].load(),
+            g_track_world_pointee_nested_identity_relations[2].load(),
+            g_track_world_pointee_nested_identity_relations[3].load(),
+            g_track_world_pointee_nested_identity_relations[4].load(),
+            g_track_world_pointee_nested_identity_relations[5].load(),
+            g_track_world_pointee_nested_identity_relations[6].load(),
+            g_track_world_pointee_nested_identity_relations[7].load(),
+            g_track_world_pointee_nested_identity_relations[8].load(),
+            g_track_world_pointee_nested_identity_relations[9].load(),
+            g_track_world_pointee_nested_identity_relations[10].load(),
+            g_track_world_pointee_nested_identity_relations[11].load(),
+            g_track_world_pointee_nested_identity_relations[12].load(),
+            g_track_world_pointee_nested_identity_relations[13].load())},
        {"world_resource_shared_identity_joins",
         std::to_string(g_track_world_resource_shared_identity_joins.load(
             std::memory_order_relaxed))},

--- a/tools/summarize-native-renderer-track-model-runtime-join.py
+++ b/tools/summarize-native-renderer-track-model-runtime-join.py
@@ -7,7 +7,7 @@ import pathlib
 import sys
 
 
-SCHEMA = "pinyon-shift.native-renderer-track-model-runtime-join.v3"
+SCHEMA = "pinyon-shift.native-renderer-track-model-runtime-join.v4"
 CONFIG = "native_renderer.discovery.track_render_model_runtime_join_config"
 SUMMARY = "native_renderer.discovery.track_render_model_runtime_join_summary"
 CHECKPOINT = (
@@ -39,6 +39,22 @@ WORLD_RELATIONS = (
 SHARED_WORLD_RELATIONS = tuple(
     f"shared_{relation}" for relation in WORLD_RELATIONS
 )
+POINTEE_RELATIONS = (
+    "track_model",
+    "track_mesh",
+    "track_submodel",
+    "procedural_object",
+    "procedural_resource",
+    "pvs_object",
+    "pvs_resource",
+    "simple_renderer",
+    "simple_resource",
+    "simple_model",
+    "simple_submodel",
+    "simple_mesh",
+    "deferred_renderer",
+    "model_presentation",
+)
 
 
 def integer(mapping, key):
@@ -49,6 +65,21 @@ def integer(mapping, key):
     if value < 0:
         raise ValueError(f"negative {key}")
     return value
+
+
+def relation_counts(mapping, key):
+    raw = mapping.get(key)
+    if not isinstance(raw, str):
+        raise ValueError(f"invalid {key}")
+    result = {}
+    for part in raw.split(";"):
+        name, separator, value = part.partition("=")
+        if not separator or name in result:
+            raise ValueError(f"invalid {key}")
+        result[name] = integer({name: value}, name)
+    if tuple(result) != POINTEE_RELATIONS:
+        raise ValueError(f"invalid {key}")
+    return result
 
 
 def exact_event(events, name):
@@ -226,11 +257,46 @@ def build(events, requested_session=None, allow_checkpoint=False):
     )
     for key in prepared_partition_keys:
         totals[key] = integer(summary, key) if key in summary else 0
+    pointee_keys = (
+        "world_pointee_graph_samples",
+        "world_pointee_direct_hits",
+        "world_pointee_nested_hits",
+        "world_pointee_host_unmapped_rejections",
+        "world_pointee_direct_relations",
+        "world_pointee_nested_relations",
+    )
+    pointee_present = all(key in summary for key in pointee_keys)
+    pointee_direct_relations = {}
+    pointee_nested_relations = {}
+    if pointee_present:
+        for key in pointee_keys[:4]:
+            totals[key] = integer(summary, key)
+        pointee_direct_relations = relation_counts(
+            summary, "world_pointee_direct_relations"
+        )
+        pointee_nested_relations = relation_counts(
+            summary, "world_pointee_nested_relations"
+        )
     failures = []
     if any(key in summary for key in prepared_partition_keys) and not (
         prepared_partition_present
     ):
         failures.append("prepared command semantic-origin partition is incomplete")
+    if any(key in summary for key in pointee_keys) and not pointee_present:
+        failures.append("world-pointee census is incomplete")
+    if pointee_present:
+        if totals["world_pointee_graph_samples"] != (
+            2 * totals["world_resource_graph_cache_misses"]
+        ):
+            failures.append("world-pointee sample accounting drifted")
+        if totals["world_pointee_direct_hits"] != sum(
+            pointee_direct_relations.values()
+        ):
+            failures.append("direct world-pointee relation accounting drifted")
+        if totals["world_pointee_nested_hits"] != sum(
+            pointee_nested_relations.values()
+        ):
+            failures.append("nested world-pointee relation accounting drifted")
     classified = (
         totals["exact_scopes"]
         + totals["invalid_root"]
@@ -345,6 +411,11 @@ def build(events, requested_session=None, allow_checkpoint=False):
         },
         "shared_world_resource_relations": {
             key: totals[key] for key in SHARED_WORLD_RELATIONS
+        },
+        "world_pointee_census": {
+            "available": pointee_present,
+            "direct_relations": pointee_direct_relations,
+            "nested_relations": pointee_nested_relations,
         },
         "qualification": {
             "track_render_model_scope_to_submission_proved": False,

--- a/tools/tests/test_native_renderer_track_model_runtime_join.py
+++ b/tools/tests/test_native_renderer_track_model_runtime_join.py
@@ -27,6 +27,10 @@ def safety():
 
 
 def fixture(shared=3):
+    pointee_names = ";".join(
+        f"{name}={1 if name in ('track_mesh', 'simple_mesh') else 0}"
+        for name in MODULE.POINTEE_RELATIONS
+    )
     config = event(
         MODULE.CONFIG,
         status="armed",
@@ -96,6 +100,12 @@ def fixture(shared=3):
         world_resource_graph_cache_misses="2",
         world_resource_graph_reference_overflow="0",
         world_resource_graph_host_unmapped_rejections="3",
+        world_pointee_graph_samples="4",
+        world_pointee_direct_hits="2",
+        world_pointee_nested_hits="2",
+        world_pointee_host_unmapped_rejections="1",
+        world_pointee_direct_relations=pointee_names,
+        world_pointee_nested_relations=pointee_names,
         world_resource_shared_identity_joins=str(shared),
         scope_overlaps="0",
         exit_without_entry="0",
@@ -111,6 +121,19 @@ def fixture(shared=3):
 
 
 class TrackModelRuntimeJoinTests(unittest.TestCase):
+    def test_runtime_census_is_bounded_and_observation_only(self):
+        source = (ROOT / "src/native_renderer/graphics_hooks.cpp").read_text(
+            encoding="utf-8"
+        )
+        self.assertIn("kTrackWorldPointeePrefixWords = 16", source)
+        self.assertIn("CensusTrackWorldPointees", source)
+        self.assertIn("world_pointee_direct_relations", source)
+        self.assertIn("world_pointee_nested_relations", source)
+        census = source.split("void CensusTrackWorldPointees", 1)[1].split(
+            "void AddTrackWorldResourceReference", 1
+        )[0]
+        self.assertNotIn("identity_mask", census)
+
     def test_qualifies_scope_and_shared_identity(self):
         document = MODULE.build(fixture())
         self.assertEqual("complete", document["status"])
@@ -128,6 +151,13 @@ class TrackModelRuntimeJoinTests(unittest.TestCase):
             document["qualification"][
                 "track_world_resource_to_submission_identity_proved"
             ]
+        )
+        self.assertTrue(document["world_pointee_census"]["available"])
+        self.assertEqual(
+            1,
+            document["world_pointee_census"]["nested_relations"][
+                "simple_mesh"
+            ],
         )
 
     def test_qualifies_scope_without_claiming_shared_identity(self):
@@ -185,6 +215,30 @@ class TrackModelRuntimeJoinTests(unittest.TestCase):
         events[-1].pop("command_prepared_draw_joins_without_semantic_origin")
         document = MODULE.build(events)
         self.assertEqual("complete", document["status"])
+
+    def test_accepts_legacy_summary_without_pointee_census(self):
+        events = copy.deepcopy(fixture())
+        for key in (
+            "world_pointee_graph_samples",
+            "world_pointee_direct_hits",
+            "world_pointee_nested_hits",
+            "world_pointee_host_unmapped_rejections",
+            "world_pointee_direct_relations",
+            "world_pointee_nested_relations",
+        ):
+            events[-1].pop(key)
+        document = MODULE.build(events)
+        self.assertEqual("complete", document["status"])
+        self.assertFalse(document["world_pointee_census"]["available"])
+
+    def test_rejects_pointee_relation_accounting_drift(self):
+        events = copy.deepcopy(fixture())
+        events[-1]["world_pointee_nested_hits"] = "3"
+        document = MODULE.build(events)
+        self.assertIn(
+            "nested world-pointee relation accounting drifted",
+            document["failures"],
+        )
 
     def test_latest_checkpoint_is_diagnostic_not_admission_evidence(self):
         events = fixture()


### PR DESCRIPTION
## Summary\n- inspect a bounded 16-root/16-word one-level graph only on exact C1 cache misses\n- distinguish direct and nested RTTI matches for proved track-world and SimpleModel types\n- add strict, backward-compatible v4 report accounting\n\n## Safety\n- nested observations never enter command identity or native selection\n- Xenos remains authoritative and suppression stays disabled\n- reads require guest access and committed host mapping\n\n## Tests\n- 37 focused Python tests passed\n- incremental Release build passed