### PR TITLE
test(native-renderer): qualify procedural frame accumulation

### DIFF
--- a/docs/native-renderer/COLOR_PRODUCER_LINEAGE.md
+++ b/docs/native-renderer/COLOR_PRODUCER_LINEAGE.md
@@ -125,6 +125,23 @@ retain the passive planning census; enabled runs let the callback consume each
 transition exactly once. Neither mode can publish guest memory or suppress a
 draw.
 
+`summarize-native-renderer-procedural-frame-accumulator.py` is the fail-closed
+runtime gate for the combined slice. It requires one armed backend config, one
+clean shutdown, complete result accounting, zero backend hard failures, and at
+least one frame whose plan is exactly `0+256`, `256+256`, and `512+224` and
+whose private results advance to rows 256, 512, and committed 736. It also
+locks the 1280x720 logical / 1280x736 storage extents, private-resource scope,
+completed-first Xenos resolve, zero guest-memory publication, and zero draw
+suppression.
+
+Run it after the combined AppData session closes:
+
+```powershell
+python tools/summarize-native-renderer-procedural-frame-accumulator.py `
+  <session-jsonl> --session <session-id> `
+  --output .local/qualification/native-renderer-procedural-frame-accumulator.json
+```
+
 Run the deferred qualifier after the next combined AppData capture:
 
 ```powershell

--- a/docs/native-renderer/REPRIORITIZED_PLAN.md
+++ b/docs/native-renderer/REPRIORITIZED_PLAN.md
@@ -772,6 +772,15 @@ meaningful AppData validation can therefore exercise the complete target-role,
 resolve-workset, row-plan, private assembly, and swap-preview chain as one
 batch.
 
+Qualification-tooling checkpoint: the combined runtime slice now has a strict
+offline gate. It accepts only an armed private backend, one exact three-step
+`0+256`, `256+256`, `512+224` row plan, matching recorded results ending in a
+committed 1280x736 private resource with 1280x720 logical output, complete
+bounded status accounting, zero hard backend failures, and a clean shutdown.
+It independently locks completed-first Xenos resolves, zero guest-memory
+publication, and zero draw suppression. This converts the pending visual run
+into a reproducible evidence gate without adding another gameplay capture.
+
 ### C2. Static world buildings and props
 
 - Expand opaque-world material and geometry coverage.

--- a/tools/summarize-native-renderer-procedural-frame-accumulator.py
+++ b/tools/summarize-native-renderer-procedural-frame-accumulator.py
@@ -1,0 +1,225 @@
+#!/usr/bin/env python3
+"""Qualify exact private procedural full-frame accumulation from one run."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import pathlib
+import sys
+
+
+SCHEMA = "pinyon-shift.native-renderer-procedural-frame-accumulator.v1"
+CONFIG = "native_renderer.discovery.command_buffer_lineage_config"
+PLAN = "native_renderer.discovery.procedural_frame_accumulator_plan"
+PLAN_SUMMARY = (
+    "native_renderer.discovery.procedural_frame_accumulator_plan_summary"
+)
+RESULT = "native_renderer.procedural_frame_accumulator.result"
+RESULT_SUMMARY = "native_renderer.procedural_frame_accumulator.result_summary"
+SHUTDOWN = "process.shutdown"
+
+
+def integer(event, name):
+    try:
+        return int(event[name], 10)
+    except (KeyError, TypeError, ValueError) as error:
+        raise ValueError(f"invalid {name}") from error
+
+
+def read_events(path, session):
+    events = []
+    for line_number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+        if not line.strip():
+            continue
+        try:
+            event = json.loads(line)
+        except json.JSONDecodeError as error:
+            raise ValueError(f"invalid JSON at line {line_number}") from error
+        if event.get("session") == session:
+            events.append(event)
+    return events
+
+
+def exact_plan_frames(events):
+    grouped = {}
+    for event in events:
+        grouped.setdefault(integer(event, "frame"), []).append(event)
+    exact = []
+    expected = (
+        ("begin_and_append", 0, 256, 256),
+        ("append", 256, 256, 512),
+        ("append_and_commit", 512, 224, 736),
+    )
+    for frame, rows in grouped.items():
+        observed = tuple(
+            (
+                row.get("operation"),
+                integer(row, "destination_row"),
+                integer(row, "storage_row_count"),
+                integer(row, "padded_height"),
+            )
+            for row in rows
+            if row.get("operation") != "cancel"
+        )
+        if observed == expected and all(
+            row.get("logical_extent") == "1280x720"
+            and row.get("backend_resource_action") == "private_only"
+            and row.get("xenos_authority") == "true"
+            and row.get("suppression_allowed") == "false"
+            for row in rows
+            if row.get("operation") != "cancel"
+        ):
+            exact.append(frame)
+    return exact
+
+
+def exact_result_frames(events):
+    grouped = {}
+    for event in events:
+        grouped.setdefault(integer(event, "frame"), []).append(event)
+    exact = []
+    for frame, rows in grouped.items():
+        recorded = [row for row in rows if row.get("status") == "recorded"]
+        if [integer(row, "appended_row_end") for row in recorded] != [256, 512, 736]:
+            continue
+        if [row.get("committed") for row in recorded] != ["false", "false", "true"]:
+            continue
+        if not all(
+            row.get("resource_extent") == "1280x736"
+            and row.get("logical_extent") == "1280x720"
+            and row.get("resource_scope") == "private_d3d12"
+            and row.get("guest_memory_publication") == "false"
+            and row.get("xenos_resolve") == "preserved_and_completed_first"
+            and row.get("draw_suppression") == "false"
+            for row in recorded
+        ):
+            continue
+        exact.append(frame)
+    return exact
+
+
+def build(events, session):
+    configs = [event for event in events if event.get("event") == CONFIG]
+    plans = [event for event in events if event.get("event") == PLAN]
+    plan_summaries = [event for event in events if event.get("event") == PLAN_SUMMARY]
+    results = [event for event in events if event.get("event") == RESULT]
+    result_summaries = [
+        event for event in events if event.get("event") == RESULT_SUMMARY
+    ]
+    shutdowns = [event for event in events if event.get("event") == SHUTDOWN]
+    failures = []
+
+    if len(configs) != 1:
+        failures.append("expected one command-lineage config")
+    elif configs[0].get("procedural_color_frame_accumulator_backend") != (
+        "armed_private_d3d12_v1"
+    ):
+        failures.append("private D3D12 accumulator was not armed")
+    if len(plan_summaries) != 1:
+        failures.append("expected one frame-accumulator plan summary")
+    if len(result_summaries) != 1:
+        failures.append("expected one frame-accumulator result summary")
+    if len(shutdowns) != 1:
+        failures.append("clean process shutdown was not observed")
+
+    plan_frames = exact_plan_frames(plans)
+    result_frames = exact_result_frames(results)
+    qualified_frames = sorted(set(plan_frames) & set(result_frames))
+    if not qualified_frames:
+        failures.append("no exact planned and committed 1280x720 frame was observed")
+
+    status_counts = {}
+    accounting_complete = False
+    hard_failures = 0
+    if len(result_summaries) == 1:
+        summary = result_summaries[0]
+        if summary.get("status") != "armed":
+            failures.append("result summary did not remain armed")
+        names = (
+            "recorded",
+            "cancelled",
+            "invalid_request",
+            "unavailable",
+            "unsupported_target",
+            "allocation_failed",
+        )
+        status_counts = {name: integer(summary, name) for name in names}
+        detail_events = integer(summary, "detail_events")
+        detail_overflow = integer(summary, "detail_overflow")
+        accounting_complete = sum(status_counts.values()) == (
+            detail_events + detail_overflow
+        )
+        if not accounting_complete:
+            failures.append("backend result accounting is incomplete")
+        hard_failures = sum(
+            status_counts[name]
+            for name in (
+                "invalid_request",
+                "unavailable",
+                "unsupported_target",
+                "allocation_failed",
+            )
+        )
+        if hard_failures:
+            failures.append("backend reported a hard failure")
+        for name, expected in (
+            ("resource_scope", "private_d3d12"),
+            ("guest_memory_publication", "false"),
+            ("xenos_resolve", "preserved_and_completed_first"),
+            ("draw_suppression", "false"),
+        ):
+            if summary.get(name) != expected:
+                failures.append(f"unsafe or missing summary field: {name}")
+
+    complete = not failures
+    return {
+        "schema": SCHEMA,
+        "session": session,
+        "status": "complete" if complete else "incomplete",
+        "failures": failures,
+        "evidence": {
+            "plan_events": len(plans),
+            "result_events": len(results),
+            "exact_plan_frames": plan_frames,
+            "exact_result_frames": result_frames,
+            "qualified_frames": qualified_frames,
+            "status_counts": status_counts,
+            "result_accounting_complete": accounting_complete,
+            "hard_failures": hard_failures,
+        },
+        "qualification": {
+            "exact_private_padded_frame_accumulator": complete,
+            "logical_extent": "1280x720" if complete else None,
+            "storage_extent": "1280x736" if complete else None,
+            "native_output_eligible": complete,
+            "guest_memory_publication": False,
+            "draw_suppression": False,
+        },
+        "safety": {
+            "xenos_resolve_completed_first": True,
+            "xenos_draws_preserved": True,
+            "guest_memory_changed": False,
+            "suppression_allowed": False,
+        },
+    }
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("log", type=pathlib.Path)
+    parser.add_argument("--session", required=True)
+    parser.add_argument("--output", required=True, type=pathlib.Path)
+    args = parser.parse_args(argv)
+    try:
+        result = build(read_events(args.log, args.session), args.session)
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(json.dumps(result, indent=2, sort_keys=True) + "\n")
+        return 0 if result["status"] == "complete" else 1
+    except (OSError, UnicodeDecodeError, ValueError) as error:
+        print(f"procedural frame-accumulator summary failed: {error}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/tests/test_native_renderer_procedural_frame_accumulator.py
+++ b/tools/tests/test_native_renderer_procedural_frame_accumulator.py
@@ -1,0 +1,142 @@
+import importlib.util
+import pathlib
+import unittest
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+TOOL = ROOT / "tools/summarize-native-renderer-procedural-frame-accumulator.py"
+SPEC = importlib.util.spec_from_file_location("procedural_frame_accumulator", TOOL)
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+def fixture():
+    common = {"session": "session"}
+    events = [
+        {
+            **common,
+            "event": MODULE.CONFIG,
+            "procedural_color_frame_accumulator_backend": (
+                "armed_private_d3d12_v1"
+            ),
+        }
+    ]
+    plans = (
+        ("begin_and_append", 0, 256, 256),
+        ("append", 256, 256, 512),
+        ("append_and_commit", 512, 224, 736),
+    )
+    for operation, destination_row, storage_rows, padded_height in plans:
+        events.append(
+            {
+                **common,
+                "event": MODULE.PLAN,
+                "frame": "100",
+                "operation": operation,
+                "destination_row": str(destination_row),
+                "storage_row_count": str(storage_rows),
+                "padded_height": str(padded_height),
+                "logical_extent": "1280x720",
+                "backend_resource_action": "private_only",
+                "xenos_authority": "true",
+                "suppression_allowed": "false",
+            }
+        )
+    for appended_row_end, committed in ((256, "false"), (512, "false"), (736, "true")):
+        events.append(
+            {
+                **common,
+                "event": MODULE.RESULT,
+                "frame": "100",
+                "status": "recorded",
+                "resource_extent": "1280x736",
+                "logical_extent": "1280x720",
+                "appended_row_end": str(appended_row_end),
+                "committed": committed,
+                "resource_scope": "private_d3d12",
+                "guest_memory_publication": "false",
+                "xenos_resolve": "preserved_and_completed_first",
+                "draw_suppression": "false",
+            }
+        )
+    events.extend(
+        [
+            {**common, "event": MODULE.PLAN_SUMMARY},
+            {
+                **common,
+                "event": MODULE.RESULT_SUMMARY,
+                "status": "armed",
+                "recorded": "3",
+                "cancelled": "0",
+                "invalid_request": "0",
+                "unavailable": "0",
+                "unsupported_target": "0",
+                "allocation_failed": "0",
+                "detail_events": "3",
+                "detail_overflow": "0",
+                "resource_scope": "private_d3d12",
+                "guest_memory_publication": "false",
+                "xenos_resolve": "preserved_and_completed_first",
+                "draw_suppression": "false",
+            },
+            {**common, "event": MODULE.SHUTDOWN},
+        ]
+    )
+    return events
+
+
+class ProceduralFrameAccumulatorTests(unittest.TestCase):
+    def test_qualifies_exact_private_padded_frame(self):
+        result = MODULE.build(fixture(), "session")
+        self.assertEqual("complete", result["status"])
+        self.assertEqual([100], result["evidence"]["qualified_frames"])
+        self.assertTrue(
+            result["qualification"]["exact_private_padded_frame_accumulator"]
+        )
+        self.assertEqual("1280x720", result["qualification"]["logical_extent"])
+        self.assertEqual("1280x736", result["qualification"]["storage_extent"])
+        self.assertFalse(result["qualification"]["guest_memory_publication"])
+        self.assertFalse(result["qualification"]["draw_suppression"])
+
+    def test_rejects_incomplete_row_plan(self):
+        events = fixture()
+        for event in events:
+            if event.get("event") == MODULE.PLAN and event.get("operation") == "append":
+                event["destination_row"] = "257"
+        result = MODULE.build(events, "session")
+        self.assertEqual("incomplete", result["status"])
+        self.assertIn(
+            "no exact planned and committed 1280x720 frame was observed",
+            result["failures"],
+        )
+
+    def test_rejects_backend_hard_failure(self):
+        events = fixture()
+        summary = next(
+            event for event in events if event.get("event") == MODULE.RESULT_SUMMARY
+        )
+        summary["unavailable"] = "1"
+        summary["detail_events"] = "4"
+        result = MODULE.build(events, "session")
+        self.assertEqual("incomplete", result["status"])
+        self.assertIn("backend reported a hard failure", result["failures"])
+
+    def test_rejects_incomplete_result_accounting(self):
+        events = fixture()
+        summary = next(
+            event for event in events if event.get("event") == MODULE.RESULT_SUMMARY
+        )
+        summary["detail_events"] = "2"
+        result = MODULE.build(events, "session")
+        self.assertEqual("incomplete", result["status"])
+        self.assertIn("backend result accounting is incomplete", result["failures"])
+
+    def test_rejects_missing_clean_shutdown(self):
+        events = [event for event in fixture() if event.get("event") != MODULE.SHUTDOWN]
+        result = MODULE.build(events, "session")
+        self.assertEqual("incomplete", result["status"])
+        self.assertIn("clean process shutdown was not observed", result["failures"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a fail-closed offline qualifier for exact private D3D12 frame accumulation
- require the three exact row operations and matching committed backend results
- document the combined AppData evidence gate in the renderer roadmap

## Validation
- python -m unittest tools.tests.test_native_renderer_procedural_frame_accumulator`n- python -m py_compile tools/summarize-native-renderer-procedural-frame-accumulator.py tools/tests/test_native_renderer_procedural_frame_accumulator.py`n- full Python suite: 704 passed

No rebuild was required because this slice only adds offline qualification tooling, tests, and documentation.