### PR TITLE
feat(renderer): profile track presentation targets

### DIFF
--- a/docs/native-renderer/REPRIORITIZED_PLAN.md
+++ b/docs/native-renderer/REPRIORITIZED_PLAN.md
@@ -578,6 +578,11 @@ run can distinguish main-view color work from square shadow/reflection and
 reduced offscreen passes in the same report, avoiding another call-count-only
 capture. This records no camera payload and still admits no native draw.
 
+Target-identity batching checkpoint: raw surface, color-target, and depth-
+target registers now accompany each prepared-target profile. The next run can
+therefore distinguish exact EDRAM resources as well as attachment shape and
+spatial extent before any private replay candidate is selected.
+
 ### C2. Static world buildings and props
 
 - Expand opaque-world material and geometry coverage.

--- a/docs/native-renderer/TRACK_PRESENTATION_PASS_CENSUS.md
+++ b/docs/native-renderer/TRACK_PRESENTATION_PASS_CENSUS.md
@@ -118,6 +118,12 @@ offscreen work even when shader and attachment formats overlap. This is
 spatial-state classification only; it does not infer camera matrices or admit
 a draw.
 
+The same entry now carries the raw Xenos surface, four color-target, and depth-
+target registers. These numeric registers preserve the exact EDRAM target
+identity alongside attachment shape and spatial state, so one run can separate
+two passes that share dimensions and formats but write different tiles. The
+observer does not read target contents or change target ownership.
+
 ## Safety
 
 - The hooks read only the exact refcounted presentation-wrapper vtable already

--- a/src/native_renderer/graphics_hooks.cpp
+++ b/src/native_renderer/graphics_hooks.cpp
@@ -1136,6 +1136,9 @@ struct TrackPresentationPreparedTargetEntry {
   uint32_t viewport_transform_control = 0;
   uint32_t window_scissor_tl = 0;
   uint32_t window_scissor_br = 0;
+  uint32_t surface_info = 0;
+  std::array<uint32_t, 4> color_info{};
+  uint32_t depth_info = 0;
 };
 
 struct TrackPresentationReceiverEntry {
@@ -16167,6 +16170,11 @@ void EmitTrackPresentationPreparedTargetEntries() {
          {"scissor",
           fmt::format("{:08X}:{:08X}", entry.window_scissor_tl,
                       entry.window_scissor_br)},
+         {"target_state",
+          fmt::format("{:08X}:{:08X}:{:08X}:{:08X}:{:08X}:{:08X}",
+                      entry.surface_info, entry.color_info[0],
+                      entry.color_info[1], entry.color_info[2],
+                      entry.color_info[3], entry.depth_info)},
          {"classification",
           "exact_unified_track_presentation_pass_to_prepared_target"},
          {"guest_payload_read", "false"},
@@ -19200,9 +19208,15 @@ void RecordTrackPresentationPreparedTarget(
         uint64_t(observation.viewport_xoffset),
         uint64_t(observation.viewport_yscale),
         uint64_t(observation.viewport_yoffset),
-        uint64_t(observation.viewport_transform_control),
-        uint64_t(observation.window_scissor_tl),
-        uint64_t(observation.window_scissor_br)}) {
+         uint64_t(observation.viewport_transform_control),
+         uint64_t(observation.window_scissor_tl),
+         uint64_t(observation.window_scissor_br),
+         uint64_t(observation.surface_info),
+         uint64_t(observation.color_info[0]),
+         uint64_t(observation.color_info[1]),
+         uint64_t(observation.color_info[2]),
+         uint64_t(observation.color_info[3]),
+         uint64_t(observation.depth_info)}) {
     key = HashCombine(key, value);
   }
   for (uint32_t format : prepared.bound_render_target_formats) {
@@ -19236,6 +19250,10 @@ void RecordTrackPresentationPreparedTarget(
           observation.viewport_transform_control;
       entry.window_scissor_tl = observation.window_scissor_tl;
       entry.window_scissor_br = observation.window_scissor_br;
+      entry.surface_info = observation.surface_info;
+      std::copy(std::begin(observation.color_info),
+                std::end(observation.color_info), entry.color_info.begin());
+      entry.depth_info = observation.depth_info;
       ++g_track_presentation_prepared_target_count;
       return;
     }
@@ -19250,8 +19268,12 @@ void RecordTrackPresentationPreparedTarget(
             observation.viewport_transform_control &&
         entry.window_scissor_tl == observation.window_scissor_tl &&
         entry.window_scissor_br == observation.window_scissor_br &&
+        entry.surface_info == observation.surface_info &&
+        entry.depth_info == observation.depth_info &&
         entry.vertex_shader_hash == observation.vertex_shader_hash &&
         entry.pixel_shader_hash == observation.pixel_shader_hash &&
+        std::equal(entry.color_info.begin(), entry.color_info.end(),
+                   std::begin(observation.color_info)) &&
         std::equal(entry.bound_render_target_formats.begin(),
                    entry.bound_render_target_formats.end(),
                    std::begin(prepared.bound_render_target_formats))) {

--- a/tools/summarize-native-renderer-track-presentation-passes.py
+++ b/tools/summarize-native-renderer-track-presentation-passes.py
@@ -137,6 +137,7 @@ def build(events, requested_session=None):
             "target_shapes": {},
             "shader_pairs": {},
             "spatial_states": {},
+            "target_states": {},
         }
         for slot in SLOTS
     }
@@ -153,6 +154,7 @@ def build(events, requested_session=None):
         viewport = hexadecimal_tuple(event, "viewport", 4)
         viewport_control = hexadecimal(event, "viewport_transform_control", 8)
         scissor = hexadecimal_tuple(event, "scissor", 2)
+        target_state = hexadecimal_tuple(event, "target_state", 6)
         vertex_shader = str(event.get("vertex_shader", "")).upper()
         pixel_shader = str(event.get("pixel_shader", "")).upper()
         if len(vertex_shader) != 16 or len(pixel_shader) != 16:
@@ -177,6 +179,10 @@ def build(events, requested_session=None):
             )
             row["spatial_states"][spatial] = (
                 row["spatial_states"].get(spatial, 0) + calls
+            )
+            target = ":".join(f"{value:08X}" for value in target_state)
+            row["target_states"][target] = (
+                row["target_states"].get(target, 0) + calls
             )
 
     receiver_observations = integer(summary, "receiver_observations")

--- a/tools/tests/test_native_renderer_track_presentation_pass.py
+++ b/tools/tests/test_native_renderer_track_presentation_pass.py
@@ -49,6 +49,7 @@ class TrackPresentationPassTests(unittest.TestCase):
             '"native_renderer.discovery.track_presentation_prepared_target_entry"',
             source,
         )
+        self.assertIn('{"target_state",', source)
         self.assertIn(
             '"native_renderer.discovery.track_presentation_receiver_entry"',
             source,

--- a/tools/tests/test_native_renderer_track_presentation_pass_summary.py
+++ b/tools/tests/test_native_renderer_track_presentation_pass_summary.py
@@ -75,6 +75,7 @@ def fixture():
         viewport="43800000:44400000:C3800000:43800000",
         viewport_transform_control="00010F00",
         scissor="00000000:04000400",
+        target_state="10000410:00000000:00000000:00000000:00000000:000002D0",
         **safety(),
     )
     color = event(
@@ -92,6 +93,7 @@ def fixture():
         viewport="44200000:44200000:C4200000:44200000",
         viewport_transform_control="00010F00",
         scissor="00000000:02800280",
+        target_state="10000290:00000640:00000000:00000000:00000000:00000000",
         **safety(),
     )
     receiver_78 = event(
@@ -139,6 +141,12 @@ class TrackPresentationPassSummaryTests(unittest.TestCase):
             8,
             document["prepared_targets_by_slot"]["79"]["target_shapes"][
                 "depth_only"
+            ],
+        )
+        self.assertEqual(
+            8,
+            document["prepared_targets_by_slot"]["79"]["target_states"][
+                "10000410:00000000:00000000:00000000:00000000:000002D0"
             ],
         )
 


### PR DESCRIPTION
## Summary
- attach raw Xenos surface, color-target, and depth-target state to exact track-presentation profiles
- aggregate target identities per live slot in the payload-free report
- preserve Xenos authority with native admission and suppression disabled

## Validation
- `python -m unittest tools.tests.test_native_renderer_track_presentation_pass tools.tests.test_native_renderer_track_presentation_pass_summary` (6 passed)
- incremental Release `pinyon_shift` target build