### PR TITLE
feat(native-renderer): profile procedural color targets

### DIFF
--- a/docs/native-renderer/COLOR_PRODUCER_LINEAGE.md
+++ b/docs/native-renderer/COLOR_PRODUCER_LINEAGE.md
@@ -1,7 +1,7 @@
 # Live color-producer lineage
 
-Status: bounded runtime census implemented; qualification deferred to the next
-batched AppData run
+Status: live semantic color producer proved; exact target-role profiler
+implemented for the next batched AppData run
 
 ## Why this is the next ingress
 
@@ -12,11 +12,17 @@ constructor, owner, producer, and context functions, including exact
 `proceduralGeometry::CProceduralModels` receiver lifetime and preparation
 identity at context `82417BC0`.
 
-Historical captures contain a stable mechanically eligible color signature
-under that procedural-model producer, but those color and lineage artifacts
-were collected in different sessions. Their stable hashes are useful for
-selecting the boundary, not for proving a current runtime join. No cross-session
-frequency or shader match is promoted to semantic evidence.
+The clean `20260901T065854Z-p37928` AppData session closes that cross-session
+gap. It records 688 opaque, bounded color-plus-depth draws under the exact
+`CProceduralModels` receiver lineage. The first exact prepared signature is
+`751139AF66FBCCF4`, with vertex shader `D3EE3BD1E086935B` and pixel shader
+`CE7C54664D18A4E3`; the same session's candidate census independently records
+that exact mechanically eligible signature.
+
+That is an exact semantic + mechanical color-ingress join, but not yet a
+main-view join. Its sampled scissor is `00000000:01000500`, or 1280x256, rather
+than the preview's 1280x720 extent. It may be a reflection, horizon strip, or
+other reduced target. It therefore remains ineligible for native publication.
 
 ## Bounded target-shape census
 
@@ -42,6 +48,14 @@ every color-bearing aggregate. It ranks exact semantic receivers first, then
 opaque, bounded, and total color activity. Ranking is investigation evidence;
 it cannot enable native admission or suppression.
 
+The follow-up exact target-role profiler partitions every color draw under the
+live `82417BC0` semantic receiver by prepared signature, shaders, attachments,
+viewport, scissor, and target registers. It emits decoded scissor extents and
+separates exact 1280x720 profiles from reduced-width and other targets. Receiver
+addresses are samples only; a variation bit proves when a target profile spans
+multiple live receiver instances. The bounded table has 1,024 entries and
+fails closed on overflow or incomplete accounting.
+
 Run the deferred qualifier after the next combined AppData capture:
 
 ```powershell
@@ -51,10 +65,20 @@ python tools/summarize-native-renderer-color-producer-lineage.py `
   --output .local/qualification/native-renderer-color-producer-lineage.json
 ```
 
+Then classify the exact target profiles from the same session:
+
+```powershell
+python tools/summarize-native-renderer-procedural-color-targets.py `
+  <session-log.jsonl> `
+  --session <session> `
+  --output .local/qualification/native-renderer-procedural-color-targets.json
+```
+
 ## Promotion gate
 
-The next C1 implementation may follow one ranked origin only when the same
-clean session proves nonzero bounded opaque color draws, complete lineage
-accounting, and either exact semantic receiver identity or a separately proved
-title-owned world identity. Until then, Xenos remains authoritative and this
-census changes no rendering or control flow.
+The next C1 implementation may privately capture one profile only when a clean
+session proves complete target-profile accounting and an exact full-preview
+1280x720 profile whose calls are all bounded and opaque and never sample a
+resolved target. Reduced targets remain excluded even when mechanically
+eligible. Until then, Xenos remains authoritative and this census changes no
+rendering or control flow.

--- a/docs/native-renderer/REPRIORITIZED_PLAN.md
+++ b/docs/native-renderer/REPRIORITIZED_PLAN.md
@@ -702,17 +702,19 @@ separate live color producer; no further hook is added beneath this shadow
 family. The reproducible inventory is documented in
 [`TERRAIN_ROAD_RENDER_PATH.md`](TERRAIN_ROAD_RENDER_PATH.md).
 
-Live color-producer implementation checkpoint: the already-balanced command-
-buffer lineage now partitions every origin aggregate into depth-only,
-color-only, color-plus-depth, and other prepared-target activity. It separately
-counts opaque, bounded, and resolved-input color draws and retains one bounded
-numeric target/shader sample with variation accounting. A fail-closed offline
-ranker requires one clean session and exact reconciliation with the final
-lineage summary. Historical evidence makes exact procedural-model context
-`82417BC0` the first lead, but because its lineage and color samples came from
-different sessions, that is boundary selection rather than proof. The next
-combined AppData run will rank the live color producer without another broad
-hook pass. See [`COLOR_PRODUCER_LINEAGE.md`](COLOR_PRODUCER_LINEAGE.md).
+Live color-producer qualification checkpoint: clean AppData session
+`20260901T065854Z-p37928` proves 688 opaque, bounded color-plus-depth draws
+under exact procedural-model context `82417BC0`. Its first prepared signature
+`751139AF66FBCCF4` and shader pair are independently present in the same
+session's mechanically eligible candidate census, closing the semantic-to-
+prepared color join. That sample uses a 1280x256 scissor rather than the
+1280x720 preview extent, so it is not promoted as visible world work. A bounded
+exact target-role profiler now partitions every color draw under that semantic
+receiver by signature, shaders, viewport, scissor, attachment formats, and
+target registers. The next batched AppData run can select a full-preview
+profile for private capture, if one exists, without admitting reduced/offscreen
+targets or changing Xenos output. See
+[`COLOR_PRODUCER_LINEAGE.md`](COLOR_PRODUCER_LINEAGE.md).
 
 ### C2. Static world buildings and props
 

--- a/src/native_renderer/graphics_hooks.cpp
+++ b/src/native_renderer/graphics_hooks.cpp
@@ -64,6 +64,7 @@ constexpr size_t kSummaryLimit = 16;
 constexpr size_t kCandidateSummaryLimit = 32;
 constexpr size_t kPreparedShaderPairCapacity = 1024;
 constexpr size_t kCommandBufferLineageCapacity = 4096;
+constexpr size_t kProceduralColorTargetProfileCapacity = 1024;
 constexpr size_t kResolveTargetCapacity = 4096;
 constexpr size_t kResolvePageCapacity = 32768;
 constexpr size_t kResolveSummaryLimit = 32;
@@ -11199,6 +11200,35 @@ struct CommandBufferLineageEntry {
   bool color_sample_varied = false;
 };
 
+struct ProceduralColorTargetProfileEntry {
+  uint64_t key = 0;
+  uint64_t calls = 0;
+  uint64_t first_frame = 0;
+  uint64_t last_frame = 0;
+  uint64_t prepared_signature = 0;
+  uint64_t vertex_shader_hash = 0;
+  uint64_t pixel_shader_hash = 0;
+  uint64_t opaque_calls = 0;
+  uint64_t bounded_calls = 0;
+  uint64_t resolved_input_calls = 0;
+  uint32_t sample_semantic_receiver_address = 0;
+  uint32_t sample_semantic_receiver_generation = 0;
+  uint32_t bound_render_target_bits = 0;
+  std::array<uint32_t, 5> bound_render_target_formats{};
+  uint32_t prepared_pipeline_flags = 0;
+  uint32_t viewport_xscale = 0;
+  uint32_t viewport_xoffset = 0;
+  uint32_t viewport_yscale = 0;
+  uint32_t viewport_yoffset = 0;
+  uint32_t viewport_transform_control = 0;
+  uint32_t window_scissor_tl = 0;
+  uint32_t window_scissor_br = 0;
+  uint32_t surface_info = 0;
+  std::array<uint32_t, 4> color_info{};
+  uint32_t depth_info = 0;
+  bool semantic_receiver_varied = false;
+};
+
 std::array<CommandBufferLineageEntry, kCommandBufferLineageCapacity>
     g_command_buffer_lineages{};
 uint64_t g_command_buffer_lineage_draws = 0;
@@ -11208,6 +11238,12 @@ uint64_t g_command_buffer_lineage_invalid = 0;
 uint64_t g_command_buffer_lineage_prepared_draws = 0;
 uint64_t g_command_buffer_lineage_entry_count = 0;
 uint64_t g_command_buffer_lineage_overflow = 0;
+std::array<ProceduralColorTargetProfileEntry,
+           kProceduralColorTargetProfileCapacity>
+    g_procedural_color_target_profiles{};
+uint64_t g_procedural_color_target_profile_observations = 0;
+uint64_t g_procedural_color_target_profile_entry_count = 0;
+uint64_t g_procedural_color_target_profile_overflow = 0;
 bool g_graphics_census_installed = false;
 rex::memory::Memory *g_graphics_census_memory = nullptr;
 void *g_guest_cpu_access_callback = nullptr;
@@ -11481,6 +11517,11 @@ void ResetCommandBufferLineage() {
   g_command_buffer_lineage_prepared_draws = 0;
   g_command_buffer_lineage_entry_count = 0;
   g_command_buffer_lineage_overflow = 0;
+  std::memset(g_procedural_color_target_profiles.data(), 0,
+              sizeof(g_procedural_color_target_profiles));
+  g_procedural_color_target_profile_observations = 0;
+  g_procedural_color_target_profile_entry_count = 0;
+  g_procedural_color_target_profile_overflow = 0;
 }
 
 void ResetDependencyCensus() {
@@ -17184,6 +17225,137 @@ void AccumulateCommandBufferTargetShape(
   entry.sample_color_window_scissor_br = observation.window_scissor_br;
 }
 
+void RecordProceduralColorTargetProfile(
+    uint64_t prepared_signature,
+    const rex::system::GraphicsDrawObservation &observation,
+    bool samples_resolved_target,
+    const rex::system::GraphicsPreparedDrawObservation &prepared,
+    const ActiveTitleIndirectBuffer *active) {
+  if (!active || !(prepared.bound_render_target_bits & 2)) {
+    return;
+  }
+  const auto &context = active->constructor_origin.owner.producer.context;
+  if (!context.valid || context.function_address != 0x82417BC0 ||
+      !context.semantic_receiver_address ||
+      !context.semantic_receiver_generation) {
+    return;
+  }
+  ++g_procedural_color_target_profile_observations;
+  uint64_t key = UINT64_C(0xCBF29CE484222325);
+  for (uint64_t value :
+       {prepared_signature, observation.vertex_shader_hash,
+        observation.pixel_shader_hash,
+        uint64_t(prepared.bound_render_target_bits), uint64_t(prepared.flags),
+        uint64_t(observation.viewport_xscale),
+        uint64_t(observation.viewport_xoffset),
+        uint64_t(observation.viewport_yscale),
+        uint64_t(observation.viewport_yoffset),
+        uint64_t(observation.viewport_transform_control),
+        uint64_t(observation.window_scissor_tl),
+        uint64_t(observation.window_scissor_br),
+        uint64_t(observation.surface_info), uint64_t(observation.color_info[0]),
+        uint64_t(observation.color_info[1]), uint64_t(observation.color_info[2]),
+        uint64_t(observation.color_info[3]), uint64_t(observation.depth_info)}) {
+    key = HashCombine(key, value);
+  }
+  for (uint32_t format : prepared.bound_render_target_formats) {
+    key = HashCombine(key, format);
+  }
+  key = key ? key : 1;
+  size_t index = size_t(key % kProceduralColorTargetProfileCapacity);
+  for (size_t probe = 0; probe < kProceduralColorTargetProfileCapacity;
+       ++probe) {
+    ProceduralColorTargetProfileEntry &entry =
+        g_procedural_color_target_profiles[index];
+    if (!entry.calls) {
+      entry.key = key;
+      entry.calls = 1;
+      entry.first_frame = observation.frame_sequence;
+      entry.last_frame = observation.frame_sequence;
+      entry.prepared_signature = prepared_signature;
+      entry.vertex_shader_hash = observation.vertex_shader_hash;
+      entry.pixel_shader_hash = observation.pixel_shader_hash;
+      entry.opaque_calls = IsOpaqueColorState(observation) ? 1 : 0;
+      entry.bounded_calls =
+          !observation.vertex_binding_overflow &&
+                  !observation.vertex_attribute_overflow &&
+                  !observation.vertex_float_constant_overflow &&
+                  !observation.pixel_float_constant_overflow &&
+                  !observation.texture_state_overflow &&
+                  (prepared.flags & 3) == 3
+              ? 1
+              : 0;
+      entry.resolved_input_calls = samples_resolved_target ? 1 : 0;
+      entry.sample_semantic_receiver_address =
+          context.semantic_receiver_address;
+      entry.sample_semantic_receiver_generation =
+          context.semantic_receiver_generation;
+      entry.bound_render_target_bits = prepared.bound_render_target_bits;
+      std::copy(std::begin(prepared.bound_render_target_formats),
+                std::end(prepared.bound_render_target_formats),
+                entry.bound_render_target_formats.begin());
+      entry.prepared_pipeline_flags = prepared.flags;
+      entry.viewport_xscale = observation.viewport_xscale;
+      entry.viewport_xoffset = observation.viewport_xoffset;
+      entry.viewport_yscale = observation.viewport_yscale;
+      entry.viewport_yoffset = observation.viewport_yoffset;
+      entry.viewport_transform_control =
+          observation.viewport_transform_control;
+      entry.window_scissor_tl = observation.window_scissor_tl;
+      entry.window_scissor_br = observation.window_scissor_br;
+      entry.surface_info = observation.surface_info;
+      std::copy(std::begin(observation.color_info),
+                std::end(observation.color_info), entry.color_info.begin());
+      entry.depth_info = observation.depth_info;
+      ++g_procedural_color_target_profile_entry_count;
+      return;
+    }
+    if (entry.key == key &&
+        entry.prepared_signature == prepared_signature &&
+        entry.vertex_shader_hash == observation.vertex_shader_hash &&
+        entry.pixel_shader_hash == observation.pixel_shader_hash &&
+        entry.bound_render_target_bits == prepared.bound_render_target_bits &&
+        entry.prepared_pipeline_flags == prepared.flags &&
+        entry.viewport_xscale == observation.viewport_xscale &&
+        entry.viewport_xoffset == observation.viewport_xoffset &&
+        entry.viewport_yscale == observation.viewport_yscale &&
+        entry.viewport_yoffset == observation.viewport_yoffset &&
+        entry.viewport_transform_control ==
+            observation.viewport_transform_control &&
+        entry.window_scissor_tl == observation.window_scissor_tl &&
+        entry.window_scissor_br == observation.window_scissor_br &&
+        entry.surface_info == observation.surface_info &&
+        entry.depth_info == observation.depth_info &&
+        std::equal(entry.color_info.begin(), entry.color_info.end(),
+                   std::begin(observation.color_info)) &&
+        std::equal(entry.bound_render_target_formats.begin(),
+                   entry.bound_render_target_formats.end(),
+                   std::begin(prepared.bound_render_target_formats))) {
+      ++entry.calls;
+      entry.last_frame = observation.frame_sequence;
+      entry.opaque_calls += IsOpaqueColorState(observation) ? 1 : 0;
+      entry.bounded_calls +=
+          !observation.vertex_binding_overflow &&
+                  !observation.vertex_attribute_overflow &&
+                  !observation.vertex_float_constant_overflow &&
+                  !observation.pixel_float_constant_overflow &&
+                  !observation.texture_state_overflow &&
+                  (prepared.flags & 3) == 3
+              ? 1
+              : 0;
+      entry.resolved_input_calls += samples_resolved_target ? 1 : 0;
+      entry.semantic_receiver_varied |=
+          entry.sample_semantic_receiver_address !=
+              context.semantic_receiver_address ||
+          entry.sample_semantic_receiver_generation !=
+              context.semantic_receiver_generation;
+      return;
+    }
+    index = (index + 1) % kProceduralColorTargetProfileCapacity;
+  }
+  ++g_procedural_color_target_profile_overflow;
+}
+
 void RecordPreparedCommandBufferLineage(
     uint64_t prepared_signature,
     const rex::system::GraphicsDrawObservation &observation,
@@ -17203,6 +17375,9 @@ void RecordPreparedCommandBufferLineage(
           : UINT32_MAX;
   const ActiveTitleIndirectBuffer *active =
       CurrentTitleIndirectBuffer(observation);
+  RecordProceduralColorTargetProfile(prepared_signature, observation,
+                                     samples_resolved_target, prepared,
+                                     active);
   const uint32_t constructor_store_address =
       active ? active->constructor_store_address : 0;
   const IndirectConstructorOrigin constructor_origin =
@@ -17446,12 +17621,133 @@ void RecordPreparedCommandBufferLineage(
   ++g_command_buffer_lineage_overflow;
 }
 
+void EmitProceduralColorTargetProfiles() {
+  uint64_t accounted = 0;
+  uint64_t full_preview_extent_calls = 0;
+  uint64_t reduced_preview_width_calls = 0;
+  for (const ProceduralColorTargetProfileEntry &entry :
+       g_procedural_color_target_profiles) {
+    if (!entry.calls) {
+      continue;
+    }
+    accounted += entry.calls;
+    const uint32_t scissor_left = entry.window_scissor_tl & 0x7FFF;
+    const uint32_t scissor_top =
+        (entry.window_scissor_tl >> 16) & 0x7FFF;
+    const uint32_t scissor_right = entry.window_scissor_br & 0x7FFF;
+    const uint32_t scissor_bottom =
+        (entry.window_scissor_br >> 16) & 0x7FFF;
+    const bool full_preview_extent =
+        !scissor_left && !scissor_top && scissor_right == 1280 &&
+        scissor_bottom == 720;
+    const bool reduced_preview_width =
+        !scissor_left && !scissor_top && scissor_right == 1280 &&
+        scissor_bottom && scissor_bottom < 720;
+    full_preview_extent_calls += full_preview_extent ? entry.calls : 0;
+    reduced_preview_width_calls += reduced_preview_width ? entry.calls : 0;
+    pinyon_shift::diagnostics::RecordEvent(
+        "native_renderer.discovery.procedural_color_target_profile_entry",
+        {{"entry_key", fmt::format("{:016X}", entry.key)},
+         {"calls", std::to_string(entry.calls)},
+         {"first_frame", std::to_string(entry.first_frame)},
+         {"last_frame", std::to_string(entry.last_frame)},
+         {"prepared_signature",
+          fmt::format("{:016X}", entry.prepared_signature)},
+         {"vertex_shader",
+          fmt::format("{:016X}", entry.vertex_shader_hash)},
+         {"pixel_shader", fmt::format("{:016X}", entry.pixel_shader_hash)},
+         {"opaque_calls", std::to_string(entry.opaque_calls)},
+         {"bounded_calls", std::to_string(entry.bounded_calls)},
+         {"resolved_input_calls",
+          std::to_string(entry.resolved_input_calls)},
+         {"sample_semantic_receiver_address",
+          fmt::format("{:08X}", entry.sample_semantic_receiver_address)},
+         {"sample_semantic_receiver_generation",
+          std::to_string(entry.sample_semantic_receiver_generation)},
+         {"semantic_receiver_varied",
+          entry.semantic_receiver_varied ? "true" : "false"},
+         {"bound_render_target_bits",
+          fmt::format("{:08X}", entry.bound_render_target_bits)},
+         {"bound_render_target_formats",
+          fmt::format("{}:{}:{}:{}:{}",
+                      entry.bound_render_target_formats[0],
+                      entry.bound_render_target_formats[1],
+                      entry.bound_render_target_formats[2],
+                      entry.bound_render_target_formats[3],
+                      entry.bound_render_target_formats[4])},
+         {"prepared_pipeline_flags",
+          fmt::format("{:08X}", entry.prepared_pipeline_flags)},
+         {"viewport",
+          fmt::format("{:08X}:{:08X}:{:08X}:{:08X}",
+                      entry.viewport_xscale, entry.viewport_xoffset,
+                      entry.viewport_yscale, entry.viewport_yoffset)},
+         {"viewport_transform_control",
+          fmt::format("{:08X}", entry.viewport_transform_control)},
+         {"scissor",
+          fmt::format("{:08X}:{:08X}", entry.window_scissor_tl,
+                      entry.window_scissor_br)},
+         {"scissor_extent",
+          fmt::format("{}:{}:{}:{}", scissor_left, scissor_top,
+                      scissor_right, scissor_bottom)},
+         {"preview_extent_role",
+          full_preview_extent
+              ? "full_1280x720"
+              : (reduced_preview_width ? "reduced_1280_width" : "other")},
+         {"target_state",
+          fmt::format("{:08X}:{:08X}:{:08X}:{:08X}:{:08X}:{:08X}",
+                      entry.surface_info, entry.color_info[0],
+                      entry.color_info[1], entry.color_info[2],
+                      entry.color_info[3], entry.depth_info)},
+         {"semantic_receiver_class",
+          "proceduralGeometry::CProceduralModels"},
+         {"semantic_dispatch", "82417BC0"},
+         {"classification",
+          "exact_procedural_color_signature_target_profile"},
+         {"guest_payload_read", "false"},
+         {"guest_state_changed", "false"},
+         {"control_flow_changed", "false"},
+         {"native_admission", "false"},
+         {"native_draw", "false"},
+         {"xenos_authority", "true"},
+         {"suppression_allowed", "false"}});
+  }
+  pinyon_shift::diagnostics::RecordEvent(
+      "native_renderer.discovery.procedural_color_target_profile_summary",
+      {{"observations",
+        std::to_string(g_procedural_color_target_profile_observations)},
+       {"accounted", std::to_string(accounted)},
+       {"entries",
+        std::to_string(g_procedural_color_target_profile_entry_count)},
+       {"overflow",
+        std::to_string(g_procedural_color_target_profile_overflow)},
+       {"full_preview_extent_calls",
+        std::to_string(full_preview_extent_calls)},
+       {"reduced_preview_width_calls",
+        std::to_string(reduced_preview_width_calls)},
+       {"accounting_complete",
+        g_procedural_color_target_profile_observations ==
+                    accounted + g_procedural_color_target_profile_overflow &&
+                !g_procedural_color_target_profile_overflow
+            ? "true"
+            : "false"},
+       {"preview_extent", "1280x720"},
+       {"classification", "exact_procedural_color_target_role_census"},
+       {"guest_payload_read", "false"},
+       {"guest_state_changed", "false"},
+       {"control_flow_changed", "false"},
+       {"native_admission", "false"},
+       {"native_draw", "false"},
+       {"xenos_authority", "true"},
+       {"suppression_allowed", "false"}});
+}
+
 void EmitCommandBufferLineageSummary() {
   EmitSemanticVisibilityWorkset();
   EmitProceduralModelSemanticInstances();
   EmitProceduralModelSemanticSubmissions();
   EmitTrackRenderModelRuntimeJoinSummary();
   EmitStaticWorldRuntimeJoinSummary();
+  EmitProceduralColorTargetProfiles();
   for (const CommandBufferLineageEntry &entry : g_command_buffer_lineages) {
     if (!entry.calls) {
       continue;
@@ -30064,8 +30360,13 @@ void InstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system,
         "context_r3-r10,context_root,semantic_receiver_generation,"
         "semantic_visibility_epoch,semantic_render_state_epoch,"
         "backend_packet,prepared_target_shape,"
-        "current_buffer,parent_packet,root_buffer,depth"},
+       "current_buffer,parent_packet,root_buffer,depth"},
        {"prepared_target_shape_census", "bounded_aggregate_v1"},
+       {"procedural_color_target_profile_census", "bounded_exact_v1"},
+       {"procedural_color_target_profile_capacity",
+        std::to_string(kProceduralColorTargetProfileCapacity)},
+       {"procedural_color_target_profile_dispatch", "82417BC0"},
+       {"procedural_color_target_profile_preview_extent", "1280x720"},
        {"guest_payload_read", "false"},
        {"guest_state_changed", "false"},
        {"control_flow_changed", "false"},

--- a/tools/summarize-native-renderer-procedural-color-targets.py
+++ b/tools/summarize-native-renderer-procedural-color-targets.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python3
+"""Classify exact procedural-model color draws by render-target role."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import pathlib
+import sys
+
+
+SCHEMA = "pinyon-shift.native-renderer-procedural-color-targets.v1"
+CONFIG = "native_renderer.discovery.command_buffer_lineage_config"
+ENTRY = "native_renderer.discovery.procedural_color_target_profile_entry"
+SUMMARY = "native_renderer.discovery.procedural_color_target_profile_summary"
+SHUTDOWN = "process.shutdown"
+
+
+def integer(event, name):
+    try:
+        return int(event[name], 10)
+    except (KeyError, TypeError, ValueError) as error:
+        raise ValueError(f"invalid {name}") from error
+
+
+def read_events(path, session):
+    events = []
+    for line_number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+        if not line.strip():
+            continue
+        try:
+            event = json.loads(line)
+        except json.JSONDecodeError as error:
+            raise ValueError(f"invalid JSON at line {line_number}") from error
+        if event.get("session") == session:
+            events.append(event)
+    return events
+
+
+def extent(event):
+    value = event.get("scissor_extent")
+    if not isinstance(value, str):
+        raise ValueError("invalid scissor_extent")
+    parts = value.split(":")
+    if len(parts) != 4:
+        raise ValueError("invalid scissor_extent")
+    try:
+        return tuple(int(part, 10) for part in parts)
+    except ValueError as error:
+        raise ValueError("invalid scissor_extent") from error
+
+
+def build(events, session):
+    configs = [event for event in events if event.get("event") == CONFIG]
+    summaries = [event for event in events if event.get("event") == SUMMARY]
+    entries = [event for event in events if event.get("event") == ENTRY]
+    shutdowns = [event for event in events if event.get("event") == SHUTDOWN]
+    failures = []
+    if len(configs) != 1:
+        failures.append("expected one command-lineage config")
+    elif configs[0].get("procedural_color_target_profile_census") != "bounded_exact_v1":
+        failures.append("procedural color-target profiler was not armed")
+    if len(summaries) != 1:
+        failures.append("expected one procedural color-target summary")
+    if len(shutdowns) != 1:
+        failures.append("clean process shutdown was not observed")
+    if not summaries:
+        return document(session, failures, [], {})
+
+    summary = summaries[0]
+    observations = integer(summary, "observations")
+    accounted = integer(summary, "accounted")
+    overflow = integer(summary, "overflow")
+    expected_entries = integer(summary, "entries")
+    if expected_entries != len(entries):
+        failures.append("entry count does not match target-profile summary")
+    if summary.get("accounting_complete") != "true":
+        failures.append("target-profile accounting is incomplete")
+    if overflow:
+        failures.append("target-profile table overflowed")
+    if observations != accounted + overflow:
+        failures.append("observations do not match accounted profiles")
+
+    profiles = []
+    observed_calls = 0
+    for event in entries:
+        calls = integer(event, "calls")
+        opaque = integer(event, "opaque_calls")
+        bounded = integer(event, "bounded_calls")
+        resolved = integer(event, "resolved_input_calls")
+        observed_calls += calls
+        if opaque > calls or bounded > calls or resolved > calls:
+            failures.append("profile counters exceed calls")
+        signature = event.get("prepared_signature")
+        if not isinstance(signature, str) or len(signature) != 16:
+            failures.append("profile lacks an exact prepared signature")
+        left, top, right, bottom = extent(event)
+        exact_full_preview = left == 0 and top == 0 and right == 1280 and bottom == 720
+        reduced_preview_width = (
+            left == 0 and top == 0 and right == 1280 and 0 < bottom < 720
+        )
+        if exact_full_preview:
+            role = "full_preview_extent"
+        elif reduced_preview_width:
+            role = "reduced_preview_width"
+        else:
+            role = "other_extent"
+        profiles.append(
+            {
+                "prepared_signature": signature,
+                "calls": calls,
+                "opaque_calls": opaque,
+                "bounded_calls": bounded,
+                "resolved_input_calls": resolved,
+                "vertex_shader": event.get("vertex_shader"),
+                "pixel_shader": event.get("pixel_shader"),
+                "target_bits": event.get("bound_render_target_bits"),
+                "target_formats": event.get("bound_render_target_formats"),
+                "target_state": event.get("target_state"),
+                "viewport": event.get("viewport"),
+                "scissor": event.get("scissor"),
+                "extent": {"left": left, "top": top, "right": right, "bottom": bottom},
+                "role": role,
+                "semantic_receiver_varied": event.get("semantic_receiver_varied") == "true",
+            }
+        )
+    if observed_calls != accounted:
+        failures.append("entry calls do not match accounted profiles")
+    profiles.sort(
+        key=lambda row: (
+            row["role"] != "full_preview_extent",
+            row["resolved_input_calls"] != 0,
+            -row["bounded_calls"],
+            -row["opaque_calls"],
+            -row["calls"],
+            row["prepared_signature"] or "",
+        )
+    )
+    totals = {
+        "observations": observations,
+        "profiles": len(profiles),
+        "full_preview_profiles": sum(1 for row in profiles if row["role"] == "full_preview_extent"),
+        "full_preview_calls": sum(row["calls"] for row in profiles if row["role"] == "full_preview_extent"),
+        "reduced_preview_width_profiles": sum(1 for row in profiles if row["role"] == "reduced_preview_width"),
+        "other_extent_profiles": sum(1 for row in profiles if row["role"] == "other_extent"),
+    }
+    return document(session, failures, profiles, totals)
+
+
+def document(session, failures, profiles, totals):
+    complete = not failures
+    full_clean = [
+        row
+        for row in profiles
+        if row["role"] == "full_preview_extent"
+        and row["bounded_calls"] == row["calls"]
+        and row["opaque_calls"] == row["calls"]
+        and not row["resolved_input_calls"]
+    ]
+    return {
+        "schema": SCHEMA,
+        "session": session,
+        "status": "complete" if complete else "incomplete",
+        "failures": failures,
+        "totals": totals,
+        "profiles": profiles,
+        "qualification": {
+            "exact_semantic_target_profiles_accounted": complete,
+            "full_preview_color_profile_observed": complete and bool(full_clean),
+            "eligible_for_isolated_capture_selection": complete and bool(full_clean),
+            "native_admission": False,
+            "suppression_allowed": False,
+        },
+        "safety": {
+            "guest_payload_exported": False,
+            "guest_state_changed": False,
+            "control_flow_changed": False,
+            "native_draw": False,
+            "xenos_authority": True,
+        },
+    }
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("log", type=pathlib.Path)
+    parser.add_argument("--session", required=True)
+    parser.add_argument("--output", required=True, type=pathlib.Path)
+    args = parser.parse_args(argv)
+    try:
+        result = build(read_events(args.log, args.session), args.session)
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(json.dumps(result, indent=2, sort_keys=True) + "\n")
+        return 0 if result["status"] == "complete" else 1
+    except (OSError, UnicodeDecodeError, ValueError) as error:
+        print(f"procedural color-target summary failed: {error}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/tests/test_native_renderer_procedural_color_targets.py
+++ b/tools/tests/test_native_renderer_procedural_color_targets.py
@@ -1,0 +1,78 @@
+import importlib.util
+import pathlib
+import unittest
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+TOOL = ROOT / "tools/summarize-native-renderer-procedural-color-targets.py"
+SPEC = importlib.util.spec_from_file_location("procedural_color_targets", TOOL)
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+def fixture(scissor_extent="0:0:1280:720"):
+    common = {"session": "session"}
+    return [
+        {
+            **common,
+            "event": MODULE.CONFIG,
+            "procedural_color_target_profile_census": "bounded_exact_v1",
+        },
+        {
+            **common,
+            "event": MODULE.ENTRY,
+            "calls": "12",
+            "opaque_calls": "12",
+            "bounded_calls": "12",
+            "resolved_input_calls": "0",
+            "prepared_signature": "751139AF66FBCCF4",
+            "vertex_shader": "D3EE3BD1E086935B",
+            "pixel_shader": "CE7C54664D18A4E3",
+            "bound_render_target_bits": "00000003",
+            "bound_render_target_formats": "1:3:0:0:0",
+            "target_state": "1:2:3:4:5:6",
+            "viewport": "1:2:3:4",
+            "scissor": "00000000:02D00500",
+            "scissor_extent": scissor_extent,
+            "semantic_receiver_varied": "true",
+        },
+        {
+            **common,
+            "event": MODULE.SUMMARY,
+            "observations": "12",
+            "accounted": "12",
+            "entries": "1",
+            "overflow": "0",
+            "accounting_complete": "true",
+        },
+        {**common, "event": MODULE.SHUTDOWN},
+    ]
+
+
+class ProceduralColorTargetTests(unittest.TestCase):
+    def test_promotes_exact_full_preview_profile_to_capture_selection(self):
+        result = MODULE.build(fixture(), "session")
+        self.assertEqual("complete", result["status"])
+        self.assertEqual("full_preview_extent", result["profiles"][0]["role"])
+        self.assertTrue(
+            result["qualification"]["eligible_for_isolated_capture_selection"]
+        )
+        self.assertFalse(result["qualification"]["native_admission"])
+
+    def test_reduced_height_profile_stays_out_of_selection(self):
+        result = MODULE.build(fixture("0:0:1280:256"), "session")
+        self.assertEqual("reduced_preview_width", result["profiles"][0]["role"])
+        self.assertFalse(
+            result["qualification"]["eligible_for_isolated_capture_selection"]
+        )
+
+    def test_fails_closed_on_accounting_drift(self):
+        events = fixture()
+        events[2]["accounted"] = "11"
+        result = MODULE.build(events, "session")
+        self.assertEqual("incomplete", result["status"])
+        self.assertIn("observations do not match accounted profiles", result["failures"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- join exact CProceduralModels color draws to prepared signatures and target state
- classify 1280x720 main-view candidates separately from reduced/offscreen extents
- add a fail-closed offline qualifier and tests while Xenos remains authoritative

## Validation
- python -m unittest discover -s tools/tests (692 passed)
- incremental Windows AMD64 Release build passed
- AppData gameplay validation intentionally batched with the next runtime slice