### PR TITLE
feat(renderer): census track prepared layouts

### DIFF
--- a/docs/native-renderer/REPRIORITIZED_PLAN.md
+++ b/docs/native-renderer/REPRIORITIZED_PLAN.md
@@ -467,6 +467,19 @@ indirect route; the direct unified-track edge is deferred until a scene proves
 it live, and C2 must not infer building/prop identity from generic active
 helpers.
 
+Prepared-layout pivot checkpoint: the proven indirect track lineage now retains
+at most 512 shader-decoded prepared-layout families, keyed by the exact track
+root/child/descriptor tuple and pipeline/layout/render-state contract. Final
+shutdown emits one bounded numeric metadata sample per family plus complete
+exact, unbounded, parameter-overflow, and table-overflow accounting. The offline
+report identifies recurring finite vertex-constant register runs for comparison
+against the static world transform catalog. This replaces further speculation
+at generic direct helpers; it does not yet prove a transform, terrain/road
+identity, native admission, or suppression. The next expensive build/AppData
+run is deliberately batched until this census and its offline analyzer can
+answer that concrete transform-layout question. See
+[`TRACK_WORLD_PREPARED_LAYOUT.md`](TRACK_WORLD_PREPARED_LAYOUT.md).
+
 ### C2. Static world buildings and props
 
 - Expand opaque-world material and geometry coverage.

--- a/docs/native-renderer/TRACK_WORLD_PREPARED_LAYOUT.md
+++ b/docs/native-renderer/TRACK_WORLD_PREPARED_LAYOUT.md
@@ -1,0 +1,62 @@
+# Track-world prepared-layout census
+
+Status: implemented; one batched AppData capture remains pending
+
+## Why this is the next C1 boundary
+
+The clean festival-world census proved that the direct unified-track mesh edge
+is dormant in the tested scene. The live path is instead the exact indirect
+track command lineage: 485 balanced scopes and packets reached 732 prepared
+draws in session `20260901T022910Z-p35168`.
+
+Those prepared draws already contain the shader-decoded vertex layout,
+resources, render state, and numeric constants required to look for a concrete
+world-transform contract. Capturing that bounded metadata is more useful than
+adding semantic guesses to the two active generic direct-draw helpers.
+
+## Runtime boundary
+
+For every prepared draw reached while the exact track command context is
+active, the observer records one of three outcomes:
+
+- bounded geometry and parameter layout;
+- unbounded geometry; or
+- float-constant, texture-layout, or texture-state overflow.
+
+At most 512 distinct layout families are retained. A family key includes the
+exact track root, child, descriptor, and descriptor payload plus the prepared
+pipeline, geometry-layout, texture-layout, and render-state hashes. Each entry
+keeps one bounded metadata sample, its frame/call coverage, and parameter-hash
+variation. It never copies vertex, index, texture, or guest object payloads.
+
+Detailed entries are emitted only in the final clean-shutdown path. Periodic
+track checkpoints contain cumulative counters but no entry dump, keeping long
+sessions bounded and avoiding repeated log volume.
+
+## Offline report
+
+After the next batched AppData run:
+
+```powershell
+python tools/summarize-native-renderer-track-prepared-layout.py `
+  <session.jsonl> `
+  --output .local/qualification/native-renderer-track-prepared-layout.json
+```
+
+The report verifies process lifecycle, safety fields, exact command/prepared
+accounting, boundedness, table capacity, and per-entry call totals. It also
+lists vertex/pixel float-constant register frequency and maximal runs of at
+least four consecutive finite vertex registers.
+
+These runs are candidates, not transforms. C1 advances only after recurring
+runs are compared across changed camera/vehicle poses and matched to the static
+world transform catalog without ambiguity. Until then, terrain/road identity,
+native admission, publication, and suppression remain unproved and disabled.
+
+## Safety
+
+- Xenos draws and output remain authoritative.
+- No guest state or control flow is changed.
+- No native draw is admitted from this census.
+- No suppression path is armed.
+- The capture uses the existing AppData save in place.

--- a/src/native_renderer/graphics_hooks.cpp
+++ b/src/native_renderer/graphics_hooks.cpp
@@ -87,6 +87,7 @@ constexpr size_t kDispatchCallerCapacity = 256;
 constexpr size_t kTitlePacketProvenanceCapacity = 16384;
 constexpr size_t kTitleDrawProvenanceCapacity = 4096;
 constexpr size_t kStaticWorldPreparedLayoutCapacity = 512;
+constexpr size_t kTrackWorldPreparedLayoutCapacity = 512;
 constexpr size_t kTitleOriginStackCapacity = 32;
 constexpr size_t kTitleIndirectPacketBucketCount = 4096;
 constexpr size_t kTitleIndirectPacketWays = 4;
@@ -1093,6 +1094,21 @@ struct StaticWorldPreparedLayoutEntry {
   rex::system::GraphicsDrawObservation sample{};
 };
 
+struct TrackWorldPreparedLayoutEntry {
+  uint64_t key = 0;
+  uint64_t calls = 0;
+  uint64_t first_frame = 0;
+  uint64_t last_frame = 0;
+  uint64_t parameter_hash = 0;
+  uint64_t parameter_variations = 0;
+  uint32_t track_render_root_address = 0;
+  uint32_t track_render_child_address = 0;
+  uint32_t track_render_descriptor_address = 0;
+  uint32_t track_render_descriptor_payload = 0;
+  SemanticPreparedDrawContract contract{};
+  rex::system::GraphicsDrawObservation sample{};
+};
+
 struct TitleIndirectPacketEntry {
   uint32_t packet_physical_address = UINT32_MAX;
   uint32_t constructor_store_address = 0;
@@ -1184,6 +1200,8 @@ std::array<TitleDrawProvenanceEntry, kTitleDrawProvenanceCapacity>
 std::array<StaticWorldPreparedLayoutEntry,
            kStaticWorldPreparedLayoutCapacity>
     g_static_world_prepared_layouts{};
+std::array<TrackWorldPreparedLayoutEntry, kTrackWorldPreparedLayoutCapacity>
+    g_track_world_prepared_layouts{};
 std::array<SemanticBatchOpportunityEntry,
            kSemanticBatchOpportunityCapacity>
     g_semantic_batch_opportunities{};
@@ -2809,6 +2827,12 @@ std::atomic<uint64_t> g_static_world_prepared_layout_unbounded_geometry{};
 std::atomic<uint64_t> g_static_world_prepared_layout_parameter_overflows{};
 std::atomic<uint64_t> g_static_world_prepared_layout_table_overflow{};
 size_t g_static_world_prepared_layout_count = 0;
+std::atomic<uint64_t> g_track_world_prepared_layout_observations{};
+std::atomic<uint64_t> g_track_world_prepared_layout_exact{};
+std::atomic<uint64_t> g_track_world_prepared_layout_unbounded_geometry{};
+std::atomic<uint64_t> g_track_world_prepared_layout_parameter_overflows{};
+std::atomic<uint64_t> g_track_world_prepared_layout_table_overflow{};
+size_t g_track_world_prepared_layout_count = 0;
 std::atomic<uint64_t> g_static_world_presentation_entries{};
 std::atomic<uint64_t> g_static_world_presentation_exits{};
 std::atomic<uint64_t> g_static_world_presentation_exact{};
@@ -6344,6 +6368,10 @@ void ResetTitleDrawProvenance() {
        g_static_world_prepared_layouts) {
     entry = {};
   }
+  for (TrackWorldPreparedLayoutEntry &entry :
+       g_track_world_prepared_layouts) {
+    entry = {};
+  }
   for (SemanticBatchOpportunityEntry &entry :
        g_semantic_batch_opportunities) {
     entry = {};
@@ -6387,6 +6415,7 @@ void ResetTitleDrawProvenance() {
   g_title_draw_provenance_count = 0;
   g_title_draw_provenance_overflow = 0;
   g_static_world_prepared_layout_count = 0;
+  g_track_world_prepared_layout_count = 0;
   g_semantic_batch_observations = 0;
   g_semantic_visibility_prepared_observations = 0;
   g_semantic_visibility_prepared_selected_joins = 0;
@@ -6658,6 +6687,11 @@ void ResetTitleDrawProvenance() {
            &g_static_world_prepared_layout_unbounded_geometry,
            &g_static_world_prepared_layout_parameter_overflows,
            &g_static_world_prepared_layout_table_overflow,
+           &g_track_world_prepared_layout_observations,
+           &g_track_world_prepared_layout_exact,
+           &g_track_world_prepared_layout_unbounded_geometry,
+           &g_track_world_prepared_layout_parameter_overflows,
+           &g_track_world_prepared_layout_table_overflow,
            &g_static_world_presentation_entries,
            &g_static_world_presentation_exits,
            &g_static_world_presentation_exact,
@@ -12863,6 +12897,8 @@ void EmitProceduralModelSemanticSubmissions() {
        {"suppression_allowed", "false"}});
 }
 
+void EmitTrackWorldPreparedLayoutEntries();
+
 void EmitTrackRenderModelRuntimeJoinEvent(const char *event_name,
                                           bool final_summary,
                                           uint64_t frame_sequence) {
@@ -12904,6 +12940,25 @@ void EmitTrackRenderModelRuntimeJoinEvent(const char *event_name,
           std::memory_order_relaxed) &&
       !invalid_child && !invalid_descriptor &&
       !contract_mismatches;
+  const uint64_t prepared_layout_observations =
+      g_track_world_prepared_layout_observations.load(
+          std::memory_order_relaxed);
+  const uint64_t prepared_layout_exact =
+      g_track_world_prepared_layout_exact.load(std::memory_order_relaxed);
+  const uint64_t prepared_layout_unbounded_geometry =
+      g_track_world_prepared_layout_unbounded_geometry.load(
+          std::memory_order_relaxed);
+  const uint64_t prepared_layout_parameter_overflows =
+      g_track_world_prepared_layout_parameter_overflows.load(
+          std::memory_order_relaxed);
+  const uint64_t prepared_layout_table_overflow =
+      g_track_world_prepared_layout_table_overflow.load(
+          std::memory_order_relaxed);
+  const bool prepared_layout_accounting_complete =
+      prepared_layout_observations ==
+          prepared_layout_exact + prepared_layout_unbounded_geometry +
+              prepared_layout_parameter_overflows &&
+      !prepared_layout_table_overflow;
   pinyon_shift::diagnostics::RecordEvent(
       event_name,
       {{"status", !entries
@@ -12949,6 +13004,19 @@ void EmitTrackRenderModelRuntimeJoinEvent(const char *event_name,
         std::to_string(
             g_track_render_model_prepared_draw_joins_without_semantic_origin
                 .load(std::memory_order_relaxed))},
+       {"prepared_layout_observations",
+         std::to_string(prepared_layout_observations)},
+       {"prepared_layout_exact", std::to_string(prepared_layout_exact)},
+       {"prepared_layout_entries",
+         std::to_string(g_track_world_prepared_layout_count)},
+       {"prepared_layout_unbounded_geometry",
+         std::to_string(prepared_layout_unbounded_geometry)},
+       {"prepared_layout_parameter_overflows",
+         std::to_string(prepared_layout_parameter_overflows)},
+       {"prepared_layout_table_overflow",
+         std::to_string(prepared_layout_table_overflow)},
+       {"prepared_layout_accounting_complete",
+         prepared_layout_accounting_complete ? "true" : "false"},
        {"shared_identity_joins",
         std::to_string(g_track_render_model_shared_identity_joins.load(
             std::memory_order_relaxed))},
@@ -13118,6 +13186,7 @@ void EmitTrackRenderModelRuntimeJoinEvent(const char *event_name,
 }
 
 void EmitTrackRenderModelRuntimeJoinSummary() {
+  EmitTrackWorldPreparedLayoutEntries();
   EmitTrackRenderModelRuntimeJoinEvent(
       "native_renderer.discovery.track_render_model_runtime_join_summary",
       true, g_frame_sequence.load(std::memory_order_relaxed));
@@ -15420,6 +15489,86 @@ std::string SerializeVertexAttributes(
         attribute.flags);
   }
   return result;
+}
+
+void EmitTrackWorldPreparedLayoutEntries() {
+  for (const TrackWorldPreparedLayoutEntry &entry :
+       g_track_world_prepared_layouts) {
+    if (!entry.calls) {
+      continue;
+    }
+    const auto &sample = entry.sample;
+    const auto &contract = entry.contract;
+    pinyon_shift::diagnostics::RecordEvent(
+        "native_renderer.discovery.track_world_prepared_layout_entry",
+        {{"layout_key", fmt::format("{:016X}", entry.key)},
+         {"track_render_root",
+          fmt::format("{:08X}", entry.track_render_root_address)},
+         {"track_render_child",
+          fmt::format("{:08X}", entry.track_render_child_address)},
+         {"track_render_descriptor",
+          fmt::format("{:08X}", entry.track_render_descriptor_address)},
+         {"track_render_descriptor_payload",
+          fmt::format("{:08X}", entry.track_render_descriptor_payload)},
+         {"calls", std::to_string(entry.calls)},
+         {"first_frame", std::to_string(entry.first_frame)},
+         {"last_frame", std::to_string(entry.last_frame)},
+         {"parameter_hash", fmt::format("{:016X}", entry.parameter_hash)},
+         {"parameter_variations",
+          std::to_string(entry.parameter_variations)},
+         {"prepared_pipeline_hash",
+          fmt::format("{:016X}", contract.prepared_pipeline_hash)},
+         {"geometry_layout_hash",
+          fmt::format("{:016X}", contract.geometry_layout_hash)},
+         {"texture_layout_hash",
+          fmt::format("{:016X}", contract.texture_layout_hash)},
+         {"render_state_hash",
+          fmt::format("{:016X}", contract.render_state_hash)},
+         {"vertex_shader",
+          fmt::format("{:016X}", contract.vertex_shader_hash)},
+         {"pixel_shader",
+          fmt::format("{:016X}", contract.pixel_shader_hash)},
+         {"primitive_type", std::to_string(sample.primitive_type)},
+         {"index_count", std::to_string(sample.index_count)},
+         {"index_buffer_address",
+          fmt::format("{:08X}", sample.index_buffer_address)},
+         {"index_buffer_length",
+          std::to_string(sample.index_buffer_length)},
+         {"index_format", std::to_string(sample.index_format)},
+         {"index_endianness", std::to_string(sample.index_endianness)},
+         {"vertex_binding_count",
+          std::to_string(sample.vertex_binding_count)},
+         {"vertex_bindings", SerializeVertexBindings(sample)},
+         {"vertex_attribute_count",
+          std::to_string(sample.vertex_attribute_count)},
+         {"vertex_attributes", SerializeVertexAttributes(sample)},
+         {"vertex_float_constant_count",
+          std::to_string(sample.vertex_float_constant_count)},
+         {"vertex_float_constants",
+          SerializeFloatConstants(sample.vertex_float_constants,
+                                  sample.vertex_float_constant_count)},
+         {"pixel_float_constant_count",
+          std::to_string(sample.pixel_float_constant_count)},
+         {"pixel_float_constants",
+          SerializeFloatConstants(sample.pixel_float_constants,
+                                  sample.pixel_float_constant_count)},
+         {"bool_constants",
+          SerializeWordConstants(sample.bool_constant_bitmap,
+                                 sample.bool_constant_values,
+                                 std::size(sample.bool_constant_bitmap))},
+         {"loop_constants",
+          SerializeLoopConstants(sample.loop_constant_bitmap,
+                                 sample.loop_constant_values)},
+         {"texture_state_count",
+          std::to_string(sample.texture_state_count)},
+         {"texture_states", SerializeTextureStates(sample)},
+         {"guest_payload_read", "bounded_prepared_draw_metadata_only"},
+         {"guest_state_changed", "false"},
+         {"control_flow_changed", "false"},
+         {"native_admission", "false"},
+         {"xenos_authority", "true"},
+         {"suppression_allowed", "false"}});
+  }
 }
 
 std::string SerializeStaticWorldTransform(
@@ -18135,6 +18284,86 @@ void RecordStaticWorldPreparedLayout(
       1, std::memory_order_relaxed);
 }
 
+void RecordTrackWorldPreparedLayout(
+    const rex::system::GraphicsDrawObservation &observation,
+    const IndirectConstructorOrigin::Owner::Producer::Context &context,
+    const SemanticPreparedDrawContract &contract) {
+  g_track_world_prepared_layout_observations.fetch_add(
+      1, std::memory_order_relaxed);
+  if (!contract.geometry_bounded) {
+    g_track_world_prepared_layout_unbounded_geometry.fetch_add(
+        1, std::memory_order_relaxed);
+    return;
+  }
+  if (!contract.texture_layout_bounded ||
+      observation.vertex_float_constant_overflow ||
+      observation.pixel_float_constant_overflow ||
+      observation.texture_state_overflow) {
+    g_track_world_prepared_layout_parameter_overflows.fetch_add(
+        1, std::memory_order_relaxed);
+    return;
+  }
+  g_track_world_prepared_layout_exact.fetch_add(1, std::memory_order_relaxed);
+
+  uint64_t key = UINT64_C(0xCBF29CE484222325);
+  for (uint64_t value :
+       {uint64_t(context.track_render_root_address),
+        uint64_t(context.track_render_child_address),
+        uint64_t(context.track_render_descriptor_address),
+        uint64_t(context.track_render_descriptor_payload),
+        contract.prepared_pipeline_hash, contract.geometry_layout_hash,
+        contract.texture_layout_hash, contract.render_state_hash}) {
+    key = HashCombine(key, value);
+  }
+  key = key ? key : 1;
+  const uint64_t parameter_hash = SemanticInstanceParameterHash(observation);
+  size_t index = size_t(key % kTrackWorldPreparedLayoutCapacity);
+  for (size_t probe = 0; probe < kTrackWorldPreparedLayoutCapacity; ++probe) {
+    TrackWorldPreparedLayoutEntry &entry =
+        g_track_world_prepared_layouts[index];
+    if (!entry.calls) {
+      entry.key = key;
+      entry.calls = 1;
+      entry.first_frame = observation.frame_sequence;
+      entry.last_frame = observation.frame_sequence;
+      entry.parameter_hash = parameter_hash;
+      entry.track_render_root_address = context.track_render_root_address;
+      entry.track_render_child_address = context.track_render_child_address;
+      entry.track_render_descriptor_address =
+          context.track_render_descriptor_address;
+      entry.track_render_descriptor_payload =
+          context.track_render_descriptor_payload;
+      entry.contract = contract;
+      entry.sample = observation;
+      ++g_track_world_prepared_layout_count;
+      return;
+    }
+    if (entry.key == key &&
+        entry.track_render_root_address == context.track_render_root_address &&
+        entry.track_render_child_address ==
+            context.track_render_child_address &&
+        entry.track_render_descriptor_address ==
+            context.track_render_descriptor_address &&
+        entry.track_render_descriptor_payload ==
+            context.track_render_descriptor_payload &&
+        entry.contract.prepared_pipeline_hash ==
+            contract.prepared_pipeline_hash &&
+        entry.contract.geometry_layout_hash == contract.geometry_layout_hash &&
+        entry.contract.texture_layout_hash == contract.texture_layout_hash &&
+        entry.contract.render_state_hash == contract.render_state_hash) {
+      ++entry.calls;
+      entry.last_frame = observation.frame_sequence;
+      entry.parameter_variations +=
+          entry.parameter_hash != parameter_hash ? 1 : 0;
+      entry.parameter_hash = parameter_hash;
+      return;
+    }
+    index = (index + 1) % kTrackWorldPreparedLayoutCapacity;
+  }
+  g_track_world_prepared_layout_table_overflow.fetch_add(
+      1, std::memory_order_relaxed);
+}
+
 void UpdateSemanticPreparedDrawContract(
     SemanticPreparedDrawContract &contract,
     const rex::system::GraphicsDrawObservation &observation,
@@ -20692,6 +20921,8 @@ SemanticVisibilityPreparedAdmission RecordSemanticBatchOpportunity(
   const bool exact_track_command =
       active && active->constructor_origin.owner.producer.context
                     .track_command_lineage;
+  const SemanticPreparedDrawContract contract =
+      BuildSemanticPreparedDrawContract(observation, prepared);
   if (exact_track_command) {
     g_track_render_model_prepared_draw_joins.fetch_add(
         1, std::memory_order_relaxed);
@@ -20701,6 +20932,11 @@ SemanticVisibilityPreparedAdmission RecordSemanticBatchOpportunity(
         .fetch_add(1, std::memory_order_relaxed);
     g_track_render_model_shared_identity_relations[8].fetch_add(
         1, std::memory_order_relaxed);
+    if (contract.valid) {
+      RecordTrackWorldPreparedLayout(
+          observation, active->constructor_origin.owner.producer.context,
+          contract);
+    }
   }
   if (!origin.semantic_draw.valid) {
     return {
@@ -20721,8 +20957,6 @@ SemanticVisibilityPreparedAdmission RecordSemanticBatchOpportunity(
     identity.track_world_resource_identity_mask |=
         track_context.track_world_resource_identity_mask;
   }
-  const SemanticPreparedDrawContract contract =
-      BuildSemanticPreparedDrawContract(observation, prepared);
   const uint32_t mechanical_rejection_mask =
       IsolatedDrawMechanicalRejectionMask(
       observation, samples_resolved_target, prepared);

--- a/tools/summarize-native-renderer-track-prepared-layout.py
+++ b/tools/summarize-native-renderer-track-prepared-layout.py
@@ -1,0 +1,299 @@
+#!/usr/bin/env python3
+"""Summarize bounded prepared layouts on the exact track-command lineage."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import pathlib
+import struct
+import sys
+
+
+SCHEMA = "pinyon-shift.native-renderer-track-prepared-layout.v1"
+ENTRY = "native_renderer.discovery.track_world_prepared_layout_entry"
+SUMMARY = "native_renderer.discovery.track_render_model_runtime_join_summary"
+
+
+def read_events(paths):
+    events = []
+    for path in paths:
+        with path.open(encoding="utf-8") as stream:
+            for line_number, line in enumerate(stream, 1):
+                if not line.strip():
+                    continue
+                try:
+                    event = json.loads(line)
+                except json.JSONDecodeError as error:
+                    raise ValueError(
+                        f"invalid JSON at {path}:{line_number}: {error}"
+                    ) from error
+                if isinstance(event, dict):
+                    events.append(event)
+    return events
+
+
+def integer(event, key):
+    try:
+        value = int(event[key])
+    except (KeyError, TypeError, ValueError) as error:
+        raise ValueError(f"invalid {key}") from error
+    if value < 0:
+        raise ValueError(f"negative {key}")
+    return value
+
+
+def hexadecimal(value, width, label):
+    value = str(value).upper()
+    if len(value) != width or any(c not in "0123456789ABCDEF" for c in value):
+        raise ValueError(f"invalid {label}")
+    return value
+
+
+def require_safety(event):
+    expected = {
+        "guest_state_changed": "false",
+        "control_flow_changed": "false",
+        "native_admission": "false",
+        "xenos_authority": "true",
+        "suppression_allowed": "false",
+    }
+    if any(event.get(key) != value for key, value in expected.items()):
+        raise ValueError("track prepared-layout evidence violates safety")
+
+
+def select_session(events, requested):
+    sessions = {
+        str(event.get("session"))
+        for event in events
+        if event.get("event") == SUMMARY and event.get("session")
+    }
+    if requested:
+        if requested not in sessions:
+            raise ValueError("requested session has no final track summary")
+        session = requested
+    elif len(sessions) == 1:
+        session = next(iter(sessions))
+    else:
+        raise ValueError("input must contain exactly one candidate session")
+    return session, [event for event in events if str(event.get("session")) == session]
+
+
+def parse_float_constants(event, key):
+    raw = event.get(key)
+    if not isinstance(raw, str):
+        raise ValueError(f"invalid {key}")
+    result = {}
+    if not raw:
+        return result
+    for item in raw.split(";"):
+        parts = item.split(":")
+        if len(parts) != 5:
+            raise ValueError(f"invalid {key}")
+        try:
+            register = int(parts[0])
+        except ValueError as error:
+            raise ValueError(f"invalid {key} register") from error
+        if register < 0 or register in result:
+            raise ValueError(f"invalid {key} register")
+        words = tuple(
+            int(hexadecimal(word, 8, f"{key} word"), 16)
+            for word in parts[1:]
+        )
+        values = tuple(
+            struct.unpack(">f", word.to_bytes(4, "big"))[0] for word in words
+        )
+        if not all(math.isfinite(value) for value in values):
+            raise ValueError(f"{key} contains a non-finite value")
+        result[register] = {"words": words, "values": values}
+    return result
+
+
+def consecutive_runs(constants, minimum=4):
+    registers = sorted(constants)
+    runs = []
+    start = 0
+    while start < len(registers):
+        end = start + 1
+        while end < len(registers) and registers[end] == registers[end - 1] + 1:
+            end += 1
+        run = registers[start:end]
+        if len(run) >= minimum:
+            runs.append(run)
+        start = end
+    return runs
+
+
+def build(events, requested_session=None):
+    session, selected = select_session(events, requested_session)
+    starts = [event for event in selected if event.get("event") == "process.start"]
+    shutdowns = [event for event in selected if event.get("event") == "process.shutdown"]
+    summaries = [event for event in selected if event.get("event") == SUMMARY]
+    if len(starts) != 1 or len(shutdowns) != 1 or len(summaries) != 1:
+        raise ValueError("track prepared-layout lifecycle is incomplete")
+    summary = summaries[0]
+    require_safety(summary)
+    totals = {
+        key: integer(summary, key)
+        for key in (
+            "command_prepared_draw_joins",
+            "prepared_layout_observations",
+            "prepared_layout_exact",
+            "prepared_layout_entries",
+            "prepared_layout_unbounded_geometry",
+            "prepared_layout_parameter_overflows",
+            "prepared_layout_table_overflow",
+        )
+    }
+    entries = [event for event in selected if event.get("event") == ENTRY]
+    seen = set()
+    entry_calls = 0
+    vertex_frequency = {}
+    pixel_frequency = {}
+    candidate_runs = []
+    for event in entries:
+        require_safety(event)
+        key = hexadecimal(event.get("layout_key", ""), 16, "layout key")
+        if key in seen:
+            raise ValueError("duplicate track prepared layout key")
+        seen.add(key)
+        for address_key in (
+            "track_render_root",
+            "track_render_child",
+            "track_render_descriptor",
+            "track_render_descriptor_payload",
+        ):
+            hexadecimal(event.get(address_key, ""), 8, address_key)
+        calls = integer(event, "calls")
+        first_frame = integer(event, "first_frame")
+        last_frame = integer(event, "last_frame")
+        if not calls or first_frame > last_frame:
+            raise ValueError("invalid track prepared layout lifetime")
+        entry_calls += calls
+        vertex = parse_float_constants(event, "vertex_float_constants")
+        pixel = parse_float_constants(event, "pixel_float_constants")
+        if integer(event, "vertex_float_constant_count") != len(vertex):
+            raise ValueError("vertex float constant count drifted")
+        if integer(event, "pixel_float_constant_count") != len(pixel):
+            raise ValueError("pixel float constant count drifted")
+        for register in vertex:
+            item = vertex_frequency.setdefault(register, {"layouts": 0, "calls": 0})
+            item["layouts"] += 1
+            item["calls"] += calls
+        for register in pixel:
+            item = pixel_frequency.setdefault(register, {"layouts": 0, "calls": 0})
+            item["layouts"] += 1
+            item["calls"] += calls
+        for run in consecutive_runs(vertex):
+            candidate_runs.append(
+                {
+                    "layout_key": key,
+                    "calls": calls,
+                    "start_register": run[0],
+                    "end_register": run[-1],
+                    "register_count": len(run),
+                    "registers": [
+                        {
+                            "index": register,
+                            "words": [f"{word:08X}" for word in vertex[register]["words"]],
+                            "values": list(vertex[register]["values"]),
+                        }
+                        for register in run
+                    ],
+                }
+            )
+
+    failures = []
+    if summary.get("checkpoint_kind") != "final":
+        failures.append("track summary is not final")
+    if summary.get("prepared_layout_accounting_complete") != "true":
+        failures.append("prepared layout accounting is incomplete")
+    if totals["prepared_layout_observations"] != totals["command_prepared_draw_joins"]:
+        failures.append("prepared observations do not match exact command joins")
+    if totals["prepared_layout_observations"] != (
+        totals["prepared_layout_exact"]
+        + totals["prepared_layout_unbounded_geometry"]
+        + totals["prepared_layout_parameter_overflows"]
+    ):
+        failures.append("prepared observation classification drifted")
+    if totals["prepared_layout_entries"] != len(entries):
+        failures.append("prepared layout entry count drifted")
+    if totals["prepared_layout_exact"] != entry_calls:
+        failures.append("prepared layout call accounting drifted")
+    if not totals["prepared_layout_exact"] or not entries:
+        failures.append("no exact track prepared layouts were observed")
+    for key in (
+        "prepared_layout_unbounded_geometry",
+        "prepared_layout_parameter_overflows",
+        "prepared_layout_table_overflow",
+    ):
+        if totals[key]:
+            failures.append(f"{key} is nonzero")
+
+    def frequency_rows(frequency):
+        return [
+            {"register": register, **frequency[register]}
+            for register in sorted(frequency)
+        ]
+
+    candidate_runs.sort(
+        key=lambda item: (-item["calls"], item["layout_key"], item["start_register"])
+    )
+    status = "complete" if not failures else "incomplete"
+    return {
+        "schema": SCHEMA,
+        "session": session,
+        "status": status,
+        "failures": failures,
+        "totals": totals,
+        "constant_register_frequency": {
+            "vertex": frequency_rows(vertex_frequency),
+            "pixel": frequency_rows(pixel_frequency),
+        },
+        "vertex_consecutive_register_runs": candidate_runs,
+        "qualification": {
+            "exact_track_prepared_layouts_proved": not failures,
+            "world_transform_constant_layout_proved": False,
+            "terrain_or_road_identity_proved": False,
+            "native_admission": False,
+            "suppression_allowed": False,
+        },
+        "next_step": (
+            "compare recurring finite vertex constant runs against the static "
+            "world transform catalog across changed camera and vehicle poses"
+        ),
+        "safety": {
+            "guest_state_changed": False,
+            "control_flow_changed": False,
+            "native_admission": False,
+            "native_draw": False,
+            "xenos_authority": True,
+            "suppression_allowed": False,
+        },
+    }
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("events", nargs="+", type=pathlib.Path)
+    parser.add_argument("--session")
+    parser.add_argument("--output", required=True, type=pathlib.Path)
+    args = parser.parse_args(argv)
+    try:
+        document = build(read_events(args.events), args.session)
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(
+            json.dumps(document, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        if document["status"] != "complete":
+            raise ValueError("; ".join(document["failures"]))
+        return 0
+    except (OSError, ValueError, json.JSONDecodeError) as error:
+        print(f"track prepared-layout summary failed: {error}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/tests/test_native_renderer_track_prepared_layout.py
+++ b/tools/tests/test_native_renderer_track_prepared_layout.py
@@ -1,0 +1,119 @@
+import copy
+import importlib.util
+import pathlib
+import unittest
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+TOOL = ROOT / "tools/summarize-native-renderer-track-prepared-layout.py"
+SPEC = importlib.util.spec_from_file_location("track_prepared_layout", TOOL)
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+def event(name, **values):
+    return {"event": name, "session": "test", **values}
+
+
+def safety():
+    return {
+        "guest_state_changed": "false",
+        "control_flow_changed": "false",
+        "native_admission": "false",
+        "xenos_authority": "true",
+        "suppression_allowed": "false",
+    }
+
+
+def fixture():
+    constants = ";".join(
+        f"{register}:3F800000:00000000:00000000:3F800000"
+        for register in range(4, 8)
+    )
+    entry = event(
+        MODULE.ENTRY,
+        layout_key="0123456789ABCDEF",
+        track_render_root="10000000",
+        track_render_child="10000010",
+        track_render_descriptor="10000020",
+        track_render_descriptor_payload="10000030",
+        calls="12",
+        first_frame="100",
+        last_frame="110",
+        vertex_float_constant_count="4",
+        vertex_float_constants=constants,
+        pixel_float_constant_count="0",
+        pixel_float_constants="",
+        **safety(),
+    )
+    summary = event(
+        MODULE.SUMMARY,
+        checkpoint_kind="final",
+        command_prepared_draw_joins="12",
+        prepared_layout_observations="12",
+        prepared_layout_exact="12",
+        prepared_layout_entries="1",
+        prepared_layout_unbounded_geometry="0",
+        prepared_layout_parameter_overflows="0",
+        prepared_layout_table_overflow="0",
+        prepared_layout_accounting_complete="true",
+        native_draw="false",
+        **safety(),
+    )
+    return [
+        event("process.start"),
+        entry,
+        summary,
+        event("process.shutdown"),
+    ]
+
+
+class TrackPreparedLayoutTests(unittest.TestCase):
+    def test_summarizes_exact_layout_and_candidate_run(self):
+        document = MODULE.build(fixture())
+        self.assertEqual("complete", document["status"])
+        self.assertEqual(12, document["totals"]["prepared_layout_exact"])
+        run = document["vertex_consecutive_register_runs"][0]
+        self.assertEqual((4, 7, 4), (
+            run["start_register"], run["end_register"], run["register_count"]
+        ))
+        self.assertFalse(
+            document["qualification"]["world_transform_constant_layout_proved"]
+        )
+
+    def test_rejects_nonfinite_constant(self):
+        events = fixture()
+        events[1]["vertex_float_constants"] = events[1][
+            "vertex_float_constants"
+        ].replace("3F800000", "7F800000", 1)
+        with self.assertRaisesRegex(ValueError, "non-finite"):
+            MODULE.build(events)
+
+    def test_reports_accounting_drift(self):
+        events = copy.deepcopy(fixture())
+        events[2]["prepared_layout_exact"] = "11"
+        document = MODULE.build(events)
+        self.assertEqual("incomplete", document["status"])
+        self.assertIn(
+            "prepared layout call accounting drifted", document["failures"]
+        )
+
+    def test_runtime_census_is_shutdown_only_and_observation_only(self):
+        source = (ROOT / "src/native_renderer/graphics_hooks.cpp").read_text(
+            encoding="utf-8"
+        )
+        self.assertIn("kTrackWorldPreparedLayoutCapacity = 512", source)
+        self.assertIn("RecordTrackWorldPreparedLayout", source)
+        self.assertIn("track_world_prepared_layout_entry", source)
+        summary = source.split(
+            "void EmitTrackRenderModelRuntimeJoinSummary()", 1
+        )[1].split("void EmitTrackRenderModelRuntimeJoinCheckpoint", 1)[0]
+        self.assertIn("EmitTrackWorldPreparedLayoutEntries", summary)
+        checkpoint = source.split(
+            "void EmitTrackRenderModelRuntimeJoinCheckpoint", 1
+        )[1].split("void EmitStaticWorldRuntimeJoinEvent", 1)[0]
+        self.assertNotIn("EmitTrackWorldPreparedLayoutEntries", checkpoint)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- retain bounded shader-decoded prepared-layout families on the proven indirect track command lineage
- emit detailed numeric metadata only at final shutdown with complete fail-closed accounting
- add an offline analyzer for constant-register frequency and consecutive transform candidates
- document the C1 pivot while keeping Xenos authoritative and all admission/suppression disabled

## Tests
- `python -m unittest discover -s tools/tests -p 'test_native_renderer_*track*.py'` (38 passed)
- `python -m unittest tools.tests.test_native_renderer_static_world_runtime_join tools.tests.test_native_renderer_visibility_prepared_candidates tools.tests.test_native_renderer_c1_c2_batch` (40 passed)
- `python -m py_compile tools/summarize-native-renderer-track-prepared-layout.py`
- `git diff --check`

Full local rebuild and AppData qualification are intentionally deferred to the next meaningful Phase C batch.