### PR TITLE
fix(native-renderer): admit qualified open-world resolves

### DIFF
--- a/docs/native-renderer/REPRIORITIZED_PLAN.md
+++ b/docs/native-renderer/REPRIORITIZED_PLAN.md
@@ -806,6 +806,17 @@ retaining the exact observers used by provenance, replay, and accumulation.
 This is the first focused response to the observed prototype CPU overhead; a
 batched AppData comparison remains required before claiming a measured gain.
 
+Open-world coverage checkpoint: the first launcher-visible prototype run
+showed the qualified three-chunk 1280x736 resolve family continuing every
+frame, but using Xenos color mode 12 (`2_10_10_10_FLOAT_AS_16_16_16_16`)
+instead of mode 3. Both modes map to the same R16G16B16A16_FLOAT D3D12
+resource. A fail-closed resolve ingress now arms the private accumulator only
+from the exact proved first chunk: source surface, either of those two modes,
+destination format/pitch, address, length, and 1280x720 logical extent must all
+match. Source-mode and arm accounting is emitted for the next batched run.
+This widens producer coverage without guest publication, draw suppression, or
+relaxing any later chunk/commit check.
+
 ### C2. Static world buildings and props
 
 - Expand opaque-world material and geometry coverage.

--- a/src/native_renderer/graphics_hooks.cpp
+++ b/src/native_renderer/graphics_hooks.cpp
@@ -11289,6 +11289,9 @@ uint64_t g_procedural_frame_accumulator_commits = 0;
 uint64_t g_procedural_frame_accumulator_cancels = 0;
 uint64_t g_procedural_frame_accumulator_detail_count = 0;
 uint64_t g_procedural_frame_accumulator_detail_overflow = 0;
+uint64_t g_procedural_frame_accumulator_qualified_resolve_arms = 0;
+std::array<uint64_t, 2>
+    g_procedural_frame_accumulator_qualified_resolve_source_modes{};
 bool g_procedural_frame_accumulator_backend_armed = false;
 std::array<uint64_t, 6> g_procedural_frame_accumulator_backend_statuses{};
 uint64_t g_procedural_frame_accumulator_backend_detail_count = 0;
@@ -11583,6 +11586,8 @@ void ResetCommandBufferLineage() {
   g_procedural_frame_accumulator_cancels = 0;
   g_procedural_frame_accumulator_detail_count = 0;
   g_procedural_frame_accumulator_detail_overflow = 0;
+  g_procedural_frame_accumulator_qualified_resolve_arms = 0;
+  g_procedural_frame_accumulator_qualified_resolve_source_modes.fill(0);
   g_procedural_frame_accumulator_backend_statuses.fill(0);
   g_procedural_frame_accumulator_backend_detail_count = 0;
   g_procedural_frame_accumulator_backend_detail_overflow = 0;
@@ -18116,6 +18121,15 @@ void EmitProceduralColorTargetProfiles() {
         std::to_string(g_procedural_frame_accumulator_detail_count)},
        {"detail_overflow",
         std::to_string(g_procedural_frame_accumulator_detail_overflow)},
+       {"qualified_resolve_ingress_arms",
+        std::to_string(
+            g_procedural_frame_accumulator_qualified_resolve_arms)},
+       {"qualified_resolve_source_mode_3",
+        std::to_string(
+            g_procedural_frame_accumulator_qualified_resolve_source_modes[0])},
+       {"qualified_resolve_source_mode_12",
+        std::to_string(
+            g_procedural_frame_accumulator_qualified_resolve_source_modes[1])},
        {"detail_limit",
         std::to_string(kProceduralRuntimeDetailLimit)},
        {"backend_resource_action",
@@ -28645,6 +28659,19 @@ void ObserveCopy(const rex::system::GraphicsCopyObservation &observation) {
   }
 
   const auto copy = ProceduralResolveCopyFromObservation(observation);
+  pinyon_shift::native_renderer::ProceduralResolveTarget qualified_target;
+  if (g_procedural_frame_accumulator_backend_armed &&
+      pinyon_shift::native_renderer::
+          QualifiedProceduralResolveTargetFromFirstCopy(copy,
+                                                        qualified_target)) {
+    ++g_procedural_frame_accumulator_qualified_resolve_arms;
+    ++g_procedural_frame_accumulator_qualified_resolve_source_modes[
+        copy.source_info == 0x00030000 ? 0 : 1];
+    EmitProceduralResolveAssembly(
+        g_procedural_resolve_assembly_tracker.Arm(qualified_target));
+    EmitProceduralFrameAccumulatorTransition(
+        g_procedural_frame_accumulator_planner.Arm(qualified_target));
+  }
   EmitProceduralResolveAssembly(
       g_procedural_resolve_assembly_tracker.Observe(copy));
   if (!g_procedural_frame_accumulator_backend_armed) {

--- a/src/native_renderer/resolve_frame_accumulator.cpp
+++ b/src/native_renderer/resolve_frame_accumulator.cpp
@@ -204,4 +204,32 @@ const char *ProceduralFrameAccumulatorCancelReasonName(
   return "unknown";
 }
 
+bool QualifiedProceduralResolveTargetFromFirstCopy(
+    const ProceduralResolveCopy &copy, ProceduralResolveTarget &target_out) {
+  target_out = {};
+  constexpr uint32_t kSurfaceInfo = 0x14020500;
+  constexpr uint32_t kFloatColorInfo = 0x00030000;
+  constexpr uint32_t kFloatAs16ColorInfo = 0x000C0000;
+  constexpr uint32_t kDestinationInfo = 0x003E0382;
+  constexpr uint32_t kDestinationPitch = 0x02D00500;
+  constexpr uint32_t kFirstAddress = 0x1C4E1000;
+  constexpr uint32_t kFirstLength = 1280 * 4 * 256;
+  const bool qualified_source =
+      copy.source == 0 && copy.source_surface_info == kSurfaceInfo &&
+      (copy.source_info == kFloatColorInfo ||
+       copy.source_info == kFloatAs16ColorInfo);
+  if (!qualified_source || copy.destination_info != kDestinationInfo ||
+      copy.destination_pitch != kDestinationPitch ||
+      copy.written_address != kFirstAddress ||
+      copy.written_length != kFirstLength) {
+    return false;
+  }
+  target_out = {.frame_sequence = copy.frame_sequence,
+                .surface_info = copy.source_surface_info,
+                .color_info = copy.source_info,
+                .logical_width = 1280,
+                .logical_height = 720};
+  return true;
+}
+
 }  // namespace pinyon_shift::native_renderer

--- a/src/native_renderer/resolve_frame_accumulator.h
+++ b/src/native_renderer/resolve_frame_accumulator.h
@@ -83,6 +83,12 @@ class ProceduralFrameAccumulatorPlanner {
 const char *ProceduralFrameAccumulatorCancelReasonName(
     ProceduralFrameAccumulatorCancelReason reason);
 
+// Recognizes the exact first resolve chunk of the qualified Forza full-frame
+// family. The title uses two Xenos color modes that map to the same host
+// R16G16B16A16_FLOAT resource; every other field remains fail-closed.
+bool QualifiedProceduralResolveTargetFromFirstCopy(
+    const ProceduralResolveCopy &copy, ProceduralResolveTarget &target_out);
+
 }  // namespace pinyon_shift::native_renderer
 
 #endif  // PINYON_SHIFT_NATIVE_RENDERER_RESOLVE_FRAME_ACCUMULATOR_H_

--- a/tests/native_renderer/resolve_frame_accumulator_test.cpp
+++ b/tests/native_renderer/resolve_frame_accumulator_test.cpp
@@ -133,6 +133,41 @@ int main() {
                   nr::ProceduralFrameAccumulatorCancelReason::kChunkOverflow,
           "a ninth chunk must cancel the bounded plan");
 
+  nr::ProceduralResolveTarget qualified_target;
+  Require(nr::QualifiedProceduralResolveTargetFromFirstCopy(
+              Copy(kBase, kRows256), qualified_target) &&
+              qualified_target.frame_sequence == 10 &&
+              qualified_target.surface_info == 0x14020500 &&
+              qualified_target.color_info == 0x00030000 &&
+              qualified_target.logical_width == 1280 &&
+              qualified_target.logical_height == 720,
+          "the qualified float first chunk must arm the full-frame target");
+
+  auto float_as_16 = Copy(kBase, kRows256);
+  float_as_16.source_info = 0x000C0000;
+  Require(nr::QualifiedProceduralResolveTargetFromFirstCopy(
+              float_as_16, qualified_target) &&
+              qualified_target.color_info == 0x000C0000,
+          "the qualified float-as-16 alias must arm the same host family");
+
+  const auto rejected = [](nr::ProceduralResolveCopy copy) {
+    nr::ProceduralResolveTarget target;
+    return nr::QualifiedProceduralResolveTargetFromFirstCopy(copy, target);
+  };
+  auto near_miss = Copy(kBase, kRows256);
+  near_miss.source_info = 0x00020000;
+  Require(!rejected(near_miss), "an unproved source mode must fail closed");
+  near_miss = Copy(kBase, kRows256);
+  near_miss.destination_info ^= 1;
+  Require(!rejected(near_miss), "a destination format mismatch must fail");
+  near_miss = Copy(kBase, kRows256);
+  near_miss.destination_pitch ^= 1;
+  Require(!rejected(near_miss), "a destination extent mismatch must fail");
+  near_miss = Copy(kBase + 1, kRows256);
+  Require(!rejected(near_miss), "a first-address mismatch must fail");
+  near_miss = Copy(kBase, kRows256 - 1);
+  Require(!rejected(near_miss), "a first-row-count mismatch must fail");
+
   std::cout << "native renderer resolve frame accumulator tests passed\n";
   return EXIT_SUCCESS;
 }

--- a/tools/summarize-native-renderer-procedural-frame-accumulator.py
+++ b/tools/summarize-native-renderer-procedural-frame-accumulator.py
@@ -18,6 +18,7 @@ PLAN_SUMMARY = (
 RESULT = "native_renderer.procedural_frame_accumulator.result"
 RESULT_SUMMARY = "native_renderer.procedural_frame_accumulator.result_summary"
 SHUTDOWN = "process.shutdown"
+QUALIFIED_SOURCE_STATES = {"14020500:00030000", "14020500:000C0000"}
 
 
 def integer(event, name):
@@ -64,6 +65,7 @@ def exact_plan_frames(events):
         )
         if observed == expected and all(
             row.get("logical_extent") == "1280x720"
+            and row.get("source_state") in QUALIFIED_SOURCE_STATES
             and row.get("backend_resource_action") == "private_only"
             and row.get("xenos_authority") == "true"
             and row.get("suppression_allowed") == "false"
@@ -130,6 +132,32 @@ def build(events, session):
         failures.append("no exact planned and committed 1280x720 frame was observed")
 
     status_counts = {}
+    ingress_counts = {}
+    ingress_accounting_complete = False
+    if len(plan_summaries) == 1 and any(
+        name in plan_summaries[0]
+        for name in (
+            "qualified_resolve_ingress_arms",
+            "qualified_resolve_source_mode_3",
+            "qualified_resolve_source_mode_12",
+        )
+    ):
+        summary = plan_summaries[0]
+        ingress_counts = {
+            "arms": integer(summary, "qualified_resolve_ingress_arms"),
+            "source_mode_3": integer(
+                summary, "qualified_resolve_source_mode_3"
+            ),
+            "source_mode_12": integer(
+                summary, "qualified_resolve_source_mode_12"
+            ),
+        }
+        ingress_accounting_complete = ingress_counts["arms"] == (
+            ingress_counts["source_mode_3"]
+            + ingress_counts["source_mode_12"]
+        )
+        if not ingress_accounting_complete:
+            failures.append("qualified resolve ingress accounting is incomplete")
     accounting_complete = False
     hard_failures = 0
     if len(result_summaries) == 1:
@@ -184,6 +212,10 @@ def build(events, session):
             "exact_plan_frames": plan_frames,
             "exact_result_frames": result_frames,
             "qualified_frames": qualified_frames,
+            "qualified_resolve_ingress": ingress_counts,
+            "qualified_resolve_ingress_accounting_complete": (
+                ingress_accounting_complete
+            ),
             "status_counts": status_counts,
             "result_accounting_complete": accounting_complete,
             "hard_failures": hard_failures,

--- a/tools/tests/test_native_renderer_procedural_frame_accumulator.py
+++ b/tools/tests/test_native_renderer_procedural_frame_accumulator.py
@@ -37,6 +37,7 @@ def fixture():
                 "storage_row_count": str(storage_rows),
                 "padded_height": str(padded_height),
                 "logical_extent": "1280x720",
+                "source_state": "14020500:00030000",
                 "backend_resource_action": "private_only",
                 "xenos_authority": "true",
                 "suppression_allowed": "false",
@@ -61,7 +62,13 @@ def fixture():
         )
     events.extend(
         [
-            {**common, "event": MODULE.PLAN_SUMMARY},
+            {
+                **common,
+                "event": MODULE.PLAN_SUMMARY,
+                "qualified_resolve_ingress_arms": "1",
+                "qualified_resolve_source_mode_3": "1",
+                "qualified_resolve_source_mode_12": "0",
+            },
             {
                 **common,
                 "event": MODULE.RESULT_SUMMARY,
@@ -120,6 +127,44 @@ class ProceduralFrameAccumulatorTests(unittest.TestCase):
         result = MODULE.build(events, "session")
         self.assertEqual("incomplete", result["status"])
         self.assertIn("backend reported a hard failure", result["failures"])
+
+    def test_qualifies_float_as_16_source_alias(self):
+        events = fixture()
+        for event in events:
+            if event.get("event") == MODULE.PLAN:
+                event["source_state"] = "14020500:000C0000"
+        summary = next(
+            event for event in events if event.get("event") == MODULE.PLAN_SUMMARY
+        )
+        summary["qualified_resolve_source_mode_3"] = "0"
+        summary["qualified_resolve_source_mode_12"] = "1"
+        result = MODULE.build(events, "session")
+        self.assertEqual("complete", result["status"])
+
+    def test_rejects_unproved_source_mode(self):
+        events = fixture()
+        for event in events:
+            if event.get("event") == MODULE.PLAN:
+                event["source_state"] = "14020500:00020000"
+        result = MODULE.build(events, "session")
+        self.assertEqual("incomplete", result["status"])
+        self.assertIn(
+            "no exact planned and committed 1280x720 frame was observed",
+            result["failures"],
+        )
+
+    def test_rejects_ingress_accounting_drift(self):
+        events = fixture()
+        summary = next(
+            event for event in events if event.get("event") == MODULE.PLAN_SUMMARY
+        )
+        summary["qualified_resolve_ingress_arms"] = "2"
+        result = MODULE.build(events, "session")
+        self.assertEqual("incomplete", result["status"])
+        self.assertIn(
+            "qualified resolve ingress accounting is incomplete",
+            result["failures"],
+        )
 
     def test_rejects_incomplete_result_accounting(self):
         events = fixture()


### PR DESCRIPTION
## Summary
- arm the private full-frame accumulator from the exact qualified first resolve chunk when semantic producer lineage is absent
- accept Xenos color modes 3 and 12 only; both map to the same R16G16B16A16_FLOAT host resource
- preserve exact source surface, destination format/pitch, base address, row geometry, completed-Xenos-first ordering, fallback, and zero suppression
- extend runtime accounting and the offline qualifier for both source modes

## Evidence
The launcher-visible open-world run resolved the same 1280x736 three-chunk family continuously in mode 12, but recorded zero accumulator plans because the earlier mode-3 semantic ingress was absent. The process exited normally with complete workset accounting and zero backend hard failures.

## Tests
- incremental release compile and link of pinyon_shift
- pinyon_shift_resolve_frame_accumulator_tests.exe
- python -m unittest discover -s tools/tests -p 'test_*.py' (707 passed)
- git diff --check