### PR TITLE
feat(native-renderer): trace track adapter dispatch

### DIFF
--- a/config/rexglue/analysis/main-xex.toml
+++ b/config/rexglue/analysis/main-xex.toml
@@ -243,6 +243,28 @@ registers = ["r3"]
 address = 0x82DEAEE8
 name = "PinyonShiftObserveTrackPresentationSlot81Exit"
 
+# Slot 80 can bypass the common 82436468 render-context dispatcher through
+# the title-owned 8243BD40 adapter. These passive stages distinguish adapter
+# entry, its two title gates, and the final virtual target while an exact
+# track-presentation scope is active. They do not modify the adapter, target,
+# arguments, or control flow.
+[[midasm_hook]]
+address = 0x8243BD40
+name = "PinyonShiftObserveTrackPresentationAdapterEntry"
+
+[[midasm_hook]]
+address = 0x8243BD78
+name = "PinyonShiftObserveTrackPresentationAdapterEnabled"
+
+[[midasm_hook]]
+address = 0x8243BDA8
+name = "PinyonShiftObserveTrackPresentationAdapterEligible"
+
+[[midasm_hook]]
+address = 0x8243BEB4
+name = "PinyonShiftObserveTrackPresentationAdapterDispatch"
+registers = ["ctr"]
+
 # After the 8240E7B0 render-item predicate succeeds, title instructions have
 # resolved r31's typed child/descriptor chain and immediately read through
 # descriptor offset 244. Observe that exact-lifetime root and descriptor for a

--- a/docs/native-renderer/REPRIORITIZED_PLAN.md
+++ b/docs/native-renderer/REPRIORITIZED_PLAN.md
@@ -592,6 +592,22 @@ and inherited packet lineage independently; neither source enables admission.
 Per-slot direct/context dispatcher counters accompany the next batch so an
 empty draw result can distinguish a dormant render branch from lost lineage.
 
+Dispatcher-route result: clean AppData session `20260901T051350Z-p17184`
+reproduced the exact slot-79 shadow workload (485 context dispatches and 732
+depth-only prepared draws). Slot 80 remained receiver-exact and live for six
+calls but recorded zero direct dispatches, zero context dispatches, and zero
+prepared draws. The existing common-dispatch lineage is therefore not lost;
+this scene's slot-80 work either stops at its title gates or uses the alternate
+`8243BD40` adapter.
+
+Alternate-adapter checkpoint: passive exact-scope stages now count entry,
+enabled, eligible, and final virtual-dispatch reachability through `8243BD40`.
+The final stage records only the first/last target address and target-change
+count. The next batched AppData checkpoint can select one exact downstream
+function or close slot 80 as dormant in the saved festival without tracing
+arbitrary indirect calls. No guest state, title control flow, native admission,
+or Xenos authority changes.
+
 ### C2. Static world buildings and props
 
 - Expand opaque-world material and geometry coverage.

--- a/src/native_renderer/graphics_hooks.cpp
+++ b/src/native_renderer/graphics_hooks.cpp
@@ -2937,6 +2937,16 @@ std::array<std::atomic<uint64_t>, 4>
     g_track_presentation_pass_exit_without_entry{};
 std::array<std::array<std::atomic<uint64_t>, 2>, 4>
     g_track_presentation_dispatcher_routes{};
+std::array<std::atomic<uint64_t>, 4> g_track_presentation_adapter_entries{};
+std::array<std::atomic<uint64_t>, 4> g_track_presentation_adapter_enabled{};
+std::array<std::atomic<uint64_t>, 4> g_track_presentation_adapter_eligible{};
+std::array<std::atomic<uint64_t>, 4> g_track_presentation_adapter_dispatches{};
+std::array<std::atomic<uint32_t>, 4>
+    g_track_presentation_adapter_first_targets{};
+std::array<std::atomic<uint32_t>, 4>
+    g_track_presentation_adapter_last_targets{};
+std::array<std::atomic<uint64_t>, 4>
+    g_track_presentation_adapter_target_changes{};
 thread_local std::array<bool, 4> g_track_presentation_pass_active{};
 thread_local std::array<bool, 4> g_track_presentation_pass_accepted{};
 std::mutex g_track_presentation_receiver_mutex;
@@ -6046,6 +6056,38 @@ void RecordTrackPresentationDispatcherRoute(bool context_path) {
   }
 }
 
+void RecordTrackPresentationAdapterStage(
+    std::array<std::atomic<uint64_t>, 4> &counters) {
+  const uint32_t pass_mask = CurrentTrackPresentationPassMask();
+  for (size_t index = 0; index < counters.size(); ++index) {
+    if (pass_mask & (uint32_t(1) << index)) {
+      counters[index].fetch_add(1, std::memory_order_relaxed);
+    }
+  }
+}
+
+void RecordTrackPresentationAdapterDispatch(uint32_t target_address) {
+  const uint32_t pass_mask = CurrentTrackPresentationPassMask();
+  for (size_t index = 0; index < g_track_presentation_adapter_dispatches.size();
+       ++index) {
+    if (!(pass_mask & (uint32_t(1) << index))) {
+      continue;
+    }
+    g_track_presentation_adapter_dispatches[index].fetch_add(
+        1, std::memory_order_relaxed);
+    uint32_t expected = 0;
+    g_track_presentation_adapter_first_targets[index].compare_exchange_strong(
+        expected, target_address, std::memory_order_relaxed);
+    const uint32_t previous =
+        g_track_presentation_adapter_last_targets[index].exchange(
+            target_address, std::memory_order_relaxed);
+    if (previous && previous != target_address) {
+      g_track_presentation_adapter_target_changes[index].fetch_add(
+          1, std::memory_order_relaxed);
+    }
+  }
+}
+
 void ObserveVehicleRenderContextDispatcher(uint32_t return_address,
                                             uint32_t root_address,
                                             uint32_t vector_address,
@@ -6883,6 +6925,21 @@ void ResetTitleDrawProvenance() {
   for (auto &routes : g_track_presentation_dispatcher_routes) {
     for (std::atomic<uint64_t> &counter : routes) {
       counter.store(0, std::memory_order_relaxed);
+    }
+  }
+  for (auto *counters : {&g_track_presentation_adapter_entries,
+                         &g_track_presentation_adapter_enabled,
+                         &g_track_presentation_adapter_eligible,
+                         &g_track_presentation_adapter_dispatches,
+                         &g_track_presentation_adapter_target_changes}) {
+    for (std::atomic<uint64_t> &counter : *counters) {
+      counter.store(0, std::memory_order_relaxed);
+    }
+  }
+  for (auto *targets : {&g_track_presentation_adapter_first_targets,
+                        &g_track_presentation_adapter_last_targets}) {
+    for (std::atomic<uint32_t> &target : *targets) {
+      target.store(0, std::memory_order_relaxed);
     }
   }
   g_track_presentation_pass_active = {};
@@ -13797,6 +13854,27 @@ void EmitTrackPresentationPassSummary() {
        {"slot_78_dispatcher_context",
         std::to_string(g_track_presentation_dispatcher_routes[0][1].load(
             std::memory_order_relaxed))},
+       {"slot_78_adapter_entries",
+        std::to_string(g_track_presentation_adapter_entries[0].load(
+            std::memory_order_relaxed))},
+       {"slot_78_adapter_enabled",
+        std::to_string(g_track_presentation_adapter_enabled[0].load(
+            std::memory_order_relaxed))},
+       {"slot_78_adapter_eligible",
+        std::to_string(g_track_presentation_adapter_eligible[0].load(
+            std::memory_order_relaxed))},
+       {"slot_78_adapter_dispatches",
+        std::to_string(g_track_presentation_adapter_dispatches[0].load(
+            std::memory_order_relaxed))},
+       {"slot_78_adapter_first_target",
+        fmt::format("{:08X}", g_track_presentation_adapter_first_targets[0]
+                                  .load(std::memory_order_relaxed))},
+       {"slot_78_adapter_last_target",
+        fmt::format("{:08X}", g_track_presentation_adapter_last_targets[0].load(
+                                  std::memory_order_relaxed))},
+       {"slot_78_adapter_target_changes",
+        std::to_string(g_track_presentation_adapter_target_changes[0].load(
+            std::memory_order_relaxed))},
        {"slot_79_function", "8240E7B0"},
        {"slot_79_entries", std::to_string(entries[1])},
        {"slot_79_exits", std::to_string(exits[1])},
@@ -13807,6 +13885,27 @@ void EmitTrackPresentationPassSummary() {
             std::memory_order_relaxed))},
        {"slot_79_dispatcher_context",
         std::to_string(g_track_presentation_dispatcher_routes[1][1].load(
+            std::memory_order_relaxed))},
+       {"slot_79_adapter_entries",
+        std::to_string(g_track_presentation_adapter_entries[1].load(
+            std::memory_order_relaxed))},
+       {"slot_79_adapter_enabled",
+        std::to_string(g_track_presentation_adapter_enabled[1].load(
+            std::memory_order_relaxed))},
+       {"slot_79_adapter_eligible",
+        std::to_string(g_track_presentation_adapter_eligible[1].load(
+            std::memory_order_relaxed))},
+       {"slot_79_adapter_dispatches",
+        std::to_string(g_track_presentation_adapter_dispatches[1].load(
+            std::memory_order_relaxed))},
+       {"slot_79_adapter_first_target",
+        fmt::format("{:08X}", g_track_presentation_adapter_first_targets[1]
+                                  .load(std::memory_order_relaxed))},
+       {"slot_79_adapter_last_target",
+        fmt::format("{:08X}", g_track_presentation_adapter_last_targets[1].load(
+                                  std::memory_order_relaxed))},
+       {"slot_79_adapter_target_changes",
+        std::to_string(g_track_presentation_adapter_target_changes[1].load(
             std::memory_order_relaxed))},
        {"slot_80_function", "82DEF2B0"},
        {"slot_80_entries", std::to_string(entries[2])},
@@ -13819,6 +13918,27 @@ void EmitTrackPresentationPassSummary() {
        {"slot_80_dispatcher_context",
         std::to_string(g_track_presentation_dispatcher_routes[2][1].load(
             std::memory_order_relaxed))},
+       {"slot_80_adapter_entries",
+        std::to_string(g_track_presentation_adapter_entries[2].load(
+            std::memory_order_relaxed))},
+       {"slot_80_adapter_enabled",
+        std::to_string(g_track_presentation_adapter_enabled[2].load(
+            std::memory_order_relaxed))},
+       {"slot_80_adapter_eligible",
+        std::to_string(g_track_presentation_adapter_eligible[2].load(
+            std::memory_order_relaxed))},
+       {"slot_80_adapter_dispatches",
+        std::to_string(g_track_presentation_adapter_dispatches[2].load(
+            std::memory_order_relaxed))},
+       {"slot_80_adapter_first_target",
+        fmt::format("{:08X}", g_track_presentation_adapter_first_targets[2]
+                                  .load(std::memory_order_relaxed))},
+       {"slot_80_adapter_last_target",
+        fmt::format("{:08X}", g_track_presentation_adapter_last_targets[2].load(
+                                  std::memory_order_relaxed))},
+       {"slot_80_adapter_target_changes",
+        std::to_string(g_track_presentation_adapter_target_changes[2].load(
+            std::memory_order_relaxed))},
        {"slot_81_function", "82DEADE0"},
        {"slot_81_entries", std::to_string(entries[3])},
        {"slot_81_exits", std::to_string(exits[3])},
@@ -13830,8 +13950,29 @@ void EmitTrackPresentationPassSummary() {
        {"slot_81_dispatcher_context",
         std::to_string(g_track_presentation_dispatcher_routes[3][1].load(
             std::memory_order_relaxed))},
-       {"overlaps", std::to_string(overlaps[0] + overlaps[1] + overlaps[2] +
-                                    overlaps[3])},
+       {"slot_81_adapter_entries",
+        std::to_string(g_track_presentation_adapter_entries[3].load(
+            std::memory_order_relaxed))},
+       {"slot_81_adapter_enabled",
+        std::to_string(g_track_presentation_adapter_enabled[3].load(
+            std::memory_order_relaxed))},
+       {"slot_81_adapter_eligible",
+        std::to_string(g_track_presentation_adapter_eligible[3].load(
+            std::memory_order_relaxed))},
+       {"slot_81_adapter_dispatches",
+        std::to_string(g_track_presentation_adapter_dispatches[3].load(
+            std::memory_order_relaxed))},
+       {"slot_81_adapter_first_target",
+        fmt::format("{:08X}", g_track_presentation_adapter_first_targets[3]
+                                  .load(std::memory_order_relaxed))},
+       {"slot_81_adapter_last_target",
+        fmt::format("{:08X}", g_track_presentation_adapter_last_targets[3].load(
+                                  std::memory_order_relaxed))},
+       {"slot_81_adapter_target_changes",
+        std::to_string(g_track_presentation_adapter_target_changes[3].load(
+            std::memory_order_relaxed))},
+       {"overlaps",
+        std::to_string(overlaps[0] + overlaps[1] + overlaps[2] + overlaps[3])},
        {"exit_without_entry",
         std::to_string(exit_without_entry[0] + exit_without_entry[1] +
                        exit_without_entry[2] + exit_without_entry[3])},
@@ -32259,6 +32400,22 @@ void PinyonShiftObserveTrackPresentationSlot81Entry(PPCRegister &r3) {
 
 void PinyonShiftObserveTrackPresentationSlot81Exit() {
   EndTrackPresentationPass(3);
+}
+
+void PinyonShiftObserveTrackPresentationAdapterEntry() {
+  RecordTrackPresentationAdapterStage(g_track_presentation_adapter_entries);
+}
+
+void PinyonShiftObserveTrackPresentationAdapterEnabled() {
+  RecordTrackPresentationAdapterStage(g_track_presentation_adapter_enabled);
+}
+
+void PinyonShiftObserveTrackPresentationAdapterEligible() {
+  RecordTrackPresentationAdapterStage(g_track_presentation_adapter_eligible);
+}
+
+void PinyonShiftObserveTrackPresentationAdapterDispatch(PPCRegister &ctr) {
+  RecordTrackPresentationAdapterDispatch(ctr.u32);
 }
 
 void PinyonShiftObserveStaticWorldRendererDispatchEntry(PPCRegister &r3,

--- a/tools/summarize-native-renderer-track-presentation-passes.py
+++ b/tools/summarize-native-renderer-track-presentation-passes.py
@@ -115,6 +115,12 @@ def build(events, requested_session=None):
     slot_totals = {}
     total_slot_entries = 0
     for slot in SLOTS:
+        adapter_first_target = hexadecimal(
+            summary, f"slot_{slot}_adapter_first_target", 8
+        )
+        adapter_last_target = hexadecimal(
+            summary, f"slot_{slot}_adapter_last_target", 8
+        )
         row = {
             "function": str(summary.get(f"slot_{slot}_function", "")),
             "entries": integer(summary, f"slot_{slot}_entries"),
@@ -124,6 +130,17 @@ def build(events, requested_session=None):
             "dispatcher_routes": {
                 "direct": integer(summary, f"slot_{slot}_dispatcher_direct"),
                 "context": integer(summary, f"slot_{slot}_dispatcher_context"),
+            },
+            "adapter_route": {
+                "entries": integer(summary, f"slot_{slot}_adapter_entries"),
+                "enabled": integer(summary, f"slot_{slot}_adapter_enabled"),
+                "eligible": integer(summary, f"slot_{slot}_adapter_eligible"),
+                "dispatches": integer(summary, f"slot_{slot}_adapter_dispatches"),
+                "first_target": f"{adapter_first_target:08X}",
+                "last_target": f"{adapter_last_target:08X}",
+                "target_changes": integer(
+                    summary, f"slot_{slot}_adapter_target_changes"
+                ),
             },
         }
         slot_totals[str(slot)] = row
@@ -261,6 +278,20 @@ def build(events, requested_session=None):
         failures.append("presentation receiver table overflowed")
     if not total_slot_entries:
         failures.append("no unified track presentation pass was observed")
+    for slot, row in slot_totals.items():
+        adapter = row["adapter_route"]
+        if not (
+            adapter["dispatches"]
+            <= adapter["eligible"]
+            <= adapter["enabled"]
+            <= adapter["entries"]
+        ):
+            failures.append(f"slot {slot} adapter stage accounting drifted")
+        has_target = adapter["first_target"] != "00000000"
+        if has_target != bool(adapter["dispatches"]):
+            failures.append(f"slot {slot} adapter target accounting drifted")
+        if adapter["target_changes"] >= max(adapter["dispatches"], 1):
+            failures.append(f"slot {slot} adapter target changes drifted")
 
     live_slots = [slot for slot in SLOTS if slot_totals[str(slot)]["entries"]]
     accepted_slots = [slot for slot in SLOTS if slot_totals[str(slot)]["exact"]]
@@ -292,8 +323,9 @@ def build(events, requested_session=None):
             "suppression_allowed": False,
         },
         "next_step": (
-            "extend exact packet lineage only through a live color-producing "
-            "slot, then visually qualify its private replay"
+            "follow a live adapter target or extend exact packet lineage only "
+            "through a live color-producing slot, then visually qualify its "
+            "private replay"
         ),
         "safety": {
             "guest_state_changed": False,

--- a/tools/tests/test_native_renderer_track_presentation_pass.py
+++ b/tools/tests/test_native_renderer_track_presentation_pass.py
@@ -61,6 +61,26 @@ class TrackPresentationPassTests(unittest.TestCase):
         self.assertIn('"xenos_authority", "true"', source)
         self.assertIn('"suppression_allowed", "false"', source)
 
+    def test_slot_80_adapter_route_has_exact_passive_stages(self):
+        analysis = (
+            ROOT / "config/rexglue/analysis/main-xex.toml"
+        ).read_text(encoding="utf-8")
+        for address, name in (
+            ("0x8243BD40", "PinyonShiftObserveTrackPresentationAdapterEntry"),
+            ("0x8243BD78", "PinyonShiftObserveTrackPresentationAdapterEnabled"),
+            ("0x8243BDA8", "PinyonShiftObserveTrackPresentationAdapterEligible"),
+            ("0x8243BEB4", "PinyonShiftObserveTrackPresentationAdapterDispatch"),
+        ):
+            self.assertIn(f"address = {address}", analysis)
+            self.assertIn(f'name = "{name}"', analysis)
+
+        source = (ROOT / "src/native_renderer/graphics_hooks.cpp").read_text(
+            encoding="utf-8"
+        )
+        self.assertIn("g_track_presentation_adapter_entries", source)
+        self.assertIn("g_track_presentation_adapter_first_targets", source)
+        self.assertIn('"slot_80_adapter_dispatches"', source)
+
     def test_prepared_layout_exports_exact_target_shape(self):
         source = (ROOT / "src/native_renderer/graphics_hooks.cpp").read_text(
             encoding="utf-8"

--- a/tools/tests/test_native_renderer_track_presentation_pass_summary.py
+++ b/tools/tests/test_native_renderer_track_presentation_pass_summary.py
@@ -63,6 +63,22 @@ def fixture():
     for slot in MODULE.SLOTS:
         summary[f"slot_{slot}_dispatcher_direct"] = "3" if slot == 79 else "0"
         summary[f"slot_{slot}_dispatcher_context"] = "8" if slot == 79 else "0"
+        adapter_dispatches = 4 if slot == 80 else 0
+        summary[f"slot_{slot}_adapter_entries"] = (
+            "6" if slot == 80 else "0"
+        )
+        summary[f"slot_{slot}_adapter_enabled"] = (
+            "5" if slot == 80 else "0"
+        )
+        summary[f"slot_{slot}_adapter_eligible"] = str(adapter_dispatches)
+        summary[f"slot_{slot}_adapter_dispatches"] = str(adapter_dispatches)
+        summary[f"slot_{slot}_adapter_first_target"] = (
+            "8240F000" if slot == 80 else "00000000"
+        )
+        summary[f"slot_{slot}_adapter_last_target"] = (
+            "8240F000" if slot == 80 else "00000000"
+        )
+        summary[f"slot_{slot}_adapter_target_changes"] = "0"
     depth = event(
         MODULE.ENTRY,
         entry_key="1111222233334444",
@@ -139,6 +155,18 @@ class TrackPresentationPassSummaryTests(unittest.TestCase):
         self.assertEqual(
             {"direct": 3, "context": 8},
             document["slot_totals"]["79"]["dispatcher_routes"],
+        )
+        self.assertEqual(
+            {
+                "entries": 6,
+                "enabled": 5,
+                "eligible": 4,
+                "dispatches": 4,
+                "first_target": "8240F000",
+                "last_target": "8240F000",
+                "target_changes": 0,
+            },
+            document["slot_totals"]["80"]["adapter_route"],
         )
         self.assertEqual([78], document["qualification"]["color_target_slots"])
         self.assertEqual(


### PR DESCRIPTION
## Summary
- record exact slot-scoped entry and title-gate reachability through the alternate 8243BD40 adapter
- retain the first/last virtual target and target-change count without changing guest state or Xenos authority
- document the clean dispatcher-route result and extend the offline report/tests

## Validation
- python -m unittest tools.tests.test_native_renderer_track_presentation_pass tools.tests.test_native_renderer_track_presentation_pass_summary
- .\\tools\\build-preview.ps1 -JsonEvents
- clean AppData baseline session 20260901T051350Z-p17184 exited normally