### PR TITLE
feat(native-renderer): track procedural resolve worksets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,7 @@ if(WIN32)
         src/native_renderer/buffer_cache.cpp
         src/native_renderer/guest_output_renderer.cpp
         src/native_renderer/render_target_bridge.cpp
+        src/native_renderer/resolve_assembly_tracker.cpp
         src/native_renderer/resource_worker.cpp
         src/native_renderer/resource_identity.cpp
         src/native_renderer/shader_capture.cpp
@@ -43,6 +44,7 @@ else()
         src/native_renderer/buffer_cache.cpp
         src/native_renderer/guest_output_renderer.cpp
         src/native_renderer/render_target_bridge.cpp
+        src/native_renderer/resolve_assembly_tracker.cpp
         src/native_renderer/resource_worker.cpp
         src/native_renderer/resource_identity.cpp
         src/native_renderer/shader_capture.cpp
@@ -84,6 +86,12 @@ add_executable(pinyon_shift_resource_worker_tests EXCLUDE_FROM_ALL
     src/native_renderer/resource_worker.cpp
 )
 target_include_directories(pinyon_shift_resource_worker_tests PRIVATE src)
+
+add_executable(pinyon_shift_resolve_assembly_tracker_tests EXCLUDE_FROM_ALL
+    tests/native_renderer/resolve_assembly_tracker_test.cpp
+    src/native_renderer/resolve_assembly_tracker.cpp
+)
+target_include_directories(pinyon_shift_resolve_assembly_tracker_tests PRIVATE src)
 
 pinyon_shift_attach_rexglue(pinyon_shift)
 

--- a/docs/native-renderer/COLOR_PRODUCER_LINEAGE.md
+++ b/docs/native-renderer/COLOR_PRODUCER_LINEAGE.md
@@ -1,7 +1,7 @@
 # Live color-producer lineage
 
-Status: predicated color tile proved; exact resolve-assembly join implemented
-for the next batched AppData run
+Status: predicated color tile and exact padded full-frame resolve assembly
+proved; runtime workset tracker implemented
 
 ## Why this is the next ingress
 
@@ -78,9 +78,25 @@ source target state, and all bound source targets. The offline
 `summarize-native-renderer-procedural-resolve-assembly.py` join requires that
 source state to match the procedural target, requires the resolves to fall in
 the procedural profile frame window, and proves address contiguity, copy
-format, bytes per pixel, logical extent, and bounded row padding. This removes
-the last inference from the assembly gate. It remains diagnostic only and is
-batched with the next substantial AppData validation.
+format, bytes per pixel, logical extent, and bounded row padding.
+
+The follow-up clean AppData session `20260901T080735Z-p36580` removes the last
+inference from that gate. The exact selected source state is
+`14020500:00030000`, matching the procedural target, and the qualifier proves
+the contiguous ranges `1C4E1000`, `1C621000`, and `1C761000` with lengths
+`1310720`, `1310720`, and `1146880`. Destination state
+`003E0382:02D00500` decodes to four-byte pixels, logical 1280x720, padded
+1280x736, and exactly 16 alignment rows. The session exited normally with
+complete target and assembly accounting.
+
+The same fail-closed join now exists as a small runtime workset tracker. It
+retains at most 64 copies per frame, matches only the exact source target,
+requires one destination state and address-contiguous chunks, decodes format
+and pitch, and exposes an exact result only for the complete logical frame with
+bounded padding. It retains the latest qualified workset while capping detailed
+events at 64 and reporting any omitted details in its final summary. Its events
+are diagnostic only and are deliberately batched into the next substantial
+AppData validation.
 
 Run the deferred qualifier after the next combined AppData capture:
 
@@ -111,9 +127,10 @@ python tools/summarize-native-renderer-procedural-resolve-assembly.py `
 
 ## Promotion gate
 
-The next C1 implementation may privately capture this family only after a
-clean session proves an exact contiguous 1280x720 logical resolve assembly.
-The private target must use the complete assembly dimensions and preserve its
-16 alignment rows; no 1280x256 component may be published alone. Other reduced
-targets remain excluded. Until then, Xenos remains authoritative and this
-census changes no rendering or control flow.
+The exact contiguous 1280x720 logical resolve assembly is now proved. The next
+C1 implementation may use the runtime tracker as its private capture gate only
+after the tracker's event contract passes the next batched validation. The
+private target must use the complete assembly dimensions and preserve its 16
+alignment rows; no 1280x256 component may be published alone. Other reduced
+targets remain excluded. Xenos remains authoritative and this checkpoint
+changes no rendering or control flow.

--- a/docs/native-renderer/REPRIORITIZED_PLAN.md
+++ b/docs/native-renderer/REPRIORITIZED_PLAN.md
@@ -66,9 +66,9 @@ Already landed or substantially qualified:
 - post-processing topology census plus the mechanical presentation ingress.
 
 Phase A and B are merged and qualified. Phase C is active: C1 has reached a
-live procedural color producer and is closing its padded full-frame resolve
-assembly before any new native publication. Terrain and roads remain the next
-visible-impact target.
+live procedural color producer, proved its padded full-frame resolve assembly,
+and is moving that exact gate into the runtime workset before any new native
+publication. Terrain and roads remain the next visible-impact target.
 
 ---
 
@@ -731,6 +731,18 @@ explains its wrong camera/view. Resolve events now retain exact selected-source
 state, and a fail-closed offline join proves target identity, contiguity,
 format, logical extent, and padding on the next batched run. No native
 admission or suppression changes in this checkpoint.
+
+Exact resolve-assembly result: clean AppData session
+`20260901T080735Z-p36580` proves that selected copy-source state
+`14020500:00030000` exactly matches the procedural target. Its three contiguous
+ranges begin at `1C4E1000`, `1C621000`, and `1C761000`, use one destination
+state `003E0382:02D00500`, and decode to four-byte pixels, logical 1280x720,
+padded 1280x736, and 16 alignment rows. Target and assembly accounting are
+complete and the process exited normally. A bounded fail-closed runtime tracker
+now performs the same exact source, destination, contiguity, format, extent,
+and padding join without publishing or suppressing anything. Its event contract
+will ride the next substantial AppData batch rather than forcing a standalone
+long validation run.
 
 ### C2. Static world buildings and props
 

--- a/src/native_renderer/graphics_hooks.cpp
+++ b/src/native_renderer/graphics_hooks.cpp
@@ -30,6 +30,7 @@
 #include <rex/system/xmemory.h>
 
 #include "native_renderer/graphics_hooks.h"
+#include "native_renderer/resolve_assembly_tracker.h"
 #include "native_renderer/resource_identity.h"
 #include "pinyon_shift_diagnostics.h"
 
@@ -65,6 +66,7 @@ constexpr size_t kCandidateSummaryLimit = 32;
 constexpr size_t kPreparedShaderPairCapacity = 1024;
 constexpr size_t kCommandBufferLineageCapacity = 4096;
 constexpr size_t kProceduralColorTargetProfileCapacity = 1024;
+constexpr uint64_t kProceduralResolveAssemblyDetailLimit = 64;
 constexpr size_t kResolveTargetCapacity = 4096;
 constexpr size_t kResolvePageCapacity = 32768;
 constexpr size_t kResolveSummaryLimit = 32;
@@ -11247,6 +11249,11 @@ std::array<ProceduralColorTargetProfileEntry,
 uint64_t g_procedural_color_target_profile_observations = 0;
 uint64_t g_procedural_color_target_profile_entry_count = 0;
 uint64_t g_procedural_color_target_profile_overflow = 0;
+uint64_t g_procedural_resolve_assembly_count = 0;
+uint64_t g_procedural_resolve_assembly_detail_count = 0;
+uint64_t g_procedural_resolve_assembly_detail_overflow = 0;
+pinyon_shift::native_renderer::ProceduralResolveAssemblyTracker
+    g_procedural_resolve_assembly_tracker;
 bool g_graphics_census_installed = false;
 rex::memory::Memory *g_graphics_census_memory = nullptr;
 void *g_guest_cpu_access_callback = nullptr;
@@ -11525,6 +11532,10 @@ void ResetCommandBufferLineage() {
   g_procedural_color_target_profile_observations = 0;
   g_procedural_color_target_profile_entry_count = 0;
   g_procedural_color_target_profile_overflow = 0;
+  g_procedural_resolve_assembly_count = 0;
+  g_procedural_resolve_assembly_detail_count = 0;
+  g_procedural_resolve_assembly_detail_overflow = 0;
+  g_procedural_resolve_assembly_tracker = {};
 }
 
 void ResetDependencyCensus() {
@@ -17241,6 +17252,65 @@ void AccumulateCommandBufferTargetShape(
   entry.sample_color_window_scissor_br = observation.window_scissor_br;
 }
 
+void EmitProceduralResolveAssembly(
+    const std::optional<
+        pinyon_shift::native_renderer::ProceduralResolveAssembly> &result) {
+  if (!result || !result->exact_contiguous_full_frame) {
+    return;
+  }
+  ++g_procedural_resolve_assembly_count;
+  if (g_procedural_resolve_assembly_detail_count ==
+      kProceduralResolveAssemblyDetailLimit) {
+    ++g_procedural_resolve_assembly_detail_overflow;
+    return;
+  }
+  ++g_procedural_resolve_assembly_detail_count;
+  const auto &assembly = *result;
+  std::string addresses;
+  std::string lengths;
+  for (uint32_t index = 0; index < assembly.chunk_count; ++index) {
+    if (index) {
+      addresses += ':';
+      lengths += ':';
+    }
+    addresses += fmt::format("{:08X}", assembly.addresses[index]);
+    lengths += std::to_string(assembly.lengths[index]);
+  }
+  const uint32_t padding_rows =
+      assembly.padded_height >= assembly.logical_height
+          ? assembly.padded_height - assembly.logical_height
+          : 0;
+  pinyon_shift::diagnostics::RecordEvent(
+      "native_renderer.discovery.procedural_resolve_assembly",
+      {{"frame", std::to_string(assembly.frame_sequence)},
+       {"copy_source", std::to_string(assembly.source)},
+       {"copy_source_state",
+        fmt::format("{:08X}:{:08X}", assembly.source_surface_info,
+                    assembly.source_info)},
+       {"base_address", fmt::format("{:08X}", assembly.base_address)},
+       {"chunk_count", std::to_string(assembly.chunk_count)},
+       {"addresses", addresses},
+       {"lengths", lengths},
+       {"destination_info",
+        fmt::format("{:08X}", assembly.destination_info)},
+       {"destination_pitch",
+        fmt::format("{:08X}", assembly.destination_pitch)},
+       {"logical_extent",
+        fmt::format("{}x{}", assembly.logical_width,
+                    assembly.logical_height)},
+       {"padded_height", std::to_string(assembly.padded_height)},
+       {"padding_rows", std::to_string(padding_rows)},
+       {"bytes_per_pixel", std::to_string(assembly.bytes_per_pixel)},
+       {"total_bytes", std::to_string(assembly.total_bytes)},
+       {"copy_overflow", assembly.copy_overflow ? "true" : "false"},
+       {"status", "exact_contiguous_full_frame"},
+       {"standalone_component_publication", "false"},
+       {"native_admission", "false"},
+       {"native_draw", "false"},
+       {"xenos_authority", "true"},
+       {"suppression_allowed", "false"}});
+}
+
 void RecordProceduralColorTargetProfile(
     uint64_t prepared_signature,
     const rex::system::GraphicsDrawObservation &observation,
@@ -17256,6 +17326,12 @@ void RecordProceduralColorTargetProfile(
       !context.semantic_receiver_generation) {
     return;
   }
+  EmitProceduralResolveAssembly(g_procedural_resolve_assembly_tracker.Arm(
+      {.frame_sequence = observation.frame_sequence,
+       .surface_info = observation.surface_info,
+       .color_info = observation.color_info[0],
+       .logical_width = 1280,
+       .logical_height = 720}));
   ++g_procedural_color_target_profile_observations;
   uint64_t key = UINT64_C(0xCBF29CE484222325);
   for (uint64_t value :
@@ -17646,6 +17722,39 @@ void RecordPreparedCommandBufferLineage(
 }
 
 void EmitProceduralColorTargetProfiles() {
+  EmitProceduralResolveAssembly(g_procedural_resolve_assembly_tracker.Flush());
+  const auto &latest_assembly =
+      g_procedural_resolve_assembly_tracker.latest_qualified();
+  pinyon_shift::diagnostics::RecordEvent(
+      "native_renderer.discovery.procedural_resolve_assembly_summary",
+      {{"status", latest_assembly ? "exact_qualified" : "no_exact_assembly"},
+       {"exact_assemblies",
+        std::to_string(g_procedural_resolve_assembly_count)},
+       {"detail_events",
+        std::to_string(g_procedural_resolve_assembly_detail_count)},
+       {"detail_overflow",
+        std::to_string(g_procedural_resolve_assembly_detail_overflow)},
+       {"detail_limit",
+        std::to_string(kProceduralResolveAssemblyDetailLimit)},
+       {"latest_frame",
+        std::to_string(latest_assembly ? latest_assembly->frame_sequence : 0)},
+       {"latest_base_address",
+        latest_assembly ? fmt::format("{:08X}", latest_assembly->base_address)
+                        : "00000000"},
+       {"latest_chunk_count",
+        std::to_string(latest_assembly ? latest_assembly->chunk_count : 0)},
+       {"latest_logical_extent",
+        latest_assembly
+            ? fmt::format("{}x{}", latest_assembly->logical_width,
+                          latest_assembly->logical_height)
+            : "0x0"},
+       {"latest_padded_height",
+        std::to_string(latest_assembly ? latest_assembly->padded_height : 0)},
+       {"standalone_component_publication", "false"},
+       {"native_admission", "false"},
+       {"native_draw", "false"},
+       {"xenos_authority", "true"},
+       {"suppression_allowed", "false"}});
   uint64_t accounted = 0;
   uint64_t full_preview_extent_calls = 0;
   uint64_t reduced_preview_width_calls = 0;
@@ -28263,6 +28372,20 @@ void ObserveCopy(const rex::system::GraphicsCopyObservation &observation) {
     return;
   }
 
+  const uint32_t copy_source = observation.rb_copy_control & 7;
+  const uint32_t copy_source_info =
+      copy_source < 4 ? observation.color_info[copy_source]
+                      : observation.depth_info;
+  EmitProceduralResolveAssembly(g_procedural_resolve_assembly_tracker.Observe(
+      {.frame_sequence = observation.frame_sequence,
+       .source = copy_source,
+       .source_surface_info = observation.surface_info,
+       .source_info = copy_source_info,
+       .destination_info = observation.rb_copy_dest_info,
+       .destination_pitch = observation.rb_copy_dest_pitch,
+       .written_address = observation.written_address,
+       .written_length = observation.written_length}));
+
   ++g_dependency_census.window_resolve_count;
   g_dependency_census.window_resolve_bytes += observation.written_length;
   const size_t target_index = ResolveTargetIndex(observation.written_address);
@@ -30407,6 +30530,8 @@ void InstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system,
        {"procedural_color_target_profile_preview_extent", "1280x720"},
        {"procedural_color_target_profile_bin_state", "exact_backend_v1"},
        {"procedural_color_resolve_source_state", "exact_backend_v1"},
+       {"procedural_color_resolve_runtime_tracker",
+        "exact_contiguous_full_frame_v1"},
        {"guest_payload_read", "false"},
        {"guest_state_changed", "false"},
        {"control_flow_changed", "false"},

--- a/src/native_renderer/resolve_assembly_tracker.cpp
+++ b/src/native_renderer/resolve_assembly_tracker.cpp
@@ -1,0 +1,211 @@
+#include "native_renderer/resolve_assembly_tracker.h"
+
+#include <algorithm>
+#include <array>
+#include <limits>
+
+namespace pinyon_shift::native_renderer {
+namespace {
+
+uint32_t ColorBytesPerPixel(uint32_t format) {
+  switch (format) {
+    case 2:
+    case 8:
+    case 9:
+      return 1;
+    case 3:
+    case 4:
+    case 5:
+    case 10:
+    case 15:
+    case 24:
+    case 30:
+      return 2;
+    case 6:
+    case 7:
+    case 14:
+    case 16:
+    case 17:
+    case 25:
+    case 31:
+    case 36:
+      return 4;
+    case 26:
+    case 32:
+    case 37:
+    case 50:
+    case 54:
+    case 55:
+    case 56:
+      return 8;
+    case 38:
+      return 16;
+    default:
+      return 0;
+  }
+}
+
+}  // namespace
+
+std::optional<ProceduralResolveAssembly>
+ProceduralResolveAssemblyTracker::Advance(uint64_t frame_sequence) {
+  if (!frame_sequence_ || frame_sequence_ == frame_sequence) {
+    if (!frame_sequence_) {
+      Reset(frame_sequence);
+    }
+    return std::nullopt;
+  }
+  std::optional<ProceduralResolveAssembly> result = Finalize();
+  Reset(frame_sequence);
+  return result;
+}
+
+void ProceduralResolveAssemblyTracker::Reset(uint64_t frame_sequence) {
+  frame_sequence_ = frame_sequence;
+  target_ = {};
+  copy_count_ = 0;
+  copy_overflow_ = false;
+  target_conflict_ = false;
+}
+
+std::optional<ProceduralResolveAssembly> ProceduralResolveAssemblyTracker::Arm(
+    const ProceduralResolveTarget& target) {
+  std::optional<ProceduralResolveAssembly> result =
+      Advance(target.frame_sequence);
+  if (!target.valid()) {
+    return result;
+  }
+  if (target_conflict_) {
+    return result;
+  }
+  if (!target_.valid()) {
+    target_ = target;
+  } else if (target_.surface_info != target.surface_info ||
+             target_.color_info != target.color_info ||
+             target_.logical_width != target.logical_width ||
+             target_.logical_height != target.logical_height) {
+    target_ = {};
+    target_conflict_ = true;
+  }
+  return result;
+}
+
+std::optional<ProceduralResolveAssembly>
+ProceduralResolveAssemblyTracker::Observe(const ProceduralResolveCopy& copy) {
+  std::optional<ProceduralResolveAssembly> result =
+      Advance(copy.frame_sequence);
+  if (!copy.frame_sequence || copy.source >= 4 || !copy.written_length) {
+    return result;
+  }
+  if (copy_count_ == copies_.size()) {
+    copy_overflow_ = true;
+    return result;
+  }
+  copies_[copy_count_++] = copy;
+  return result;
+}
+
+std::optional<ProceduralResolveAssembly>
+ProceduralResolveAssemblyTracker::Finalize() {
+  if (!target_.valid()) {
+    return std::nullopt;
+  }
+
+  std::array<ProceduralResolveCopy, kMaximumCopiesPerFrame> matches{};
+  size_t match_count = 0;
+  for (size_t index = 0; index < copy_count_; ++index) {
+    const ProceduralResolveCopy& copy = copies_[index];
+    if (copy.source || copy.source_surface_info != target_.surface_info ||
+        copy.source_info != target_.color_info) {
+      continue;
+    }
+    matches[match_count++] = copy;
+  }
+  if (!match_count) {
+    return ProceduralResolveAssembly{.frame_sequence = frame_sequence_,
+                                     .source_surface_info = target_.surface_info,
+                                     .source_info = target_.color_info,
+                                     .logical_width = target_.logical_width,
+                                     .logical_height = target_.logical_height,
+                                     .copy_overflow = copy_overflow_};
+  }
+
+  std::sort(matches.begin(), matches.begin() + match_count,
+            [](const ProceduralResolveCopy& left,
+               const ProceduralResolveCopy& right) {
+              return left.written_address < right.written_address;
+            });
+
+  ProceduralResolveAssembly best{
+      .frame_sequence = frame_sequence_,
+      .source_surface_info = target_.surface_info,
+      .source_info = target_.color_info,
+      .logical_width = target_.logical_width,
+      .logical_height = target_.logical_height,
+      .copy_overflow = copy_overflow_};
+  for (size_t begin = 0; begin < match_count;) {
+    size_t end = begin + 1;
+    const ProceduralResolveCopy& first = matches[begin];
+    uint64_t total_bytes = first.written_length;
+    while (end < match_count && end - begin < best.addresses.size() &&
+           matches[end].destination_info == first.destination_info &&
+           matches[end].destination_pitch == first.destination_pitch &&
+           uint64_t(matches[end - 1].written_address) +
+                   matches[end - 1].written_length ==
+               matches[end].written_address) {
+      total_bytes += matches[end].written_length;
+      ++end;
+    }
+
+    const uint32_t chunk_count = uint32_t(end - begin);
+    const uint32_t pitch_width = first.destination_pitch & 0x3FFF;
+    const uint32_t logical_height =
+        (first.destination_pitch >> 16) & 0x3FFF;
+    const uint32_t color_format = (first.destination_info >> 7) & 0x3F;
+    const uint32_t bytes_per_pixel = ColorBytesPerPixel(color_format);
+    const uint64_t row_bytes = uint64_t(pitch_width) * bytes_per_pixel;
+    const uint32_t padded_height =
+        row_bytes && total_bytes % row_bytes == 0 &&
+                total_bytes / row_bytes <= std::numeric_limits<uint32_t>::max()
+            ? uint32_t(total_bytes / row_bytes)
+            : 0;
+    const bool exact =
+        chunk_count > 1 && pitch_width == target_.logical_width &&
+        logical_height == target_.logical_height && padded_height >= logical_height &&
+        padded_height < logical_height + 64 && bytes_per_pixel &&
+        !copy_overflow_;
+
+    if (exact || chunk_count > best.chunk_count) {
+      best.source = first.source;
+      best.destination_info = first.destination_info;
+      best.destination_pitch = first.destination_pitch;
+      best.base_address = first.written_address;
+      best.padded_height = padded_height;
+      best.bytes_per_pixel = bytes_per_pixel;
+      best.total_bytes = total_bytes;
+      best.chunk_count = chunk_count;
+      best.exact_contiguous_full_frame = exact;
+      for (size_t index = begin; index < end; ++index) {
+        best.addresses[index - begin] = matches[index].written_address;
+        best.lengths[index - begin] = matches[index].written_length;
+      }
+    }
+    if (exact) {
+      break;
+    }
+    begin = end;
+  }
+  if (best.exact_contiguous_full_frame) {
+    latest_qualified_ = best;
+  }
+  return best;
+}
+
+std::optional<ProceduralResolveAssembly>
+ProceduralResolveAssemblyTracker::Flush() {
+  std::optional<ProceduralResolveAssembly> result = Finalize();
+  Reset(0);
+  return result;
+}
+
+}  // namespace pinyon_shift::native_renderer

--- a/src/native_renderer/resolve_assembly_tracker.h
+++ b/src/native_renderer/resolve_assembly_tracker.h
@@ -1,0 +1,85 @@
+#ifndef PINYON_SHIFT_NATIVE_RENDERER_RESOLVE_ASSEMBLY_TRACKER_H_
+#define PINYON_SHIFT_NATIVE_RENDERER_RESOLVE_ASSEMBLY_TRACKER_H_
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <optional>
+
+namespace pinyon_shift::native_renderer {
+
+struct ProceduralResolveTarget {
+  uint64_t frame_sequence = 0;
+  uint32_t surface_info = 0;
+  uint32_t color_info = 0;
+  uint32_t logical_width = 0;
+  uint32_t logical_height = 0;
+
+  bool valid() const {
+    return frame_sequence && logical_width && logical_height;
+  }
+};
+
+struct ProceduralResolveCopy {
+  uint64_t frame_sequence = 0;
+  uint32_t source = 0;
+  uint32_t source_surface_info = 0;
+  uint32_t source_info = 0;
+  uint32_t destination_info = 0;
+  uint32_t destination_pitch = 0;
+  uint32_t written_address = 0;
+  uint32_t written_length = 0;
+};
+
+struct ProceduralResolveAssembly {
+  static constexpr size_t kMaximumChunks = 8;
+
+  uint64_t frame_sequence = 0;
+  uint32_t source = 0;
+  uint32_t source_surface_info = 0;
+  uint32_t source_info = 0;
+  uint32_t destination_info = 0;
+  uint32_t destination_pitch = 0;
+  uint32_t base_address = 0;
+  uint32_t logical_width = 0;
+  uint32_t logical_height = 0;
+  uint32_t padded_height = 0;
+  uint32_t bytes_per_pixel = 0;
+  uint64_t total_bytes = 0;
+  uint32_t chunk_count = 0;
+  std::array<uint32_t, kMaximumChunks> addresses{};
+  std::array<uint32_t, kMaximumChunks> lengths{};
+  bool exact_contiguous_full_frame = false;
+  bool copy_overflow = false;
+};
+
+class ProceduralResolveAssemblyTracker {
+ public:
+  static constexpr size_t kMaximumCopiesPerFrame = 64;
+
+  std::optional<ProceduralResolveAssembly> Arm(
+      const ProceduralResolveTarget& target);
+  std::optional<ProceduralResolveAssembly> Observe(
+      const ProceduralResolveCopy& copy);
+  std::optional<ProceduralResolveAssembly> Flush();
+  const std::optional<ProceduralResolveAssembly>& latest_qualified() const {
+    return latest_qualified_;
+  }
+
+ private:
+  std::optional<ProceduralResolveAssembly> Advance(uint64_t frame_sequence);
+  std::optional<ProceduralResolveAssembly> Finalize();
+  void Reset(uint64_t frame_sequence);
+
+  uint64_t frame_sequence_ = 0;
+  ProceduralResolveTarget target_{};
+  std::array<ProceduralResolveCopy, kMaximumCopiesPerFrame> copies_{};
+  size_t copy_count_ = 0;
+  bool copy_overflow_ = false;
+  bool target_conflict_ = false;
+  std::optional<ProceduralResolveAssembly> latest_qualified_;
+};
+
+}  // namespace pinyon_shift::native_renderer
+
+#endif  // PINYON_SHIFT_NATIVE_RENDERER_RESOLVE_ASSEMBLY_TRACKER_H_

--- a/tests/native_renderer/resolve_assembly_tracker_test.cpp
+++ b/tests/native_renderer/resolve_assembly_tracker_test.cpp
@@ -1,0 +1,110 @@
+#include "native_renderer/resolve_assembly_tracker.h"
+
+#include <cstdlib>
+#include <iostream>
+
+namespace nr = pinyon_shift::native_renderer;
+
+namespace {
+
+void Require(bool condition, const char* message) {
+  if (!condition) {
+    std::cerr << message << '\n';
+    std::exit(EXIT_FAILURE);
+  }
+}
+
+nr::ProceduralResolveCopy Copy(uint32_t address, uint32_t length,
+                               uint64_t frame = 10) {
+  return {.frame_sequence = frame,
+          .source = 0,
+          .source_surface_info = 0x14020500,
+          .source_info = 0x00030000,
+          .destination_info = 0x003E0382,
+          .destination_pitch = 0x02D00500,
+          .written_address = address,
+          .written_length = length};
+}
+
+nr::ProceduralResolveTarget Target(uint64_t frame = 10) {
+  return {.frame_sequence = frame,
+          .surface_info = 0x14020500,
+          .color_info = 0x00030000,
+          .logical_width = 1280,
+          .logical_height = 720};
+}
+
+}  // namespace
+
+int main() {
+  constexpr uint32_t kFirstLength = 1280 * 256 * 4;
+  constexpr uint32_t kLastLength = 1280 * 224 * 4;
+  constexpr uint32_t kBase = 0x1C4E1000;
+
+  nr::ProceduralResolveAssemblyTracker tracker;
+  Require(!tracker.Observe(Copy(kBase, kFirstLength)),
+          "the current frame must remain pending");
+  Require(!tracker.Arm(Target()), "arming must not finalize the same frame");
+  Require(!tracker.Observe(Copy(kBase + kFirstLength, kFirstLength)),
+          "the second chunk must remain pending");
+  Require(!tracker.Observe(
+              Copy(kBase + 2 * kFirstLength, kLastLength)),
+          "the final chunk must remain pending until frame advance");
+  const auto exact = tracker.Arm(Target(11));
+  Require(exact && exact->exact_contiguous_full_frame &&
+              exact->chunk_count == 3 && exact->logical_width == 1280 &&
+              exact->logical_height == 720 && exact->padded_height == 736 &&
+              exact->bytes_per_pixel == 4 &&
+              exact->total_bytes == uint64_t(1280) * 736 * 4,
+          "three contiguous chunks must qualify the padded full frame");
+  Require(tracker.latest_qualified() &&
+              tracker.latest_qualified()->frame_sequence == 10,
+          "the last exact assembly must remain queryable");
+
+  nr::ProceduralResolveAssemblyTracker gap;
+  gap.Arm(Target());
+  gap.Observe(Copy(kBase, kFirstLength));
+  gap.Observe(Copy(kBase + kFirstLength + 0x1000, kFirstLength));
+  const auto incomplete = gap.Flush();
+  Require(incomplete && !incomplete->exact_contiguous_full_frame,
+          "a gap must fail closed");
+
+  nr::ProceduralResolveAssemblyTracker mismatch;
+  mismatch.Arm(Target());
+  auto wrong_source = Copy(kBase, kFirstLength);
+  wrong_source.source_info = 0x00040000;
+  mismatch.Observe(wrong_source);
+  const auto rejected = mismatch.Flush();
+  Require(rejected && !rejected->chunk_count,
+          "a source-state mismatch must not enter the assembly");
+
+  nr::ProceduralResolveAssemblyTracker conflicting_target;
+  conflicting_target.Arm(Target());
+  auto other_target = Target();
+  other_target.color_info = 0x00040000;
+  conflicting_target.Arm(other_target);
+  conflicting_target.Arm(Target());
+  conflicting_target.Observe(Copy(kBase, kFirstLength));
+  Require(!conflicting_target.Flush(),
+          "conflicting target states must invalidate the entire frame");
+
+  nr::ProceduralResolveAssemblyTracker overflow;
+  overflow.Arm(Target());
+  overflow.Observe(Copy(kBase, kFirstLength));
+  overflow.Observe(Copy(kBase + kFirstLength, kFirstLength));
+  overflow.Observe(Copy(kBase + 2 * kFirstLength, kLastLength));
+  for (size_t index = 3;
+       index <= nr::ProceduralResolveAssemblyTracker::kMaximumCopiesPerFrame;
+       ++index) {
+    auto unrelated = Copy(0x1000 + uint32_t(index) * 0x1000, 0x1000);
+    unrelated.source_info = 0x00040000;
+    overflow.Observe(unrelated);
+  }
+  const auto overflowed = overflow.Flush();
+  Require(overflowed && overflowed->copy_overflow &&
+              !overflowed->exact_contiguous_full_frame,
+          "copy overflow must fail the exact assembly closed");
+
+  std::cout << "native renderer resolve assembly tracker tests passed\n";
+  return EXIT_SUCCESS;
+}

--- a/tools/tests/test_native_renderer_procedural_resolve_assembly.py
+++ b/tools/tests/test_native_renderer_procedural_resolve_assembly.py
@@ -65,6 +65,19 @@ class ProceduralResolveAssemblyTests(unittest.TestCase):
             '{"procedural_color_resolve_source_state", "exact_backend_v1"}',
             source,
         )
+        self.assertIn(
+            '"native_renderer.discovery.procedural_resolve_assembly"', source
+        )
+        self.assertIn(
+            '"native_renderer.discovery.procedural_resolve_assembly_summary"',
+            source,
+        )
+        self.assertIn(
+            '"exact_contiguous_full_frame_v1"', source
+        )
+        self.assertIn(
+            "g_procedural_resolve_assembly_tracker.Observe", source
+        )
 
     def test_qualifies_three_contiguous_resolves_as_full_frame(self):
         result = MODULE.build(fixture(), "session")


### PR DESCRIPTION
## Summary\n- track the exact procedural color source and its contiguous padded full-frame resolve workset at runtime\n- fail closed on target conflicts, source mismatches, gaps, unsupported formats, or bounded-copy overflow\n- emit capped diagnostic details plus a final summary while keeping Xenos authoritative\n- record the exact 1280x720 / 1280x736 AppData qualification result\n\n## Validation\n- pinyon_shift_resolve_assembly_tracker_tests\n- python -m unittest discover -s tools/tests -p 'test_*.py' (698 tests)\n- Release pinyon_shift build\n\nNo new native admission, publication, or suppression is enabled.