### PR TITLE
fix(native-renderer): bound nested track references

### DIFF
--- a/docs/native-renderer/REPRIORITIZED_PLAN.md
+++ b/docs/native-renderer/REPRIORITIZED_PLAN.md
@@ -654,7 +654,7 @@ semantic mesh/world-section ingress instead of tracing deeper through either
 presentation shadow route. No native draw or suppression was admitted.
 
 Combined-report compatibility checkpoint: the C1/C2 join now consumes the
-current track-model v5 and continuous-workset v7 schemas. This repairs report
+current track-model v6 and continuous-workset v7 schemas. This repairs report
 composition only; every incomplete component remains fail closed.
 
 Nested world-identity implementation checkpoint: the bounded one-level
@@ -676,6 +676,18 @@ identity only when the same bounded draw layout reaches a prepared draw. This
 closes the instrumentation hop needed to select exact mesh/submodel-owned C1
 layouts after the next batched run; it still changes no native admission or
 output behavior.
+
+Nested prepared-lineage runtime result: clean AppData session
+`20260901T062819Z-p15356` reached the saved festival and exited normally. All
+2,574 bounded prepared draws carried exact nested `CTrackSubModel` ownership;
+2,526 also carried `CTrackMesh`, across 730 layouts with zero geometry,
+parameter, or table faults. Every joined target was depth-only. This proves the
+semantic mesh/submodel-to-prepared hop but classifies this command route as a
+track-owned depth/shadow family, not the missing opaque color world. The run
+also exposed 72 retained-reference overflows at the original 16-entry bound.
+The reference store is now independently raised to 64 while the 16-root scan
+bound remains unchanged, and schema v6 reports its high-water mark and makes
+any overflow fail the runtime status itself.
 
 ### C2. Static world buildings and props
 

--- a/docs/native-renderer/TERRAIN_ROAD_RENDER_PATH.md
+++ b/docs/native-renderer/TERRAIN_ROAD_RENDER_PATH.md
@@ -419,3 +419,19 @@ frequency and exposes a separate
 `nested_track_world_to_prepared_layout_proved` result. This is the exact gate
 for choosing the first nested mesh/submodel isolated replay candidate in the
 next AppData batch, not permission to admit or suppress it before that run.
+
+Clean AppData session `20260901T062819Z-p15356` proved the retained identity
+survives that full path: 2,574 exact bounded prepared draws carried nested
+`CTrackSubModel`, 2,526 also carried nested `CTrackMesh`, and no prepared-layout
+geometry, parameter, or table bound failed. All 2,574 draws were depth-only.
+The route is therefore exact track-owned shadow/depth work and is closed as an
+opaque terrain/road color lead.
+
+Promoting nested references also showed that the old 16-entry reference store
+was smaller than the already-bounded census: 72 additions overflowed across
+222 cache misses. The retained-reference capacity is now 64, independent from
+the unchanged 16-root and 16-word-prefix scan bounds. A reported high-water
+mark proves actual demand, and any remaining overflow makes the runtime event
+itself incomplete instead of leaving that mismatch solely to the offline
+qualifier. This capacity correction does not expand the guest-memory scan or
+change rendering behavior.

--- a/docs/native-renderer/TRACK_WORLD_PREPARED_LAYOUT.md
+++ b/docs/native-renderer/TRACK_WORLD_PREPARED_LAYOUT.md
@@ -49,6 +49,9 @@ lists vertex/pixel float-constant register frequency and maximal runs of at
 least four consecutive finite vertex registers. The extended report groups
 the exact backend target bitmask and five formats by layout and call count so
 depth-only, color-only, paired, and unusual attachment shapes remain distinct.
+Schema v2 additionally carries the complete track-world identity mask and its
+exact nested subset into each layout, reports per-class layout/call frequency,
+and rejects a nested identity outside the owning scope's complete mask.
 
 The checked-in catalog classifier then evaluates every four-register window
 under both plausible title matrix conventions:
@@ -70,6 +73,16 @@ positions cannot qualify it.
 These runs are candidates, not transforms. Terrain/road identity, native
 admission, publication, and suppression remain unproved and disabled unless a
 single mapping passes the full catalog contract.
+
+## Nested-identity runtime result
+
+Clean session `20260901T062819Z-p15356` retained 730 exact layouts across 2,574
+prepared calls. Every call carried nested `CTrackSubModel`; 2,526 also carried
+nested `CTrackMesh`. Geometry and parameters remained bounded and the layout
+table did not overflow. Every joined target was depth-only, so the report now
+pivots this exact family away from opaque-world color ingress. It remains
+useful shadow/depth evidence but cannot establish visible terrain or road
+coverage.
 
 ## First runtime result
 

--- a/src/native_renderer/graphics_hooks.cpp
+++ b/src/native_renderer/graphics_hooks.cpp
@@ -249,7 +249,8 @@ constexpr uint32_t kTrackProceduralGeometryObjectVtable = 0x82144CF8;
 constexpr uint32_t kTrackProceduralGeometryResourceVtable = 0x82144D7C;
 constexpr uint32_t kTrackPvsZoneObjectVtable = 0x82144DE0;
 constexpr uint32_t kTrackPvsZoneResourceVtable = 0x82144E64;
-constexpr size_t kTrackWorldResourceIdentityCapacity = 16;
+constexpr size_t kTrackWorldPointeeRootCapacity = 16;
+constexpr size_t kTrackWorldResourceReferenceCapacity = 64;
 constexpr size_t kTrackWorldResourceGraphCacheCapacity = 1024;
 constexpr size_t kTrackWorldPointeePrefixWords = 16;
 constexpr size_t kTrackWorldPointeeIdentityCount = 14;
@@ -2597,7 +2598,7 @@ struct TrackWorldResourceGraphCacheEntry {
   uint32_t nested_identity_mask = 0;
   uint32_t reference_count = 0;
   std::array<TrackWorldResourceReference,
-             kTrackWorldResourceIdentityCapacity>
+             kTrackWorldResourceReferenceCapacity>
       references{};
 };
 
@@ -2614,7 +2615,7 @@ struct TrackRenderModelDispatchScope {
   uint32_t world_resource_shared_identity_mask = 0;
   uint32_t world_resource_reference_count = 0;
   std::array<TrackWorldResourceReference,
-             kTrackWorldResourceIdentityCapacity>
+             kTrackWorldResourceReferenceCapacity>
       world_resource_references{};
   bool active = false;
   bool exact = false;
@@ -2815,6 +2816,7 @@ thread_local PendingTrackWorldReferenceSpatial
 std::atomic<uint64_t> g_track_world_resource_graph_cache_hits{};
 std::atomic<uint64_t> g_track_world_resource_graph_cache_misses{};
 std::atomic<uint64_t> g_track_world_resource_graph_reference_overflow{};
+std::atomic<uint64_t> g_track_world_resource_graph_reference_high_watermark{};
 std::atomic<uint64_t> g_track_world_resource_graph_host_unmapped_rejections{};
 std::atomic<uint64_t> g_track_world_resource_graph_scopes{};
 std::atomic<uint64_t> g_track_world_resource_nested_graph_scopes{};
@@ -3688,7 +3690,7 @@ void CensusTrackWorldPointees(rex::memory::Memory *memory,
                               const std::array<uint32_t, N> &words,
                               TrackWorldResourceGraphCacheEntry &entry) {
   ++g_track_world_pointee_graph_samples;
-  std::array<uint32_t, kTrackWorldResourceIdentityCapacity> roots{};
+  std::array<uint32_t, kTrackWorldPointeeRootCapacity> roots{};
   size_t root_count = 0;
   for (uint32_t address : words) {
     uint32_t vtable = 0;
@@ -3768,6 +3770,15 @@ void AddTrackWorldResourceReference(
       .identity = identity,
       .provenance = provenance,
   };
+  uint64_t observed_high_watermark =
+      g_track_world_resource_graph_reference_high_watermark.load(
+          std::memory_order_relaxed);
+  while (observed_high_watermark < entry.reference_count &&
+         !g_track_world_resource_graph_reference_high_watermark
+              .compare_exchange_weak(observed_high_watermark,
+                                     entry.reference_count,
+                                     std::memory_order_relaxed)) {
+  }
 }
 
 template <size_t N>
@@ -13527,7 +13538,9 @@ void EmitTrackRenderModelRuntimeJoinEvent(const char *event_name,
       g_track_render_model_prepared_draw_joins.load(
           std::memory_order_relaxed) &&
       !invalid_child && !invalid_descriptor &&
-      !contract_mismatches;
+      !contract_mismatches &&
+      !g_track_world_resource_graph_reference_overflow.load(
+          std::memory_order_relaxed);
   const uint64_t prepared_layout_observations =
       g_track_world_prepared_layout_observations.load(
           std::memory_order_relaxed);
@@ -13722,6 +13735,10 @@ void EmitTrackRenderModelRuntimeJoinEvent(const char *event_name,
        {"world_resource_graph_reference_overflow",
         std::to_string(g_track_world_resource_graph_reference_overflow.load(
             std::memory_order_relaxed))},
+       {"world_resource_graph_reference_high_watermark",
+        std::to_string(
+            g_track_world_resource_graph_reference_high_watermark.load(
+                std::memory_order_relaxed))},
        {"world_resource_graph_host_unmapped_rejections",
         std::to_string(
             g_track_world_resource_graph_host_unmapped_rejections.load(
@@ -30181,7 +30198,10 @@ void InstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system,
        {"world_resource_shared_identity",
         "exact_address_equality_to_submission_objects_or_resources"},
        {"world_resource_graph_cache_capacity", "1024"},
-       {"world_resource_reference_capacity", "16"},
+       {"world_resource_reference_capacity",
+        std::to_string(kTrackWorldResourceReferenceCapacity)},
+       {"world_pointee_root_capacity",
+        std::to_string(kTrackWorldPointeeRootCapacity)},
        {"scope_spatial_capacity",
         std::to_string(kTrackWorldScopeSpatialCapacity)},
        {"scope_spatial_words", "child_16_descriptor_62"},

--- a/tools/summarize-native-renderer-c1-c2-batch.py
+++ b/tools/summarize-native-renderer-c1-c2-batch.py
@@ -9,7 +9,7 @@ import sys
 
 SCHEMA = "pinyon-shift.native-renderer-c1-c2-batch.v1"
 INPUT_SCHEMAS = {
-    "track": "pinyon-shift.native-renderer-track-model-runtime-join.v5",
+    "track": "pinyon-shift.native-renderer-track-model-runtime-join.v6",
     "presentation": (
         "pinyon-shift.native-renderer-track-presentation-passes.v1"
     ),

--- a/tools/summarize-native-renderer-track-model-runtime-join.py
+++ b/tools/summarize-native-renderer-track-model-runtime-join.py
@@ -7,7 +7,7 @@ import pathlib
 import sys
 
 
-SCHEMA = "pinyon-shift.native-renderer-track-model-runtime-join.v5"
+SCHEMA = "pinyon-shift.native-renderer-track-model-runtime-join.v6"
 CONFIG = "native_renderer.discovery.track_render_model_runtime_join_config"
 SUMMARY = "native_renderer.discovery.track_render_model_runtime_join_summary"
 CHECKPOINT = (
@@ -183,7 +183,8 @@ def build(events, requested_session=None, allow_checkpoint=False):
             "exact_address_equality_to_submission_objects_or_resources"
         ),
         "world_resource_graph_cache_capacity": "1024",
-        "world_resource_reference_capacity": "16",
+        "world_resource_reference_capacity": "64",
+        "world_pointee_root_capacity": "16",
         "guest_payload_read": (
             "bounded_320_bytes_plus_direct_and_16_word_nested_vtable_census_per_"
             "cache_miss"
@@ -247,6 +248,7 @@ def build(events, requested_session=None, allow_checkpoint=False):
         "world_resource_graph_cache_hits",
         "world_resource_graph_cache_misses",
         "world_resource_graph_reference_overflow",
+        "world_resource_graph_reference_high_watermark",
         "world_resource_graph_host_unmapped_rejections",
         "world_resource_shared_identity_joins",
         *RELATIONS,
@@ -368,6 +370,13 @@ def build(events, requested_session=None, allow_checkpoint=False):
         failures.append("nested world-resource scopes exceed graph scopes")
     if totals["world_resource_graph_reference_overflow"]:
         failures.append("world-resource graph reference overflow is nonzero")
+    if totals["world_resource_graph_reference_high_watermark"] > 64:
+        failures.append("world-resource graph reference capacity drifted")
+    if (
+        totals["world_resource_graph_scopes"]
+        and not totals["world_resource_graph_reference_high_watermark"]
+    ):
+        failures.append("world-resource graph reference watermark is empty")
     if totals["world_resource_graph_scopes"] and not any(
         totals[key] for key in WORLD_RELATIONS
     ):

--- a/tools/summarize-native-renderer-track-prepared-layout.py
+++ b/tools/summarize-native-renderer-track-prepared-layout.py
@@ -378,8 +378,13 @@ def build(events, requested_session=None):
             "suppression_allowed": False,
         },
         "next_step": (
-            "correlate exact target shapes with the adjacent unified track "
-            "presentation pass census before extending opaque-pass lineage"
+            "pivot away from this exact depth-only family and locate the "
+            "semantic color-world ingress"
+            if nested_identity_calls
+            and not any(bits & 2 for bits, _ in target_shape_frequency)
+            else "correlate exact target shapes with the adjacent unified "
+            "track presentation pass census before extending opaque-pass "
+            "lineage"
         ),
         "safety": {
             "guest_state_changed": False,

--- a/tools/tests/test_native_renderer_track_model_runtime_join.py
+++ b/tools/tests/test_native_renderer_track_model_runtime_join.py
@@ -58,7 +58,8 @@ def fixture(shared=3):
             "exact_address_equality_to_submission_objects_or_resources"
         ),
         world_resource_graph_cache_capacity="1024",
-        world_resource_reference_capacity="16",
+        world_resource_reference_capacity="64",
+        world_pointee_root_capacity="16",
         guest_payload_read=(
             "bounded_320_bytes_plus_direct_and_16_word_nested_vtable_census_per_"
             "cache_miss"
@@ -106,6 +107,7 @@ def fixture(shared=3):
         world_resource_graph_cache_hits="8",
         world_resource_graph_cache_misses="2",
         world_resource_graph_reference_overflow="0",
+        world_resource_graph_reference_high_watermark="24" if shared else "0",
         world_resource_graph_host_unmapped_rejections="3",
         world_pointee_graph_samples="4",
         world_pointee_direct_hits="2",
@@ -134,6 +136,8 @@ class TrackModelRuntimeJoinTests(unittest.TestCase):
             encoding="utf-8"
         )
         self.assertIn("kTrackWorldPointeePrefixWords = 16", source)
+        self.assertIn("kTrackWorldPointeeRootCapacity = 16", source)
+        self.assertIn("kTrackWorldResourceReferenceCapacity = 64", source)
         self.assertIn("CensusTrackWorldPointees", source)
         self.assertIn("world_pointee_direct_relations", source)
         self.assertIn("world_pointee_nested_relations", source)
@@ -257,6 +261,15 @@ class TrackModelRuntimeJoinTests(unittest.TestCase):
         document = MODULE.build(events)
         self.assertIn(
             "nested world-pointee relation accounting drifted",
+            document["failures"],
+        )
+
+    def test_rejects_reference_watermark_beyond_capacity(self):
+        events = fixture()
+        events[-1]["world_resource_graph_reference_high_watermark"] = "65"
+        document = MODULE.build(events)
+        self.assertIn(
+            "world-resource graph reference capacity drifted",
             document["failures"],
         )
 

--- a/tools/tests/test_native_renderer_track_prepared_layout.py
+++ b/tools/tests/test_native_renderer_track_prepared_layout.py
@@ -127,6 +127,15 @@ class TrackPreparedLayoutTests(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "nested track identity exceeds"):
             MODULE.build(events)
 
+    def test_pivots_nested_depth_only_family_from_color_ingress(self):
+        events = fixture()
+        events[1]["bound_render_target_bits"] = "00000001"
+        document = MODULE.build(events)
+        self.assertFalse(
+            document["qualification"]["color_target_layout_observed"]
+        )
+        self.assertIn("pivot away", document["next_step"])
+
     def test_runtime_census_is_shutdown_only_and_observation_only(self):
         source = (ROOT / "src/native_renderer/graphics_hooks.cpp").read_text(
             encoding="utf-8"


### PR DESCRIPTION
## Summary
- raise retained exact world references from 16 to 64 without expanding the 16-root/16-word guest scan
- report reference high-water demand and make overflow fail runtime qualification directly
- record the clean batch result: nested track mesh/submodel lineage is proved but depth-only, closing it as an opaque color lead

## Runtime evidence
- clean AppData session 20260901T062819Z-p15356, normal exit
- 2,574 exact bounded prepared calls; 2,526 nested CTrackMesh and 2,574 nested CTrackSubModel calls
- all targets depth-only; zero prepared geometry, parameter, or table faults
- 72 retained-reference overflows at the previous 16-entry bound

## Validation
- Release pinyon_shift target built successfully
- 684 Python tests passed
- Xenos authority preserved; no native admission or suppression