### PR TITLE
fix(renderer): use track pass runtime receiver

### DIFF
--- a/docs/native-renderer/REPRIORITIZED_PLAN.md
+++ b/docs/native-renderer/REPRIORITIZED_PLAN.md
@@ -564,6 +564,13 @@ complete overflow accounting. The next AppData run can therefore identify a
 live color-producing pass directly; no intermediate call-count-only run is
 needed, and no candidate gains admission before private visual proof.
 
+The first lineage run proved slots 79 and 80 live but exposed an incorrect
+static-owner receiver gate. Slot 79's already-qualified runtime receiver is
+the unified track render-model instance (`820019CC`), not the presentation
+vtable that merely contains the function address. The corrected slice admits
+only that exact diagnostic scope and inventories neighboring runtime receiver
+signatures; rendering authority and suppression remain unchanged.
+
 ### C2. Static world buildings and props
 
 - Expand opaque-world material and geometry coverage.

--- a/docs/native-renderer/TRACK_PRESENTATION_PASS_CENSUS.md
+++ b/docs/native-renderer/TRACK_PRESENTATION_PASS_CENSUS.md
@@ -77,6 +77,27 @@ only through a live color-producing slot after visual proof. A depth-only slot
 may feed the native shadow slice, but it cannot satisfy C1 opaque world
 coverage.
 
+## First pass-lineage run and receiver correction
+
+AppData session `20260901T042139Z-p17172` reached the saved festival and
+exited normally. Slot 79 made four balanced calls and slot 80 made six;
+slots 78 and 81 were idle. All ten calls failed the initial receiver check,
+so no prepared target inherited a pass mask. The zero-target result therefore
+does not reject either live slot.
+
+The check incorrectly treated membership in the static `82243774`
+presentation vtable as a runtime receiver constraint. Existing qualified
+evidence inside slot 79 already identifies its live `r3` receiver as unified
+track render-model instance vtable `820019CC`. Slot 79 now accepts only that
+proved runtime type. A bounded receiver-signature census records the readable
+`r3` vtable for every neighboring slot with exact observation, entry,
+read-fault, and overflow accounting. Slots 78, 80, and 81 remain unaccepted
+until their runtime receiver types are captured and classified.
+
+This correction still changes no renderer behavior: it only allows the
+already diagnostic packet lineage to retain slot 79's identity. Xenos remains
+authoritative, and native admission, publication, and suppression stay closed.
+
 ## Safety
 
 - The hooks read only the presentation vtable already live at entry.

--- a/src/native_renderer/graphics_hooks.cpp
+++ b/src/native_renderer/graphics_hooks.cpp
@@ -91,6 +91,7 @@ constexpr size_t kTrackWorldPreparedLayoutCapacity = 1024;
 constexpr size_t kTrackWorldScopeSpatialCapacity = 1024;
 constexpr size_t kTrackWorldReferenceSpatialCapacity = 2048;
 constexpr size_t kTrackPresentationPreparedTargetCapacity = 256;
+constexpr size_t kTrackPresentationReceiverCapacity = 32;
 constexpr size_t kTitleOriginStackCapacity = 32;
 constexpr size_t kTitleIndirectPacketBucketCount = 4096;
 constexpr size_t kTitleIndirectPacketWays = 4;
@@ -1127,6 +1128,12 @@ struct TrackPresentationPreparedTargetEntry {
   uint32_t bound_render_target_bits = 0;
   std::array<uint32_t, 5> bound_render_target_formats{};
   uint32_t prepared_pipeline_flags = 0;
+};
+
+struct TrackPresentationReceiverEntry {
+  uint64_t calls = 0;
+  uint32_t pass_index = 0;
+  uint32_t receiver_vtable = 0;
 };
 
 struct TrackWorldScopeSpatialEntry {
@@ -2917,6 +2924,14 @@ std::array<std::atomic<uint64_t>, 4>
     g_track_presentation_pass_exit_without_entry{};
 thread_local std::array<bool, 4> g_track_presentation_pass_active{};
 thread_local std::array<bool, 4> g_track_presentation_pass_accepted{};
+std::mutex g_track_presentation_receiver_mutex;
+std::array<TrackPresentationReceiverEntry,
+           kTrackPresentationReceiverCapacity>
+    g_track_presentation_receivers{};
+std::atomic<uint64_t> g_track_presentation_receiver_observations{};
+std::atomic<uint64_t> g_track_presentation_receiver_read_faults{};
+std::atomic<uint64_t> g_track_presentation_receiver_overflow{};
+size_t g_track_presentation_receiver_count = 0;
 std::array<TrackPresentationPreparedTargetEntry,
            kTrackPresentationPreparedTargetCapacity>
     g_track_presentation_prepared_targets{};
@@ -3910,12 +3925,40 @@ void BeginTrackPresentationPass(size_t pass_index, uint32_t root_address) {
       g_command_buffer_lineage_memory.load(std::memory_order_acquire);
   if (!g_command_buffer_lineage_installed.load(std::memory_order_acquire) ||
       !IsReadableVehicleGuestRange(memory, root_address, sizeof(uint32_t))) {
+    ++g_track_presentation_receiver_read_faults;
     ++g_track_presentation_pass_invalid_root[pass_index];
     return;
   }
   std::array<uint32_t, 1> root_words{};
   LoadSemanticGuestWords(memory, root_address, root_words);
-  if (root_words[0] != kTrackPresentationUnifiedVtable) {
+  ++g_track_presentation_receiver_observations;
+  {
+    std::scoped_lock lock(g_track_presentation_receiver_mutex);
+    TrackPresentationReceiverEntry *available = nullptr;
+    for (TrackPresentationReceiverEntry &entry :
+         g_track_presentation_receivers) {
+      if (entry.calls && entry.pass_index == pass_index &&
+          entry.receiver_vtable == root_words[0]) {
+        ++entry.calls;
+        available = &entry;
+        break;
+      }
+      if (!entry.calls && !available) {
+        available = &entry;
+      }
+    }
+    if (available && !available->calls) {
+      available->calls = 1;
+      available->pass_index = static_cast<uint32_t>(pass_index);
+      available->receiver_vtable = root_words[0];
+      ++g_track_presentation_receiver_count;
+    } else if (!available) {
+      ++g_track_presentation_receiver_overflow;
+    }
+  }
+  const uint32_t expected_receiver_vtable =
+      pass_index == 1 ? kTrackRenderModelInstanceUnifiedVtable : 0;
+  if (!expected_receiver_vtable || root_words[0] != expected_receiver_vtable) {
     ++g_track_presentation_pass_invalid_root[pass_index];
     return;
   }
@@ -6574,6 +6617,14 @@ void ResetTitleDrawProvenance() {
        g_track_presentation_prepared_targets) {
     entry = {};
   }
+  {
+    std::scoped_lock receiver_lock(g_track_presentation_receiver_mutex);
+    for (TrackPresentationReceiverEntry &entry :
+         g_track_presentation_receivers) {
+      entry = {};
+    }
+    g_track_presentation_receiver_count = 0;
+  }
   for (TrackWorldScopeSpatialEntry &entry :
        g_track_world_scope_spatial_entries) {
     entry = {};
@@ -6920,6 +6971,9 @@ void ResetTitleDrawProvenance() {
            &g_track_world_prepared_layout_table_overflow,
            &g_track_presentation_prepared_target_observations,
            &g_track_presentation_prepared_target_overflow,
+           &g_track_presentation_receiver_observations,
+           &g_track_presentation_receiver_read_faults,
+           &g_track_presentation_receiver_overflow,
            &g_track_world_scope_spatial_observations,
            &g_track_world_scope_spatial_table_overflow,
            &g_track_world_reference_spatial_observations,
@@ -13263,6 +13317,7 @@ void EmitTrackWorldScopeSpatialEntries();
 void EmitTrackWorldReferenceSpatialEntries();
 void EmitTrackWorldPreparedLayoutEntries();
 void EmitTrackPresentationPreparedTargetEntries();
+void EmitTrackPresentationReceiverEntries();
 
 void EmitTrackRenderModelRuntimeJoinEvent(const char *event_name,
                                           bool final_summary,
@@ -13645,6 +13700,27 @@ void EmitTrackPresentationPassSummary() {
       prepared_target_observations ==
           prepared_target_accounted + prepared_target_overflow &&
       !prepared_target_overflow;
+  uint64_t receiver_accounted = 0;
+  size_t receiver_entry_count = 0;
+  {
+    std::scoped_lock lock(g_track_presentation_receiver_mutex);
+    for (const TrackPresentationReceiverEntry &entry :
+         g_track_presentation_receivers) {
+      receiver_accounted += entry.calls;
+    }
+    receiver_entry_count = g_track_presentation_receiver_count;
+  }
+  const uint64_t receiver_observations =
+      g_track_presentation_receiver_observations.load(
+          std::memory_order_relaxed);
+  const uint64_t receiver_read_faults =
+      g_track_presentation_receiver_read_faults.load(
+          std::memory_order_relaxed);
+  const uint64_t receiver_overflow =
+      g_track_presentation_receiver_overflow.load(std::memory_order_relaxed);
+  const bool receiver_accounting_complete =
+      receiver_observations == receiver_accounted + receiver_overflow &&
+      !receiver_overflow;
   bool accounting_complete = true;
   for (size_t index = 0; index < entries.size(); ++index) {
     entries[index] = g_track_presentation_pass_entries[index].load(
@@ -13666,8 +13742,9 @@ void EmitTrackPresentationPassSummary() {
         entries[index] == exact[index] + invalid_root[index] &&
         !overlaps[index] && !exit_without_entry[index];
   }
-  accounting_complete =
-      accounting_complete && prepared_target_accounting_complete;
+  accounting_complete = accounting_complete &&
+                        prepared_target_accounting_complete &&
+                        receiver_accounting_complete;
   pinyon_shift::diagnostics::RecordEvent(
       "native_renderer.discovery.track_presentation_pass_summary",
       {{"status", !total_entries
@@ -13675,6 +13752,8 @@ void EmitTrackPresentationPassSummary() {
                       : (accounting_complete ? "complete" : "incomplete")},
        {"presentation_vtable",
         fmt::format("{:08X}", kTrackPresentationUnifiedVtable)},
+       {"slot_79_runtime_receiver_vtable",
+        fmt::format("{:08X}", kTrackRenderModelInstanceUnifiedVtable)},
        {"slot_78_function", "82DEEEE0"},
        {"slot_78_entries", std::to_string(entries[0])},
        {"slot_78_exits", std::to_string(exits[0])},
@@ -13707,6 +13786,12 @@ void EmitTrackPresentationPassSummary() {
        {"prepared_target_overflow", std::to_string(prepared_target_overflow)},
        {"prepared_target_accounting_complete",
         prepared_target_accounting_complete ? "true" : "false"},
+       {"receiver_observations", std::to_string(receiver_observations)},
+       {"receiver_entries", std::to_string(receiver_entry_count)},
+       {"receiver_read_faults", std::to_string(receiver_read_faults)},
+       {"receiver_overflow", std::to_string(receiver_overflow)},
+       {"receiver_accounting_complete",
+        receiver_accounting_complete ? "true" : "false"},
        {"accounting_complete", accounting_complete ? "true" : "false"},
        {"classification", "unified_track_presentation_adjacent_pass_census"},
        {"guest_state_changed", "false"},
@@ -13719,6 +13804,7 @@ void EmitTrackPresentationPassSummary() {
 
 void EmitTrackRenderModelRuntimeJoinSummary() {
   EmitTrackPresentationPassSummary();
+  EmitTrackPresentationReceiverEntries();
   EmitTrackPresentationPreparedTargetEntries();
   EmitTrackWorldScopeSpatialEntries();
   EmitTrackWorldReferenceSpatialEntries();
@@ -16068,6 +16154,30 @@ void EmitTrackPresentationPreparedTargetEntries() {
           fmt::format("{:08X}", entry.prepared_pipeline_flags)},
          {"classification",
           "exact_unified_track_presentation_pass_to_prepared_target"},
+         {"guest_payload_read", "false"},
+         {"guest_state_changed", "false"},
+         {"control_flow_changed", "false"},
+         {"native_admission", "false"},
+         {"native_draw", "false"},
+         {"xenos_authority", "true"},
+         {"suppression_allowed", "false"}});
+  }
+}
+
+void EmitTrackPresentationReceiverEntries() {
+  std::scoped_lock lock(g_track_presentation_receiver_mutex);
+  for (const TrackPresentationReceiverEntry &entry :
+       g_track_presentation_receivers) {
+    if (!entry.calls) {
+      continue;
+    }
+    pinyon_shift::diagnostics::RecordEvent(
+        "native_renderer.discovery.track_presentation_receiver_entry",
+        {{"pass_mask", fmt::format("{:08X}",
+                                    uint32_t(1) << entry.pass_index)},
+         {"receiver_vtable", fmt::format("{:08X}", entry.receiver_vtable)},
+         {"calls", std::to_string(entry.calls)},
+         {"classification", "track_presentation_runtime_receiver_signature"},
          {"guest_payload_read", "false"},
          {"guest_state_changed", "false"},
          {"control_flow_changed", "false"},

--- a/tools/summarize-native-renderer-track-presentation-passes.py
+++ b/tools/summarize-native-renderer-track-presentation-passes.py
@@ -12,6 +12,7 @@ import sys
 SCHEMA = "pinyon-shift.native-renderer-track-presentation-passes.v1"
 SUMMARY = "native_renderer.discovery.track_presentation_pass_summary"
 ENTRY = "native_renderer.discovery.track_presentation_prepared_target_entry"
+RECEIVER = "native_renderer.discovery.track_presentation_receiver_entry"
 SLOTS = (78, 79, 80, 81)
 
 
@@ -143,6 +144,32 @@ def build(events, requested_session=None):
             pair = f"{vertex_shader}:{pixel_shader}"
             row["shader_pairs"][pair] = row["shader_pairs"].get(pair, 0) + calls
 
+    receiver_observations = integer(summary, "receiver_observations")
+    receiver_entry_count = integer(summary, "receiver_entries")
+    receiver_read_faults = integer(summary, "receiver_read_faults")
+    receiver_overflow = integer(summary, "receiver_overflow")
+    receiver_entries = [
+        event for event in selected if event.get("event") == RECEIVER
+    ]
+    receiver_calls = 0
+    receiver_profiles = {str(slot): {} for slot in SLOTS}
+    for event in receiver_entries:
+        require_safety(event)
+        pass_mask = hexadecimal(event, "pass_mask", 8)
+        if not pass_mask or pass_mask & ~0xF or pass_mask.bit_count() != 1:
+            raise ValueError("invalid receiver pass mask")
+        receiver_vtable = str(event.get("receiver_vtable", "")).upper()
+        if len(receiver_vtable) != 8 or any(
+            c not in "0123456789ABCDEF" for c in receiver_vtable
+        ):
+            raise ValueError("invalid receiver vtable")
+        calls = integer(event, "calls")
+        if not calls:
+            raise ValueError("empty receiver entry")
+        receiver_calls += calls
+        slot = SLOTS[pass_mask.bit_length() - 1]
+        receiver_profiles[str(slot)][receiver_vtable] = calls
+
     failures = []
     if summary.get("status") not in ("complete", "not_observed"):
         failures.append("track presentation summary is incomplete")
@@ -156,10 +183,21 @@ def build(events, requested_session=None):
         failures.append("prepared target call accounting drifted")
     if prepared_overflow:
         failures.append("prepared target table overflowed")
+    if summary.get("receiver_accounting_complete") != "true":
+        failures.append("receiver accounting is incomplete")
+    if receiver_entry_count != len(receiver_entries):
+        failures.append("receiver entry count drifted")
+    if receiver_observations != receiver_calls + receiver_overflow:
+        failures.append("receiver call accounting drifted")
+    if receiver_read_faults:
+        failures.append("presentation receiver reads faulted")
+    if receiver_overflow:
+        failures.append("presentation receiver table overflowed")
     if not total_slot_entries:
         failures.append("no unified track presentation pass was observed")
 
-    live_slots = [slot for slot in SLOTS if slot_totals[str(slot)]["exact"]]
+    live_slots = [slot for slot in SLOTS if slot_totals[str(slot)]["entries"]]
+    accepted_slots = [slot for slot in SLOTS if slot_totals[str(slot)]["exact"]]
     color_slots = [
         slot
         for slot in SLOTS
@@ -178,8 +216,10 @@ def build(events, requested_session=None):
             "overflow": prepared_overflow,
         },
         "prepared_targets_by_slot": per_slot,
+        "runtime_receivers_by_slot": receiver_profiles,
         "qualification": {
             "live_slots": live_slots,
+            "accepted_receiver_slots": accepted_slots,
             "color_target_slots": color_slots,
             "opaque_world_slot_proved": False,
             "native_admission": False,

--- a/tools/tests/test_native_renderer_track_presentation_pass.py
+++ b/tools/tests/test_native_renderer_track_presentation_pass.py
@@ -42,8 +42,13 @@ class TrackPresentationPassTests(unittest.TestCase):
             source,
         )
         self.assertIn("track_presentation_pass_mask", source)
+        self.assertIn("kTrackRenderModelInstanceUnifiedVtable", source)
         self.assertIn(
             '"native_renderer.discovery.track_presentation_prepared_target_entry"',
+            source,
+        )
+        self.assertIn(
+            '"native_renderer.discovery.track_presentation_receiver_entry"',
             source,
         )
         self.assertIn('"native_admission", "false"', source)

--- a/tools/tests/test_native_renderer_track_presentation_pass_summary.py
+++ b/tools/tests/test_native_renderer_track_presentation_pass_summary.py
@@ -36,6 +36,11 @@ def fixture():
         prepared_target_entries="2",
         prepared_target_overflow="0",
         prepared_target_accounting_complete="true",
+        receiver_observations="12",
+        receiver_entries="2",
+        receiver_read_faults="0",
+        receiver_overflow="0",
+        receiver_accounting_complete="true",
         accounting_complete="true",
         **{
             f"slot_{slot}_{field}": value
@@ -83,7 +88,29 @@ def fixture():
         prepared_pipeline_flags="00000003",
         **safety(),
     )
-    return [event("process.start"), depth, color, summary, event("process.shutdown")]
+    receiver_78 = event(
+        MODULE.RECEIVER,
+        pass_mask="00000001",
+        receiver_vtable="82112233",
+        calls="4",
+        **safety(),
+    )
+    receiver_79 = event(
+        MODULE.RECEIVER,
+        pass_mask="00000002",
+        receiver_vtable="820019CC",
+        calls="8",
+        **safety(),
+    )
+    return [
+        event("process.start"),
+        depth,
+        color,
+        receiver_78,
+        receiver_79,
+        summary,
+        event("process.shutdown"),
+    ]
 
 
 class TrackPresentationPassSummaryTests(unittest.TestCase):
@@ -91,7 +118,13 @@ class TrackPresentationPassSummaryTests(unittest.TestCase):
         document = MODULE.build(fixture())
         self.assertEqual("complete", document["status"])
         self.assertEqual([78, 79], document["qualification"]["live_slots"])
+        self.assertEqual(
+            [78, 79], document["qualification"]["accepted_receiver_slots"]
+        )
         self.assertEqual([78], document["qualification"]["color_target_slots"])
+        self.assertEqual(
+            {"820019CC": 8}, document["runtime_receivers_by_slot"]["79"]
+        )
         self.assertEqual(
             8,
             document["prepared_targets_by_slot"]["79"]["target_shapes"][


### PR DESCRIPTION
## Summary
- correct slot 79's runtime receiver gate to the already-qualified unified track render-model instance
- census neighboring slot receiver signatures with bounded accounting
- distinguish observed slots from accepted receiver slots in the report
- record the first pass-lineage AppData result and preserve fail-closed renderer authority

## Validation
- AppData session 20260901T042139Z-p17172: saved festival, normal exit
- 21 focused Python tests
- release target build
- git diff --check