### PR TITLE
feat(renderer): replay exact track color targets

### DIFF
--- a/docs/native-renderer/REPRIORITIZED_PLAN.md
+++ b/docs/native-renderer/REPRIORITIZED_PLAN.md
@@ -426,6 +426,25 @@ native selection, or suppression. The next combined run can therefore tell us
 whether C2's live static objects sit behind the already-live command graph
 without widening either renderer contract or doing another broad draw census.
 
+Combined eligibility result: clean AppData session
+`20260901T011508Z-p39720` reached 1,744 balanced exact track scopes and 2,570
+prepared-draw joins. All 2,570 candidates failed only the render-target gate;
+every other mechanical replay requirement passed. The same live graph census
+found 1,189 nested `CTrackMesh` and 1,875 nested `CTrackSubModel` identities,
+with zero direct or nested SimpleModel-family identities. C1 therefore advances
+through the observed color-only target shape, while C2 leaves this graph and
+continues toward a separate live construction or draw-producing ingress.
+
+Color-only replay implementation checkpoint: the exact track selector may
+clear only the generic paired-target rejection when the prepared backend draw
+proves first-color-only binding (`bound_render_target_bits == 2`). The D3D12
+private replay path validates that depth/stencil and later color targets are
+absent, copies and binds a private clone of the authoritative first color
+target, and retains the existing swap-committed, fail-closed lifecycle. This
+does not widen generic isolated replay, publish into guest targets, suppress a
+draw, or change Xenos authority. Runtime visual qualification remains batched
+with the next meaningful Phase C slice.
+
 ### C2. Static world buildings and props
 
 - Expand opaque-world material and geometry coverage.

--- a/patches/rexglue/0106-d3d12-color-only-isolated-replay.patch
+++ b/patches/rexglue/0106-d3d12-color-only-isolated-replay.patch
@@ -1,0 +1,330 @@
+diff --git a/include/rex/graphics/d3d12/render_target_cache.h b/include/rex/graphics/d3d12/render_target_cache.h
+index df7cb5b..114167c 100644
+--- a/include/rex/graphics/d3d12/render_target_cache.h
++++ b/include/rex/graphics/d3d12/render_target_cache.h
+@@ -103,11 +103,13 @@ class D3D12RenderTargetCache final : public RenderTargetCache {
+                                  uint32_t logical_width,
+                                  uint32_t logical_height,
+                                  bool stencil_seed_probe_requested,
+-                                 bool depth_only_target = false);
++                                 bool depth_only_target = false,
++                                 bool color_only_target = false);
+   bool ResumeIsolatedReplayTarget(uint32_t& width_out, uint32_t& height_out,
+                                   uint32_t logical_width,
+                                   uint32_t logical_height,
+-                                  bool depth_only_target = false);
++                                  bool depth_only_target = false,
++                                  bool color_only_target = false);
+   system::GraphicsIsolatedDrawReadbackStatus QueueIsolatedReplayReadback(
+       system::GraphicsIsolatedDrawReadbackCompletion completion,
+       uint32_t* failure_detail_out);
+diff --git a/include/rex/system/interfaces/graphics.h b/include/rex/system/interfaces/graphics.h
+index 211ca95..63b94a9 100644
+--- a/include/rex/system/interfaces/graphics.h
++++ b/include/rex/system/interfaces/graphics.h
+@@ -508,6 +508,10 @@ struct GraphicsIsolatedDrawRequest {
+   // Duplicate a draw that has only a depth/stencil attachment. The backend
+   // must reject this mode if any guest color target is bound.
+   bool depth_only_target = false;
++  // Duplicate a draw that has only the first color attachment. The backend
++  // must reject this mode if a guest depth/stencil or later color target is
++  // bound. Mutually exclusive with depth_only_target.
++  bool color_only_target = false;
+   bool readback_requested = false;
+   // Capture the authoritative guest color target after the original draw.
+   // This is independent of the private replay readback and never suppresses
+diff --git a/src/graphics/d3d12/command_processor.cpp b/src/graphics/d3d12/command_processor.cpp
+index 98b3525..dbf4f3a 100644
+--- a/src/graphics/d3d12/command_processor.cpp
++++ b/src/graphics/d3d12/command_processor.cpp
+@@ -3816,14 +3816,16 @@ bool D3D12CommandProcessor::IssueDraw(xenos::PrimitiveType primitive_type, uint3
+                       isolated_replay_logical_width,
+                       isolated_replay_logical_height,
+                       isolated_draw_request.stencil_seed_probe_requested,
+-                      isolated_draw_request.depth_only_target)) ||
++                      isolated_draw_request.depth_only_target,
++                      isolated_draw_request.color_only_target)) ||
+                  (isolated_draw_request.reuse_target &&
+                   render_target_cache_->ResumeIsolatedReplayTarget(
+                       isolated_result.target_width,
+                       isolated_result.target_height,
+                       isolated_replay_logical_width,
+                       isolated_replay_logical_height,
+-                      isolated_draw_request.depth_only_target))) {
++                      isolated_draw_request.depth_only_target,
++                      isolated_draw_request.color_only_target))) {
+         if (isolated_draw_request.reference_seed_depth_readback_requested &&
+             isolated_draw_request.reference_seed_depth_readback_completion) {
+           uint32_t readback_detail = 0;
+@@ -4072,14 +4074,16 @@ bool D3D12CommandProcessor::IssueDraw(xenos::PrimitiveType primitive_type, uint3
+                       isolated_replay_logical_width,
+                       isolated_replay_logical_height,
+                       isolated_draw_request.stencil_seed_probe_requested,
+-                      isolated_draw_request.depth_only_target)) ||
++                      isolated_draw_request.depth_only_target,
++                      isolated_draw_request.color_only_target)) ||
+                  (isolated_draw_request.reuse_target &&
+                   render_target_cache_->ResumeIsolatedReplayTarget(
+                       isolated_result.target_width,
+                       isolated_result.target_height,
+                       isolated_replay_logical_width,
+                       isolated_replay_logical_height,
+-                      isolated_draw_request.depth_only_target))) {
++                      isolated_draw_request.depth_only_target,
++                      isolated_draw_request.color_only_target))) {
+         if (isolated_draw_request.reference_seed_depth_readback_requested &&
+             isolated_draw_request.reference_seed_depth_readback_completion) {
+           uint32_t readback_detail = 0;
+diff --git a/src/graphics/d3d12/render_target_cache.cpp b/src/graphics/d3d12/render_target_cache.cpp
+index 0f10307..412800d 100644
+--- a/src/graphics/d3d12/render_target_cache.cpp
++++ b/src/graphics/d3d12/render_target_cache.cpp
+@@ -1776,10 +1776,15 @@ RenderTargetCache::RenderTarget* D3D12RenderTargetCache::CreateRenderTarget(Rend
+ bool D3D12RenderTargetCache::BeginIsolatedReplayTarget(
+     uint32_t& width_out, uint32_t& height_out,
+     uint32_t logical_width, uint32_t logical_height,
+-    bool stencil_seed_probe_requested, bool depth_only_target) {
++    bool stencil_seed_probe_requested, bool depth_only_target,
++    bool color_only_target) {
+   width_out = 0;
+   height_out = 0;
+   isolated_replay_active_depth_target_ = nullptr;
++  if ((depth_only_target && color_only_target) ||
++      (stencil_seed_probe_requested && color_only_target)) {
++    return false;
++  }
+   if (!depth_only_target) {
+     isolated_replay_deferred_preview_frame_sequence_ = 0;
+     isolated_replay_deferred_preview_width_ = 0;
+@@ -1792,7 +1797,9 @@ bool D3D12RenderTargetCache::BeginIsolatedReplayTarget(
+   }
+   RenderTarget* const* guest_targets =
+       last_update_accumulated_render_targets();
+-  if (!guest_targets[0] || (!depth_only_target && !guest_targets[1])) {
++  if ((!color_only_target && !guest_targets[0]) ||
++      (color_only_target && guest_targets[0]) ||
++      (!depth_only_target && !guest_targets[1])) {
+     return false;
+   }
+   for (uint32_t i = depth_only_target ? 1 : 2;
+@@ -1805,10 +1812,12 @@ bool D3D12RenderTargetCache::BeginIsolatedReplayTarget(
+   auto& isolated_replay_depth_target =
+       depth_only_target ? isolated_replay_depth_only_target_
+                         : isolated_replay_depth_target_;
+-  const RenderTargetKey depth_key = guest_targets[0]->key();
+-  if (!isolated_replay_depth_target ||
+-      isolated_replay_depth_target->key() != depth_key) {
+-    isolated_replay_depth_target.reset(CreateRenderTarget(depth_key));
++  if (!color_only_target) {
++    const RenderTargetKey depth_key = guest_targets[0]->key();
++    if (!isolated_replay_depth_target ||
++        isolated_replay_depth_target->key() != depth_key) {
++      isolated_replay_depth_target.reset(CreateRenderTarget(depth_key));
++    }
+   }
+   if (!depth_only_target) {
+     const RenderTargetKey color_key = guest_targets[1]->key();
+@@ -1817,9 +1826,11 @@ bool D3D12RenderTargetCache::BeginIsolatedReplayTarget(
+       isolated_replay_color_target_.reset(CreateRenderTarget(color_key));
+     }
+   }
+-  if (!isolated_replay_depth_target ||
++  if ((!color_only_target && !isolated_replay_depth_target) ||
+       (!depth_only_target && !isolated_replay_color_target_)) {
+-    isolated_replay_depth_target.reset();
++    if (!color_only_target) {
++      isolated_replay_depth_target.reset();
++    }
+     if (!depth_only_target) {
+       isolated_replay_color_target_.reset();
+     }
+@@ -1827,9 +1838,14 @@ bool D3D12RenderTargetCache::BeginIsolatedReplayTarget(
+     return false;
+   }
+ 
+-  auto* isolated_depth = static_cast<D3D12RenderTarget*>(
+-      isolated_replay_depth_target.get());
+-  auto* guest_depth = static_cast<D3D12RenderTarget*>(guest_targets[0]);
++  auto* isolated_depth =
++      color_only_target
++          ? nullptr
++          : static_cast<D3D12RenderTarget*>(
++                isolated_replay_depth_target.get());
++  auto* guest_depth = color_only_target
++                          ? nullptr
++                          : static_cast<D3D12RenderTarget*>(guest_targets[0]);
+   auto* isolated_color = depth_only_target
+                              ? nullptr
+                              : static_cast<D3D12RenderTarget*>(
+@@ -1868,27 +1884,35 @@ bool D3D12RenderTargetCache::BeginIsolatedReplayTarget(
+   }
+ 
+   const D3D12_RESOURCE_STATES guest_depth_state =
+-      guest_depth->SetResourceState(D3D12_RESOURCE_STATE_COPY_SOURCE);
++      guest_depth ? guest_depth->SetResourceState(
++                        D3D12_RESOURCE_STATE_COPY_SOURCE)
++                  : D3D12_RESOURCE_STATE_COMMON;
+   const D3D12_RESOURCE_STATES guest_color_state =
+       guest_color ? guest_color->SetResourceState(D3D12_RESOURCE_STATE_COPY_SOURCE)
+                   : D3D12_RESOURCE_STATE_COMMON;
+   const D3D12_RESOURCE_STATES isolated_depth_state =
+-      isolated_depth->SetResourceState(D3D12_RESOURCE_STATE_COPY_DEST);
++      isolated_depth ? isolated_depth->SetResourceState(
++                           D3D12_RESOURCE_STATE_COPY_DEST)
++                     : D3D12_RESOURCE_STATE_COMMON;
+   const D3D12_RESOURCE_STATES isolated_color_state =
+       isolated_color
+           ? isolated_color->SetResourceState(D3D12_RESOURCE_STATE_COPY_DEST)
+           : D3D12_RESOURCE_STATE_COMMON;
+-  command_processor_.PushTransitionBarrier(
+-      guest_depth->resource(), guest_depth_state,
+-      D3D12_RESOURCE_STATE_COPY_SOURCE);
++  if (guest_depth) {
++    command_processor_.PushTransitionBarrier(
++        guest_depth->resource(), guest_depth_state,
++        D3D12_RESOURCE_STATE_COPY_SOURCE);
++  }
+   if (guest_color) {
+     command_processor_.PushTransitionBarrier(
+         guest_color->resource(), guest_color_state,
+         D3D12_RESOURCE_STATE_COPY_SOURCE);
+   }
+-  command_processor_.PushTransitionBarrier(
+-      isolated_depth->resource(), isolated_depth_state,
+-      D3D12_RESOURCE_STATE_COPY_DEST);
++  if (isolated_depth) {
++    command_processor_.PushTransitionBarrier(
++        isolated_depth->resource(), isolated_depth_state,
++        D3D12_RESOURCE_STATE_COPY_DEST);
++  }
+   if (isolated_color) {
+     command_processor_.PushTransitionBarrier(
+         isolated_color->resource(), isolated_color_state,
+@@ -1901,43 +1925,49 @@ bool D3D12RenderTargetCache::BeginIsolatedReplayTarget(
+   // Copy depth/stencil plane-by-plane so the diagnostic replay contract
+   // explicitly covers every plane of the typeless MSAA target. This also
+   // makes plane coverage independently reviewable from the readback path.
+-  const D3D12_RESOURCE_DESC depth_desc =
+-      isolated_depth->resource()->GetDesc();
+-  D3D12_FEATURE_DATA_FORMAT_INFO depth_format_info = {depth_desc.Format, 0};
+-  ID3D12Device* device = command_processor_.GetD3D12Provider().GetDevice();
+-  if (!device ||
+-      FAILED(device->CheckFeatureSupport(D3D12_FEATURE_FORMAT_INFO,
+-                                         &depth_format_info,
+-                                         sizeof(depth_format_info))) ||
+-      !depth_format_info.PlaneCount) {
+-    return false;
+-  }
+-  for (uint32_t plane = 0; plane < depth_format_info.PlaneCount; ++plane) {
+-    D3D12_TEXTURE_COPY_LOCATION destination = {};
+-    destination.pResource = isolated_depth->resource();
+-    destination.Type = D3D12_TEXTURE_COPY_TYPE_SUBRESOURCE_INDEX;
+-    destination.SubresourceIndex =
+-        plane * uint32_t(depth_desc.MipLevels) *
+-        uint32_t(depth_desc.DepthOrArraySize);
+-    D3D12_TEXTURE_COPY_LOCATION source = {};
+-    source.pResource = guest_depth->resource();
+-    source.Type = D3D12_TEXTURE_COPY_TYPE_SUBRESOURCE_INDEX;
+-    source.SubresourceIndex = destination.SubresourceIndex;
+-    command_list.D3DCopyTextureRegion(&destination, 0, 0, 0, &source,
+-                                       nullptr);
++  if (isolated_depth) {
++    const D3D12_RESOURCE_DESC depth_desc =
++        isolated_depth->resource()->GetDesc();
++    D3D12_FEATURE_DATA_FORMAT_INFO depth_format_info = {depth_desc.Format, 0};
++    ID3D12Device* device = command_processor_.GetD3D12Provider().GetDevice();
++    if (!device ||
++        FAILED(device->CheckFeatureSupport(D3D12_FEATURE_FORMAT_INFO,
++                                           &depth_format_info,
++                                           sizeof(depth_format_info))) ||
++        !depth_format_info.PlaneCount) {
++      return false;
++    }
++    for (uint32_t plane = 0; plane < depth_format_info.PlaneCount; ++plane) {
++      D3D12_TEXTURE_COPY_LOCATION destination = {};
++      destination.pResource = isolated_depth->resource();
++      destination.Type = D3D12_TEXTURE_COPY_TYPE_SUBRESOURCE_INDEX;
++      destination.SubresourceIndex =
++          plane * uint32_t(depth_desc.MipLevels) *
++          uint32_t(depth_desc.DepthOrArraySize);
++      D3D12_TEXTURE_COPY_LOCATION source = {};
++      source.pResource = guest_depth->resource();
++      source.Type = D3D12_TEXTURE_COPY_TYPE_SUBRESOURCE_INDEX;
++      source.SubresourceIndex = destination.SubresourceIndex;
++      command_list.D3DCopyTextureRegion(&destination, 0, 0, 0, &source,
++                                         nullptr);
++    }
+   }
+   if (isolated_color) {
+     command_list.D3DCopyResource(isolated_color->resource(),
+                                  guest_color->resource());
+   }
+ 
+-  guest_depth->SetResourceState(guest_depth_state);
++  if (guest_depth) {
++    guest_depth->SetResourceState(guest_depth_state);
++  }
+   if (guest_color) {
+     guest_color->SetResourceState(guest_color_state);
+   }
+-  command_processor_.PushTransitionBarrier(
+-      guest_depth->resource(), D3D12_RESOURCE_STATE_COPY_SOURCE,
+-      guest_depth_state);
++  if (guest_depth) {
++    command_processor_.PushTransitionBarrier(
++        guest_depth->resource(), D3D12_RESOURCE_STATE_COPY_SOURCE,
++        guest_depth_state);
++  }
+   if (guest_color) {
+     command_processor_.PushTransitionBarrier(
+         guest_color->resource(), D3D12_RESOURCE_STATE_COPY_SOURCE,
+@@ -1958,23 +1988,30 @@ bool D3D12RenderTargetCache::BeginIsolatedReplayTarget(
+ 
+ bool D3D12RenderTargetCache::ResumeIsolatedReplayTarget(
+     uint32_t& width_out, uint32_t& height_out, uint32_t logical_width,
+-    uint32_t logical_height, bool depth_only_target) {
++    uint32_t logical_height, bool depth_only_target,
++    bool color_only_target) {
+   width_out = 0;
+   height_out = 0;
+   isolated_replay_active_depth_target_ = nullptr;
++  if (depth_only_target && color_only_target) {
++    return false;
++  }
+   auto& isolated_replay_depth_target =
+       depth_only_target ? isolated_replay_depth_only_target_
+                         : isolated_replay_depth_target_;
+   if (GetPath() != Path::kHostRenderTargets ||
+-      !isolated_replay_depth_target ||
++      (!color_only_target && !isolated_replay_depth_target) ||
+       (!depth_only_target && !isolated_replay_color_target_)) {
+     isolated_replay_active_depth_target_ = nullptr;
+     return false;
+   }
+   RenderTarget* const* guest_targets =
+       last_update_accumulated_render_targets();
+-  if (!guest_targets[0] || (!depth_only_target && !guest_targets[1]) ||
+-      guest_targets[0]->key() != isolated_replay_depth_target->key()) {
++  if ((!color_only_target && !guest_targets[0]) ||
++      (color_only_target && guest_targets[0]) ||
++      (!depth_only_target && !guest_targets[1]) ||
++      (!color_only_target &&
++       guest_targets[0]->key() != isolated_replay_depth_target->key())) {
+     isolated_replay_active_depth_target_ = nullptr;
+     return false;
+   }
+@@ -1989,8 +2026,11 @@ bool D3D12RenderTargetCache::ResumeIsolatedReplayTarget(
+     }
+   }
+ 
+-  auto* isolated_depth = static_cast<D3D12RenderTarget*>(
+-      isolated_replay_depth_target.get());
++  auto* isolated_depth =
++      color_only_target
++          ? nullptr
++          : static_cast<D3D12RenderTarget*>(
++                isolated_replay_depth_target.get());
+   auto* isolated_color = depth_only_target
+                              ? nullptr
+                              : static_cast<D3D12RenderTarget*>(
+

--- a/src/native_renderer/graphics_hooks.cpp
+++ b/src/native_renderer/graphics_hooks.cpp
@@ -9205,6 +9205,7 @@ struct IsolatedDrawState {
   bool valid = true;
   bool prepared_candidate_valid = false;
   bool prepared_candidate_eligible = false;
+  bool prepared_color_only_target = false;
   uint32_t prepared_candidate_rejection_mask = 0;
   bool prepared_shadow_depth_seed_eligible = false;
   bool prepared_shadow_depth_batch_member = false;
@@ -22210,6 +22211,7 @@ void CommitPassConsumer(
 void ObservePreparedDraw(
     const rex::system::GraphicsPreparedDrawObservation &observation) {
   g_isolated_draw.prepared_candidate_valid = false;
+  g_isolated_draw.prepared_color_only_target = false;
   g_isolated_draw.prepared_shadow_depth_seed_eligible = false;
   g_isolated_draw.prepared_shadow_depth_batch_member = false;
   g_isolated_draw.prepared_shadow_depth_batch_family =
@@ -22261,6 +22263,16 @@ void ObservePreparedDraw(
             : IsolatedDrawMechanicalRejectionMask(
                   sample, g_pending_candidate.samples_resolved_target,
                   observation);
+    const bool exact_track_color_only =
+        visibility_admission.track_render_model_scope &&
+        (visibility_admission.track_world_resource_shared_identity_mask ||
+         visibility_admission.track_command_lineage) &&
+        observation.bound_render_target_bits == 2;
+    if (exact_track_color_only) {
+      g_isolated_draw.prepared_candidate_rejection_mask &=
+          ~kIsolatedRejectRenderTargets;
+      g_isolated_draw.prepared_color_only_target = true;
+    }
     g_isolated_draw.prepared_candidate_eligible =
         dedicated_shadow_mode
             ? g_isolated_draw.prepared_shadow_depth_seed_eligible
@@ -24648,6 +24660,8 @@ void RequestIsolatedDraw(
       ++g_continuous_world_workset.static_world_requests;
     }
     request.requested = true;
+    request.color_only_target =
+        exact_track_world && g_isolated_draw.prepared_color_only_target;
     request.retain_target = true;
     request.reuse_target = reuse_target;
     request.defer_preview_publication_until_swap = true;

--- a/tools/tests/test_native_renderer_continuous_world_workset.py
+++ b/tools/tests/test_native_renderer_continuous_world_workset.py
@@ -166,6 +166,27 @@ class ContinuousWorldWorksetTests(unittest.TestCase):
             "PINYON_SHIFT_NATIVE_RENDERER_CONTINUOUS_WORLD_WORKSET", capture
         )
 
+    def test_exact_track_color_only_replay_is_private_and_bounded(self):
+        source = (ROOT / "src/native_renderer/graphics_hooks.cpp").read_text(
+            encoding="utf-8"
+        )
+        self.assertIn("const bool exact_track_color_only", source)
+        self.assertIn("observation.bound_render_target_bits == 2", source)
+        self.assertIn("~kIsolatedRejectRenderTargets", source)
+        self.assertIn("request.color_only_target", source)
+        self.assertIn("exact_track_world &&", source)
+
+        patch = (
+            ROOT
+            / "patches/rexglue/0106-d3d12-color-only-isolated-replay.patch"
+        ).read_text(encoding="utf-8")
+        self.assertIn("bool color_only_target = false", patch)
+        self.assertIn("depth_only_target && color_only_target", patch)
+        self.assertIn("color_only_target && guest_targets[0]", patch)
+        self.assertIn("color_only_target\n+          ? nullptr", patch)
+        self.assertIn("guest_targets[1]", patch)
+        self.assertNotIn("SetDrawSuppression", patch)
+
     def test_qualifies_complete_multi_draw_worksets(self):
         document = MODULE.build(fixture())
         self.assertEqual("complete", document["status"])

--- a/tools/tests/test_release_contract.py
+++ b/tools/tests/test_release_contract.py
@@ -43,10 +43,10 @@ class ReleaseContractTests(unittest.TestCase):
 
     def test_rexglue_patches_have_stable_order_and_no_binary_payload(self):
         patches = sorted((ROOT / "patches/rexglue").glob("*.patch"))
-        self.assertEqual(len(patches), 105)
+        self.assertEqual(len(patches), 106)
         self.assertEqual(
             patches[-1].name,
-            "0105-graphics-draw-constant-write-provenance.patch",
+            "0106-d3d12-color-only-isolated-replay.patch",
         )
         self.assertEqual(len(patches), len({path.name[:4] for path in patches}))
         for path in patches:


### PR DESCRIPTION
Admits exact track-world draws whose only failed mechanical gate is the observed first-color-only render-target layout. Extends the D3D12 private replay target with strict color-only attachment validation while preserving swap-committed fallback, all Xenos draws, and zero suppression. Documents the decisive AppData census and the separate C2 direction. Tests: 646 Python tests passed; clean 106-patch application passed; Release preview build passed.