### PR TITLE
feat(renderer): preserve presentation packet lineage

### DIFF
--- a/docs/native-renderer/REPRIORITIZED_PLAN.md
+++ b/docs/native-renderer/REPRIORITIZED_PLAN.md
@@ -615,6 +615,26 @@ closes a gated adapter and pivots to semantic world ingress. Neither outcome
 is treated as opaque-world color proof, keeping promotion fail closed while
 making the expensive combined run decisive.
 
+Combined runtime result: clean AppData session `20260901T054234Z-p276`
+reached the saved festival and exited normally. Slot 80 crossed the alternate
+adapter's final gate 135 times and held one stable target, `823FDE50`, with no
+target changes. Static AOT flow shows that target enumerates presentation
+records through `82414A00`, which reaches the already-proved procedural model
+resource/submission path. Slot 79 remained the known depth-only shadow route.
+The corrected C2 census classified all 8,576 null generic-presentation
+resources as missing resources with zero guest-memory read faults; no exact
+static-world renderer/resource/PM4 join was present in this scene.
+
+Deferred-packet lineage checkpoint: exact presentation provenance is now
+captured when a title indirect packet is constructed, then retained until its
+later prepared draw is consumed. Per-slot packet-construction counters keep
+this construction-time source distinct from both synchronous prepared-draw
+scope and the older context-specific packet lineage. The next batched run can
+therefore determine whether slot 80 produces the main-view color target through
+`823FDE50` without widening hooks below its 50 indirect dispatch sites. This is
+passive evidence only; Xenos remains authoritative and native admission stays
+disabled.
+
 ### C2. Static world buildings and props
 
 - Expand opaque-world material and geometry coverage.

--- a/src/native_renderer/graphics_hooks.cpp
+++ b/src/native_renderer/graphics_hooks.cpp
@@ -2941,6 +2941,8 @@ std::array<std::atomic<uint64_t>, 4> g_track_presentation_adapter_entries{};
 std::array<std::atomic<uint64_t>, 4> g_track_presentation_adapter_enabled{};
 std::array<std::atomic<uint64_t>, 4> g_track_presentation_adapter_eligible{};
 std::array<std::atomic<uint64_t>, 4> g_track_presentation_adapter_dispatches{};
+std::array<std::atomic<uint64_t>, 4>
+    g_track_presentation_packet_constructions{};
 std::array<std::atomic<uint32_t>, 4>
     g_track_presentation_adapter_first_targets{};
 std::array<std::atomic<uint32_t>, 4>
@@ -6941,7 +6943,8 @@ void ResetTitleDrawProvenance() {
                          &g_track_presentation_adapter_enabled,
                          &g_track_presentation_adapter_eligible,
                          &g_track_presentation_adapter_dispatches,
-                         &g_track_presentation_adapter_target_changes}) {
+                         &g_track_presentation_adapter_target_changes,
+                         &g_track_presentation_packet_constructions}) {
     for (std::atomic<uint64_t> &counter : *counters) {
       counter.store(0, std::memory_order_relaxed);
     }
@@ -9327,8 +9330,21 @@ void RecordTitleIndirectPacket(uint32_t packet_guest_address,
       origin.owner.producer.context.track_render_descriptor_payload;
   entry.track_world_resource_identity_mask =
       origin.owner.producer.context.track_world_resource_identity_mask;
+  const uint32_t presentation_construction_mask =
+      CurrentTrackPresentationPassMask();
+  // The title may defer consuming an indirect packet until after its exact
+  // presentation call returns. Preserve that synchronous construction scope
+  // on the packet so the later prepared draw retains its slot provenance.
   entry.track_presentation_pass_mask =
-      origin.owner.producer.context.track_presentation_pass_mask;
+      origin.owner.producer.context.track_presentation_pass_mask |
+      presentation_construction_mask;
+  for (size_t index = 0;
+       index < g_track_presentation_packet_constructions.size(); ++index) {
+    if (presentation_construction_mask & (uint32_t(1) << index)) {
+      g_track_presentation_packet_constructions[index].fetch_add(
+          1, std::memory_order_relaxed);
+    }
+  }
   entry.submission_sequence = ++g_title_indirect_packet_submission_sequence;
   entry.constructor_origin_known = origin.valid;
   entry.owner_origin_known = origin.owner.valid;
@@ -13890,6 +13906,9 @@ void EmitTrackPresentationPassSummary() {
        {"slot_78_adapter_target_changes",
         std::to_string(g_track_presentation_adapter_target_changes[0].load(
             std::memory_order_relaxed))},
+       {"slot_78_packet_constructions",
+        std::to_string(g_track_presentation_packet_constructions[0].load(
+            std::memory_order_relaxed))},
        {"slot_79_function", "8240E7B0"},
        {"slot_79_entries", std::to_string(entries[1])},
        {"slot_79_exits", std::to_string(exits[1])},
@@ -13921,6 +13940,9 @@ void EmitTrackPresentationPassSummary() {
                                   std::memory_order_relaxed))},
        {"slot_79_adapter_target_changes",
         std::to_string(g_track_presentation_adapter_target_changes[1].load(
+            std::memory_order_relaxed))},
+       {"slot_79_packet_constructions",
+        std::to_string(g_track_presentation_packet_constructions[1].load(
             std::memory_order_relaxed))},
        {"slot_80_function", "82DEF2B0"},
        {"slot_80_entries", std::to_string(entries[2])},
@@ -13954,6 +13976,9 @@ void EmitTrackPresentationPassSummary() {
        {"slot_80_adapter_target_changes",
         std::to_string(g_track_presentation_adapter_target_changes[2].load(
             std::memory_order_relaxed))},
+       {"slot_80_packet_constructions",
+        std::to_string(g_track_presentation_packet_constructions[2].load(
+            std::memory_order_relaxed))},
        {"slot_81_function", "82DEADE0"},
        {"slot_81_entries", std::to_string(entries[3])},
        {"slot_81_exits", std::to_string(exits[3])},
@@ -13985,6 +14010,9 @@ void EmitTrackPresentationPassSummary() {
                                   std::memory_order_relaxed))},
        {"slot_81_adapter_target_changes",
         std::to_string(g_track_presentation_adapter_target_changes[3].load(
+            std::memory_order_relaxed))},
+       {"slot_81_packet_constructions",
+        std::to_string(g_track_presentation_packet_constructions[3].load(
             std::memory_order_relaxed))},
        {"overlaps",
         std::to_string(overlaps[0] + overlaps[1] + overlaps[2] + overlaps[3])},

--- a/tools/summarize-native-renderer-track-presentation-passes.py
+++ b/tools/summarize-native-renderer-track-presentation-passes.py
@@ -142,6 +142,9 @@ def build(events, requested_session=None):
                     summary, f"slot_{slot}_adapter_target_changes"
                 ),
             },
+            "packet_constructions": integer(
+                summary, f"slot_{slot}_packet_constructions"
+            ),
         }
         slot_totals[str(slot)] = row
         total_slot_entries += row["entries"]

--- a/tools/tests/test_native_renderer_track_presentation_pass.py
+++ b/tools/tests/test_native_renderer_track_presentation_pass.py
@@ -80,6 +80,8 @@ class TrackPresentationPassTests(unittest.TestCase):
         self.assertIn("g_track_presentation_adapter_entries", source)
         self.assertIn("g_track_presentation_adapter_first_targets", source)
         self.assertIn('"slot_80_adapter_dispatches"', source)
+        self.assertIn("presentation_construction_mask", source)
+        self.assertIn('"slot_80_packet_constructions"', source)
 
     def test_prepared_layout_exports_exact_target_shape(self):
         source = (ROOT / "src/native_renderer/graphics_hooks.cpp").read_text(

--- a/tools/tests/test_native_renderer_track_presentation_pass_summary.py
+++ b/tools/tests/test_native_renderer_track_presentation_pass_summary.py
@@ -79,6 +79,9 @@ def fixture():
             "8240F000" if slot == 80 else "00000000"
         )
         summary[f"slot_{slot}_adapter_target_changes"] = "0"
+        summary[f"slot_{slot}_packet_constructions"] = (
+            "4" if slot == 80 else "0"
+        )
     depth = event(
         MODULE.ENTRY,
         entry_key="1111222233334444",
@@ -167,6 +170,9 @@ class TrackPresentationPassSummaryTests(unittest.TestCase):
                 "target_changes": 0,
             },
             document["slot_totals"]["80"]["adapter_route"],
+        )
+        self.assertEqual(
+            4, document["slot_totals"]["80"]["packet_constructions"]
         )
         self.assertEqual([78], document["qualification"]["color_target_slots"])
         self.assertEqual(


### PR DESCRIPTION
## Summary
- retain exact track-presentation scope on title indirect packets at construction time
- export per-slot packet construction counts and consume them in the offline report
- document the combined slot-80 runtime result and next qualification gate

## Safety
- observation-only; no guest state or control-flow changes
- native admission remains disabled
- Xenos remains authoritative

## Validation
- 30 focused native-renderer tests
- release preview build