### PR TITLE
feat(native-renderer): add private frame accumulator backend

### DIFF
--- a/docs/native-renderer/COLOR_PRODUCER_LINEAGE.md
+++ b/docs/native-renderer/COLOR_PRODUCER_LINEAGE.md
@@ -1,7 +1,8 @@
 # Live color-producer lineage
 
 Status: predicated color tile and exact padded full-frame resolve assembly
-proved; runtime workset tracker and private accumulator plan implemented
+proved; runtime workset tracker, row planner, and private D3D12 accumulator
+backend implemented
 
 ## Why this is the next ingress
 
@@ -106,8 +107,18 @@ the proved workset its row operations are `0+256`, `256+256`, and `512+224`;
 the final operation exposes 208 logical rows and preserves the trailing 16
 storage rows. Frame advance, target conflict, destination mismatch, malformed
 row geometry, or chunk overflow cancels the plan and poisons the remainder of
-that frame. The planner owns no backend resource yet, so this checkpoint still
-cannot publish a component or change rendering.
+that frame.
+
+The D3D12 backend now implements the corresponding private padded-frame
+resource contract. It accepts operations only after the authoritative Xenos
+resolve succeeds, requires contiguous rows and one exact 1280x736 resource,
+resolves multisampled private tiles before copying, and re-seeds the private
+replay target from authoritative guest EDRAM between component tiles. Only an
+exact committed frame may enter the existing swap-time preview; an incomplete,
+conflicting, malformed, or allocation-failed frame remains unavailable so the
+guest output falls back to Xenos. The callback is not registered yet, so this
+slice is dormant by default and cannot publish guest memory, suppress a draw,
+or change rendering until the title-side planner is wired.
 
 Run the deferred qualifier after the next combined AppData capture:
 

--- a/docs/native-renderer/REPRIORITIZED_PLAN.md
+++ b/docs/native-renderer/REPRIORITIZED_PLAN.md
@@ -754,6 +754,18 @@ payload-free. This creates the fail-closed contract for the next D3D12 private
 resource slice, but performs no backend resource action, native admission,
 publication, or suppression itself.
 
+Private D3D12 accumulator checkpoint: a dormant backend callback now consumes
+those exact row operations only after the authoritative Xenos resolve has
+succeeded. It assembles a single-sample private 1280x736 resource, re-seeds the
+isolated replay target from authoritative guest EDRAM between tiles, and makes
+only a fully committed 1280x720 logical frame eligible for the existing
+swap-time preview. Gaps, overlap, target or extent changes, unsupported formats,
+and allocation failures clear the active sequence; an incomplete frame cannot
+replace the guest output. The callback remains unregistered in this slice, and
+there is still no guest-memory publication or draw suppression. Title-side
+planner registration and result diagnostics are the next implementation slice
+and will form the next meaningful AppData validation batch.
+
 ### C2. Static world buildings and props
 
 - Expand opaque-world material and geometry coverage.

--- a/patches/rexglue/0108-d3d12-procedural-frame-accumulator.patch
+++ b/patches/rexglue/0108-d3d12-procedural-frame-accumulator.patch
@@ -1,0 +1,578 @@
+diff --git a/include/rex/graphics/d3d12/render_target_cache.h b/include/rex/graphics/d3d12/render_target_cache.h
+index 114167c..dc9e9f0 100644
+--- a/include/rex/graphics/d3d12/render_target_cache.h
++++ b/include/rex/graphics/d3d12/render_target_cache.h
+@@ -145,6 +145,10 @@ class D3D12RenderTargetCache final : public RenderTargetCache {
+   void CancelDeferredIsolatedReplayPreview(uint64_t frame_sequence);
+   system::GraphicsIsolatedDrawPublicationResult PublishIsolatedReplayTarget(
+       bool depth_only_target = false);
++  system::GraphicsNativeFrameAccumulatorResult
++  ApplyIsolatedReplayFrameAccumulator(
++      uint64_t frame_sequence,
++      const system::GraphicsNativeFrameAccumulatorRequest& request);
+ 
+   struct IsolatedReplayPreviewSource {
+     ID3D12Resource* resource = nullptr;
+@@ -156,6 +160,7 @@ class D3D12RenderTargetCache final : public RenderTargetCache {
+     uint32_t logical_height = 0;
+     uint64_t frame_sequence = 0;
+     bool resolved = false;
++    bool frame_accumulator = false;
+   };
+   bool BeginIsolatedReplayPreview(uint64_t required_frame_sequence,
+                                   IsolatedReplayPreviewSource& source_out);
+@@ -743,6 +748,21 @@ class D3D12RenderTargetCache final : public RenderTargetCache {
+       isolated_replay_preview_resolved_target_;
+   D3D12_RESOURCE_STATES isolated_replay_preview_resolved_target_state_ =
+       D3D12_RESOURCE_STATE_RESOLVE_DEST;
++  Microsoft::WRL::ComPtr<ID3D12Resource>
++      isolated_replay_frame_accumulator_target_;
++  D3D12_RESOURCE_STATES isolated_replay_frame_accumulator_target_state_ =
++      D3D12_RESOURCE_STATE_COPY_DEST;
++  Microsoft::WRL::ComPtr<ID3D12Resource>
++      isolated_replay_frame_accumulator_tile_;
++  D3D12_RESOURCE_STATES isolated_replay_frame_accumulator_tile_state_ =
++      D3D12_RESOURCE_STATE_RESOLVE_DEST;
++  uint64_t isolated_replay_frame_accumulator_frame_sequence_ = 0;
++  uint64_t isolated_replay_frame_accumulator_committed_frame_sequence_ = 0;
++  uint32_t isolated_replay_frame_accumulator_width_ = 0;
++  uint32_t isolated_replay_frame_accumulator_height_ = 0;
++  uint32_t isolated_replay_frame_accumulator_logical_height_ = 0;
++  uint32_t isolated_replay_frame_accumulator_appended_row_end_ = 0;
++  bool isolated_replay_frame_accumulator_reseed_required_ = false;
+   uint64_t isolated_replay_preview_frame_sequence_ = 0;
+   uint64_t isolated_replay_deferred_preview_frame_sequence_ = 0;
+   uint32_t isolated_replay_active_preview_width_ = 0;
+diff --git a/include/rex/graphics/graphics_system.h b/include/rex/graphics/graphics_system.h
+index ddfc1ee..40c5d66 100644
+--- a/include/rex/graphics/graphics_system.h
++++ b/include/rex/graphics/graphics_system.h
+@@ -141,6 +141,16 @@ class GraphicsSystem : public system::IGraphicsSystem {
+   system::GraphicsNativeResolveObserver native_resolve_observer() const {
+     return native_resolve_observer_.load(std::memory_order_acquire);
+   }
++  void SetNativeFrameAccumulatorPlanner(
++      system::GraphicsNativeFrameAccumulatorPlanner planner) override {
++    native_frame_accumulator_planner_.store(planner,
++                                             std::memory_order_release);
++  }
++  system::GraphicsNativeFrameAccumulatorPlanner
++  native_frame_accumulator_planner() const {
++    return native_frame_accumulator_planner_.load(
++        std::memory_order_acquire);
++  }
+   void SetNativeGuestOutputRenderer(
+       system::NativeGuestOutputRenderer renderer) override {
+     native_guest_output_renderer_.Set(renderer);
+@@ -229,6 +239,8 @@ class GraphicsSystem : public system::IGraphicsSystem {
+       native_texture_set_observer_{nullptr};
+   std::atomic<system::GraphicsNativeResolveObserver> native_resolve_observer_{
+       nullptr};
++  std::atomic<system::GraphicsNativeFrameAccumulatorPlanner>
++      native_frame_accumulator_planner_{nullptr};
+   system::NativeGuestOutputRendererRegistration native_guest_output_renderer_;
+ 
+   std::atomic_flag host_gpu_loss_reported_;
+diff --git a/include/rex/system/interfaces/graphics.h b/include/rex/system/interfaces/graphics.h
+index b7a5c79..dd3b75a 100644
+--- a/include/rex/system/interfaces/graphics.h
++++ b/include/rex/system/interfaces/graphics.h
+@@ -359,6 +359,51 @@ struct GraphicsCopyObservation {
+ 
+ using GraphicsCopyObserver = void (*)(const GraphicsCopyObservation& observation);
+ 
++enum class GraphicsNativeFrameAccumulatorStatus : uint32_t {
++  kRecorded = 1,
++  kCancelled = 2,
++  kInvalidRequest = 3,
++  kUnavailable = 4,
++  kUnsupportedTarget = 5,
++  kAllocationFailed = 6,
++};
++
++struct GraphicsNativeFrameAccumulatorResult {
++  GraphicsNativeFrameAccumulatorStatus status =
++      GraphicsNativeFrameAccumulatorStatus::kInvalidRequest;
++  uint64_t frame_sequence = 0;
++  uint32_t resource_width = 0;
++  uint32_t resource_height = 0;
++  uint32_t logical_width = 0;
++  uint32_t logical_height = 0;
++  uint32_t appended_row_end = 0;
++  bool committed = false;
++};
++
++using GraphicsNativeFrameAccumulatorCompletion = void (*)(
++    const GraphicsNativeFrameAccumulatorResult& result);
++
++// A fail-closed request to copy rows from the current private isolated color
++// replay target into a private single-sample frame accumulator. The request is
++// produced only after the authoritative Xenos resolve succeeds. It cannot
++// alter the guest resolve, publish to guest memory, or suppress a guest draw.
++struct GraphicsNativeFrameAccumulatorRequest {
++  uint32_t logical_width = 0;
++  uint32_t logical_height = 0;
++  uint32_t storage_height = 0;
++  uint32_t destination_row = 0;
++  uint32_t storage_row_count = 0;
++  bool begin = false;
++  bool append = false;
++  bool commit = false;
++  bool cancel = false;
++  GraphicsNativeFrameAccumulatorCompletion completion = nullptr;
++};
++
++using GraphicsNativeFrameAccumulatorPlanner = bool (*)(
++    const GraphicsCopyObservation& observation,
++    GraphicsNativeFrameAccumulatorRequest& request_out);
++
+ enum class GraphicsShaderStage : uint32_t {
+   kVertex = 1,
+   kPixel = 2,
+@@ -657,6 +702,10 @@ class IGraphicsSystem {
+       GraphicsNativeResolveObserver observer) {
+     (void)observer;
+   }
++  virtual void SetNativeFrameAccumulatorPlanner(
++      GraphicsNativeFrameAccumulatorPlanner planner) {
++    (void)planner;
++  }
+   virtual void SetNativeGuestOutputRenderer(NativeGuestOutputRenderer renderer) {
+     (void)renderer;
+   }
+diff --git a/src/graphics/d3d12/command_processor.cpp b/src/graphics/d3d12/command_processor.cpp
+index dbf4f3a..3b3bf5e 100644
+--- a/src/graphics/d3d12/command_processor.cpp
++++ b/src/graphics/d3d12/command_processor.cpp
+@@ -4463,7 +4463,10 @@ bool D3D12CommandProcessor::IssueCopy() {
+ 
+   auto copy_observer = graphics_system_->copy_observer();
+   auto native_resolve_observer = graphics_system_->native_resolve_observer();
+-  if (copy_observer || native_resolve_observer) {
++  auto native_frame_accumulator_planner =
++      graphics_system_->native_frame_accumulator_planner();
++  if (copy_observer || native_resolve_observer ||
++      native_frame_accumulator_planner) {
+     system::GraphicsCopyObservation observation;
+     observation.frame_sequence = observation_frame_sequence_;
+     observation.copy_sequence = ++observation_copy_sequence_;
+@@ -4485,6 +4488,18 @@ bool D3D12CommandProcessor::IssueCopy() {
+     if (copy_observer) {
+       copy_observer(observation);
+     }
++    if (native_frame_accumulator_planner && observation.succeeded) {
++      system::GraphicsNativeFrameAccumulatorRequest accumulator_request;
++      if (native_frame_accumulator_planner(observation,
++                                           accumulator_request)) {
++        system::GraphicsNativeFrameAccumulatorResult accumulator_result =
++            render_target_cache_->ApplyIsolatedReplayFrameAccumulator(
++                observation.frame_sequence, accumulator_request);
++        if (accumulator_request.completion) {
++          accumulator_request.completion(accumulator_result);
++        }
++      }
++    }
+     if (native_resolve_observer) {
+       native_resolve_observer(observation);
+     }
+diff --git a/src/graphics/d3d12/render_target_cache.cpp b/src/graphics/d3d12/render_target_cache.cpp
+index 412800d..7de9127 100644
+--- a/src/graphics/d3d12/render_target_cache.cpp
++++ b/src/graphics/d3d12/render_target_cache.cpp
+@@ -1044,6 +1044,19 @@ void D3D12RenderTargetCache::Shutdown(bool from_destructor) {
+   isolated_replay_preview_resolved_target_.Reset();
+   isolated_replay_preview_resolved_target_state_ =
+       D3D12_RESOURCE_STATE_RESOLVE_DEST;
++  isolated_replay_frame_accumulator_target_.Reset();
++  isolated_replay_frame_accumulator_target_state_ =
++      D3D12_RESOURCE_STATE_COPY_DEST;
++  isolated_replay_frame_accumulator_tile_.Reset();
++  isolated_replay_frame_accumulator_tile_state_ =
++      D3D12_RESOURCE_STATE_RESOLVE_DEST;
++  isolated_replay_frame_accumulator_frame_sequence_ = 0;
++  isolated_replay_frame_accumulator_committed_frame_sequence_ = 0;
++  isolated_replay_frame_accumulator_width_ = 0;
++  isolated_replay_frame_accumulator_height_ = 0;
++  isolated_replay_frame_accumulator_logical_height_ = 0;
++  isolated_replay_frame_accumulator_appended_row_end_ = 0;
++  isolated_replay_frame_accumulator_reseed_required_ = false;
+   isolated_replay_preview_frame_sequence_ = 0;
+   isolated_replay_deferred_preview_frame_sequence_ = 0;
+   isolated_replay_active_depth_target_ = nullptr;
+@@ -1990,6 +2003,12 @@ bool D3D12RenderTargetCache::ResumeIsolatedReplayTarget(
+     uint32_t& width_out, uint32_t& height_out, uint32_t logical_width,
+     uint32_t logical_height, bool depth_only_target,
+     bool color_only_target) {
++  if (isolated_replay_frame_accumulator_reseed_required_) {
++    isolated_replay_frame_accumulator_reseed_required_ = false;
++    return BeginIsolatedReplayTarget(
++        width_out, height_out, logical_width, logical_height, false,
++        depth_only_target, color_only_target);
++  }
+   width_out = 0;
+   height_out = 0;
+   isolated_replay_active_depth_target_ = nullptr;
+@@ -2525,6 +2544,252 @@ system::GraphicsIsolatedDrawReadbackStatus D3D12RenderTargetCache::QueueRenderTa
+   return system::GraphicsIsolatedDrawReadbackStatus::kReady;
+ }
+ 
++system::GraphicsNativeFrameAccumulatorResult
++D3D12RenderTargetCache::ApplyIsolatedReplayFrameAccumulator(
++    uint64_t frame_sequence,
++    const system::GraphicsNativeFrameAccumulatorRequest& request) {
++  system::GraphicsNativeFrameAccumulatorResult result;
++  result.frame_sequence = frame_sequence;
++  const auto clear_active = [&]() {
++    isolated_replay_frame_accumulator_frame_sequence_ = 0;
++    isolated_replay_frame_accumulator_committed_frame_sequence_ = 0;
++    isolated_replay_frame_accumulator_width_ = 0;
++    isolated_replay_frame_accumulator_height_ = 0;
++    isolated_replay_frame_accumulator_logical_height_ = 0;
++    isolated_replay_frame_accumulator_appended_row_end_ = 0;
++    isolated_replay_frame_accumulator_reseed_required_ = false;
++  };
++  if (request.cancel && !request.begin && !request.append &&
++      !request.commit) {
++    clear_active();
++    result.status =
++        system::GraphicsNativeFrameAccumulatorStatus::kCancelled;
++    return result;
++  }
++  if (!frame_sequence || request.cancel || !request.append ||
++      (request.commit && !request.append) || !request.logical_width ||
++      !request.logical_height ||
++      request.storage_height < request.logical_height ||
++      request.storage_height >= request.logical_height + 64 ||
++      !request.storage_row_count ||
++      request.destination_row > request.storage_height ||
++      request.storage_row_count >
++          request.storage_height - request.destination_row ||
++      (request.begin && request.destination_row) ||
++      (!request.begin &&
++       (isolated_replay_frame_accumulator_frame_sequence_ != frame_sequence ||
++        request.destination_row !=
++            isolated_replay_frame_accumulator_appended_row_end_))) {
++    clear_active();
++    result.status =
++        system::GraphicsNativeFrameAccumulatorStatus::kInvalidRequest;
++    return result;
++  }
++  if (GetPath() != Path::kHostRenderTargets ||
++      !isolated_replay_color_target_ ||
++      isolated_replay_deferred_preview_frame_sequence_ != frame_sequence) {
++    clear_active();
++    result.status =
++        system::GraphicsNativeFrameAccumulatorStatus::kUnavailable;
++    return result;
++  }
++
++  auto* isolated_color = static_cast<D3D12RenderTarget*>(
++      isolated_replay_color_target_.get());
++  ID3D12Resource* source_resource = isolated_color->resource();
++  const D3D12_RESOURCE_DESC source_desc = source_resource->GetDesc();
++  if (source_desc.Dimension != D3D12_RESOURCE_DIMENSION_TEXTURE2D ||
++      source_desc.DepthOrArraySize != 1 || source_desc.MipLevels != 1 ||
++      !source_desc.SampleDesc.Count ||
++      source_desc.Format != DXGI_FORMAT_R16G16B16A16_FLOAT ||
++      source_desc.Width < request.logical_width ||
++      source_desc.Height < request.storage_row_count) {
++    clear_active();
++    result.status =
++        system::GraphicsNativeFrameAccumulatorStatus::kUnsupportedTarget;
++    return result;
++  }
++  ID3D12Device* device = command_processor_.GetD3D12Provider().GetDevice();
++  if (!device) {
++    clear_active();
++    result.status =
++        system::GraphicsNativeFrameAccumulatorStatus::kUnavailable;
++    return result;
++  }
++
++  if (request.begin) {
++    bool recreate = !isolated_replay_frame_accumulator_target_;
++    if (!recreate) {
++      const D3D12_RESOURCE_DESC current =
++          isolated_replay_frame_accumulator_target_->GetDesc();
++      recreate = current.Width != request.logical_width ||
++                 current.Height != request.storage_height ||
++                 current.Format != source_desc.Format;
++    }
++    if (recreate) {
++      D3D12_RESOURCE_DESC target_desc = source_desc;
++      target_desc.Alignment = 0;
++      target_desc.Width = request.logical_width;
++      target_desc.Height = request.storage_height;
++      target_desc.SampleDesc.Count = 1;
++      target_desc.SampleDesc.Quality = 0;
++      target_desc.Flags = D3D12_RESOURCE_FLAG_NONE;
++      Microsoft::WRL::ComPtr<ID3D12Resource> target;
++      HRESULT create_result = device->CreateCommittedResource(
++          &ui::d3d12::util::kHeapPropertiesDefault,
++          command_processor_.GetD3D12Provider()
++              .GetHeapFlagCreateNotZeroed(),
++          &target_desc, D3D12_RESOURCE_STATE_COPY_DEST, nullptr,
++          IID_PPV_ARGS(&target));
++      if (FAILED(create_result)) {
++        clear_active();
++        result.status =
++            system::GraphicsNativeFrameAccumulatorStatus::kAllocationFailed;
++        return result;
++      }
++      target->SetName(L"Pinyon Shift private procedural frame accumulator");
++      isolated_replay_frame_accumulator_target_ = std::move(target);
++      isolated_replay_frame_accumulator_target_state_ =
++          D3D12_RESOURCE_STATE_COPY_DEST;
++    }
++    isolated_replay_frame_accumulator_frame_sequence_ = frame_sequence;
++    isolated_replay_frame_accumulator_committed_frame_sequence_ = 0;
++    isolated_replay_frame_accumulator_width_ = request.logical_width;
++    isolated_replay_frame_accumulator_height_ = request.storage_height;
++    isolated_replay_frame_accumulator_logical_height_ =
++        request.logical_height;
++    isolated_replay_frame_accumulator_appended_row_end_ = 0;
++  } else if (isolated_replay_frame_accumulator_width_ !=
++                 request.logical_width ||
++             isolated_replay_frame_accumulator_height_ !=
++                 request.storage_height ||
++             isolated_replay_frame_accumulator_logical_height_ !=
++                 request.logical_height) {
++    clear_active();
++    result.status =
++        system::GraphicsNativeFrameAccumulatorStatus::kInvalidRequest;
++    return result;
++  }
++
++  ID3D12Resource* copy_source = source_resource;
++  D3D12_RESOURCE_STATES source_previous_state =
++      D3D12_RESOURCE_STATE_COMMON;
++  bool source_is_resolved_tile = false;
++  if (source_desc.SampleDesc.Count > 1) {
++    bool recreate_tile = !isolated_replay_frame_accumulator_tile_;
++    if (!recreate_tile) {
++      const D3D12_RESOURCE_DESC current =
++          isolated_replay_frame_accumulator_tile_->GetDesc();
++      recreate_tile = current.Width != source_desc.Width ||
++                      current.Height != source_desc.Height ||
++                      current.Format != source_desc.Format;
++    }
++    if (recreate_tile) {
++      D3D12_RESOURCE_DESC tile_desc = source_desc;
++      tile_desc.Alignment = 0;
++      tile_desc.SampleDesc.Count = 1;
++      tile_desc.SampleDesc.Quality = 0;
++      tile_desc.Flags = D3D12_RESOURCE_FLAG_ALLOW_RENDER_TARGET;
++      Microsoft::WRL::ComPtr<ID3D12Resource> tile;
++      HRESULT create_result = device->CreateCommittedResource(
++          &ui::d3d12::util::kHeapPropertiesDefault,
++          command_processor_.GetD3D12Provider()
++              .GetHeapFlagCreateNotZeroed(),
++          &tile_desc, D3D12_RESOURCE_STATE_RESOLVE_DEST, nullptr,
++          IID_PPV_ARGS(&tile));
++      if (FAILED(create_result)) {
++        clear_active();
++        result.status =
++            system::GraphicsNativeFrameAccumulatorStatus::kAllocationFailed;
++        return result;
++      }
++      tile->SetName(L"Pinyon Shift private procedural resolved tile");
++      isolated_replay_frame_accumulator_tile_ = std::move(tile);
++      isolated_replay_frame_accumulator_tile_state_ =
++          D3D12_RESOURCE_STATE_RESOLVE_DEST;
++    }
++    source_previous_state =
++        isolated_color->SetResourceState(D3D12_RESOURCE_STATE_RESOLVE_SOURCE);
++    command_processor_.PushTransitionBarrier(
++        source_resource, source_previous_state,
++        D3D12_RESOURCE_STATE_RESOLVE_SOURCE);
++    command_processor_.PushTransitionBarrier(
++        isolated_replay_frame_accumulator_tile_.Get(),
++        isolated_replay_frame_accumulator_tile_state_,
++        D3D12_RESOURCE_STATE_RESOLVE_DEST);
++    command_processor_.SubmitBarriers();
++    command_processor_.GetDeferredCommandList().D3DResolveSubresource(
++        isolated_replay_frame_accumulator_tile_.Get(), 0, source_resource, 0,
++        source_desc.Format);
++    isolated_color->SetResourceState(source_previous_state);
++    command_processor_.PushTransitionBarrier(
++        source_resource, D3D12_RESOURCE_STATE_RESOLVE_SOURCE,
++        source_previous_state);
++    command_processor_.PushTransitionBarrier(
++        isolated_replay_frame_accumulator_tile_.Get(),
++        D3D12_RESOURCE_STATE_RESOLVE_DEST,
++        D3D12_RESOURCE_STATE_COPY_SOURCE);
++    isolated_replay_frame_accumulator_tile_state_ =
++        D3D12_RESOURCE_STATE_COPY_SOURCE;
++    copy_source = isolated_replay_frame_accumulator_tile_.Get();
++    source_is_resolved_tile = true;
++  } else {
++    source_previous_state =
++        isolated_color->SetResourceState(D3D12_RESOURCE_STATE_COPY_SOURCE);
++    command_processor_.PushTransitionBarrier(
++        source_resource, source_previous_state,
++        D3D12_RESOURCE_STATE_COPY_SOURCE);
++  }
++  command_processor_.PushTransitionBarrier(
++      isolated_replay_frame_accumulator_target_.Get(),
++      isolated_replay_frame_accumulator_target_state_,
++      D3D12_RESOURCE_STATE_COPY_DEST);
++  command_processor_.SubmitBarriers();
++
++  D3D12_TEXTURE_COPY_LOCATION destination{};
++  destination.pResource = isolated_replay_frame_accumulator_target_.Get();
++  destination.Type = D3D12_TEXTURE_COPY_TYPE_SUBRESOURCE_INDEX;
++  D3D12_TEXTURE_COPY_LOCATION source{};
++  source.pResource = copy_source;
++  source.Type = D3D12_TEXTURE_COPY_TYPE_SUBRESOURCE_INDEX;
++  D3D12_BOX source_box{0, 0, 0, request.logical_width,
++                       request.storage_row_count, 1};
++  command_processor_.GetDeferredCommandList().D3DCopyTextureRegion(
++      &destination, 0, request.destination_row, 0, &source, &source_box);
++  if (!source_is_resolved_tile) {
++    isolated_color->SetResourceState(source_previous_state);
++    command_processor_.PushTransitionBarrier(
++        source_resource, D3D12_RESOURCE_STATE_COPY_SOURCE,
++        source_previous_state);
++  }
++
++  isolated_replay_frame_accumulator_appended_row_end_ =
++      request.destination_row + request.storage_row_count;
++  if (request.commit) {
++    if (isolated_replay_frame_accumulator_appended_row_end_ !=
++        request.storage_height) {
++      clear_active();
++      result.status =
++          system::GraphicsNativeFrameAccumulatorStatus::kInvalidRequest;
++      return result;
++    }
++    isolated_replay_frame_accumulator_committed_frame_sequence_ =
++        frame_sequence;
++    isolated_replay_frame_accumulator_reseed_required_ = false;
++  } else {
++    isolated_replay_frame_accumulator_reseed_required_ = true;
++  }
++  result.status = system::GraphicsNativeFrameAccumulatorStatus::kRecorded;
++  result.resource_width = isolated_replay_frame_accumulator_width_;
++  result.resource_height = isolated_replay_frame_accumulator_height_;
++  result.logical_width = isolated_replay_frame_accumulator_width_;
++  result.logical_height = isolated_replay_frame_accumulator_logical_height_;
++  result.appended_row_end =
++      isolated_replay_frame_accumulator_appended_row_end_;
++  result.committed = request.commit;
++  return result;
++}
++
+ void D3D12RenderTargetCache::EndIsolatedReplayTarget(
+     uint64_t frame_sequence, bool defer_preview_publication_until_swap,
+     bool depth_only_target) {
+@@ -2556,9 +2821,18 @@ void D3D12RenderTargetCache::EndIsolatedReplayTarget(
+ void D3D12RenderTargetCache::CommitDeferredIsolatedReplayPreview(
+     uint64_t frame_sequence) {
+   if (isolated_replay_deferred_preview_frame_sequence_ == frame_sequence) {
+-    isolated_replay_preview_frame_sequence_ = frame_sequence;
+-    isolated_replay_preview_width_ = isolated_replay_deferred_preview_width_;
+-    isolated_replay_preview_height_ = isolated_replay_deferred_preview_height_;
++    if (isolated_replay_frame_accumulator_frame_sequence_ != frame_sequence) {
++      isolated_replay_preview_frame_sequence_ = frame_sequence;
++      isolated_replay_preview_width_ = isolated_replay_deferred_preview_width_;
++      isolated_replay_preview_height_ = isolated_replay_deferred_preview_height_;
++    } else if (isolated_replay_frame_accumulator_committed_frame_sequence_ ==
++               frame_sequence) {
++      isolated_replay_preview_frame_sequence_ = frame_sequence;
++      isolated_replay_preview_width_ =
++          isolated_replay_frame_accumulator_width_;
++      isolated_replay_preview_height_ =
++          isolated_replay_frame_accumulator_logical_height_;
++    }
+   }
+   isolated_replay_deferred_preview_frame_sequence_ = 0;
+   isolated_replay_deferred_preview_width_ = 0;
+@@ -2572,6 +2846,12 @@ void D3D12RenderTargetCache::CancelDeferredIsolatedReplayPreview(
+     isolated_replay_deferred_preview_width_ = 0;
+     isolated_replay_deferred_preview_height_ = 0;
+   }
++  if (isolated_replay_frame_accumulator_frame_sequence_ == frame_sequence) {
++    isolated_replay_frame_accumulator_frame_sequence_ = 0;
++    isolated_replay_frame_accumulator_committed_frame_sequence_ = 0;
++    isolated_replay_frame_accumulator_appended_row_end_ = 0;
++    isolated_replay_frame_accumulator_reseed_required_ = false;
++  }
+ }
+ 
+ system::GraphicsIsolatedDrawPublicationResult
+@@ -2734,14 +3014,25 @@ bool D3D12RenderTargetCache::BeginIsolatedReplayPreview(
+     uint64_t required_frame_sequence,
+     IsolatedReplayPreviewSource& source_out) {
+   source_out = {};
+-  if (GetPath() != Path::kHostRenderTargets ||
+-      !isolated_replay_color_target_ || !required_frame_sequence ||
+-      isolated_replay_preview_frame_sequence_ != required_frame_sequence) {
++  const bool use_frame_accumulator =
++      isolated_replay_frame_accumulator_target_ &&
++      isolated_replay_frame_accumulator_committed_frame_sequence_ ==
++          required_frame_sequence &&
++      isolated_replay_preview_frame_sequence_ == required_frame_sequence;
++  if (GetPath() != Path::kHostRenderTargets || !required_frame_sequence ||
++      isolated_replay_preview_frame_sequence_ != required_frame_sequence ||
++      (!use_frame_accumulator && !isolated_replay_color_target_)) {
+     return false;
+   }
+-  auto* isolated_color = static_cast<D3D12RenderTarget*>(
+-      isolated_replay_color_target_.get());
+-  ID3D12Resource* resource = isolated_color->resource();
++  auto* isolated_color =
++      use_frame_accumulator
++          ? nullptr
++          : static_cast<D3D12RenderTarget*>(
++                isolated_replay_color_target_.get());
++  ID3D12Resource* resource =
++      use_frame_accumulator
++          ? isolated_replay_frame_accumulator_target_.Get()
++          : isolated_color->resource();
+   const D3D12_RESOURCE_DESC resource_desc = resource->GetDesc();
+   // The first retained Forza pass has an RGBA16F target. Keep this preview
+   // exact rather than guessing how to interpret later targets, but resolve its
+@@ -2783,6 +3074,18 @@ bool D3D12RenderTargetCache::BeginIsolatedReplayPreview(
+     return false;
+   }
+   source_out.frame_sequence = isolated_replay_preview_frame_sequence_;
++  source_out.frame_accumulator = use_frame_accumulator;
++  if (use_frame_accumulator) {
++    source_out.previous_state =
++        isolated_replay_frame_accumulator_target_state_;
++    command_processor_.PushTransitionBarrier(
++        resource, source_out.previous_state,
++        D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE);
++    isolated_replay_frame_accumulator_target_state_ =
++        D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE;
++    command_processor_.SubmitBarriers();
++    return true;
++  }
+   if (resource_desc.SampleDesc.Count > 1) {
+     D3D12_RESOURCE_DESC resolved_desc = resource_desc;
+     resolved_desc.Alignment = 0;
+@@ -2863,7 +3166,22 @@ bool D3D12RenderTargetCache::BeginIsolatedReplayPreview(
+ 
+ void D3D12RenderTargetCache::EndIsolatedReplayPreview(
+     const IsolatedReplayPreviewSource& source) {
+-  if (!source.resource || !isolated_replay_color_target_) {
++  if (!source.resource) {
++    return;
++  }
++  if (source.frame_accumulator) {
++    if (isolated_replay_frame_accumulator_target_.Get() !=
++        source.resource) {
++      return;
++    }
++    command_processor_.PushTransitionBarrier(
++        source.resource, D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE,
++        source.previous_state);
++    isolated_replay_frame_accumulator_target_state_ =
++        source.previous_state;
++    return;
++  }
++  if (!isolated_replay_color_target_) {
+     return;
+   }
+   if (source.resolved) {
+

--- a/tools/tests/test_native_renderer_contract.py
+++ b/tools/tests/test_native_renderer_contract.py
@@ -2026,6 +2026,29 @@ class NativeRendererContractTests(unittest.TestCase):
         self.assertIn("ShadowDepthBatch requires IsolatedDrawDir", capture)
         self.assertIn("PINYON_SHIFT_NATIVE_RENDERER_SHADOW_DEPTH_BATCH", capture)
 
+    def test_procedural_frame_accumulator_backend_is_private_and_fail_closed(self):
+        patch = (
+            ROOT
+            / "patches/rexglue/0108-d3d12-procedural-frame-accumulator.patch"
+        ).read_text(encoding="utf-8")
+        self.assertIn("GraphicsNativeFrameAccumulatorRequest", patch)
+        self.assertIn("SetNativeFrameAccumulatorPlanner", patch)
+        self.assertIn("observation.succeeded", patch)
+        self.assertIn("ApplyIsolatedReplayFrameAccumulator", patch)
+        self.assertIn("request.destination_row !=", patch)
+        self.assertIn("request.storage_height - request.destination_row", patch)
+        self.assertIn("isolated_replay_frame_accumulator_reseed_required_", patch)
+        self.assertIn("return BeginIsolatedReplayTarget(", patch)
+        self.assertIn(
+            "isolated_replay_frame_accumulator_committed_frame_sequence_ ==",
+            patch,
+        )
+        self.assertIn("D3D12_RESOURCE_STATE_COPY_DEST", patch)
+        self.assertIn("D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE", patch)
+        self.assertNotIn("SetDrawSuppression", patch)
+        self.assertNotIn("+      PublishIsolatedReplayTarget(", patch)
+        self.assertNotIn("+            PublishIsolatedReplayTarget(", patch)
+
     def test_census_ledger_tracks_exact_starting_baseline(self):
         ledger = (ROOT / "docs/native-renderer/RENDER_PASS_CENSUS.md").read_text(
             encoding="utf-8"

--- a/tools/tests/test_release_contract.py
+++ b/tools/tests/test_release_contract.py
@@ -43,10 +43,10 @@ class ReleaseContractTests(unittest.TestCase):
 
     def test_rexglue_patches_have_stable_order_and_no_binary_payload(self):
         patches = sorted((ROOT / "patches/rexglue").glob("*.patch"))
-        self.assertEqual(len(patches), 107)
+        self.assertEqual(len(patches), 108)
         self.assertEqual(
             patches[-1].name,
-            "0107-graphics-draw-bin-state-observer.patch",
+            "0108-d3d12-procedural-frame-accumulator.patch",
         )
         self.assertEqual(len(patches), len({path.name[:4] for path in patches}))
         for path in patches:


### PR DESCRIPTION
## Summary
- add a dormant backend callback for exact procedural padded-frame assembly
- keep intermediate tiles private and expose only fully committed frames at swap
- re-seed private replay from authoritative guest EDRAM between tiles
- preserve Xenos resolves, guest memory, and draw execution unchanged

## Validation
- python -m unittest discover -s tools/tests (699 passed)
- cmake --build --preset win-amd64-release --target pinyon_shift
- replayed all 108 ReXGlue patches from the pinned base with git apply --check

The callback remains unregistered in this slice; title-side planner wiring is the next batched step.