### PR TITLE
docs(renderer): record combined runtime priorities

### DIFF
--- a/docs/native-renderer/REPRIORITIZED_PLAN.md
+++ b/docs/native-renderer/REPRIORITIZED_PLAN.md
@@ -758,6 +758,16 @@ accounting. It neither embeds the local catalog nor changes the normal
 prototype selector, Xenos execution, publication authority, or suppression.
 Runtime and visual proof is batched with the pending C1/C2 AppData run.
 
+Representative-scene result: clean festival session
+`20260901T042139Z-p17172` exercised 6,016 exact generic model-presentation
+scopes but joined none to a `CSimpleModelRenderer`, resource graph, PM4 packet,
+or prepared draw. The same run exposed 6,016 asset-metadata read faults and
+5,772 resource-transition receiver-vtable mismatches. The generic SimpleModel
+route is therefore not a visible-prototype lead in this scene and requires a
+runtime-receiver correction plus a scene that exercises its renderer before
+C2 admission resumes. C1 color-pass lineage remains ahead of this route; final
+C2 scope is unchanged.
+
 ### C3. Semantic batching, culling, and LOD
 
 - Promote the existing visibility and prepared-draw evidence into production
@@ -787,6 +797,15 @@ to `(false, 0)`, while different proved LODs can never share a run. Family-local
 LOD opportunity signals remain measurement-only; independent native LOD
 selection is still disabled until the batched runtime evidence proves this
 passthrough boundary.
+
+First combined runtime result: the same clean festival session retained 38
+fresh track-texture candidates in nine bounded families; 11 draws in two
+families were mechanically replayable, with zero future decisions or table
+overflow. Exact track-world, title-LOD, and static-world lineage remained
+absent. The current semantic batch key then partitioned 2,873 eligible draws
+into 2,873 single-draw runs (maximum length one), proving zero command
+reduction for this evidence set. C3 executor and optimization work stays behind
+C1 semantic identity instead of optimizing an unbatchable key.
 
 ### C4. Player and traffic vehicles
 

--- a/docs/native-renderer/SEMANTIC_BATCH_ADMISSION.md
+++ b/docs/native-renderer/SEMANTIC_BATCH_ADMISSION.md
@@ -156,3 +156,11 @@ See `SEMANTIC_BATCH_EQUIVALENCE.md`.
 The measured material and pipeline opportunities feed a bounded shadow cache
 without enabling native state objects or execution. See
 `SEMANTIC_STATE_CACHE.md`.
+
+The smaller combined C1/C2 session `20260901T042139Z-p17172` independently
+reconfirmed the same scheduling result after world-family and title-LOD tags
+were added to the key. Its 2,873 eligible draws formed 2,873 consecutive runs,
+all length one, with zero opportunity overflow and zero projected command
+reduction. No exact track-world, static-world, or title-LOD group was present.
+The executor remains correctly deferred until C1 supplies a stronger semantic
+identity or a separately qualified coarser equivalence.

--- a/docs/native-renderer/VISIBILITY_PREPARED_CANDIDATES.md
+++ b/docs/native-renderer/VISIBILITY_PREPARED_CANDIDATES.md
@@ -186,3 +186,11 @@ that absence was explicitly reconciled without inferring an index. The game
 loaded the installed AppData festival save and remained visually stable.
 Native output stayed private, the original Xenos draws remained authoritative,
 and publication and suppression stayed disabled.
+
+Release/AppData session `20260901T042139Z-p17172` requalified the passive
+handoff during the C1/C2 batch. It retained 38 fresh candidates in nine exact
+track-texture families; 11 draws in two families passed the mechanical replay
+contract. Missing, rejected, and stale exclusions reconciled all 3,310
+observations, with zero future decisions or table overflow. Exact track-world,
+static-world, and title-LOD lineage were absent, so this result keeps the
+handoff proved but does not promote a semantic world family.


### PR DESCRIPTION
## Summary
- record the clean combined-session visibility handoff result
- record the zero-reduction semantic batch result
- defer the dormant/mismatched generic SimpleModel route behind C1 color-pass identity
- keep the full native renderer scope unchanged

## Validation
- visibility prepared-candidate report: complete
- semantic batch report: complete
- static-world report: fail-closed with explicit missing/mismatched runtime gates
- git diff --check