### PR TITLE
feat(native-renderer): rank live color producer lineage

### DIFF
--- a/docs/native-renderer/COLOR_PRODUCER_LINEAGE.md
+++ b/docs/native-renderer/COLOR_PRODUCER_LINEAGE.md
@@ -1,0 +1,60 @@
+# Live color-producer lineage
+
+Status: bounded runtime census implemented; qualification deferred to the next
+batched AppData run
+
+## Why this is the next ingress
+
+The complete unified track-presentation inventory closes the only live exact
+slots in the representative festival as depth-only shadow work. The broader
+command-buffer lineage already resolves title packet construction through
+constructor, owner, producer, and context functions, including exact
+`proceduralGeometry::CProceduralModels` receiver lifetime and preparation
+identity at context `82417BC0`.
+
+Historical captures contain a stable mechanically eligible color signature
+under that procedural-model producer, but those color and lineage artifacts
+were collected in different sessions. Their stable hashes are useful for
+selecting the boundary, not for proving a current runtime join. No cross-session
+frequency or shader match is promoted to semantic evidence.
+
+## Bounded target-shape census
+
+Every existing command-lineage aggregate now partitions its prepared draws
+into exact attachment shapes:
+
+- depth only;
+- first color only;
+- first color plus depth; and
+- any other target shape.
+
+Color activity is further counted as opaque, bounded, or sampling a resolved
+input. The first color sample retains only prepared signature, shader hashes,
+attachment formats, pipeline flags, target registers, and scissor state. A
+variation bit records whether later color draws differ from that sample. No
+guest payload, shader bytecode, texture data, or camera data is exported, and
+the existing 4,096-entry lineage capacity is unchanged.
+
+`tools/summarize-native-renderer-color-producer-lineage.py` requires one armed
+target-shape config, one final lineage summary, a clean shutdown, zero lineage
+faults or overflow, complete per-entry target accounting, and exact samples for
+every color-bearing aggregate. It ranks exact semantic receivers first, then
+opaque, bounded, and total color activity. Ranking is investigation evidence;
+it cannot enable native admission or suppression.
+
+Run the deferred qualifier after the next combined AppData capture:
+
+```powershell
+python tools/summarize-native-renderer-color-producer-lineage.py `
+  <session-log.jsonl> `
+  --session <session> `
+  --output .local/qualification/native-renderer-color-producer-lineage.json
+```
+
+## Promotion gate
+
+The next C1 implementation may follow one ranked origin only when the same
+clean session proves nonzero bounded opaque color draws, complete lineage
+accounting, and either exact semantic receiver identity or a separately proved
+title-owned world identity. Until then, Xenos remains authoritative and this
+census changes no rendering or control flow.

--- a/docs/native-renderer/REPRIORITIZED_PLAN.md
+++ b/docs/native-renderer/REPRIORITIZED_PLAN.md
@@ -702,6 +702,18 @@ separate live color producer; no further hook is added beneath this shadow
 family. The reproducible inventory is documented in
 [`TERRAIN_ROAD_RENDER_PATH.md`](TERRAIN_ROAD_RENDER_PATH.md).
 
+Live color-producer implementation checkpoint: the already-balanced command-
+buffer lineage now partitions every origin aggregate into depth-only,
+color-only, color-plus-depth, and other prepared-target activity. It separately
+counts opaque, bounded, and resolved-input color draws and retains one bounded
+numeric target/shader sample with variation accounting. A fail-closed offline
+ranker requires one clean session and exact reconciliation with the final
+lineage summary. Historical evidence makes exact procedural-model context
+`82417BC0` the first lead, but because its lineage and color samples came from
+different sessions, that is boundary selection rather than proof. The next
+combined AppData run will rank the live color producer without another broad
+hook pass. See [`COLOR_PRODUCER_LINEAGE.md`](COLOR_PRODUCER_LINEAGE.md).
+
 ### C2. Static world buildings and props
 
 - Expand opaque-world material and geometry coverage.

--- a/src/native_renderer/graphics_hooks.cpp
+++ b/src/native_renderer/graphics_hooks.cpp
@@ -11120,7 +11120,16 @@ uint64_t g_candidate_prepared_without_observation_count = 0;
 
 struct CommandBufferLineageEntry {
   uint64_t sample_prepared_signature = 0;
+  uint64_t sample_color_prepared_signature = 0;
   uint64_t calls = 0;
+  uint64_t depth_only_draws = 0;
+  uint64_t color_only_draws = 0;
+  uint64_t color_depth_draws = 0;
+  uint64_t other_target_draws = 0;
+  uint64_t other_color_draws = 0;
+  uint64_t opaque_color_draws = 0;
+  uint64_t bounded_color_draws = 0;
+  uint64_t resolved_input_color_draws = 0;
   uint64_t first_frame = 0;
   uint64_t last_frame = 0;
   uint64_t first_draw = 0;
@@ -11167,6 +11176,16 @@ struct CommandBufferLineageEntry {
   uint32_t track_world_resource_identity_mask = 0;
   uint32_t track_world_resource_nested_identity_mask = 0;
   uint32_t track_presentation_pass_mask = 0;
+  uint64_t sample_color_vertex_shader = 0;
+  uint64_t sample_color_pixel_shader = 0;
+  uint32_t sample_color_bound_render_target_bits = 0;
+  std::array<uint32_t, 5> sample_color_bound_render_target_formats{};
+  uint32_t sample_color_prepared_pipeline_flags = 0;
+  uint32_t sample_color_surface_info = 0;
+  std::array<uint32_t, 4> sample_color_info{};
+  uint32_t sample_color_depth_info = 0;
+  uint32_t sample_color_window_scissor_tl = 0;
+  uint32_t sample_color_window_scissor_br = 0;
   uint32_t depth = 0;
   bool constructor_origin_known = false;
   bool owner_origin_known = false;
@@ -11176,6 +11195,8 @@ struct CommandBufferLineageEntry {
   bool track_command_lineage = false;
   bool semantic_preparation_epoch_varied = false;
   bool prepared_signature_varied = false;
+  bool sample_color_known = false;
+  bool color_sample_varied = false;
 };
 
 std::array<CommandBufferLineageEntry, kCommandBufferLineageCapacity>
@@ -17103,9 +17124,71 @@ void ObserveCommandBufferLineage(
   }
 }
 
+bool IsOpaqueColorState(
+    const rex::system::GraphicsDrawObservation &observation);
+
+void AccumulateCommandBufferTargetShape(
+    CommandBufferLineageEntry &entry, uint64_t prepared_signature,
+    const rex::system::GraphicsDrawObservation &observation,
+    bool samples_resolved_target,
+    const rex::system::GraphicsPreparedDrawObservation &prepared) {
+  switch (prepared.bound_render_target_bits) {
+  case 1:
+    ++entry.depth_only_draws;
+    break;
+  case 2:
+    ++entry.color_only_draws;
+    break;
+  case 3:
+    ++entry.color_depth_draws;
+    break;
+  default:
+    ++entry.other_target_draws;
+    entry.other_color_draws +=
+        (prepared.bound_render_target_bits & 2) ? 1 : 0;
+    break;
+  }
+  if (!(prepared.bound_render_target_bits & 2)) {
+    return;
+  }
+  entry.opaque_color_draws += IsOpaqueColorState(observation) ? 1 : 0;
+  entry.resolved_input_color_draws += samples_resolved_target ? 1 : 0;
+  const bool bounded =
+      !observation.vertex_binding_overflow &&
+      !observation.vertex_attribute_overflow &&
+      !observation.vertex_float_constant_overflow &&
+      !observation.pixel_float_constant_overflow &&
+      !observation.texture_state_overflow && (prepared.flags & 3) == 3;
+  entry.bounded_color_draws += bounded ? 1 : 0;
+  if (entry.sample_color_known) {
+    entry.color_sample_varied |=
+        entry.sample_color_prepared_signature != prepared_signature;
+    return;
+  }
+  entry.sample_color_known = true;
+  entry.sample_color_prepared_signature = prepared_signature;
+  entry.sample_color_vertex_shader = observation.vertex_shader_hash;
+  entry.sample_color_pixel_shader = observation.pixel_shader_hash;
+  entry.sample_color_bound_render_target_bits =
+      prepared.bound_render_target_bits;
+  std::copy(std::begin(prepared.bound_render_target_formats),
+            std::end(prepared.bound_render_target_formats),
+            entry.sample_color_bound_render_target_formats.begin());
+  entry.sample_color_prepared_pipeline_flags = prepared.flags;
+  entry.sample_color_surface_info = observation.surface_info;
+  std::copy(std::begin(observation.color_info),
+            std::end(observation.color_info),
+            entry.sample_color_info.begin());
+  entry.sample_color_depth_info = observation.depth_info;
+  entry.sample_color_window_scissor_tl = observation.window_scissor_tl;
+  entry.sample_color_window_scissor_br = observation.window_scissor_br;
+}
+
 void RecordPreparedCommandBufferLineage(
     uint64_t prepared_signature,
-    const rex::system::GraphicsDrawObservation &observation) {
+    const rex::system::GraphicsDrawObservation &observation,
+    bool samples_resolved_target,
+    const rex::system::GraphicsPreparedDrawObservation &prepared) {
   if (!HasValidCommandBufferLineage(observation)) {
     return;
   }
@@ -17240,6 +17323,9 @@ void RecordPreparedCommandBufferLineage(
       entry.track_command_lineage = constructor_origin.owner.producer.context
                                         .track_command_lineage;
       entry.depth = observation.command_buffer_depth;
+      AccumulateCommandBufferTargetShape(
+          entry, prepared_signature, observation, samples_resolved_target,
+          prepared);
       ++g_command_buffer_lineage_entry_count;
       return;
     }
@@ -17309,6 +17395,9 @@ void RecordPreparedCommandBufferLineage(
                    parent_root_offset_bytes);
       entry.prepared_signature_varied |=
           entry.sample_prepared_signature != prepared_signature;
+      AccumulateCommandBufferTargetShape(
+          entry, prepared_signature, observation, samples_resolved_target,
+          prepared);
       if (entry.constructor_origin_known && constructor_origin.valid) {
         for (size_t argument = 0;
              argument < entry.sample_constructor_arguments.size(); ++argument) {
@@ -17373,6 +17462,66 @@ void EmitCommandBufferLineageSummary() {
           fmt::format("{:016X}", entry.sample_prepared_signature)},
          {"prepared_signature_varied",
           entry.prepared_signature_varied ? "true" : "false"},
+         {"depth_only_draws", std::to_string(entry.depth_only_draws)},
+         {"color_only_draws", std::to_string(entry.color_only_draws)},
+         {"color_depth_draws", std::to_string(entry.color_depth_draws)},
+         {"other_target_draws", std::to_string(entry.other_target_draws)},
+         {"other_color_draws", std::to_string(entry.other_color_draws)},
+         {"opaque_color_draws", std::to_string(entry.opaque_color_draws)},
+         {"bounded_color_draws", std::to_string(entry.bounded_color_draws)},
+         {"resolved_input_color_draws",
+          std::to_string(entry.resolved_input_color_draws)},
+         {"sample_color_prepared_signature",
+          entry.sample_color_known
+              ? fmt::format("{:016X}",
+                            entry.sample_color_prepared_signature)
+              : "none"},
+         {"color_sample_varied",
+          entry.color_sample_varied ? "true" : "false"},
+         {"sample_color_vertex_shader",
+          entry.sample_color_known
+              ? fmt::format("{:016X}", entry.sample_color_vertex_shader)
+              : "none"},
+         {"sample_color_pixel_shader",
+          entry.sample_color_known
+              ? fmt::format("{:016X}", entry.sample_color_pixel_shader)
+              : "none"},
+         {"sample_color_bound_render_target_bits",
+          entry.sample_color_known
+              ? fmt::format(
+                    "{:08X}", entry.sample_color_bound_render_target_bits)
+              : "none"},
+         {"sample_color_bound_render_target_formats",
+          entry.sample_color_known
+              ? fmt::format(
+                    "{}:{}:{}:{}:{}",
+                    entry.sample_color_bound_render_target_formats[0],
+                    entry.sample_color_bound_render_target_formats[1],
+                    entry.sample_color_bound_render_target_formats[2],
+                    entry.sample_color_bound_render_target_formats[3],
+                    entry.sample_color_bound_render_target_formats[4])
+              : "none"},
+         {"sample_color_prepared_pipeline_flags",
+          entry.sample_color_known
+              ? fmt::format("{:08X}",
+                            entry.sample_color_prepared_pipeline_flags)
+              : "none"},
+         {"sample_color_target_state",
+          entry.sample_color_known
+              ? fmt::format("{:08X}:{:08X}:{:08X}:{:08X}:{:08X}:{:08X}",
+                            entry.sample_color_surface_info,
+                            entry.sample_color_info[0],
+                            entry.sample_color_info[1],
+                            entry.sample_color_info[2],
+                            entry.sample_color_info[3],
+                            entry.sample_color_depth_info)
+              : "none"},
+         {"sample_color_scissor",
+          entry.sample_color_known
+              ? fmt::format("{:08X}:{:08X}",
+                            entry.sample_color_window_scissor_tl,
+                            entry.sample_color_window_scissor_br)
+              : "none"},
          {"calls", std::to_string(entry.calls)},
          {"first_frame", std::to_string(entry.first_frame)},
          {"last_frame", std::to_string(entry.last_frame)},
@@ -24306,7 +24455,9 @@ void ObservePreparedDraw(
         sample, g_pending_candidate.samples_resolved_target, observation);
     const SemanticPreparedDrawContract prepared_semantic_contract =
         BuildSemanticPreparedDrawContract(sample, observation);
-    RecordPreparedCommandBufferLineage(prepared_signature, sample);
+    RecordPreparedCommandBufferLineage(
+        prepared_signature, sample,
+        g_pending_candidate.samples_resolved_target, observation);
     RecordTitleDrawProvenance(prepared_signature, true, 0, sample,
                               g_pending_candidate.title_origin,
                               &observation);
@@ -29912,8 +30063,9 @@ void InstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system,
         "producer_return,producer_r3-r10,context_function,context_return,"
         "context_r3-r10,context_root,semantic_receiver_generation,"
         "semantic_visibility_epoch,semantic_render_state_epoch,"
-        "backend_packet,"
+        "backend_packet,prepared_target_shape,"
         "current_buffer,parent_packet,root_buffer,depth"},
+       {"prepared_target_shape_census", "bounded_aggregate_v1"},
        {"guest_payload_read", "false"},
        {"guest_state_changed", "false"},
        {"control_flow_changed", "false"},

--- a/tools/summarize-native-renderer-color-producer-lineage.py
+++ b/tools/summarize-native-renderer-color-producer-lineage.py
@@ -1,0 +1,210 @@
+#!/usr/bin/env python3
+"""Rank live command-buffer origins by prepared color-target activity."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import pathlib
+import sys
+
+
+SCHEMA = "pinyon-shift.native-renderer-color-producer-lineage.v1"
+CONFIG = "native_renderer.discovery.command_buffer_lineage_config"
+ENTRY = "native_renderer.discovery.command_buffer_lineage_entry"
+SUMMARY = "native_renderer.discovery.command_buffer_lineage_summary"
+SHUTDOWN = "process.shutdown"
+
+
+def integer(event, name):
+    try:
+        return int(event[name], 10)
+    except (KeyError, TypeError, ValueError) as error:
+        raise ValueError(f"invalid {name}") from error
+
+
+def exact_address(event, name):
+    value = event.get(name)
+    if value == "unknown":
+        return None
+    if not isinstance(value, str) or len(value) != 8:
+        raise ValueError(f"invalid {name}")
+    int(value, 16)
+    return value
+
+
+def read_events(path, session):
+    events = []
+    for line_number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+        if not line.strip():
+            continue
+        try:
+            event = json.loads(line)
+        except json.JSONDecodeError as error:
+            raise ValueError(f"invalid JSON at line {line_number}") from error
+        if event.get("session") == session:
+            events.append(event)
+    return events
+
+
+def build(events, session):
+    configs = [event for event in events if event.get("event") == CONFIG]
+    summaries = [event for event in events if event.get("event") == SUMMARY]
+    entries = [event for event in events if event.get("event") == ENTRY]
+    shutdowns = [event for event in events if event.get("event") == SHUTDOWN]
+    failures = []
+    if len(configs) != 1:
+        failures.append("expected one command-lineage config")
+    elif configs[0].get("prepared_target_shape_census") != "bounded_aggregate_v1":
+        failures.append("prepared target-shape census was not armed")
+    if len(summaries) != 1:
+        failures.append("expected one command-lineage summary")
+    if len(shutdowns) != 1:
+        failures.append("clean process shutdown was not observed")
+    if not summaries:
+        return document(session, failures, [], {})
+
+    summary = summaries[0]
+    expected_entries = integer(summary, "entries")
+    prepared_draws = integer(summary, "prepared_draws")
+    if expected_entries != len(entries):
+        failures.append("entry count does not match command-lineage summary")
+    for name in ("invalid_lineages", "overflow", "indirect_buffer_stack_faults",
+                 "indirect_draw_stack_faults", "indirect_constructor_stack_faults",
+                 "indirect_constructor_owner_mismatches", "indirect_owner_stack_faults",
+                 "indirect_owner_producer_mismatches", "indirect_producer_stack_faults",
+                 "indirect_producer_context_mismatches", "indirect_context_stack_faults"):
+        if integer(summary, name):
+            failures.append(f"nonzero {name}")
+
+    rows = []
+    observed_draws = 0
+    for event in entries:
+        calls = integer(event, "calls")
+        depth_only = integer(event, "depth_only_draws")
+        color_only = integer(event, "color_only_draws")
+        color_depth = integer(event, "color_depth_draws")
+        other = integer(event, "other_target_draws")
+        other_color = integer(event, "other_color_draws")
+        opaque = integer(event, "opaque_color_draws")
+        bounded = integer(event, "bounded_color_draws")
+        resolved = integer(event, "resolved_input_color_draws")
+        color = color_only + color_depth + other_color
+        observed_draws += calls
+        if depth_only + color_only + color_depth + other != calls:
+            failures.append("entry target-shape accounting is incomplete")
+        if opaque > color or bounded > color or resolved > color:
+            failures.append("entry color counters exceed color draws")
+        if other_color > other:
+            failures.append("entry other-color counter exceeds other targets")
+        sample = event.get("sample_color_prepared_signature")
+        if color and (not isinstance(sample, str) or len(sample) != 16):
+            failures.append("color entry lacks an exact prepared sample")
+        if not color:
+            continue
+        row = {
+            "calls": calls,
+            "color_draws": color,
+            "color_only_draws": color_only,
+            "color_depth_draws": color_depth,
+            "other_color_draws": other_color,
+            "depth_only_draws": depth_only,
+            "other_target_draws": other,
+            "opaque_color_draws": opaque,
+            "bounded_color_draws": bounded,
+            "resolved_input_color_draws": resolved,
+            "color_share": round(color / calls, 6) if calls else 0.0,
+            "constructor_function": exact_address(event, "constructor_function_address"),
+            "owner_function": exact_address(event, "owner_function_address"),
+            "producer_function": exact_address(event, "producer_function_address"),
+            "context_function": exact_address(event, "context_function_address"),
+            "semantic_receiver_class": event.get("semantic_receiver_class"),
+            "semantic_receiver_exact": event.get("semantic_receiver_class") != "unknown",
+            "track_command_lineage": event.get("track_command_lineage") == "true",
+            "sample_color_prepared_signature": sample,
+            "color_sample_varied": event.get("color_sample_varied") == "true",
+            "sample_color_vertex_shader": event.get("sample_color_vertex_shader"),
+            "sample_color_pixel_shader": event.get("sample_color_pixel_shader"),
+            "sample_color_bound_render_target_bits": event.get(
+                "sample_color_bound_render_target_bits"
+            ),
+            "sample_color_bound_render_target_formats": event.get(
+                "sample_color_bound_render_target_formats"
+            ),
+            "sample_color_prepared_pipeline_flags": event.get(
+                "sample_color_prepared_pipeline_flags"
+            ),
+            "sample_color_target_state": event.get("sample_color_target_state"),
+            "sample_color_scissor": event.get("sample_color_scissor"),
+        }
+        rows.append(row)
+    if observed_draws != prepared_draws:
+        failures.append("entry draws do not match prepared-draw summary")
+    rows.sort(
+        key=lambda row: (
+            not row["semantic_receiver_exact"],
+            -row["opaque_color_draws"],
+            -row["bounded_color_draws"],
+            -row["color_draws"],
+            row["context_function"] or "FFFFFFFF",
+        )
+    )
+    totals = {
+        "entries": len(entries),
+        "prepared_draws": prepared_draws,
+        "color_candidates": len(rows),
+        "color_draws": sum(row["color_draws"] for row in rows),
+        "opaque_color_draws": sum(row["opaque_color_draws"] for row in rows),
+        "bounded_color_draws": sum(row["bounded_color_draws"] for row in rows),
+        "semantic_color_candidates": sum(
+            1 for row in rows if row["semantic_receiver_exact"]
+        ),
+    }
+    return document(session, failures, rows, totals)
+
+
+def document(session, failures, candidates, totals):
+    complete = not failures
+    return {
+        "schema": SCHEMA,
+        "session": session,
+        "status": "complete" if complete else "incomplete",
+        "failures": failures,
+        "totals": totals,
+        "candidates": candidates,
+        "qualification": {
+            "runtime_target_shape_accounting_proved": complete,
+            "live_color_producers_ranked": complete and bool(candidates),
+            "semantic_color_candidate_observed": complete
+            and any(row["semantic_receiver_exact"] for row in candidates),
+            "native_admission": False,
+            "suppression_allowed": False,
+        },
+        "safety": {
+            "guest_payload_exported": False,
+            "guest_state_changed": False,
+            "control_flow_changed": False,
+            "native_draw": False,
+            "xenos_authority": True,
+        },
+    }
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("log", type=pathlib.Path)
+    parser.add_argument("--session", required=True)
+    parser.add_argument("--output", required=True, type=pathlib.Path)
+    args = parser.parse_args(argv)
+    try:
+        result = build(read_events(args.log, args.session), args.session)
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(json.dumps(result, indent=2, sort_keys=True) + "\n")
+        return 0 if result["status"] == "complete" else 1
+    except (OSError, UnicodeDecodeError, ValueError) as error:
+        print(f"color-producer lineage summary failed: {error}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/tests/test_native_renderer_color_producer_lineage.py
+++ b/tools/tests/test_native_renderer_color_producer_lineage.py
@@ -1,0 +1,90 @@
+import importlib.util
+import pathlib
+import unittest
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+TOOL = ROOT / "tools/summarize-native-renderer-color-producer-lineage.py"
+SPEC = importlib.util.spec_from_file_location("color_producer_lineage", TOOL)
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+def fixture():
+    session = "session"
+    common = {"session": session}
+    config = {
+        **common,
+        "event": MODULE.CONFIG,
+        "prepared_target_shape_census": "bounded_aggregate_v1",
+    }
+    entry = {
+        **common,
+        "event": MODULE.ENTRY,
+        "calls": "12",
+        "depth_only_draws": "2",
+        "color_only_draws": "8",
+        "color_depth_draws": "2",
+        "other_target_draws": "0",
+        "other_color_draws": "0",
+        "opaque_color_draws": "9",
+        "bounded_color_draws": "10",
+        "resolved_input_color_draws": "0",
+        "constructor_function_address": "82416A00",
+        "owner_function_address": "824167F8",
+        "producer_function_address": "82417060",
+        "context_function_address": "82417BC0",
+        "semantic_receiver_class": "proceduralGeometry::CProceduralModels",
+        "track_command_lineage": "false",
+        "sample_color_prepared_signature": "0123456789ABCDEF",
+        "color_sample_varied": "true",
+        "sample_color_vertex_shader": "1111111111111111",
+        "sample_color_pixel_shader": "2222222222222222",
+        "sample_color_bound_render_target_bits": "00000002",
+        "sample_color_bound_render_target_formats": "0:1:0:0:0",
+        "sample_color_prepared_pipeline_flags": "00000003",
+        "sample_color_target_state": "1:2:3:4:5:6",
+        "sample_color_scissor": "00000000:050002D0",
+    }
+    summary = {
+        **common,
+        "event": MODULE.SUMMARY,
+        "entries": "1",
+        "prepared_draws": "12",
+        "invalid_lineages": "0",
+        "overflow": "0",
+        "indirect_buffer_stack_faults": "0",
+        "indirect_draw_stack_faults": "0",
+        "indirect_constructor_stack_faults": "0",
+        "indirect_constructor_owner_mismatches": "0",
+        "indirect_owner_stack_faults": "0",
+        "indirect_owner_producer_mismatches": "0",
+        "indirect_producer_stack_faults": "0",
+        "indirect_producer_context_mismatches": "0",
+        "indirect_context_stack_faults": "0",
+    }
+    shutdown = {**common, "event": MODULE.SHUTDOWN}
+    return [config, entry, summary, shutdown]
+
+
+class ColorProducerLineageTests(unittest.TestCase):
+    def test_ranks_exact_semantic_color_candidate(self):
+        result = MODULE.build(fixture(), "session")
+        self.assertEqual("complete", result["status"])
+        self.assertEqual(10, result["totals"]["color_draws"])
+        self.assertEqual("82417BC0", result["candidates"][0]["context_function"])
+        self.assertTrue(result["qualification"]["semantic_color_candidate_observed"])
+        self.assertFalse(result["qualification"]["native_admission"])
+
+    def test_fails_closed_on_target_accounting_drift(self):
+        events = fixture()
+        events[1]["color_only_draws"] = "7"
+        result = MODULE.build(events, "session")
+        self.assertEqual("incomplete", result["status"])
+        self.assertIn(
+            "entry target-shape accounting is incomplete", result["failures"]
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- partition every exact command-lineage aggregate by prepared attachment shape
- retain bounded opaque/color evidence and one numeric target/shader sample per origin
- add a fail-closed offline ranker and document the C1 live-color pivot

## Safety
- passive census only; no guest writes, native admission, suppression, or authority change
- existing 4,096-entry lineage capacity is unchanged

## Validation
- Release build
- python -m unittest discover -s tools/tests -p 'test_*.py' (689 tests)