### PR TITLE
feat(native-renderer): rank track presentation call paths

### DIFF
--- a/docs/native-renderer/REPRIORITIZED_PLAN.md
+++ b/docs/native-renderer/REPRIORITIZED_PLAN.md
@@ -689,6 +689,19 @@ The reference store is now independently raised to 64 while the 16-root scan
 bound remains unchanged, and schema v6 reports its high-water mark and makes
 any overflow fail the runtime status itself.
 
+Complete presentation-callgraph checkpoint: a payload-free six-edge static
+trace now inventories all 135 exact unified track-presentation wrapper slots.
+Only slots 75, 78, 79, and 80 directly reach the track dispatcher, unified
+track-mesh helper, and indexed-draw emitter. The complete saved-festival runtime
+census observed only 79 and 80; both are already proved 1024x1024 depth-only
+shadow routes. Slots 75 and 78 were inactive, and the other 61 static
+candidates terminate at unclassified indirect boundaries without a known
+graphics sink. This closes the exact presentation surface as the missing C1
+opaque-color ingress for this scene. The next visible-world slice must select a
+separate live color producer; no further hook is added beneath this shadow
+family. The reproducible inventory is documented in
+[`TERRAIN_ROAD_RENDER_PATH.md`](TERRAIN_ROAD_RENDER_PATH.md).
+
 ### C2. Static world buildings and props
 
 - Expand opaque-world material and geometry coverage.

--- a/docs/native-renderer/TERRAIN_ROAD_RENDER_PATH.md
+++ b/docs/native-renderer/TERRAIN_ROAD_RENDER_PATH.md
@@ -398,8 +398,10 @@ RTTI-backed track, procedural-geometry, and PVS-zone classes accepted by the
 direct world-resource classifier may enter the graph. `CSimpleModelRenderer`,
 `CSimpleModelResource`, model-presentation, and the remaining SimpleModel
 family continue to be counted for investigation but cannot establish C1 track
-ownership. References are still deduplicated inside the existing 16-entry
-cache record, with overflow and host-mapping failures visible in the report.
+ownership. References are deduplicated inside the independently bounded
+64-entry cache record, while the guest-memory census remains limited to 16
+roots and 16 words per root. Overflow and host-mapping failures stay visible
+in the report.
 
 Track-model report schema v5 separates nested graph scopes and per-class
 relations from direct graph evidence. This proves where the identity came from
@@ -435,3 +437,36 @@ mark proves actual demand, and any remaining overflow makes the runtime event
 itself incomplete instead of leaving that mismatch solely to the offline
 qualifier. This capacity correction does not expand the guest-memory scan or
 change rendering behavior.
+
+## Complete track-presentation callgraph inventory
+
+`tools/discover-native-renderer-track-presentation-callgraph.py` now traces all
+135 exact runtime wrapper-vtable slots through the generated AOT direct-call
+graph. The analysis is payload-free and bounded to six call edges. It ranks
+shortest paths to the known track dispatcher, command context, unified track
+mesh helper, procedural/simple-model helpers, and indexed-draw emitter, while
+reporting reachable indirect-call boundaries separately. It makes no runtime
+activity or color-target claim.
+
+Against the locked retail image and generated corpus, only slots 75, 78, 79,
+and 80 have a direct path to the track dispatcher and unified track-mesh draw.
+The earlier complete runtime presentation census observed only slots 79 and 80
+in the saved festival. Their packet, prepared-draw, and target lineage is
+already closed as 1024x1024 depth-only shadow work. Slots 75 and 78 were
+inactive in that census, so static reachability cannot promote them.
+
+This closes the exact unified track-presentation surface as the missing opaque
+terrain/road color ingress for the representative scene. The remaining 61
+static candidates reach only indirect dispatch boundaries and have neither a
+known graphics sink nor runtime activity. They remain investigation leads, not
+admission candidates. C1 therefore stays focused on a separate live color-world
+producer instead of adding another hook beneath the known shadow family.
+
+The inventory can be reproduced without launching the game:
+
+```powershell
+python tools/discover-native-renderer-track-presentation-callgraph.py `
+  .local/generated/default `
+  --image .local/analysis/default-image.bin `
+  --output .local/qualification/native-renderer-track-presentation-callgraph.json
+```

--- a/tools/discover-native-renderer-track-presentation-callgraph.py
+++ b/tools/discover-native-renderer-track-presentation-callgraph.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+"""Rank exact unified track-presentation slots by graphics call paths."""
+
+from __future__ import annotations
+
+import argparse
+import collections
+import json
+import pathlib
+import re
+import sys
+
+
+SCHEMA = "pinyon-shift.native-renderer-track-presentation-callgraph.v1"
+IMAGE_BASE = 0x82000000
+UNIFIED_VTABLE = 0x82243774
+WRAPPER_VTABLE = 0x82003CCC
+SLOT_COUNT = 135
+MAXIMUM_DEPTH = 6
+FUNCTION_RE = re.compile(r"^DEFINE_REX_FUNC\(sub_([0-9A-F]{8})\) \{")
+CALL_RE = re.compile(r"\bsub_([0-9A-F]{8})\(ctx, base\)")
+SINKS = {
+    0x82416380: "direct_indexed_draw",
+    0x82436468: "track_dispatcher",
+    0x824365B0: "track_command_context",
+    0x82417BC0: "procedural_model_dispatch",
+    0x82C4CCC8: "simple_model_renderer",
+    0x82C5ADC0: "unified_track_mesh_draw",
+}
+
+
+def image_u32(image: bytes, address: int) -> int:
+    offset = address - IMAGE_BASE
+    if offset < 0 or offset + 4 > len(image):
+        raise ValueError(f"image address is out of range: {address:08X}")
+    return int.from_bytes(image[offset : offset + 4], "big")
+
+
+def read_vtable(image: bytes, address: int) -> list[int]:
+    return [image_u32(image, address + 4 * slot) for slot in range(SLOT_COUNT)]
+
+
+def parse_generated(paths: list[pathlib.Path]):
+    graph = collections.defaultdict(set)
+    indirect_calls = collections.Counter()
+    current = None
+    for path in sorted(paths, key=lambda item: item.as_posix()):
+        for line in path.read_text(encoding="utf-8").splitlines():
+            match = FUNCTION_RE.match(line)
+            if match:
+                current = int(match.group(1), 16)
+                graph[current]
+                continue
+            if current is None:
+                continue
+            graph[current].update(int(value, 16) for value in CALL_RE.findall(line))
+            if "REX_CALL_INDIRECT_FUNC" in line:
+                indirect_calls[current] += 1
+    return {key: tuple(sorted(value)) for key, value in graph.items()}, indirect_calls
+
+
+def trace(source: int, graph, indirect_calls):
+    queue = collections.deque([(source, (source,))])
+    visited = {source}
+    sink_paths = {}
+    reachable_indirect_calls = 0
+    while queue:
+        address, path = queue.popleft()
+        reachable_indirect_calls += indirect_calls.get(address, 0)
+        if address in SINKS and address != source:
+            sink_paths.setdefault(SINKS[address], path)
+        if len(path) > MAXIMUM_DEPTH:
+            continue
+        for target in graph.get(address, ()):
+            if target in visited:
+                continue
+            visited.add(target)
+            queue.append((target, (*path, target)))
+    return {
+        "reachable_function_count": len(visited),
+        "reachable_indirect_calls": reachable_indirect_calls,
+        "sink_paths": {
+            name: [f"{address:08X}" for address in path]
+            for name, path in sorted(sink_paths.items())
+        },
+    }
+
+
+def build(graph, indirect_calls, unified_slots, wrapper_slots):
+    if len(unified_slots) != SLOT_COUNT or len(wrapper_slots) != SLOT_COUNT:
+        raise ValueError("track-presentation vtable length drifted")
+    rows = []
+    for slot, (unified, wrapper) in enumerate(zip(unified_slots, wrapper_slots)):
+        evidence = trace(wrapper, graph, indirect_calls)
+        rows.append(
+            {
+                "slot": slot,
+                "unified_target": f"{unified:08X}",
+                "wrapper_target": f"{wrapper:08X}",
+                "wrapper_matches_unified": wrapper == unified,
+                **evidence,
+            }
+        )
+    candidates = [
+        row
+        for row in rows
+        if row["sink_paths"] or row["reachable_indirect_calls"]
+    ]
+    candidates.sort(
+        key=lambda row: (
+            not bool(row["sink_paths"]),
+            min(
+                (len(path) for path in row["sink_paths"].values()),
+                default=UINT_MAX,
+            ),
+            -row["reachable_indirect_calls"],
+            row["slot"],
+        )
+    )
+    return {
+        "schema": SCHEMA,
+        "status": "complete",
+        "maximum_call_depth": MAXIMUM_DEPTH,
+        "slot_count": SLOT_COUNT,
+        "candidate_count": len(candidates),
+        "sinks": {f"{address:08X}": name for address, name in SINKS.items()},
+        "candidates": candidates,
+        "slots": rows,
+        "qualification": {
+            "exact_runtime_wrapper_vtable_enumerated": True,
+            "direct_static_graphics_paths_ranked": True,
+            "runtime_activity_proved": False,
+            "color_target_proved": False,
+            "native_admission": False,
+            "suppression_allowed": False,
+        },
+        "safety": {
+            "static_analysis_only": True,
+            "guest_payload_exported": False,
+            "runtime_hook_enabled": False,
+            "xenos_authority_required": True,
+        },
+    }
+
+
+UINT_MAX = (1 << 63) - 1
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("generated_root", type=pathlib.Path)
+    parser.add_argument("--image", required=True, type=pathlib.Path)
+    parser.add_argument("--output", required=True, type=pathlib.Path)
+    args = parser.parse_args(argv)
+    try:
+        paths = list(args.generated_root.glob("pinyon_shift_recomp.*.cpp"))
+        if not paths:
+            raise ValueError("no generated AOT C++ files found")
+        graph, indirect_calls = parse_generated(paths)
+        image = args.image.read_bytes()
+        document = build(
+            graph,
+            indirect_calls,
+            read_vtable(image, UNIFIED_VTABLE),
+            read_vtable(image, WRAPPER_VTABLE),
+        )
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(
+            json.dumps(document, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        return 0
+    except (OSError, UnicodeDecodeError, ValueError) as error:
+        print(f"track-presentation callgraph discovery failed: {error}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/tests/test_native_renderer_track_presentation_callgraph.py
+++ b/tools/tests/test_native_renderer_track_presentation_callgraph.py
@@ -1,0 +1,52 @@
+import importlib.util
+import pathlib
+import tempfile
+import unittest
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+TOOL = ROOT / "tools/discover-native-renderer-track-presentation-callgraph.py"
+SPEC = importlib.util.spec_from_file_location("track_presentation_callgraph", TOOL)
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+class TrackPresentationCallgraphTests(unittest.TestCase):
+    def test_parses_direct_and_indirect_calls(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path = pathlib.Path(directory) / "pinyon_shift_recomp.0.cpp"
+            path.write_text(
+                "DEFINE_REX_FUNC(sub_82000010) {\n"
+                "  sub_82000020(ctx, base);\n"
+                "  REX_CALL_INDIRECT_FUNC(ctx.ctr.u32);\n"
+                "}\n"
+                "DEFINE_REX_FUNC(sub_82000020) {\n}\n",
+                encoding="utf-8",
+            )
+            graph, indirect = MODULE.parse_generated([path])
+        self.assertEqual((0x82000020,), graph[0x82000010])
+        self.assertEqual(1, indirect[0x82000010])
+
+    def test_ranks_shortest_exact_sink_path(self):
+        wrapper_slots = [0x82000010] * MODULE.SLOT_COUNT
+        unified_slots = list(wrapper_slots)
+        graph = {
+            0x82000010: (0x82000020,),
+            0x82000020: (0x82416380,),
+            0x82416380: (),
+        }
+        document = MODULE.build(graph, {}, unified_slots, wrapper_slots)
+        self.assertEqual("complete", document["status"])
+        self.assertEqual(
+            ["82000010", "82000020", "82416380"],
+            document["candidates"][0]["sink_paths"]["direct_indexed_draw"],
+        )
+        self.assertFalse(document["qualification"]["runtime_activity_proved"])
+
+    def test_rejects_incomplete_vtable(self):
+        with self.assertRaisesRegex(ValueError, "vtable length"):
+            MODULE.build({}, {}, [0], [0])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- inventory all 135 exact unified track-presentation wrapper slots through a bounded static AOT callgraph
- rank known graphics sinks and preserve indirect-only candidates without runtime or color claims
- close the observed presentation surface as an opaque-color lead and pivot C1 to a separate live producer

## Validation
- python -m unittest tools.tests.test_native_renderer_track_presentation_callgraph
- python -m unittest discover -s tools/tests -p 'test_*.py' (687 tests)
- reproduced the retail inventory: 135 slots, 65 candidates, 4 known-sink candidates