### PR TITLE
feat(renderer): correlate track reference composition

### DIFF
--- a/docs/native-renderer/REPRIORITIZED_PLAN.md
+++ b/docs/native-renderer/REPRIORITIZED_PLAN.md
@@ -517,6 +517,18 @@ or suppression, and its AppData qualification is deliberately batched with a
 larger renderer slice. See
 [`TRACK_WORLD_SCOPE_SPATIAL.md`](TRACK_WORLD_SCOPE_SPATIAL.md).
 
+Reference-composition extension: static flow in the same exact title function
+already proves a live object/reference matrix and its composed constant payload
+at `8240EB5C`, immediately before the accepted `8240EC80` track scope. The
+observer now stages those two finite matrices and consumes them only after the
+exact unified instance/model and type-21 predicates pass. Offline correlation
+tests every local child/descriptor window under both matrix sources,
+multiplication orders, and title conventions. This materially strengthens the
+next batch: one run can prove an authored local-to-world composition or close
+both raw and reference-composed interpretations without another build cycle.
+See
+[`TRACK_WORLD_REFERENCE_COMPOSITION.md`](TRACK_WORLD_REFERENCE_COMPOSITION.md).
+
 ### C2. Static world buildings and props
 
 - Expand opaque-world material and geometry coverage.

--- a/docs/native-renderer/TRACK_WORLD_REFERENCE_COMPOSITION.md
+++ b/docs/native-renderer/TRACK_WORLD_REFERENCE_COMPOSITION.md
@@ -1,0 +1,67 @@
+# Track-world reference composition census
+
+Status: implemented; runtime qualification batched with scope spatial census
+
+## Why this is a stronger transform lead
+
+Retail instruction flow in `8240E7B0` proves two complete 64-byte matrices
+immediately before the exact unified track render-model dispatch:
+
+- `r22` is the live object/reference input matrix; and
+- `r5` is the fully composed stack matrix passed to constant writer `82435E78`.
+
+Earlier vehicle work correctly rejected both as absolute vehicle poses. Phase
+C1 subsequently proved the same function's root and child are the unified
+track render-model instance/model pair. The matrices are therefore useful
+track reference-space evidence even though they were not a vehicle bridge.
+
+The raw child/descriptor spatial census tests for an authored absolute matrix.
+This companion census tests the more likely alternative: a local track-section
+matrix becomes an authored world position only after composition with one of
+these title-proved reference matrices.
+
+## Exact runtime join
+
+The existing hook at `8240EB5C` stages both finite matrices in thread-local
+storage. The later exact scope entry at `8240EC80` consumes the stage only after
+the unified instance/model vtables and type-21 descriptor predicates pass.
+Invalid roots cannot publish a reference snapshot, and ordinary calls never
+inherit an accepted track identity.
+
+A fixed 2,048-entry table is keyed by exact child/descriptor addresses plus
+both matrix hashes. It retains the numeric matrices and call/frame coverage.
+Detailed entries are emitted only at clean final shutdown. Missing same-thread
+stages, invalid ranges, non-finite matrices, and table overflow are independently
+counted. No stack pointer is retained after the synchronous copy.
+
+## Offline composition qualifier
+
+After the next meaningful AppData run:
+
+```powershell
+python tools/classify-native-renderer-track-reference-composition.py `
+  <session.jsonl> `
+  --catalog .local/qualification/native-renderer-static-world-instance-catalog.json `
+  --output .local/qualification/native-renderer-track-reference-composition.json
+```
+
+The classifier joins each reference snapshot to the stable child/descriptor
+snapshot with the same exact addresses. For every finite local 16-word window,
+it evaluates both reference sources, both multiplication orders, and both
+supported title matrix conventions. Each candidate translation is matched to
+the 24,025-entry authored spatial catalog.
+
+Qualification requires complete lifecycle and call accounting, zero missing
+stage or overflow, every snapshot mapping unambiguously, at least eight
+distinct catalog instances including a collision prop, and exactly one
+local-source/offset/reference/order/convention mapping. A negative result
+closes both absolute and reference-composed interpretations of these bounded
+structures before C1 moves farther upstream.
+
+## Safety
+
+- Both 64-byte ranges are statically proved live at the existing hook.
+- Guest state and title control flow are unchanged.
+- Xenos remains authoritative.
+- Native upload, publication, admission, and suppression remain disabled.
+- Runtime validation is batched with the pending scope census.

--- a/docs/native-renderer/TRACK_WORLD_SCOPE_SPATIAL.md
+++ b/docs/native-renderer/TRACK_WORLD_SCOPE_SPATIAL.md
@@ -54,6 +54,12 @@ An incomplete report is a useful negative result: it closes these raw numeric
 windows and sends C1 to the next upstream title-owned section carrier. It never
 widens native admission or suppression.
 
+The same batched capture also retains the two title-proved reference matrices
+immediately upstream of the exact scope. The companion qualifier in
+[`TRACK_WORLD_REFERENCE_COMPOSITION.md`](TRACK_WORLD_REFERENCE_COMPOSITION.md)
+tests whether any local child/descriptor window maps to authored world space
+only after that reference composition.
+
 ## Safety
 
 - Xenos output remains authoritative.

--- a/src/native_renderer/graphics_hooks.cpp
+++ b/src/native_renderer/graphics_hooks.cpp
@@ -89,6 +89,7 @@ constexpr size_t kTitleDrawProvenanceCapacity = 4096;
 constexpr size_t kStaticWorldPreparedLayoutCapacity = 512;
 constexpr size_t kTrackWorldPreparedLayoutCapacity = 1024;
 constexpr size_t kTrackWorldScopeSpatialCapacity = 1024;
+constexpr size_t kTrackWorldReferenceSpatialCapacity = 2048;
 constexpr size_t kTitleOriginStackCapacity = 32;
 constexpr size_t kTitleIndirectPacketBucketCount = 4096;
 constexpr size_t kTitleIndirectPacketWays = 4;
@@ -1125,6 +1126,25 @@ struct TrackWorldScopeSpatialEntry {
       descriptor_words{};
 };
 
+struct TrackWorldReferenceSpatialEntry {
+  uint64_t key = 0;
+  uint64_t calls = 0;
+  uint64_t first_frame = 0;
+  uint64_t last_frame = 0;
+  uint32_t child_address = 0;
+  uint32_t descriptor_address = 0;
+  std::array<uint32_t, 16> object_matrix_words{};
+  std::array<uint32_t, 16> composed_matrix_words{};
+};
+
+struct PendingTrackWorldReferenceSpatial {
+  uint32_t object_matrix_address = 0;
+  uint32_t composed_matrix_address = 0;
+  std::array<uint32_t, 16> object_matrix_words{};
+  std::array<uint32_t, 16> composed_matrix_words{};
+  bool valid = false;
+};
+
 struct TitleIndirectPacketEntry {
   uint32_t packet_physical_address = UINT32_MAX;
   uint32_t constructor_store_address = 0;
@@ -1220,6 +1240,9 @@ std::array<TrackWorldPreparedLayoutEntry, kTrackWorldPreparedLayoutCapacity>
     g_track_world_prepared_layouts{};
 std::array<TrackWorldScopeSpatialEntry, kTrackWorldScopeSpatialCapacity>
     g_track_world_scope_spatial_entries{};
+std::array<TrackWorldReferenceSpatialEntry,
+           kTrackWorldReferenceSpatialCapacity>
+    g_track_world_reference_spatial_entries{};
 std::array<SemanticBatchOpportunityEntry,
            kSemanticBatchOpportunityCapacity>
     g_semantic_batch_opportunities{};
@@ -2727,6 +2750,15 @@ std::mutex g_track_world_scope_spatial_mutex;
 std::atomic<uint64_t> g_track_world_scope_spatial_observations{};
 std::atomic<uint64_t> g_track_world_scope_spatial_table_overflow{};
 size_t g_track_world_scope_spatial_count = 0;
+std::mutex g_track_world_reference_spatial_mutex;
+std::atomic<uint64_t> g_track_world_reference_spatial_observations{};
+std::atomic<uint64_t> g_track_world_reference_spatial_missing_stage{};
+std::atomic<uint64_t> g_track_world_reference_spatial_invalid_range{};
+std::atomic<uint64_t> g_track_world_reference_spatial_non_finite{};
+std::atomic<uint64_t> g_track_world_reference_spatial_table_overflow{};
+size_t g_track_world_reference_spatial_count = 0;
+thread_local PendingTrackWorldReferenceSpatial
+    g_pending_track_world_reference_spatial{};
 std::atomic<uint64_t> g_track_world_resource_graph_cache_hits{};
 std::atomic<uint64_t> g_track_world_resource_graph_cache_misses{};
 std::atomic<uint64_t> g_track_world_resource_graph_reference_overflow{};
@@ -3331,6 +3363,10 @@ void LoadSemanticGuestWords(rex::memory::Memory *memory, uint32_t address,
                             std::array<uint32_t, N> &words);
 template <size_t N>
 uint64_t HashSemanticWords(const std::array<uint32_t, N> &words);
+void StageTrackWorldReferenceSpatial(uint32_t object_matrix_address,
+                                     uint32_t composed_matrix_address);
+void ConsumeTrackWorldReferenceSpatial(uint32_t child_address,
+                                       uint32_t descriptor_address);
 
 const char *VehicleIdentityAddressKindName(VehicleIdentityAddressKind kind) {
   switch (kind) {
@@ -3802,6 +3838,7 @@ void BeginTrackRenderModelDispatch(uint32_t root_address) {
   }
   RecordTrackWorldScopeSpatialSnapshot(child_address, descriptor_address,
                                        child_words, descriptor_words);
+  ConsumeTrackWorldReferenceSpatial(child_address, descriptor_address);
   g_track_render_model_scope.root_address = root_address;
   g_track_render_model_scope.child_address = child_address;
   g_track_render_model_scope.descriptor_address = descriptor_address;
@@ -6450,6 +6487,10 @@ void ResetTitleDrawProvenance() {
        g_track_world_scope_spatial_entries) {
     entry = {};
   }
+  for (TrackWorldReferenceSpatialEntry &entry :
+       g_track_world_reference_spatial_entries) {
+    entry = {};
+  }
   for (SemanticBatchOpportunityEntry &entry :
        g_semantic_batch_opportunities) {
     entry = {};
@@ -6495,6 +6536,8 @@ void ResetTitleDrawProvenance() {
   g_static_world_prepared_layout_count = 0;
   g_track_world_prepared_layout_count = 0;
   g_track_world_scope_spatial_count = 0;
+  g_track_world_reference_spatial_count = 0;
+  g_pending_track_world_reference_spatial = {};
   g_semantic_batch_observations = 0;
   g_semantic_visibility_prepared_observations = 0;
   g_semantic_visibility_prepared_selected_joins = 0;
@@ -6773,6 +6816,11 @@ void ResetTitleDrawProvenance() {
            &g_track_world_prepared_layout_table_overflow,
            &g_track_world_scope_spatial_observations,
            &g_track_world_scope_spatial_table_overflow,
+           &g_track_world_reference_spatial_observations,
+           &g_track_world_reference_spatial_missing_stage,
+           &g_track_world_reference_spatial_invalid_range,
+           &g_track_world_reference_spatial_non_finite,
+           &g_track_world_reference_spatial_table_overflow,
            &g_static_world_presentation_entries,
            &g_static_world_presentation_exits,
            &g_static_world_presentation_exact,
@@ -10785,6 +10833,103 @@ bool g_graphics_census_installed = false;
 rex::memory::Memory *g_graphics_census_memory = nullptr;
 void *g_guest_cpu_access_callback = nullptr;
 
+void StageTrackWorldReferenceSpatial(uint32_t object_matrix_address,
+                                     uint32_t composed_matrix_address) {
+  g_pending_track_world_reference_spatial = {};
+  if (!g_graphics_census_installed || !g_graphics_census_memory) {
+    return;
+  }
+  if (!IsReadableVehicleGuestRange(g_graphics_census_memory,
+                                   object_matrix_address, 64) ||
+      !IsReadableVehicleGuestRange(g_graphics_census_memory,
+                                   composed_matrix_address, 64)) {
+    g_track_world_reference_spatial_invalid_range.fetch_add(
+        1, std::memory_order_relaxed);
+    return;
+  }
+  LoadSemanticGuestWords(
+      g_graphics_census_memory, object_matrix_address,
+      g_pending_track_world_reference_spatial.object_matrix_words);
+  LoadSemanticGuestWords(
+      g_graphics_census_memory, composed_matrix_address,
+      g_pending_track_world_reference_spatial.composed_matrix_words);
+  for (uint32_t word :
+       g_pending_track_world_reference_spatial.object_matrix_words) {
+    if (!std::isfinite(std::bit_cast<float>(word))) {
+      g_track_world_reference_spatial_non_finite.fetch_add(
+          1, std::memory_order_relaxed);
+      g_pending_track_world_reference_spatial = {};
+      return;
+    }
+  }
+  for (uint32_t word :
+       g_pending_track_world_reference_spatial.composed_matrix_words) {
+    if (!std::isfinite(std::bit_cast<float>(word))) {
+      g_track_world_reference_spatial_non_finite.fetch_add(
+          1, std::memory_order_relaxed);
+      g_pending_track_world_reference_spatial = {};
+      return;
+    }
+  }
+  g_pending_track_world_reference_spatial.object_matrix_address =
+      object_matrix_address;
+  g_pending_track_world_reference_spatial.composed_matrix_address =
+      composed_matrix_address;
+  g_pending_track_world_reference_spatial.valid = true;
+}
+
+void ConsumeTrackWorldReferenceSpatial(uint32_t child_address,
+                                       uint32_t descriptor_address) {
+  g_track_world_reference_spatial_observations.fetch_add(
+      1, std::memory_order_relaxed);
+  PendingTrackWorldReferenceSpatial snapshot =
+      g_pending_track_world_reference_spatial;
+  g_pending_track_world_reference_spatial = {};
+  if (!snapshot.valid) {
+    g_track_world_reference_spatial_missing_stage.fetch_add(
+        1, std::memory_order_relaxed);
+    return;
+  }
+  uint64_t key = HashCombine(UINT64_C(0xCBF29CE484222325), child_address);
+  key = HashCombine(key, descriptor_address);
+  key = HashCombine(key, HashSemanticWords(snapshot.object_matrix_words));
+  key = HashCombine(key, HashSemanticWords(snapshot.composed_matrix_words));
+  key = key ? key : 1;
+  const uint64_t frame_sequence =
+      g_frame_sequence.load(std::memory_order_relaxed);
+
+  std::scoped_lock lock(g_track_world_reference_spatial_mutex);
+  size_t index = size_t(key % kTrackWorldReferenceSpatialCapacity);
+  for (size_t probe = 0; probe < kTrackWorldReferenceSpatialCapacity;
+       ++probe) {
+    TrackWorldReferenceSpatialEntry &entry =
+        g_track_world_reference_spatial_entries[index];
+    if (!entry.calls) {
+      entry.key = key;
+      entry.calls = 1;
+      entry.first_frame = frame_sequence;
+      entry.last_frame = frame_sequence;
+      entry.child_address = child_address;
+      entry.descriptor_address = descriptor_address;
+      entry.object_matrix_words = snapshot.object_matrix_words;
+      entry.composed_matrix_words = snapshot.composed_matrix_words;
+      ++g_track_world_reference_spatial_count;
+      return;
+    }
+    if (entry.key == key && entry.child_address == child_address &&
+        entry.descriptor_address == descriptor_address &&
+        entry.object_matrix_words == snapshot.object_matrix_words &&
+        entry.composed_matrix_words == snapshot.composed_matrix_words) {
+      ++entry.calls;
+      entry.last_frame = frame_sequence;
+      return;
+    }
+    index = (index + 1) % kTrackWorldReferenceSpatialCapacity;
+  }
+  g_track_world_reference_spatial_table_overflow.fetch_add(
+      1, std::memory_order_relaxed);
+}
+
 struct GuestCpuVisibilityTargetEntry {
   std::atomic<uint32_t> address{};
   std::atomic<uint32_t> length{};
@@ -12979,6 +13124,7 @@ void EmitProceduralModelSemanticSubmissions() {
 }
 
 void EmitTrackWorldScopeSpatialEntries();
+void EmitTrackWorldReferenceSpatialEntries();
 void EmitTrackWorldPreparedLayoutEntries();
 
 void EmitTrackRenderModelRuntimeJoinEvent(const char *event_name,
@@ -13061,6 +13207,36 @@ void EmitTrackRenderModelRuntimeJoinEvent(const char *event_name,
       scope_spatial_observations ==
           scope_spatial_accounted + scope_spatial_table_overflow &&
       !scope_spatial_table_overflow;
+  const uint64_t reference_spatial_observations =
+      g_track_world_reference_spatial_observations.load(
+          std::memory_order_relaxed);
+  const uint64_t reference_spatial_missing_stage =
+      g_track_world_reference_spatial_missing_stage.load(
+          std::memory_order_relaxed);
+  const uint64_t reference_spatial_invalid_range =
+      g_track_world_reference_spatial_invalid_range.load(
+          std::memory_order_relaxed);
+  const uint64_t reference_spatial_non_finite =
+      g_track_world_reference_spatial_non_finite.load(
+          std::memory_order_relaxed);
+  const uint64_t reference_spatial_table_overflow =
+      g_track_world_reference_spatial_table_overflow.load(
+          std::memory_order_relaxed);
+  uint64_t reference_spatial_accounted = 0;
+  size_t reference_spatial_entries = 0;
+  {
+    std::scoped_lock lock(g_track_world_reference_spatial_mutex);
+    reference_spatial_entries = g_track_world_reference_spatial_count;
+    for (const TrackWorldReferenceSpatialEntry &entry :
+         g_track_world_reference_spatial_entries) {
+      reference_spatial_accounted += entry.calls;
+    }
+  }
+  const bool reference_spatial_accounting_complete =
+      reference_spatial_observations ==
+          reference_spatial_accounted + reference_spatial_missing_stage +
+              reference_spatial_table_overflow &&
+      !reference_spatial_missing_stage && !reference_spatial_table_overflow;
   pinyon_shift::diagnostics::RecordEvent(
       event_name,
       {{"status", !entries
@@ -13127,6 +13303,20 @@ void EmitTrackRenderModelRuntimeJoinEvent(const char *event_name,
         std::to_string(scope_spatial_table_overflow)},
        {"scope_spatial_accounting_complete",
         scope_spatial_accounting_complete ? "true" : "false"},
+       {"reference_spatial_observations",
+        std::to_string(reference_spatial_observations)},
+       {"reference_spatial_entries",
+        std::to_string(reference_spatial_entries)},
+       {"reference_spatial_missing_stage",
+        std::to_string(reference_spatial_missing_stage)},
+       {"reference_spatial_invalid_range",
+        std::to_string(reference_spatial_invalid_range)},
+       {"reference_spatial_non_finite",
+        std::to_string(reference_spatial_non_finite)},
+       {"reference_spatial_table_overflow",
+        std::to_string(reference_spatial_table_overflow)},
+       {"reference_spatial_accounting_complete",
+        reference_spatial_accounting_complete ? "true" : "false"},
        {"shared_identity_joins",
         std::to_string(g_track_render_model_shared_identity_joins.load(
             std::memory_order_relaxed))},
@@ -13297,6 +13487,7 @@ void EmitTrackRenderModelRuntimeJoinEvent(const char *event_name,
 
 void EmitTrackRenderModelRuntimeJoinSummary() {
   EmitTrackWorldScopeSpatialEntries();
+  EmitTrackWorldReferenceSpatialEntries();
   EmitTrackWorldPreparedLayoutEntries();
   EmitTrackRenderModelRuntimeJoinEvent(
       "native_renderer.discovery.track_render_model_runtime_join_summary",
@@ -15641,6 +15832,44 @@ void EmitTrackWorldScopeSpatialEntries() {
          {"classification", "exact_track_scope_numeric_spatial_candidate"},
          {"guest_payload_read",
           "bounded_validated_track_child_and_descriptor_words_only"},
+         {"plaintext_identity_exported", "false"},
+         {"guest_state_changed", "false"},
+         {"control_flow_changed", "false"},
+         {"native_admission", "false"},
+         {"native_draw", "false"},
+         {"xenos_authority", "true"},
+         {"suppression_allowed", "false"}});
+  }
+}
+
+void EmitTrackWorldReferenceSpatialEntries() {
+  std::scoped_lock lock(g_track_world_reference_spatial_mutex);
+  for (const TrackWorldReferenceSpatialEntry &entry :
+       g_track_world_reference_spatial_entries) {
+    if (!entry.calls) {
+      continue;
+    }
+    pinyon_shift::diagnostics::RecordEvent(
+        "native_renderer.discovery.track_world_reference_spatial_entry",
+        {{"snapshot_key", fmt::format("{:016X}", entry.key)},
+         {"child_address", fmt::format("{:08X}", entry.child_address)},
+         {"descriptor_address",
+          fmt::format("{:08X}", entry.descriptor_address)},
+         {"calls", std::to_string(entry.calls)},
+         {"first_frame", std::to_string(entry.first_frame)},
+         {"last_frame", std::to_string(entry.last_frame)},
+         {"object_matrix_word_count",
+          std::to_string(entry.object_matrix_words.size())},
+         {"object_matrix_words",
+          SerializeHexWords(entry.object_matrix_words)},
+         {"composed_matrix_word_count",
+          std::to_string(entry.composed_matrix_words.size())},
+         {"composed_matrix_words",
+          SerializeHexWords(entry.composed_matrix_words)},
+         {"classification",
+          "exact_track_scope_reference_composition_candidate"},
+         {"guest_payload_read",
+          "two_title_proved_live_64_byte_matrix_ranges"},
          {"plaintext_identity_exported", "false"},
          {"guest_state_changed", "false"},
          {"control_flow_changed", "false"},
@@ -29050,6 +29279,13 @@ void InstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system,
         std::to_string(kTrackWorldScopeSpatialCapacity)},
        {"scope_spatial_words", "child_16_descriptor_62"},
        {"scope_spatial_export", "numeric_words_hash_variation_only"},
+       {"reference_spatial_hook",
+        "8240EB5C:r22_object_matrix,r5_composed_matrix"},
+       {"reference_spatial_capacity",
+        std::to_string(kTrackWorldReferenceSpatialCapacity)},
+       {"reference_spatial_join",
+        "staged_same_thread_then_exact_8240EC80_scope"},
+       {"reference_spatial_export", "two_numeric_16_word_matrices_only"},
        {"guest_payload_read",
         "bounded_320_bytes_plus_direct_vtable_words_per_cache_miss"},
        {"guest_state_changed", "false"},
@@ -31511,6 +31747,7 @@ void PinyonShiftObserveStaticWorldResourceRefreshResetExit(
 
 void PinyonShiftObserveVehicleComposedMatrix(PPCRegister &r5,
                                              PPCRegister &r22) {
+  StageTrackWorldReferenceSpatial(r22.u32, r5.u32);
   ObserveVehicleComposedMatrix(r22.u32, r5.u32);
 }
 

--- a/tools/classify-native-renderer-track-reference-composition.py
+++ b/tools/classify-native-renderer-track-reference-composition.py
@@ -1,0 +1,276 @@
+#!/usr/bin/env python3
+"""Match track-local matrices composed with title reference matrices."""
+
+from __future__ import annotations
+
+import argparse
+import collections
+import importlib.util
+import json
+import math
+import pathlib
+import struct
+import sys
+
+
+SCHEMA = "pinyon-shift.native-renderer-track-reference-composition-classification.v1"
+REFERENCE_ENTRY = "native_renderer.discovery.track_world_reference_spatial_entry"
+SOURCE_TOOL = pathlib.Path(__file__).with_name(
+    "classify-native-renderer-track-scope-spatial.py"
+)
+SPEC = importlib.util.spec_from_file_location("track_scope_spatial", SOURCE_TOOL)
+SCOPE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(SCOPE)
+
+
+def floats(words):
+    values = tuple(
+        struct.unpack(">f", word.to_bytes(4, "big"))[0] for word in words
+    )
+    return values if all(math.isfinite(value) for value in values) else None
+
+
+def multiply(left, right):
+    result = tuple(
+        sum(left[row * 4 + inner] * right[inner * 4 + column] for inner in range(4))
+        for row in range(4)
+        for column in range(4)
+    )
+    return result if all(math.isfinite(value) for value in result) else None
+
+
+def parse_scope_entries(selected):
+    result = {}
+    calls = 0
+    for event in selected:
+        if event.get("event") != SCOPE.ENTRY:
+            continue
+        SCOPE.require_safety(event)
+        child_address = SCOPE.hexadecimal(event.get("child_address", ""), 8, "child address")
+        descriptor_address = SCOPE.hexadecimal(event.get("descriptor_address", ""), 8, "descriptor address")
+        key = (child_address, descriptor_address)
+        if key in result or SCOPE.integer(event, "snapshot_variations"):
+            raise ValueError("track-scope spatial source is duplicate or unstable")
+        entry_calls = SCOPE.integer(event, "calls")
+        calls += entry_calls
+        result[key] = {
+            "child": SCOPE.parse_words(event, "child", 16),
+            "descriptor": SCOPE.parse_words(event, "descriptor", 62),
+        }
+    return result, calls
+
+
+def parse_reference_entries(selected, scopes):
+    result = []
+    calls = 0
+    seen = set()
+    for event in selected:
+        if event.get("event") != REFERENCE_ENTRY:
+            continue
+        SCOPE.require_safety(event)
+        snapshot_key = SCOPE.hexadecimal(event.get("snapshot_key", ""), 16, "reference snapshot key")
+        if snapshot_key in seen:
+            raise ValueError("duplicate track reference snapshot key")
+        seen.add(snapshot_key)
+        source_key = (
+            SCOPE.hexadecimal(event.get("child_address", ""), 8, "child address"),
+            SCOPE.hexadecimal(event.get("descriptor_address", ""), 8, "descriptor address"),
+        )
+        if source_key not in scopes:
+            raise ValueError("track reference snapshot has no scope source")
+        entry_calls = SCOPE.integer(event, "calls")
+        if not entry_calls or SCOPE.integer(event, "first_frame") > SCOPE.integer(event, "last_frame"):
+            raise ValueError("invalid track reference lifetime")
+        calls += entry_calls
+        result.append({
+            "snapshot_key": snapshot_key,
+            "scope": scopes[source_key],
+            "object_matrix": SCOPE.parse_words(event, "object_matrix", 16),
+            "composed_matrix": SCOPE.parse_words(event, "composed_matrix", 16),
+        })
+    return result, calls
+
+
+def build(events, catalog, requested_session=None, tolerance=SCOPE.DEFAULT_TOLERANCE,
+          minimum_matches=SCOPE.DEFAULT_MINIMUM_MATCHES):
+    if not math.isfinite(tolerance) or tolerance <= 0 or tolerance > 1:
+        raise ValueError("match tolerance is outside the safe range")
+    if minimum_matches < 1:
+        raise ValueError("minimum matches must be positive")
+    instances = SCOPE.validate_catalog(catalog)
+    session, selected = SCOPE.select_session(events, requested_session)
+    starts = [event for event in selected if event.get("event") == "process.start"]
+    shutdowns = [event for event in selected if event.get("event") == "process.shutdown"]
+    summaries = [event for event in selected if event.get("event") == SCOPE.SUMMARY]
+    if len(starts) != 1 or len(shutdowns) != 1 or len(summaries) != 1:
+        raise ValueError("track reference-composition lifecycle is incomplete")
+    summary = summaries[0]
+    SCOPE.require_safety(summary)
+    if summary.get("checkpoint_kind") != "final":
+        raise ValueError("track reference-composition summary is not final")
+    scopes, scope_calls = parse_scope_entries(selected)
+    references, reference_calls = parse_reference_entries(selected, scopes)
+    if (
+        len(scopes) != SCOPE.integer(summary, "scope_spatial_entries")
+        or scope_calls != SCOPE.integer(summary, "scope_spatial_observations")
+        or SCOPE.integer(summary, "scope_spatial_table_overflow")
+        or summary.get("scope_spatial_accounting_complete") != "true"
+        or len(references) != SCOPE.integer(summary, "reference_spatial_entries")
+        or reference_calls != SCOPE.integer(summary, "reference_spatial_observations")
+        or SCOPE.integer(summary, "reference_spatial_missing_stage")
+        or SCOPE.integer(summary, "reference_spatial_table_overflow")
+        or summary.get("reference_spatial_accounting_complete") != "true"
+    ):
+        raise ValueError("track reference-composition accounting is incomplete")
+
+    groups = collections.defaultdict(list)
+    for reference in references:
+        reference_matrices = {
+            source: floats(reference[source])
+            for source in ("object_matrix", "composed_matrix")
+        }
+        if any(matrix is None for matrix in reference_matrices.values()):
+            raise ValueError("track reference matrix is non-finite")
+        for local_source in ("child", "descriptor"):
+            local_words = reference["scope"][local_source]
+            for word_offset in range(len(local_words) - 15):
+                local = floats(local_words[word_offset : word_offset + 16])
+                if local is None:
+                    continue
+                for reference_source, reference_matrix in reference_matrices.items():
+                    products = {
+                        "reference_times_local": multiply(reference_matrix, local),
+                        "local_times_reference": multiply(local, reference_matrix),
+                    }
+                    for order, product in products.items():
+                        if product is None:
+                            continue
+                        for convention, indices in SCOPE.CONVENTIONS.items():
+                            groups[(local_source, word_offset, reference_source, order, convention)].append(
+                                (reference["snapshot_key"], tuple(product[index] for index in indices))
+                            )
+
+    spatial = SCOPE.spatial_index(instances, tolerance)
+    reports = []
+    qualified = []
+    for key, candidates in sorted(groups.items()):
+        local_source, word_offset, reference_source, order, convention = key
+        matches = []
+        unmatched = 0
+        ambiguous = 0
+        for snapshot_key, position in candidates:
+            outcome, match = SCOPE.match_position(spatial, position, tolerance)
+            if outcome == "unmatched":
+                unmatched += 1
+            elif outcome == "ambiguous":
+                ambiguous += 1
+            else:
+                distance, instance = match
+                matches.append({
+                    "snapshot_key": snapshot_key,
+                    "category": instance["category"],
+                    "catalog_identity_hash": instance["identity_hash"],
+                    "catalog_index": instance["catalog_index"],
+                    "distance": round(distance, 9),
+                })
+        distinct = len({item["catalog_index"] for item in matches})
+        categories = collections.Counter(item["category"] for item in matches)
+        complete = (
+            len(candidates) == len(references)
+            and len(matches) == len(references)
+            and distinct >= minimum_matches
+            and categories["collision_prop"] > 0
+            and not unmatched
+            and not ambiguous
+        )
+        report = {
+            "local_source": local_source,
+            "word_offset": word_offset,
+            "reference_source": reference_source,
+            "multiplication_order": order,
+            "convention": convention,
+            "observed_snapshots": len(candidates),
+            "matched": len(matches),
+            "distinct_catalog_matches": distinct,
+            "unmatched": unmatched,
+            "ambiguous": ambiguous,
+            "category_counts": dict(sorted(categories.items())),
+            "complete": complete,
+            "matches": matches,
+        }
+        reports.append(report)
+        if complete:
+            qualified.append(report)
+
+    failures = []
+    if not references:
+        failures.append("no exact track reference snapshots were observed")
+    if len(qualified) != 1:
+        failures.append("track reference composition is not uniquely proved")
+    selected_mapping = qualified[0] if len(qualified) == 1 else None
+    mapping_keys = (
+        "local_source", "word_offset", "reference_source",
+        "multiplication_order", "convention",
+    )
+    return {
+        "schema": SCHEMA,
+        "session": session,
+        "status": "complete" if not failures else "incomplete",
+        "failures": failures,
+        "catalog_instance_count": len(instances),
+        "scope_count": len(scopes),
+        "reference_snapshot_count": len(references),
+        "candidate_group_count": len(reports),
+        "minimum_distinct_matches": minimum_matches,
+        "position_tolerance": tolerance,
+        "selected_mapping": None if selected_mapping is None else {
+            key: selected_mapping[key] for key in mapping_keys
+        },
+        "candidate_groups": reports,
+        "qualification": {
+            "exact_track_reference_join_proved": True,
+            "world_transform_composition_proved": not failures,
+            "native_admission": False,
+            "suppression_allowed": False,
+        },
+        "safety": {
+            "guest_state_changed": False,
+            "source_files_changed": False,
+            "plaintext_identity_exported": False,
+            "xenos_authority": True,
+            "native_admission": False,
+            "native_draw": False,
+            "suppression_allowed": False,
+        },
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("logs", nargs="+", type=pathlib.Path)
+    parser.add_argument("--catalog", required=True, type=pathlib.Path)
+    parser.add_argument("--output", required=True, type=pathlib.Path)
+    parser.add_argument("--session")
+    parser.add_argument("--tolerance", type=float, default=SCOPE.DEFAULT_TOLERANCE)
+    parser.add_argument("--minimum-matches", type=int, default=SCOPE.DEFAULT_MINIMUM_MATCHES)
+    arguments = parser.parse_args()
+    try:
+        document = build(
+            SCOPE.read_events(arguments.logs),
+            json.loads(arguments.catalog.read_text(encoding="utf-8")),
+            requested_session=arguments.session,
+            tolerance=arguments.tolerance,
+            minimum_matches=arguments.minimum_matches,
+        )
+        arguments.output.parent.mkdir(parents=True, exist_ok=True)
+        arguments.output.write_text(json.dumps(document, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+        if document["status"] != "complete":
+            raise ValueError("; ".join(document["failures"]))
+        return 0
+    except (json.JSONDecodeError, OSError, ValueError) as error:
+        print(f"track reference-composition classification failed: {error}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/tests/test_native_renderer_track_reference_composition.py
+++ b/tools/tests/test_native_renderer_track_reference_composition.py
@@ -1,0 +1,120 @@
+import importlib.util
+import pathlib
+import struct
+import unittest
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+TOOL = ROOT / "tools/classify-native-renderer-track-reference-composition.py"
+SPEC = importlib.util.spec_from_file_location("track_reference_composition", TOOL)
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+def word(value):
+    return f"{int.from_bytes(struct.pack('>f', float(value)), 'big'):08X}"
+
+
+def safety():
+    return {
+        "guest_state_changed": "false", "control_flow_changed": "false",
+        "native_admission": "false", "xenos_authority": "true",
+        "suppression_allowed": "false",
+    }
+
+
+def catalog():
+    instances = [
+        {
+            "category": "collision_prop" if index == 0 else "gameplay_object",
+            "identity_hash": f"{index + 1:016X}",
+            "position": [index * 10.0 + 1, index * 10.0 + 2, index * 10.0 + 3],
+        }
+        for index in range(8)
+    ]
+    return {
+        "schema": MODULE.SCOPE.CATALOG_SCHEMA, "status": "complete",
+        "instance_count": 8, "instances": instances,
+        "safety": {
+            "source_files_changed": False, "plaintext_identity_exported": False,
+            "numeric_spatial_metadata_only": True, "native_admission": False,
+            "suppression_allowed": False,
+        },
+    }
+
+
+def words(values):
+    return ":".join(word(value) for value in values)
+
+
+def evidence():
+    object_reference = [2, 0, 0, 0, 0, 2, 0, 0, 0, 0, 2, 0, 0, 0, 0, 1]
+    bad_reference = [3, 0, 0, 0, 0, 3, 0, 0, 0, 0, 3, 0, 1000, 1000, 1000, 1]
+    events = [{"event": "process.start", "session": "test"}]
+    for index in range(8):
+        child_address = f"{0x1000 + index * 0x100:08X}"
+        descriptor_address = f"{0x2000 + index * 0x100:08X}"
+        position = [index * 10.0 + 1, index * 10.0 + 2, index * 10.0 + 3]
+        local_position = [value / 2 for value in position]
+        local = [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, *local_position, 1]
+        descriptor = [3000 + index] * 8 + local + [4000 + index] * 38
+        events.append({
+            "event": MODULE.SCOPE.ENTRY, "session": "test",
+            "snapshot_key": f"{index + 1:016X}",
+            "child_address": child_address, "descriptor_address": descriptor_address,
+            "calls": "1", "first_frame": "1", "last_frame": "2",
+            "snapshot_variations": "0", "child_word_count": "16",
+            "child_words": words([5000 + index] * 16),
+            "descriptor_word_count": "62", "descriptor_words": words(descriptor),
+            **safety(),
+        })
+        events.append({
+            "event": MODULE.REFERENCE_ENTRY, "session": "test",
+            "snapshot_key": f"{index + 101:016X}",
+            "child_address": child_address, "descriptor_address": descriptor_address,
+            "calls": "1", "first_frame": "1", "last_frame": "2",
+            "object_matrix_word_count": "16", "object_matrix_words": words(object_reference),
+            "composed_matrix_word_count": "16", "composed_matrix_words": words(bad_reference),
+            **safety(),
+        })
+    events.extend([
+        {
+            "event": MODULE.SCOPE.SUMMARY, "session": "test", "checkpoint_kind": "final",
+            "scope_spatial_entries": "8", "scope_spatial_observations": "8",
+            "scope_spatial_table_overflow": "0", "scope_spatial_accounting_complete": "true",
+            "reference_spatial_entries": "8", "reference_spatial_observations": "8",
+            "reference_spatial_missing_stage": "0", "reference_spatial_table_overflow": "0",
+            "reference_spatial_accounting_complete": "true", **safety(),
+        },
+        {"event": "process.shutdown", "session": "test"},
+    ])
+    return events
+
+
+class TrackReferenceCompositionTests(unittest.TestCase):
+    def test_proves_unique_local_reference_composition(self):
+        document = MODULE.build(evidence(), catalog())
+        self.assertEqual("complete", document["status"])
+        self.assertEqual("descriptor", document["selected_mapping"]["local_source"])
+        self.assertEqual(8, document["selected_mapping"]["word_offset"])
+        self.assertEqual("object_matrix", document["selected_mapping"]["reference_source"])
+        self.assertEqual("translation_words_12_13_14", document["selected_mapping"]["convention"])
+
+    def test_rejects_missing_exact_stage(self):
+        events = evidence()
+        events[-2]["reference_spatial_missing_stage"] = "1"
+        events[-2]["reference_spatial_accounting_complete"] = "false"
+        with self.assertRaisesRegex(ValueError, "accounting is incomplete"):
+            MODULE.build(events, catalog())
+
+    def test_source_contract_is_exact_and_passive(self):
+        source = (ROOT / "src/native_renderer/graphics_hooks.cpp").read_text(encoding="utf-8")
+        self.assertIn("kTrackWorldReferenceSpatialCapacity = 2048", source)
+        self.assertIn("StageTrackWorldReferenceSpatial(r22.u32, r5.u32)", source)
+        self.assertIn("ConsumeTrackWorldReferenceSpatial(child_address, descriptor_address)", source)
+        self.assertIn(MODULE.REFERENCE_ENTRY, source)
+        self.assertIn('"suppression_allowed", "false"', source)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Stages the two retail-proved live matrices at 8240EB5C, consumes them only after the exact unified track scope qualifies, and adds an offline local-to-world composition classifier against the authored spatial catalog. Xenos remains authoritative; native admission and suppression stay disabled. Tests: 31 focused unittest cases, py_compile, and git diff --check.