### PR TITLE
feat(native-renderer): join nested track identity to layouts

### DIFF
--- a/docs/native-renderer/REPRIORITIZED_PLAN.md
+++ b/docs/native-renderer/REPRIORITIZED_PLAN.md
@@ -668,6 +668,15 @@ without enabling native admission, suppression, or changing Xenos authority.
 Runtime qualification is intentionally deferred to the next meaningful C1
 batch.
 
+Nested prepared-lineage implementation checkpoint: nested track-resource masks
+now survive the exact context, deferred packet, active indirect buffer, and
+prepared-layout path. Prepared-layout schema v2 reports both the complete
+world-resource mask and its nested subset, then qualifies per-class nested
+identity only when the same bounded draw layout reaches a prepared draw. This
+closes the instrumentation hop needed to select exact mesh/submodel-owned C1
+layouts after the next batched run; it still changes no native admission or
+output behavior.
+
 ### C2. Static world buildings and props
 
 - Expand opaque-world material and geometry coverage.

--- a/docs/native-renderer/TERRAIN_ROAD_RENDER_PATH.md
+++ b/docs/native-renderer/TERRAIN_ROAD_RENDER_PATH.md
@@ -408,3 +408,14 @@ prepared-draw lineage. It does not infer terrain or road visual identity,
 enable native admission, suppress Xenos work, or change output authority. The
 next batched AppData qualification must observe nonzero nested graph scopes
 with complete accounting before this boundary can guide isolated replay.
+
+The nested subset is also retained across deferred command construction. It is
+copied from the accepted render-model scope into the command context, packet
+provenance, active indirect buffer, command-lineage record, and bounded
+prepared-layout entry. The layout key includes both the complete resource mask
+and its nested subset so changing ownership cannot coalesce unrelated layouts.
+Track prepared-layout schema v2 reports per-class nested layout and call
+frequency and exposes a separate
+`nested_track_world_to_prepared_layout_proved` result. This is the exact gate
+for choosing the first nested mesh/submodel isolated replay candidate in the
+next AppData batch, not permission to admit or suppress it before that run.

--- a/src/native_renderer/graphics_hooks.cpp
+++ b/src/native_renderer/graphics_hooks.cpp
@@ -1111,6 +1111,8 @@ struct TrackWorldPreparedLayoutEntry {
   uint32_t track_render_child_address = 0;
   uint32_t track_render_descriptor_address = 0;
   uint32_t track_render_descriptor_payload = 0;
+  uint32_t track_world_resource_identity_mask = 0;
+  uint32_t track_world_resource_nested_identity_mask = 0;
   uint32_t bound_render_target_bits = 0;
   std::array<uint32_t, 5> bound_render_target_formats{};
   uint32_t prepared_pipeline_flags = 0;
@@ -1210,6 +1212,7 @@ struct TitleIndirectPacketEntry {
   uint32_t track_render_descriptor_address = 0;
   uint32_t track_render_descriptor_payload = 0;
   uint32_t track_world_resource_identity_mask = 0;
+  uint32_t track_world_resource_nested_identity_mask = 0;
   uint32_t track_presentation_pass_mask = 0;
   uint64_t submission_sequence = 0;
   bool constructor_origin_known = false;
@@ -1239,6 +1242,7 @@ struct IndirectConstructorOrigin {
         uint32_t track_render_descriptor_address = 0;
         uint32_t track_render_descriptor_payload = 0;
         uint32_t track_world_resource_identity_mask = 0;
+        uint32_t track_world_resource_nested_identity_mask = 0;
         uint32_t track_presentation_pass_mask = 0;
         bool semantic_receiver_known = false;
         bool track_command_lineage = false;
@@ -8987,6 +8991,8 @@ void PushIndirectContextOrigin(uint32_t function_address,
           track_scope.descriptor_payload;
       context.track_world_resource_identity_mask =
           track_scope.world_resource_identity_mask;
+      context.track_world_resource_nested_identity_mask =
+          track_scope.world_resource_nested_identity_mask;
       context.track_command_lineage = true;
       ++track_scope.command_context_bridges;
       g_track_render_model_context_bridges.fetch_add(
@@ -9366,6 +9372,8 @@ void RecordTitleIndirectPacket(uint32_t packet_guest_address,
       origin.owner.producer.context.track_render_descriptor_payload;
   entry.track_world_resource_identity_mask =
       origin.owner.producer.context.track_world_resource_identity_mask;
+  entry.track_world_resource_nested_identity_mask =
+      origin.owner.producer.context.track_world_resource_nested_identity_mask;
   const uint32_t presentation_construction_mask =
       CurrentTrackPresentationPassMask();
   // The title may defer consuming an indirect packet until after its exact
@@ -9503,6 +9511,9 @@ void ObserveIndirectBuffer(
     active.constructor_origin.owner.producer.context
         .track_world_resource_identity_mask =
         matched.track_world_resource_identity_mask;
+    active.constructor_origin.owner.producer.context
+        .track_world_resource_nested_identity_mask =
+        matched.track_world_resource_nested_identity_mask;
     active.constructor_origin.owner.producer.context
         .track_presentation_pass_mask = matched.track_presentation_pass_mask;
     active.constructor_origin.owner.producer.context.semantic_receiver_known =
@@ -11143,6 +11154,7 @@ struct CommandBufferLineageEntry {
   uint32_t track_render_descriptor_address = 0;
   uint32_t track_render_descriptor_payload = 0;
   uint32_t track_world_resource_identity_mask = 0;
+  uint32_t track_world_resource_nested_identity_mask = 0;
   uint32_t track_presentation_pass_mask = 0;
   uint32_t depth = 0;
   bool constructor_origin_known = false;
@@ -16623,6 +16635,11 @@ void EmitTrackWorldPreparedLayoutEntries() {
           fmt::format("{:08X}", entry.track_render_descriptor_address)},
          {"track_render_descriptor_payload",
           fmt::format("{:08X}", entry.track_render_descriptor_payload)},
+         {"track_world_resource_identity_mask",
+          fmt::format("{:08X}", entry.track_world_resource_identity_mask)},
+         {"track_world_resource_nested_identity_mask",
+          fmt::format("{:08X}",
+                      entry.track_world_resource_nested_identity_mask)},
          {"calls", std::to_string(entry.calls)},
          {"first_frame", std::to_string(entry.first_frame)},
          {"last_frame", std::to_string(entry.last_frame)},
@@ -17108,6 +17125,10 @@ void RecordPreparedCommandBufferLineage(
                      .track_command_lineage),
         uint64_t(constructor_origin.owner.producer.context
                      .track_render_root_address),
+        uint64_t(constructor_origin.owner.producer.context
+                     .track_world_resource_identity_mask),
+        uint64_t(constructor_origin.owner.producer.context
+                     .track_world_resource_nested_identity_mask),
         uint64_t(observation.command_buffer_depth)}) {
     key = HashCombine(key, value);
   }
@@ -17193,6 +17214,9 @@ void RecordPreparedCommandBufferLineage(
       entry.track_world_resource_identity_mask =
           constructor_origin.owner.producer.context
               .track_world_resource_identity_mask;
+      entry.track_world_resource_nested_identity_mask =
+          constructor_origin.owner.producer.context
+              .track_world_resource_nested_identity_mask;
       entry.track_presentation_pass_mask =
           constructor_origin.owner.producer.context
               .track_presentation_pass_mask;
@@ -17227,6 +17251,12 @@ void RecordPreparedCommandBufferLineage(
         entry.track_render_root_address ==
             constructor_origin.owner.producer.context
                 .track_render_root_address &&
+        entry.track_world_resource_identity_mask ==
+            constructor_origin.owner.producer.context
+                .track_world_resource_identity_mask &&
+        entry.track_world_resource_nested_identity_mask ==
+            constructor_origin.owner.producer.context
+                .track_world_resource_nested_identity_mask &&
         entry.track_presentation_pass_mask ==
             constructor_origin.owner.producer.context
                 .track_presentation_pass_mask &&
@@ -17497,6 +17527,11 @@ void EmitCommandBufferLineageSummary() {
           entry.track_command_lineage
               ? fmt::format("{:08X}",
                             entry.track_world_resource_identity_mask)
+              : "unknown"},
+         {"track_world_resource_nested_identity_mask",
+          entry.track_command_lineage
+              ? fmt::format(
+                    "{:08X}", entry.track_world_resource_nested_identity_mask)
               : "unknown"},
          {"track_command_lineage_classification",
           entry.track_command_lineage
@@ -19438,6 +19473,8 @@ void RecordTrackWorldPreparedLayout(
         uint64_t(context.track_render_child_address),
         uint64_t(context.track_render_descriptor_address),
         uint64_t(context.track_render_descriptor_payload),
+        uint64_t(context.track_world_resource_identity_mask),
+        uint64_t(context.track_world_resource_nested_identity_mask),
         contract.prepared_pipeline_hash, contract.geometry_layout_hash,
         contract.texture_layout_hash, contract.render_state_hash}) {
     key = HashCombine(key, value);
@@ -19460,6 +19497,10 @@ void RecordTrackWorldPreparedLayout(
           context.track_render_descriptor_address;
       entry.track_render_descriptor_payload =
           context.track_render_descriptor_payload;
+      entry.track_world_resource_identity_mask =
+          context.track_world_resource_identity_mask;
+      entry.track_world_resource_nested_identity_mask =
+          context.track_world_resource_nested_identity_mask;
       entry.bound_render_target_bits = prepared.bound_render_target_bits;
       std::copy(std::begin(prepared.bound_render_target_formats),
                 std::end(prepared.bound_render_target_formats),
@@ -19478,6 +19519,10 @@ void RecordTrackWorldPreparedLayout(
             context.track_render_descriptor_address &&
         entry.track_render_descriptor_payload ==
             context.track_render_descriptor_payload &&
+        entry.track_world_resource_identity_mask ==
+            context.track_world_resource_identity_mask &&
+        entry.track_world_resource_nested_identity_mask ==
+            context.track_world_resource_nested_identity_mask &&
         entry.bound_render_target_bits == prepared.bound_render_target_bits &&
         std::equal(entry.bound_render_target_formats.begin(),
                    entry.bound_render_target_formats.end(),

--- a/tools/classify-native-renderer-track-prepared-transforms.py
+++ b/tools/classify-native-renderer-track-prepared-transforms.py
@@ -13,7 +13,7 @@ import sys
 
 
 SCHEMA = "pinyon-shift.native-renderer-track-prepared-transform-classification.v1"
-PREPARED_SCHEMA = "pinyon-shift.native-renderer-track-prepared-layout.v1"
+PREPARED_SCHEMA = "pinyon-shift.native-renderer-track-prepared-layout.v2"
 CATALOG_SCHEMA = "pinyon-shift.native-renderer-static-world-instance-catalog.v1"
 DEFAULT_TOLERANCE = 0.05
 DEFAULT_MINIMUM_MATCHES = 8

--- a/tools/summarize-native-renderer-track-prepared-layout.py
+++ b/tools/summarize-native-renderer-track-prepared-layout.py
@@ -11,9 +11,18 @@ import struct
 import sys
 
 
-SCHEMA = "pinyon-shift.native-renderer-track-prepared-layout.v1"
+SCHEMA = "pinyon-shift.native-renderer-track-prepared-layout.v2"
 ENTRY = "native_renderer.discovery.track_world_prepared_layout_entry"
 SUMMARY = "native_renderer.discovery.track_render_model_runtime_join_summary"
+TRACK_WORLD_IDENTITIES = (
+    "track_model",
+    "track_mesh",
+    "track_submodel",
+    "procedural_geometry_object",
+    "procedural_geometry_resource",
+    "pvs_zone_object",
+    "pvs_zone_resource",
+)
 
 
 def read_events(paths):
@@ -161,6 +170,11 @@ def build(events, requested_session=None):
     pixel_frequency = {}
     vertex_shader_frequency = {}
     target_shape_frequency = {}
+    nested_identity_frequency = {
+        name: {"layouts": 0, "calls": 0} for name in TRACK_WORLD_IDENTITIES
+    }
+    nested_identity_layouts = 0
+    nested_identity_calls = 0
     candidate_runs = []
     for event in entries:
         require_safety(event)
@@ -200,12 +214,39 @@ def build(events, requested_session=None):
             "track_render_descriptor_payload",
         ):
             hexadecimal(event.get(address_key, ""), 8, address_key)
+        resource_identity_mask = int(
+            hexadecimal(
+                event.get("track_world_resource_identity_mask", ""),
+                8,
+                "track world resource identity mask",
+            ),
+            16,
+        )
+        nested_identity_mask = int(
+            hexadecimal(
+                event.get("track_world_resource_nested_identity_mask", ""),
+                8,
+                "track world nested resource identity mask",
+            ),
+            16,
+        )
+        if nested_identity_mask & ~resource_identity_mask:
+            raise ValueError("nested track identity exceeds resource identity")
+        if resource_identity_mask & ~((1 << len(TRACK_WORLD_IDENTITIES)) - 1):
+            raise ValueError("unknown track world resource identity")
         calls = integer(event, "calls")
         first_frame = integer(event, "first_frame")
         last_frame = integer(event, "last_frame")
         if not calls or first_frame > last_frame:
             raise ValueError("invalid track prepared layout lifetime")
         entry_calls += calls
+        if nested_identity_mask:
+            nested_identity_layouts += 1
+            nested_identity_calls += calls
+        for bit, name in enumerate(TRACK_WORLD_IDENTITIES):
+            if nested_identity_mask & (1 << bit):
+                nested_identity_frequency[name]["layouts"] += 1
+                nested_identity_frequency[name]["calls"] += calls
         shader_item = vertex_shader_frequency.setdefault(
             vertex_shader, {"layouts": 0, "calls": 0}
         )
@@ -317,9 +358,17 @@ def build(events, requested_session=None):
                 item["bound_render_target_formats"],
             ),
         ),
+        "nested_track_world_identity": {
+            "layouts": nested_identity_layouts,
+            "calls": nested_identity_calls,
+            "relations": nested_identity_frequency,
+        },
         "vertex_consecutive_register_runs": candidate_runs,
         "qualification": {
             "exact_track_prepared_layouts_proved": not failures,
+            "nested_track_world_to_prepared_layout_proved": (
+                not failures and nested_identity_calls > 0
+            ),
             "color_target_layout_observed": any(
                 bits & 2 for bits, _ in target_shape_frequency
             ),

--- a/tools/tests/test_native_renderer_track_prepared_layout.py
+++ b/tools/tests/test_native_renderer_track_prepared_layout.py
@@ -38,6 +38,8 @@ def fixture():
         track_render_child="10000010",
         track_render_descriptor="10000020",
         track_render_descriptor_payload="10000030",
+        track_world_resource_identity_mask="00000006",
+        track_world_resource_nested_identity_mask="00000006",
         calls="12",
         first_frame="100",
         last_frame="110",
@@ -87,6 +89,17 @@ class TrackPreparedLayoutTests(unittest.TestCase):
         self.assertTrue(
             document["qualification"]["color_target_layout_observed"]
         )
+        self.assertTrue(
+            document["qualification"][
+                "nested_track_world_to_prepared_layout_proved"
+            ]
+        )
+        self.assertEqual(
+            12,
+            document["nested_track_world_identity"]["relations"][
+                "track_mesh"
+            ]["calls"],
+        )
         self.assertEqual(
             "color_only", document["render_target_shape_frequency"][0]["shape"]
         )
@@ -107,6 +120,12 @@ class TrackPreparedLayoutTests(unittest.TestCase):
         self.assertIn(
             "prepared layout call accounting drifted", document["failures"]
         )
+
+    def test_rejects_nested_identity_outside_resource_mask(self):
+        events = fixture()
+        events[1]["track_world_resource_identity_mask"] = "00000002"
+        with self.assertRaisesRegex(ValueError, "nested track identity exceeds"):
+            MODULE.build(events)
 
     def test_runtime_census_is_shutdown_only_and_observation_only(self):
         source = (ROOT / "src/native_renderer/graphics_hooks.cpp").read_text(


### PR DESCRIPTION
## Summary
- carry the exact nested track-resource mask through deferred packet provenance
- separate ownership changes in command and prepared-layout keys
- report per-class nested prepared-layout frequency in schema v2

## Safety
- native admission and suppression remain disabled
- Xenos remains authoritative
- no save or AppData data was touched

## Validation
- Release pinyon_shift target built successfully
- 682 Python tests passed
- runtime qualification remains batched with the preceding C1 slice