### PR TITLE
feat(renderer): census track dispatcher routes

### DIFF
--- a/docs/native-renderer/REPRIORITIZED_PLAN.md
+++ b/docs/native-renderer/REPRIORITIZED_PLAN.md
@@ -589,6 +589,8 @@ world color. Slot 80 is receiver-exact and live but carries no draw through the
 existing `824365B0` packet lineage. AOT flow shows its alternate dispatcher
 path may bypass that context. The census now labels exact synchronous scope
 and inherited packet lineage independently; neither source enables admission.
+Per-slot direct/context dispatcher counters accompany the next batch so an
+empty draw result can distinguish a dormant render branch from lost lineage.
 
 ### C2. Static world buildings and props
 

--- a/docs/native-renderer/TRACK_PRESENTATION_PASS_CENSUS.md
+++ b/docs/native-renderer/TRACK_PRESENTATION_PASS_CENSUS.md
@@ -145,6 +145,11 @@ direct presentation scope and inherited packet lineage. Direct scope remains
 diagnostic temporal attribution only; it cannot by itself prove semantic
 ownership or native admission.
 
+The same batch counts `82436468` calls per accepted slot and separates its
+direct and context routes. These bounded counters establish whether a live
+slot submits work, chooses the context branch, or only prepares state even
+when neither draw-attribution source observes a prepared draw.
+
 ## Safety
 
 - The hooks read only the exact refcounted presentation-wrapper vtable already

--- a/src/native_renderer/graphics_hooks.cpp
+++ b/src/native_renderer/graphics_hooks.cpp
@@ -2935,6 +2935,8 @@ std::array<std::atomic<uint64_t>, 4> g_track_presentation_pass_invalid_root{};
 std::array<std::atomic<uint64_t>, 4> g_track_presentation_pass_overlaps{};
 std::array<std::atomic<uint64_t>, 4>
     g_track_presentation_pass_exit_without_entry{};
+std::array<std::array<std::atomic<uint64_t>, 2>, 4>
+    g_track_presentation_dispatcher_routes{};
 thread_local std::array<bool, 4> g_track_presentation_pass_active{};
 thread_local std::array<bool, 4> g_track_presentation_pass_accepted{};
 std::mutex g_track_presentation_receiver_mutex;
@@ -6031,10 +6033,24 @@ void ObserveVehicleTypedRenderItem(uint32_t root_address,
   }
 }
 
+uint32_t CurrentTrackPresentationPassMask();
+
+void RecordTrackPresentationDispatcherRoute(bool context_path) {
+  const uint32_t pass_mask = CurrentTrackPresentationPassMask();
+  for (size_t index = 0; index < g_track_presentation_dispatcher_routes.size();
+       ++index) {
+    if (pass_mask & (uint32_t(1) << index)) {
+      g_track_presentation_dispatcher_routes[index][context_path ? 1 : 0]
+          .fetch_add(1, std::memory_order_relaxed);
+    }
+  }
+}
+
 void ObserveVehicleRenderContextDispatcher(uint32_t return_address,
-                                           uint32_t root_address,
-                                           uint32_t vector_address,
-                                           bool context_path) {
+                                            uint32_t root_address,
+                                            uint32_t vector_address,
+                                            bool context_path) {
+  RecordTrackPresentationDispatcherRoute(context_path);
   g_pending_vehicle_render_context_dispatcher = {};
   if (!g_vehicle_discovery_installed.load(std::memory_order_acquire)) {
     return;
@@ -6861,6 +6877,11 @@ void ResetTitleDrawProvenance() {
                          &g_track_presentation_pass_overlaps,
                          &g_track_presentation_pass_exit_without_entry}) {
     for (std::atomic<uint64_t> &counter : *counters) {
+      counter.store(0, std::memory_order_relaxed);
+    }
+  }
+  for (auto &routes : g_track_presentation_dispatcher_routes) {
+    for (std::atomic<uint64_t> &counter : routes) {
       counter.store(0, std::memory_order_relaxed);
     }
   }
@@ -13770,21 +13791,45 @@ void EmitTrackPresentationPassSummary() {
        {"slot_78_exits", std::to_string(exits[0])},
        {"slot_78_exact", std::to_string(exact[0])},
        {"slot_78_invalid_root", std::to_string(invalid_root[0])},
+       {"slot_78_dispatcher_direct",
+        std::to_string(g_track_presentation_dispatcher_routes[0][0].load(
+            std::memory_order_relaxed))},
+       {"slot_78_dispatcher_context",
+        std::to_string(g_track_presentation_dispatcher_routes[0][1].load(
+            std::memory_order_relaxed))},
        {"slot_79_function", "8240E7B0"},
        {"slot_79_entries", std::to_string(entries[1])},
        {"slot_79_exits", std::to_string(exits[1])},
        {"slot_79_exact", std::to_string(exact[1])},
        {"slot_79_invalid_root", std::to_string(invalid_root[1])},
+       {"slot_79_dispatcher_direct",
+        std::to_string(g_track_presentation_dispatcher_routes[1][0].load(
+            std::memory_order_relaxed))},
+       {"slot_79_dispatcher_context",
+        std::to_string(g_track_presentation_dispatcher_routes[1][1].load(
+            std::memory_order_relaxed))},
        {"slot_80_function", "82DEF2B0"},
        {"slot_80_entries", std::to_string(entries[2])},
        {"slot_80_exits", std::to_string(exits[2])},
        {"slot_80_exact", std::to_string(exact[2])},
        {"slot_80_invalid_root", std::to_string(invalid_root[2])},
+       {"slot_80_dispatcher_direct",
+        std::to_string(g_track_presentation_dispatcher_routes[2][0].load(
+            std::memory_order_relaxed))},
+       {"slot_80_dispatcher_context",
+        std::to_string(g_track_presentation_dispatcher_routes[2][1].load(
+            std::memory_order_relaxed))},
        {"slot_81_function", "82DEADE0"},
        {"slot_81_entries", std::to_string(entries[3])},
        {"slot_81_exits", std::to_string(exits[3])},
        {"slot_81_exact", std::to_string(exact[3])},
        {"slot_81_invalid_root", std::to_string(invalid_root[3])},
+       {"slot_81_dispatcher_direct",
+        std::to_string(g_track_presentation_dispatcher_routes[3][0].load(
+            std::memory_order_relaxed))},
+       {"slot_81_dispatcher_context",
+        std::to_string(g_track_presentation_dispatcher_routes[3][1].load(
+            std::memory_order_relaxed))},
        {"overlaps", std::to_string(overlaps[0] + overlaps[1] + overlaps[2] +
                                     overlaps[3])},
        {"exit_without_entry",

--- a/tools/summarize-native-renderer-track-presentation-passes.py
+++ b/tools/summarize-native-renderer-track-presentation-passes.py
@@ -121,6 +121,10 @@ def build(events, requested_session=None):
             "exits": integer(summary, f"slot_{slot}_exits"),
             "exact": integer(summary, f"slot_{slot}_exact"),
             "invalid_root": integer(summary, f"slot_{slot}_invalid_root"),
+            "dispatcher_routes": {
+                "direct": integer(summary, f"slot_{slot}_dispatcher_direct"),
+                "context": integer(summary, f"slot_{slot}_dispatcher_context"),
+            },
         }
         slot_totals[str(slot)] = row
         total_slot_entries += row["entries"]

--- a/tools/tests/test_native_renderer_track_presentation_pass.py
+++ b/tools/tests/test_native_renderer_track_presentation_pass.py
@@ -52,6 +52,7 @@ class TrackPresentationPassTests(unittest.TestCase):
         self.assertIn('{"target_state",', source)
         self.assertIn('{"direct_scope_mask",', source)
         self.assertIn('{"packet_lineage_mask",', source)
+        self.assertIn("g_track_presentation_dispatcher_routes", source)
         self.assertIn(
             '"native_renderer.discovery.track_presentation_receiver_entry"',
             source,

--- a/tools/tests/test_native_renderer_track_presentation_pass_summary.py
+++ b/tools/tests/test_native_renderer_track_presentation_pass_summary.py
@@ -60,6 +60,9 @@ def fixture():
         },
         **safety(),
     )
+    for slot in MODULE.SLOTS:
+        summary[f"slot_{slot}_dispatcher_direct"] = "3" if slot == 79 else "0"
+        summary[f"slot_{slot}_dispatcher_context"] = "8" if slot == 79 else "0"
     depth = event(
         MODULE.ENTRY,
         entry_key="1111222233334444",
@@ -132,6 +135,10 @@ class TrackPresentationPassSummaryTests(unittest.TestCase):
         self.assertEqual([78, 79], document["qualification"]["live_slots"])
         self.assertEqual(
             [78, 79], document["qualification"]["accepted_receiver_slots"]
+        )
+        self.assertEqual(
+            {"direct": 3, "context": 8},
+            document["slot_totals"]["79"]["dispatcher_routes"],
         )
         self.assertEqual([78], document["qualification"]["color_target_slots"])
         self.assertEqual(


### PR DESCRIPTION
## Summary
- count common dispatcher calls within each exact accepted presentation slot
- separate direct and context routes in the payload-free report
- combine route census with direct-scope and packet-lineage attribution for the next batched run

## Validation
- `python -m unittest tools.tests.test_native_renderer_track_presentation_pass tools.tests.test_native_renderer_track_presentation_pass_summary` (6 passed)
- incremental Release `pinyon_shift` target build