### PR TITLE
feat(native-renderer): prove procedural resolve assembly

### DIFF
--- a/docs/native-renderer/COLOR_PRODUCER_LINEAGE.md
+++ b/docs/native-renderer/COLOR_PRODUCER_LINEAGE.md
@@ -1,7 +1,7 @@
 # Live color-producer lineage
 
-Status: live semantic color producer proved; exact target-role profiler
-implemented for the next batched AppData run
+Status: predicated color tile proved; exact resolve-assembly join implemented
+for the next batched AppData run
 
 ## Why this is the next ingress
 
@@ -60,6 +60,28 @@ targets. Receiver addresses are samples only; a variation bit proves when a
 target profile spans multiple live receiver instances. The bounded table has
 1,024 entries and fails closed on overflow or incomplete accounting.
 
+The clean AppData-backed festival session `20260901T073926Z-p40856` completes
+that target-role checkpoint. All 382 exact procedural color draws are bounded,
+opaque, predicated, and use the same 1280x256 scissor, target state
+`14020500:00030000:00000000:00000000:00000000:00010400`, and bin intersection
+`0000000080000003`. There is no monolithic 1280x720 profile. The same final
+resolve census exposes three contiguous source-zero ranges on surface
+`14020500`, with byte lengths `1310720`, `1310720`, and `1146880`. Their
+destination pitch declares 1280x720, format 7 is four bytes per pixel, and the
+combined storage is 1280x736: the logical 720 rows plus 16 rows of alignment.
+This is strong resolve-topology evidence that the 1280x256 draw extent is one
+piece of the padded full-frame assembly, not an independently publishable
+camera view.
+
+The resolve census now exports the exact selected source index, selected
+source target state, and all bound source targets. The offline
+`summarize-native-renderer-procedural-resolve-assembly.py` join requires that
+source state to match the procedural target, requires the resolves to fall in
+the procedural profile frame window, and proves address contiguity, copy
+format, bytes per pixel, logical extent, and bounded row padding. This removes
+the last inference from the assembly gate. It remains diagnostic only and is
+batched with the next substantial AppData validation.
+
 Run the deferred qualifier after the next combined AppData capture:
 
 ```powershell
@@ -78,12 +100,20 @@ python tools/summarize-native-renderer-procedural-color-targets.py `
   --output .local/qualification/native-renderer-procedural-color-targets.json
 ```
 
+Finally, prove the exact resolve assembly:
+
+```powershell
+python tools/summarize-native-renderer-procedural-resolve-assembly.py `
+  <session-log.jsonl> `
+  --session <session> `
+  --output .local/qualification/native-renderer-procedural-resolve-assembly.json
+```
+
 ## Promotion gate
 
-The next C1 implementation may privately capture a monolithic profile only
-when a clean session proves complete target-profile accounting and an exact
-full-preview 1280x720 profile whose calls are all bounded and opaque and never
-sample a resolved target. A predicated 1280-wide EDRAM tile instead advances to
-tile-sequence and resolve-assembly investigation; it cannot be published alone.
-Other reduced targets remain excluded. Until then, Xenos remains authoritative
-and this census changes no rendering or control flow.
+The next C1 implementation may privately capture this family only after a
+clean session proves an exact contiguous 1280x720 logical resolve assembly.
+The private target must use the complete assembly dimensions and preserve its
+16 alignment rows; no 1280x256 component may be published alone. Other reduced
+targets remain excluded. Until then, Xenos remains authoritative and this
+census changes no rendering or control flow.

--- a/docs/native-renderer/REPRIORITIZED_PLAN.md
+++ b/docs/native-renderer/REPRIORITIZED_PLAN.md
@@ -65,9 +65,10 @@ Already landed or substantially qualified:
   vehicle-map pool lineage is the final bounded follow-up; and
 - post-processing topology census plus the mechanical presentation ingress.
 
-Phase A and B1-B5 are merged. The active B6 slice qualifies the first coherent
-continuous frame and closes the retained-target lifecycle discovered during
-the AppData run. Phase C terrain and roads are the next visible-impact target.
+Phase A and B are merged and qualified. Phase C is active: C1 has reached a
+live procedural color producer and is closing its padded full-frame resolve
+assembly before any new native publication. Terrain and roads remain the next
+visible-impact target.
 
 ---
 
@@ -717,6 +718,19 @@ registers. The next batched AppData run can distinguish monolithic profiles
 from EDRAM tiles; a tile advances to resolve-assembly work and is never
 published alone. Xenos output remains authoritative. See
 [`COLOR_PRODUCER_LINEAGE.md`](COLOR_PRODUCER_LINEAGE.md).
+
+EDRAM target-role runtime result: clean AppData session
+`20260901T073926Z-p40856` reached the saved festival and exited normally. All
+382 exact procedural color draws are bounded opaque 1280x256 predicated draws
+with bin intersection `0000000080000003`; no monolithic 1280x720 draw profile
+exists. The final resolve census independently exposes a three-range contiguous
+source-zero candidate on the same surface with 1280x720 destination pitch and
+1280x736 physical storage. The extra 16 rows are bounded alignment, so the
+earlier 1280x256 publication was one component of the padded full frame and
+explains its wrong camera/view. Resolve events now retain exact selected-source
+state, and a fail-closed offline join proves target identity, contiguity,
+format, logical extent, and padding on the next batched run. No native
+admission or suppression changes in this checkpoint.
 
 ### C2. Static world buildings and props
 

--- a/src/native_renderer/graphics_hooks.cpp
+++ b/src/native_renderer/graphics_hooks.cpp
@@ -16956,6 +16956,10 @@ void EmitDependencyCensusWindow() {
       break;
     }
     const bool sampled = target.sampled_draw_count != 0;
+    const uint32_t copy_source = target.sample.rb_copy_control & 7;
+    const uint32_t copy_source_info =
+        copy_source < 4 ? target.sample.color_info[copy_source]
+                        : target.sample.depth_info;
     const std::string query_relation =
         target.conditional_sample_draw_count ||
                 target.query_state_sample_draw_count
@@ -16988,6 +16992,15 @@ void EmitDependencyCensusWindow() {
                                     target.sample.rb_copy_dest_info,
                                     target.sample.rb_copy_dest_pitch,
                                     target.sample.surface_info)},
+         {"copy_source", number(copy_source)},
+         {"copy_source_state",
+          fmt::format("{:08X}:{:08X}", target.sample.surface_info,
+                      copy_source_info)},
+         {"copy_source_targets",
+          fmt::format("{:08X}:{:08X}:{:08X}:{:08X}:{:08X}",
+                      target.sample.color_info[0], target.sample.color_info[1],
+                      target.sample.color_info[2], target.sample.color_info[3],
+                      target.sample.depth_info)},
          {"presentation_only", "unknown_uninstrumented"},
          {"guest_cpu_read", "unknown_uninstrumented"},
          {"query_dependency", query_relation},
@@ -30393,6 +30406,7 @@ void InstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system,
        {"procedural_color_target_profile_dispatch", "82417BC0"},
        {"procedural_color_target_profile_preview_extent", "1280x720"},
        {"procedural_color_target_profile_bin_state", "exact_backend_v1"},
+       {"procedural_color_resolve_source_state", "exact_backend_v1"},
        {"guest_payload_read", "false"},
        {"guest_state_changed", "false"},
        {"control_flow_changed", "false"},

--- a/tools/summarize-native-renderer-procedural-resolve-assembly.py
+++ b/tools/summarize-native-renderer-procedural-resolve-assembly.py
@@ -1,0 +1,288 @@
+#!/usr/bin/env python3
+"""Join exact procedural color targets to their contiguous resolve assembly."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import pathlib
+import sys
+
+
+SCHEMA = "pinyon-shift.native-renderer-procedural-resolve-assembly.v1"
+CONFIG = "native_renderer.discovery.command_buffer_lineage_config"
+PROFILE = "native_renderer.discovery.procedural_color_target_profile_entry"
+PROFILE_SUMMARY = (
+    "native_renderer.discovery.procedural_color_target_profile_summary"
+)
+RESOLVE = "native_renderer.census.resolve_target"
+SHUTDOWN = "process.shutdown"
+
+# Xenos ColorFormat storage sizes for the formats useful to the native renderer.
+COLOR_BYTES_PER_PIXEL = {
+    2: 1,
+    3: 2,
+    4: 2,
+    5: 2,
+    6: 4,
+    7: 4,
+    8: 1,
+    9: 1,
+    10: 2,
+    14: 4,
+    15: 2,
+    16: 4,
+    17: 4,
+    24: 2,
+    25: 4,
+    26: 8,
+    30: 2,
+    31: 4,
+    32: 8,
+    36: 4,
+    37: 8,
+    38: 16,
+    50: 8,
+    54: 8,
+    55: 8,
+    56: 8,
+}
+
+
+def integer(event, name):
+    try:
+        return int(event[name], 10)
+    except (KeyError, TypeError, ValueError) as error:
+        raise ValueError(f"invalid {name}") from error
+
+
+def hexadecimal(event, name):
+    try:
+        return int(event[name], 16)
+    except (KeyError, TypeError, ValueError) as error:
+        raise ValueError(f"invalid {name}") from error
+
+
+def read_events(path, session):
+    events = []
+    for line_number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+        if not line.strip():
+            continue
+        try:
+            event = json.loads(line)
+        except json.JSONDecodeError as error:
+            raise ValueError(f"invalid JSON at line {line_number}") from error
+        if event.get("session") == session:
+            events.append(event)
+    return events
+
+
+def split_hex_words(value, count, name):
+    if not isinstance(value, str):
+        raise ValueError(f"invalid {name}")
+    words = value.split(":")
+    if len(words) != count:
+        raise ValueError(f"invalid {name}")
+    try:
+        return tuple(int(word, 16) for word in words)
+    except ValueError as error:
+        raise ValueError(f"invalid {name}") from error
+
+
+def profile_sources(event):
+    target = split_hex_words(event.get("target_state"), 6, "target_state")
+    return {(target[0], source, target[source + 1]) for source in range(4)}
+
+
+def copy_state(event):
+    return split_hex_words(event.get("copy_state"), 4, "copy_state")
+
+
+def latest_resolves(events):
+    latest = {}
+    for event in events:
+        address = hexadecimal(event, "address")
+        previous = latest.get(address)
+        if previous is None or integer(event, "last_resolve_frame") >= integer(
+            previous, "last_resolve_frame"
+        ):
+            latest[address] = event
+    return latest
+
+
+def contiguous_chains(rows):
+    chains = []
+    for row in sorted(rows, key=lambda item: item["address"]):
+        if chains and chains[-1][-1]["address"] + chains[-1][-1]["length"] == row[
+            "address"
+        ]:
+            chains[-1].append(row)
+        else:
+            chains.append([row])
+    return chains
+
+
+def build(events, session):
+    configs = [event for event in events if event.get("event") == CONFIG]
+    profiles = [event for event in events if event.get("event") == PROFILE]
+    summaries = [event for event in events if event.get("event") == PROFILE_SUMMARY]
+    shutdowns = [event for event in events if event.get("event") == SHUTDOWN]
+    failures = []
+    if len(configs) != 1:
+        failures.append("expected one command-lineage config")
+    elif configs[0].get("procedural_color_resolve_source_state") != "exact_backend_v1":
+        failures.append("exact resolve source state was not armed")
+    if len(summaries) != 1 or summaries[0].get("accounting_complete") != "true":
+        failures.append("complete procedural color-target accounting was not observed")
+    if not profiles:
+        failures.append("procedural color-target profiles were not observed")
+    if len(shutdowns) != 1:
+        failures.append("clean process shutdown was not observed")
+
+    profile_first = min(
+        (integer(event, "first_frame") for event in profiles), default=0
+    )
+    profile_last = max((integer(event, "last_frame") for event in profiles), default=0)
+    sources = set()
+    for profile in profiles:
+        sources.update(profile_sources(profile))
+
+    resolve_events = [event for event in events if event.get("event") == RESOLVE]
+    selected = []
+    for event in latest_resolves(resolve_events).values():
+        source = integer(event, "copy_source")
+        if source >= 4:
+            continue
+        source_surface, source_info = split_hex_words(
+            event.get("copy_source_state"), 2, "copy_source_state"
+        )
+        last_frame = integer(event, "last_resolve_frame")
+        if (source_surface, source, source_info) not in sources:
+            continue
+        if not profile_first <= last_frame <= profile_last:
+            continue
+        control, destination_info, destination_pitch, surface = copy_state(event)
+        selected.append(
+            {
+                "address": hexadecimal(event, "address"),
+                "length": integer(event, "length"),
+                "last_frame": last_frame,
+                "source": source,
+                "source_state": f"{source_surface:08X}:{source_info:08X}",
+                "control": control,
+                "destination_info": destination_info,
+                "destination_pitch": destination_pitch,
+                "surface": surface,
+            }
+        )
+
+    groups = {}
+    for row in selected:
+        key = (
+            row["source"],
+            row["source_state"],
+            row["destination_info"],
+            row["destination_pitch"],
+        )
+        groups.setdefault(key, []).append(row)
+
+    assemblies = []
+    for key, rows in groups.items():
+        source, source_state, destination_info, destination_pitch = key
+        pitch_width = destination_pitch & 0x3FFF
+        logical_height = (destination_pitch >> 16) & 0x3FFF
+        color_format = (destination_info >> 7) & 0x3F
+        bytes_per_pixel = COLOR_BYTES_PER_PIXEL.get(color_format)
+        for chain in contiguous_chains(rows):
+            total_bytes = sum(row["length"] for row in chain)
+            padded_height = None
+            if bytes_per_pixel and pitch_width:
+                row_bytes = pitch_width * bytes_per_pixel
+                if total_bytes % row_bytes == 0:
+                    padded_height = total_bytes // row_bytes
+            exact_full_frame = (
+                len(chain) > 1
+                and bytes_per_pixel is not None
+                and pitch_width == 1280
+                and logical_height == 720
+                and padded_height is not None
+                and logical_height <= padded_height < logical_height + 64
+            )
+            assemblies.append(
+                {
+                    "source": source,
+                    "source_state": source_state,
+                    "base_address": f"{chain[0]['address']:08X}",
+                    "addresses": [f"{row['address']:08X}" for row in chain],
+                    "lengths": [row["length"] for row in chain],
+                    "copy_count": len(chain),
+                    "total_bytes": total_bytes,
+                    "destination_info": f"{destination_info:08X}",
+                    "destination_pitch": f"{destination_pitch:08X}",
+                    "color_format": color_format,
+                    "bytes_per_pixel": bytes_per_pixel,
+                    "pitch_width": pitch_width,
+                    "logical_height": logical_height,
+                    "padded_height": padded_height,
+                    "padding_rows": (
+                        padded_height - logical_height
+                        if padded_height is not None
+                        else None
+                    ),
+                    "exact_contiguous_full_frame": exact_full_frame,
+                }
+            )
+
+    assemblies.sort(
+        key=lambda row: (
+            not row["exact_contiguous_full_frame"],
+            -row["total_bytes"],
+            row["base_address"],
+        )
+    )
+    exact = [row for row in assemblies if row["exact_contiguous_full_frame"]]
+    if not exact and not failures:
+        failures.append("no exact contiguous full-frame color resolve assembly")
+    complete = not failures
+    return {
+        "schema": SCHEMA,
+        "session": session,
+        "status": "complete" if complete else "incomplete",
+        "failures": failures,
+        "profile_window": {"first_frame": profile_first, "last_frame": profile_last},
+        "assemblies": assemblies,
+        "qualification": {
+            "exact_procedural_color_resolve_assembly": complete and bool(exact),
+            "standalone_1280x256_publication_allowed": False,
+            "logical_extent": "1280x720" if complete and exact else None,
+            "native_admission": False,
+            "suppression_allowed": False,
+        },
+        "safety": {
+            "guest_payload_exported": False,
+            "guest_state_changed": False,
+            "control_flow_changed": False,
+            "native_draw": False,
+            "xenos_authority": True,
+        },
+    }
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("log", type=pathlib.Path)
+    parser.add_argument("--session", required=True)
+    parser.add_argument("--output", required=True, type=pathlib.Path)
+    args = parser.parse_args(argv)
+    try:
+        result = build(read_events(args.log, args.session), args.session)
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(json.dumps(result, indent=2, sort_keys=True) + "\n")
+        return 0 if result["status"] == "complete" else 1
+    except (OSError, UnicodeDecodeError, ValueError) as error:
+        print(f"procedural resolve-assembly summary failed: {error}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/tests/test_native_renderer_procedural_resolve_assembly.py
+++ b/tools/tests/test_native_renderer_procedural_resolve_assembly.py
@@ -1,0 +1,115 @@
+import importlib.util
+import pathlib
+import unittest
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+TOOL = ROOT / "tools/summarize-native-renderer-procedural-resolve-assembly.py"
+SPEC = importlib.util.spec_from_file_location("procedural_resolve_assembly", TOOL)
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+def fixture():
+    common = {"session": "session"}
+    events = [
+        {
+            **common,
+            "event": MODULE.CONFIG,
+            "procedural_color_resolve_source_state": "exact_backend_v1",
+        },
+        {
+            **common,
+            "event": MODULE.PROFILE,
+            "first_frame": "100",
+            "last_frame": "110",
+            "target_state": (
+                "14020500:00030000:00000000:00000000:00000000:00010400"
+            ),
+        },
+        {
+            **common,
+            "event": MODULE.PROFILE_SUMMARY,
+            "accounting_complete": "true",
+        },
+    ]
+    base = 0x1C4E1000
+    lengths = [1280 * 256 * 4, 1280 * 256 * 4, 1280 * 224 * 4]
+    for length in lengths:
+        events.append(
+            {
+                **common,
+                "event": MODULE.RESOLVE,
+                "address": f"{base:08X}",
+                "length": str(length),
+                "last_resolve_frame": "110",
+                "copy_source": "0",
+                "copy_source_state": "14020500:00030000",
+                "copy_state": "00100360:003E0382:02D00500:14020500",
+            }
+        )
+        base += length
+    events.append({**common, "event": MODULE.SHUTDOWN})
+    return events
+
+
+class ProceduralResolveAssemblyTests(unittest.TestCase):
+    def test_runtime_exports_exact_copy_source_state(self):
+        source = (ROOT / "src/native_renderer/graphics_hooks.cpp").read_text(
+            encoding="utf-8"
+        )
+        self.assertIn('{"copy_source", number(copy_source)}', source)
+        self.assertIn('{"copy_source_state",', source)
+        self.assertIn('{"copy_source_targets",', source)
+        self.assertIn(
+            '{"procedural_color_resolve_source_state", "exact_backend_v1"}',
+            source,
+        )
+
+    def test_qualifies_three_contiguous_resolves_as_full_frame(self):
+        result = MODULE.build(fixture(), "session")
+        self.assertEqual("complete", result["status"])
+        assembly = result["assemblies"][0]
+        self.assertEqual(3, assembly["copy_count"])
+        self.assertEqual(1280, assembly["pitch_width"])
+        self.assertEqual(720, assembly["logical_height"])
+        self.assertEqual(736, assembly["padded_height"])
+        self.assertEqual(16, assembly["padding_rows"])
+        self.assertTrue(assembly["exact_contiguous_full_frame"])
+        self.assertTrue(
+            result["qualification"]["exact_procedural_color_resolve_assembly"]
+        )
+        self.assertFalse(
+            result["qualification"]["standalone_1280x256_publication_allowed"]
+        )
+
+    def test_rejects_gap_between_resolve_chunks(self):
+        events = fixture()
+        events[5]["address"] = "1C762000"
+        result = MODULE.build(events, "session")
+        self.assertEqual("incomplete", result["status"])
+        self.assertIn(
+            "no exact contiguous full-frame color resolve assembly",
+            result["failures"],
+        )
+
+    def test_fails_closed_without_exact_source_state_capability(self):
+        events = fixture()
+        del events[0]["procedural_color_resolve_source_state"]
+        result = MODULE.build(events, "session")
+        self.assertEqual("incomplete", result["status"])
+        self.assertIn("exact resolve source state was not armed", result["failures"])
+
+    def test_ignores_depth_resolves(self):
+        events = fixture()
+        for event in events:
+            if event.get("event") == MODULE.RESOLVE:
+                event["copy_source"] = "4"
+                event["copy_source_state"] = "14020500:00010400"
+        result = MODULE.build(events, "session")
+        self.assertEqual("incomplete", result["status"])
+        self.assertEqual([], result["assemblies"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- export exact resolve source state from the dependency census
- add a fail-closed procedural color resolve-assembly qualifier
- document the 1280x736 padded / 1280x720 logical frame topology

## Validation
- python -m unittest discover -s tools/tests -p test_*.py (698 passed)
- Release preview build succeeded

Xenos remains authoritative; this PR enables no native admission or suppression.