### PR TITLE
feat(renderer): carry track pass target lineage

### DIFF
--- a/docs/native-renderer/REPRIORITIZED_PLAN.md
+++ b/docs/native-renderer/REPRIORITIZED_PLAN.md
@@ -557,6 +557,13 @@ packet lineage; depth-only activity may feed shadows but cannot satisfy C1.
 See
 [`TRACK_PRESENTATION_PASS_CENSUS.md`](TRACK_PRESENTATION_PASS_CENSUS.md).
 
+Pass-lineage batching checkpoint: exact slot identity now follows the existing
+`824365B0` context/producer/owner/constructor/packet chain into prepared draws.
+A bounded final report partitions shader and attachment shapes per slot with
+complete overflow accounting. The next AppData run can therefore identify a
+live color-producing pass directly; no intermediate call-count-only run is
+needed, and no candidate gains admission before private visual proof.
+
 ### C2. Static world buildings and props
 
 - Expand opaque-world material and geometry coverage.

--- a/docs/native-renderer/TRACK_PRESENTATION_PASS_CENSUS.md
+++ b/docs/native-renderer/TRACK_PRESENTATION_PASS_CENSUS.md
@@ -47,11 +47,35 @@ bitmask, five numeric formats, and prepared-pipeline flags already present in
 the observer. This distinguishes depth-only, color-only, paired, and unusual
 target shapes without copying a guest or GPU payload.
 
-The next batched AppData run must first identify which adjacent slots are live
-and reconcile slot 79's exact target shapes with its 732 render-target-only
-rejections. Packet/prepared lineage will then be extended only through the
-live color-producing slot. A depth-only slot may feed the native shadow slice,
-but it cannot satisfy C1 opaque world coverage.
+## Packet-to-prepared correlation
+
+An accepted presentation slot is now attached to the existing exact
+`824365B0` command-context bridge while that balanced title scope is active.
+The four-bit slot mask follows the already-proved context, producer, owner,
+constructor, indirect packet, and prepared-draw lineage. Final shutdown emits
+one bounded entry per slot-mask, shader pair, attachment shape, and pipeline-
+flag tuple. The 256-entry table has independent observation, entry, and
+overflow accounting.
+
+Build the payload-free report after the next batched run:
+
+```powershell
+python tools/summarize-native-renderer-track-presentation-passes.py `
+  <session.jsonl> `
+  --output .local/qualification/native-renderer-track-presentation-passes.json
+```
+
+The report reconciles process lifecycle, every balanced slot, and every
+prepared target entry. It lists live slots plus depth-only, color-only, paired,
+and unusual target calls per slot. A color-producing slot is still a candidate,
+not an opaque-world proof; private replay and visual comparison remain the
+next gate.
+
+The next batched AppData run will identify which adjacent slots are live and
+which exact prepared target shapes each produces. Lineage will be promoted
+only through a live color-producing slot after visual proof. A depth-only slot
+may feed the native shadow slice, but it cannot satisfy C1 opaque world
+coverage.
 
 ## Safety
 

--- a/src/native_renderer/graphics_hooks.cpp
+++ b/src/native_renderer/graphics_hooks.cpp
@@ -90,6 +90,7 @@ constexpr size_t kStaticWorldPreparedLayoutCapacity = 512;
 constexpr size_t kTrackWorldPreparedLayoutCapacity = 1024;
 constexpr size_t kTrackWorldScopeSpatialCapacity = 1024;
 constexpr size_t kTrackWorldReferenceSpatialCapacity = 2048;
+constexpr size_t kTrackPresentationPreparedTargetCapacity = 256;
 constexpr size_t kTitleOriginStackCapacity = 32;
 constexpr size_t kTitleIndirectPacketBucketCount = 4096;
 constexpr size_t kTitleIndirectPacketWays = 4;
@@ -1115,6 +1116,19 @@ struct TrackWorldPreparedLayoutEntry {
   rex::system::GraphicsDrawObservation sample{};
 };
 
+struct TrackPresentationPreparedTargetEntry {
+  uint64_t key = 0;
+  uint64_t calls = 0;
+  uint64_t first_frame = 0;
+  uint64_t last_frame = 0;
+  uint64_t vertex_shader_hash = 0;
+  uint64_t pixel_shader_hash = 0;
+  uint32_t pass_mask = 0;
+  uint32_t bound_render_target_bits = 0;
+  std::array<uint32_t, 5> bound_render_target_formats{};
+  uint32_t prepared_pipeline_flags = 0;
+};
+
 struct TrackWorldScopeSpatialEntry {
   uint64_t key = 0;
   uint64_t calls = 0;
@@ -1176,6 +1190,7 @@ struct TitleIndirectPacketEntry {
   uint32_t track_render_descriptor_address = 0;
   uint32_t track_render_descriptor_payload = 0;
   uint32_t track_world_resource_identity_mask = 0;
+  uint32_t track_presentation_pass_mask = 0;
   uint64_t submission_sequence = 0;
   bool constructor_origin_known = false;
   bool owner_origin_known = false;
@@ -1204,6 +1219,7 @@ struct IndirectConstructorOrigin {
         uint32_t track_render_descriptor_address = 0;
         uint32_t track_render_descriptor_payload = 0;
         uint32_t track_world_resource_identity_mask = 0;
+        uint32_t track_presentation_pass_mask = 0;
         bool semantic_receiver_known = false;
         bool track_command_lineage = false;
         bool valid = false;
@@ -2900,6 +2916,13 @@ std::array<std::atomic<uint64_t>, 4> g_track_presentation_pass_overlaps{};
 std::array<std::atomic<uint64_t>, 4>
     g_track_presentation_pass_exit_without_entry{};
 thread_local std::array<bool, 4> g_track_presentation_pass_active{};
+thread_local std::array<bool, 4> g_track_presentation_pass_accepted{};
+std::array<TrackPresentationPreparedTargetEntry,
+           kTrackPresentationPreparedTargetCapacity>
+    g_track_presentation_prepared_targets{};
+std::atomic<uint64_t> g_track_presentation_prepared_target_observations{};
+std::atomic<uint64_t> g_track_presentation_prepared_target_overflow{};
+size_t g_track_presentation_prepared_target_count = 0;
 std::atomic<uint64_t> g_static_world_presentation_entries{};
 std::atomic<uint64_t> g_static_world_presentation_exits{};
 std::atomic<uint64_t> g_static_world_presentation_exact{};
@@ -3882,6 +3905,7 @@ void BeginTrackPresentationPass(size_t pass_index, uint32_t root_address) {
     ++g_track_presentation_pass_overlaps[pass_index];
   }
   g_track_presentation_pass_active[pass_index] = true;
+  g_track_presentation_pass_accepted[pass_index] = false;
   rex::memory::Memory *memory =
       g_command_buffer_lineage_memory.load(std::memory_order_acquire);
   if (!g_command_buffer_lineage_installed.load(std::memory_order_acquire) ||
@@ -3896,6 +3920,7 @@ void BeginTrackPresentationPass(size_t pass_index, uint32_t root_address) {
     return;
   }
   ++g_track_presentation_pass_exact[pass_index];
+  g_track_presentation_pass_accepted[pass_index] = true;
 }
 
 void EndTrackPresentationPass(size_t pass_index) {
@@ -3908,6 +3933,7 @@ void EndTrackPresentationPass(size_t pass_index) {
     return;
   }
   g_track_presentation_pass_active[pass_index] = false;
+  g_track_presentation_pass_accepted[pass_index] = false;
 }
 
 void EndTrackRenderModelDispatch() {
@@ -6544,6 +6570,10 @@ void ResetTitleDrawProvenance() {
        g_track_world_prepared_layouts) {
     entry = {};
   }
+  for (TrackPresentationPreparedTargetEntry &entry :
+       g_track_presentation_prepared_targets) {
+    entry = {};
+  }
   for (TrackWorldScopeSpatialEntry &entry :
        g_track_world_scope_spatial_entries) {
     entry = {};
@@ -6596,6 +6626,7 @@ void ResetTitleDrawProvenance() {
   g_title_draw_provenance_overflow = 0;
   g_static_world_prepared_layout_count = 0;
   g_track_world_prepared_layout_count = 0;
+  g_track_presentation_prepared_target_count = 0;
   g_track_world_scope_spatial_count = 0;
   g_track_world_reference_spatial_count = 0;
   g_pending_track_world_reference_spatial = {};
@@ -6772,6 +6803,7 @@ void ResetTitleDrawProvenance() {
     }
   }
   g_track_presentation_pass_active = {};
+  g_track_presentation_pass_accepted = {};
   for (UnifiedTrackMeshTransformEntry &entry :
        g_unified_track_mesh_transforms) {
     entry.key.store(0, std::memory_order_relaxed);
@@ -6886,6 +6918,8 @@ void ResetTitleDrawProvenance() {
            &g_track_world_prepared_layout_unbounded_geometry,
            &g_track_world_prepared_layout_parameter_overflows,
            &g_track_world_prepared_layout_table_overflow,
+           &g_track_presentation_prepared_target_observations,
+           &g_track_presentation_prepared_target_overflow,
            &g_track_world_scope_spatial_observations,
            &g_track_world_scope_spatial_table_overflow,
            &g_track_world_reference_spatial_observations,
@@ -8705,6 +8739,18 @@ bool ResolveSemanticReceiver(uint32_t address, uint32_t *generation,
   return *generation != 0;
 }
 
+uint32_t CurrentTrackPresentationPassMask() {
+  uint32_t mask = 0;
+  for (size_t index = 0; index < g_track_presentation_pass_accepted.size();
+       ++index) {
+    if (g_track_presentation_pass_active[index] &&
+        g_track_presentation_pass_accepted[index]) {
+      mask |= uint32_t(1) << index;
+    }
+  }
+  return mask;
+}
+
 void PushIndirectContextOrigin(uint32_t function_address,
                                uint32_t return_address, uint32_t r3,
                                uint32_t r4, uint32_t r5, uint32_t r6,
@@ -8729,6 +8775,8 @@ void PushIndirectContextOrigin(uint32_t function_address,
   context.root_address =
       DeriveIndirectContextRoot(function_address, context.arguments);
   if (function_address == 0x824365B0) {
+    context.track_presentation_pass_mask =
+        CurrentTrackPresentationPassMask();
     g_track_render_model_context_observations.fetch_add(
         1, std::memory_order_relaxed);
     TrackRenderModelDispatchScope &track_scope =
@@ -9121,6 +9169,8 @@ void RecordTitleIndirectPacket(uint32_t packet_guest_address,
       origin.owner.producer.context.track_render_descriptor_payload;
   entry.track_world_resource_identity_mask =
       origin.owner.producer.context.track_world_resource_identity_mask;
+  entry.track_presentation_pass_mask =
+      origin.owner.producer.context.track_presentation_pass_mask;
   entry.submission_sequence = ++g_title_indirect_packet_submission_sequence;
   entry.constructor_origin_known = origin.valid;
   entry.owner_origin_known = origin.owner.valid;
@@ -9243,6 +9293,8 @@ void ObserveIndirectBuffer(
     active.constructor_origin.owner.producer.context
         .track_world_resource_identity_mask =
         matched.track_world_resource_identity_mask;
+    active.constructor_origin.owner.producer.context
+        .track_presentation_pass_mask = matched.track_presentation_pass_mask;
     active.constructor_origin.owner.producer.context.semantic_receiver_known =
         matched.semantic_receiver_known;
     active.constructor_origin.owner.producer.context.track_command_lineage =
@@ -10881,6 +10933,7 @@ struct CommandBufferLineageEntry {
   uint32_t track_render_descriptor_address = 0;
   uint32_t track_render_descriptor_payload = 0;
   uint32_t track_world_resource_identity_mask = 0;
+  uint32_t track_presentation_pass_mask = 0;
   uint32_t depth = 0;
   bool constructor_origin_known = false;
   bool owner_origin_known = false;
@@ -13209,6 +13262,7 @@ void EmitProceduralModelSemanticSubmissions() {
 void EmitTrackWorldScopeSpatialEntries();
 void EmitTrackWorldReferenceSpatialEntries();
 void EmitTrackWorldPreparedLayoutEntries();
+void EmitTrackPresentationPreparedTargetEntries();
 
 void EmitTrackRenderModelRuntimeJoinEvent(const char *event_name,
                                           bool final_summary,
@@ -13576,6 +13630,21 @@ void EmitTrackPresentationPassSummary() {
   std::array<uint64_t, 4> overlaps{};
   std::array<uint64_t, 4> exit_without_entry{};
   uint64_t total_entries = 0;
+  uint64_t prepared_target_accounted = 0;
+  for (const TrackPresentationPreparedTargetEntry &entry :
+       g_track_presentation_prepared_targets) {
+    prepared_target_accounted += entry.calls;
+  }
+  const uint64_t prepared_target_observations =
+      g_track_presentation_prepared_target_observations.load(
+          std::memory_order_relaxed);
+  const uint64_t prepared_target_overflow =
+      g_track_presentation_prepared_target_overflow.load(
+          std::memory_order_relaxed);
+  const bool prepared_target_accounting_complete =
+      prepared_target_observations ==
+          prepared_target_accounted + prepared_target_overflow &&
+      !prepared_target_overflow;
   bool accounting_complete = true;
   for (size_t index = 0; index < entries.size(); ++index) {
     entries[index] = g_track_presentation_pass_entries[index].load(
@@ -13597,6 +13666,8 @@ void EmitTrackPresentationPassSummary() {
         entries[index] == exact[index] + invalid_root[index] &&
         !overlaps[index] && !exit_without_entry[index];
   }
+  accounting_complete =
+      accounting_complete && prepared_target_accounting_complete;
   pinyon_shift::diagnostics::RecordEvent(
       "native_renderer.discovery.track_presentation_pass_summary",
       {{"status", !total_entries
@@ -13629,6 +13700,13 @@ void EmitTrackPresentationPassSummary() {
        {"exit_without_entry",
         std::to_string(exit_without_entry[0] + exit_without_entry[1] +
                        exit_without_entry[2] + exit_without_entry[3])},
+       {"prepared_target_observations",
+        std::to_string(prepared_target_observations)},
+       {"prepared_target_entries",
+        std::to_string(g_track_presentation_prepared_target_count)},
+       {"prepared_target_overflow", std::to_string(prepared_target_overflow)},
+       {"prepared_target_accounting_complete",
+        prepared_target_accounting_complete ? "true" : "false"},
        {"accounting_complete", accounting_complete ? "true" : "false"},
        {"classification", "unified_track_presentation_adjacent_pass_census"},
        {"guest_state_changed", "false"},
@@ -13641,6 +13719,7 @@ void EmitTrackPresentationPassSummary() {
 
 void EmitTrackRenderModelRuntimeJoinSummary() {
   EmitTrackPresentationPassSummary();
+  EmitTrackPresentationPreparedTargetEntries();
   EmitTrackWorldScopeSpatialEntries();
   EmitTrackWorldReferenceSpatialEntries();
   EmitTrackWorldPreparedLayoutEntries();
@@ -15960,6 +16039,45 @@ std::string SerializeHexWords(const std::array<uint32_t, N> &words) {
   return result;
 }
 
+void EmitTrackPresentationPreparedTargetEntries() {
+  for (const TrackPresentationPreparedTargetEntry &entry :
+       g_track_presentation_prepared_targets) {
+    if (!entry.calls) {
+      continue;
+    }
+    const std::string bound_render_target_formats = fmt::format(
+        "{}:{}:{}:{}:{}", entry.bound_render_target_formats[0],
+        entry.bound_render_target_formats[1],
+        entry.bound_render_target_formats[2],
+        entry.bound_render_target_formats[3],
+        entry.bound_render_target_formats[4]);
+    pinyon_shift::diagnostics::RecordEvent(
+        "native_renderer.discovery.track_presentation_prepared_target_entry",
+        {{"entry_key", fmt::format("{:016X}", entry.key)},
+         {"pass_mask", fmt::format("{:08X}", entry.pass_mask)},
+         {"calls", std::to_string(entry.calls)},
+         {"first_frame", std::to_string(entry.first_frame)},
+         {"last_frame", std::to_string(entry.last_frame)},
+         {"vertex_shader",
+          fmt::format("{:016X}", entry.vertex_shader_hash)},
+         {"pixel_shader", fmt::format("{:016X}", entry.pixel_shader_hash)},
+         {"bound_render_target_bits",
+          fmt::format("{:08X}", entry.bound_render_target_bits)},
+         {"bound_render_target_formats", bound_render_target_formats},
+         {"prepared_pipeline_flags",
+          fmt::format("{:08X}", entry.prepared_pipeline_flags)},
+         {"classification",
+          "exact_unified_track_presentation_pass_to_prepared_target"},
+         {"guest_payload_read", "false"},
+         {"guest_state_changed", "false"},
+         {"control_flow_changed", "false"},
+         {"native_admission", "false"},
+         {"native_draw", "false"},
+         {"xenos_authority", "true"},
+         {"suppression_allowed", "false"}});
+  }
+}
+
 void EmitTrackWorldScopeSpatialEntries() {
   std::scoped_lock lock(g_track_world_scope_spatial_mutex);
   for (const TrackWorldScopeSpatialEntry &entry :
@@ -16632,6 +16750,9 @@ void RecordPreparedCommandBufferLineage(
       entry.track_world_resource_identity_mask =
           constructor_origin.owner.producer.context
               .track_world_resource_identity_mask;
+      entry.track_presentation_pass_mask =
+          constructor_origin.owner.producer.context
+              .track_presentation_pass_mask;
       entry.track_command_lineage = constructor_origin.owner.producer.context
                                         .track_command_lineage;
       entry.depth = observation.command_buffer_depth;
@@ -16663,6 +16784,9 @@ void RecordPreparedCommandBufferLineage(
         entry.track_render_root_address ==
             constructor_origin.owner.producer.context
                 .track_render_root_address &&
+        entry.track_presentation_pass_mask ==
+            constructor_origin.owner.producer.context
+                .track_presentation_pass_mask &&
         entry.depth == observation.command_buffer_depth) {
       ++entry.calls;
       entry.semantic_preparation_epoch_varied |=
@@ -16908,6 +17032,8 @@ void EmitCommandBufferLineageSummary() {
           entry.semantic_preparation_epoch_varied ? "true" : "false"},
          {"track_command_lineage",
           entry.track_command_lineage ? "true" : "false"},
+         {"track_presentation_pass_mask",
+          fmt::format("{:08X}", entry.track_presentation_pass_mask)},
          {"track_render_root_address",
           entry.track_command_lineage
               ? fmt::format("{:08X}", entry.track_render_root_address)
@@ -18929,6 +19055,66 @@ void RecordTrackWorldPreparedLayout(
     index = (index + 1) % kTrackWorldPreparedLayoutCapacity;
   }
   g_track_world_prepared_layout_table_overflow.fetch_add(
+      1, std::memory_order_relaxed);
+}
+
+void RecordTrackPresentationPreparedTarget(
+    const rex::system::GraphicsDrawObservation &observation,
+    const rex::system::GraphicsPreparedDrawObservation &prepared,
+    uint32_t pass_mask) {
+  if (!pass_mask) {
+    return;
+  }
+  g_track_presentation_prepared_target_observations.fetch_add(
+      1, std::memory_order_relaxed);
+  uint64_t key = UINT64_C(0xCBF29CE484222325);
+  for (uint64_t value :
+       {uint64_t(pass_mask), uint64_t(prepared.bound_render_target_bits),
+        uint64_t(prepared.flags), observation.vertex_shader_hash,
+        observation.pixel_shader_hash}) {
+    key = HashCombine(key, value);
+  }
+  for (uint32_t format : prepared.bound_render_target_formats) {
+    key = HashCombine(key, format);
+  }
+  key = key ? key : 1;
+  size_t index =
+      size_t(key % kTrackPresentationPreparedTargetCapacity);
+  for (size_t probe = 0; probe < kTrackPresentationPreparedTargetCapacity;
+       ++probe) {
+    TrackPresentationPreparedTargetEntry &entry =
+        g_track_presentation_prepared_targets[index];
+    if (!entry.calls) {
+      entry.key = key;
+      entry.calls = 1;
+      entry.first_frame = observation.frame_sequence;
+      entry.last_frame = observation.frame_sequence;
+      entry.vertex_shader_hash = observation.vertex_shader_hash;
+      entry.pixel_shader_hash = observation.pixel_shader_hash;
+      entry.pass_mask = pass_mask;
+      entry.bound_render_target_bits = prepared.bound_render_target_bits;
+      std::copy(std::begin(prepared.bound_render_target_formats),
+                std::end(prepared.bound_render_target_formats),
+                entry.bound_render_target_formats.begin());
+      entry.prepared_pipeline_flags = prepared.flags;
+      ++g_track_presentation_prepared_target_count;
+      return;
+    }
+    if (entry.key == key && entry.pass_mask == pass_mask &&
+        entry.bound_render_target_bits == prepared.bound_render_target_bits &&
+        entry.prepared_pipeline_flags == prepared.flags &&
+        entry.vertex_shader_hash == observation.vertex_shader_hash &&
+        entry.pixel_shader_hash == observation.pixel_shader_hash &&
+        std::equal(entry.bound_render_target_formats.begin(),
+                   entry.bound_render_target_formats.end(),
+                   std::begin(prepared.bound_render_target_formats))) {
+      ++entry.calls;
+      entry.last_frame = observation.frame_sequence;
+      return;
+    }
+    index = (index + 1) % kTrackPresentationPreparedTargetCapacity;
+  }
+  g_track_presentation_prepared_target_overflow.fetch_add(
       1, std::memory_order_relaxed);
 }
 
@@ -21489,8 +21675,14 @@ SemanticVisibilityPreparedAdmission RecordSemanticBatchOpportunity(
   const bool exact_track_command =
       active && active->constructor_origin.owner.producer.context
                     .track_command_lineage;
+  const uint32_t track_presentation_pass_mask =
+      active ? active->constructor_origin.owner.producer.context
+                   .track_presentation_pass_mask
+             : 0;
   const SemanticPreparedDrawContract contract =
       BuildSemanticPreparedDrawContract(observation, prepared);
+  RecordTrackPresentationPreparedTarget(observation, prepared,
+                                        track_presentation_pass_mask);
   if (exact_track_command) {
     g_track_render_model_prepared_draw_joins.fetch_add(
         1, std::memory_order_relaxed);

--- a/tools/summarize-native-renderer-track-presentation-passes.py
+++ b/tools/summarize-native-renderer-track-presentation-passes.py
@@ -1,0 +1,224 @@
+#!/usr/bin/env python3
+"""Summarize unified track-presentation passes and prepared target shapes."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import pathlib
+import sys
+
+
+SCHEMA = "pinyon-shift.native-renderer-track-presentation-passes.v1"
+SUMMARY = "native_renderer.discovery.track_presentation_pass_summary"
+ENTRY = "native_renderer.discovery.track_presentation_prepared_target_entry"
+SLOTS = (78, 79, 80, 81)
+
+
+def read_events(paths):
+    events = []
+    for path in paths:
+        with path.open(encoding="utf-8") as stream:
+            for line_number, line in enumerate(stream, 1):
+                if not line.strip():
+                    continue
+                try:
+                    event = json.loads(line)
+                except json.JSONDecodeError as error:
+                    raise ValueError(
+                        f"invalid JSON at {path}:{line_number}: {error}"
+                    ) from error
+                if isinstance(event, dict):
+                    events.append(event)
+    return events
+
+
+def integer(event, key):
+    try:
+        value = int(event[key])
+    except (KeyError, TypeError, ValueError) as error:
+        raise ValueError(f"invalid {key}") from error
+    if value < 0:
+        raise ValueError(f"negative {key}")
+    return value
+
+
+def hexadecimal(event, key, width):
+    value = str(event.get(key, "")).upper()
+    if len(value) != width or any(c not in "0123456789ABCDEF" for c in value):
+        raise ValueError(f"invalid {key}")
+    return int(value, 16)
+
+
+def require_safety(event):
+    expected = {
+        "guest_state_changed": "false",
+        "control_flow_changed": "false",
+        "native_admission": "false",
+        "xenos_authority": "true",
+        "suppression_allowed": "false",
+    }
+    if any(event.get(key) != value for key, value in expected.items()):
+        raise ValueError("track presentation evidence violates safety")
+
+
+def target_shape(bits):
+    return {
+        1: "depth_only",
+        2: "color_only",
+        3: "color_and_depth",
+    }.get(bits, "other")
+
+
+def build(events, requested_session=None):
+    summaries = [event for event in events if event.get("event") == SUMMARY]
+    sessions = {
+        str(event.get("session")) for event in summaries if event.get("session")
+    }
+    if requested_session:
+        session = requested_session
+        if session not in sessions:
+            raise ValueError("requested session has no track presentation summary")
+    elif len(sessions) == 1:
+        session = next(iter(sessions))
+    else:
+        raise ValueError("input must contain exactly one candidate session")
+    selected = [event for event in events if str(event.get("session")) == session]
+    starts = [event for event in selected if event.get("event") == "process.start"]
+    shutdowns = [event for event in selected if event.get("event") == "process.shutdown"]
+    summaries = [event for event in selected if event.get("event") == SUMMARY]
+    if len(starts) != 1 or len(shutdowns) != 1 or len(summaries) != 1:
+        raise ValueError("track presentation lifecycle is incomplete")
+    summary = summaries[0]
+    require_safety(summary)
+
+    slot_totals = {}
+    total_slot_entries = 0
+    for slot in SLOTS:
+        row = {
+            "function": str(summary.get(f"slot_{slot}_function", "")),
+            "entries": integer(summary, f"slot_{slot}_entries"),
+            "exits": integer(summary, f"slot_{slot}_exits"),
+            "exact": integer(summary, f"slot_{slot}_exact"),
+            "invalid_root": integer(summary, f"slot_{slot}_invalid_root"),
+        }
+        slot_totals[str(slot)] = row
+        total_slot_entries += row["entries"]
+
+    prepared_observations = integer(summary, "prepared_target_observations")
+    prepared_entries = integer(summary, "prepared_target_entries")
+    prepared_overflow = integer(summary, "prepared_target_overflow")
+    entries = [event for event in selected if event.get("event") == ENTRY]
+    seen = set()
+    entry_calls = 0
+    per_slot = {
+        str(slot): {"calls": 0, "target_shapes": {}, "shader_pairs": {}}
+        for slot in SLOTS
+    }
+    for event in entries:
+        require_safety(event)
+        key = hexadecimal(event, "entry_key", 16)
+        if key in seen:
+            raise ValueError("duplicate prepared target entry key")
+        seen.add(key)
+        pass_mask = hexadecimal(event, "pass_mask", 8)
+        if not pass_mask or pass_mask & ~0xF:
+            raise ValueError("invalid pass mask")
+        bits = hexadecimal(event, "bound_render_target_bits", 8)
+        vertex_shader = str(event.get("vertex_shader", "")).upper()
+        pixel_shader = str(event.get("pixel_shader", "")).upper()
+        if len(vertex_shader) != 16 or len(pixel_shader) != 16:
+            raise ValueError("invalid shader hash")
+        calls = integer(event, "calls")
+        if not calls:
+            raise ValueError("empty prepared target entry")
+        entry_calls += calls
+        for index, slot in enumerate(SLOTS):
+            if not pass_mask & (1 << index):
+                continue
+            row = per_slot[str(slot)]
+            row["calls"] += calls
+            shape = target_shape(bits)
+            row["target_shapes"][shape] = row["target_shapes"].get(shape, 0) + calls
+            pair = f"{vertex_shader}:{pixel_shader}"
+            row["shader_pairs"][pair] = row["shader_pairs"].get(pair, 0) + calls
+
+    failures = []
+    if summary.get("status") not in ("complete", "not_observed"):
+        failures.append("track presentation summary is incomplete")
+    if summary.get("accounting_complete") != "true":
+        failures.append("track presentation accounting is incomplete")
+    if summary.get("prepared_target_accounting_complete") != "true":
+        failures.append("prepared target accounting is incomplete")
+    if prepared_entries != len(entries):
+        failures.append("prepared target entry count drifted")
+    if prepared_observations != entry_calls + prepared_overflow:
+        failures.append("prepared target call accounting drifted")
+    if prepared_overflow:
+        failures.append("prepared target table overflowed")
+    if not total_slot_entries:
+        failures.append("no unified track presentation pass was observed")
+
+    live_slots = [slot for slot in SLOTS if slot_totals[str(slot)]["exact"]]
+    color_slots = [
+        slot
+        for slot in SLOTS
+        if per_slot[str(slot)]["target_shapes"].get("color_only", 0)
+        or per_slot[str(slot)]["target_shapes"].get("color_and_depth", 0)
+    ]
+    return {
+        "schema": SCHEMA,
+        "session": session,
+        "status": "complete" if not failures else "incomplete",
+        "failures": failures,
+        "slot_totals": slot_totals,
+        "prepared_target_totals": {
+            "observations": prepared_observations,
+            "entries": prepared_entries,
+            "overflow": prepared_overflow,
+        },
+        "prepared_targets_by_slot": per_slot,
+        "qualification": {
+            "live_slots": live_slots,
+            "color_target_slots": color_slots,
+            "opaque_world_slot_proved": False,
+            "native_admission": False,
+            "suppression_allowed": False,
+        },
+        "next_step": (
+            "extend exact packet lineage only through a live color-producing "
+            "slot, then visually qualify its private replay"
+        ),
+        "safety": {
+            "guest_state_changed": False,
+            "control_flow_changed": False,
+            "native_admission": False,
+            "native_draw": False,
+            "xenos_authority": True,
+            "suppression_allowed": False,
+        },
+    }
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("events", nargs="+", type=pathlib.Path)
+    parser.add_argument("--session")
+    parser.add_argument("--output", required=True, type=pathlib.Path)
+    args = parser.parse_args(argv)
+    try:
+        document = build(read_events(args.events), args.session)
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(
+            json.dumps(document, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+        )
+        if document["status"] != "complete":
+            raise ValueError("; ".join(document["failures"]))
+        return 0
+    except (OSError, ValueError, json.JSONDecodeError) as error:
+        print(f"track presentation summary failed: {error}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/tests/test_native_renderer_track_presentation_pass.py
+++ b/tools/tests/test_native_renderer_track_presentation_pass.py
@@ -41,6 +41,11 @@ class TrackPresentationPassTests(unittest.TestCase):
             '"native_renderer.discovery.track_presentation_pass_summary"',
             source,
         )
+        self.assertIn("track_presentation_pass_mask", source)
+        self.assertIn(
+            '"native_renderer.discovery.track_presentation_prepared_target_entry"',
+            source,
+        )
         self.assertIn('"native_admission", "false"', source)
         self.assertIn('"xenos_authority", "true"', source)
         self.assertIn('"suppression_allowed", "false"', source)

--- a/tools/tests/test_native_renderer_track_presentation_pass_summary.py
+++ b/tools/tests/test_native_renderer_track_presentation_pass_summary.py
@@ -1,0 +1,119 @@
+import copy
+import importlib.util
+import pathlib
+import unittest
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+TOOL = ROOT / "tools/summarize-native-renderer-track-presentation-passes.py"
+SPEC = importlib.util.spec_from_file_location("track_presentation_passes", TOOL)
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+def event(name, **values):
+    return {"event": name, "session": "test", **values}
+
+
+def safety():
+    return {
+        "guest_state_changed": "false",
+        "control_flow_changed": "false",
+        "native_admission": "false",
+        "xenos_authority": "true",
+        "suppression_allowed": "false",
+    }
+
+
+def fixture():
+    summary = event(
+        MODULE.SUMMARY,
+        status="complete",
+        presentation_vtable="82243774",
+        overlaps="0",
+        exit_without_entry="0",
+        prepared_target_observations="12",
+        prepared_target_entries="2",
+        prepared_target_overflow="0",
+        prepared_target_accounting_complete="true",
+        accounting_complete="true",
+        **{
+            f"slot_{slot}_{field}": value
+            for slot, function, entries in (
+                (78, "82DEEEE0", 4),
+                (79, "8240E7B0", 8),
+                (80, "82DEF2B0", 0),
+                (81, "82DEADE0", 0),
+            )
+            for field, value in (
+                ("function", function),
+                ("entries", str(entries)),
+                ("exits", str(entries)),
+                ("exact", str(entries)),
+                ("invalid_root", "0"),
+            )
+        },
+        **safety(),
+    )
+    depth = event(
+        MODULE.ENTRY,
+        entry_key="1111222233334444",
+        pass_mask="00000002",
+        calls="8",
+        first_frame="10",
+        last_frame="11",
+        vertex_shader="AAAABBBBCCCCDDDD",
+        pixel_shader="0000000000000000",
+        bound_render_target_bits="00000001",
+        bound_render_target_formats="0:0:0:0:0",
+        prepared_pipeline_flags="00000003",
+        **safety(),
+    )
+    color = event(
+        MODULE.ENTRY,
+        entry_key="5555666677778888",
+        pass_mask="00000001",
+        calls="4",
+        first_frame="10",
+        last_frame="11",
+        vertex_shader="1111222233334444",
+        pixel_shader="9999AAAABBBBCCCC",
+        bound_render_target_bits="00000002",
+        bound_render_target_formats="0:6:0:0:0",
+        prepared_pipeline_flags="00000003",
+        **safety(),
+    )
+    return [event("process.start"), depth, color, summary, event("process.shutdown")]
+
+
+class TrackPresentationPassSummaryTests(unittest.TestCase):
+    def test_correlates_live_slots_and_target_shapes(self):
+        document = MODULE.build(fixture())
+        self.assertEqual("complete", document["status"])
+        self.assertEqual([78, 79], document["qualification"]["live_slots"])
+        self.assertEqual([78], document["qualification"]["color_target_slots"])
+        self.assertEqual(
+            8,
+            document["prepared_targets_by_slot"]["79"]["target_shapes"][
+                "depth_only"
+            ],
+        )
+
+    def test_reports_prepared_accounting_drift(self):
+        events = copy.deepcopy(fixture())
+        events[-2]["prepared_target_observations"] = "13"
+        document = MODULE.build(events)
+        self.assertEqual("incomplete", document["status"])
+        self.assertIn(
+            "prepared target call accounting drifted", document["failures"]
+        )
+
+    def test_rejects_unsafe_entry(self):
+        events = copy.deepcopy(fixture())
+        events[1]["native_admission"] = "true"
+        with self.assertRaisesRegex(ValueError, "violates safety"):
+            MODULE.build(events)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- preserve exact unified track presentation slot identity through indirect packet lineage
- correlate presentation slots with prepared shader and render-target shapes
- add a bounded, safety-gated report and update the reprioritized renderer plan

## Validation
- 21 focused Python tests
- release target build
- git diff --check