### PR TITLE
fix(renderer): classify track presentation wrapper

### DIFF
--- a/docs/native-renderer/REPRIORITIZED_PLAN.md
+++ b/docs/native-renderer/REPRIORITIZED_PLAN.md
@@ -565,11 +565,12 @@ live color-producing pass directly; no intermediate call-count-only run is
 needed, and no candidate gains admission before private visual proof.
 
 The first lineage run proved slots 79 and 80 live but exposed an incorrect
-static-owner receiver gate. Slot 79's already-qualified runtime receiver is
-the unified track render-model instance (`820019CC`), not the presentation
-vtable that merely contains the function address. The corrected slice admits
-only that exact diagnostic scope and inventories neighboring runtime receiver
-signatures; rendering authority and suppression remain unchanged.
+static-owner receiver gate. A controlled retry then showed all ten calls use
+vtable `82003CCC`. Retail RTTI proves this is the 135-slot thread-safe
+refcounted wrapper around unified `CTrackPresentation`, and its slots 78-81
+resolve to the exact hooked AOT targets. The corrected slice accepts only that
+wrapper for diagnostic lineage; the inner render-model instance (`820019CC`)
+remains a separate scope. Rendering authority and suppression are unchanged.
 
 Spatial-state batching checkpoint: the same per-slot prepared-target key now
 includes raw viewport, viewport-transform control, and scissor state. The next

--- a/docs/native-renderer/TRACK_PRESENTATION_PASS_CENSUS.md
+++ b/docs/native-renderer/TRACK_PRESENTATION_PASS_CENSUS.md
@@ -20,7 +20,10 @@ opaque road/terrain color pass that the visible prototype needs.
 ## Static pass ownership
 
 Retail RTTI identifies vtable `82243774` as
-`Presentation_Unified::CTrackPresentation`. Its adjacent slots are:
+`Presentation_Unified::CTrackPresentation`. Runtime qualification then proved
+that calls use its exact thread-safe refcounted wrapper at vtable `82003CCC`.
+Both tables have 135 entries and the wrapper carries these same adjacent
+targets:
 
 | Slot | Function |
 |---:|---:|
@@ -86,19 +89,28 @@ so no prepared target inherited a pass mask. The zero-target result therefore
 does not reject either live slot.
 
 The check incorrectly treated membership in the static `82243774`
-presentation vtable as a runtime receiver constraint. Existing qualified
-evidence inside slot 79 already identifies its live `r3` receiver as unified
-track render-model instance vtable `820019CC`. Slot 79 now accepts only that
-proved runtime type. A bounded receiver-signature census records the readable
-`r3` vtable for every neighboring slot with exact observation, entry,
-read-fault, and overflow accounting. Slots 78, 80, and 81 remain unaccepted
-until their runtime receiver types are captured and classified.
+presentation vtable as a runtime receiver constraint. A first correction also
+mistook the inner slot-79 render-model scope (`820019CC`) for the outer method
+receiver. Controlled retry session `20260901T044525Z-p9440` resolved the
+ambiguity: all four slot-79 calls and all six slot-80 calls used `82003CCC`.
+Retail RTTI identifies that exact complete-object vtable as
+`TRefCountedObjectThreadSafe<CTrackPresentation<Presentation_Unified>>`, and
+its slots 78-81 resolve to the four already hooked AOT targets. The census now
+accepts only this proved wrapper receiver for all four slots; observed runtime
+activity remains limited to slots 79 and 80.
 
 This correction still changes no renderer behavior: it only allows the
 already diagnostic packet lineage to retain slot 79's identity. Xenos remains
 authoritative, and native admission, publication, and suppression stay closed.
 
-The prepared-target key now also retains the already observed raw viewport,
+The retry exited normally with zero receiver read faults, overflow, overlap,
+or lifecycle drift. It intentionally produced no prepared-target entries
+because the incorrect inner-scope receiver gate rejected all ten calls. That
+result closes the receiver classification rather than classifying either live
+pass. The next batched run can carry both exact live slot masks into prepared
+draws.
+
+The prepared-target key also retains the already observed raw viewport,
 viewport-transform control, and window scissor. The offline report decodes
 only the scissor extent while preserving the raw state. The next batched run
 can therefore separate main-view color, square shadow/reflection, and reduced
@@ -108,7 +120,8 @@ a draw.
 
 ## Safety
 
-- The hooks read only the presentation vtable already live at entry.
+- The hooks read only the exact refcounted presentation-wrapper vtable already
+  live at entry.
 - Prepared target data is bounded numeric metadata from the existing backend
   observer.
 - Guest state, title control flow, Xenos draws, and output are unchanged.

--- a/src/native_renderer/graphics_hooks.cpp
+++ b/src/native_renderer/graphics_hooks.cpp
@@ -204,6 +204,7 @@ constexpr uint32_t kTrackTexturePredicate44Method = 0x82DF0B40;
 constexpr uint32_t kTrackRenderModelInstanceUnifiedVtable = 0x820019CC;
 constexpr uint32_t kTrackRenderModelUnifiedVtable = 0x82001D74;
 constexpr uint32_t kTrackPresentationUnifiedVtable = 0x82243774;
+constexpr uint32_t kTrackPresentationRefCountedUnifiedVtable = 0x82003CCC;
 constexpr uint32_t kTrackRenderModelDescriptorType = 21;
 constexpr uint32_t kTrackRenderModelDescriptorFlag = 1;
 constexpr uint32_t kTrackRenderModelDescriptorBytes = 248;
@@ -3963,9 +3964,7 @@ void BeginTrackPresentationPass(size_t pass_index, uint32_t root_address) {
       ++g_track_presentation_receiver_overflow;
     }
   }
-  const uint32_t expected_receiver_vtable =
-      pass_index == 1 ? kTrackRenderModelInstanceUnifiedVtable : 0;
-  if (!expected_receiver_vtable || root_words[0] != expected_receiver_vtable) {
+  if (root_words[0] != kTrackPresentationRefCountedUnifiedVtable) {
     ++g_track_presentation_pass_invalid_root[pass_index];
     return;
   }
@@ -13759,8 +13758,8 @@ void EmitTrackPresentationPassSummary() {
                       : (accounting_complete ? "complete" : "incomplete")},
        {"presentation_vtable",
         fmt::format("{:08X}", kTrackPresentationUnifiedVtable)},
-       {"slot_79_runtime_receiver_vtable",
-        fmt::format("{:08X}", kTrackRenderModelInstanceUnifiedVtable)},
+       {"runtime_receiver_vtable",
+        fmt::format("{:08X}", kTrackPresentationRefCountedUnifiedVtable)},
        {"slot_78_function", "82DEEEE0"},
        {"slot_78_entries", std::to_string(entries[0])},
        {"slot_78_exits", std::to_string(exits[0])},

--- a/tools/discover-native-renderer-track-ingress.py
+++ b/tools/discover-native-renderer-track-ingress.py
@@ -29,6 +29,13 @@ CLASSES = {
         "destructor": 0x82DF3C80,
         "role": "active_unified_track_presentation",
     },
+    "track_presentation_refcounted_unified": {
+        "decorated_name": ".?AV?$TRefCountedObjectThreadSafe@VCTrackPresentation@Presentation_Unified@@@@",
+        "vtable": 0x82003CCC,
+        "slots": 135,
+        "destructor": 0x82DE6DA8,
+        "role": "active_refcounted_unified_track_presentation_receiver",
+    },
     "track_render_model": {
         "decorated_name": ".?AVCTrackRenderModel@@",
         "vtable": 0x82243414,
@@ -123,6 +130,11 @@ CLASSES = {
 }
 
 RELATIONSHIPS = (
+    (
+        "track_presentation_refcounted_unified",
+        "track_presentation_unified",
+        "refcounted_unified_presentation_overrides",
+    ),
     ("track_presentation_unified", "track_presentation", "unified_presentation_overrides"),
     ("track_render_model_unified", "track_render_model", "unified_render_model_overrides"),
     ("track_render_model_instance_unified", "track_render_model_instance", "unified_render_instance_overrides"),
@@ -131,6 +143,12 @@ RELATIONSHIPS = (
 )
 
 KEY_SLOTS = {
+    "track_presentation_refcounted_unified": {
+        78: 0x82DEEEE0,
+        79: 0x8240E7B0,
+        80: 0x82DEF2B0,
+        81: 0x82DEADE0,
+    },
     "track_presentation_unified": {
         38: 0x82DF2D40, 52: 0x82DEC6F0, 53: 0x82DEEAE0,
         68: 0x82DF2528, 77: 0x82DF3AC0, 79: 0x8240E7B0,

--- a/tools/tests/test_native_renderer_track_ingress.py
+++ b/tools/tests/test_native_renderer_track_ingress.py
@@ -66,6 +66,20 @@ class NativeRendererTrackIngressTests(unittest.TestCase):
             135,
             document["classes"]["track_presentation_unified"]["vtable_slot_count"],
         )
+        self.assertEqual(
+            "active_refcounted_unified_track_presentation_receiver",
+            document["classes"]["track_presentation_refcounted_unified"]["role"],
+        )
+        self.assertEqual(
+            "8240E7B0",
+            next(
+                row["target"]
+                for row in document["passive_observation_candidates"][
+                    "track_presentation_refcounted_unified"
+                ]
+                if row["slot"] == 79
+            ),
+        )
         self.assertEqual(64, document["runtime_graph_probe"]["child_bytes"])
         self.assertEqual(248, document["runtime_graph_probe"]["descriptor_bytes"])
         self.assertEqual(

--- a/tools/tests/test_native_renderer_track_presentation_pass.py
+++ b/tools/tests/test_native_renderer_track_presentation_pass.py
@@ -42,7 +42,9 @@ class TrackPresentationPassTests(unittest.TestCase):
             source,
         )
         self.assertIn("track_presentation_pass_mask", source)
-        self.assertIn("kTrackRenderModelInstanceUnifiedVtable", source)
+        self.assertIn(
+            "kTrackPresentationRefCountedUnifiedVtable = 0x82003CCC", source
+        )
         self.assertIn(
             '"native_renderer.discovery.track_presentation_prepared_target_entry"',
             source,

--- a/tools/tests/test_native_renderer_track_presentation_pass_summary.py
+++ b/tools/tests/test_native_renderer_track_presentation_pass_summary.py
@@ -104,7 +104,7 @@ def fixture():
     receiver_79 = event(
         MODULE.RECEIVER,
         pass_mask="00000002",
-        receiver_vtable="820019CC",
+        receiver_vtable="82003CCC",
         calls="8",
         **safety(),
     )
@@ -129,7 +129,7 @@ class TrackPresentationPassSummaryTests(unittest.TestCase):
         )
         self.assertEqual([78], document["qualification"]["color_target_slots"])
         self.assertEqual(
-            {"820019CC": 8}, document["runtime_receivers_by_slot"]["79"]
+            {"82003CCC": 8}, document["runtime_receivers_by_slot"]["79"]
         )
         self.assertIn(
             "1024x1024:43800000:44400000:C3800000:43800000:00010F00",


### PR DESCRIPTION
## Summary
- prove the live thread-safe refcounted unified track-presentation receiver from retail RTTI
- accept adjacent presentation scopes only for that exact 135-slot wrapper
- record the controlled AppData receiver result and keep native admission/suppression closed

## Validation
- `python -m unittest tools.tests.test_native_renderer_track_ingress tools.tests.test_native_renderer_track_presentation_pass tools.tests.test_native_renderer_track_presentation_pass_summary tools.tests.test_native_renderer_track_model_runtime_join` (25 passed)
- retail-image track ingress discovery (complete)
- incremental Release `pinyon_shift` target build