### PR TITLE
feat(renderer): classify track transform constants

### DIFF
--- a/docs/native-renderer/REPRIORITIZED_PLAN.md
+++ b/docs/native-renderer/REPRIORITIZED_PLAN.md
@@ -480,6 +480,16 @@ run is deliberately batched until this census and its offline analyzer can
 answer that concrete transform-layout question. See
 [`TRACK_WORLD_PREPARED_LAYOUT.md`](TRACK_WORLD_PREPARED_LAYOUT.md).
 
+Catalog-correlation checkpoint: a second payload-free classifier now tests
+every four-register vertex-constant window against the existing 24,025-entry
+title-authored spatial catalog under both plausible matrix conventions. It
+groups evidence by exact vertex shader and starting register, requires at least
+eight distinct unambiguous positions including a collision prop, rejects any
+unmatched layout in the group, and requires exactly one qualifying mapping.
+This is ready before the batched capture, so that run can either prove one
+concrete transform contract or close the constant-window lead without another
+instrumentation cycle.
+
 ### C2. Static world buildings and props
 
 - Expand opaque-world material and geometry coverage.

--- a/docs/native-renderer/TRACK_WORLD_PREPARED_LAYOUT.md
+++ b/docs/native-renderer/TRACK_WORLD_PREPARED_LAYOUT.md
@@ -48,6 +48,23 @@ accounting, boundedness, table capacity, and per-entry call totals. It also
 lists vertex/pixel float-constant register frequency and maximal runs of at
 least four consecutive finite vertex registers.
 
+The checked-in catalog classifier then evaluates every four-register window
+under both plausible title matrix conventions:
+
+```powershell
+python tools/classify-native-renderer-track-prepared-transforms.py `
+  --prepared .local/qualification/native-renderer-track-prepared-layout.json `
+  --catalog .local/qualification/native-renderer-static-world-instance-catalog.json `
+  --output .local/qualification/native-renderer-track-prepared-transforms.json
+```
+
+Candidates are grouped by exact vertex shader, starting constant register, and
+matrix convention. A group passes only when every observed layout maps to one
+unambiguous catalog position, at least eight distinct catalog instances match,
+at least one is a collision prop, and exactly one group satisfies the whole
+contract. Shader similarity, frequency, near misses, and duplicate catalog
+positions cannot qualify it.
+
 These runs are candidates, not transforms. C1 advances only after recurring
 runs are compared across changed camera/vehicle poses and matched to the static
 world transform catalog without ambiguity. Until then, terrain/road identity,

--- a/tools/classify-native-renderer-track-prepared-transforms.py
+++ b/tools/classify-native-renderer-track-prepared-transforms.py
@@ -1,0 +1,333 @@
+#!/usr/bin/env python3
+"""Match track prepared constant windows to the title-authored world catalog."""
+
+from __future__ import annotations
+
+import argparse
+import collections
+import itertools
+import json
+import math
+import pathlib
+import sys
+
+
+SCHEMA = "pinyon-shift.native-renderer-track-prepared-transform-classification.v1"
+PREPARED_SCHEMA = "pinyon-shift.native-renderer-track-prepared-layout.v1"
+CATALOG_SCHEMA = "pinyon-shift.native-renderer-static-world-instance-catalog.v1"
+DEFAULT_TOLERANCE = 0.05
+DEFAULT_MINIMUM_MATCHES = 8
+CONVENTIONS = {
+    "translation_words_12_13_14": (12, 13, 14),
+    "translation_words_3_7_11": (3, 7, 11),
+}
+
+
+def hexadecimal(value, width, label):
+    value = str(value).upper()
+    if len(value) != width or any(c not in "0123456789ABCDEF" for c in value):
+        raise ValueError(f"invalid {label}")
+    return value
+
+
+def validate_catalog(document):
+    if document.get("schema") != CATALOG_SCHEMA or document.get("status") != "complete":
+        raise ValueError("static-world instance catalog is unsupported")
+    safety = document.get("safety", {})
+    if (
+        safety.get("source_files_changed") is not False
+        or safety.get("plaintext_identity_exported") is not False
+        or safety.get("numeric_spatial_metadata_only") is not True
+        or safety.get("native_admission") is not False
+        or safety.get("suppression_allowed") is not False
+    ):
+        raise ValueError("static-world instance catalog safety drifted")
+    instances = document.get("instances")
+    if not isinstance(instances, list) or len(instances) != document.get("instance_count"):
+        raise ValueError("static-world instance catalog count drifted")
+    validated = []
+    for index, instance in enumerate(instances):
+        category = instance.get("category")
+        if category not in ("collision_prop", "gameplay_object"):
+            raise ValueError("static-world instance category is invalid")
+        identity_hash = hexadecimal(
+            instance.get("identity_hash", ""), 16, "catalog identity hash"
+        )
+        position = instance.get("position")
+        if (
+            not isinstance(position, list)
+            or len(position) != 3
+            or not all(
+                isinstance(value, (int, float)) and math.isfinite(value)
+                for value in position
+            )
+        ):
+            raise ValueError("static-world catalog position is invalid")
+        validated.append(
+            {
+                "catalog_index": index,
+                "category": category,
+                "identity_hash": identity_hash,
+                "position": tuple(float(value) for value in position),
+            }
+        )
+    return validated
+
+
+def validate_prepared(document):
+    if document.get("schema") != PREPARED_SCHEMA or document.get("status") != "complete":
+        raise ValueError("track prepared-layout report is incomplete")
+    qualification = document.get("qualification", {})
+    safety = document.get("safety", {})
+    if (
+        qualification.get("exact_track_prepared_layouts_proved") is not True
+        or qualification.get("world_transform_constant_layout_proved") is not False
+        or safety.get("guest_state_changed") is not False
+        or safety.get("control_flow_changed") is not False
+        or safety.get("xenos_authority") is not True
+        or safety.get("native_admission") is not False
+        or safety.get("suppression_allowed") is not False
+    ):
+        raise ValueError("track prepared-layout report safety drifted")
+    runs = document.get("vertex_consecutive_register_runs")
+    if not isinstance(runs, list):
+        raise ValueError("track prepared-layout candidate runs are invalid")
+    shader_frequency = document.get("vertex_shader_layout_frequency")
+    if not isinstance(shader_frequency, list):
+        raise ValueError("track prepared-layout shader frequency is invalid")
+    shader_layouts = {}
+    for item in shader_frequency:
+        shader = hexadecimal(item.get("vertex_shader", ""), 16, "vertex shader")
+        layouts = item.get("layouts")
+        if not isinstance(layouts, int) or layouts < 1 or shader in shader_layouts:
+            raise ValueError("track prepared-layout shader frequency is invalid")
+        shader_layouts[shader] = layouts
+    validated = []
+    for run in runs:
+        layout_key = hexadecimal(run.get("layout_key", ""), 16, "layout key")
+        vertex_shader = hexadecimal(
+            run.get("vertex_shader", ""), 16, "vertex shader"
+        )
+        if vertex_shader not in shader_layouts:
+            raise ValueError("track prepared run has no shader frequency")
+        registers = run.get("registers")
+        if not isinstance(registers, list) or len(registers) < 4:
+            raise ValueError("track prepared register run is too short")
+        parsed = []
+        for register in registers:
+            index = register.get("index")
+            values = register.get("values")
+            if (
+                not isinstance(index, int)
+                or not isinstance(values, list)
+                or len(values) != 4
+                or not all(
+                    isinstance(value, (int, float)) and math.isfinite(value)
+                    for value in values
+                )
+            ):
+                raise ValueError("track prepared register is invalid")
+            if parsed and index != parsed[-1][0] + 1:
+                raise ValueError("track prepared register run is not consecutive")
+            parsed.append((index, tuple(float(value) for value in values)))
+        if (
+            run.get("start_register") != parsed[0][0]
+            or run.get("end_register") != parsed[-1][0]
+            or run.get("register_count") != len(parsed)
+        ):
+            raise ValueError("track prepared register run bounds drifted")
+        validated.append(
+            {
+                "layout_key": layout_key,
+                "vertex_shader": vertex_shader,
+                "registers": parsed,
+            }
+        )
+    return validated, shader_layouts
+
+
+def spatial_index(instances, tolerance):
+    result = collections.defaultdict(list)
+    for instance in instances:
+        key = tuple(math.floor(value / tolerance) for value in instance["position"])
+        result[key].append(instance)
+    return result
+
+
+def match_position(index, position, tolerance):
+    key = tuple(math.floor(value / tolerance) for value in position)
+    candidates = []
+    for offset in itertools.product((-1, 0, 1), repeat=3):
+        adjacent = tuple(key[axis] + offset[axis] for axis in range(3))
+        for instance in index.get(adjacent, ()):
+            distance = math.dist(position, instance["position"])
+            if distance <= tolerance:
+                candidates.append((distance, instance))
+    candidates.sort(key=lambda item: (item[0], item[1]["catalog_index"]))
+    if not candidates:
+        return "unmatched", None
+    if len(candidates) != 1:
+        return "ambiguous", None
+    return "matched", candidates[0]
+
+
+def build(
+    catalog,
+    prepared,
+    tolerance=DEFAULT_TOLERANCE,
+    minimum_matches=DEFAULT_MINIMUM_MATCHES,
+):
+    if not math.isfinite(tolerance) or tolerance <= 0 or tolerance > 1:
+        raise ValueError("match tolerance is outside the safe range")
+    if minimum_matches < 1:
+        raise ValueError("minimum matches must be positive")
+    instances = validate_catalog(catalog)
+    runs, shader_layouts = validate_prepared(prepared)
+    index = spatial_index(instances, tolerance)
+    groups = collections.defaultdict(list)
+    for run in runs:
+        registers = run["registers"]
+        for offset in range(len(registers) - 3):
+            window = registers[offset : offset + 4]
+            words = tuple(value for _, values in window for value in values)
+            for convention, indices in CONVENTIONS.items():
+                position = tuple(words[word] for word in indices)
+                groups[(run["vertex_shader"], window[0][0], convention)].append(
+                    (run["layout_key"], position)
+                )
+
+    reports = []
+    qualified = []
+    for (vertex_shader, start_register, convention), observations in sorted(groups.items()):
+        matches = []
+        unmatched = 0
+        ambiguous = 0
+        for layout_key, position in observations:
+            outcome, match = match_position(index, position, tolerance)
+            if outcome == "unmatched":
+                unmatched += 1
+                continue
+            if outcome == "ambiguous":
+                ambiguous += 1
+                continue
+            distance, instance = match
+            matches.append(
+                {
+                    "layout_key": layout_key,
+                    "category": instance["category"],
+                    "catalog_identity_hash": instance["identity_hash"],
+                    "catalog_index": instance["catalog_index"],
+                    "distance": round(distance, 9),
+                }
+            )
+        distinct_catalog_matches = len(
+            {match["catalog_index"] for match in matches}
+        )
+        category_counts = collections.Counter(
+            match["category"] for match in matches
+        )
+        complete = (
+            len(observations) >= minimum_matches
+            and len(observations) == shader_layouts[vertex_shader]
+            and len(matches) == len(observations)
+            and distinct_catalog_matches >= minimum_matches
+            and not unmatched
+            and not ambiguous
+            and category_counts["collision_prop"] > 0
+        )
+        report = {
+            "vertex_shader": vertex_shader,
+            "start_register": start_register,
+            "convention": convention,
+            "observed_layouts": len(observations),
+            "shader_layouts": shader_layouts[vertex_shader],
+            "matched": len(matches),
+            "distinct_catalog_matches": distinct_catalog_matches,
+            "unmatched": unmatched,
+            "ambiguous": ambiguous,
+            "category_counts": dict(sorted(category_counts.items())),
+            "complete": complete,
+            "matches": matches,
+        }
+        reports.append(report)
+        if complete:
+            qualified.append(report)
+
+    failures = []
+    if not runs:
+        failures.append("no consecutive vertex constant runs were observed")
+    if len(qualified) != 1:
+        failures.append("track world transform constant mapping is not uniquely proved")
+    selected = qualified[0] if len(qualified) == 1 else None
+    status = "complete" if not failures else "incomplete"
+    return {
+        "schema": SCHEMA,
+        "session": prepared.get("session"),
+        "status": status,
+        "failures": failures,
+        "catalog_instance_count": len(instances),
+        "candidate_group_count": len(reports),
+        "minimum_distinct_matches": minimum_matches,
+        "position_tolerance": tolerance,
+        "selected_mapping": (
+            None
+            if selected is None
+            else {
+                key: selected[key]
+                for key in ("vertex_shader", "start_register", "convention")
+            }
+        ),
+        "candidate_groups": reports,
+        "qualification": {
+            "exact_track_prepared_layouts_proved": True,
+            "world_transform_constant_layout_proved": not failures,
+            "terrain_or_road_instance_identity_proved": not failures,
+            "native_admission": False,
+            "suppression_allowed": False,
+        },
+        "safety": {
+            "guest_state_changed": False,
+            "source_files_changed": False,
+            "plaintext_identity_exported": False,
+            "xenos_authority": True,
+            "native_admission": False,
+            "native_draw": False,
+            "suppression_allowed": False,
+        },
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--catalog", required=True, type=pathlib.Path)
+    parser.add_argument("--prepared", required=True, type=pathlib.Path)
+    parser.add_argument("--output", required=True, type=pathlib.Path)
+    parser.add_argument("--tolerance", type=float, default=DEFAULT_TOLERANCE)
+    parser.add_argument(
+        "--minimum-matches", type=int, default=DEFAULT_MINIMUM_MATCHES
+    )
+    arguments = parser.parse_args()
+    try:
+        catalog = json.loads(arguments.catalog.read_text(encoding="utf-8"))
+        prepared = json.loads(arguments.prepared.read_text(encoding="utf-8"))
+        document = build(
+            catalog,
+            prepared,
+            tolerance=arguments.tolerance,
+            minimum_matches=arguments.minimum_matches,
+        )
+        arguments.output.parent.mkdir(parents=True, exist_ok=True)
+        arguments.output.write_text(
+            json.dumps(document, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        if document["status"] != "complete":
+            raise ValueError("; ".join(document["failures"]))
+        return 0
+    except (json.JSONDecodeError, OSError, ValueError) as error:
+        print(f"track prepared-transform classification failed: {error}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/summarize-native-renderer-track-prepared-layout.py
+++ b/tools/summarize-native-renderer-track-prepared-layout.py
@@ -151,10 +151,14 @@ def build(events, requested_session=None):
     entry_calls = 0
     vertex_frequency = {}
     pixel_frequency = {}
+    vertex_shader_frequency = {}
     candidate_runs = []
     for event in entries:
         require_safety(event)
         key = hexadecimal(event.get("layout_key", ""), 16, "layout key")
+        vertex_shader = hexadecimal(
+            event.get("vertex_shader", ""), 16, "vertex shader"
+        )
         if key in seen:
             raise ValueError("duplicate track prepared layout key")
         seen.add(key)
@@ -171,6 +175,11 @@ def build(events, requested_session=None):
         if not calls or first_frame > last_frame:
             raise ValueError("invalid track prepared layout lifetime")
         entry_calls += calls
+        shader_item = vertex_shader_frequency.setdefault(
+            vertex_shader, {"layouts": 0, "calls": 0}
+        )
+        shader_item["layouts"] += 1
+        shader_item["calls"] += calls
         vertex = parse_float_constants(event, "vertex_float_constants")
         pixel = parse_float_constants(event, "pixel_float_constants")
         if integer(event, "vertex_float_constant_count") != len(vertex):
@@ -189,6 +198,7 @@ def build(events, requested_session=None):
             candidate_runs.append(
                 {
                     "layout_key": key,
+                    "vertex_shader": vertex_shader,
                     "calls": calls,
                     "start_register": run[0],
                     "end_register": run[-1],
@@ -251,6 +261,10 @@ def build(events, requested_session=None):
             "vertex": frequency_rows(vertex_frequency),
             "pixel": frequency_rows(pixel_frequency),
         },
+        "vertex_shader_layout_frequency": [
+            {"vertex_shader": shader, **vertex_shader_frequency[shader]}
+            for shader in sorted(vertex_shader_frequency)
+        ],
         "vertex_consecutive_register_runs": candidate_runs,
         "qualification": {
             "exact_track_prepared_layouts_proved": not failures,

--- a/tools/tests/test_native_renderer_track_prepared_layout.py
+++ b/tools/tests/test_native_renderer_track_prepared_layout.py
@@ -33,6 +33,7 @@ def fixture():
     entry = event(
         MODULE.ENTRY,
         layout_key="0123456789ABCDEF",
+        vertex_shader="1111222233334444",
         track_render_root="10000000",
         track_render_child="10000010",
         track_render_descriptor="10000020",

--- a/tools/tests/test_native_renderer_track_prepared_transforms.py
+++ b/tools/tests/test_native_renderer_track_prepared_transforms.py
@@ -1,0 +1,127 @@
+import copy
+import importlib.util
+import pathlib
+import unittest
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+TOOL = ROOT / "tools/classify-native-renderer-track-prepared-transforms.py"
+SPEC = importlib.util.spec_from_file_location("track_prepared_transforms", TOOL)
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+def catalog():
+    instances = [
+        {
+            "category": "collision_prop",
+            "identity_hash": f"{index + 1:016X}",
+            "position": [float(index * 10 + 1), float(index * 10 + 2), float(index * 10 + 3)],
+        }
+        for index in range(8)
+    ]
+    return {
+        "schema": MODULE.CATALOG_SCHEMA,
+        "status": "complete",
+        "instance_count": len(instances),
+        "instances": instances,
+        "safety": {
+            "source_files_changed": False,
+            "plaintext_identity_exported": False,
+            "numeric_spatial_metadata_only": True,
+            "native_admission": False,
+            "suppression_allowed": False,
+        },
+    }
+
+
+def prepared():
+    runs = []
+    for index in range(8):
+        position = (float(index * 10 + 1), float(index * 10 + 2), float(index * 10 + 3))
+        values = (
+            (1.0, 0.0, 0.0, 1000.0 + index),
+            (0.0, 1.0, 0.0, 2000.0 + index),
+            (0.0, 0.0, 1.0, 3000.0 + index),
+            (*position, 1.0),
+        )
+        runs.append(
+            {
+                "layout_key": f"{index + 100:016X}",
+                "vertex_shader": "1111222233334444",
+                "calls": 1,
+                "start_register": 4,
+                "end_register": 7,
+                "register_count": 4,
+                "registers": [
+                    {"index": register + 4, "words": ["00000000"] * 4, "values": list(row)}
+                    for register, row in enumerate(values)
+                ],
+            }
+        )
+    return {
+        "schema": MODULE.PREPARED_SCHEMA,
+        "session": "test",
+        "status": "complete",
+        "vertex_consecutive_register_runs": runs,
+        "vertex_shader_layout_frequency": [
+            {
+                "vertex_shader": "1111222233334444",
+                "layouts": 8,
+                "calls": 8,
+            }
+        ],
+        "qualification": {
+            "exact_track_prepared_layouts_proved": True,
+            "world_transform_constant_layout_proved": False,
+        },
+        "safety": {
+            "guest_state_changed": False,
+            "control_flow_changed": False,
+            "xenos_authority": True,
+            "native_admission": False,
+            "suppression_allowed": False,
+        },
+    }
+
+
+class TrackPreparedTransformTests(unittest.TestCase):
+    def test_proves_unique_shader_register_and_matrix_convention(self):
+        document = MODULE.build(catalog(), prepared())
+        self.assertEqual("complete", document["status"])
+        self.assertEqual(
+            {
+                "vertex_shader": "1111222233334444",
+                "start_register": 4,
+                "convention": "translation_words_12_13_14",
+            },
+            document["selected_mapping"],
+        )
+        self.assertTrue(
+            document["qualification"]["world_transform_constant_layout_proved"]
+        )
+        self.assertFalse(document["qualification"]["native_admission"])
+
+    def test_rejects_ambiguous_catalog_position(self):
+        duplicated = catalog()
+        duplicate = copy.deepcopy(duplicated["instances"][0])
+        duplicate["identity_hash"] = "FFFFFFFFFFFFFFFF"
+        duplicated["instances"].append(duplicate)
+        duplicated["instance_count"] += 1
+        document = MODULE.build(duplicated, prepared())
+        self.assertEqual("incomplete", document["status"])
+        self.assertIsNone(document["selected_mapping"])
+
+    def test_rejects_unsafe_prepared_report(self):
+        report = prepared()
+        report["safety"]["xenos_authority"] = False
+        with self.assertRaisesRegex(ValueError, "safety drifted"):
+            MODULE.build(catalog(), report)
+
+    def test_rejects_too_few_distinct_matches(self):
+        document = MODULE.build(catalog(), prepared(), minimum_matches=9)
+        self.assertEqual("incomplete", document["status"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add vertex-shader coverage to the exact track prepared-layout report
- classify every consecutive four-register constant window against the existing title-authored spatial catalog
- require a unique, fully covered shader/register/matrix mapping with eight distinct unambiguous positions
- keep terrain/road admission and suppression disabled until runtime evidence passes

## Tests
- `python -m unittest tools.tests.test_native_renderer_track_prepared_layout tools.tests.test_native_renderer_track_prepared_transforms` (8 passed)
- `python -m unittest discover -s tools/tests -p 'test_native_renderer_*track*.py'` (42 passed)
- `python -m unittest tools.tests.test_native_renderer_static_world_instance_classification` (7 passed)
- Python syntax compilation and `git diff --check`

This completes the offline decision path for the next batched AppData capture; it does not launch or rebuild locally.