### PR TITLE
feat(renderer): census exact track scope spatial data

### DIFF
--- a/docs/native-renderer/REPRIORITIZED_PLAN.md
+++ b/docs/native-renderer/REPRIORITIZED_PLAN.md
@@ -501,6 +501,22 @@ This is ready before the batched capture, so that run can either prove one
 concrete transform contract or close the constant-window lead without another
 instrumentation cycle.
 
+Qualified prepared-layout result: clean session
+`20260901T031325Z-p38496` retained 562 families from all 732 exact observations
+with zero geometry, parameter, or table overflow and a normal shutdown. Across
+90 complete shader/register/convention groups, catalog correlation produced
+zero unique world-position matches (2,066 unmatched and 1,022 ambiguous
+common-value windows). The prepared constant lead is closed.
+
+Upstream spatial pivot: the next passive census retains bounded numeric words
+from the exact command's already-validated 64-byte child and 248-byte type-21
+descriptor, grouped by exact address pair with hash-variation accounting. Its
+offline classifier applies the same fail-closed spatial-catalog contract to
+every finite 16-word window. This adds no guest reads, admission, native draw,
+or suppression, and its AppData qualification is deliberately batched with a
+larger renderer slice. See
+[`TRACK_WORLD_SCOPE_SPATIAL.md`](TRACK_WORLD_SCOPE_SPATIAL.md).
+
 ### C2. Static world buildings and props
 
 - Expand opaque-world material and geometry coverage.

--- a/docs/native-renderer/TRACK_WORLD_PREPARED_LAYOUT.md
+++ b/docs/native-renderer/TRACK_WORLD_PREPARED_LAYOUT.md
@@ -1,6 +1,6 @@
 # Track-world prepared-layout census
 
-Status: implemented; capacity correction awaits one batched AppData rerun
+Status: qualified; prepared constant-window lead closed
 
 ## Why this is the next C1 boundary
 
@@ -35,7 +35,7 @@ sessions bounded and avoiding repeated log volume.
 
 ## Offline report
 
-After the next batched AppData run:
+For a qualified AppData run:
 
 ```powershell
 python tools/summarize-native-renderer-track-prepared-layout.py `
@@ -65,10 +65,9 @@ at least one is a collision prop, and exactly one group satisfies the whole
 contract. Shader similarity, frequency, near misses, and duplicate catalog
 positions cannot qualify it.
 
-These runs are candidates, not transforms. C1 advances only after recurring
-runs are compared across changed camera/vehicle poses and matched to the static
-world transform catalog without ambiguity. Until then, terrain/road identity,
-native admission, publication, and suppression remain unproved and disabled.
+These runs are candidates, not transforms. Terrain/road identity, native
+admission, publication, and suppression remain unproved and disabled unless a
+single mapping passes the full catalog contract.
 
 ## First runtime result
 
@@ -79,17 +78,31 @@ parameter metadata stayed bounded: there were zero unbounded-geometry and zero
 parameter-overflow observations. The 512-entry assumption, rather than the
 exact join, was therefore too small for this scene.
 
-The census capacity is now 1,024 entries. This remains a fixed startup
+The census capacity was raised to 1,024 entries. This remains a fixed startup
 allocation and comfortably covers the first run's worst case of 566 distinct
-families while preserving fail-closed overflow accounting. A new clean run is
-required before transform classification can qualify, because the classifier
-correctly rejects any incomplete source census.
+families while preserving fail-closed overflow accounting.
 
 An immediately preceding identical launch, session
 `20260901T025802Z-p39560`, hit the existing intermittent guest null dereference
 at RVA `0x48844D8` while loading the world, before any track prepared-layout
 observation was recorded. The controlled retry reached gameplay and exited
 normally, so that fault is not attributed to this observer.
+
+## Qualified runtime result
+
+Clean controlled retry `20260901T031325Z-p38496` reached the saved festival
+world, retained 562 families from all 732 exact prepared observations, and
+exited normally. There were zero unbounded-geometry, parameter-overflow, or
+table-overflow observations, and all per-entry call accounting reconciled.
+
+The catalog classifier evaluated 90 complete shader/register/convention groups
+against the 24,025-entry title-authored spatial catalog. It found zero unique
+world-position matches: 2,066 windows were unmatched and 1,022 contained
+ambiguous common or zero values. No mapping qualified. The prepared shader
+constant windows are therefore not the authored terrain/road transform carrier
+for this population, and C1 pivots upstream to the exact command's validated
+track child and type-21 descriptor rather than collecting more shader-state
+captures.
 
 ## Safety
 

--- a/docs/native-renderer/TRACK_WORLD_SCOPE_SPATIAL.md
+++ b/docs/native-renderer/TRACK_WORLD_SCOPE_SPATIAL.md
@@ -1,0 +1,63 @@
+# Track-world scope spatial census
+
+Status: implemented; runtime qualification deliberately batched
+
+## Purpose
+
+The exact indirect track command reaches prepared draws, but its prepared
+vertex-constant windows do not correlate with title-authored world positions.
+The next narrow C1 boundary is therefore upstream: the already-validated
+64-byte track child and 248-byte type-21 descriptor that define each exact
+command scope.
+
+This census tests whether either title-owned structure carries a stable
+four-by-four numeric transform window. It does not add another object walk,
+speculative pointer dereference, broad draw census, or shader-state guess.
+
+## Runtime contract
+
+At exact scope entry, after the existing child and descriptor bounds, type, and
+flag checks succeed, the observer retains one numeric snapshot per exact
+child/descriptor address pair. The fixed 1,024-entry table records:
+
+- all 16 child words and all 62 descriptor words;
+- snapshot hash and variation count;
+- exact call and first/last-frame coverage; and
+- explicit table overflow.
+
+The observer reads no new guest range: both arrays were already copied for the
+exact scope and world-resource classifier. Detailed entries are emitted once,
+only during clean final shutdown. No plaintext identity or asset payload is
+exported.
+
+## Offline classifier
+
+After the next meaningful batched AppData run:
+
+```powershell
+python tools/classify-native-renderer-track-scope-spatial.py `
+  <session.jsonl> `
+  --catalog .local/qualification/native-renderer-static-world-instance-catalog.json `
+  --output .local/qualification/native-renderer-track-scope-spatial.json
+```
+
+The classifier requires one complete lifecycle, one final summary, exact entry
+and call accounting, zero overflow, and stable snapshots. It interprets every
+finite consecutive 16-word window under the two supported title matrix
+conventions and compares translations with the existing static-world catalog.
+A mapping qualifies only when every retained scope snapshot matches exactly one
+catalog position within 0.05 units, at least eight distinct catalog instances
+match, a collision prop is included, and exactly one source/offset/convention
+group passes.
+
+An incomplete report is a useful negative result: it closes these raw numeric
+windows and sends C1 to the next upstream title-owned section carrier. It never
+widens native admission or suppression.
+
+## Safety
+
+- Xenos output remains authoritative.
+- Guest state and control flow are unchanged.
+- Native upload and drawing remain disabled for this evidence.
+- Suppression remains disabled.
+- Capture uses the installed AppData save in place.

--- a/src/native_renderer/graphics_hooks.cpp
+++ b/src/native_renderer/graphics_hooks.cpp
@@ -88,6 +88,7 @@ constexpr size_t kTitlePacketProvenanceCapacity = 16384;
 constexpr size_t kTitleDrawProvenanceCapacity = 4096;
 constexpr size_t kStaticWorldPreparedLayoutCapacity = 512;
 constexpr size_t kTrackWorldPreparedLayoutCapacity = 1024;
+constexpr size_t kTrackWorldScopeSpatialCapacity = 1024;
 constexpr size_t kTitleOriginStackCapacity = 32;
 constexpr size_t kTitleIndirectPacketBucketCount = 4096;
 constexpr size_t kTitleIndirectPacketWays = 4;
@@ -1109,6 +1110,21 @@ struct TrackWorldPreparedLayoutEntry {
   rex::system::GraphicsDrawObservation sample{};
 };
 
+struct TrackWorldScopeSpatialEntry {
+  uint64_t key = 0;
+  uint64_t calls = 0;
+  uint64_t first_frame = 0;
+  uint64_t last_frame = 0;
+  uint64_t snapshot_hash = 0;
+  uint64_t snapshot_variations = 0;
+  uint32_t child_address = 0;
+  uint32_t descriptor_address = 0;
+  std::array<uint32_t, kTrackRenderModelGraphBytes / sizeof(uint32_t)>
+      child_words{};
+  std::array<uint32_t, kTrackRenderModelDescriptorBytes / sizeof(uint32_t)>
+      descriptor_words{};
+};
+
 struct TitleIndirectPacketEntry {
   uint32_t packet_physical_address = UINT32_MAX;
   uint32_t constructor_store_address = 0;
@@ -1202,6 +1218,8 @@ std::array<StaticWorldPreparedLayoutEntry,
     g_static_world_prepared_layouts{};
 std::array<TrackWorldPreparedLayoutEntry, kTrackWorldPreparedLayoutCapacity>
     g_track_world_prepared_layouts{};
+std::array<TrackWorldScopeSpatialEntry, kTrackWorldScopeSpatialCapacity>
+    g_track_world_scope_spatial_entries{};
 std::array<SemanticBatchOpportunityEntry,
            kSemanticBatchOpportunityCapacity>
     g_semantic_batch_opportunities{};
@@ -2705,6 +2723,10 @@ std::atomic<uint64_t>
 std::atomic<uint64_t> g_track_render_model_shared_identity_joins{};
 std::array<std::atomic<uint64_t>, 9>
     g_track_render_model_shared_identity_relations{};
+std::mutex g_track_world_scope_spatial_mutex;
+std::atomic<uint64_t> g_track_world_scope_spatial_observations{};
+std::atomic<uint64_t> g_track_world_scope_spatial_table_overflow{};
+size_t g_track_world_scope_spatial_count = 0;
 std::atomic<uint64_t> g_track_world_resource_graph_cache_hits{};
 std::atomic<uint64_t> g_track_world_resource_graph_cache_misses{};
 std::atomic<uint64_t> g_track_world_resource_graph_reference_overflow{};
@@ -3674,6 +3696,56 @@ void PopulateTrackWorldResourceGraph(
   }
 }
 
+void RecordTrackWorldScopeSpatialSnapshot(
+    uint32_t child_address, uint32_t descriptor_address,
+    const std::array<uint32_t,
+                     kTrackRenderModelGraphBytes / sizeof(uint32_t)>
+        &child_words,
+    const std::array<uint32_t,
+                     kTrackRenderModelDescriptorBytes / sizeof(uint32_t)>
+        &descriptor_words) {
+  g_track_world_scope_spatial_observations.fetch_add(
+      1, std::memory_order_relaxed);
+  uint64_t key = HashCombine(UINT64_C(0xCBF29CE484222325), child_address);
+  key = HashCombine(key, descriptor_address);
+  key = key ? key : 1;
+  uint64_t snapshot_hash = HashSemanticWords(child_words);
+  snapshot_hash = HashCombine(snapshot_hash,
+                              HashSemanticWords(descriptor_words));
+  const uint64_t frame_sequence =
+      g_frame_sequence.load(std::memory_order_relaxed);
+
+  std::scoped_lock lock(g_track_world_scope_spatial_mutex);
+  size_t index = size_t(key % kTrackWorldScopeSpatialCapacity);
+  for (size_t probe = 0; probe < kTrackWorldScopeSpatialCapacity; ++probe) {
+    TrackWorldScopeSpatialEntry &entry =
+        g_track_world_scope_spatial_entries[index];
+    if (!entry.calls) {
+      entry.key = key;
+      entry.calls = 1;
+      entry.first_frame = frame_sequence;
+      entry.last_frame = frame_sequence;
+      entry.snapshot_hash = snapshot_hash;
+      entry.child_address = child_address;
+      entry.descriptor_address = descriptor_address;
+      entry.child_words = child_words;
+      entry.descriptor_words = descriptor_words;
+      ++g_track_world_scope_spatial_count;
+      return;
+    }
+    if (entry.key == key && entry.child_address == child_address &&
+        entry.descriptor_address == descriptor_address) {
+      ++entry.calls;
+      entry.last_frame = frame_sequence;
+      entry.snapshot_variations += entry.snapshot_hash != snapshot_hash ? 1 : 0;
+      return;
+    }
+    index = (index + 1) % kTrackWorldScopeSpatialCapacity;
+  }
+  g_track_world_scope_spatial_table_overflow.fetch_add(
+      1, std::memory_order_relaxed);
+}
+
 void BeginTrackRenderModelDispatch(uint32_t root_address) {
   ++g_track_render_model_scope_entries;
   if (g_track_render_model_scope.active) {
@@ -3728,6 +3800,8 @@ void BeginTrackRenderModelDispatch(uint32_t root_address) {
     ++g_track_render_model_scope_contract_mismatches;
     return;
   }
+  RecordTrackWorldScopeSpatialSnapshot(child_address, descriptor_address,
+                                       child_words, descriptor_words);
   g_track_render_model_scope.root_address = root_address;
   g_track_render_model_scope.child_address = child_address;
   g_track_render_model_scope.descriptor_address = descriptor_address;
@@ -6372,6 +6446,10 @@ void ResetTitleDrawProvenance() {
        g_track_world_prepared_layouts) {
     entry = {};
   }
+  for (TrackWorldScopeSpatialEntry &entry :
+       g_track_world_scope_spatial_entries) {
+    entry = {};
+  }
   for (SemanticBatchOpportunityEntry &entry :
        g_semantic_batch_opportunities) {
     entry = {};
@@ -6416,6 +6494,7 @@ void ResetTitleDrawProvenance() {
   g_title_draw_provenance_overflow = 0;
   g_static_world_prepared_layout_count = 0;
   g_track_world_prepared_layout_count = 0;
+  g_track_world_scope_spatial_count = 0;
   g_semantic_batch_observations = 0;
   g_semantic_visibility_prepared_observations = 0;
   g_semantic_visibility_prepared_selected_joins = 0;
@@ -6692,6 +6771,8 @@ void ResetTitleDrawProvenance() {
            &g_track_world_prepared_layout_unbounded_geometry,
            &g_track_world_prepared_layout_parameter_overflows,
            &g_track_world_prepared_layout_table_overflow,
+           &g_track_world_scope_spatial_observations,
+           &g_track_world_scope_spatial_table_overflow,
            &g_static_world_presentation_entries,
            &g_static_world_presentation_exits,
            &g_static_world_presentation_exact,
@@ -12897,6 +12978,7 @@ void EmitProceduralModelSemanticSubmissions() {
        {"suppression_allowed", "false"}});
 }
 
+void EmitTrackWorldScopeSpatialEntries();
 void EmitTrackWorldPreparedLayoutEntries();
 
 void EmitTrackRenderModelRuntimeJoinEvent(const char *event_name,
@@ -12959,6 +13041,26 @@ void EmitTrackRenderModelRuntimeJoinEvent(const char *event_name,
           prepared_layout_exact + prepared_layout_unbounded_geometry +
               prepared_layout_parameter_overflows &&
       !prepared_layout_table_overflow;
+  const uint64_t scope_spatial_observations =
+      g_track_world_scope_spatial_observations.load(
+          std::memory_order_relaxed);
+  const uint64_t scope_spatial_table_overflow =
+      g_track_world_scope_spatial_table_overflow.load(
+          std::memory_order_relaxed);
+  uint64_t scope_spatial_accounted = 0;
+  size_t scope_spatial_entries = 0;
+  {
+    std::scoped_lock lock(g_track_world_scope_spatial_mutex);
+    scope_spatial_entries = g_track_world_scope_spatial_count;
+    for (const TrackWorldScopeSpatialEntry &entry :
+         g_track_world_scope_spatial_entries) {
+      scope_spatial_accounted += entry.calls;
+    }
+  }
+  const bool scope_spatial_accounting_complete =
+      scope_spatial_observations ==
+          scope_spatial_accounted + scope_spatial_table_overflow &&
+      !scope_spatial_table_overflow;
   pinyon_shift::diagnostics::RecordEvent(
       event_name,
       {{"status", !entries
@@ -13017,6 +13119,14 @@ void EmitTrackRenderModelRuntimeJoinEvent(const char *event_name,
          std::to_string(prepared_layout_table_overflow)},
        {"prepared_layout_accounting_complete",
          prepared_layout_accounting_complete ? "true" : "false"},
+       {"scope_spatial_observations",
+        std::to_string(scope_spatial_observations)},
+       {"scope_spatial_entries",
+        std::to_string(scope_spatial_entries)},
+       {"scope_spatial_table_overflow",
+        std::to_string(scope_spatial_table_overflow)},
+       {"scope_spatial_accounting_complete",
+        scope_spatial_accounting_complete ? "true" : "false"},
        {"shared_identity_joins",
         std::to_string(g_track_render_model_shared_identity_joins.load(
             std::memory_order_relaxed))},
@@ -13186,6 +13296,7 @@ void EmitTrackRenderModelRuntimeJoinEvent(const char *event_name,
 }
 
 void EmitTrackRenderModelRuntimeJoinSummary() {
+  EmitTrackWorldScopeSpatialEntries();
   EmitTrackWorldPreparedLayoutEntries();
   EmitTrackRenderModelRuntimeJoinEvent(
       "native_renderer.discovery.track_render_model_runtime_join_summary",
@@ -15489,6 +15600,55 @@ std::string SerializeVertexAttributes(
         attribute.flags);
   }
   return result;
+}
+
+template <size_t N>
+std::string SerializeHexWords(const std::array<uint32_t, N> &words) {
+  std::string result;
+  for (uint32_t word : words) {
+    if (!result.empty()) {
+      result += ":";
+    }
+    result += fmt::format("{:08X}", word);
+  }
+  return result;
+}
+
+void EmitTrackWorldScopeSpatialEntries() {
+  std::scoped_lock lock(g_track_world_scope_spatial_mutex);
+  for (const TrackWorldScopeSpatialEntry &entry :
+       g_track_world_scope_spatial_entries) {
+    if (!entry.calls) {
+      continue;
+    }
+    pinyon_shift::diagnostics::RecordEvent(
+        "native_renderer.discovery.track_world_scope_spatial_entry",
+        {{"snapshot_key", fmt::format("{:016X}", entry.key)},
+         {"child_address", fmt::format("{:08X}", entry.child_address)},
+         {"descriptor_address",
+          fmt::format("{:08X}", entry.descriptor_address)},
+         {"calls", std::to_string(entry.calls)},
+         {"first_frame", std::to_string(entry.first_frame)},
+         {"last_frame", std::to_string(entry.last_frame)},
+         {"snapshot_hash", fmt::format("{:016X}", entry.snapshot_hash)},
+         {"snapshot_variations",
+          std::to_string(entry.snapshot_variations)},
+         {"child_word_count", std::to_string(entry.child_words.size())},
+         {"child_words", SerializeHexWords(entry.child_words)},
+         {"descriptor_word_count",
+          std::to_string(entry.descriptor_words.size())},
+         {"descriptor_words", SerializeHexWords(entry.descriptor_words)},
+         {"classification", "exact_track_scope_numeric_spatial_candidate"},
+         {"guest_payload_read",
+          "bounded_validated_track_child_and_descriptor_words_only"},
+         {"plaintext_identity_exported", "false"},
+         {"guest_state_changed", "false"},
+         {"control_flow_changed", "false"},
+         {"native_admission", "false"},
+         {"native_draw", "false"},
+         {"xenos_authority", "true"},
+         {"suppression_allowed", "false"}});
+  }
 }
 
 void EmitTrackWorldPreparedLayoutEntries() {
@@ -28886,6 +29046,10 @@ void InstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system,
         "exact_address_equality_to_submission_objects_or_resources"},
        {"world_resource_graph_cache_capacity", "1024"},
        {"world_resource_reference_capacity", "16"},
+       {"scope_spatial_capacity",
+        std::to_string(kTrackWorldScopeSpatialCapacity)},
+       {"scope_spatial_words", "child_16_descriptor_62"},
+       {"scope_spatial_export", "numeric_words_hash_variation_only"},
        {"guest_payload_read",
         "bounded_320_bytes_plus_direct_vtable_words_per_cache_miss"},
        {"guest_state_changed", "false"},

--- a/tools/classify-native-renderer-track-scope-spatial.py
+++ b/tools/classify-native-renderer-track-scope-spatial.py
@@ -1,0 +1,346 @@
+#!/usr/bin/env python3
+"""Match exact track-scope numeric windows to the static-world catalog."""
+
+from __future__ import annotations
+
+import argparse
+import collections
+import itertools
+import json
+import math
+import pathlib
+import struct
+import sys
+
+
+SCHEMA = "pinyon-shift.native-renderer-track-scope-spatial-classification.v1"
+CATALOG_SCHEMA = "pinyon-shift.native-renderer-static-world-instance-catalog.v1"
+ENTRY = "native_renderer.discovery.track_world_scope_spatial_entry"
+SUMMARY = "native_renderer.discovery.track_render_model_runtime_join_summary"
+DEFAULT_TOLERANCE = 0.05
+DEFAULT_MINIMUM_MATCHES = 8
+CONVENTIONS = {
+    "translation_words_12_13_14": (12, 13, 14),
+    "translation_words_3_7_11": (3, 7, 11),
+}
+
+
+def hexadecimal(value, width, label):
+    value = str(value).upper()
+    if len(value) != width or any(c not in "0123456789ABCDEF" for c in value):
+        raise ValueError(f"invalid {label}")
+    return value
+
+
+def integer(event, key):
+    try:
+        value = int(event[key])
+    except (KeyError, TypeError, ValueError) as error:
+        raise ValueError(f"invalid {key}") from error
+    if value < 0:
+        raise ValueError(f"negative {key}")
+    return value
+
+
+def require_safety(event):
+    expected = {
+        "guest_state_changed": "false",
+        "control_flow_changed": "false",
+        "native_admission": "false",
+        "xenos_authority": "true",
+        "suppression_allowed": "false",
+    }
+    if any(event.get(key) != value for key, value in expected.items()):
+        raise ValueError("track-scope spatial evidence violates safety")
+
+
+def read_events(paths):
+    events = []
+    for path in paths:
+        with path.open(encoding="utf-8") as stream:
+            for line_number, line in enumerate(stream, 1):
+                if not line.strip():
+                    continue
+                try:
+                    event = json.loads(line)
+                except json.JSONDecodeError as error:
+                    raise ValueError(f"invalid JSON at {path}:{line_number}") from error
+                if isinstance(event, dict):
+                    events.append(event)
+    return events
+
+
+def parse_words(event, prefix, expected_count):
+    if integer(event, f"{prefix}_word_count") != expected_count:
+        raise ValueError(f"{prefix} word count drifted")
+    raw = event.get(f"{prefix}_words")
+    if not isinstance(raw, str):
+        raise ValueError(f"invalid {prefix} words")
+    words = tuple(
+        int(hexadecimal(word, 8, f"{prefix} word"), 16)
+        for word in raw.split(":")
+    )
+    if len(words) != expected_count:
+        raise ValueError(f"{prefix} payload count drifted")
+    return words
+
+
+def validate_catalog(document):
+    if document.get("schema") != CATALOG_SCHEMA or document.get("status") != "complete":
+        raise ValueError("static-world instance catalog is unsupported")
+    safety = document.get("safety", {})
+    if (
+        safety.get("source_files_changed") is not False
+        or safety.get("plaintext_identity_exported") is not False
+        or safety.get("numeric_spatial_metadata_only") is not True
+        or safety.get("native_admission") is not False
+        or safety.get("suppression_allowed") is not False
+    ):
+        raise ValueError("static-world instance catalog safety drifted")
+    instances = document.get("instances")
+    if not isinstance(instances, list) or len(instances) != document.get("instance_count"):
+        raise ValueError("static-world instance catalog count drifted")
+    result = []
+    for index, instance in enumerate(instances):
+        position = instance.get("position")
+        if (
+            instance.get("category") not in ("collision_prop", "gameplay_object")
+            or not isinstance(position, list)
+            or len(position) != 3
+            or not all(isinstance(value, (int, float)) and math.isfinite(value) for value in position)
+        ):
+            raise ValueError("invalid static-world catalog instance")
+        result.append({
+            "catalog_index": index,
+            "category": instance["category"],
+            "identity_hash": hexadecimal(instance.get("identity_hash", ""), 16, "catalog identity hash"),
+            "position": tuple(float(value) for value in position),
+        })
+    return result
+
+
+def spatial_index(instances, tolerance):
+    result = collections.defaultdict(list)
+    for instance in instances:
+        key = tuple(math.floor(value / tolerance) for value in instance["position"])
+        result[key].append(instance)
+    return result
+
+
+def match_position(index, position, tolerance):
+    key = tuple(math.floor(value / tolerance) for value in position)
+    matches = []
+    for offset in itertools.product((-1, 0, 1), repeat=3):
+        adjacent = tuple(key[axis] + offset[axis] for axis in range(3))
+        for instance in index.get(adjacent, ()):
+            distance = math.dist(position, instance["position"])
+            if distance <= tolerance:
+                matches.append((distance, instance))
+    matches.sort(key=lambda item: (item[0], item[1]["catalog_index"]))
+    if not matches:
+        return "unmatched", None
+    if len(matches) != 1:
+        return "ambiguous", None
+    return "matched", matches[0]
+
+
+def select_session(events, requested):
+    sessions = {
+        str(event.get("session"))
+        for event in events
+        if event.get("event") == SUMMARY and event.get("session")
+    }
+    if requested:
+        if requested not in sessions:
+            raise ValueError("requested session has no final track summary")
+        session = requested
+    elif len(sessions) == 1:
+        session = next(iter(sessions))
+    else:
+        raise ValueError("input must contain exactly one candidate session")
+    return session, [event for event in events if str(event.get("session")) == session]
+
+
+def build(events, catalog, requested_session=None, tolerance=DEFAULT_TOLERANCE,
+          minimum_matches=DEFAULT_MINIMUM_MATCHES):
+    if not math.isfinite(tolerance) or tolerance <= 0 or tolerance > 1:
+        raise ValueError("match tolerance is outside the safe range")
+    if minimum_matches < 1:
+        raise ValueError("minimum matches must be positive")
+    instances = validate_catalog(catalog)
+    session, selected = select_session(events, requested_session)
+    starts = [event for event in selected if event.get("event") == "process.start"]
+    shutdowns = [event for event in selected if event.get("event") == "process.shutdown"]
+    summaries = [event for event in selected if event.get("event") == SUMMARY]
+    if len(starts) != 1 or len(shutdowns) != 1 or len(summaries) != 1:
+        raise ValueError("track-scope spatial lifecycle is incomplete")
+    summary = summaries[0]
+    require_safety(summary)
+    if summary.get("checkpoint_kind") != "final":
+        raise ValueError("track-scope spatial summary is not final")
+    entries = [event for event in selected if event.get("event") == ENTRY]
+    expected_entries = integer(summary, "scope_spatial_entries")
+    observations = integer(summary, "scope_spatial_observations")
+    if (
+        len(entries) != expected_entries
+        or integer(summary, "scope_spatial_table_overflow") != 0
+        or summary.get("scope_spatial_accounting_complete") != "true"
+    ):
+        raise ValueError("track-scope spatial accounting is incomplete")
+
+    parsed = []
+    seen = set()
+    calls = 0
+    for event in entries:
+        require_safety(event)
+        key = hexadecimal(event.get("snapshot_key", ""), 16, "snapshot key")
+        if key in seen:
+            raise ValueError("duplicate track-scope spatial key")
+        seen.add(key)
+        hexadecimal(event.get("child_address", ""), 8, "child address")
+        hexadecimal(event.get("descriptor_address", ""), 8, "descriptor address")
+        entry_calls = integer(event, "calls")
+        first_frame = integer(event, "first_frame")
+        last_frame = integer(event, "last_frame")
+        if not entry_calls or first_frame > last_frame or integer(event, "snapshot_variations"):
+            raise ValueError("track-scope spatial snapshot is unstable")
+        calls += entry_calls
+        parsed.append({
+            "snapshot_key": key,
+            "child": parse_words(event, "child", 16),
+            "descriptor": parse_words(event, "descriptor", 62),
+        })
+    if calls != observations:
+        raise ValueError("track-scope spatial call accounting drifted")
+
+    index = spatial_index(instances, tolerance)
+    groups = collections.defaultdict(list)
+    for entry in parsed:
+        for source in ("child", "descriptor"):
+            words = entry[source]
+            for word_offset in range(len(words) - 15):
+                window = words[word_offset : word_offset + 16]
+                values = tuple(struct.unpack(">f", word.to_bytes(4, "big"))[0] for word in window)
+                if not all(math.isfinite(value) for value in values):
+                    continue
+                for convention, indices in CONVENTIONS.items():
+                    groups[(source, word_offset, convention)].append(
+                        (entry["snapshot_key"], tuple(values[i] for i in indices))
+                    )
+
+    reports = []
+    qualified = []
+    for (source, word_offset, convention), candidates in sorted(groups.items()):
+        matches = []
+        unmatched = 0
+        ambiguous = 0
+        for snapshot_key, position in candidates:
+            outcome, match = match_position(index, position, tolerance)
+            if outcome == "unmatched":
+                unmatched += 1
+            elif outcome == "ambiguous":
+                ambiguous += 1
+            else:
+                distance, instance = match
+                matches.append({
+                    "snapshot_key": snapshot_key,
+                    "category": instance["category"],
+                    "catalog_identity_hash": instance["identity_hash"],
+                    "catalog_index": instance["catalog_index"],
+                    "distance": round(distance, 9),
+                })
+        distinct = len({match["catalog_index"] for match in matches})
+        categories = collections.Counter(match["category"] for match in matches)
+        complete = (
+            len(candidates) == len(parsed)
+            and len(matches) == len(parsed)
+            and distinct >= minimum_matches
+            and categories["collision_prop"] > 0
+            and not unmatched
+            and not ambiguous
+        )
+        report = {
+            "source": source,
+            "word_offset": word_offset,
+            "convention": convention,
+            "observed_snapshots": len(candidates),
+            "matched": len(matches),
+            "distinct_catalog_matches": distinct,
+            "unmatched": unmatched,
+            "ambiguous": ambiguous,
+            "category_counts": dict(sorted(categories.items())),
+            "complete": complete,
+            "matches": matches,
+        }
+        reports.append(report)
+        if complete:
+            qualified.append(report)
+
+    failures = []
+    if not parsed:
+        failures.append("no exact track-scope snapshots were observed")
+    if len(qualified) != 1:
+        failures.append("track-scope world transform mapping is not uniquely proved")
+    selected_mapping = qualified[0] if len(qualified) == 1 else None
+    return {
+        "schema": SCHEMA,
+        "session": session,
+        "status": "complete" if not failures else "incomplete",
+        "failures": failures,
+        "catalog_instance_count": len(instances),
+        "snapshot_count": len(parsed),
+        "observation_count": observations,
+        "candidate_group_count": len(reports),
+        "minimum_distinct_matches": minimum_matches,
+        "position_tolerance": tolerance,
+        "selected_mapping": None if selected_mapping is None else {
+            key: selected_mapping[key] for key in ("source", "word_offset", "convention")
+        },
+        "candidate_groups": reports,
+        "qualification": {
+            "exact_track_scope_snapshots_proved": True,
+            "world_transform_layout_proved": not failures,
+            "native_admission": False,
+            "suppression_allowed": False,
+        },
+        "safety": {
+            "guest_state_changed": False,
+            "source_files_changed": False,
+            "plaintext_identity_exported": False,
+            "xenos_authority": True,
+            "native_admission": False,
+            "native_draw": False,
+            "suppression_allowed": False,
+        },
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("logs", nargs="+", type=pathlib.Path)
+    parser.add_argument("--catalog", required=True, type=pathlib.Path)
+    parser.add_argument("--output", required=True, type=pathlib.Path)
+    parser.add_argument("--session")
+    parser.add_argument("--tolerance", type=float, default=DEFAULT_TOLERANCE)
+    parser.add_argument("--minimum-matches", type=int, default=DEFAULT_MINIMUM_MATCHES)
+    arguments = parser.parse_args()
+    try:
+        document = build(
+            read_events(arguments.logs),
+            json.loads(arguments.catalog.read_text(encoding="utf-8")),
+            requested_session=arguments.session,
+            tolerance=arguments.tolerance,
+            minimum_matches=arguments.minimum_matches,
+        )
+        arguments.output.parent.mkdir(parents=True, exist_ok=True)
+        arguments.output.write_text(json.dumps(document, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+        if document["status"] != "complete":
+            raise ValueError("; ".join(document["failures"]))
+        return 0
+    except (json.JSONDecodeError, OSError, ValueError) as error:
+        print(f"track-scope spatial classification failed: {error}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/tests/test_native_renderer_track_scope_spatial.py
+++ b/tools/tests/test_native_renderer_track_scope_spatial.py
@@ -1,0 +1,122 @@
+import copy
+import importlib.util
+import pathlib
+import struct
+import unittest
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+TOOL = ROOT / "tools/classify-native-renderer-track-scope-spatial.py"
+SPEC = importlib.util.spec_from_file_location("track_scope_spatial", TOOL)
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+def word(value):
+    return f"{int.from_bytes(struct.pack('>f', float(value)), 'big'):08X}"
+
+
+def catalog():
+    instances = [
+        {
+            "category": "collision_prop" if index == 0 else "gameplay_object",
+            "identity_hash": f"{index + 1:016X}",
+            "position": [float(index * 10 + 1), float(index * 10 + 2), float(index * 10 + 3)],
+        }
+        for index in range(8)
+    ]
+    return {
+        "schema": MODULE.CATALOG_SCHEMA,
+        "status": "complete",
+        "instance_count": len(instances),
+        "instances": instances,
+        "safety": {
+            "source_files_changed": False,
+            "plaintext_identity_exported": False,
+            "numeric_spatial_metadata_only": True,
+            "native_admission": False,
+            "suppression_allowed": False,
+        },
+    }
+
+
+def event(name, session="test", **values):
+    return {"event": name, "session": session, **values}
+
+
+def evidence():
+    safety = {
+        "guest_state_changed": "false",
+        "control_flow_changed": "false",
+        "native_admission": "false",
+        "xenos_authority": "true",
+        "suppression_allowed": "false",
+    }
+    events = [event("process.start")]
+    for index in range(8):
+        position = (index * 10 + 1, index * 10 + 2, index * 10 + 3)
+        matrix = [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, *position, 1]
+        descriptor = [word(1000 + index)] * 8 + [word(value) for value in matrix] + [word(2000 + index)] * 38
+        events.append(event(
+            MODULE.ENTRY,
+            snapshot_key=f"{index + 1:016X}",
+            child_address=f"{0x1000 + index * 0x100:08X}",
+            descriptor_address=f"{0x2000 + index * 0x100:08X}",
+            calls="1", first_frame="1", last_frame="2",
+            snapshot_variations="0", child_word_count="16",
+            child_words=":".join([word(3000 + index)] * 16),
+            descriptor_word_count="62", descriptor_words=":".join(descriptor),
+            **safety,
+        ))
+    events.extend([
+        event(MODULE.SUMMARY, checkpoint_kind="final", scope_spatial_entries="8",
+              scope_spatial_observations="8", scope_spatial_table_overflow="0",
+              scope_spatial_accounting_complete="true", **safety),
+        event("process.shutdown"),
+    ])
+    return events
+
+
+class TrackScopeSpatialTests(unittest.TestCase):
+    def test_proves_unique_descriptor_matrix_window(self):
+        document = MODULE.build(evidence(), catalog())
+        self.assertEqual("complete", document["status"])
+        self.assertEqual(
+            {"source": "descriptor", "word_offset": 8, "convention": "translation_words_12_13_14"},
+            document["selected_mapping"],
+        )
+        self.assertFalse(document["qualification"]["native_admission"])
+
+    def test_reports_unmatched_windows_without_admission(self):
+        changed = catalog()
+        for instance in changed["instances"]:
+            instance["position"] = [value + 0.5 for value in instance["position"]]
+        document = MODULE.build(evidence(), changed)
+        self.assertEqual("incomplete", document["status"])
+        self.assertIsNone(document["selected_mapping"])
+        self.assertFalse(document["safety"]["suppression_allowed"])
+
+    def test_rejects_snapshot_variation(self):
+        events = evidence()
+        events[1]["snapshot_variations"] = "1"
+        with self.assertRaisesRegex(ValueError, "unstable"):
+            MODULE.build(events, catalog())
+
+    def test_rejects_unsafe_summary(self):
+        events = copy.deepcopy(evidence())
+        events[-2]["xenos_authority"] = "false"
+        with self.assertRaisesRegex(ValueError, "violates safety"):
+            MODULE.build(events, catalog())
+
+    def test_source_contract_is_passive_and_bounded(self):
+        source = (ROOT / "src/native_renderer/graphics_hooks.cpp").read_text(encoding="utf-8")
+        self.assertIn("kTrackWorldScopeSpatialCapacity = 1024", source)
+        self.assertIn("RecordTrackWorldScopeSpatialSnapshot", source)
+        self.assertIn(MODULE.ENTRY, source)
+        self.assertIn('"scope_spatial_export", "numeric_words_hash_variation_only"', source)
+        self.assertIn('"native_admission", "false"', source)
+        self.assertIn('"suppression_allowed", "false"', source)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Captures bounded numeric snapshots from the already-validated exact track child and type-21 descriptor, adds a fail-closed catalog classifier, and records the qualified prepared-constant negative result. Xenos remains authoritative; native admission and suppression stay disabled. Tests: 13 focused unittest cases, py_compile, and git diff --check.