### PR TITLE
feat(native-renderer): gate c1 on presentation identity

### DIFF
--- a/docs/native-renderer/C1_C2_BATCH_QUALIFICATION.md
+++ b/docs/native-renderer/C1_C2_BATCH_QUALIFICATION.md
@@ -3,9 +3,10 @@
 Status: implementation complete; first clean AppData batch incomplete
 
 The combined gate turns one exact runtime session into a single promotion
-decision. It joins four independently strict, payload-free reports:
+decision. It joins five independently strict, payload-free reports:
 
 - exact track scope-to-command-packet-to-prepared-draw lineage;
+- exact unified track-presentation color/adapter route classification;
 - complete SimpleModel presentation/resource/mesh lineage;
 - runtime transform classification against the title-authored spatial catalog;
   and
@@ -32,11 +33,12 @@ does not request the isolated per-resource vehicle readback: shadow-depth
 capture and the continuous workset are mutually exclusive, so conflating them
 would invalidate both gates.
 
-Run the four component qualifiers first, then join them:
+Run the five component qualifiers first, then join them:
 
 ```powershell
 python tools/summarize-native-renderer-c1-c2-batch.py `
   --track .local/qualification/track-model-runtime-join.json `
+  --presentation .local/qualification/track-presentation-passes.json `
   --static-world .local/qualification/static-world-runtime-join.json `
   --classification .local/qualification/static-world-classification.json `
   --workset .local/qualification/continuous-world-workset.json `
@@ -51,6 +53,12 @@ family promotion, or suppression. Those remain the next gates.
 
 This report never reads or modifies the AppData save and cannot enable runtime
 behavior. It only joins existing payload-free evidence.
+
+The presentation input also makes an incomplete batch actionable. A stable
+slot-80 adapter target selects that exact downstream function for the next
+instrumentation slice; an observed adapter that never dispatches closes slot
+80 for the representative scene and pivots C1 to semantic world ingress. It
+does not promote either result to an opaque-world color-pass proof.
 
 The first clean combined run reached exact C1 scope, context, and indirect
 packet identity but exposed an observer-ordering gap at the prepared boundary.

--- a/docs/native-renderer/REPRIORITIZED_PLAN.md
+++ b/docs/native-renderer/REPRIORITIZED_PLAN.md
@@ -608,6 +608,13 @@ function or close slot 80 as dormant in the saved festival without tracing
 arbitrary indirect calls. No guest state, title control flow, native admission,
 or Xenos authority changes.
 
+Combined-gate checkpoint: the C1/C2 batch join now requires the exact
+track-presentation report from the same clean session. An incomplete batch
+routes a stable slot-80 adapter target to exact downstream instrumentation, or
+closes a gated adapter and pivots to semantic world ingress. Neither outcome
+is treated as opaque-world color proof, keeping promotion fail closed while
+making the expensive combined run decisive.
+
 ### C2. Static world buildings and props
 
 - Expand opaque-world material and geometry coverage.

--- a/tools/summarize-native-renderer-c1-c2-batch.py
+++ b/tools/summarize-native-renderer-c1-c2-batch.py
@@ -10,6 +10,9 @@ import sys
 SCHEMA = "pinyon-shift.native-renderer-c1-c2-batch.v1"
 INPUT_SCHEMAS = {
     "track": "pinyon-shift.native-renderer-track-model-runtime-join.v3",
+    "presentation": (
+        "pinyon-shift.native-renderer-track-presentation-passes.v1"
+    ),
     "static_world": "pinyon-shift.native-renderer-static-world-runtime-join.v10",
     "classification": (
         "pinyon-shift.native-renderer-static-world-instance-classification.v1"
@@ -35,6 +38,9 @@ def require_mapping(document, key, label):
 
 def validate_safety(reports):
     track = require_mapping(reports["track"], "safety", "track report")
+    presentation = require_mapping(
+        reports["presentation"], "safety", "presentation report"
+    )
     static_world = require_mapping(
         reports["static_world"], "safety", "static-world report"
     )
@@ -50,6 +56,7 @@ def validate_safety(reports):
     }
     for label, safety in (
         ("track", track),
+        ("presentation", presentation),
         ("static-world", static_world),
     ):
         if any(safety.get(key) != value for key, value in passive.items()):
@@ -98,6 +105,9 @@ def build(reports):
             failures.append(f"{label} report does not prove session exit")
 
     track = require_mapping(reports["track"], "qualification", "track report")
+    presentation = require_mapping(
+        reports["presentation"], "qualification", "presentation report"
+    )
     static_world = require_mapping(
         reports["static_world"], "qualification", "static-world report"
     )
@@ -114,6 +124,39 @@ def build(reports):
     for key in required_track:
         if track.get(key) is not True:
             failures.append(f"track gate is unproved: {key}")
+
+    color_slots = presentation.get("color_target_slots")
+    if not isinstance(color_slots, list):
+        raise ValueError("presentation color-target slots are missing")
+    opaque_world_slot_proved = (
+        presentation.get("opaque_world_slot_proved") is True
+    )
+    if not opaque_world_slot_proved:
+        failures.append("track presentation color-pass identity is unproved")
+
+    presentation_slots = require_mapping(
+        reports["presentation"], "slot_totals", "presentation report"
+    )
+    slot_80 = require_mapping(presentation_slots, "80", "presentation slots")
+    adapter = require_mapping(slot_80, "adapter_route", "slot 80")
+    adapter_entries = adapter.get("entries")
+    adapter_dispatches = adapter.get("dispatches")
+    adapter_first_target = adapter.get("first_target")
+    adapter_last_target = adapter.get("last_target")
+    adapter_target_changes = adapter.get("target_changes")
+    stable_adapter_target = (
+        isinstance(adapter_dispatches, int)
+        and adapter_dispatches > 0
+        and isinstance(adapter_first_target, str)
+        and adapter_first_target != "00000000"
+        and adapter_first_target == adapter_last_target
+        and adapter_target_changes == 0
+    )
+    gated_adapter = (
+        isinstance(adapter_entries, int)
+        and adapter_entries > 0
+        and adapter_dispatches == 0
+    )
 
     required_static = (
         "simple_model_renderer_scope_proved",
@@ -147,6 +190,7 @@ def build(reports):
 
     track_ready = not any(
         failure.startswith("track gate")
+        or failure.startswith("track presentation")
         or failure.startswith("continuous-output gate")
         for failure in failures
     )
@@ -173,10 +217,27 @@ def build(reports):
             "family_promotion_allowed": False,
             "suppression_allowed": False,
         },
+        "presentation_lead": {
+            "color_target_slots": color_slots,
+            "opaque_world_slot_proved": opaque_world_slot_proved,
+            "slot_80_adapter_entries": adapter_entries,
+            "slot_80_adapter_dispatches": adapter_dispatches,
+            "slot_80_stable_adapter_target": (
+                adapter_first_target if stable_adapter_target else None
+            ),
+        },
         "next_gate": (
             "manual_visual_and_representative_race_streaming_qualification"
             if not failures
-            else "resolve_reported_batch_failures"
+            else (
+                "instrument_slot_80_adapter_target"
+                if stable_adapter_target
+                else (
+                    "close_slot_80_and_pivot_to_semantic_world_ingress"
+                    if gated_adapter
+                    else "resolve_reported_batch_failures"
+                )
+            )
         ),
         "safety": {
             "xenos_authority_preserved": True,
@@ -191,6 +252,7 @@ def build(reports):
 def main(argv=None):
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--track", required=True, type=pathlib.Path)
+    parser.add_argument("--presentation", required=True, type=pathlib.Path)
     parser.add_argument("--static-world", required=True, type=pathlib.Path)
     parser.add_argument("--classification", required=True, type=pathlib.Path)
     parser.add_argument("--workset", required=True, type=pathlib.Path)
@@ -200,6 +262,7 @@ def main(argv=None):
         document = build(
             {
                 "track": read_document(args.track),
+                "presentation": read_document(args.presentation),
                 "static_world": read_document(args.static_world),
                 "classification": read_document(args.classification),
                 "workset": read_document(args.workset),

--- a/tools/tests/test_native_renderer_c1_c2_batch.py
+++ b/tools/tests/test_native_renderer_c1_c2_batch.py
@@ -33,6 +33,30 @@ def fixture():
             },
             "safety": passive_safety,
         },
+        "presentation": {
+            "schema": MODULE.INPUT_SCHEMAS["presentation"],
+            "session": "session-1",
+            "status": "complete",
+            "failures": [],
+            "qualification": {
+                "color_target_slots": [80],
+                "opaque_world_slot_proved": True,
+            },
+            "slot_totals": {
+                "80": {
+                    "adapter_route": {
+                        "entries": 4,
+                        "enabled": 4,
+                        "eligible": 4,
+                        "dispatches": 4,
+                        "first_target": "8240F000",
+                        "last_target": "8240F000",
+                        "target_changes": 0,
+                    }
+                }
+            },
+            "safety": passive_safety,
+        },
         "static_world": {
             "schema": MODULE.INPUT_SCHEMAS["static_world"],
             "session": "session-1",
@@ -109,6 +133,12 @@ class NativeRendererC1C2BatchTests(unittest.TestCase):
             document["qualification"]["manual_visual_acceptance_proved"]
         )
         self.assertFalse(document["qualification"]["suppression_allowed"])
+        self.assertEqual(
+            "8240F000",
+            document["presentation_lead"][
+                "slot_80_stable_adapter_target"
+            ],
+        )
 
     def test_rejects_cross_session_evidence(self):
         reports = fixture()
@@ -137,6 +167,40 @@ class NativeRendererC1C2BatchTests(unittest.TestCase):
             "track gate is unproved: "
             "track_command_lineage_to_prepared_draw_proved",
             document["failures"],
+        )
+
+    def test_routes_unproved_color_pass_to_stable_adapter_target(self):
+        reports = fixture()
+        reports["presentation"]["qualification"][
+            "opaque_world_slot_proved"
+        ] = False
+        reports["presentation"]["qualification"]["color_target_slots"] = []
+        document = MODULE.build(reports)
+        self.assertEqual("incomplete", document["status"])
+        self.assertIn(
+            "track presentation color-pass identity is unproved",
+            document["failures"],
+        )
+        self.assertEqual(
+            "instrument_slot_80_adapter_target", document["next_gate"]
+        )
+
+    def test_closes_gated_slot_80_before_semantic_pivot(self):
+        reports = fixture()
+        reports["presentation"]["qualification"][
+            "opaque_world_slot_proved"
+        ] = False
+        reports["presentation"]["qualification"]["color_target_slots"] = []
+        adapter = reports["presentation"]["slot_totals"]["80"][
+            "adapter_route"
+        ]
+        adapter["dispatches"] = 0
+        adapter["first_target"] = "00000000"
+        adapter["last_target"] = "00000000"
+        document = MODULE.build(reports)
+        self.assertEqual(
+            "close_slot_80_and_pivot_to_semantic_world_ingress",
+            document["next_gate"],
         )
 
     def test_rejects_safety_drift(self):


### PR DESCRIPTION
## Summary
- require exact track-presentation evidence in the same-session C1/C2 batch
- keep opaque-world promotion fail closed when only an adapter lead exists
- route a stable slot-80 target to exact instrumentation or close a gated adapter and pivot
- update the batch contract and roadmap

## Validation
- python -m unittest tools.tests.test_native_renderer_c1_c2_batch tools.tests.test_native_renderer_track_presentation_pass tools.tests.test_native_renderer_track_presentation_pass_summary