### PR TITLE
fix(renderer): retain exact track spatial snapshots

### DIFF
--- a/docs/native-renderer/REPRIORITIZED_PLAN.md
+++ b/docs/native-renderer/REPRIORITIZED_PLAN.md
@@ -529,6 +529,17 @@ both raw and reference-composed interpretations without another build cycle.
 See
 [`TRACK_WORLD_REFERENCE_COMPOSITION.md`](TRACK_WORLD_REFERENCE_COMPOSITION.md).
 
+First combined-census correction: clean session
+`20260901T033932Z-p38084` reached the saved festival with 485 exact scopes,
+zero table overflow, normal Xenos output, and a normal exit. It exposed two
+content-lineage facts before classification: 79 child/descriptor address pairs
+changed contents during the run, and four upstream matrix stages fed all 485
+downstream scopes. Scope entries are now keyed by address plus exact content
+hash, while the current same-thread matrix stage remains valid until the next
+proved upstream stage overwrites it. Reference entries carry that exact scope
+content hash. This preserves every changing sample and the one-to-many retail
+control flow without widening the accepted scope or weakening accounting.
+
 ### C2. Static world buildings and props
 
 - Expand opaque-world material and geometry coverage.

--- a/docs/native-renderer/TRACK_WORLD_REFERENCE_COMPOSITION.md
+++ b/docs/native-renderer/TRACK_WORLD_REFERENCE_COMPOSITION.md
@@ -23,13 +23,16 @@ these title-proved reference matrices.
 ## Exact runtime join
 
 The existing hook at `8240EB5C` stages both finite matrices in thread-local
-storage. The later exact scope entry at `8240EC80` consumes the stage only after
-the unified instance/model vtables and type-21 descriptor predicates pass.
-Invalid roots cannot publish a reference snapshot, and ordinary calls never
-inherit an accepted track identity.
+storage. Each later exact scope entry at `8240EC80` reuses the current stage
+only after the unified instance/model vtables and type-21 descriptor predicates
+pass. Static control flow proves one staged pair can feed many downstream exact
+scopes before the next function invocation overwrites it. Invalid roots cannot
+publish a reference snapshot, and ordinary calls never inherit an accepted
+track identity.
 
-A fixed 2,048-entry table is keyed by exact child/descriptor addresses plus
-both matrix hashes. It retains the numeric matrices and call/frame coverage.
+A fixed 2,048-entry table is keyed by exact child/descriptor addresses, exact
+child/descriptor content hash, and both matrix hashes. It retains the numeric
+matrices and call/frame coverage.
 Detailed entries are emitted only at clean final shutdown. Missing same-thread
 stages, invalid ranges, non-finite matrices, and table overflow are independently
 counted. No stack pointer is retained after the synchronous copy.

--- a/docs/native-renderer/TRACK_WORLD_SCOPE_SPATIAL.md
+++ b/docs/native-renderer/TRACK_WORLD_SCOPE_SPATIAL.md
@@ -17,11 +17,12 @@ speculative pointer dereference, broad draw census, or shader-state guess.
 ## Runtime contract
 
 At exact scope entry, after the existing child and descriptor bounds, type, and
-flag checks succeed, the observer retains one numeric snapshot per exact
-child/descriptor address pair. The fixed 1,024-entry table records:
+flag checks succeed, the observer retains each numeric snapshot by exact
+child/descriptor addresses plus combined content hash. The fixed 1,024-entry
+table records:
 
 - all 16 child words and all 62 descriptor words;
-- snapshot hash and variation count;
+- snapshot hash and collision/variation count;
 - exact call and first/last-frame coverage; and
 - explicit table overflow.
 

--- a/src/native_renderer/graphics_hooks.cpp
+++ b/src/native_renderer/graphics_hooks.cpp
@@ -1128,6 +1128,7 @@ struct TrackWorldScopeSpatialEntry {
 
 struct TrackWorldReferenceSpatialEntry {
   uint64_t key = 0;
+  uint64_t scope_snapshot_hash = 0;
   uint64_t calls = 0;
   uint64_t first_frame = 0;
   uint64_t last_frame = 0;
@@ -3366,7 +3367,13 @@ uint64_t HashSemanticWords(const std::array<uint32_t, N> &words);
 void StageTrackWorldReferenceSpatial(uint32_t object_matrix_address,
                                      uint32_t composed_matrix_address);
 void ConsumeTrackWorldReferenceSpatial(uint32_t child_address,
-                                       uint32_t descriptor_address);
+                                       uint32_t descriptor_address,
+    const std::array<uint32_t,
+                     kTrackRenderModelGraphBytes / sizeof(uint32_t)>
+        &child_words,
+    const std::array<uint32_t,
+                     kTrackRenderModelDescriptorBytes / sizeof(uint32_t)>
+        &descriptor_words);
 
 const char *VehicleIdentityAddressKindName(VehicleIdentityAddressKind kind) {
   switch (kind) {
@@ -3744,10 +3751,11 @@ void RecordTrackWorldScopeSpatialSnapshot(
       1, std::memory_order_relaxed);
   uint64_t key = HashCombine(UINT64_C(0xCBF29CE484222325), child_address);
   key = HashCombine(key, descriptor_address);
-  key = key ? key : 1;
   uint64_t snapshot_hash = HashSemanticWords(child_words);
   snapshot_hash = HashCombine(snapshot_hash,
                               HashSemanticWords(descriptor_words));
+  key = HashCombine(key, snapshot_hash);
+  key = key ? key : 1;
   const uint64_t frame_sequence =
       g_frame_sequence.load(std::memory_order_relaxed);
 
@@ -3770,7 +3778,10 @@ void RecordTrackWorldScopeSpatialSnapshot(
       return;
     }
     if (entry.key == key && entry.child_address == child_address &&
-        entry.descriptor_address == descriptor_address) {
+        entry.descriptor_address == descriptor_address &&
+        entry.snapshot_hash == snapshot_hash &&
+        entry.child_words == child_words &&
+        entry.descriptor_words == descriptor_words) {
       ++entry.calls;
       entry.last_frame = frame_sequence;
       entry.snapshot_variations += entry.snapshot_hash != snapshot_hash ? 1 : 0;
@@ -3838,7 +3849,8 @@ void BeginTrackRenderModelDispatch(uint32_t root_address) {
   }
   RecordTrackWorldScopeSpatialSnapshot(child_address, descriptor_address,
                                        child_words, descriptor_words);
-  ConsumeTrackWorldReferenceSpatial(child_address, descriptor_address);
+  ConsumeTrackWorldReferenceSpatial(child_address, descriptor_address,
+                                    child_words, descriptor_words);
   g_track_render_model_scope.root_address = root_address;
   g_track_render_model_scope.child_address = child_address;
   g_track_render_model_scope.descriptor_address = descriptor_address;
@@ -10879,12 +10891,17 @@ void StageTrackWorldReferenceSpatial(uint32_t object_matrix_address,
 }
 
 void ConsumeTrackWorldReferenceSpatial(uint32_t child_address,
-                                       uint32_t descriptor_address) {
+                                       uint32_t descriptor_address,
+    const std::array<uint32_t,
+                     kTrackRenderModelGraphBytes / sizeof(uint32_t)>
+        &child_words,
+    const std::array<uint32_t,
+                     kTrackRenderModelDescriptorBytes / sizeof(uint32_t)>
+        &descriptor_words) {
   g_track_world_reference_spatial_observations.fetch_add(
       1, std::memory_order_relaxed);
   PendingTrackWorldReferenceSpatial snapshot =
       g_pending_track_world_reference_spatial;
-  g_pending_track_world_reference_spatial = {};
   if (!snapshot.valid) {
     g_track_world_reference_spatial_missing_stage.fetch_add(
         1, std::memory_order_relaxed);
@@ -10892,6 +10909,10 @@ void ConsumeTrackWorldReferenceSpatial(uint32_t child_address,
   }
   uint64_t key = HashCombine(UINT64_C(0xCBF29CE484222325), child_address);
   key = HashCombine(key, descriptor_address);
+  uint64_t scope_snapshot_hash = HashSemanticWords(child_words);
+  scope_snapshot_hash =
+      HashCombine(scope_snapshot_hash, HashSemanticWords(descriptor_words));
+  key = HashCombine(key, scope_snapshot_hash);
   key = HashCombine(key, HashSemanticWords(snapshot.object_matrix_words));
   key = HashCombine(key, HashSemanticWords(snapshot.composed_matrix_words));
   key = key ? key : 1;
@@ -10906,6 +10927,7 @@ void ConsumeTrackWorldReferenceSpatial(uint32_t child_address,
         g_track_world_reference_spatial_entries[index];
     if (!entry.calls) {
       entry.key = key;
+      entry.scope_snapshot_hash = scope_snapshot_hash;
       entry.calls = 1;
       entry.first_frame = frame_sequence;
       entry.last_frame = frame_sequence;
@@ -10918,6 +10940,7 @@ void ConsumeTrackWorldReferenceSpatial(uint32_t child_address,
     }
     if (entry.key == key && entry.child_address == child_address &&
         entry.descriptor_address == descriptor_address &&
+        entry.scope_snapshot_hash == scope_snapshot_hash &&
         entry.object_matrix_words == snapshot.object_matrix_words &&
         entry.composed_matrix_words == snapshot.composed_matrix_words) {
       ++entry.calls;
@@ -15852,6 +15875,8 @@ void EmitTrackWorldReferenceSpatialEntries() {
     pinyon_shift::diagnostics::RecordEvent(
         "native_renderer.discovery.track_world_reference_spatial_entry",
         {{"snapshot_key", fmt::format("{:016X}", entry.key)},
+         {"scope_snapshot_hash",
+          fmt::format("{:016X}", entry.scope_snapshot_hash)},
          {"child_address", fmt::format("{:08X}", entry.child_address)},
          {"descriptor_address",
           fmt::format("{:08X}", entry.descriptor_address)},

--- a/tools/classify-native-renderer-track-reference-composition.py
+++ b/tools/classify-native-renderer-track-reference-composition.py
@@ -48,7 +48,8 @@ def parse_scope_entries(selected):
         SCOPE.require_safety(event)
         child_address = SCOPE.hexadecimal(event.get("child_address", ""), 8, "child address")
         descriptor_address = SCOPE.hexadecimal(event.get("descriptor_address", ""), 8, "descriptor address")
-        key = (child_address, descriptor_address)
+        snapshot_hash = SCOPE.hexadecimal(event.get("snapshot_hash", ""), 16, "scope snapshot hash")
+        key = (child_address, descriptor_address, snapshot_hash)
         if key in result or SCOPE.integer(event, "snapshot_variations"):
             raise ValueError("track-scope spatial source is duplicate or unstable")
         entry_calls = SCOPE.integer(event, "calls")
@@ -75,6 +76,7 @@ def parse_reference_entries(selected, scopes):
         source_key = (
             SCOPE.hexadecimal(event.get("child_address", ""), 8, "child address"),
             SCOPE.hexadecimal(event.get("descriptor_address", ""), 8, "descriptor address"),
+            SCOPE.hexadecimal(event.get("scope_snapshot_hash", ""), 16, "scope snapshot hash"),
         )
         if source_key not in scopes:
             raise ValueError("track reference snapshot has no scope source")

--- a/tools/tests/test_native_renderer_track_reference_composition.py
+++ b/tools/tests/test_native_renderer_track_reference_composition.py
@@ -61,6 +61,7 @@ def evidence():
         events.append({
             "event": MODULE.SCOPE.ENTRY, "session": "test",
             "snapshot_key": f"{index + 1:016X}",
+            "snapshot_hash": f"{index + 1001:016X}",
             "child_address": child_address, "descriptor_address": descriptor_address,
             "calls": "1", "first_frame": "1", "last_frame": "2",
             "snapshot_variations": "0", "child_word_count": "16",
@@ -71,6 +72,7 @@ def evidence():
         events.append({
             "event": MODULE.REFERENCE_ENTRY, "session": "test",
             "snapshot_key": f"{index + 101:016X}",
+            "scope_snapshot_hash": f"{index + 1001:016X}",
             "child_address": child_address, "descriptor_address": descriptor_address,
             "calls": "1", "first_frame": "1", "last_frame": "2",
             "object_matrix_word_count": "16", "object_matrix_words": words(object_reference),
@@ -111,7 +113,8 @@ class TrackReferenceCompositionTests(unittest.TestCase):
         source = (ROOT / "src/native_renderer/graphics_hooks.cpp").read_text(encoding="utf-8")
         self.assertIn("kTrackWorldReferenceSpatialCapacity = 2048", source)
         self.assertIn("StageTrackWorldReferenceSpatial(r22.u32, r5.u32)", source)
-        self.assertIn("ConsumeTrackWorldReferenceSpatial(child_address, descriptor_address)", source)
+        self.assertIn("ConsumeTrackWorldReferenceSpatial(child_address, descriptor_address,", source)
+        self.assertNotIn("g_pending_track_world_reference_spatial = {};\n  if (!snapshot.valid)", source)
         self.assertIn(MODULE.REFERENCE_ENTRY, source)
         self.assertIn('"suppression_allowed", "false"', source)
 

--- a/tools/tests/test_native_renderer_track_scope_spatial.py
+++ b/tools/tests/test_native_renderer_track_scope_spatial.py
@@ -60,6 +60,7 @@ def evidence():
         events.append(event(
             MODULE.ENTRY,
             snapshot_key=f"{index + 1:016X}",
+            snapshot_hash=f"{index + 1001:016X}",
             child_address=f"{0x1000 + index * 0x100:08X}",
             descriptor_address=f"{0x2000 + index * 0x100:08X}",
             calls="1", first_frame="1", last_frame="2",


### PR DESCRIPTION
Corrects the first combined runtime findings by keying changing child/descriptor payloads by exact content and preserving the proved one-to-many reference stage across all downstream exact scopes. Reference entries now join to the exact scope-content hash. Xenos authority and zero suppression are unchanged. Tests: 31 focused unittest cases, clean local release build, py_compile, and git diff --check.