### PR TITLE
fix(native-renderer): classify null static resources

### DIFF
--- a/docs/native-renderer/C1_C2_BATCH_QUALIFICATION.md
+++ b/docs/native-renderer/C1_C2_BATCH_QUALIFICATION.md
@@ -83,3 +83,9 @@ provenance, and the spatial classifier can evaluate that origin with
 live route before investing further in the dormant SimpleModel construction
 path. This changes evidence priority only; the combined promotion gate and its
 Xenos-authority requirements remain unchanged.
+
+The dormant SimpleModel population is now classified precisely: a null
+presentation resource is an expected missing-resource outcome, not a mapped
+read fault. It remains ineligible for C2 because exact metadata and renderer
+joins are still mandatory, but it no longer obscures genuine memory-safety
+failures in the combined report.

--- a/docs/native-renderer/REPRIORITIZED_PLAN.md
+++ b/docs/native-renderer/REPRIORITIZED_PLAN.md
@@ -812,6 +812,14 @@ runtime-receiver correction plus a scene that exercises its renderer before
 C2 admission resumes. C1 color-pass lineage remains ahead of this route; final
 C2 scope is unchanged.
 
+Null-resource classification correction: all 6,016 exact presentation scopes
+in that session carried a null offset-148 resource, so their metadata outcome
+was absence rather than a guest-memory read fault. Runtime accounting now
+reports null presentation resources and metadata-missing-resource outcomes
+separately from genuine mapped-read failures. Broad generic presentation
+scopes may be null without poisoning safety accounting, while C2 qualification
+still requires exact resource metadata and renderer joins.
+
 ### C3. Semantic batching, culling, and LOD
 
 - Promote the existing visibility and prepared-draw evidence into production

--- a/src/native_renderer/graphics_hooks.cpp
+++ b/src/native_renderer/graphics_hooks.cpp
@@ -3024,10 +3024,12 @@ std::atomic<uint32_t> g_static_world_presentation_handoff_sample_target{};
 std::atomic<uint64_t> g_static_world_presentation_resource_vtable_exact{};
 std::atomic<uint64_t> g_static_world_presentation_resource_vtable_mismatches{};
 std::atomic<uint64_t> g_static_world_presentation_resource_vtable_read_faults{};
+std::atomic<uint64_t> g_static_world_presentation_resource_null{};
 std::atomic<uint32_t> g_static_world_presentation_resource_sample_vtable{};
 std::atomic<uint64_t> g_static_world_asset_metadata_observations{};
 std::atomic<uint64_t> g_static_world_asset_metadata_exact{};
 std::atomic<uint64_t> g_static_world_asset_metadata_empty_keys{};
+std::atomic<uint64_t> g_static_world_asset_metadata_missing_resources{};
 std::atomic<uint64_t> g_static_world_asset_metadata_read_faults{};
 std::atomic<uint64_t> g_static_world_asset_metadata_joins{};
 std::atomic<uint64_t> g_static_world_asset_metadata_missing_joins{};
@@ -4185,17 +4187,20 @@ void ObserveVehicleMaterialBinding(uint32_t root_address,
 enum class StaticWorldAssetMetadataResult {
   kExact,
   kEmptyKey,
+  kMissingResource,
   kReadFault,
 };
 
 StaticWorldAssetMetadataResult ReadStaticWorldAssetMetadata(
     rex::memory::Memory *memory, uint32_t presentation_address,
     uint32_t resource_address, StaticWorldPresentationDispatchScope &scope) {
-  if (!memory || !resource_address ||
-      presentation_address >
+  if (!memory || presentation_address >
           UINT32_MAX - kModelPresentationNameOffset -
               kMsvcStringCapacityOffset - sizeof(uint32_t)) {
     return StaticWorldAssetMetadataResult::kReadFault;
+  }
+  if (!resource_address) {
+    return StaticWorldAssetMetadataResult::kMissingResource;
   }
   const uint32_t string_address =
       presentation_address + kModelPresentationNameOffset;
@@ -4960,8 +4965,10 @@ void BeginStaticWorldPresentationDispatch(uint32_t presentation_address) {
     return;
   }
   uint32_t resource_vtable = 0;
-  if (!LoadMappedGuestU32(memory, scope.resource_address,
-                          resource_vtable)) {
+  if (!scope.resource_address) {
+    ++g_static_world_presentation_resource_null;
+  } else if (!LoadMappedGuestU32(memory, scope.resource_address,
+                                 resource_vtable)) {
     ++g_static_world_presentation_resource_vtable_read_faults;
   } else if (resource_vtable == kSimpleModelResourceVtable) {
     ++g_static_world_presentation_resource_vtable_exact;
@@ -4978,6 +4985,9 @@ void BeginStaticWorldPresentationDispatch(uint32_t presentation_address) {
     break;
   case StaticWorldAssetMetadataResult::kEmptyKey:
     ++g_static_world_asset_metadata_empty_keys;
+    break;
+  case StaticWorldAssetMetadataResult::kMissingResource:
+    ++g_static_world_asset_metadata_missing_resources;
     break;
   case StaticWorldAssetMetadataResult::kReadFault:
     ++g_static_world_asset_metadata_read_faults;
@@ -7083,9 +7093,14 @@ void ResetTitleDrawProvenance() {
            &g_static_world_presentation_renderer_joins,
            &g_static_world_presentation_renderer_mismatches,
            &g_static_world_presentation_resource_mismatches,
+           &g_static_world_presentation_resource_vtable_exact,
+           &g_static_world_presentation_resource_vtable_mismatches,
+           &g_static_world_presentation_resource_vtable_read_faults,
+           &g_static_world_presentation_resource_null,
            &g_static_world_asset_metadata_observations,
            &g_static_world_asset_metadata_exact,
            &g_static_world_asset_metadata_empty_keys,
+           &g_static_world_asset_metadata_missing_resources,
            &g_static_world_asset_metadata_read_faults,
            &g_static_world_asset_metadata_joins,
            &g_static_world_asset_metadata_missing_joins,
@@ -14290,6 +14305,9 @@ void EmitStaticWorldRuntimeJoinEvent(const char *event_name,
   const uint64_t asset_metadata_empty_keys =
       g_static_world_asset_metadata_empty_keys.load(
           std::memory_order_relaxed);
+  const uint64_t asset_metadata_missing_resources =
+      g_static_world_asset_metadata_missing_resources.load(
+          std::memory_order_relaxed);
   const uint64_t asset_metadata_read_faults =
       g_static_world_asset_metadata_read_faults.load(
           std::memory_order_relaxed);
@@ -14448,7 +14466,7 @@ void EmitStaticWorldRuntimeJoinEvent(const char *event_name,
       asset_metadata_observations == presentation_exact &&
       asset_metadata_observations ==
           asset_metadata_exact + asset_metadata_empty_keys +
-              asset_metadata_read_faults &&
+              asset_metadata_missing_resources + asset_metadata_read_faults &&
       presentation_renderer_joins ==
           asset_metadata_joins + asset_metadata_missing_joins &&
       transform_observations == presentation_exact &&
@@ -14899,6 +14917,9 @@ void EmitStaticWorldRuntimeJoinEvent(const char *event_name,
         std::to_string(
             g_static_world_presentation_resource_vtable_read_faults.load(
                 std::memory_order_relaxed))},
+       {"presentation_resource_null",
+        std::to_string(g_static_world_presentation_resource_null.load(
+            std::memory_order_relaxed))},
        {"presentation_resource_sample_vtable",
         fmt::format("{:08X}",
                     g_static_world_presentation_resource_sample_vtable.load(
@@ -14908,6 +14929,8 @@ void EmitStaticWorldRuntimeJoinEvent(const char *event_name,
        {"asset_metadata_exact", std::to_string(asset_metadata_exact)},
        {"asset_metadata_empty_keys",
         std::to_string(asset_metadata_empty_keys)},
+       {"asset_metadata_missing_resources",
+        std::to_string(asset_metadata_missing_resources)},
        {"asset_metadata_read_faults",
         std::to_string(asset_metadata_read_faults)},
        {"asset_metadata_joins", std::to_string(asset_metadata_joins)},

--- a/tools/summarize-native-renderer-static-world-runtime-join.py
+++ b/tools/summarize-native-renderer-static-world-runtime-join.py
@@ -886,9 +886,11 @@ def build(
         "presentation_renderer_joins",
         "presentation_renderer_mismatches",
         "presentation_resource_mismatches",
+        "presentation_resource_null",
         "asset_metadata_observations",
         "asset_metadata_exact",
         "asset_metadata_empty_keys",
+        "asset_metadata_missing_resources",
         "asset_metadata_read_faults",
         "asset_metadata_joins",
         "asset_metadata_missing_joins",
@@ -1094,9 +1096,14 @@ def build(
     if totals["asset_metadata_observations"] != (
         totals["asset_metadata_exact"]
         + totals["asset_metadata_empty_keys"]
+        + totals["asset_metadata_missing_resources"]
         + totals["asset_metadata_read_faults"]
     ):
         failures.append("static-world asset metadata classification drifted")
+    if totals["presentation_resource_null"] != totals[
+        "asset_metadata_missing_resources"
+    ]:
+        failures.append("static-world missing resource accounting drifted")
     if totals["presentation_renderer_joins"] != (
         totals["asset_metadata_joins"]
         + totals["asset_metadata_missing_joins"]

--- a/tools/tests/test_native_renderer_static_world_runtime_join.py
+++ b/tools/tests/test_native_renderer_static_world_runtime_join.py
@@ -641,9 +641,11 @@ def fixture():
         presentation_renderer_joins="8",
         presentation_renderer_mismatches="0",
         presentation_resource_mismatches="0",
+        presentation_resource_null="0",
         asset_metadata_observations="12",
         asset_metadata_exact="10",
         asset_metadata_empty_keys="2",
+        asset_metadata_missing_resources="0",
         asset_metadata_read_faults="0",
         asset_metadata_joins="8",
         asset_metadata_missing_joins="0",
@@ -1032,6 +1034,39 @@ class StaticWorldRuntimeJoinTests(unittest.TestCase):
         self.assertEqual("incomplete", document["status"])
         self.assertIn(
             "asset_metadata_missing_joins is nonzero", document["failures"]
+        )
+
+    def test_classifies_null_resources_without_read_faults(self):
+        events = copy.deepcopy(fixture())
+        events[-1].update(
+            status="incomplete",
+            presentation_scopes_with_renderer="0",
+            presentation_scopes_without_renderer="12",
+            presentation_renderer_joins="0",
+            presentation_resource_null="12",
+            asset_metadata_exact="0",
+            asset_metadata_empty_keys="0",
+            asset_metadata_missing_resources="12",
+            asset_metadata_joins="0",
+            qualification_complete="false",
+        )
+        document = MODULE.build(
+            static_ingress(),
+            static_lifetime(),
+            static_resource(),
+            static_streaming(),
+            static_graph(),
+            static_owner(),
+            static_asset_metadata(),
+            static_mesh_semantics(),
+            events,
+        )
+        self.assertEqual(12, document["totals"]["presentation_resource_null"])
+        self.assertEqual(
+            12, document["totals"]["asset_metadata_missing_resources"]
+        )
+        self.assertNotIn(
+            "asset_metadata_read_faults is nonzero", document["failures"]
         )
 
     def test_rejects_mesh_semantic_read_fault(self):


### PR DESCRIPTION
## Summary
- classify null CModelPresentation resources as dormant missing-resource outcomes
- reserve read-fault counters for genuine mapped-memory failures
- preserve fail-closed C2 admission requirements for metadata, renderer, and prepared-draw joins
- update offline accounting, regression coverage, and roadmap notes

## Validation
- python -m unittest tools.tests.test_native_renderer_static_world_runtime_join tools.tests.test_native_renderer_static_world_asset_metadata
- .\\tools\\build-preview.ps1 -JsonEvents