### PR TITLE
feat(native-renderer): plan procedural frame accumulation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,7 @@ if(WIN32)
         src/native_renderer/guest_output_renderer.cpp
         src/native_renderer/render_target_bridge.cpp
         src/native_renderer/resolve_assembly_tracker.cpp
+        src/native_renderer/resolve_frame_accumulator.cpp
         src/native_renderer/resource_worker.cpp
         src/native_renderer/resource_identity.cpp
         src/native_renderer/shader_capture.cpp
@@ -45,6 +46,7 @@ else()
         src/native_renderer/guest_output_renderer.cpp
         src/native_renderer/render_target_bridge.cpp
         src/native_renderer/resolve_assembly_tracker.cpp
+        src/native_renderer/resolve_frame_accumulator.cpp
         src/native_renderer/resource_worker.cpp
         src/native_renderer/resource_identity.cpp
         src/native_renderer/shader_capture.cpp
@@ -92,6 +94,13 @@ add_executable(pinyon_shift_resolve_assembly_tracker_tests EXCLUDE_FROM_ALL
     src/native_renderer/resolve_assembly_tracker.cpp
 )
 target_include_directories(pinyon_shift_resolve_assembly_tracker_tests PRIVATE src)
+
+add_executable(pinyon_shift_resolve_frame_accumulator_tests EXCLUDE_FROM_ALL
+    tests/native_renderer/resolve_frame_accumulator_test.cpp
+    src/native_renderer/resolve_frame_accumulator.cpp
+    src/native_renderer/resolve_assembly_tracker.cpp
+)
+target_include_directories(pinyon_shift_resolve_frame_accumulator_tests PRIVATE src)
 
 pinyon_shift_attach_rexglue(pinyon_shift)
 

--- a/docs/native-renderer/COLOR_PRODUCER_LINEAGE.md
+++ b/docs/native-renderer/COLOR_PRODUCER_LINEAGE.md
@@ -1,7 +1,7 @@
 # Live color-producer lineage
 
 Status: predicated color tile and exact padded full-frame resolve assembly
-proved; runtime workset tracker implemented
+proved; runtime workset tracker and private accumulator plan implemented
 
 ## Why this is the next ingress
 
@@ -98,6 +98,17 @@ events at 64 and reporting any omitted details in its final summary. Its events
 are diagnostic only and are deliberately batched into the next substantial
 AppData validation.
 
+The next implementation checkpoint converts each qualified copy into an exact
+backend-neutral private-accumulator operation. The plan begins at row 0,
+appends only same-state address-contiguous chunks, and commits only after more
+than one chunk covers all 720 logical rows with fewer than 64 padding rows. For
+the proved workset its row operations are `0+256`, `256+256`, and `512+224`;
+the final operation exposes 208 logical rows and preserves the trailing 16
+storage rows. Frame advance, target conflict, destination mismatch, malformed
+row geometry, or chunk overflow cancels the plan and poisons the remainder of
+that frame. The planner owns no backend resource yet, so this checkpoint still
+cannot publish a component or change rendering.
+
 Run the deferred qualifier after the next combined AppData capture:
 
 ```powershell
@@ -128,9 +139,9 @@ python tools/summarize-native-renderer-procedural-resolve-assembly.py `
 ## Promotion gate
 
 The exact contiguous 1280x720 logical resolve assembly is now proved. The next
-C1 implementation may use the runtime tracker as its private capture gate only
-after the tracker's event contract passes the next batched validation. The
-private target must use the complete assembly dimensions and preserve its 16
-alignment rows; no 1280x256 component may be published alone. Other reduced
-targets remain excluded. Xenos remains authoritative and this checkpoint
-changes no rendering or control flow.
+C1 implementation may use the runtime tracker and accumulator plan as its
+private capture gate only after their event contracts pass the next batched
+validation. The private target must use the complete assembly dimensions and
+preserve its 16 alignment rows; no 1280x256 component may be published alone.
+Other reduced targets remain excluded. Xenos remains authoritative and this
+checkpoint changes no rendering or control flow.

--- a/docs/native-renderer/REPRIORITIZED_PLAN.md
+++ b/docs/native-renderer/REPRIORITIZED_PLAN.md
@@ -744,6 +744,16 @@ and padding join without publishing or suppressing anything. Its event contract
 will ride the next substantial AppData batch rather than forcing a standalone
 long validation run.
 
+Private-accumulator planning checkpoint: the proved three-copy workset now
+produces exact backend-neutral row operations `0+256`, `256+256`, and
+`512+224`, with only 208 logical rows in the last stored chunk. The plan commits
+only at 720 logical / 736 padded rows and cancels on frame advance, target
+conflict, destination mismatch, malformed row geometry, or bounded chunk
+overflow. Runtime details are capped at 64 and final counters remain
+payload-free. This creates the fail-closed contract for the next D3D12 private
+resource slice, but performs no backend resource action, native admission,
+publication, or suppression itself.
+
 ### C2. Static world buildings and props
 
 - Expand opaque-world material and geometry coverage.

--- a/src/native_renderer/graphics_hooks.cpp
+++ b/src/native_renderer/graphics_hooks.cpp
@@ -31,6 +31,7 @@
 
 #include "native_renderer/graphics_hooks.h"
 #include "native_renderer/resolve_assembly_tracker.h"
+#include "native_renderer/resolve_frame_accumulator.h"
 #include "native_renderer/resource_identity.h"
 #include "pinyon_shift_diagnostics.h"
 
@@ -66,7 +67,7 @@ constexpr size_t kCandidateSummaryLimit = 32;
 constexpr size_t kPreparedShaderPairCapacity = 1024;
 constexpr size_t kCommandBufferLineageCapacity = 4096;
 constexpr size_t kProceduralColorTargetProfileCapacity = 1024;
-constexpr uint64_t kProceduralResolveAssemblyDetailLimit = 64;
+constexpr uint64_t kProceduralRuntimeDetailLimit = 64;
 constexpr size_t kResolveTargetCapacity = 4096;
 constexpr size_t kResolvePageCapacity = 32768;
 constexpr size_t kResolveSummaryLimit = 32;
@@ -11254,6 +11255,14 @@ uint64_t g_procedural_resolve_assembly_detail_count = 0;
 uint64_t g_procedural_resolve_assembly_detail_overflow = 0;
 pinyon_shift::native_renderer::ProceduralResolveAssemblyTracker
     g_procedural_resolve_assembly_tracker;
+pinyon_shift::native_renderer::ProceduralFrameAccumulatorPlanner
+    g_procedural_frame_accumulator_planner;
+uint64_t g_procedural_frame_accumulator_begins = 0;
+uint64_t g_procedural_frame_accumulator_appends = 0;
+uint64_t g_procedural_frame_accumulator_commits = 0;
+uint64_t g_procedural_frame_accumulator_cancels = 0;
+uint64_t g_procedural_frame_accumulator_detail_count = 0;
+uint64_t g_procedural_frame_accumulator_detail_overflow = 0;
 bool g_graphics_census_installed = false;
 rex::memory::Memory *g_graphics_census_memory = nullptr;
 void *g_guest_cpu_access_callback = nullptr;
@@ -11536,6 +11545,13 @@ void ResetCommandBufferLineage() {
   g_procedural_resolve_assembly_detail_count = 0;
   g_procedural_resolve_assembly_detail_overflow = 0;
   g_procedural_resolve_assembly_tracker = {};
+  g_procedural_frame_accumulator_planner = {};
+  g_procedural_frame_accumulator_begins = 0;
+  g_procedural_frame_accumulator_appends = 0;
+  g_procedural_frame_accumulator_commits = 0;
+  g_procedural_frame_accumulator_cancels = 0;
+  g_procedural_frame_accumulator_detail_count = 0;
+  g_procedural_frame_accumulator_detail_overflow = 0;
 }
 
 void ResetDependencyCensus() {
@@ -17260,7 +17276,7 @@ void EmitProceduralResolveAssembly(
   }
   ++g_procedural_resolve_assembly_count;
   if (g_procedural_resolve_assembly_detail_count ==
-      kProceduralResolveAssemblyDetailLimit) {
+      kProceduralRuntimeDetailLimit) {
     ++g_procedural_resolve_assembly_detail_overflow;
     return;
   }
@@ -17311,6 +17327,64 @@ void EmitProceduralResolveAssembly(
        {"suppression_allowed", "false"}});
 }
 
+void EmitProceduralFrameAccumulatorTransition(
+    const pinyon_shift::native_renderer::
+        ProceduralFrameAccumulatorTransition &transition) {
+  if (!transition.actionable()) {
+    return;
+  }
+  g_procedural_frame_accumulator_begins += transition.begin ? 1 : 0;
+  g_procedural_frame_accumulator_appends += transition.append ? 1 : 0;
+  g_procedural_frame_accumulator_commits += transition.commit ? 1 : 0;
+  g_procedural_frame_accumulator_cancels += transition.cancel ? 1 : 0;
+  if (g_procedural_frame_accumulator_detail_count ==
+      kProceduralRuntimeDetailLimit) {
+    ++g_procedural_frame_accumulator_detail_overflow;
+    return;
+  }
+  ++g_procedural_frame_accumulator_detail_count;
+  const char *operation =
+      transition.cancel
+          ? "cancel"
+          : (transition.commit
+                 ? "append_and_commit"
+                 : (transition.begin ? "begin_and_append" : "append"));
+  pinyon_shift::diagnostics::RecordEvent(
+      "native_renderer.discovery.procedural_frame_accumulator_plan",
+      {{"frame", std::to_string(transition.frame_sequence)},
+       {"operation", operation},
+       {"cancel_reason",
+        pinyon_shift::native_renderer::
+            ProceduralFrameAccumulatorCancelReasonName(
+                transition.cancel_reason)},
+       {"source_state",
+        fmt::format("{:08X}:{:08X}", transition.source_surface_info,
+                    transition.source_info)},
+       {"destination_state",
+        fmt::format("{:08X}:{:08X}", transition.destination_info,
+                    transition.destination_pitch)},
+       {"base_address", fmt::format("{:08X}", transition.base_address)},
+       {"copy_address", fmt::format("{:08X}", transition.copy_address)},
+       {"copy_length", std::to_string(transition.copy_length)},
+       {"destination_row", std::to_string(transition.destination_row)},
+       {"storage_row_count",
+        std::to_string(transition.storage_row_count)},
+       {"logical_row_count",
+        std::to_string(transition.logical_row_count)},
+       {"logical_extent",
+        fmt::format("{}x{}", transition.logical_width,
+                    transition.logical_height)},
+       {"padded_height", std::to_string(transition.padded_height)},
+       {"bytes_per_pixel", std::to_string(transition.bytes_per_pixel)},
+       {"chunk_count", std::to_string(transition.chunk_count)},
+       {"backend_resource_action", "false"},
+       {"standalone_component_publication", "false"},
+       {"native_admission", "false"},
+       {"native_draw", "false"},
+       {"xenos_authority", "true"},
+       {"suppression_allowed", "false"}});
+}
+
 void RecordProceduralColorTargetProfile(
     uint64_t prepared_signature,
     const rex::system::GraphicsDrawObservation &observation,
@@ -17326,12 +17400,16 @@ void RecordProceduralColorTargetProfile(
       !context.semantic_receiver_generation) {
     return;
   }
-  EmitProceduralResolveAssembly(g_procedural_resolve_assembly_tracker.Arm(
-      {.frame_sequence = observation.frame_sequence,
-       .surface_info = observation.surface_info,
-       .color_info = observation.color_info[0],
-       .logical_width = 1280,
-       .logical_height = 720}));
+  const pinyon_shift::native_renderer::ProceduralResolveTarget target{
+      .frame_sequence = observation.frame_sequence,
+      .surface_info = observation.surface_info,
+      .color_info = observation.color_info[0],
+      .logical_width = 1280,
+      .logical_height = 720};
+  EmitProceduralResolveAssembly(
+      g_procedural_resolve_assembly_tracker.Arm(target));
+  EmitProceduralFrameAccumulatorTransition(
+      g_procedural_frame_accumulator_planner.Arm(target));
   ++g_procedural_color_target_profile_observations;
   uint64_t key = UINT64_C(0xCBF29CE484222325);
   for (uint64_t value :
@@ -17723,6 +17801,8 @@ void RecordPreparedCommandBufferLineage(
 
 void EmitProceduralColorTargetProfiles() {
   EmitProceduralResolveAssembly(g_procedural_resolve_assembly_tracker.Flush());
+  EmitProceduralFrameAccumulatorTransition(
+      g_procedural_frame_accumulator_planner.Flush());
   const auto &latest_assembly =
       g_procedural_resolve_assembly_tracker.latest_qualified();
   pinyon_shift::diagnostics::RecordEvent(
@@ -17735,7 +17815,7 @@ void EmitProceduralColorTargetProfiles() {
        {"detail_overflow",
         std::to_string(g_procedural_resolve_assembly_detail_overflow)},
        {"detail_limit",
-        std::to_string(kProceduralResolveAssemblyDetailLimit)},
+        std::to_string(kProceduralRuntimeDetailLimit)},
        {"latest_frame",
         std::to_string(latest_assembly ? latest_assembly->frame_sequence : 0)},
        {"latest_base_address",
@@ -17882,6 +17962,24 @@ void EmitProceduralColorTargetProfiles() {
        {"guest_payload_read", "false"},
        {"guest_state_changed", "false"},
        {"control_flow_changed", "false"},
+       {"native_admission", "false"},
+       {"native_draw", "false"},
+       {"xenos_authority", "true"},
+       {"suppression_allowed", "false"}});
+  pinyon_shift::diagnostics::RecordEvent(
+      "native_renderer.discovery.procedural_frame_accumulator_plan_summary",
+      {{"begins", std::to_string(g_procedural_frame_accumulator_begins)},
+       {"appends", std::to_string(g_procedural_frame_accumulator_appends)},
+       {"commits", std::to_string(g_procedural_frame_accumulator_commits)},
+       {"cancels", std::to_string(g_procedural_frame_accumulator_cancels)},
+       {"detail_events",
+        std::to_string(g_procedural_frame_accumulator_detail_count)},
+       {"detail_overflow",
+        std::to_string(g_procedural_frame_accumulator_detail_overflow)},
+       {"detail_limit",
+        std::to_string(kProceduralRuntimeDetailLimit)},
+       {"backend_resource_action", "false"},
+       {"standalone_component_publication", "false"},
        {"native_admission", "false"},
        {"native_draw", "false"},
        {"xenos_authority", "true"},
@@ -28376,15 +28474,19 @@ void ObserveCopy(const rex::system::GraphicsCopyObservation &observation) {
   const uint32_t copy_source_info =
       copy_source < 4 ? observation.color_info[copy_source]
                       : observation.depth_info;
-  EmitProceduralResolveAssembly(g_procedural_resolve_assembly_tracker.Observe(
-      {.frame_sequence = observation.frame_sequence,
-       .source = copy_source,
-       .source_surface_info = observation.surface_info,
-       .source_info = copy_source_info,
-       .destination_info = observation.rb_copy_dest_info,
-       .destination_pitch = observation.rb_copy_dest_pitch,
-       .written_address = observation.written_address,
-       .written_length = observation.written_length}));
+  const pinyon_shift::native_renderer::ProceduralResolveCopy copy{
+      .frame_sequence = observation.frame_sequence,
+      .source = copy_source,
+      .source_surface_info = observation.surface_info,
+      .source_info = copy_source_info,
+      .destination_info = observation.rb_copy_dest_info,
+      .destination_pitch = observation.rb_copy_dest_pitch,
+      .written_address = observation.written_address,
+      .written_length = observation.written_length};
+  EmitProceduralResolveAssembly(
+      g_procedural_resolve_assembly_tracker.Observe(copy));
+  EmitProceduralFrameAccumulatorTransition(
+      g_procedural_frame_accumulator_planner.Observe(copy));
 
   ++g_dependency_census.window_resolve_count;
   g_dependency_census.window_resolve_bytes += observation.written_length;
@@ -30532,6 +30634,7 @@ void InstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system,
        {"procedural_color_resolve_source_state", "exact_backend_v1"},
        {"procedural_color_resolve_runtime_tracker",
         "exact_contiguous_full_frame_v1"},
+       {"procedural_color_frame_accumulator_plan", "exact_padded_rows_v1"},
        {"guest_payload_read", "false"},
        {"guest_state_changed", "false"},
        {"control_flow_changed", "false"},

--- a/src/native_renderer/resolve_assembly_tracker.cpp
+++ b/src/native_renderer/resolve_assembly_tracker.cpp
@@ -5,9 +5,8 @@
 #include <limits>
 
 namespace pinyon_shift::native_renderer {
-namespace {
 
-uint32_t ColorBytesPerPixel(uint32_t format) {
+uint32_t XenosColorBytesPerPixel(uint32_t format) {
   switch (format) {
     case 2:
     case 8:
@@ -44,8 +43,6 @@ uint32_t ColorBytesPerPixel(uint32_t format) {
       return 0;
   }
 }
-
-}  // namespace
 
 std::optional<ProceduralResolveAssembly>
 ProceduralResolveAssemblyTracker::Advance(uint64_t frame_sequence) {
@@ -162,7 +159,7 @@ ProceduralResolveAssemblyTracker::Finalize() {
     const uint32_t logical_height =
         (first.destination_pitch >> 16) & 0x3FFF;
     const uint32_t color_format = (first.destination_info >> 7) & 0x3F;
-    const uint32_t bytes_per_pixel = ColorBytesPerPixel(color_format);
+    const uint32_t bytes_per_pixel = XenosColorBytesPerPixel(color_format);
     const uint64_t row_bytes = uint64_t(pitch_width) * bytes_per_pixel;
     const uint32_t padded_height =
         row_bytes && total_bytes % row_bytes == 0 &&

--- a/src/native_renderer/resolve_assembly_tracker.h
+++ b/src/native_renderer/resolve_assembly_tracker.h
@@ -8,6 +8,8 @@
 
 namespace pinyon_shift::native_renderer {
 
+uint32_t XenosColorBytesPerPixel(uint32_t format);
+
 struct ProceduralResolveTarget {
   uint64_t frame_sequence = 0;
   uint32_t surface_info = 0;

--- a/src/native_renderer/resolve_frame_accumulator.cpp
+++ b/src/native_renderer/resolve_frame_accumulator.cpp
@@ -1,0 +1,207 @@
+#include "native_renderer/resolve_frame_accumulator.h"
+
+#include <algorithm>
+#include <limits>
+
+namespace pinyon_shift::native_renderer {
+
+void ProceduralFrameAccumulatorPlanner::Reset(uint64_t frame_sequence) {
+  frame_sequence_ = frame_sequence;
+  target_ = {};
+  source_surface_info_ = 0;
+  source_info_ = 0;
+  destination_info_ = 0;
+  destination_pitch_ = 0;
+  base_address_ = 0;
+  next_address_ = 0;
+  bytes_per_pixel_ = 0;
+  padded_height_ = 0;
+  chunk_count_ = 0;
+  active_ = false;
+  committed_ = false;
+  target_conflict_ = false;
+  frame_invalid_ = false;
+}
+
+ProceduralFrameAccumulatorTransition
+ProceduralFrameAccumulatorPlanner::Cancel(
+    ProceduralFrameAccumulatorCancelReason reason) {
+  ProceduralFrameAccumulatorTransition transition{
+      .frame_sequence = frame_sequence_,
+      .source_surface_info = source_surface_info_,
+      .source_info = source_info_,
+      .destination_info = destination_info_,
+      .destination_pitch = destination_pitch_,
+      .base_address = base_address_,
+      .logical_width = target_.logical_width,
+      .logical_height = target_.logical_height,
+      .padded_height = padded_height_,
+      .bytes_per_pixel = bytes_per_pixel_,
+      .chunk_count = chunk_count_,
+      .cancel = active_ && !committed_,
+      .cancel_reason = reason};
+  active_ = false;
+  if (reason != ProceduralFrameAccumulatorCancelReason::kFrameAdvanced) {
+    frame_invalid_ = true;
+  }
+  return transition;
+}
+
+ProceduralFrameAccumulatorTransition
+ProceduralFrameAccumulatorPlanner::Advance(uint64_t frame_sequence) {
+  if (!frame_sequence_ || frame_sequence_ == frame_sequence) {
+    if (!frame_sequence_) {
+      Reset(frame_sequence);
+    }
+    return {};
+  }
+  ProceduralFrameAccumulatorTransition transition =
+      Cancel(ProceduralFrameAccumulatorCancelReason::kFrameAdvanced);
+  Reset(frame_sequence);
+  return transition;
+}
+
+ProceduralFrameAccumulatorTransition
+ProceduralFrameAccumulatorPlanner::Arm(
+    const ProceduralResolveTarget &target) {
+  ProceduralFrameAccumulatorTransition transition =
+      Advance(target.frame_sequence);
+  if (!target.valid() || target_conflict_) {
+    return transition;
+  }
+  if (!target_.valid()) {
+    target_ = target;
+    return transition;
+  }
+  if (target_.surface_info == target.surface_info &&
+      target_.color_info == target.color_info &&
+      target_.logical_width == target.logical_width &&
+      target_.logical_height == target.logical_height) {
+    return transition;
+  }
+  ProceduralFrameAccumulatorTransition conflict =
+      Cancel(ProceduralFrameAccumulatorCancelReason::kTargetConflict);
+  target_ = {};
+  target_conflict_ = true;
+  return conflict.actionable() ? conflict : transition;
+}
+
+ProceduralFrameAccumulatorTransition
+ProceduralFrameAccumulatorPlanner::Observe(
+    const ProceduralResolveCopy &copy) {
+  ProceduralFrameAccumulatorTransition transition =
+      Advance(copy.frame_sequence);
+  if (transition.actionable() || !target_.valid() || target_conflict_ ||
+      frame_invalid_ ||
+      copy.source || copy.source_surface_info != target_.surface_info ||
+      copy.source_info != target_.color_info || !copy.written_length ||
+      committed_) {
+    return transition;
+  }
+
+  const uint32_t pitch_width = copy.destination_pitch & 0x3FFF;
+  const uint32_t logical_height = (copy.destination_pitch >> 16) & 0x3FFF;
+  const uint32_t color_format = (copy.destination_info >> 7) & 0x3F;
+  const uint32_t bytes_per_pixel = XenosColorBytesPerPixel(color_format);
+  const uint64_t row_bytes = uint64_t(pitch_width) * bytes_per_pixel;
+  const bool valid_chunk =
+      pitch_width == target_.logical_width &&
+      logical_height == target_.logical_height && bytes_per_pixel &&
+      row_bytes <= std::numeric_limits<uint32_t>::max() &&
+      copy.written_length % row_bytes == 0 &&
+      copy.written_length / row_bytes > 0 &&
+      copy.written_length / row_bytes <=
+          std::numeric_limits<uint32_t>::max();
+  if (!valid_chunk) {
+    return Cancel(ProceduralFrameAccumulatorCancelReason::kInvalidChunk);
+  }
+
+  if (!active_) {
+    active_ = true;
+    source_surface_info_ = copy.source_surface_info;
+    source_info_ = copy.source_info;
+    destination_info_ = copy.destination_info;
+    destination_pitch_ = copy.destination_pitch;
+    base_address_ = copy.written_address;
+    next_address_ = copy.written_address;
+    bytes_per_pixel_ = bytes_per_pixel;
+  } else if (copy.destination_info != destination_info_ ||
+             copy.destination_pitch != destination_pitch_ ||
+             copy.written_address != next_address_) {
+    return Cancel(
+        ProceduralFrameAccumulatorCancelReason::kDestinationMismatch);
+  }
+  if (chunk_count_ == kMaximumChunks) {
+    return Cancel(ProceduralFrameAccumulatorCancelReason::kChunkOverflow);
+  }
+
+  const uint32_t storage_rows = uint32_t(copy.written_length / row_bytes);
+  if (padded_height_ > target_.logical_height + 63 ||
+      storage_rows > target_.logical_height + 63 - padded_height_ ||
+      uint64_t(copy.written_address) + copy.written_length > UINT32_MAX) {
+    return Cancel(ProceduralFrameAccumulatorCancelReason::kInvalidChunk);
+  }
+  const uint32_t destination_row = padded_height_;
+  const uint32_t logical_rows =
+      destination_row >= target_.logical_height
+          ? 0
+          : std::min(storage_rows,
+                     target_.logical_height - destination_row);
+  padded_height_ += storage_rows;
+  next_address_ = copy.written_address + copy.written_length;
+  ++chunk_count_;
+
+  const bool complete = chunk_count_ > 1 &&
+                        padded_height_ >= target_.logical_height &&
+                        padded_height_ < target_.logical_height + 64;
+  transition = {.frame_sequence = frame_sequence_,
+                .source_surface_info = source_surface_info_,
+                .source_info = source_info_,
+                .destination_info = destination_info_,
+                .destination_pitch = destination_pitch_,
+                .base_address = base_address_,
+                .copy_address = copy.written_address,
+                .copy_length = copy.written_length,
+                .destination_row = destination_row,
+                .storage_row_count = storage_rows,
+                .logical_row_count = logical_rows,
+                .logical_width = target_.logical_width,
+                .logical_height = target_.logical_height,
+                .padded_height = padded_height_,
+                .bytes_per_pixel = bytes_per_pixel_,
+                .chunk_count = chunk_count_,
+                .begin = chunk_count_ == 1,
+                .append = true,
+                .commit = complete};
+  committed_ = complete;
+  return transition;
+}
+
+ProceduralFrameAccumulatorTransition
+ProceduralFrameAccumulatorPlanner::Flush() {
+  ProceduralFrameAccumulatorTransition transition =
+      Cancel(ProceduralFrameAccumulatorCancelReason::kFrameAdvanced);
+  Reset(0);
+  return transition;
+}
+
+const char *ProceduralFrameAccumulatorCancelReasonName(
+    ProceduralFrameAccumulatorCancelReason reason) {
+  switch (reason) {
+    case ProceduralFrameAccumulatorCancelReason::kNone:
+      return "none";
+    case ProceduralFrameAccumulatorCancelReason::kFrameAdvanced:
+      return "frame_advanced";
+    case ProceduralFrameAccumulatorCancelReason::kTargetConflict:
+      return "target_conflict";
+    case ProceduralFrameAccumulatorCancelReason::kDestinationMismatch:
+      return "destination_mismatch";
+    case ProceduralFrameAccumulatorCancelReason::kInvalidChunk:
+      return "invalid_chunk";
+    case ProceduralFrameAccumulatorCancelReason::kChunkOverflow:
+      return "chunk_overflow";
+  }
+  return "unknown";
+}
+
+}  // namespace pinyon_shift::native_renderer

--- a/src/native_renderer/resolve_frame_accumulator.h
+++ b/src/native_renderer/resolve_frame_accumulator.h
@@ -1,0 +1,88 @@
+#ifndef PINYON_SHIFT_NATIVE_RENDERER_RESOLVE_FRAME_ACCUMULATOR_H_
+#define PINYON_SHIFT_NATIVE_RENDERER_RESOLVE_FRAME_ACCUMULATOR_H_
+
+#include <cstdint>
+
+#include "native_renderer/resolve_assembly_tracker.h"
+
+namespace pinyon_shift::native_renderer {
+
+enum class ProceduralFrameAccumulatorCancelReason : uint8_t {
+  kNone,
+  kFrameAdvanced,
+  kTargetConflict,
+  kDestinationMismatch,
+  kInvalidChunk,
+  kChunkOverflow,
+};
+
+struct ProceduralFrameAccumulatorTransition {
+  uint64_t frame_sequence = 0;
+  uint32_t source_surface_info = 0;
+  uint32_t source_info = 0;
+  uint32_t destination_info = 0;
+  uint32_t destination_pitch = 0;
+  uint32_t base_address = 0;
+  uint32_t copy_address = 0;
+  uint32_t copy_length = 0;
+  uint32_t destination_row = 0;
+  uint32_t storage_row_count = 0;
+  uint32_t logical_row_count = 0;
+  uint32_t logical_width = 0;
+  uint32_t logical_height = 0;
+  uint32_t padded_height = 0;
+  uint32_t bytes_per_pixel = 0;
+  uint32_t chunk_count = 0;
+  bool begin = false;
+  bool append = false;
+  bool commit = false;
+  bool cancel = false;
+  ProceduralFrameAccumulatorCancelReason cancel_reason =
+      ProceduralFrameAccumulatorCancelReason::kNone;
+
+  bool actionable() const { return begin || append || commit || cancel; }
+};
+
+// Produces a backend-neutral, fail-closed row-copy plan for assembling the
+// proved procedural EDRAM chunks into one private padded frame. It owns no GPU
+// resources and cannot publish, suppress, or otherwise alter guest rendering.
+class ProceduralFrameAccumulatorPlanner {
+ public:
+  static constexpr uint32_t kMaximumChunks =
+      ProceduralResolveAssembly::kMaximumChunks;
+
+  ProceduralFrameAccumulatorTransition Arm(
+      const ProceduralResolveTarget &target);
+  ProceduralFrameAccumulatorTransition Observe(
+      const ProceduralResolveCopy &copy);
+  ProceduralFrameAccumulatorTransition Flush();
+
+ private:
+  ProceduralFrameAccumulatorTransition Advance(uint64_t frame_sequence);
+  ProceduralFrameAccumulatorTransition Cancel(
+      ProceduralFrameAccumulatorCancelReason reason);
+  void Reset(uint64_t frame_sequence);
+
+  uint64_t frame_sequence_ = 0;
+  ProceduralResolveTarget target_{};
+  uint32_t source_surface_info_ = 0;
+  uint32_t source_info_ = 0;
+  uint32_t destination_info_ = 0;
+  uint32_t destination_pitch_ = 0;
+  uint32_t base_address_ = 0;
+  uint32_t next_address_ = 0;
+  uint32_t bytes_per_pixel_ = 0;
+  uint32_t padded_height_ = 0;
+  uint32_t chunk_count_ = 0;
+  bool active_ = false;
+  bool committed_ = false;
+  bool target_conflict_ = false;
+  bool frame_invalid_ = false;
+};
+
+const char *ProceduralFrameAccumulatorCancelReasonName(
+    ProceduralFrameAccumulatorCancelReason reason);
+
+}  // namespace pinyon_shift::native_renderer
+
+#endif  // PINYON_SHIFT_NATIVE_RENDERER_RESOLVE_FRAME_ACCUMULATOR_H_

--- a/tests/native_renderer/resolve_frame_accumulator_test.cpp
+++ b/tests/native_renderer/resolve_frame_accumulator_test.cpp
@@ -1,0 +1,138 @@
+#include "native_renderer/resolve_frame_accumulator.h"
+
+#include <cstdlib>
+#include <iostream>
+
+namespace nr = pinyon_shift::native_renderer;
+
+namespace {
+
+void Require(bool condition, const char *message) {
+  if (!condition) {
+    std::cerr << message << '\n';
+    std::exit(EXIT_FAILURE);
+  }
+}
+
+nr::ProceduralResolveTarget Target(uint64_t frame = 10) {
+  return {.frame_sequence = frame,
+          .surface_info = 0x14020500,
+          .color_info = 0x00030000,
+          .logical_width = 1280,
+          .logical_height = 720};
+}
+
+nr::ProceduralResolveCopy Copy(uint32_t address, uint32_t length,
+                               uint64_t frame = 10) {
+  return {.frame_sequence = frame,
+          .source = 0,
+          .source_surface_info = 0x14020500,
+          .source_info = 0x00030000,
+          .destination_info = 0x003E0382,
+          .destination_pitch = 0x02D00500,
+          .written_address = address,
+          .written_length = length};
+}
+
+}  // namespace
+
+int main() {
+  constexpr uint32_t kRows256 = 1280 * 256 * 4;
+  constexpr uint32_t kRows224 = 1280 * 224 * 4;
+  constexpr uint32_t kBase = 0x1C4E1000;
+
+  nr::ProceduralFrameAccumulatorPlanner planner;
+  Require(!planner.Arm(Target()).actionable(), "arming must be passive");
+  const auto first = planner.Observe(Copy(kBase, kRows256));
+  Require(first.begin && first.append && !first.commit && !first.cancel &&
+              first.destination_row == 0 &&
+              first.storage_row_count == 256 &&
+              first.logical_row_count == 256,
+          "the first chunk must begin at row zero");
+  const auto second = planner.Observe(Copy(kBase + kRows256, kRows256));
+  Require(!second.begin && second.append && !second.commit &&
+              second.destination_row == 256 &&
+              second.storage_row_count == 256,
+          "the second chunk must append at row 256");
+  const auto third =
+      planner.Observe(Copy(kBase + 2 * kRows256, kRows224));
+  Require(third.append && third.commit && !third.cancel &&
+              third.destination_row == 512 &&
+              third.storage_row_count == 224 &&
+              third.logical_row_count == 208 &&
+              third.padded_height == 736 && third.chunk_count == 3,
+          "the final chunk must commit 720 logical and 736 stored rows");
+  Require(!planner.Flush().actionable(),
+          "a committed frame must not be cancelled at shutdown");
+
+  nr::ProceduralFrameAccumulatorPlanner gap;
+  gap.Arm(Target());
+  gap.Observe(Copy(kBase, kRows256));
+  const auto gap_result =
+      gap.Observe(Copy(kBase + kRows256 + 0x1000, kRows256));
+  Require(gap_result.cancel && !gap_result.append &&
+              gap_result.cancel_reason ==
+                  nr::ProceduralFrameAccumulatorCancelReason::
+                      kDestinationMismatch,
+          "an address gap must cancel the private plan");
+
+  nr::ProceduralFrameAccumulatorPlanner mismatch;
+  mismatch.Arm(Target());
+  auto wrong_source = Copy(kBase, kRows256);
+  wrong_source.source_info = 0x00040000;
+  Require(!mismatch.Observe(wrong_source).actionable(),
+          "a source mismatch must remain outside the plan");
+
+  nr::ProceduralFrameAccumulatorPlanner invalid;
+  invalid.Arm(Target());
+  auto malformed = Copy(kBase, kRows256);
+  malformed.destination_pitch = 0x02D00400;
+  Require(!invalid.Observe(malformed).actionable(),
+          "an invalid first chunk has no backend resource to cancel");
+  Require(!invalid.Observe(Copy(kBase, kRows256)).actionable(),
+          "an invalid matching chunk must poison the rest of the frame");
+
+  nr::ProceduralFrameAccumulatorPlanner conflict;
+  conflict.Arm(Target());
+  conflict.Observe(Copy(kBase, kRows256));
+  auto other_target = Target();
+  other_target.color_info = 0x00040000;
+  const auto conflict_result = conflict.Arm(other_target);
+  Require(conflict_result.cancel &&
+              conflict_result.cancel_reason ==
+                  nr::ProceduralFrameAccumulatorCancelReason::kTargetConflict,
+          "a target conflict must cancel the active plan");
+
+  nr::ProceduralFrameAccumulatorPlanner advance;
+  advance.Arm(Target());
+  advance.Observe(Copy(kBase, kRows256));
+  const auto advanced = advance.Arm(Target(11));
+  Require(advanced.cancel &&
+              advanced.cancel_reason ==
+                  nr::ProceduralFrameAccumulatorCancelReason::kFrameAdvanced,
+          "an incomplete frame must cancel on frame advance");
+
+  nr::ProceduralFrameAccumulatorPlanner overflow;
+  overflow.Arm(Target());
+  constexpr uint32_t kRows80 = 1280 * 80 * 4;
+  for (uint32_t chunk = 0;
+       chunk < nr::ProceduralFrameAccumulatorPlanner::kMaximumChunks;
+       ++chunk) {
+    const auto appended =
+        overflow.Observe(Copy(kBase + chunk * kRows80, kRows80));
+    Require(appended.append && !appended.commit && !appended.cancel,
+            "bounded partial chunks must append before the cap");
+  }
+  const auto overflowed = overflow.Observe(
+      Copy(kBase +
+               nr::ProceduralFrameAccumulatorPlanner::kMaximumChunks *
+                   kRows80,
+           kRows80));
+  Require(overflowed.cancel &&
+              overflowed.cancel_reason ==
+                  nr::ProceduralFrameAccumulatorCancelReason::kChunkOverflow,
+          "a ninth chunk must cancel the bounded plan");
+
+  std::cout << "native renderer resolve frame accumulator tests passed\n";
+  return EXIT_SUCCESS;
+}

--- a/tools/tests/test_native_renderer_procedural_resolve_assembly.py
+++ b/tools/tests/test_native_renderer_procedural_resolve_assembly.py
@@ -78,6 +78,15 @@ class ProceduralResolveAssemblyTests(unittest.TestCase):
         self.assertIn(
             "g_procedural_resolve_assembly_tracker.Observe", source
         )
+        self.assertIn(
+            '"native_renderer.discovery.procedural_frame_accumulator_plan"',
+            source,
+        )
+        self.assertIn(
+            '{"procedural_color_frame_accumulator_plan", '
+            '"exact_padded_rows_v1"}',
+            source,
+        )
 
     def test_qualifies_three_contiguous_resolves_as_full_frame(self):
         result = MODULE.build(fixture(), "session")


### PR DESCRIPTION
## Summary\n- translate exact procedural resolve chunks into private-frame row operations\n- preserve 720 logical rows and all 736 padded storage rows\n- cancel on frame rollover, state conflicts, gaps, malformed chunks, or bounded overflow\n- emit capped payload-free plan diagnostics while keeping backend resource action disabled\n\n## Validation\n- pinyon_shift_resolve_frame_accumulator_tests\n- pinyon_shift_resolve_assembly_tracker_tests\n- python unittest discovery (698 tests)\n- Release pinyon_shift build\n\nXenos remains authoritative; this PR enables no native publication or suppression.