### PR TITLE
feat(renderer): classify track pass spatial state

### DIFF
--- a/docs/native-renderer/REPRIORITIZED_PLAN.md
+++ b/docs/native-renderer/REPRIORITIZED_PLAN.md
@@ -571,6 +571,12 @@ vtable that merely contains the function address. The corrected slice admits
 only that exact diagnostic scope and inventories neighboring runtime receiver
 signatures; rendering authority and suppression remain unchanged.
 
+Spatial-state batching checkpoint: the same per-slot prepared-target key now
+includes raw viewport, viewport-transform control, and scissor state. The next
+run can distinguish main-view color work from square shadow/reflection and
+reduced offscreen passes in the same report, avoiding another call-count-only
+capture. This records no camera payload and still admits no native draw.
+
 ### C2. Static world buildings and props
 
 - Expand opaque-world material and geometry coverage.

--- a/docs/native-renderer/TRACK_PRESENTATION_PASS_CENSUS.md
+++ b/docs/native-renderer/TRACK_PRESENTATION_PASS_CENSUS.md
@@ -98,6 +98,14 @@ This correction still changes no renderer behavior: it only allows the
 already diagnostic packet lineage to retain slot 79's identity. Xenos remains
 authoritative, and native admission, publication, and suppression stay closed.
 
+The prepared-target key now also retains the already observed raw viewport,
+viewport-transform control, and window scissor. The offline report decodes
+only the scissor extent while preserving the raw state. The next batched run
+can therefore separate main-view color, square shadow/reflection, and reduced
+offscreen work even when shader and attachment formats overlap. This is
+spatial-state classification only; it does not infer camera matrices or admit
+a draw.
+
 ## Safety
 
 - The hooks read only the presentation vtable already live at entry.

--- a/src/native_renderer/graphics_hooks.cpp
+++ b/src/native_renderer/graphics_hooks.cpp
@@ -1128,6 +1128,13 @@ struct TrackPresentationPreparedTargetEntry {
   uint32_t bound_render_target_bits = 0;
   std::array<uint32_t, 5> bound_render_target_formats{};
   uint32_t prepared_pipeline_flags = 0;
+  uint32_t viewport_xscale = 0;
+  uint32_t viewport_xoffset = 0;
+  uint32_t viewport_yscale = 0;
+  uint32_t viewport_yoffset = 0;
+  uint32_t viewport_transform_control = 0;
+  uint32_t window_scissor_tl = 0;
+  uint32_t window_scissor_br = 0;
 };
 
 struct TrackPresentationReceiverEntry {
@@ -16152,6 +16159,15 @@ void EmitTrackPresentationPreparedTargetEntries() {
          {"bound_render_target_formats", bound_render_target_formats},
          {"prepared_pipeline_flags",
           fmt::format("{:08X}", entry.prepared_pipeline_flags)},
+         {"viewport",
+          fmt::format("{:08X}:{:08X}:{:08X}:{:08X}",
+                      entry.viewport_xscale, entry.viewport_xoffset,
+                      entry.viewport_yscale, entry.viewport_yoffset)},
+         {"viewport_transform_control",
+          fmt::format("{:08X}", entry.viewport_transform_control)},
+         {"scissor",
+          fmt::format("{:08X}:{:08X}", entry.window_scissor_tl,
+                      entry.window_scissor_br)},
          {"classification",
           "exact_unified_track_presentation_pass_to_prepared_target"},
          {"guest_payload_read", "false"},
@@ -19181,7 +19197,13 @@ void RecordTrackPresentationPreparedTarget(
   for (uint64_t value :
        {uint64_t(pass_mask), uint64_t(prepared.bound_render_target_bits),
         uint64_t(prepared.flags), observation.vertex_shader_hash,
-        observation.pixel_shader_hash}) {
+        observation.pixel_shader_hash, uint64_t(observation.viewport_xscale),
+        uint64_t(observation.viewport_xoffset),
+        uint64_t(observation.viewport_yscale),
+        uint64_t(observation.viewport_yoffset),
+        uint64_t(observation.viewport_transform_control),
+        uint64_t(observation.window_scissor_tl),
+        uint64_t(observation.window_scissor_br)}) {
     key = HashCombine(key, value);
   }
   for (uint32_t format : prepared.bound_render_target_formats) {
@@ -19207,12 +19229,28 @@ void RecordTrackPresentationPreparedTarget(
                 std::end(prepared.bound_render_target_formats),
                 entry.bound_render_target_formats.begin());
       entry.prepared_pipeline_flags = prepared.flags;
+      entry.viewport_xscale = observation.viewport_xscale;
+      entry.viewport_xoffset = observation.viewport_xoffset;
+      entry.viewport_yscale = observation.viewport_yscale;
+      entry.viewport_yoffset = observation.viewport_yoffset;
+      entry.viewport_transform_control =
+          observation.viewport_transform_control;
+      entry.window_scissor_tl = observation.window_scissor_tl;
+      entry.window_scissor_br = observation.window_scissor_br;
       ++g_track_presentation_prepared_target_count;
       return;
     }
     if (entry.key == key && entry.pass_mask == pass_mask &&
         entry.bound_render_target_bits == prepared.bound_render_target_bits &&
         entry.prepared_pipeline_flags == prepared.flags &&
+        entry.viewport_xscale == observation.viewport_xscale &&
+        entry.viewport_xoffset == observation.viewport_xoffset &&
+        entry.viewport_yscale == observation.viewport_yscale &&
+        entry.viewport_yoffset == observation.viewport_yoffset &&
+        entry.viewport_transform_control ==
+            observation.viewport_transform_control &&
+        entry.window_scissor_tl == observation.window_scissor_tl &&
+        entry.window_scissor_br == observation.window_scissor_br &&
         entry.vertex_shader_hash == observation.vertex_shader_hash &&
         entry.pixel_shader_hash == observation.pixel_shader_hash &&
         std::equal(entry.bound_render_target_formats.begin(),

--- a/tools/summarize-native-renderer-track-presentation-passes.py
+++ b/tools/summarize-native-renderer-track-presentation-passes.py
@@ -71,6 +71,25 @@ def target_shape(bits):
     }.get(bits, "other")
 
 
+def hexadecimal_tuple(event, key, count):
+    parts = str(event.get(key, "")).upper().split(":")
+    if len(parts) != count or any(
+        len(part) != 8 or any(c not in "0123456789ABCDEF" for c in part)
+        for part in parts
+    ):
+        raise ValueError(f"invalid {key}")
+    return tuple(int(part, 16) for part in parts)
+
+
+def scissor_extent(scissor):
+    tl, br = scissor
+    left, top = tl & 0x7FFF, (tl >> 16) & 0x7FFF
+    right, bottom = br & 0x7FFF, (br >> 16) & 0x7FFF
+    if right < left or bottom < top:
+        return "invalid"
+    return f"{right - left}x{bottom - top}"
+
+
 def build(events, requested_session=None):
     summaries = [event for event in events if event.get("event") == SUMMARY]
     sessions = {
@@ -113,7 +132,12 @@ def build(events, requested_session=None):
     seen = set()
     entry_calls = 0
     per_slot = {
-        str(slot): {"calls": 0, "target_shapes": {}, "shader_pairs": {}}
+        str(slot): {
+            "calls": 0,
+            "target_shapes": {},
+            "shader_pairs": {},
+            "spatial_states": {},
+        }
         for slot in SLOTS
     }
     for event in entries:
@@ -126,6 +150,9 @@ def build(events, requested_session=None):
         if not pass_mask or pass_mask & ~0xF:
             raise ValueError("invalid pass mask")
         bits = hexadecimal(event, "bound_render_target_bits", 8)
+        viewport = hexadecimal_tuple(event, "viewport", 4)
+        viewport_control = hexadecimal(event, "viewport_transform_control", 8)
+        scissor = hexadecimal_tuple(event, "scissor", 2)
         vertex_shader = str(event.get("vertex_shader", "")).upper()
         pixel_shader = str(event.get("pixel_shader", "")).upper()
         if len(vertex_shader) != 16 or len(pixel_shader) != 16:
@@ -143,6 +170,14 @@ def build(events, requested_session=None):
             row["target_shapes"][shape] = row["target_shapes"].get(shape, 0) + calls
             pair = f"{vertex_shader}:{pixel_shader}"
             row["shader_pairs"][pair] = row["shader_pairs"].get(pair, 0) + calls
+            spatial = (
+                f"{scissor_extent(scissor)}:"
+                f"{':'.join(f'{value:08X}' for value in viewport)}:"
+                f"{viewport_control:08X}"
+            )
+            row["spatial_states"][spatial] = (
+                row["spatial_states"].get(spatial, 0) + calls
+            )
 
     receiver_observations = integer(summary, "receiver_observations")
     receiver_entry_count = integer(summary, "receiver_entries")

--- a/tools/tests/test_native_renderer_track_presentation_pass_summary.py
+++ b/tools/tests/test_native_renderer_track_presentation_pass_summary.py
@@ -72,6 +72,9 @@ def fixture():
         bound_render_target_bits="00000001",
         bound_render_target_formats="0:0:0:0:0",
         prepared_pipeline_flags="00000003",
+        viewport="43800000:44400000:C3800000:43800000",
+        viewport_transform_control="00010F00",
+        scissor="00000000:04000400",
         **safety(),
     )
     color = event(
@@ -86,6 +89,9 @@ def fixture():
         bound_render_target_bits="00000002",
         bound_render_target_formats="0:6:0:0:0",
         prepared_pipeline_flags="00000003",
+        viewport="44200000:44200000:C4200000:44200000",
+        viewport_transform_control="00010F00",
+        scissor="00000000:02800280",
         **safety(),
     )
     receiver_78 = event(
@@ -124,6 +130,10 @@ class TrackPresentationPassSummaryTests(unittest.TestCase):
         self.assertEqual([78], document["qualification"]["color_target_slots"])
         self.assertEqual(
             {"820019CC": 8}, document["runtime_receivers_by_slot"]["79"]
+        )
+        self.assertIn(
+            "1024x1024:43800000:44400000:C3800000:43800000:00010F00",
+            document["prepared_targets_by_slot"]["79"]["spatial_states"],
         )
         self.assertEqual(
             8,


### PR DESCRIPTION
## Summary
- include raw viewport, viewport-transform, and scissor state in track-pass prepared target keys
- decode scissor extents in the payload-free slot report
- distinguish main-view candidates from square or reduced offscreen passes
- preserve Xenos authority and keep admission/suppression disabled

## Validation
- 21 focused Python tests
- release target build
- git diff --check