### PR TITLE
perf(native-renderer): skip prototype-only census work

### DIFF
--- a/docs/native-renderer/COLOR_PRODUCER_LINEAGE.md
+++ b/docs/native-renderer/COLOR_PRODUCER_LINEAGE.md
@@ -174,6 +174,13 @@ qualification, and
 restart-time fail-safe override. Missing, incomplete, or unsupported work still
 falls back to Xenos without publication or suppression.
 
+Prototype-only runs also bypass the broad candidate hash tables, prepared-shader
+catalog, and periodic draw-census serialization when the census cvar is off.
+The minimum draw/prepared/copy observers required for exact title provenance,
+resolved-input joins, continuous replay, and frame accumulation remain active.
+This removes discovery-only CPU and log work from the launcher path without
+weakening any native admission or fallback check.
+
 Run it after the combined AppData session closes:
 
 ```powershell

--- a/docs/native-renderer/REPRIORITIZED_PLAN.md
+++ b/docs/native-renderer/REPRIORITIZED_PLAN.md
@@ -800,6 +800,11 @@ the qualified private accumulator by default, with an explicit restart-time
 environment override for fail-safe disablement. This promotes the corrected
 full-frame source into the launcher-visible prototype while preserving exact
 current-frame admission, Xenos fallback, and zero suppression/publication.
+When the explicit census cvar is off, prototype mode now skips broad candidate
+hashing, prepared-shader cataloging, and periodic census serialization while
+retaining the exact observers used by provenance, replay, and accumulation.
+This is the first focused response to the observed prototype CPU overhead; a
+batched AppData comparison remains required before claiming a measured gain.
 
 ### C2. Static world buildings and props
 

--- a/src/native_renderer/graphics_hooks.cpp
+++ b/src/native_renderer/graphics_hooks.cpp
@@ -11294,6 +11294,7 @@ std::array<uint64_t, 6> g_procedural_frame_accumulator_backend_statuses{};
 uint64_t g_procedural_frame_accumulator_backend_detail_count = 0;
 uint64_t g_procedural_frame_accumulator_backend_detail_overflow = 0;
 bool g_graphics_census_installed = false;
+bool g_graphics_full_census_armed = false;
 rex::memory::Memory *g_graphics_census_memory = nullptr;
 void *g_guest_cpu_access_callback = nullptr;
 
@@ -25469,9 +25470,14 @@ void ObservePreparedDraw(
         g_pass_follower.awaiting_follower = true;
       }
     }
-    RecordCandidate(sample, g_pending_candidate.samples_resolved_target,
-                    observation);
+    if (g_graphics_full_census_armed) {
+      RecordCandidate(sample, g_pending_candidate.samples_resolved_target,
+                      observation);
+    }
     g_pending_candidate.valid = false;
+  }
+  if (!g_graphics_full_census_armed) {
+    return;
   }
   uint64_t identity = 0xCBF29CE484222325ull;
   for (uint64_t value :
@@ -28919,6 +28925,9 @@ void ObserveDraw(const rex::system::GraphicsDrawObservation &observation) {
   candidate.samples_resolved_target = samples_resolved_target;
   g_pending_candidate = candidate;
   g_pending_candidate.valid = true;
+  if (!g_graphics_full_census_armed) {
+    return;
+  }
   size_t index = size_t(signature % kSignatureCapacity);
   for (size_t probe = 0; probe < kSignatureCapacity; ++probe) {
     DrawSignatureEntry &entry = g_draw_census.entries[index];
@@ -30685,6 +30694,7 @@ void InstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system,
       REXCVAR_GET(pinyon_shift_native_renderer_sky_horizon_suppression);
   const bool census_requested =
       REXCVAR_GET(pinyon_shift_native_renderer_census);
+  g_graphics_full_census_armed = census_requested;
   const bool prototype_selected = NativePrototypeSelected();
   const bool procedural_frame_accumulator_requested =
       ProceduralFrameAccumulatorSelected(prototype_selected);
@@ -31563,6 +31573,7 @@ void UninstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system) {
   EmitDispatchDiscoverySummary();
   if (!g_graphics_census_installed) {
     g_procedural_frame_accumulator_backend_armed = false;
+    g_graphics_full_census_armed = false;
     return;
   }
   const bool guest_cpu_observer_installed =
@@ -31948,6 +31959,7 @@ void UninstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system) {
        {"xenos_fallback",
         "mandatory_on_state_yield_replay_or_publication_failure"}});
   g_graphics_census_installed = false;
+  g_graphics_full_census_armed = false;
   g_procedural_frame_accumulator_backend_armed = false;
   g_graphics_census_memory = nullptr;
   if (g_draw_census.window_first_frame && g_draw_census.window_draw_count) {

--- a/tools/tests/test_native_renderer_contract.py
+++ b/tools/tests/test_native_renderer_contract.py
@@ -2095,6 +2095,11 @@ class NativeRendererContractTests(unittest.TestCase):
             scanner,
         )
         self.assertIn("prototype_selected ||", scanner)
+        self.assertIn("g_graphics_full_census_armed = census_requested", scanner)
+        self.assertIn(
+            "if (!g_graphics_full_census_armed) {\n    return;\n  }",
+            scanner,
+        )
         self.assertIn("PlanProceduralFrameAccumulatorBackend", scanner)
         self.assertIn("SetNativeFrameAccumulatorPlanner(", scanner)
         self.assertIn("kProceduralFrameAccumulatorStorageHeight = 736", scanner)


### PR DESCRIPTION
## Summary\n- skip broad draw-candidate hashing and prepared-shader cataloging in launcher prototype mode\n- retain exact title provenance, resolved-input, continuous replay, and accumulator observers\n- document the optimization as unmeasured until the next batched AppData comparison\n\n## Validation\n- python -m unittest discover -s tools/tests -p test_*.py (704 passed)\n- git diff --check\n\nThe running AppData session uses the previous clean binary; the next full build remains deferred to the next substantial batch.