### PR TITLE
fix(native-renderer): address procedural source rows

### DIFF
--- a/docs/native-renderer/COLOR_PRODUCER_LINEAGE.md
+++ b/docs/native-renderer/COLOR_PRODUCER_LINEAGE.md
@@ -151,6 +151,21 @@ off, and no guest-memory publication occurred. This closes structural
 accumulator qualification; the visibly repeated/corrupt scene regions remain a
 separate source-row addressing problem for the next slice.
 
+Patch `0111` closes that addressing defect. Each 256-row isolated source keeps
+the guest destination row encoded in its source texture, so the second and
+third accumulator operations must load source rows 256-511 and 512-735 rather
+than replaying rows from zero. The corrected compute path adds
+`destination_row` to both the source and destination Y coordinates while
+retaining the already-qualified two-sample horizontal expansion. A visual
+AppData probe replaced the repeated horizontal bands and noisy right edge with
+one coherent scene. Equivalent Phase-C AppData session
+`20260901T104300Z-p42688` then recorded nine exact frames and 27 successful
+operations with zero hard failures before exiting normally. Every operation
+used `1280x736` storage and `1280x720` logical extents, Xenos resolves completed
+first, and draw suppression and guest-memory publication remained off. This
+qualifies the corrected source-row path rather than relying only on the earlier
+structural session.
+
 Run it after the combined AppData session closes:
 
 ```powershell

--- a/docs/native-renderer/REPRIORITIZED_PLAN.md
+++ b/docs/native-renderer/REPRIORITIZED_PLAN.md
@@ -67,8 +67,10 @@ Already landed or substantially qualified:
 
 Phase A and B are merged and qualified. Phase C is active: C1 has reached a
 live procedural color producer, proved its padded full-frame resolve assembly,
-and is moving that exact gate into the runtime workset before any new native
-publication. Terrain and roads remain the next visible-impact target.
+and has corrected the 2x-MSAA sample topology plus source-row addressing in its
+private 1280x736 accumulator. The corrected source is visually coherent, while
+Xenos remains authoritative and no guest publication or suppression is enabled.
+Terrain and roads remain the next visible-impact target.
 
 ---
 
@@ -788,9 +790,12 @@ samples instead of averaging them. AppData session
 `20260901T102213Z-p45980` recorded 12 exact frames / 36 operations, all at
 `1280x736` storage and `1280x720` logical extent, with zero hard failures,
 normal exit, completed-first Xenos resolves, no draw suppression, and no guest
-memory publication. Structural accumulation is qualified. The resulting frame
-still exposes incorrect/repeated scene regions, so exact source-row addressing
-is the next visual correctness gate before expanding producer coverage.
+memory publication. Structural accumulation is qualified. Patch `0111` then
+corrected source-row addressing: equivalent Phase-C AppData session
+`20260901T104300Z-p42688` recorded nine exact frames / 27 operations, all
+successful, with the same extents and safety invariants before a normal exit.
+The corrected frame is visually coherent, so producer coverage and continuous
+presentation are now the next visible gates.
 
 ### C2. Static world buildings and props
 

--- a/patches/rexglue/0111-d3d12-procedural-frame-accumulator-source-rows.patch
+++ b/patches/rexglue/0111-d3d12-procedural-frame-accumulator-source-rows.patch
@@ -1,0 +1,171 @@
+diff --git a/src/graphics/shaders/procedural_frame_accumulator_2xmsaa.cs.hlsl b/src/graphics/shaders/procedural_frame_accumulator_2xmsaa.cs.hlsl
+index 183cf20..744434c 100644
+--- a/src/graphics/shaders/procedural_frame_accumulator_2xmsaa.cs.hlsl
++++ b/src/graphics/shaders/procedural_frame_accumulator_2xmsaa.cs.hlsl
+@@ -18,5 +18,6 @@ void main(uint3 dispatch_thread_id : SV_DispatchThreadID) {
+   uint sample_index = output_position.x & 1;
+   frame_accumulator[uint2(output_position.x,
+                           destination_row + output_position.y)] =
+-      source_tile.Load(uint2(source_x, output_position.y), sample_index);
++      source_tile.Load(uint2(source_x, destination_row + output_position.y),
++                       sample_index);
+ }
+diff --git a/src/graphics/shaders/bytecode/d3d12_5_1/procedural_frame_accumulator_2xmsaa_cs.h b/src/graphics/shaders/bytecode/d3d12_5_1/procedural_frame_accumulator_2xmsaa_cs.h
+index 7b349d7..9e6e9f1 100644
+--- a/src/graphics/shaders/bytecode/d3d12_5_1/procedural_frame_accumulator_2xmsaa_cs.h
++++ b/src/graphics/shaders/bytecode/d3d12_5_1/procedural_frame_accumulator_2xmsaa_cs.h
+@@ -42,7 +42,7 @@ dcl_constantbuffer CB0[0:0][1], immediateIndexed, space=0
+ dcl_resource_texture2dms(2) (float,float,float,float) T0[0:0], space=0
+ dcl_uav_typed_texture2d (float,float,float,float) U0[0:0], space=0
+ dcl_input vThreadID.xy
+-dcl_temps 3
++dcl_temps 2
+ dcl_thread_group 8, 8, 1
+ ishl r0.x, CB0[0][0].x, l(1)
+ uge r0.x, vThreadID.x, r0.x
+@@ -53,27 +53,26 @@ if_nz r0.x
+ endif 
+ ushr r0.x, vThreadID.x, l(1)
+ and r1.x, vThreadID.x, l(1)
+-iadd r2.yzw, vThreadID.yyyy, CB0[0][0].zzzz
+-mov r0.y, vThreadID.y
+-mov r0.zw, l(0,0,0,0)
+-ldms r0.xyzw, r0.xyzw, T0[0].xyzw, r1.x
+-mov r2.x, vThreadID.x
+-store_uav_typed U0[0].xyzw, r2.xyzw, r0.xyzw
++iadd r0.y, vThreadID.y, CB0[0][0].z
++mov r0.z, l(0)
++ldms r1.xyzw, r0.xyzz, T0[0].xyzw, r1.x
++mov r0.w, vThreadID.x
++store_uav_typed U0[0].xyzw, r0.wyyy, r1.xyzw
+ ret 
+-// Approximately 16 instruction slots used
++// Approximately 15 instruction slots used
+ #endif
+ 
+ const BYTE procedural_frame_accumulator_2xmsaa_cs[] =
+ {
+-     68,  88,  66,  67, 246,  11, 
+-     91,   7, 145, 214,  54,  12, 
+-    235,  11, 217,  77,  65, 189, 
+-     75, 217,   1,   0,   0,   0, 
+-     32,   5,   0,   0,   5,   0, 
++     68,  88,  66,  67, 136, 246, 
++      2, 135, 125, 104, 241,  79, 
++    122, 179, 185, 142, 219, 241, 
++     60,   3,   1,   0,   0,   0, 
++      4,   5,   0,   0,   5,   0, 
+       0,   0,  52,   0,   0,   0, 
+     116,   2,   0,   0, 132,   2, 
+       0,   0, 148,   2,   0,   0, 
+-    132,   4,   0,   0,  82,  68, 
++    104,   4,   0,   0,  82,  68, 
+      69,  70,  56,   2,   0,   0, 
+       1,   0,   0,   0, 248,   0, 
+       0,   0,   3,   0,   0,   0, 
+@@ -175,9 +174,9 @@ const BYTE procedural_frame_accumulator_2xmsaa_cs[] =
+       0,   0,  79,  83,  71,  78, 
+       8,   0,   0,   0,   0,   0, 
+       0,   0,   8,   0,   0,   0, 
+-     83,  72,  69,  88, 232,   1, 
++     83,  72,  69,  88, 204,   1, 
+       0,   0,  81,   0,   5,   0, 
+-    122,   0,   0,   0, 106,   8, 
++    115,   0,   0,   0, 106,   8, 
+       0,   1,  89,   0,   0,   7, 
+      70, 142,  48,   0,   0,   0, 
+       0,   0,   0,   0,   0,   0, 
+@@ -194,7 +193,7 @@ const BYTE procedural_frame_accumulator_2xmsaa_cs[] =
+      85,  85,   0,   0,   0,   0, 
+       0,   0,  95,   0,   0,   2, 
+      50,   0,   2,   0, 104,   0, 
+-      0,   2,   3,   0,   0,   0, 
++      0,   2,   2,   0,   0,   0, 
+     155,   0,   0,   4,   8,   0, 
+       0,   0,   8,   0,   0,   0, 
+       1,   0,   0,   0,  41,   0, 
+@@ -229,50 +228,45 @@ const BYTE procedural_frame_accumulator_2xmsaa_cs[] =
+      16,   0,   1,   0,   0,   0, 
+      10,   0,   2,   0,   1,  64, 
+       0,   0,   1,   0,   0,   0, 
+-     30,   0,   0,   8, 226,   0, 
+-     16,   0,   2,   0,   0,   0, 
+-     86,   5,   2,   0, 166, 138, 
++     30,   0,   0,   8,  34,   0, 
++     16,   0,   0,   0,   0,   0, 
++     26,   0,   2,   0,  42, 128, 
+      48,   0,   0,   0,   0,   0, 
+       0,   0,   0,   0,   0,   0, 
+-      0,   0,  54,   0,   0,   4, 
+-     34,   0,  16,   0,   0,   0, 
+-      0,   0,  26,   0,   2,   0, 
+-     54,   0,   0,   8, 194,   0, 
++      0,   0,  54,   0,   0,   5, 
++     66,   0,  16,   0,   0,   0, 
++      0,   0,   1,  64,   0,   0, 
++      0,   0,   0,   0,  46,   0, 
++      0,  10, 242,   0,  16,   0, 
++      1,   0,   0,   0,  70,  10, 
+      16,   0,   0,   0,   0,   0, 
+-      2,  64,   0,   0,   0,   0, 
+-      0,   0,   0,   0,   0,   0, 
+-      0,   0,   0,   0,   0,   0, 
+-      0,   0,  46,   0,   0,  10, 
+-    242,   0,  16,   0,   0,   0, 
+-      0,   0,  70,  14,  16,   0, 
+-      0,   0,   0,   0,  70, 126, 
+-     32,   0,   0,   0,   0,   0, 
+-      0,   0,   0,   0,  10,   0, 
+-     16,   0,   1,   0,   0,   0, 
+-     54,   0,   0,   4,  18,   0, 
+-     16,   0,   2,   0,   0,   0, 
+-     10,   0,   2,   0, 164,   0, 
+-      0,   8, 242, 224,  33,   0, 
++     70, 126,  32,   0,   0,   0, 
+       0,   0,   0,   0,   0,   0, 
+-      0,   0,  70,  14,  16,   0, 
+-      2,   0,   0,   0,  70,  14, 
++     10,   0,  16,   0,   1,   0, 
++      0,   0,  54,   0,   0,   4, 
++    130,   0,  16,   0,   0,   0, 
++      0,   0,  10,   0,   2,   0, 
++    164,   0,   0,   8, 242, 224, 
++     33,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0, 118,   5, 
+      16,   0,   0,   0,   0,   0, 
+-     62,   0,   0,   1,  83,  84, 
+-     65,  84, 148,   0,   0,   0, 
+-     16,   0,   0,   0,   3,   0, 
+-      0,   0,   0,   0,   0,   0, 
+-      1,   0,   0,   0,   0,   0, 
+-      0,   0,   2,   0,   0,   0, 
+-      5,   0,   0,   0,   2,   0, 
++     70,  14,  16,   0,   1,   0, 
++      0,   0,  62,   0,   0,   1, 
++     83,  84,  65,  84, 148,   0, 
++      0,   0,  15,   0,   0,   0, 
++      2,   0,   0,   0,   0,   0, 
+       0,   0,   1,   0,   0,   0, 
++      0,   0,   0,   0,   2,   0, 
++      0,   0,   5,   0,   0,   0, 
++      2,   0,   0,   0,   1,   0, 
+       0,   0,   0,   0,   0,   0, 
+       0,   0,   0,   0,   0,   0, 
+       0,   0,   0,   0,   0,   0, 
+       0,   0,   0,   0,   0,   0, 
+-      1,   0,   0,   0,   0,   0, 
++      0,   0,   1,   0,   0,   0, 
+       0,   0,   0,   0,   0,   0, 
+-      0,   0,   0,   0,   3,   0, 
+       0,   0,   0,   0,   0,   0, 
++      2,   0,   0,   0,   0,   0, 
+       0,   0,   0,   0,   0,   0, 
+       0,   0,   0,   0,   0,   0, 
+       0,   0,   0,   0,   0,   0, 
+@@ -283,5 +277,5 @@ const BYTE procedural_frame_accumulator_2xmsaa_cs[] =
+       0,   0,   0,   0,   0,   0, 
+       0,   0,   0,   0,   0,   0, 
+       0,   0,   0,   0,   0,   0, 
+-      1,   0,   0,   0
++      0,   0,   1,   0,   0,   0
+ };

--- a/tools/tests/test_native_renderer_contract.py
+++ b/tools/tests/test_native_renderer_contract.py
@@ -2070,6 +2070,18 @@ class NativeRendererContractTests(unittest.TestCase):
         self.assertNotIn("SetDrawSuppression", topology_patch)
         self.assertNotIn("PublishIsolatedReplayTarget", topology_patch)
 
+        source_rows_patch = (
+            ROOT
+            / "patches/rexglue/0111-d3d12-procedural-frame-accumulator-source-rows.patch"
+        ).read_text(encoding="utf-8")
+        self.assertIn(
+            "source_x, destination_row + output_position.y",
+            source_rows_patch,
+        )
+        self.assertIn("destination_row + output_position.y", source_rows_patch)
+        self.assertNotIn("SetDrawSuppression", source_rows_patch)
+        self.assertNotIn("PublishIsolatedReplayTarget", source_rows_patch)
+
         scanner = (ROOT / "src/native_renderer/graphics_hooks.cpp").read_text(
             encoding="utf-8"
         )

--- a/tools/tests/test_release_contract.py
+++ b/tools/tests/test_release_contract.py
@@ -43,10 +43,10 @@ class ReleaseContractTests(unittest.TestCase):
 
     def test_rexglue_patches_have_stable_order_and_no_binary_payload(self):
         patches = sorted((ROOT / "patches/rexglue").glob("*.patch"))
-        self.assertEqual(len(patches), 110)
+        self.assertEqual(len(patches), 111)
         self.assertEqual(
             patches[-1].name,
-            "0110-d3d12-procedural-frame-accumulator-msaa-topology.patch",
+            "0111-d3d12-procedural-frame-accumulator-source-rows.patch",
         )
         self.assertEqual(len(patches), len({path.name[:4] for path in patches}))
         for path in patches:


### PR DESCRIPTION
## Summary
- load each procedural accumulator component from its guest destination row
- regenerate the private D3D12 compute bytecode
- lock the addressing and no-publication/no-suppression contracts
- record the coherent visual probe and controlled normal-exit evidence

## Validation
- patch applies cleanly after patch 0110
- focused release/native-renderer contract tests pass
- incremental ReXGlue build succeeded for the prepared SDK
- AppData controlled run exited normally with no fatal, access-violation, or device-loss signature
- prior exact structural gate remains 36/36 recorded operations