### PR TITLE
feat(renderer): trace direct track presentation scope

### DIFF
--- a/docs/native-renderer/REPRIORITIZED_PLAN.md
+++ b/docs/native-renderer/REPRIORITIZED_PLAN.md
@@ -583,6 +583,13 @@ target registers now accompany each prepared-target profile. The next run can
 therefore distinguish exact EDRAM resources as well as attachment shape and
 spatial extent before any private replay candidate is selected.
 
+Exact pass result: clean AppData session `20260901T050049Z-p8056` proved slot
+79 owns 732 depth-only draws on the known dynamic-shadow target, not opaque
+world color. Slot 80 is receiver-exact and live but carries no draw through the
+existing `824365B0` packet lineage. AOT flow shows its alternate dispatcher
+path may bypass that context. The census now labels exact synchronous scope
+and inherited packet lineage independently; neither source enables admission.
+
 ### C2. Static world buildings and props
 
 - Expand opaque-world material and geometry coverage.

--- a/docs/native-renderer/TRACK_PRESENTATION_PASS_CENSUS.md
+++ b/docs/native-renderer/TRACK_PRESENTATION_PASS_CENSUS.md
@@ -124,6 +124,27 @@ identity alongside attachment shape and spatial state, so one run can separate
 two passes that share dimensions and formats but write different tiles. The
 observer does not read target contents or change target ownership.
 
+## Exact live-pass result
+
+Clean AppData session `20260901T050049Z-p8056` reached the saved festival and
+exited normally. Slots 79 and 80 again made four and six balanced calls,
+respectively. All ten used exact wrapper vtable `82003CCC`; there were no read
+faults, overlaps, lifecycle faults, or table overflows.
+
+Slot 79 inherited 732 prepared draws through exact packet lineage. Every draw
+was depth-only on target state
+`10000410:00000000:00000000:00000000:00000000:000002D0`, with 1024-square or
+512-square scissor work. It is the already known dynamic-shadow route, not the
+opaque road/terrain color pass. Slot 80 inherited zero prepared draws, so the
+existing `824365B0` packet-context path does not classify its work.
+
+Static AOT control flow explains the gap: slot 80 calls common dispatcher
+`82436468` with the alternate-context flag and may bypass `824365B0`. The next
+profile therefore combines two independently labeled sources: exact balanced
+direct presentation scope and inherited packet lineage. Direct scope remains
+diagnostic temporal attribution only; it cannot by itself prove semantic
+ownership or native admission.
+
 ## Safety
 
 - The hooks read only the exact refcounted presentation-wrapper vtable already

--- a/src/native_renderer/graphics_hooks.cpp
+++ b/src/native_renderer/graphics_hooks.cpp
@@ -1126,6 +1126,8 @@ struct TrackPresentationPreparedTargetEntry {
   uint64_t vertex_shader_hash = 0;
   uint64_t pixel_shader_hash = 0;
   uint32_t pass_mask = 0;
+  uint32_t direct_scope_mask = 0;
+  uint32_t packet_lineage_mask = 0;
   uint32_t bound_render_target_bits = 0;
   std::array<uint32_t, 5> bound_render_target_formats{};
   uint32_t prepared_pipeline_flags = 0;
@@ -16150,6 +16152,10 @@ void EmitTrackPresentationPreparedTargetEntries() {
         "native_renderer.discovery.track_presentation_prepared_target_entry",
         {{"entry_key", fmt::format("{:016X}", entry.key)},
          {"pass_mask", fmt::format("{:08X}", entry.pass_mask)},
+         {"direct_scope_mask",
+          fmt::format("{:08X}", entry.direct_scope_mask)},
+         {"packet_lineage_mask",
+          fmt::format("{:08X}", entry.packet_lineage_mask)},
          {"calls", std::to_string(entry.calls)},
          {"first_frame", std::to_string(entry.first_frame)},
          {"last_frame", std::to_string(entry.last_frame)},
@@ -19194,7 +19200,8 @@ void RecordTrackWorldPreparedLayout(
 void RecordTrackPresentationPreparedTarget(
     const rex::system::GraphicsDrawObservation &observation,
     const rex::system::GraphicsPreparedDrawObservation &prepared,
-    uint32_t pass_mask) {
+    uint32_t direct_scope_mask, uint32_t packet_lineage_mask) {
+  const uint32_t pass_mask = direct_scope_mask | packet_lineage_mask;
   if (!pass_mask) {
     return;
   }
@@ -19202,7 +19209,9 @@ void RecordTrackPresentationPreparedTarget(
       1, std::memory_order_relaxed);
   uint64_t key = UINT64_C(0xCBF29CE484222325);
   for (uint64_t value :
-       {uint64_t(pass_mask), uint64_t(prepared.bound_render_target_bits),
+       {uint64_t(pass_mask), uint64_t(direct_scope_mask),
+        uint64_t(packet_lineage_mask),
+        uint64_t(prepared.bound_render_target_bits),
         uint64_t(prepared.flags), observation.vertex_shader_hash,
         observation.pixel_shader_hash, uint64_t(observation.viewport_xscale),
         uint64_t(observation.viewport_xoffset),
@@ -19237,6 +19246,8 @@ void RecordTrackPresentationPreparedTarget(
       entry.vertex_shader_hash = observation.vertex_shader_hash;
       entry.pixel_shader_hash = observation.pixel_shader_hash;
       entry.pass_mask = pass_mask;
+      entry.direct_scope_mask = direct_scope_mask;
+      entry.packet_lineage_mask = packet_lineage_mask;
       entry.bound_render_target_bits = prepared.bound_render_target_bits;
       std::copy(std::begin(prepared.bound_render_target_formats),
                 std::end(prepared.bound_render_target_formats),
@@ -19258,6 +19269,8 @@ void RecordTrackPresentationPreparedTarget(
       return;
     }
     if (entry.key == key && entry.pass_mask == pass_mask &&
+        entry.direct_scope_mask == direct_scope_mask &&
+        entry.packet_lineage_mask == packet_lineage_mask &&
         entry.bound_render_target_bits == prepared.bound_render_target_bits &&
         entry.prepared_pipeline_flags == prepared.flags &&
         entry.viewport_xscale == observation.viewport_xscale &&
@@ -21844,14 +21857,17 @@ SemanticVisibilityPreparedAdmission RecordSemanticBatchOpportunity(
   const bool exact_track_command =
       active && active->constructor_origin.owner.producer.context
                     .track_command_lineage;
-  const uint32_t track_presentation_pass_mask =
+  const uint32_t track_presentation_packet_lineage_mask =
       active ? active->constructor_origin.owner.producer.context
                    .track_presentation_pass_mask
              : 0;
+  const uint32_t track_presentation_direct_scope_mask =
+      CurrentTrackPresentationPassMask();
   const SemanticPreparedDrawContract contract =
       BuildSemanticPreparedDrawContract(observation, prepared);
-  RecordTrackPresentationPreparedTarget(observation, prepared,
-                                        track_presentation_pass_mask);
+  RecordTrackPresentationPreparedTarget(
+      observation, prepared, track_presentation_direct_scope_mask,
+      track_presentation_packet_lineage_mask);
   if (exact_track_command) {
     g_track_render_model_prepared_draw_joins.fetch_add(
         1, std::memory_order_relaxed);

--- a/tools/summarize-native-renderer-track-presentation-passes.py
+++ b/tools/summarize-native-renderer-track-presentation-passes.py
@@ -134,6 +134,7 @@ def build(events, requested_session=None):
     per_slot = {
         str(slot): {
             "calls": 0,
+            "attribution_sources": {},
             "target_shapes": {},
             "shader_pairs": {},
             "spatial_states": {},
@@ -150,6 +151,14 @@ def build(events, requested_session=None):
         pass_mask = hexadecimal(event, "pass_mask", 8)
         if not pass_mask or pass_mask & ~0xF:
             raise ValueError("invalid pass mask")
+        direct_scope_mask = hexadecimal(event, "direct_scope_mask", 8)
+        packet_lineage_mask = hexadecimal(event, "packet_lineage_mask", 8)
+        if (
+            direct_scope_mask & ~0xF
+            or packet_lineage_mask & ~0xF
+            or direct_scope_mask | packet_lineage_mask != pass_mask
+        ):
+            raise ValueError("invalid attribution masks")
         bits = hexadecimal(event, "bound_render_target_bits", 8)
         viewport = hexadecimal_tuple(event, "viewport", 4)
         viewport_control = hexadecimal(event, "viewport_transform_control", 8)
@@ -168,6 +177,18 @@ def build(events, requested_session=None):
                 continue
             row = per_slot[str(slot)]
             row["calls"] += calls
+            direct = bool(direct_scope_mask & (1 << index))
+            packet = bool(packet_lineage_mask & (1 << index))
+            source = (
+                "direct_scope_and_packet_lineage"
+                if direct and packet
+                else "direct_scope"
+                if direct
+                else "packet_lineage"
+            )
+            row["attribution_sources"][source] = (
+                row["attribution_sources"].get(source, 0) + calls
+            )
             shape = target_shape(bits)
             row["target_shapes"][shape] = row["target_shapes"].get(shape, 0) + calls
             pair = f"{vertex_shader}:{pixel_shader}"

--- a/tools/tests/test_native_renderer_track_presentation_pass.py
+++ b/tools/tests/test_native_renderer_track_presentation_pass.py
@@ -50,6 +50,8 @@ class TrackPresentationPassTests(unittest.TestCase):
             source,
         )
         self.assertIn('{"target_state",', source)
+        self.assertIn('{"direct_scope_mask",', source)
+        self.assertIn('{"packet_lineage_mask",', source)
         self.assertIn(
             '"native_renderer.discovery.track_presentation_receiver_entry"',
             source,

--- a/tools/tests/test_native_renderer_track_presentation_pass_summary.py
+++ b/tools/tests/test_native_renderer_track_presentation_pass_summary.py
@@ -64,6 +64,8 @@ def fixture():
         MODULE.ENTRY,
         entry_key="1111222233334444",
         pass_mask="00000002",
+        direct_scope_mask="00000000",
+        packet_lineage_mask="00000002",
         calls="8",
         first_frame="10",
         last_frame="11",
@@ -82,6 +84,8 @@ def fixture():
         MODULE.ENTRY,
         entry_key="5555666677778888",
         pass_mask="00000001",
+        direct_scope_mask="00000001",
+        packet_lineage_mask="00000000",
         calls="4",
         first_frame="10",
         last_frame="11",
@@ -147,6 +151,12 @@ class TrackPresentationPassSummaryTests(unittest.TestCase):
             8,
             document["prepared_targets_by_slot"]["79"]["target_states"][
                 "10000410:00000000:00000000:00000000:00000000:000002D0"
+            ],
+        )
+        self.assertEqual(
+            {"packet_lineage": 8},
+            document["prepared_targets_by_slot"]["79"][
+                "attribution_sources"
             ],
         )
 


### PR DESCRIPTION
## Summary
- preserve exact synchronous presentation scope separately from inherited packet lineage
- cover slot 80's statically proved alternate dispatcher path without claiming semantic ownership
- record the clean AppData result that classifies slot 79 as the dynamic-shadow route

## Validation
- `python -m unittest tools.tests.test_native_renderer_track_presentation_pass tools.tests.test_native_renderer_track_presentation_pass_summary` (6 passed)
- incremental Release `pinyon_shift` target build