### PR TITLE
feat(renderer): trace direct indexed draw producers

### DIFF
--- a/config/rexglue/analysis/main-xex.toml
+++ b/config/rexglue/analysis/main-xex.toml
@@ -272,6 +272,16 @@ address = 0x82BA61DC
 name = "PinyonShiftObserveStaticWorldDeferredTaskHandoff"
 registers = ["r3", "r11"]
 
+# The title has thirteen statically enumerated direct calls to the indexed-draw
+# emitter. At entry, LR identifies the exact producer. Only the unified track
+# mesh return also interprets preserved r26 as the RTTI-proved CTrackMesh and
+# r31 as the 64-byte transform consumed by that producer. The bounded census
+# changes no arguments, packets, guest state, authority, or suppression.
+[[midasm_hook]]
+address = 0x82416380
+name = "PinyonShiftObserveDirectIndexedDrawProducer"
+registers = ["r26", "r31", "lr"]
+
 # Phase C2 exact SimpleModel renderer scope. Retail RTTI proves vtable slot 12
 # resolves to 0x82C4CCC8. Entry r3 is the CSimpleModelRenderer instance and r4
 # is its render context; every path converges at 0x82C4DEA0. The scope attaches

--- a/docs/native-renderer/DIRECT_INDEXED_DRAW_PRODUCERS.md
+++ b/docs/native-renderer/DIRECT_INDEXED_DRAW_PRODUCERS.md
@@ -1,0 +1,72 @@
+# Direct indexed-draw producers and the live C2 candidate
+
+Status: static producer inventory proved; batched runtime qualification pending
+
+## Why C2 changed direction
+
+The clean combined session `20260901T011508Z-p39720` proved that the original
+`CSimpleModelRenderer` route is dormant in the tested festival/open-world
+population. Two renderer instances were constructed, but neither was bound or
+dispatched, the `CSimpleModelResource` factory was never reached, and the live
+track command graph contained no direct or nested SimpleModel-family identity.
+
+The next C2 boundary therefore starts at a draw-producing edge rather than
+adding more assumptions to that dormant object graph.
+
+## Exact producer inventory
+
+`tools/discover-native-renderer-direct-indexed-producers.py` proves every
+static direct call to title indexed-draw emitter `82416380`. There are exactly
+13 callsites across 11 functions. Their guest return addresses form a small,
+closed runtime discriminator; no shader, frequency, or texture heuristic is
+needed.
+
+One producer is the exact unified track-presentation mesh helper `82C5ADC0`.
+Its direct draw returns to `82C5B038`. Static instruction flow proves that:
+
+- preserved `r26` is the selected mesh passed into the helper;
+- the helper binds `r26 + 96`, reads primitive type at `r26 + 36`, and reads
+  source element count at `r26 + 100` before the draw;
+- preserved `r31` is the live 64-byte transform whose float rows are uploaded
+  immediately before the draw; and
+- the upstream `82DED198 -> 82436468` route is owned by exact RTTI-proved
+  `Presentation_Unified::CTrackPresentation` methods.
+
+The runtime observer at `82416380` is armed only with census plus dispatch
+discovery. It counts all 13 exact return-address families and, only for
+`82C5B038`, requires `r26` vtable `8200143C` (`CTrackMesh`) before retaining a
+bounded 4,096-entry table of mesh address plus 16 numeric transform words. It
+does not run during ordinary prototype gameplay.
+
+Generate the static report with:
+
+```powershell
+python tools/discover-native-renderer-direct-indexed-producers.py `
+  .local/generated/default `
+  --image .local/analysis/default-image.bin `
+  --output .local/qualification/native-renderer-direct-indexed-producers.json
+```
+
+## Next batched gate
+
+The next combined AppData session must establish that `82C5B038` is active,
+that every observation has the exact `CTrackMesh` vtable and a finite mapped
+transform, and that the transform table has no overflow. Those transforms can
+then be evaluated against the already-built collision-prop and gameplay-object
+catalog to determine whether this live track-owned path supplies C2's concrete
+building/prop identity.
+
+The fail-closed runtime qualifier requires a clean process lifecycle, all 13
+producer records, zero unknown callers, at least eight distinct transforms,
+and complete observation accounting:
+
+```powershell
+python tools/summarize-native-renderer-direct-indexed-producers.py `
+  .local/preview/logs/<session>.jsonl `
+  --session <session> `
+  --output .local/qualification/native-renderer-direct-indexed-runtime.json
+```
+
+Until that evidence exists, this is a candidate ingress only. It enables no
+native admission, guest publication, Xenos suppression, or building/prop
+claim; Xenos remains authoritative.

--- a/docs/native-renderer/REPRIORITIZED_PLAN.md
+++ b/docs/native-renderer/REPRIORITIZED_PLAN.md
@@ -445,6 +445,18 @@ does not widen generic isolated replay, publish into guest targets, suppress a
 draw, or change Xenos authority. Runtime visual qualification remains batched
 with the next meaningful Phase C slice.
 
+C2 producer-pivot checkpoint: static AOT flow now enumerates all 13 direct
+callsites to indexed-draw emitter `82416380` and gives each an exact guest
+return-address discriminator. The `82C5B038` family is an exact
+`Presentation_Unified::CTrackPresentation` mesh draw: preserved `r26` is the
+selected `CTrackMesh`, while `r31` supplies the 64-byte transform consumed by
+the draw helper. A default-off census records the 13 producer counts and a
+bounded table of exact track-mesh transforms only when census plus dispatch
+discovery are armed. This replaces the dormant SimpleModel assumption with a
+live-candidate draw edge without yet claiming runtime activity or a concrete
+building/prop category. Static proof and the next batched gate are documented
+in [`DIRECT_INDEXED_DRAW_PRODUCERS.md`](DIRECT_INDEXED_DRAW_PRODUCERS.md).
+
 ### C2. Static world buildings and props
 
 - Expand opaque-world material and geometry coverage.

--- a/src/native_renderer/graphics_hooks.cpp
+++ b/src/native_renderer/graphics_hooks.cpp
@@ -246,6 +246,11 @@ constexpr size_t kTrackWorldResourceIdentityCapacity = 16;
 constexpr size_t kTrackWorldResourceGraphCacheCapacity = 1024;
 constexpr size_t kTrackWorldPointeePrefixWords = 16;
 constexpr size_t kTrackWorldPointeeIdentityCount = 14;
+constexpr uint32_t kDirectIndexedDrawEmitter = 0x82416380;
+constexpr uint32_t kUnifiedTrackMeshDrawReturn = 0x82C5B038;
+constexpr size_t kDirectIndexedDrawProducerCount = 13;
+constexpr size_t kUnifiedTrackMeshTransformCapacity = 4096;
+constexpr uint64_t kUnifiedTrackMeshTransformClaimed = UINT64_MAX;
 constexpr uint64_t kSkyHorizonAnchorSignature = UINT64_C(0x747837906D0BF484);
 constexpr uint64_t kSkyHorizonFollowerSignature = UINT64_C(0x1D253A52B55C9FB3);
 constexpr uint64_t kShadowDepthVertexShader = UINT64_C(0x4E1DA281CC3D7EDB);
@@ -575,6 +580,41 @@ struct DeferredSimpleModelTaskDispatch {
   uint32_t renderer_address = 0;
   uint32_t target_address = 0;
   bool active = false;
+};
+
+struct DirectIndexedDrawProducerSpec {
+  uint32_t return_address;
+  uint32_t producer_function;
+  const char *classification;
+};
+
+constexpr std::array<DirectIndexedDrawProducerSpec,
+                     kDirectIndexedDrawProducerCount>
+    kDirectIndexedDrawProducers{{
+        {0x823F59C8, 0x823F5980, "d3d9_device"},
+        {0x8240F020, 0x8240EE98, "navigation_map_renderer"},
+        {0x82412D90, 0x82412A28, "vector_font"},
+        {0x824131F4, 0x824131B8, "d3d9_device"},
+        {0x8243C8FC, 0x8243C050, "title_graphics_helper"},
+        {0x82473BDC, 0x82473868, "mirror_renderer"},
+        {0x82C4DC58, 0x82C4CCC8, "simple_model_renderer"},
+        {kUnifiedTrackMeshDrawReturn, 0x82C5ADC0,
+         "unified_track_presentation_mesh"},
+        {0x82C8E79C, 0x82C8E610, "livery_renderer"},
+        {0x82D841DC, 0x82D83350, "title_graphics_helper"},
+        {0x82DA154C, 0x82DA1148, "title_graphics_helper"},
+        {0x82DA1678, 0x82DA1148, "title_graphics_helper"},
+        {0x82DA1754, 0x82DA1148, "title_graphics_helper"},
+    }};
+
+struct UnifiedTrackMeshTransformEntry {
+  std::atomic<uint64_t> key{};
+  std::atomic<uint64_t> observations{};
+  std::atomic<uint64_t> last_frame{};
+  uint64_t transform_hash = 0;
+  uint64_t first_frame = 0;
+  uint32_t mesh_address = 0;
+  std::array<uint32_t, kModelPresentationTransformWordCount> transform_words{};
 };
 
 struct TitleDrawOrigin {
@@ -2827,6 +2867,22 @@ std::atomic<uint64_t> g_static_world_transform_joins{};
 std::atomic<uint64_t> g_static_world_transform_missing_joins{};
 std::atomic<uint64_t> g_static_world_transform_packet_origins{};
 std::atomic<uint64_t> g_static_world_transform_missing_packet_origins{};
+std::array<std::atomic<uint64_t>, kDirectIndexedDrawProducerCount>
+    g_direct_indexed_draw_producer_observations{};
+std::atomic<bool> g_direct_indexed_draw_producer_census_armed{};
+std::atomic<uint64_t> g_direct_indexed_draw_observations{};
+std::atomic<uint64_t> g_direct_indexed_draw_unknown_callers{};
+std::array<UnifiedTrackMeshTransformEntry,
+           kUnifiedTrackMeshTransformCapacity>
+    g_unified_track_mesh_transforms{};
+std::atomic<uint64_t> g_unified_track_mesh_observations{};
+std::atomic<uint64_t> g_unified_track_mesh_exact{};
+std::atomic<uint64_t> g_unified_track_mesh_read_faults{};
+std::atomic<uint64_t> g_unified_track_mesh_vtable_mismatches{};
+std::atomic<uint64_t> g_unified_track_mesh_nonfinite_transforms{};
+std::atomic<uint64_t> g_unified_track_mesh_transform_collisions{};
+std::atomic<uint64_t> g_unified_track_mesh_transform_overflow{};
+std::atomic<uint64_t> g_unified_track_mesh_transform_count{};
 std::array<SemanticBindingCacheSlot, 5> g_semantic_binding_cache_slots{};
 std::array<SemanticResolverCacheSlot, 5> g_semantic_resolver_cache_slots{};
 thread_local PendingSemanticResourceBindings g_pending_semantic_bindings{};
@@ -6243,6 +6299,8 @@ TitleDrawOrigin MakeTitleDrawOrigin(DispatchWrapper wrapper, uint32_t caller,
 }
 
 void ResetTitleDrawProvenance() {
+  g_direct_indexed_draw_producer_census_armed.store(
+      false, std::memory_order_release);
   std::scoped_lock lock(g_title_packet_provenance_mutex);
   for (TitlePacketProvenanceEntry &entry : g_title_packet_provenance) {
     entry = {};
@@ -6455,6 +6513,20 @@ void ResetTitleDrawProvenance() {
     entry.registrations.store(0, std::memory_order_relaxed);
     entry.renderer_joins.store(0, std::memory_order_relaxed);
   }
+  for (std::atomic<uint64_t> &observations :
+       g_direct_indexed_draw_producer_observations) {
+    observations.store(0, std::memory_order_relaxed);
+  }
+  for (UnifiedTrackMeshTransformEntry &entry :
+       g_unified_track_mesh_transforms) {
+    entry.key.store(0, std::memory_order_relaxed);
+    entry.observations.store(0, std::memory_order_relaxed);
+    entry.last_frame.store(0, std::memory_order_relaxed);
+    entry.transform_hash = 0;
+    entry.first_frame = 0;
+    entry.mesh_address = 0;
+    entry.transform_words = {};
+  }
   for (std::atomic<uint64_t> *counter : {
            &g_static_world_scope_entries,
            &g_static_world_scope_exits,
@@ -6579,6 +6651,16 @@ void ResetTitleDrawProvenance() {
            &g_static_world_transform_missing_joins,
            &g_static_world_transform_packet_origins,
            &g_static_world_transform_missing_packet_origins,
+           &g_direct_indexed_draw_observations,
+           &g_direct_indexed_draw_unknown_callers,
+           &g_unified_track_mesh_observations,
+           &g_unified_track_mesh_exact,
+           &g_unified_track_mesh_read_faults,
+           &g_unified_track_mesh_vtable_mismatches,
+           &g_unified_track_mesh_nonfinite_transforms,
+           &g_unified_track_mesh_transform_collisions,
+           &g_unified_track_mesh_transform_overflow,
+           &g_unified_track_mesh_transform_count,
        }) {
     counter->store(0, std::memory_order_relaxed);
   }
@@ -10794,6 +10876,137 @@ uint64_t HashCombine(uint64_t hash, uint64_t value) {
   return hash ^ value;
 }
 
+size_t DirectIndexedDrawProducerIndex(uint32_t return_address) {
+  for (size_t index = 0; index < kDirectIndexedDrawProducers.size();
+       ++index) {
+    if (kDirectIndexedDrawProducers[index].return_address == return_address) {
+      return index;
+    }
+  }
+  return kDirectIndexedDrawProducers.size();
+}
+
+void RecordUnifiedTrackMeshTransform(uint32_t mesh_address,
+                                     uint32_t transform_address) {
+  g_unified_track_mesh_observations.fetch_add(1,
+                                               std::memory_order_relaxed);
+  rex::memory::Memory *memory =
+      g_title_provenance_memory.load(std::memory_order_acquire);
+  if (!memory || !mesh_address || !transform_address ||
+      (mesh_address & 3) || (transform_address & 3) ||
+      transform_address >
+          UINT32_MAX - kModelPresentationTransformWordCount * 4) {
+    g_unified_track_mesh_read_faults.fetch_add(1,
+                                               std::memory_order_relaxed);
+    return;
+  }
+
+  uint32_t vtable = 0;
+  if (!LoadMappedGuestU32(memory, mesh_address, vtable)) {
+    g_unified_track_mesh_read_faults.fetch_add(1,
+                                               std::memory_order_relaxed);
+    return;
+  }
+  if (vtable != kTrackMeshVtable) {
+    g_unified_track_mesh_vtable_mismatches.fetch_add(
+        1, std::memory_order_relaxed);
+    return;
+  }
+
+  std::array<uint32_t, kModelPresentationTransformWordCount> words{};
+  bool finite = true;
+  for (size_t index = 0; index < words.size(); ++index) {
+    if (!LoadMappedGuestU32(memory,
+                            transform_address + uint32_t(index * 4),
+                            words[index])) {
+      g_unified_track_mesh_read_faults.fetch_add(
+          1, std::memory_order_relaxed);
+      return;
+    }
+    finite = finite && std::isfinite(std::bit_cast<float>(words[index]));
+  }
+  if (!finite) {
+    g_unified_track_mesh_nonfinite_transforms.fetch_add(
+        1, std::memory_order_relaxed);
+    return;
+  }
+
+  uint64_t transform_hash = 0xCBF29CE484222325ull;
+  for (uint32_t word : words) {
+    transform_hash = HashCombine(transform_hash, word);
+  }
+  transform_hash = transform_hash ? transform_hash : 1;
+  uint64_t key = HashCombine(transform_hash, mesh_address);
+  if (!key || key == kUnifiedTrackMeshTransformClaimed) {
+    key ^= UINT64_C(0x9E3779B97F4A7C15);
+  }
+  const uint64_t frame =
+      g_frame_sequence.load(std::memory_order_relaxed);
+  size_t table_index = size_t(key % kUnifiedTrackMeshTransformCapacity);
+  for (size_t probe = 0; probe < kUnifiedTrackMeshTransformCapacity;
+       ++probe) {
+    UnifiedTrackMeshTransformEntry &entry =
+        g_unified_track_mesh_transforms[table_index];
+    uint64_t observed = entry.key.load(std::memory_order_acquire);
+    if (!observed && entry.key.compare_exchange_strong(
+                         observed, kUnifiedTrackMeshTransformClaimed,
+                         std::memory_order_acq_rel,
+                         std::memory_order_acquire)) {
+      entry.transform_hash = transform_hash;
+      entry.first_frame = frame;
+      entry.mesh_address = mesh_address;
+      entry.transform_words = words;
+      entry.observations.store(1, std::memory_order_relaxed);
+      entry.last_frame.store(frame, std::memory_order_relaxed);
+      entry.key.store(key, std::memory_order_release);
+      g_unified_track_mesh_transform_count.fetch_add(
+          1, std::memory_order_relaxed);
+      g_unified_track_mesh_exact.fetch_add(1,
+                                           std::memory_order_relaxed);
+      return;
+    }
+    if (observed == key) {
+      if (entry.mesh_address == mesh_address &&
+          entry.transform_hash == transform_hash &&
+          entry.transform_words == words) {
+        entry.observations.fetch_add(1, std::memory_order_relaxed);
+        entry.last_frame.store(frame, std::memory_order_relaxed);
+        g_unified_track_mesh_exact.fetch_add(1,
+                                             std::memory_order_relaxed);
+        return;
+      }
+      g_unified_track_mesh_transform_collisions.fetch_add(
+          1, std::memory_order_relaxed);
+    }
+    table_index = (table_index + 1) % kUnifiedTrackMeshTransformCapacity;
+  }
+  g_unified_track_mesh_transform_overflow.fetch_add(
+      1, std::memory_order_relaxed);
+}
+
+void ObserveDirectIndexedDrawProducer(uint32_t mesh_address,
+                                      uint32_t transform_address,
+                                      uint32_t return_address) {
+  if (!g_direct_indexed_draw_producer_census_armed.load(
+          std::memory_order_acquire)) {
+    return;
+  }
+  g_direct_indexed_draw_observations.fetch_add(1,
+                                               std::memory_order_relaxed);
+  const size_t producer_index =
+      DirectIndexedDrawProducerIndex(return_address);
+  if (producer_index == kDirectIndexedDrawProducers.size()) {
+    g_direct_indexed_draw_unknown_callers.fetch_add(
+        1, std::memory_order_relaxed);
+    return;
+  }
+  g_direct_indexed_draw_producer_observations[producer_index].fetch_add(
+      1, std::memory_order_relaxed);
+  if (return_address == kUnifiedTrackMeshDrawReturn) {
+    RecordUnifiedTrackMeshTransform(mesh_address, transform_address);
+  }
+}
+
 uint32_t LoadSemanticGuestU32(rex::memory::Memory *memory,
                               uint32_t address) {
   return static_cast<uint32_t>(
@@ -13731,7 +13944,129 @@ void EmitStaticWorldRuntimeJoinEvent(const char *event_name,
        {"suppression_allowed", "false"}});
 }
 
+void EmitDirectIndexedDrawProducerSummary() {
+  uint64_t classified = 0;
+  for (size_t index = 0; index < kDirectIndexedDrawProducers.size();
+       ++index) {
+    const DirectIndexedDrawProducerSpec &producer =
+        kDirectIndexedDrawProducers[index];
+    const uint64_t observations =
+        g_direct_indexed_draw_producer_observations[index].load(
+            std::memory_order_relaxed);
+    classified += observations;
+    pinyon_shift::diagnostics::RecordEvent(
+        "native_renderer.discovery.direct_indexed_draw_producer_entry",
+        {{"emitter", fmt::format("{:08X}", kDirectIndexedDrawEmitter)},
+         {"return_address", fmt::format("{:08X}", producer.return_address)},
+         {"producer_function",
+          fmt::format("{:08X}", producer.producer_function)},
+         {"classification", producer.classification},
+         {"observations", std::to_string(observations)},
+         {"guest_payload_read", "false"},
+         {"guest_state_changed", "false"},
+         {"control_flow_changed", "false"},
+         {"native_admission", "false"},
+         {"native_draw", "false"},
+         {"xenos_authority", "true"},
+         {"suppression_allowed", "false"}});
+  }
+
+  uint64_t emitted_transforms = 0;
+  for (const UnifiedTrackMeshTransformEntry &entry :
+       g_unified_track_mesh_transforms) {
+    const uint64_t key = entry.key.load(std::memory_order_acquire);
+    if (!key || key == kUnifiedTrackMeshTransformClaimed) {
+      continue;
+    }
+    ++emitted_transforms;
+    pinyon_shift::diagnostics::RecordEvent(
+        "native_renderer.discovery.unified_track_mesh_transform_entry",
+        {{"emitter", fmt::format("{:08X}", kDirectIndexedDrawEmitter)},
+         {"return_address",
+          fmt::format("{:08X}", kUnifiedTrackMeshDrawReturn)},
+         {"producer_function", "82C5ADC0"},
+         {"mesh_vtable", fmt::format("{:08X}", kTrackMeshVtable)},
+         {"mesh_address", fmt::format("{:08X}", entry.mesh_address)},
+         {"transform_hash", fmt::format("{:016X}", entry.transform_hash)},
+         {"transform_words", FormatSemanticWords(entry.transform_words)},
+         {"observations",
+          std::to_string(entry.observations.load(
+              std::memory_order_relaxed))},
+         {"first_frame", std::to_string(entry.first_frame)},
+         {"last_frame",
+          std::to_string(entry.last_frame.load(std::memory_order_relaxed))},
+         {"classification", "exact_unified_track_mesh_draw_transform"},
+         {"guest_payload_read", "bounded_64_byte_live_transform"},
+         {"guest_state_changed", "false"},
+         {"control_flow_changed", "false"},
+         {"native_admission", "false"},
+         {"native_draw", "false"},
+         {"xenos_authority", "true"},
+         {"suppression_allowed", "false"}});
+  }
+
+  const uint64_t observations =
+      g_direct_indexed_draw_observations.load(std::memory_order_relaxed);
+  const uint64_t unknown =
+      g_direct_indexed_draw_unknown_callers.load(std::memory_order_relaxed);
+  const uint64_t track_observations =
+      g_unified_track_mesh_observations.load(std::memory_order_relaxed);
+  const uint64_t track_exact =
+      g_unified_track_mesh_exact.load(std::memory_order_relaxed);
+  const uint64_t read_faults =
+      g_unified_track_mesh_read_faults.load(std::memory_order_relaxed);
+  const uint64_t vtable_mismatches =
+      g_unified_track_mesh_vtable_mismatches.load(
+          std::memory_order_relaxed);
+  const uint64_t nonfinite =
+      g_unified_track_mesh_nonfinite_transforms.load(
+          std::memory_order_relaxed);
+  const uint64_t overflow =
+      g_unified_track_mesh_transform_overflow.load(
+          std::memory_order_relaxed);
+  const uint64_t transform_count =
+      g_unified_track_mesh_transform_count.load(std::memory_order_relaxed);
+  const bool accounting_complete =
+      observations == classified + unknown &&
+      track_observations ==
+          track_exact + read_faults + vtable_mismatches + nonfinite +
+              overflow &&
+      transform_count == emitted_transforms;
+  pinyon_shift::diagnostics::RecordEvent(
+      "native_renderer.discovery.direct_indexed_draw_producer_summary",
+      {{"status", accounting_complete ? "complete" : "incomplete"},
+       {"emitter", fmt::format("{:08X}", kDirectIndexedDrawEmitter)},
+       {"observations", std::to_string(observations)},
+       {"classified_observations", std::to_string(classified)},
+       {"unknown_callers", std::to_string(unknown)},
+       {"producer_count", std::to_string(kDirectIndexedDrawProducerCount)},
+       {"unified_track_mesh_observations",
+        std::to_string(track_observations)},
+       {"unified_track_mesh_exact", std::to_string(track_exact)},
+       {"unified_track_mesh_read_faults", std::to_string(read_faults)},
+       {"unified_track_mesh_vtable_mismatches",
+        std::to_string(vtable_mismatches)},
+       {"unified_track_mesh_nonfinite_transforms",
+        std::to_string(nonfinite)},
+       {"unified_track_mesh_transform_entries",
+        std::to_string(transform_count)},
+       {"unified_track_mesh_transform_collisions",
+        std::to_string(g_unified_track_mesh_transform_collisions.load(
+            std::memory_order_relaxed))},
+       {"unified_track_mesh_transform_overflow", std::to_string(overflow)},
+       {"accounting_complete", accounting_complete ? "true" : "false"},
+       {"classification",
+        "bounded_exact_direct_draw_producer_and_track_mesh_transform_census"},
+       {"guest_state_changed", "false"},
+       {"control_flow_changed", "false"},
+       {"native_admission", "false"},
+       {"native_draw", "false"},
+       {"xenos_authority", "true"},
+       {"suppression_allowed", "false"}});
+}
+
 void EmitStaticWorldRuntimeJoinSummary() {
+  EmitDirectIndexedDrawProducerSummary();
   EmitStaticWorldRuntimeJoinEvent(
       "native_renderer.discovery.static_world_runtime_join_summary", true,
       g_frame_sequence.load(std::memory_order_relaxed));
@@ -27751,6 +28086,11 @@ void InstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system,
        REXCVAR_GET(pinyon_shift_native_renderer_dispatch_discovery));
   ConfigureVehicleDiscovery(census_requested, memory);
   ConfigureTitleDrawProvenance(title_provenance_requested, memory);
+  g_direct_indexed_draw_producer_census_armed.store(
+      census_requested &&
+          REXCVAR_GET(pinyon_shift_native_renderer_dispatch_discovery) &&
+          memory,
+      std::memory_order_release);
   ConfigureShadowCasterProvenance(census_requested);
   const bool lineage_armed = observation_requested && memory;
   g_command_buffer_lineage_installed.store(false, std::memory_order_release);
@@ -28186,6 +28526,22 @@ void InstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system,
        {"deferred_task_handoff_hook", "82BA61DC"},
        {"deferred_task_join",
         "exact_deferred_renderer_to_task_to_callback_target"},
+       {"direct_indexed_draw_emitter", "82416380"},
+       {"direct_indexed_draw_producer_count",
+        std::to_string(kDirectIndexedDrawProducerCount)},
+       {"direct_indexed_draw_producer_hook", "82416380:r26,r31,lr"},
+       {"direct_indexed_draw_producer_census",
+        g_direct_indexed_draw_producer_census_armed.load(
+            std::memory_order_acquire)
+            ? "armed"
+            : "disabled"},
+       {"unified_track_mesh_draw_return", "82C5B038"},
+       {"unified_track_mesh_draw_producer", "82C5ADC0"},
+       {"unified_track_mesh_vtable", "8200143C"},
+       {"unified_track_mesh_transform",
+        "live_r31_16_be_u32_at_exact_draw_entry"},
+       {"unified_track_mesh_transform_capacity",
+        std::to_string(kUnifiedTrackMeshTransformCapacity)},
        {"presentation_resource_field", "presentation_plus_148"},
        {"presentation_renderer_field", "presentation_plus_1608"},
        {"presentation_resource_join",
@@ -30475,6 +30831,11 @@ void PinyonShiftObserveStaticWorldDeferredTaskCallback(
 void PinyonShiftObserveStaticWorldDeferredTaskHandoff(
     PPCRegister &r3, PPCRegister &r11) {
   ObserveStaticWorldDeferredTaskHandoff(r3.u32, r11.u32);
+}
+
+void PinyonShiftObserveDirectIndexedDrawProducer(
+    PPCRegister &r26, PPCRegister &r31, uint64_t &lr) {
+  ObserveDirectIndexedDrawProducer(r26.u32, r31.u32, uint32_t(lr));
 }
 
 void PinyonShiftObserveStaticWorldPresentationRendererHandoff(

--- a/tools/discover-native-renderer-direct-indexed-producers.py
+++ b/tools/discover-native-renderer-direct-indexed-producers.py
@@ -1,0 +1,233 @@
+#!/usr/bin/env python3
+"""Prove the bounded direct indexed-draw producer inventory and C2 track lead."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import pathlib
+import re
+import sys
+
+
+SCHEMA = "pinyon-shift.native-renderer-direct-indexed-producers.v1"
+IMAGE_BASE = 0x82000000
+FUNCTION_RE = re.compile(r"^DEFINE_REX_FUNC\(sub_([0-9A-F]{8})\) \{")
+LABEL_RE = re.compile(r"^loc_([0-9A-F]{8}):")
+COMMENT_RE = re.compile(r"^\s*//\s+(.+?)\s*$")
+DRAW_EMITTER = 0x82416380
+TRACK_MESH_VTABLE = 0x8200143C
+TRACK_PRESENTATION_VTABLE = 0x82243774
+TRACK_HELPER = 0x82C5ADC0
+TRACK_HELPER_RETURN = 0x82C5B038
+
+EXPECTED_CALLS = (
+    (0x823F5980, 0x823F59C4, 0x823F59C8, "d3d9_device"),
+    (0x8240EE98, 0x8240F01C, 0x8240F020, "navigation_map_renderer"),
+    (0x82412A28, 0x82412D8C, 0x82412D90, "vector_font"),
+    (0x824131B8, 0x824131F0, 0x824131F4, "d3d9_device"),
+    (0x8243C050, 0x8243C8F8, 0x8243C8FC, "title_graphics_helper"),
+    (0x82473868, 0x82473BD8, 0x82473BDC, "mirror_renderer"),
+    (0x82C4CCC8, 0x82C4DC54, 0x82C4DC58, "simple_model_renderer"),
+    (TRACK_HELPER, 0x82C5B034, TRACK_HELPER_RETURN,
+     "unified_track_presentation_mesh"),
+    (0x82C8E610, 0x82C8E798, 0x82C8E79C, "livery_renderer"),
+    (0x82D83350, 0x82D841D8, 0x82D841DC, "title_graphics_helper"),
+    (0x82DA1148, 0x82DA1548, 0x82DA154C, "title_graphics_helper"),
+    (0x82DA1148, 0x82DA1674, 0x82DA1678, "title_graphics_helper"),
+    (0x82DA1148, 0x82DA1750, 0x82DA1754, "title_graphics_helper"),
+)
+
+
+def parse_functions(paths: list[pathlib.Path]) -> dict[int, dict[int, str]]:
+    functions: dict[int, dict[int, str]] = {}
+    for path in sorted(paths, key=lambda item: item.as_posix()):
+        current = None
+        address = None
+        for line in path.read_text(encoding="utf-8").splitlines():
+            match = FUNCTION_RE.match(line)
+            if match:
+                current = functions.setdefault(int(match.group(1), 16), {})
+                address = int(match.group(1), 16)
+                continue
+            label = LABEL_RE.match(line)
+            if current is not None and label:
+                address = int(label.group(1), 16)
+                continue
+            comment = COMMENT_RE.match(line)
+            if current is not None and comment and address is not None:
+                current[address] = comment.group(1)
+                address += 4
+    return functions
+
+
+def image_u32(image: bytes, address: int) -> int:
+    offset = address - IMAGE_BASE
+    if offset < 0 or offset + 4 > len(image):
+        raise ValueError(f"image address is out of range: {address:08X}")
+    return int.from_bytes(image[offset : offset + 4], "big")
+
+
+def image_string(image: bytes, address: int) -> str:
+    offset = address - IMAGE_BASE
+    if offset < 0 or offset >= len(image):
+        raise ValueError(f"image string is out of range: {address:08X}")
+    end = image.find(b"\0", offset, min(offset + 192, len(image)))
+    if end < 0:
+        raise ValueError(f"image string is unterminated: {address:08X}")
+    return image[offset:end].decode("ascii")
+
+
+def require_instructions(functions, function_address, expected):
+    instructions = functions.get(function_address)
+    if instructions is None:
+        raise ValueError(f"missing function {function_address:08X}")
+    for address, text in expected.items():
+        if instructions.get(address) != text:
+            raise ValueError(
+                f"instruction drift at {address:08X}: "
+                f"expected {text!r}, got {instructions.get(address)!r}"
+            )
+
+
+def rtti_name(image: bytes, vtable: int) -> str:
+    locator = image_u32(image, vtable - 4)
+    if image_u32(image, locator) != 0:
+        raise ValueError(f"invalid complete-object locator at {locator:08X}")
+    descriptor = image_u32(image, locator + 12)
+    return image_string(image, descriptor + 8)
+
+
+def build(functions: dict[int, dict[int, str]], image: bytes) -> dict:
+    observed = sorted(
+        (function, address, address + 4)
+        for function, instructions in functions.items()
+        for address, text in instructions.items()
+        if text == f"bl 0x{DRAW_EMITTER:08x}"
+    )
+    expected = sorted((function, call, ret) for function, call, ret, _ in EXPECTED_CALLS)
+    if observed != expected:
+        raise ValueError("direct indexed-draw producer inventory drifted")
+
+    if rtti_name(image, TRACK_MESH_VTABLE) != ".?AVCTrackMesh@@":
+        raise ValueError("CTrackMesh RTTI evidence drifted")
+    if rtti_name(image, TRACK_PRESENTATION_VTABLE) != (
+        ".?AVCTrackPresentation@Presentation_Unified@@"
+    ):
+        raise ValueError("unified CTrackPresentation RTTI evidence drifted")
+
+    require_instructions(
+        functions,
+        TRACK_HELPER,
+        {
+            0x82C5ADD8: "mr r26,r6",
+            0x82C5ADE4: "mr r31,r7",
+            0x82C5AE04: "lfs f0,48(r31)",
+            0x82C5AE68: "lfs f0,16(r31)",
+            0x82C5AE98: "lfs f0,0(r31)",
+            0x82C5B014: "lwz r4,96(r26)",
+            0x82C5B024: "lwz r7,100(r26)",
+            0x82C5B02C: "lwz r4,36(r26)",
+            0x82C5B034: "bl 0x82416380",
+        },
+    )
+    require_instructions(
+        functions,
+        0x82DED198,
+        {
+            0x82DEDA2C: "addi r8,r1,688",
+            0x82DEDA30: "addi r7,r1,240",
+            0x82DEDA34: "mr r6,r29",
+            0x82DEDA44: "bl 0x82c5adc0",
+        },
+    )
+    require_instructions(
+        functions,
+        0x82436468,
+        {
+            0x82436500: "mr r7,r25",
+            0x82436504: "mr r6,r27",
+            0x82436514: "bl 0x82ded198",
+        },
+    )
+
+    presentation_dispatch = (0x8240E7B0, 0x82439B70, 0x82DEEEE0, 0x82DEF2B0)
+    for target in presentation_dispatch:
+        if not any(
+            text == "bl 0x82436468"
+            for text in functions.get(target, {}).values()
+        ):
+            raise ValueError(
+                f"unified track presentation caller {target:08X} drifted"
+            )
+    for slot, target in zip((79, 75, 78, 80), presentation_dispatch):
+        if image_u32(image, TRACK_PRESENTATION_VTABLE + slot * 4) != target:
+            raise ValueError(f"unified track presentation slot {slot} drifted")
+
+    return {
+        "schema": SCHEMA,
+        "status": "complete",
+        "classification": "bounded_direct_indexed_draw_producer_inventory",
+        "draw_emitter": f"{DRAW_EMITTER:08X}",
+        "producers": [
+            {
+                "function": f"{function:08X}",
+                "callsite": f"{call:08X}",
+                "return_address": f"{ret:08X}",
+                "classification": classification,
+            }
+            for function, call, ret, classification in EXPECTED_CALLS
+        ],
+        "c2_live_candidate": {
+            "producer": f"{TRACK_HELPER:08X}",
+            "return_address": f"{TRACK_HELPER_RETURN:08X}",
+            "mesh_class": "CTrackMesh",
+            "mesh_vtable": f"{TRACK_MESH_VTABLE:08X}",
+            "mesh_register": "r26",
+            "transform_register": "r31",
+            "transform_words": 16,
+            "upstream_owner": "Presentation_Unified::CTrackPresentation",
+            "upstream_owner_vtable": f"{TRACK_PRESENTATION_VTABLE:08X}",
+            "runtime_observation_pending": True,
+        },
+        "claims": {
+            "all_direct_callers_enumerated": True,
+            "unified_track_mesh_draw_edge_proved": True,
+            "unified_track_mesh_transform_edge_proved": True,
+            "runtime_activity_proved": False,
+            "building_or_prop_identity_proved": False,
+        },
+        "safety": {
+            "static_analysis_only": True,
+            "guest_payload_exported": False,
+            "native_admission": False,
+            "suppression_allowed": False,
+            "xenos_authority_required": True,
+        },
+    }
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("generated", type=pathlib.Path)
+    parser.add_argument("--image", required=True, type=pathlib.Path)
+    parser.add_argument("--output", required=True, type=pathlib.Path)
+    args = parser.parse_args(argv)
+    try:
+        document = build(
+            parse_functions(list(args.generated.glob("*.cpp"))),
+            args.image.read_bytes(),
+        )
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(
+            json.dumps(document, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        return 0
+    except (OSError, ValueError, UnicodeDecodeError) as error:
+        print(f"direct indexed producer discovery failed: {error}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/summarize-native-renderer-direct-indexed-producers.py
+++ b/tools/summarize-native-renderer-direct-indexed-producers.py
@@ -1,0 +1,264 @@
+#!/usr/bin/env python3
+"""Qualify the direct indexed-draw producer census and C2 track-mesh lead."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import pathlib
+import struct
+import sys
+
+
+SCHEMA = "pinyon-shift.native-renderer-direct-indexed-runtime.v1"
+CONFIG = "native_renderer.discovery.static_world_runtime_join_config"
+PRODUCER = "native_renderer.discovery.direct_indexed_draw_producer_entry"
+TRANSFORM = "native_renderer.discovery.unified_track_mesh_transform_entry"
+SUMMARY = "native_renderer.discovery.direct_indexed_draw_producer_summary"
+EXPECTED_RETURNS = (
+    "823F59C8", "8240F020", "82412D90", "824131F4", "8243C8FC",
+    "82473BDC", "82C4DC58", "82C5B038", "82C8E79C", "82D841DC",
+    "82DA154C", "82DA1678", "82DA1754",
+)
+MINIMUM_TRANSFORMS = 8
+
+
+def read_events(paths):
+    events = []
+    for path in paths:
+        with path.open(encoding="utf-8") as stream:
+            for line_number, line in enumerate(stream, 1):
+                if not line.strip():
+                    continue
+                try:
+                    event = json.loads(line)
+                except json.JSONDecodeError as error:
+                    raise ValueError(
+                        f"invalid JSON at {path}:{line_number}: {error}"
+                    ) from error
+                if isinstance(event, dict):
+                    events.append(event)
+    return events
+
+
+def integer(event, key):
+    try:
+        value = int(event[key])
+    except (KeyError, TypeError, ValueError) as error:
+        raise ValueError(f"invalid {key}") from error
+    if value < 0:
+        raise ValueError(f"negative {key}")
+    return value
+
+
+def hexadecimal(value, width, label):
+    value = str(value).upper()
+    if len(value) != width or any(c not in "0123456789ABCDEF" for c in value):
+        raise ValueError(f"invalid {label}")
+    return value
+
+
+def require_safety(event):
+    expected = {
+        "guest_state_changed": "false",
+        "control_flow_changed": "false",
+        "native_admission": "false",
+        "native_draw": "false",
+        "xenos_authority": "true",
+        "suppression_allowed": "false",
+    }
+    if any(event.get(key) != value for key, value in expected.items()):
+        raise ValueError("direct indexed producer evidence violates safety")
+
+
+def select_session(events, requested):
+    sessions = {
+        str(event.get("session"))
+        for event in events
+        if event.get("event") == CONFIG and event.get("session")
+    }
+    if requested:
+        if requested not in sessions:
+            raise ValueError("requested session is missing")
+        session = requested
+    elif len(sessions) == 1:
+        session = next(iter(sessions))
+    else:
+        raise ValueError("input must contain exactly one candidate session")
+    return session, [event for event in events if str(event.get("session")) == session]
+
+
+def parse_words(event):
+    raw = str(event.get("transform_words", "")).split(",")
+    if len(raw) != 16:
+        raise ValueError("track mesh transform does not contain 16 words")
+    words = tuple(int(hexadecimal(word, 8, "transform word"), 16) for word in raw)
+    if not all(math.isfinite(struct.unpack(">f", word.to_bytes(4, "big"))[0]) for word in words):
+        raise ValueError("track mesh transform contains a non-finite word")
+    return words
+
+
+def build(events, requested_session=None, minimum_transforms=MINIMUM_TRANSFORMS):
+    if minimum_transforms < 1:
+        raise ValueError("minimum transforms must be positive")
+    session, selected = select_session(events, requested_session)
+    configs = [event for event in selected if event.get("event") == CONFIG]
+    summaries = [event for event in selected if event.get("event") == SUMMARY]
+    starts = [event for event in selected if event.get("event") == "process.start"]
+    shutdowns = [event for event in selected if event.get("event") == "process.shutdown"]
+    if len(configs) != 1 or len(summaries) != 1:
+        raise ValueError("direct indexed producer lifecycle is incomplete")
+    if len(starts) != 1 or len(shutdowns) != 1:
+        raise ValueError("process lifecycle is incomplete")
+    config = configs[0]
+    summary = summaries[0]
+    expected_config = {
+        "status": "armed",
+        "direct_indexed_draw_emitter": "82416380",
+        "direct_indexed_draw_producer_count": "13",
+        "direct_indexed_draw_producer_hook": "82416380:r26,r31,lr",
+        "direct_indexed_draw_producer_census": "armed",
+        "unified_track_mesh_draw_return": "82C5B038",
+        "unified_track_mesh_draw_producer": "82C5ADC0",
+        "unified_track_mesh_vtable": "8200143C",
+        "unified_track_mesh_transform": "live_r31_16_be_u32_at_exact_draw_entry",
+        "unified_track_mesh_transform_capacity": "4096",
+    }
+    if any(config.get(key) != value for key, value in expected_config.items()):
+        raise ValueError("direct indexed producer config drifted")
+    require_safety(summary)
+
+    producers = [event for event in selected if event.get("event") == PRODUCER]
+    if len(producers) != len(EXPECTED_RETURNS):
+        raise ValueError("direct indexed producer entry count drifted")
+    by_return = {}
+    classified = 0
+    for event in producers:
+        require_safety(event)
+        if event.get("emitter") != "82416380":
+            raise ValueError("direct indexed producer emitter drifted")
+        address = hexadecimal(event.get("return_address", ""), 8, "return address")
+        if address in by_return:
+            raise ValueError("duplicate direct indexed producer")
+        by_return[address] = event
+        classified += integer(event, "observations")
+    if tuple(sorted(by_return)) != tuple(sorted(EXPECTED_RETURNS)):
+        raise ValueError("direct indexed producer inventory drifted")
+
+    transforms = [event for event in selected if event.get("event") == TRANSFORM]
+    transform_keys = set()
+    transform_observations = 0
+    for event in transforms:
+        require_safety(event)
+        if (
+            event.get("emitter") != "82416380"
+            or event.get("return_address") != "82C5B038"
+            or event.get("producer_function") != "82C5ADC0"
+            or event.get("mesh_vtable") != "8200143C"
+            or event.get("classification") != "exact_unified_track_mesh_draw_transform"
+        ):
+            raise ValueError("unified track mesh transform boundary drifted")
+        key = (
+            hexadecimal(event.get("mesh_address", ""), 8, "mesh address"),
+            hexadecimal(event.get("transform_hash", ""), 16, "transform hash"),
+        )
+        words = parse_words(event)
+        if key in transform_keys:
+            raise ValueError("duplicate unified track mesh transform")
+        transform_keys.add(key)
+        observations = integer(event, "observations")
+        first_frame = integer(event, "first_frame")
+        last_frame = integer(event, "last_frame")
+        if not observations or first_frame > last_frame or not any(words):
+            raise ValueError("invalid unified track mesh transform entry")
+        transform_observations += observations
+
+    totals = {
+        key: integer(summary, key)
+        for key in (
+            "observations", "classified_observations", "unknown_callers",
+            "producer_count", "unified_track_mesh_observations",
+            "unified_track_mesh_exact", "unified_track_mesh_read_faults",
+            "unified_track_mesh_vtable_mismatches",
+            "unified_track_mesh_nonfinite_transforms",
+            "unified_track_mesh_transform_entries",
+            "unified_track_mesh_transform_collisions",
+            "unified_track_mesh_transform_overflow",
+        )
+    }
+    failures = []
+    if summary.get("status") != "complete" or summary.get("accounting_complete") != "true":
+        failures.append("runtime accounting is incomplete")
+    if totals["observations"] != classified or totals["classified_observations"] != classified:
+        failures.append("producer observation accounting does not balance")
+    if totals["producer_count"] != len(EXPECTED_RETURNS):
+        failures.append("producer count drifted")
+    if totals["unknown_callers"]:
+        failures.append("unknown direct indexed-draw callers were observed")
+    track_calls = integer(by_return["82C5B038"], "observations")
+    if not track_calls or track_calls != totals["unified_track_mesh_observations"]:
+        failures.append("unified track mesh producer was not observed exactly")
+    if totals["unified_track_mesh_exact"] != track_calls or transform_observations != track_calls:
+        failures.append("unified track mesh exact accounting does not balance")
+    for key in (
+        "unified_track_mesh_read_faults",
+        "unified_track_mesh_vtable_mismatches",
+        "unified_track_mesh_nonfinite_transforms",
+        "unified_track_mesh_transform_collisions",
+        "unified_track_mesh_transform_overflow",
+    ):
+        if totals[key]:
+            failures.append(f"{key} is nonzero")
+    if totals["unified_track_mesh_transform_entries"] != len(transforms):
+        failures.append("unified track mesh transform entry count does not balance")
+    if len(transforms) < minimum_transforms:
+        failures.append("too few distinct unified track mesh transforms")
+
+    status = "complete" if not failures else "incomplete"
+    return {
+        "schema": SCHEMA,
+        "session": session,
+        "status": status,
+        "failures": failures,
+        "totals": totals,
+        "qualification": {
+            "direct_indexed_draw_producer_inventory_proved": not failures,
+            "unified_track_mesh_draw_activity_proved": not failures,
+            "unified_track_mesh_transform_boundary_proved": not failures,
+            "building_or_prop_instance_identity_proved": False,
+            "native_admission": False,
+            "suppression_allowed": False,
+        },
+        "safety": {
+            "guest_state_changed": False,
+            "control_flow_changed": False,
+            "native_admission": False,
+            "native_draw": False,
+            "xenos_authority": True,
+            "suppression_allowed": False,
+        },
+    }
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("events", nargs="+", type=pathlib.Path)
+    parser.add_argument("--session")
+    parser.add_argument("--minimum-transforms", type=int, default=MINIMUM_TRANSFORMS)
+    parser.add_argument("--output", required=True, type=pathlib.Path)
+    args = parser.parse_args(argv)
+    try:
+        document = build(read_events(args.events), args.session, args.minimum_transforms)
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(json.dumps(document, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+        if document["status"] != "complete":
+            raise ValueError("; ".join(document["failures"]))
+        return 0
+    except (OSError, ValueError, json.JSONDecodeError) as error:
+        print(f"direct indexed producer qualification failed: {error}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/tests/test_native_renderer_direct_indexed_producers.py
+++ b/tools/tests/test_native_renderer_direct_indexed_producers.py
@@ -1,0 +1,121 @@
+import importlib.util
+import pathlib
+import unittest
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / "tools" / "discover-native-renderer-direct-indexed-producers.py"
+SPEC = importlib.util.spec_from_file_location("direct_indexed_producers", SCRIPT)
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+def fixture():
+    functions = {}
+    for function, call, _return, _classification in MODULE.EXPECTED_CALLS:
+        functions.setdefault(function, {})[call] = "bl 0x82416380"
+    functions[MODULE.TRACK_HELPER].update(
+        {
+            0x82C5ADD8: "mr r26,r6",
+            0x82C5ADE4: "mr r31,r7",
+            0x82C5AE04: "lfs f0,48(r31)",
+            0x82C5AE68: "lfs f0,16(r31)",
+            0x82C5AE98: "lfs f0,0(r31)",
+            0x82C5B014: "lwz r4,96(r26)",
+            0x82C5B024: "lwz r7,100(r26)",
+            0x82C5B02C: "lwz r4,36(r26)",
+        }
+    )
+    functions[0x82DED198] = {
+        0x82DEDA2C: "addi r8,r1,688",
+        0x82DEDA30: "addi r7,r1,240",
+        0x82DEDA34: "mr r6,r29",
+        0x82DEDA44: "bl 0x82c5adc0",
+    }
+    functions[0x82436468] = {
+        0x82436500: "mr r7,r25",
+        0x82436504: "mr r6,r27",
+        0x82436514: "bl 0x82ded198",
+    }
+    presentation_dispatch = (0x8240E7B0, 0x82439B70, 0x82DEEEE0, 0x82DEF2B0)
+    for target in presentation_dispatch:
+        functions[target] = {target: "bl 0x82436468"}
+
+    image = bytearray(0x310000)
+
+    def put_u32(address, value):
+        offset = address - MODULE.IMAGE_BASE
+        image[offset : offset + 4] = value.to_bytes(4, "big")
+
+    def put_rtti(vtable, locator, descriptor, name):
+        put_u32(vtable - 4, locator)
+        put_u32(locator, 0)
+        put_u32(locator + 12, descriptor)
+        encoded = name.encode("ascii") + b"\0"
+        offset = descriptor + 8 - MODULE.IMAGE_BASE
+        image[offset : offset + len(encoded)] = encoded
+
+    put_rtti(
+        MODULE.TRACK_MESH_VTABLE,
+        0x82300000,
+        0x82300100,
+        ".?AVCTrackMesh@@",
+    )
+    put_rtti(
+        MODULE.TRACK_PRESENTATION_VTABLE,
+        0x82300200,
+        0x82300300,
+        ".?AVCTrackPresentation@Presentation_Unified@@",
+    )
+    for slot, target in zip((79, 75, 78, 80), presentation_dispatch):
+        put_u32(MODULE.TRACK_PRESENTATION_VTABLE + slot * 4, target)
+    return functions, bytes(image)
+
+
+class DirectIndexedProducerTests(unittest.TestCase):
+    def test_proves_inventory_and_track_mesh_candidate(self):
+        functions, image = fixture()
+        report = MODULE.build(functions, image)
+        self.assertEqual("complete", report["status"])
+        self.assertEqual(13, len(report["producers"]))
+        candidate = report["c2_live_candidate"]
+        self.assertEqual("82C5ADC0", candidate["producer"])
+        self.assertEqual("CTrackMesh", candidate["mesh_class"])
+        self.assertEqual(16, candidate["transform_words"])
+        self.assertFalse(report["claims"]["runtime_activity_proved"])
+        self.assertFalse(report["claims"]["building_or_prop_identity_proved"])
+
+    def test_rejects_a_missing_draw_producer(self):
+        functions, image = fixture()
+        del functions[0x8240EE98][0x8240F01C]
+        with self.assertRaisesRegex(ValueError, "inventory drifted"):
+            MODULE.build(functions, image)
+
+    def test_rejects_track_transform_drift(self):
+        functions, image = fixture()
+        functions[MODULE.TRACK_HELPER][0x82C5ADE4] = "mr r30,r7"
+        with self.assertRaisesRegex(ValueError, "instruction drift"):
+            MODULE.build(functions, image)
+
+    def test_runtime_hook_is_bounded_and_passive(self):
+        analysis = (
+            ROOT / "config" / "rexglue" / "analysis" / "main-xex.toml"
+        ).read_text(encoding="utf-8")
+        hooks = (ROOT / "src" / "native_renderer" / "graphics_hooks.cpp").read_text(
+            encoding="utf-8"
+        )
+        self.assertIn("address = 0x82416380", analysis)
+        self.assertIn(
+            'name = "PinyonShiftObserveDirectIndexedDrawProducer"', analysis
+        )
+        self.assertIn('registers = ["r26", "r31", "lr"]', analysis)
+        self.assertIn("kDirectIndexedDrawProducerCount = 13", hooks)
+        self.assertIn("kUnifiedTrackMeshTransformCapacity = 4096", hooks)
+        self.assertIn("bounded_64_byte_live_transform", hooks)
+        self.assertIn('{"guest_state_changed", "false"}', hooks)
+        self.assertIn('{"native_admission", "false"}', hooks)
+        self.assertIn('{"xenos_authority", "true"}', hooks)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/tests/test_native_renderer_direct_indexed_runtime.py
+++ b/tools/tests/test_native_renderer_direct_indexed_runtime.py
@@ -1,0 +1,156 @@
+import importlib.util
+import pathlib
+import struct
+import unittest
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / "tools" / "summarize-native-renderer-direct-indexed-producers.py"
+SPEC = importlib.util.spec_from_file_location("direct_indexed_runtime", SCRIPT)
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+SESSION = "direct-indexed-test"
+
+
+def safety():
+    return {
+        "guest_state_changed": "false",
+        "control_flow_changed": "false",
+        "native_admission": "false",
+        "native_draw": "false",
+        "xenos_authority": "true",
+        "suppression_allowed": "false",
+    }
+
+
+def float_word(value):
+    return f"{int.from_bytes(struct.pack('>f', value), 'big'):08X}"
+
+
+def events():
+    result = [
+        {"event": "process.start", "session": SESSION},
+        {
+            "event": MODULE.CONFIG,
+            "session": SESSION,
+            "status": "armed",
+            "direct_indexed_draw_emitter": "82416380",
+            "direct_indexed_draw_producer_count": "13",
+            "direct_indexed_draw_producer_hook": "82416380:r26,r31,lr",
+            "direct_indexed_draw_producer_census": "armed",
+            "unified_track_mesh_draw_return": "82C5B038",
+            "unified_track_mesh_draw_producer": "82C5ADC0",
+            "unified_track_mesh_vtable": "8200143C",
+            "unified_track_mesh_transform": "live_r31_16_be_u32_at_exact_draw_entry",
+            "unified_track_mesh_transform_capacity": "4096",
+        },
+    ]
+    for index, address in enumerate(MODULE.EXPECTED_RETURNS):
+        observations = 16 if address == "82C5B038" else (84 if index == 0 else 0)
+        result.append(
+            {
+                "event": MODULE.PRODUCER,
+                "session": SESSION,
+                "emitter": "82416380",
+                "return_address": address,
+                "producer_function": "82C5ADC0" if address == "82C5B038" else "82400000",
+                "classification": "unified_track_presentation_mesh" if address == "82C5B038" else "fixture",
+                "observations": str(observations),
+                **safety(),
+            }
+        )
+    identity = [
+        float_word(1.0), float_word(0.0), float_word(0.0), float_word(0.0),
+        float_word(0.0), float_word(1.0), float_word(0.0), float_word(0.0),
+        float_word(0.0), float_word(0.0), float_word(1.0), float_word(0.0),
+        float_word(0.0), float_word(0.0), float_word(0.0), float_word(1.0),
+    ]
+    for index in range(8):
+        words = list(identity)
+        words[12] = float_word(float(index + 1))
+        result.append(
+            {
+                "event": MODULE.TRANSFORM,
+                "session": SESSION,
+                "emitter": "82416380",
+                "return_address": "82C5B038",
+                "producer_function": "82C5ADC0",
+                "mesh_vtable": "8200143C",
+                "mesh_address": f"A000{index:04X}",
+                "transform_hash": f"{index + 1:016X}",
+                "transform_words": ",".join(words),
+                "observations": "2",
+                "first_frame": str(index + 1),
+                "last_frame": str(index + 2),
+                "classification": "exact_unified_track_mesh_draw_transform",
+                **safety(),
+            }
+        )
+    result.extend(
+        [
+            {
+                "event": MODULE.SUMMARY,
+                "session": SESSION,
+                "status": "complete",
+                "observations": "100",
+                "classified_observations": "100",
+                "unknown_callers": "0",
+                "producer_count": "13",
+                "unified_track_mesh_observations": "16",
+                "unified_track_mesh_exact": "16",
+                "unified_track_mesh_read_faults": "0",
+                "unified_track_mesh_vtable_mismatches": "0",
+                "unified_track_mesh_nonfinite_transforms": "0",
+                "unified_track_mesh_transform_entries": "8",
+                "unified_track_mesh_transform_collisions": "0",
+                "unified_track_mesh_transform_overflow": "0",
+                "accounting_complete": "true",
+                **safety(),
+            },
+            {"event": "process.shutdown", "session": SESSION},
+        ]
+    )
+    return result
+
+
+class DirectIndexedRuntimeTests(unittest.TestCase):
+    def test_qualifies_exact_track_mesh_activity(self):
+        report = MODULE.build(events())
+        self.assertEqual("complete", report["status"])
+        self.assertTrue(
+            report["qualification"]["unified_track_mesh_transform_boundary_proved"]
+        )
+        self.assertFalse(
+            report["qualification"]["building_or_prop_instance_identity_proved"]
+        )
+
+    def test_rejects_unknown_caller(self):
+        observed = events()
+        summary = next(event for event in observed if event["event"] == MODULE.SUMMARY)
+        summary["unknown_callers"] = "1"
+        summary["observations"] = "101"
+        report = MODULE.build(observed)
+        self.assertEqual("incomplete", report["status"])
+        self.assertTrue(any("unknown" in failure for failure in report["failures"]))
+
+    def test_rejects_too_few_transforms(self):
+        observed = [event for event in events() if not (
+            event.get("event") == MODULE.TRANSFORM and event.get("mesh_address") == "A0000007"
+        )]
+        summary = next(event for event in observed if event["event"] == MODULE.SUMMARY)
+        summary["unified_track_mesh_transform_entries"] = "7"
+        summary["unified_track_mesh_exact"] = "14"
+        summary["unified_track_mesh_observations"] = "14"
+        producer = next(event for event in observed if event.get("return_address") == "82C5B038" and event.get("event") == MODULE.PRODUCER)
+        producer["observations"] = "14"
+        summary["observations"] = "98"
+        summary["classified_observations"] = "98"
+        report = MODULE.build(observed)
+        self.assertEqual("incomplete", report["status"])
+        self.assertIn("too few distinct unified track mesh transforms", report["failures"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- enumerate all 13 direct callers of the title indexed-draw emitter
- capture the exact unified track-presentation CTrackMesh and live transform as the new C2 ingress candidate
- add static and runtime fail-closed qualifiers while preserving Xenos authority

## Validation
- incremental Release build and link
- 31 focused native-renderer tests
- static producer proof against the generated AOT tree and retail image

Full AppData gameplay validation is intentionally batched with the next transform-to-catalog slice.