### PR TITLE
feat(native-renderer): retain nested track world identity

### DIFF
--- a/docs/native-renderer/REPRIORITIZED_PLAN.md
+++ b/docs/native-renderer/REPRIORITIZED_PLAN.md
@@ -654,8 +654,19 @@ semantic mesh/world-section ingress instead of tracing deeper through either
 presentation shadow route. No native draw or suppression was admitted.
 
 Combined-report compatibility checkpoint: the C1/C2 join now consumes the
-current track-model v4 and continuous-workset v7 schemas. This repairs report
+current track-model v5 and continuous-workset v7 schemas. This repairs report
 composition only; every incomplete component remains fail closed.
+
+Nested world-identity implementation checkpoint: the bounded one-level
+pointee census now retains exact RTTI-backed `CTrackModel`, `CTrackMesh`,
+`CTrackSubModel`, procedural-geometry, and PVS-zone objects in the cached
+track-world graph instead of discarding their addresses after diagnostic
+counting. Direct and nested provenance remain separately reported, and the
+broader SimpleModel-family census cannot enter this C1 graph. This carries a
+semantic track-owned resource identity into the existing command lineage
+without enabling native admission, suppression, or changing Xenos authority.
+Runtime qualification is intentionally deferred to the next meaningful C1
+batch.
 
 ### C2. Static world buildings and props
 

--- a/docs/native-renderer/TERRAIN_ROAD_RENDER_PATH.md
+++ b/docs/native-renderer/TERRAIN_ROAD_RENDER_PATH.md
@@ -385,3 +385,26 @@ explicitly `checkpoint_complete` or `checkpoint_incomplete`, records that
 session exit was not proved, and cannot serve as native-admission evidence. A
 later final summary always wins. This makes long-run crash diagnosis durable
 without weakening the clean-shutdown gate that remains required for C1.
+
+## Exact nested track-world identity
+
+The earlier bounded pointee census repeatedly observed exact `CTrackMesh` and
+`CTrackSubModel` vtables one pointer below the accepted child/descriptor graph,
+but discarded their addresses after incrementing diagnostic counters. The
+world graph now retains those addresses with explicit nested provenance.
+
+Promotion remains narrower than the diagnostic census. Only the seven exact
+RTTI-backed track, procedural-geometry, and PVS-zone classes accepted by the
+direct world-resource classifier may enter the graph. `CSimpleModelRenderer`,
+`CSimpleModelResource`, model-presentation, and the remaining SimpleModel
+family continue to be counted for investigation but cannot establish C1 track
+ownership. References are still deduplicated inside the existing 16-entry
+cache record, with overflow and host-mapping failures visible in the report.
+
+Track-model report schema v5 separates nested graph scopes and per-class
+relations from direct graph evidence. This proves where the identity came from
+while carrying the same exact object address into the established command and
+prepared-draw lineage. It does not infer terrain or road visual identity,
+enable native admission, suppress Xenos work, or change output authority. The
+next batched AppData qualification must observe nonzero nested graph scopes
+with complete accounting before this boundary can guide isolated replay.

--- a/src/native_renderer/graphics_hooks.cpp
+++ b/src/native_renderer/graphics_hooks.cpp
@@ -2574,9 +2574,15 @@ enum TrackWorldResourceIdentity : uint32_t {
   kTrackWorldResourcePvsZoneResource = 1u << 6,
 };
 
+enum TrackWorldResourceProvenance : uint32_t {
+  kTrackWorldResourceDirectPointer = 1u << 0,
+  kTrackWorldResourceNestedPointer = 1u << 1,
+};
+
 struct TrackWorldResourceReference {
   uint32_t address = 0;
   uint32_t identity = 0;
+  uint32_t provenance = 0;
 };
 
 struct TrackWorldResourceGraphCacheEntry {
@@ -2584,6 +2590,7 @@ struct TrackWorldResourceGraphCacheEntry {
   uint32_t child_address = 0;
   uint32_t descriptor_address = 0;
   uint32_t identity_mask = 0;
+  uint32_t nested_identity_mask = 0;
   uint32_t reference_count = 0;
   std::array<TrackWorldResourceReference,
              kTrackWorldResourceIdentityCapacity>
@@ -2599,6 +2606,7 @@ struct TrackRenderModelDispatchScope {
   uint32_t descriptor_payload = 0;
   uint32_t shared_identity_mask = 0;
   uint32_t world_resource_identity_mask = 0;
+  uint32_t world_resource_nested_identity_mask = 0;
   uint32_t world_resource_shared_identity_mask = 0;
   uint32_t world_resource_reference_count = 0;
   std::array<TrackWorldResourceReference,
@@ -2805,9 +2813,12 @@ std::atomic<uint64_t> g_track_world_resource_graph_cache_misses{};
 std::atomic<uint64_t> g_track_world_resource_graph_reference_overflow{};
 std::atomic<uint64_t> g_track_world_resource_graph_host_unmapped_rejections{};
 std::atomic<uint64_t> g_track_world_resource_graph_scopes{};
+std::atomic<uint64_t> g_track_world_resource_nested_graph_scopes{};
 std::atomic<uint64_t> g_track_world_resource_shared_identity_joins{};
 std::array<std::atomic<uint64_t>, 7>
     g_track_world_resource_identity_relations{};
+std::array<std::atomic<uint64_t>, 7>
+    g_track_world_resource_nested_identity_relations{};
 std::array<std::atomic<uint64_t>, 7>
     g_track_world_resource_shared_identity_relations{};
 std::atomic<uint64_t> g_track_world_pointee_graph_samples{};
@@ -3664,9 +3675,14 @@ bool TryReadTrackWorldPointeeVtable(rex::memory::Memory *memory,
   return true;
 }
 
+void AddTrackWorldResourceReference(
+    TrackWorldResourceGraphCacheEntry &entry, uint32_t address,
+    uint32_t identity, uint32_t provenance);
+
 template <size_t N>
 void CensusTrackWorldPointees(rex::memory::Memory *memory,
-                              const std::array<uint32_t, N> &words) {
+                              const std::array<uint32_t, N> &words,
+                              TrackWorldResourceGraphCacheEntry &entry) {
   ++g_track_world_pointee_graph_samples;
   std::array<uint32_t, kTrackWorldResourceIdentityCapacity> roots{};
   size_t root_count = 0;
@@ -3714,13 +3730,20 @@ void CensusTrackWorldPointees(rex::memory::Memory *memory,
       }
       ++g_track_world_pointee_nested_hits;
       ++g_track_world_pointee_nested_identity_relations[identity];
+      const uint32_t track_identity =
+          ClassifyTrackWorldResourceVtable(nested_vtable);
+      if (track_identity) {
+        entry.nested_identity_mask |= track_identity;
+        AddTrackWorldResourceReference(entry, nested_address, track_identity,
+                                       kTrackWorldResourceNestedPointer);
+      }
     }
   }
 }
 
 void AddTrackWorldResourceReference(
     TrackWorldResourceGraphCacheEntry &entry, uint32_t address,
-    uint32_t identity) {
+    uint32_t identity, uint32_t provenance) {
   if (!address || !identity) {
     return;
   }
@@ -3728,6 +3751,7 @@ void AddTrackWorldResourceReference(
   for (size_t index = 0; index < entry.reference_count; ++index) {
     if (entry.references[index].address == address) {
       entry.references[index].identity |= identity;
+      entry.references[index].provenance |= provenance;
       return;
     }
   }
@@ -3738,6 +3762,7 @@ void AddTrackWorldResourceReference(
   entry.references[entry.reference_count++] = {
       .address = address,
       .identity = identity,
+      .provenance = provenance,
   };
 }
 
@@ -3762,7 +3787,8 @@ void ScanTrackWorldResourcePointers(
     const uint32_t identity = ClassifyTrackWorldResourceVtable(
         static_cast<uint32_t>(
             *memory->TranslateVirtual<rex::be_u32 *>(address)));
-    AddTrackWorldResourceReference(entry, address, identity);
+    AddTrackWorldResourceReference(entry, address, identity,
+                                   kTrackWorldResourceDirectPointer);
   }
 }
 
@@ -3800,11 +3826,12 @@ void PopulateTrackWorldResourceGraph(
     };
     ScanTrackWorldResourcePointers(memory, child_words, entry);
     ScanTrackWorldResourcePointers(memory, descriptor_words, entry);
-    CensusTrackWorldPointees(memory, child_words);
-    CensusTrackWorldPointees(memory, descriptor_words);
+    CensusTrackWorldPointees(memory, child_words, entry);
+    CensusTrackWorldPointees(memory, descriptor_words, entry);
   }
   TrackRenderModelDispatchScope &scope = g_track_render_model_scope;
   scope.world_resource_identity_mask = entry.identity_mask;
+  scope.world_resource_nested_identity_mask = entry.nested_identity_mask;
   scope.world_resource_reference_count = entry.reference_count;
   scope.world_resource_references = entry.references;
   if (entry.identity_mask) {
@@ -3813,6 +3840,15 @@ void PopulateTrackWorldResourceGraph(
          bit < g_track_world_resource_identity_relations.size(); ++bit) {
       if (entry.identity_mask & (1u << bit)) {
         ++g_track_world_resource_identity_relations[bit];
+      }
+    }
+  }
+  if (entry.nested_identity_mask) {
+    ++g_track_world_resource_nested_graph_scopes;
+    for (size_t bit = 0;
+         bit < g_track_world_resource_nested_identity_relations.size(); ++bit) {
+      if (entry.nested_identity_mask & (1u << bit)) {
+        ++g_track_world_resource_nested_identity_relations[bit];
       }
     }
   }
@@ -13662,6 +13698,9 @@ void EmitTrackRenderModelRuntimeJoinEvent(const char *event_name,
        {"world_resource_graph_scopes",
         std::to_string(g_track_world_resource_graph_scopes.load(
             std::memory_order_relaxed))},
+       {"world_resource_nested_graph_scopes",
+        std::to_string(g_track_world_resource_nested_graph_scopes.load(
+            std::memory_order_relaxed))},
        {"world_resource_graph_cache_hits",
         std::to_string(g_track_world_resource_graph_cache_hits.load(
             std::memory_order_relaxed))},
@@ -13754,6 +13793,34 @@ void EmitTrackRenderModelRuntimeJoinEvent(const char *event_name,
        {"world_pvs_zone_resource",
         std::to_string(g_track_world_resource_identity_relations[6].load(
             std::memory_order_relaxed))},
+       {"nested_world_track_model",
+        std::to_string(
+            g_track_world_resource_nested_identity_relations[0].load(
+                std::memory_order_relaxed))},
+       {"nested_world_track_mesh",
+        std::to_string(
+            g_track_world_resource_nested_identity_relations[1].load(
+                std::memory_order_relaxed))},
+       {"nested_world_track_submodel",
+        std::to_string(
+            g_track_world_resource_nested_identity_relations[2].load(
+                std::memory_order_relaxed))},
+       {"nested_world_procedural_geometry_object",
+        std::to_string(
+            g_track_world_resource_nested_identity_relations[3].load(
+                std::memory_order_relaxed))},
+       {"nested_world_procedural_geometry_resource",
+        std::to_string(
+            g_track_world_resource_nested_identity_relations[4].load(
+                std::memory_order_relaxed))},
+       {"nested_world_pvs_zone_object",
+        std::to_string(
+            g_track_world_resource_nested_identity_relations[5].load(
+                std::memory_order_relaxed))},
+       {"nested_world_pvs_zone_resource",
+        std::to_string(
+            g_track_world_resource_nested_identity_relations[6].load(
+                std::memory_order_relaxed))},
        {"shared_world_track_model",
         std::to_string(
             g_track_world_resource_shared_identity_relations[0].load(
@@ -30064,7 +30131,8 @@ void InstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system,
        {"world_resource_vtables",
         "820016B4,8200143C,82001474,82144CF8,82144D7C,82144DE0,82144E64"},
        {"world_resource_graph",
-        "host_mapped_direct_child_or_descriptor_pointer_with_exact_rtti_vtable"},
+        "host_mapped_direct_or_one_level_nested_child_or_descriptor_pointer_"
+        "with_exact_track_rtti_vtable"},
        {"world_resource_shared_identity",
         "exact_address_equality_to_submission_objects_or_resources"},
        {"world_resource_graph_cache_capacity", "1024"},
@@ -30081,7 +30149,8 @@ void InstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system,
         "staged_same_thread_then_exact_8240EC80_scope"},
        {"reference_spatial_export", "two_numeric_16_word_matrices_only"},
        {"guest_payload_read",
-        "bounded_320_bytes_plus_direct_vtable_words_per_cache_miss"},
+        "bounded_320_bytes_plus_direct_and_16_word_nested_vtable_census_per_"
+        "cache_miss"},
        {"guest_state_changed", "false"},
        {"control_flow_changed", "false"},
        {"native_admission", "false"},

--- a/tools/summarize-native-renderer-c1-c2-batch.py
+++ b/tools/summarize-native-renderer-c1-c2-batch.py
@@ -9,7 +9,7 @@ import sys
 
 SCHEMA = "pinyon-shift.native-renderer-c1-c2-batch.v1"
 INPUT_SCHEMAS = {
-    "track": "pinyon-shift.native-renderer-track-model-runtime-join.v4",
+    "track": "pinyon-shift.native-renderer-track-model-runtime-join.v5",
     "presentation": (
         "pinyon-shift.native-renderer-track-presentation-passes.v1"
     ),

--- a/tools/summarize-native-renderer-track-model-runtime-join.py
+++ b/tools/summarize-native-renderer-track-model-runtime-join.py
@@ -7,7 +7,7 @@ import pathlib
 import sys
 
 
-SCHEMA = "pinyon-shift.native-renderer-track-model-runtime-join.v4"
+SCHEMA = "pinyon-shift.native-renderer-track-model-runtime-join.v5"
 CONFIG = "native_renderer.discovery.track_render_model_runtime_join_config"
 SUMMARY = "native_renderer.discovery.track_render_model_runtime_join_summary"
 CHECKPOINT = (
@@ -38,6 +38,9 @@ WORLD_RELATIONS = (
 
 SHARED_WORLD_RELATIONS = tuple(
     f"shared_{relation}" for relation in WORLD_RELATIONS
+)
+NESTED_WORLD_RELATIONS = tuple(
+    f"nested_{relation}" for relation in WORLD_RELATIONS
 )
 POINTEE_RELATIONS = (
     "track_model",
@@ -173,7 +176,8 @@ def build(events, requested_session=None, allow_checkpoint=False):
             "82144E64"
         ),
         "world_resource_graph": (
-            "host_mapped_direct_child_or_descriptor_pointer_with_exact_rtti_vtable"
+            "host_mapped_direct_or_one_level_nested_child_or_descriptor_pointer_"
+            "with_exact_track_rtti_vtable"
         ),
         "world_resource_shared_identity": (
             "exact_address_equality_to_submission_objects_or_resources"
@@ -181,7 +185,8 @@ def build(events, requested_session=None, allow_checkpoint=False):
         "world_resource_graph_cache_capacity": "1024",
         "world_resource_reference_capacity": "16",
         "guest_payload_read": (
-            "bounded_320_bytes_plus_direct_vtable_words_per_cache_miss"
+            "bounded_320_bytes_plus_direct_and_16_word_nested_vtable_census_per_"
+            "cache_miss"
         ),
     }
     if any(config.get(key) != value for key, value in expected_config.items()):
@@ -238,6 +243,7 @@ def build(events, requested_session=None, allow_checkpoint=False):
         "scope_overlaps",
         "exit_without_entry",
         "world_resource_graph_scopes",
+        "world_resource_nested_graph_scopes",
         "world_resource_graph_cache_hits",
         "world_resource_graph_cache_misses",
         "world_resource_graph_reference_overflow",
@@ -245,6 +251,7 @@ def build(events, requested_session=None, allow_checkpoint=False):
         "world_resource_shared_identity_joins",
         *RELATIONS,
         *WORLD_RELATIONS,
+        *NESTED_WORLD_RELATIONS,
         *SHARED_WORLD_RELATIONS,
     )
     totals = {key: integer(summary, key) for key in keys}
@@ -354,6 +361,11 @@ def build(events, requested_session=None, allow_checkpoint=False):
         failures.append("world-resource graph cache accounting drifted")
     if totals["world_resource_graph_scopes"] > totals["exact_scopes"]:
         failures.append("world-resource graph scopes exceed exact scopes")
+    if (
+        totals["world_resource_nested_graph_scopes"]
+        > totals["world_resource_graph_scopes"]
+    ):
+        failures.append("nested world-resource scopes exceed graph scopes")
     if totals["world_resource_graph_reference_overflow"]:
         failures.append("world-resource graph reference overflow is nonzero")
     if totals["world_resource_graph_scopes"] and not any(
@@ -365,6 +377,15 @@ def build(events, requested_session=None, allow_checkpoint=False):
         for key in WORLD_RELATIONS
     ):
         failures.append("world-resource graph relation exceeds graph scopes")
+    if totals["world_resource_nested_graph_scopes"] and not any(
+        totals[key] for key in NESTED_WORLD_RELATIONS
+    ):
+        failures.append("nested world-resource relation accounting is empty")
+    if any(
+        totals[key] > totals["world_resource_nested_graph_scopes"]
+        for key in NESTED_WORLD_RELATIONS
+    ):
+        failures.append("nested world-resource relation exceeds nested scopes")
     if (
         totals["world_resource_shared_identity_joins"]
         > totals["submission_joins"]
@@ -409,6 +430,9 @@ def build(events, requested_session=None, allow_checkpoint=False):
         "world_resource_relations": {
             key: totals[key] for key in WORLD_RELATIONS
         },
+        "nested_world_resource_relations": {
+            key: totals[key] for key in NESTED_WORLD_RELATIONS
+        },
         "shared_world_resource_relations": {
             key: totals[key] for key in SHARED_WORLD_RELATIONS
         },
@@ -425,6 +449,10 @@ def build(events, requested_session=None, allow_checkpoint=False):
             ),
             "track_world_resource_graph_identity_proved": (
                 not failures and totals["world_resource_graph_scopes"] > 0
+            ),
+            "nested_track_world_resource_graph_identity_proved": (
+                not failures
+                and totals["world_resource_nested_graph_scopes"] > 0
             ),
             "track_world_resource_to_submission_identity_proved": (
                 not failures

--- a/tools/tests/test_native_renderer_track_model_runtime_join.py
+++ b/tools/tests/test_native_renderer_track_model_runtime_join.py
@@ -51,7 +51,8 @@ def fixture(shared=3):
             "82144E64"
         ),
         world_resource_graph=(
-            "host_mapped_direct_child_or_descriptor_pointer_with_exact_rtti_vtable"
+            "host_mapped_direct_or_one_level_nested_child_or_descriptor_pointer_"
+            "with_exact_track_rtti_vtable"
         ),
         world_resource_shared_identity=(
             "exact_address_equality_to_submission_objects_or_resources"
@@ -59,7 +60,8 @@ def fixture(shared=3):
         world_resource_graph_cache_capacity="1024",
         world_resource_reference_capacity="16",
         guest_payload_read=(
-            "bounded_320_bytes_plus_direct_vtable_words_per_cache_miss"
+            "bounded_320_bytes_plus_direct_and_16_word_nested_vtable_census_per_"
+            "cache_miss"
         ),
         **safety(),
     )
@@ -68,9 +70,13 @@ def fixture(shared=3):
     shared_world_relations = {
         key: "0" for key in MODULE.SHARED_WORLD_RELATIONS
     }
+    nested_world_relations = {
+        key: "0" for key in MODULE.NESTED_WORLD_RELATIONS
+    }
     if shared:
         relations["shared_descriptor_payload_bound_resource"] = str(shared)
         world_relations["world_track_mesh"] = "6"
+        nested_world_relations["nested_world_track_mesh"] = "4"
         shared_world_relations["shared_world_track_mesh"] = str(shared)
     relations["shared_command_lineage"] = "24"
     summary = event(
@@ -96,6 +102,7 @@ def fixture(shared=3):
         command_prepared_draw_joins_without_semantic_origin="15",
         shared_identity_joins=str(shared),
         world_resource_graph_scopes="6" if shared else "0",
+        world_resource_nested_graph_scopes="4" if shared else "0",
         world_resource_graph_cache_hits="8",
         world_resource_graph_cache_misses="2",
         world_resource_graph_reference_overflow="0",
@@ -114,6 +121,7 @@ def fixture(shared=3):
         classification="exact_track_scope_to_indirect_command_packet_to_prepared_draw",
         **relations,
         **world_relations,
+        **nested_world_relations,
         **shared_world_relations,
         **safety(),
     )
@@ -121,7 +129,7 @@ def fixture(shared=3):
 
 
 class TrackModelRuntimeJoinTests(unittest.TestCase):
-    def test_runtime_census_is_bounded_and_observation_only(self):
+    def test_runtime_census_promotes_only_exact_nested_track_identity(self):
         source = (ROOT / "src/native_renderer/graphics_hooks.cpp").read_text(
             encoding="utf-8"
         )
@@ -132,7 +140,8 @@ class TrackModelRuntimeJoinTests(unittest.TestCase):
         census = source.split("void CensusTrackWorldPointees", 1)[1].split(
             "void AddTrackWorldResourceReference", 1
         )[0]
-        self.assertNotIn("identity_mask", census)
+        self.assertIn("ClassifyTrackWorldResourceVtable(nested_vtable)", census)
+        self.assertIn("kTrackWorldResourceNestedPointer", census)
 
     def test_qualifies_scope_and_shared_identity(self):
         document = MODULE.build(fixture())
@@ -153,6 +162,17 @@ class TrackModelRuntimeJoinTests(unittest.TestCase):
             ]
         )
         self.assertTrue(document["world_pointee_census"]["available"])
+        self.assertTrue(
+            document["qualification"][
+                "nested_track_world_resource_graph_identity_proved"
+            ]
+        )
+        self.assertEqual(
+            4,
+            document["nested_world_resource_relations"][
+                "nested_world_track_mesh"
+            ],
+        )
         self.assertEqual(
             1,
             document["world_pointee_census"]["nested_relations"][


### PR DESCRIPTION
## Summary
- retain exact one-level nested CTrack/procedural/PVS identities in the bounded world graph
- report direct and nested provenance independently through track-model schema v5
- keep SimpleModel census evidence diagnostic and native admission/Xenos authority unchanged

## Validation
- Release pinyon_shift target built successfully
- python -m unittest discover -s tools/tests -p 'test_*.py' (681 tests)
- AppData qualification intentionally deferred to the next meaningful C1 batch