### PR TITLE
feat(renderer): include exact track world in prototype

### DIFF
--- a/docs/native-renderer/CONTINUOUS_WORLD_WORKSET.md
+++ b/docs/native-renderer/CONTINUOUS_WORLD_WORKSET.md
@@ -4,9 +4,11 @@ Phase B1 promotes the qualified visibility-selected private replay from one
 draw per frame to a bounded multi-draw target that can participate in the
 existing continuous native composition path.
 
-This checkpoint is default-off and does not suppress any Xenos work. It proves
-the accumulation and freshness contract before expanding material-family
-coverage or claiming a coherent native scene.
+As a standalone experiment this checkpoint is default-off and does not
+suppress any Xenos work. The `native_prototype` renderer selector arms the
+workset and its exact track-world family automatically. It proves the
+accumulation and freshness contract before expanding material-family coverage
+or claiming a coherent native scene.
 
 ## Selection
 
@@ -23,7 +25,9 @@ census and semantic dispatch discovery so every admitted draw has:
   prepared-layout lineage; and
 - exact title-to-backend lineage.
 
-For the C1 qualification probe, add `-ContinuousTrackWorld`. Semantic draws
+For an explicit C1 qualification probe, add `-ContinuousTrackWorld`. The same
+selection is the default when `native_prototype` is active unless
+`PINYON_SHIFT_NATIVE_RENDERER_CONTINUOUS_TRACK_WORLD=false` is set. Semantic draws
 then require both the exact unified track render-model scope and a nonzero
 shared world-resource identity mask: the same RTTI-proved track model, mesh,
 submodel, procedural-geometry, or PVS-zone object/resource address must occur

--- a/docs/native-renderer/DIRECT_INDEXED_DRAW_PRODUCERS.md
+++ b/docs/native-renderer/DIRECT_INDEXED_DRAW_PRODUCERS.md
@@ -1,6 +1,6 @@
 # Direct indexed-draw producers and the live C2 candidate
 
-Status: producer-to-prepared provenance implemented; batched runtime qualification pending
+Status: producer-to-prepared provenance implemented; tested candidate inactive
 
 ## Why C2 changed direction
 
@@ -54,9 +54,25 @@ python tools/discover-native-renderer-direct-indexed-producers.py `
   --output .local/qualification/native-renderer-direct-indexed-producers.json
 ```
 
-## Next batched gate
+## Runtime result
 
-The next combined AppData session must establish that `82C5B038` is active,
+Clean AppData session `20260901T022910Z-p35168` completed normally in the
+festival world with Xenos authoritative. All 68,356 direct indexed-draw scopes
+balanced, all observations belonged to the closed 13-caller inventory, and no
+scope overlap, missing exit, unknown caller, or accounting failure occurred.
+The exact `82C5B038` unified-track helper recorded zero calls. The dormant
+`82C4DC58` SimpleModel helper also remained at zero.
+
+The active direct families were vector font (50,974), D3D9 device (10,589),
+and generic title graphics helpers (6,793). None supplies the RTTI-proved
+static-world instance and transform contract required by C2. The exact unified
+track edge is therefore retained as safe passive instrumentation, but it is not
+the active road or building/prop ingress in this representative saved scene.
+No catalog classification was attempted from an empty exact population.
+
+## Deferred recheck gate
+
+Any future scene-specific recheck must establish that `82C5B038` is active,
 that every observation has the exact `CTrackMesh` vtable and a finite mapped
 transform, and that every exact scope reaches a prepared draw. The existing
 offline instance classifier now accepts `--origin unified_track_mesh`; it tests
@@ -81,6 +97,6 @@ python tools/summarize-native-renderer-static-world-instance-classification.py `
   --output .local/qualification/native-renderer-track-mesh-classification.json
 ```
 
-Until that evidence exists, this is a candidate ingress only. It enables no
+Until that evidence exists, this remains an inactive candidate ingress only. It enables no
 native admission, guest publication, Xenos suppression, or building/prop
 claim; Xenos remains authoritative.

--- a/docs/native-renderer/NATIVE_PROTOTYPE_PRESENTATION.md
+++ b/docs/native-renderer/NATIVE_PROTOTYPE_PRESENTATION.md
@@ -3,8 +3,11 @@
 Phase B2 replaces the retained-pass diagnostic crop with a complete logical
 scene presentation mode. The `native_prototype` renderer remains
 restart-gated, default-off, and fail-closed. Selecting it automatically arms
-the bounded continuous world workset from Phase B1; the environment override
-remains available to capture tooling.
+the bounded continuous world workset from Phase B1 and the runtime-proved exact
+indirect track-world family from C1. Environment overrides remain available to
+capture tooling; setting
+`PINYON_SHIFT_NATIVE_RENDERER_CONTINUOUS_TRACK_WORLD=false` explicitly removes
+the exact track family without changing the Xenos fallback.
 
 For an exact current-frame retained target, ReXGlue maps the draw-derived
 logical scene extent out of the padded backing allocation into a private

--- a/docs/native-renderer/REPRIORITIZED_PLAN.md
+++ b/docs/native-renderer/REPRIORITIZED_PLAN.md
@@ -457,6 +457,16 @@ live-candidate draw edge without yet claiming runtime activity or a concrete
 building/prop category. Static proof and the next batched gate are documented
 in [`DIRECT_INDEXED_DRAW_PRODUCERS.md`](DIRECT_INDEXED_DRAW_PRODUCERS.md).
 
+Runtime pivot result: clean festival-world session
+`20260901T022910Z-p35168` balanced all 68,356 direct indexed-draw scopes with
+zero unknown callers or lifecycle faults, but both the exact unified-track
+helper `82C5B038` and SimpleModel helper `82C4DC58` remained inactive. The
+proven indirect track route remained healthy with 485 balanced exact scopes,
+485 packet joins, and 732 prepared-draw joins. C1 therefore stays on that
+indirect route; the direct unified-track edge is deferred until a scene proves
+it live, and C2 must not infer building/prop identity from generic active
+helpers.
+
 ### C2. Static world buildings and props
 
 - Expand opaque-world material and geometry coverage.
@@ -601,7 +611,7 @@ collision and gameplay manifests produce a payload-free catalog of 24,025
 hashed spatial entries (21,877 collision props and 2,148 gameplay objects).
 See
 [`STATIC_WORLD_INSTANCE_CLASSIFICATION.md`](STATIC_WORLD_INSTANCE_CLASSIFICATION.md).
-The next combined C1/C2 AppData run must prove the matrix convention and a
+The next C2-specific AppData run must prove the matrix convention and a
 unique runtime-to-catalog match; no building/prop category, native admission,
 or suppression is claimed yet.
 
@@ -613,17 +623,27 @@ process lifecycle, and a complete static-world runtime summary. The qualifier
 is ready for the deferred combined AppData run; it cannot self-qualify from
 static fixtures and still enables no native admission or suppression.
 
-Live C2 ingress checkpoint: the closed 13-caller indexed-draw inventory found
-an active candidate independent of the dormant SimpleModel graph. Exact unified
+Candidate C2 ingress checkpoint: the closed 13-caller indexed-draw inventory
+found a statically exact candidate independent of the dormant SimpleModel
+graph. Exact unified
 track helper `82C5ADC0` carries RTTI-proved `CTrackMesh` plus its 64-byte live
 transform into emitter `82416380`. A balanced entry/common-exit scope now joins
 that identity through the synchronous PM4 packet into prepared-draw provenance,
 with separate lifecycle, packet, and prepared counters. The catalog qualifier
 can consume this alternate origin via `--origin unified_track_mesh`. See
-[`DIRECT_INDEXED_DRAW_PRODUCERS.md`](DIRECT_INDEXED_DRAW_PRODUCERS.md). The next
-batched AppData run must prove the path is live and uniquely maps at least eight
+[`DIRECT_INDEXED_DRAW_PRODUCERS.md`](DIRECT_INDEXED_DRAW_PRODUCERS.md). Clean
+session `20260901T022910Z-p35168` proved the complete direct producer inventory
+and balanced lifecycle, but recorded zero calls from `82C5B038`. A future
+scene-specific recheck must first prove the path live and then uniquely map at least eight
 instances, including a collision prop. This is evidence-only: native admission
 and suppression remain disabled and Xenos remains authoritative.
+
+C1 visible-prototype promotion checkpoint: because the same clean session
+reconfirmed the indirect route's exact packet/prepared lineage, selecting
+`native_prototype` now also requests the exact track-world family by default.
+An explicit `PINYON_SHIFT_NATIVE_RENDERER_CONTINUOUS_TRACK_WORLD=false` remains
+a fail-safe override. The existing mechanical eligibility, one-frame private
+target, swap commit, fallback, and Xenos-authority gates are unchanged.
 
 Native-output implementation checkpoint: the existing one-frame,
 swap-committed continuous world target now has an independent default-off

--- a/src/native_renderer/graphics_hooks.cpp
+++ b/src/native_renderer/graphics_hooks.cpp
@@ -10362,10 +10362,10 @@ void ConfigureContinuousWorldWorkset() {
 
   value = nullptr;
   length = 0;
-  if (_dupenv_s(
-          &value, &length,
-          "PINYON_SHIFT_NATIVE_RENDERER_CONTINUOUS_TRACK_WORLD") == 0 &&
-      value && length > 1) {
+  const errno_t track_world_environment = _dupenv_s(
+      &value, &length,
+      "PINYON_SHIFT_NATIVE_RENDERER_CONTINUOUS_TRACK_WORLD");
+  if (track_world_environment == 0 && value && length > 1) {
     const std::string setting(value);
     if (setting != "false") {
       g_continuous_world_workset.track_world_requested = true;
@@ -10373,6 +10373,12 @@ void ConfigureContinuousWorldWorkset() {
         g_continuous_world_workset.valid = false;
       }
     }
+  } else if (track_world_environment == 0 && prototype_selected) {
+    // The exact indirect track lineage is the only runtime-proved terrain and
+    // road family. Include it in the visible prototype by default while
+    // preserving an explicit false environment override and every existing
+    // mechanical, publication, and Xenos-authority gate.
+    g_continuous_world_workset.track_world_requested = true;
   }
   std::free(value);
   if (g_continuous_world_workset.track_world_requested &&

--- a/tools/tests/test_native_renderer_continuous_world_workset.py
+++ b/tools/tests/test_native_renderer_continuous_world_workset.py
@@ -138,6 +138,9 @@ class ContinuousWorldWorksetTests(unittest.TestCase):
         self.assertIn(
             "PINYON_SHIFT_NATIVE_RENDERER_CONTINUOUS_TRACK_WORLD", source
         )
+        self.assertIn(
+            "track_world_environment == 0 && prototype_selected", source
+        )
         self.assertIn("kTrackTextureUnifiedVtable = 0x82001708", source)
         self.assertIn("non_track_provider_rejections", source)
         self.assertIn('"native_renderer.continuous_world_workset.summary"', source)


### PR DESCRIPTION
## Summary
- default the proven indirect track-world family on when 
ative_prototype is selected
- preserve the explicit false override, mechanical gates, private swap-committed target, Xenos draws, and fallback
- record the clean AppData result that the direct unified-track and SimpleModel candidates are inactive in the representative festival scene

## Validation
- clean AppData session 20260901T022910Z-p35168: normal exit, 68,356/68,356 balanced direct scopes, 0 unknown callers, 485/485 exact indirect track scopes, 485 packet joins, 732 prepared joins
- python -m unittest tools.tests.test_native_renderer_continuous_world_workset tools.tests.test_native_renderer_direct_indexed_producers tools.tests.test_native_renderer_phase_c_profile (23 passed)
- full local rebuild intentionally deferred to the next batched visual checkpoint; CI is the compile gate for this focused slice