### PR TITLE
fix(native-renderer): present qualified procedural frames

### DIFF
--- a/docs/native-renderer/COLOR_PRODUCER_LINEAGE.md
+++ b/docs/native-renderer/COLOR_PRODUCER_LINEAGE.md
@@ -166,6 +166,14 @@ first, and draw suppression and guest-memory publication remained off. This
 qualifies the corrected source-row path rather than relying only on the earlier
 structural session.
 
+The prototype selectors now arm this qualified private accumulator by default,
+so the launcher-visible prototype uses the coherent padded full frame instead
+of the earlier single-tile view. The standalone ReX cvar remains available for
+qualification, and
+`PINYON_SHIFT_NATIVE_RENDERER_PROCEDURAL_FRAME_ACCUMULATOR=false` is a
+restart-time fail-safe override. Missing, incomplete, or unsupported work still
+falls back to Xenos without publication or suppression.
+
 Run it after the combined AppData session closes:
 
 ```powershell

--- a/docs/native-renderer/REPRIORITIZED_PLAN.md
+++ b/docs/native-renderer/REPRIORITIZED_PLAN.md
@@ -795,7 +795,11 @@ corrected source-row addressing: equivalent Phase-C AppData session
 `20260901T104300Z-p42688` recorded nine exact frames / 27 operations, all
 successful, with the same extents and safety invariants before a normal exit.
 The corrected frame is visually coherent, so producer coverage and continuous
-presentation are now the next visible gates.
+presentation are now the next visible gates. The prototype selectors now arm
+the qualified private accumulator by default, with an explicit restart-time
+environment override for fail-safe disablement. This promotes the corrected
+full-frame source into the launcher-visible prototype while preserving exact
+current-frame admission, Xenos fallback, and zero suppression/publication.
 
 ### C2. Static world buildings and props
 

--- a/src/native_renderer/graphics_hooks.cpp
+++ b/src/native_renderer/graphics_hooks.cpp
@@ -67,6 +67,24 @@ bool NativePrototypeSelected() {
          mode == "comparison_native" || mode == "comparison_xenos";
 }
 
+bool ProceduralFrameAccumulatorSelected(bool prototype_selected) {
+  bool selected =
+      prototype_selected ||
+      REXCVAR_GET(pinyon_shift_native_renderer_procedural_frame_accumulator);
+  char *value = nullptr;
+  size_t length = 0;
+  if (_dupenv_s(
+          &value, &length,
+          "PINYON_SHIFT_NATIVE_RENDERER_PROCEDURAL_FRAME_ACCUMULATOR") == 0 &&
+      value && length > 1) {
+    // Keep a restart-time emergency escape hatch for prototype regressions.
+    // Unknown values fail closed rather than silently arming native output.
+    selected = std::string(value) == "true";
+  }
+  std::free(value);
+  return selected;
+}
+
 constexpr size_t kSummaryLimit = 16;
 constexpr size_t kCandidateSummaryLimit = 32;
 constexpr size_t kPreparedShaderPairCapacity = 1024;
@@ -30668,8 +30686,8 @@ void InstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system,
   const bool census_requested =
       REXCVAR_GET(pinyon_shift_native_renderer_census);
   const bool prototype_selected = NativePrototypeSelected();
-  const bool procedural_frame_accumulator_requested = REXCVAR_GET(
-      pinyon_shift_native_renderer_procedural_frame_accumulator);
+  const bool procedural_frame_accumulator_requested =
+      ProceduralFrameAccumulatorSelected(prototype_selected);
   const bool observation_requested = census_requested || prototype_selected ||
                                      procedural_frame_accumulator_requested;
   const bool title_provenance_requested =

--- a/tools/tests/test_native_renderer_contract.py
+++ b/tools/tests/test_native_renderer_contract.py
@@ -2089,6 +2089,12 @@ class NativeRendererContractTests(unittest.TestCase):
             "pinyon_shift_native_renderer_procedural_frame_accumulator",
             scanner,
         )
+        self.assertIn("ProceduralFrameAccumulatorSelected", scanner)
+        self.assertIn(
+            '"PINYON_SHIFT_NATIVE_RENDERER_PROCEDURAL_FRAME_ACCUMULATOR"',
+            scanner,
+        )
+        self.assertIn("prototype_selected ||", scanner)
         self.assertIn("PlanProceduralFrameAccumulatorBackend", scanner)
         self.assertIn("SetNativeFrameAccumulatorPlanner(", scanner)
         self.assertIn("kProceduralFrameAccumulatorStorageHeight = 736", scanner)


### PR DESCRIPTION
## Summary\n- arm the qualified private procedural frame accumulator automatically for prototype and comparison modes\n- retain an explicit restart-time fail-safe override\n- document the launcher-visible full-frame promotion and unchanged Xenos safety gates\n\n## Validation\n- python -m unittest tools.tests.test_native_renderer_contract.NativeRendererContractTests.test_procedural_frame_accumulator_backend_is_private_and_fail_closed tools.tests.test_native_renderer_prototype_presentation tools.tests.test_native_renderer_prototype_comparison\n- git diff --check\n\nA full build/AppData run is intentionally deferred to the next substantial native-renderer batch.