### PR TITLE
feat(native-renderer): correlate exact EDRAM tile state

### DIFF
--- a/docs/native-renderer/COLOR_PRODUCER_LINEAGE.md
+++ b/docs/native-renderer/COLOR_PRODUCER_LINEAGE.md
@@ -20,9 +20,12 @@ gap. It records 688 opaque, bounded color-plus-depth draws under the exact
 that exact mechanically eligible signature.
 
 That is an exact semantic + mechanical color-ingress join, but not yet a
-main-view join. Its sampled scissor is `00000000:01000500`, or 1280x256, rather
-than the preview's 1280x720 extent. It may be a reflection, horizon strip, or
-other reduced target. It therefore remains ineligible for native publication.
+main-view assembly join. Its sampled scissor is `00000000:01000500`, or
+1280x256. The same session contains no 1280x720 draw scissor at all, while the
+title has proved bin-mask/select wrappers and a tiled 1280x720 presentation
+resource. The 1280x256 region may therefore be one predicated EDRAM tile of the
+main view, rather than an offscreen pass. Replaying it as a complete frame is
+still invalid and explains the earlier wrong-view prototype symptom.
 
 ## Bounded target-shape census
 
@@ -50,11 +53,12 @@ it cannot enable native admission or suppression.
 
 The follow-up exact target-role profiler partitions every color draw under the
 live `82417BC0` semantic receiver by prepared signature, shaders, attachments,
-viewport, scissor, and target registers. It emits decoded scissor extents and
-separates exact 1280x720 profiles from reduced-width and other targets. Receiver
-addresses are samples only; a variation bit proves when a target profile spans
-multiple live receiver instances. The bounded table has 1,024 entries and
-fails closed on overflow or incomplete accounting.
+viewport, scissor, target registers, and exact backend bin-select/mask state.
+It emits decoded scissor extents and separates monolithic 1280x720 profiles,
+predicated 1280-wide EDRAM tiles, unpredicated reduced targets, and other
+targets. Receiver addresses are samples only; a variation bit proves when a
+target profile spans multiple live receiver instances. The bounded table has
+1,024 entries and fails closed on overflow or incomplete accounting.
 
 Run the deferred qualifier after the next combined AppData capture:
 
@@ -76,9 +80,10 @@ python tools/summarize-native-renderer-procedural-color-targets.py `
 
 ## Promotion gate
 
-The next C1 implementation may privately capture one profile only when a clean
-session proves complete target-profile accounting and an exact full-preview
-1280x720 profile whose calls are all bounded and opaque and never sample a
-resolved target. Reduced targets remain excluded even when mechanically
-eligible. Until then, Xenos remains authoritative and this census changes no
-rendering or control flow.
+The next C1 implementation may privately capture a monolithic profile only
+when a clean session proves complete target-profile accounting and an exact
+full-preview 1280x720 profile whose calls are all bounded and opaque and never
+sample a resolved target. A predicated 1280-wide EDRAM tile instead advances to
+tile-sequence and resolve-assembly investigation; it cannot be published alone.
+Other reduced targets remain excluded. Until then, Xenos remains authoritative
+and this census changes no rendering or control flow.

--- a/docs/native-renderer/REPRIORITIZED_PLAN.md
+++ b/docs/native-renderer/REPRIORITIZED_PLAN.md
@@ -707,13 +707,15 @@ Live color-producer qualification checkpoint: clean AppData session
 under exact procedural-model context `82417BC0`. Its first prepared signature
 `751139AF66FBCCF4` and shader pair are independently present in the same
 session's mechanically eligible candidate census, closing the semantic-to-
-prepared color join. That sample uses a 1280x256 scissor rather than the
-1280x720 preview extent, so it is not promoted as visible world work. A bounded
-exact target-role profiler now partitions every color draw under that semantic
-receiver by signature, shaders, viewport, scissor, attachment formats, and
-target registers. The next batched AppData run can select a full-preview
-profile for private capture, if one exists, without admitting reduced/offscreen
-targets or changing Xenos output. See
+prepared color join. That sample uses a 1280x256 scissor, and the same session
+contains no monolithic 1280x720 draw scissor. Because the title has proved
+bin-mask/select wrappers and a tiled 1280x720 presentation resource, this may
+be a predicated EDRAM tile of the main view rather than an offscreen pass. A
+bounded exact target-role profiler now retains backend bin-select/mask state in
+addition to signature, shaders, viewport, scissor, attachments, and target
+registers. The next batched AppData run can distinguish monolithic profiles
+from EDRAM tiles; a tile advances to resolve-assembly work and is never
+published alone. Xenos output remains authoritative. See
 [`COLOR_PRODUCER_LINEAGE.md`](COLOR_PRODUCER_LINEAGE.md).
 
 ### C2. Static world buildings and props

--- a/patches/rexglue/0107-graphics-draw-bin-state-observer.patch
+++ b/patches/rexglue/0107-graphics-draw-bin-state-observer.patch
@@ -1,0 +1,23 @@
+diff --git a/include/rex/system/interfaces/graphics.h b/include/rex/system/interfaces/graphics.h
+--- a/include/rex/system/interfaces/graphics.h
++++ b/include/rex/system/interfaces/graphics.h
+@@ -239,6 +239,8 @@ struct GraphicsDrawObservation {
+   uint32_t command_buffer_parent_packet_physical_address = UINT32_MAX;
+   uint32_t command_buffer_root_physical_address = UINT32_MAX;
+   uint32_t command_buffer_depth = 0;
++  uint64_t bin_select = 0;
++  uint64_t bin_mask = 0;
+   uint32_t packet = 0;
+   uint32_t initiator = 0;
+   uint32_t primitive_type = 0;
+diff --git a/src/graphics/command_processor.cpp b/src/graphics/command_processor.cpp
+--- a/src/graphics/command_processor.cpp
++++ b/src/graphics/command_processor.cpp
+@@ -1599,5 +1599,7 @@ bool CommandProcessor::ExecutePacketType3Draw(memory::RingBuffer* reader, uint32
+             observation_command_buffer_.root_physical_address;
+         observation.command_buffer_depth = observation_command_buffer_.depth;
++        observation.bin_select = bin_select_;
++        observation.bin_mask = bin_mask_;
+         observation.packet = packet;
+         observation.initiator = vgt_draw_initiator.value;
+         observation.primitive_type = uint32_t(vgt_draw_initiator.prim_type);

--- a/src/native_renderer/graphics_hooks.cpp
+++ b/src/native_renderer/graphics_hooks.cpp
@@ -11208,6 +11208,8 @@ struct ProceduralColorTargetProfileEntry {
   uint64_t prepared_signature = 0;
   uint64_t vertex_shader_hash = 0;
   uint64_t pixel_shader_hash = 0;
+  uint64_t bin_select = 0;
+  uint64_t bin_mask = 0;
   uint64_t opaque_calls = 0;
   uint64_t bounded_calls = 0;
   uint64_t resolved_input_calls = 0;
@@ -11226,6 +11228,7 @@ struct ProceduralColorTargetProfileEntry {
   uint32_t surface_info = 0;
   std::array<uint32_t, 4> color_info{};
   uint32_t depth_info = 0;
+  bool predicated = false;
   bool semantic_receiver_varied = false;
 };
 
@@ -17253,6 +17256,8 @@ void RecordProceduralColorTargetProfile(
         uint64_t(observation.viewport_transform_control),
         uint64_t(observation.window_scissor_tl),
         uint64_t(observation.window_scissor_br),
+        observation.bin_select, observation.bin_mask,
+        uint64_t(observation.packet & 1),
         uint64_t(observation.surface_info), uint64_t(observation.color_info[0]),
         uint64_t(observation.color_info[1]), uint64_t(observation.color_info[2]),
         uint64_t(observation.color_info[3]), uint64_t(observation.depth_info)}) {
@@ -17275,6 +17280,8 @@ void RecordProceduralColorTargetProfile(
       entry.prepared_signature = prepared_signature;
       entry.vertex_shader_hash = observation.vertex_shader_hash;
       entry.pixel_shader_hash = observation.pixel_shader_hash;
+      entry.bin_select = observation.bin_select;
+      entry.bin_mask = observation.bin_mask;
       entry.opaque_calls = IsOpaqueColorState(observation) ? 1 : 0;
       entry.bounded_calls =
           !observation.vertex_binding_overflow &&
@@ -17307,6 +17314,7 @@ void RecordProceduralColorTargetProfile(
       std::copy(std::begin(observation.color_info),
                 std::end(observation.color_info), entry.color_info.begin());
       entry.depth_info = observation.depth_info;
+      entry.predicated = (observation.packet & 1) != 0;
       ++g_procedural_color_target_profile_entry_count;
       return;
     }
@@ -17314,6 +17322,9 @@ void RecordProceduralColorTargetProfile(
         entry.prepared_signature == prepared_signature &&
         entry.vertex_shader_hash == observation.vertex_shader_hash &&
         entry.pixel_shader_hash == observation.pixel_shader_hash &&
+        entry.bin_select == observation.bin_select &&
+        entry.bin_mask == observation.bin_mask &&
+        entry.predicated == ((observation.packet & 1) != 0) &&
         entry.bound_render_target_bits == prepared.bound_render_target_bits &&
         entry.prepared_pipeline_flags == prepared.flags &&
         entry.viewport_xscale == observation.viewport_xscale &&
@@ -17625,6 +17636,7 @@ void EmitProceduralColorTargetProfiles() {
   uint64_t accounted = 0;
   uint64_t full_preview_extent_calls = 0;
   uint64_t reduced_preview_width_calls = 0;
+  uint64_t predicated_edram_tile_calls = 0;
   for (const ProceduralColorTargetProfileEntry &entry :
        g_procedural_color_target_profiles) {
     if (!entry.calls) {
@@ -17643,8 +17655,11 @@ void EmitProceduralColorTargetProfiles() {
     const bool reduced_preview_width =
         !scissor_left && !scissor_top && scissor_right == 1280 &&
         scissor_bottom && scissor_bottom < 720;
+    const bool predicated_edram_tile =
+        reduced_preview_width && entry.predicated;
     full_preview_extent_calls += full_preview_extent ? entry.calls : 0;
     reduced_preview_width_calls += reduced_preview_width ? entry.calls : 0;
+    predicated_edram_tile_calls += predicated_edram_tile ? entry.calls : 0;
     pinyon_shift::diagnostics::RecordEvent(
         "native_renderer.discovery.procedural_color_target_profile_entry",
         {{"entry_key", fmt::format("{:016X}", entry.key)},
@@ -17656,6 +17671,11 @@ void EmitProceduralColorTargetProfiles() {
          {"vertex_shader",
           fmt::format("{:016X}", entry.vertex_shader_hash)},
          {"pixel_shader", fmt::format("{:016X}", entry.pixel_shader_hash)},
+         {"bin_select", fmt::format("{:016X}", entry.bin_select)},
+         {"bin_mask", fmt::format("{:016X}", entry.bin_mask)},
+         {"bin_intersection",
+          fmt::format("{:016X}", entry.bin_select & entry.bin_mask)},
+         {"predicated", entry.predicated ? "true" : "false"},
          {"opaque_calls", std::to_string(entry.opaque_calls)},
          {"bounded_calls", std::to_string(entry.bounded_calls)},
          {"resolved_input_calls",
@@ -17692,7 +17712,10 @@ void EmitProceduralColorTargetProfiles() {
          {"preview_extent_role",
           full_preview_extent
               ? "full_1280x720"
-              : (reduced_preview_width ? "reduced_1280_width" : "other")},
+              : (predicated_edram_tile
+                     ? "predicated_edram_tile"
+                     : (reduced_preview_width ? "reduced_1280_width"
+                                              : "other"))},
          {"target_state",
           fmt::format("{:08X}:{:08X}:{:08X}:{:08X}:{:08X}:{:08X}",
                       entry.surface_info, entry.color_info[0],
@@ -17724,6 +17747,8 @@ void EmitProceduralColorTargetProfiles() {
         std::to_string(full_preview_extent_calls)},
        {"reduced_preview_width_calls",
         std::to_string(reduced_preview_width_calls)},
+       {"predicated_edram_tile_calls",
+        std::to_string(predicated_edram_tile_calls)},
        {"accounting_complete",
         g_procedural_color_target_profile_observations ==
                     accounted + g_procedural_color_target_profile_overflow &&
@@ -30362,11 +30387,12 @@ void InstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system,
         "backend_packet,prepared_target_shape,"
        "current_buffer,parent_packet,root_buffer,depth"},
        {"prepared_target_shape_census", "bounded_aggregate_v1"},
-       {"procedural_color_target_profile_census", "bounded_exact_v1"},
+       {"procedural_color_target_profile_census", "bounded_exact_v2"},
        {"procedural_color_target_profile_capacity",
         std::to_string(kProceduralColorTargetProfileCapacity)},
        {"procedural_color_target_profile_dispatch", "82417BC0"},
        {"procedural_color_target_profile_preview_extent", "1280x720"},
+       {"procedural_color_target_profile_bin_state", "exact_backend_v1"},
        {"guest_payload_read", "false"},
        {"guest_state_changed", "false"},
        {"control_flow_changed", "false"},

--- a/tools/summarize-native-renderer-procedural-color-targets.py
+++ b/tools/summarize-native-renderer-procedural-color-targets.py
@@ -9,7 +9,7 @@ import pathlib
 import sys
 
 
-SCHEMA = "pinyon-shift.native-renderer-procedural-color-targets.v1"
+SCHEMA = "pinyon-shift.native-renderer-procedural-color-targets.v2"
 CONFIG = "native_renderer.discovery.command_buffer_lineage_config"
 ENTRY = "native_renderer.discovery.procedural_color_target_profile_entry"
 SUMMARY = "native_renderer.discovery.procedural_color_target_profile_summary"
@@ -58,8 +58,10 @@ def build(events, session):
     failures = []
     if len(configs) != 1:
         failures.append("expected one command-lineage config")
-    elif configs[0].get("procedural_color_target_profile_census") != "bounded_exact_v1":
+    elif configs[0].get("procedural_color_target_profile_census") != "bounded_exact_v2":
         failures.append("procedural color-target profiler was not armed")
+    elif configs[0].get("procedural_color_target_profile_bin_state") != "exact_backend_v1":
+        failures.append("exact backend bin state was not armed")
     if len(summaries) != 1:
         failures.append("expected one procedural color-target summary")
     if len(shutdowns) != 1:
@@ -95,12 +97,24 @@ def build(events, session):
         if not isinstance(signature, str) or len(signature) != 16:
             failures.append("profile lacks an exact prepared signature")
         left, top, right, bottom = extent(event)
+        predicated = event.get("predicated") == "true"
+        try:
+            bin_select = int(event["bin_select"], 16)
+            bin_mask = int(event["bin_mask"], 16)
+            bin_intersection = int(event["bin_intersection"], 16)
+        except (KeyError, TypeError, ValueError) as error:
+            raise ValueError("invalid exact bin state") from error
+        if bin_intersection != bin_select & bin_mask:
+            failures.append("bin intersection does not match select and mask")
         exact_full_preview = left == 0 and top == 0 and right == 1280 and bottom == 720
         reduced_preview_width = (
             left == 0 and top == 0 and right == 1280 and 0 < bottom < 720
         )
+        predicated_edram_tile = reduced_preview_width and predicated
         if exact_full_preview:
             role = "full_preview_extent"
+        elif predicated_edram_tile:
+            role = "predicated_edram_tile"
         elif reduced_preview_width:
             role = "reduced_preview_width"
         else:
@@ -121,6 +135,10 @@ def build(events, session):
                 "scissor": event.get("scissor"),
                 "extent": {"left": left, "top": top, "right": right, "bottom": bottom},
                 "role": role,
+                "predicated": predicated,
+                "bin_select": f"{bin_select:016X}",
+                "bin_mask": f"{bin_mask:016X}",
+                "bin_intersection": f"{bin_intersection:016X}",
                 "semantic_receiver_varied": event.get("semantic_receiver_varied") == "true",
             }
         )
@@ -142,6 +160,8 @@ def build(events, session):
         "full_preview_profiles": sum(1 for row in profiles if row["role"] == "full_preview_extent"),
         "full_preview_calls": sum(row["calls"] for row in profiles if row["role"] == "full_preview_extent"),
         "reduced_preview_width_profiles": sum(1 for row in profiles if row["role"] == "reduced_preview_width"),
+        "predicated_edram_tile_profiles": sum(1 for row in profiles if row["role"] == "predicated_edram_tile"),
+        "predicated_edram_tile_calls": sum(row["calls"] for row in profiles if row["role"] == "predicated_edram_tile"),
         "other_extent_profiles": sum(1 for row in profiles if row["role"] == "other_extent"),
     }
     return document(session, failures, profiles, totals)
@@ -168,6 +188,10 @@ def document(session, failures, profiles, totals):
             "exact_semantic_target_profiles_accounted": complete,
             "full_preview_color_profile_observed": complete and bool(full_clean),
             "eligible_for_isolated_capture_selection": complete and bool(full_clean),
+            "predicated_edram_tile_profile_observed": complete
+            and any(row["role"] == "predicated_edram_tile" for row in profiles),
+            "eligible_for_tile_assembly_investigation": complete
+            and any(row["role"] == "predicated_edram_tile" for row in profiles),
             "native_admission": False,
             "suppression_allowed": False,
         },

--- a/tools/tests/test_native_renderer_procedural_color_targets.py
+++ b/tools/tests/test_native_renderer_procedural_color_targets.py
@@ -10,13 +10,14 @@ MODULE = importlib.util.module_from_spec(SPEC)
 SPEC.loader.exec_module(MODULE)
 
 
-def fixture(scissor_extent="0:0:1280:720"):
+def fixture(scissor_extent="0:0:1280:720", predicated="false"):
     common = {"session": "session"}
     return [
         {
             **common,
             "event": MODULE.CONFIG,
-            "procedural_color_target_profile_census": "bounded_exact_v1",
+            "procedural_color_target_profile_census": "bounded_exact_v2",
+            "procedural_color_target_profile_bin_state": "exact_backend_v1",
         },
         {
             **common,
@@ -34,6 +35,10 @@ def fixture(scissor_extent="0:0:1280:720"):
             "viewport": "1:2:3:4",
             "scissor": "00000000:02D00500",
             "scissor_extent": scissor_extent,
+            "predicated": predicated,
+            "bin_select": "0000000000000004",
+            "bin_mask": "000000000000000C",
+            "bin_intersection": "0000000000000004",
             "semantic_receiver_varied": "true",
         },
         {
@@ -62,6 +67,16 @@ class ProceduralColorTargetTests(unittest.TestCase):
     def test_reduced_height_profile_stays_out_of_selection(self):
         result = MODULE.build(fixture("0:0:1280:256"), "session")
         self.assertEqual("reduced_preview_width", result["profiles"][0]["role"])
+        self.assertFalse(
+            result["qualification"]["eligible_for_isolated_capture_selection"]
+        )
+
+    def test_predicated_reduced_height_profile_is_edram_tile(self):
+        result = MODULE.build(fixture("0:0:1280:256", "true"), "session")
+        self.assertEqual("predicated_edram_tile", result["profiles"][0]["role"])
+        self.assertTrue(
+            result["qualification"]["eligible_for_tile_assembly_investigation"]
+        )
         self.assertFalse(
             result["qualification"]["eligible_for_isolated_capture_selection"]
         )

--- a/tools/tests/test_release_contract.py
+++ b/tools/tests/test_release_contract.py
@@ -43,10 +43,10 @@ class ReleaseContractTests(unittest.TestCase):
 
     def test_rexglue_patches_have_stable_order_and_no_binary_payload(self):
         patches = sorted((ROOT / "patches/rexglue").glob("*.patch"))
-        self.assertEqual(len(patches), 106)
+        self.assertEqual(len(patches), 107)
         self.assertEqual(
             patches[-1].name,
-            "0106-d3d12-color-only-isolated-replay.patch",
+            "0107-graphics-draw-bin-state-observer.patch",
         )
         self.assertEqual(len(patches), len({path.name[:4] for path in patches}))
         for path in patches:


### PR DESCRIPTION
## Summary
- expose the command processor's exact bin select/mask on observed draws
- classify predicated 1280-wide regions as EDRAM tile candidates
- keep tile profiles ineligible for standalone publication and document the wrong-view cause

## Validation
- python -m unittest discover -s tools/tests (693 passed)
- ReXGlue Release build passed
- Windows AMD64 preview Release build passed
- gameplay validation remains batched for the next tile-sequence capture