### PR TITLE
fix(renderer): retain incomplete classification reports

### DIFF
--- a/docs/native-renderer/REPRIORITIZED_PLAN.md
+++ b/docs/native-renderer/REPRIORITIZED_PLAN.md
@@ -635,6 +635,14 @@ therefore determine whether slot 80 produces the main-view color target through
 passive evidence only; Xenos remains authoritative and native admission stays
 disabled.
 
+Incomplete-classification artifact checkpoint: static-world instance
+classification now emits a fail-closed JSON report when its upstream runtime
+qualification is incomplete instead of discarding all downstream evidence.
+This lets the combined C1/C2 join explain both the failed static gate and the
+successful presentation lineage from one expensive session. The artifact
+remains `incomplete`, records the upstream failure explicitly, and cannot
+enable native admission or suppression.
+
 ### C2. Static world buildings and props
 
 - Expand opaque-world material and geometry coverage.

--- a/tools/summarize-native-renderer-static-world-instance-classification.py
+++ b/tools/summarize-native-renderer-static-world-instance-classification.py
@@ -224,6 +224,7 @@ def build(
     if len(starts) != 1 or len(shutdowns) != 1:
         raise ValueError("process lifecycle is incomplete")
     summary = summaries[0]
+    failures = []
     if origin == "static_world":
         qualified = (
             summary.get("status") == "complete"
@@ -241,10 +242,9 @@ def build(
             and integer(summary, "unified_track_mesh_unprepared_matches") == 0
         )
     if not qualified:
-        raise ValueError("runtime transform qualification is incomplete")
+        failures.append("runtime transform qualification is incomplete")
 
     transforms = {}
-    failures = []
     for event in selected:
         if event.get("event") != PROVENANCE or event.get("outcome") != "prepared":
             continue

--- a/tools/tests/test_native_renderer_static_world_instance_classification.py
+++ b/tools/tests/test_native_renderer_static_world_instance_classification.py
@@ -158,8 +158,12 @@ class StaticWorldInstanceClassificationTests(unittest.TestCase):
     def test_rejects_incomplete_runtime_summary(self):
         observed = events()
         observed[-2]["status"] = "incomplete"
-        with self.assertRaisesRegex(ValueError, "qualification is incomplete"):
-            MODULE.build(catalog(), observed)
+        document = MODULE.build(catalog(), observed)
+        self.assertEqual("incomplete", document["status"])
+        self.assertIn(
+            "runtime transform qualification is incomplete",
+            document["failures"],
+        )
 
     def test_rejects_gameplay_only_classification(self):
         gameplay_catalog = catalog()
@@ -196,8 +200,12 @@ class StaticWorldInstanceClassificationTests(unittest.TestCase):
     def test_rejects_incomplete_track_packet_join(self):
         observed = track_events()
         observed[-2]["unified_track_mesh_scopes_without_packets"] = "1"
-        with self.assertRaisesRegex(ValueError, "qualification is incomplete"):
-            MODULE.build(catalog(), observed, origin="unified_track_mesh")
+        document = MODULE.build(catalog(), observed, origin="unified_track_mesh")
+        self.assertEqual("incomplete", document["status"])
+        self.assertIn(
+            "runtime transform qualification is incomplete",
+            document["failures"],
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- emit incomplete static-world classification JSON instead of dropping the artifact
- preserve an explicit upstream qualification failure
- let combined C1/C2 reporting consume both tracks from one gameplay session

## Safety
- fail closed: report status remains incomplete
- native admission and suppression remain disabled

## Validation
- 17 focused native-renderer tests