### PR TITLE
perf(native-renderer): add resolve-only prototype path

### DIFF
--- a/docs/native-renderer/REPRIORITIZED_PLAN.md
+++ b/docs/native-renderer/REPRIORITIZED_PLAN.md
@@ -817,6 +817,16 @@ match. Source-mode and arm accounting is emitted for the next batched run.
 This widens producer coverage without guest publication, draw suppression, or
 relaxing any later chunk/commit check.
 
+Prototype fast-path checkpoint: ordinary launcher `native_prototype` runs with
+the census disabled now install only the exact resolve-copy observer and the
+private frame-accumulator planner. They no longer execute draw, prepared-draw,
+indirect-buffer, draw-outcome, semantic-lineage, continuous-workset, or native-
+shadow observation on every Xenos draw. Explicit census/qualification runs
+retain the complete observer graph. The fast path preserves completed-first
+Xenos resolves, all Xenos draws, private-only native resources, and zero draw
+suppression. A measured performance claim remains gated on the next batched
+clean-build AppData comparison.
+
 ### C2. Static world buildings and props
 
 - Expand opaque-world material and geometry coverage.

--- a/src/native_renderer/graphics_hooks.cpp
+++ b/src/native_renderer/graphics_hooks.cpp
@@ -67,6 +67,10 @@ bool NativePrototypeSelected() {
          mode == "comparison_native" || mode == "comparison_xenos";
 }
 
+bool NativeResolveOnlyPrototypeSelected() {
+  return REXCVAR_GET(pinyon_shift_native_renderer) == "native_prototype";
+}
+
 bool ProceduralFrameAccumulatorSelected(bool prototype_selected) {
   bool selected =
       prototype_selected ||
@@ -11298,6 +11302,7 @@ uint64_t g_procedural_frame_accumulator_backend_detail_count = 0;
 uint64_t g_procedural_frame_accumulator_backend_detail_overflow = 0;
 bool g_graphics_census_installed = false;
 bool g_graphics_full_census_armed = false;
+bool g_graphics_resolve_only_armed = false;
 rex::memory::Memory *g_graphics_census_memory = nullptr;
 void *g_guest_cpu_access_callback = nullptr;
 
@@ -28647,18 +28652,8 @@ void ObserveDrawOutcome(
   g_pending_candidate.valid = false;
 }
 
-void ObserveCopy(const rex::system::GraphicsCopyObservation &observation) {
-  AdvanceDependencyWindow(observation.frame_sequence);
-  if (!observation.succeeded) {
-    ++g_dependency_census.window_failed_copy_count;
-    return;
-  }
-  if (!observation.written_length) {
-    ++g_dependency_census.window_zero_length_copy_count;
-    return;
-  }
-
-  const auto copy = ProceduralResolveCopyFromObservation(observation);
+void ObserveQualifiedResolveIngress(
+    const pinyon_shift::native_renderer::ProceduralResolveCopy &copy) {
   pinyon_shift::native_renderer::ProceduralResolveTarget qualified_target;
   if (g_procedural_frame_accumulator_backend_armed &&
       pinyon_shift::native_renderer::
@@ -28672,6 +28667,32 @@ void ObserveCopy(const rex::system::GraphicsCopyObservation &observation) {
     EmitProceduralFrameAccumulatorTransition(
         g_procedural_frame_accumulator_planner.Arm(qualified_target));
   }
+}
+
+void ObserveResolveOnlyCopy(
+    const rex::system::GraphicsCopyObservation &observation) {
+  if (!observation.succeeded || !observation.written_length) {
+    return;
+  }
+  const auto copy = ProceduralResolveCopyFromObservation(observation);
+  ObserveQualifiedResolveIngress(copy);
+  EmitProceduralResolveAssembly(
+      g_procedural_resolve_assembly_tracker.Observe(copy));
+}
+
+void ObserveCopy(const rex::system::GraphicsCopyObservation &observation) {
+  AdvanceDependencyWindow(observation.frame_sequence);
+  if (!observation.succeeded) {
+    ++g_dependency_census.window_failed_copy_count;
+    return;
+  }
+  if (!observation.written_length) {
+    ++g_dependency_census.window_zero_length_copy_count;
+    return;
+  }
+
+  const auto copy = ProceduralResolveCopyFromObservation(observation);
+  ObserveQualifiedResolveIngress(copy);
   EmitProceduralResolveAssembly(
       g_procedural_resolve_assembly_tracker.Observe(copy));
   if (!g_procedural_frame_accumulator_backend_armed) {
@@ -30725,6 +30746,40 @@ void InstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system,
   const bool prototype_selected = NativePrototypeSelected();
   const bool procedural_frame_accumulator_requested =
       ProceduralFrameAccumulatorSelected(prototype_selected);
+  const bool resolve_only_requested =
+      !census_requested && NativeResolveOnlyPrototypeSelected() &&
+      procedural_frame_accumulator_requested &&
+      !g_sky_horizon_suppression.requested;
+  if (resolve_only_requested) {
+    ResetCommandBufferLineage();
+    g_native_shadow_prototype_enabled.store(false, std::memory_order_release);
+    g_native_shadow_fail_closed.store(false, std::memory_order_release);
+    g_native_shadow_publication_frame.store(UINT64_MAX,
+                                             std::memory_order_release);
+    g_procedural_frame_accumulator_backend_armed = true;
+    g_graphics_resolve_only_armed = true;
+    graphics_system->SetCopyObserver(&ObserveResolveOnlyCopy);
+    graphics_system->SetNativeFrameAccumulatorPlanner(
+        &PlanProceduralFrameAccumulatorBackend);
+    diagnostics::RecordEvent(
+        "native_renderer.resolve_only.config",
+        {{"status", "armed"},
+         {"selection", "exact_qualified_full_frame_resolve"},
+         {"source_modes", "3,12"},
+         {"draw_observer", "disabled"},
+         {"prepared_draw_observer", "disabled"},
+         {"indirect_buffer_observer", "disabled"},
+         {"draw_outcome_observer", "disabled"},
+         {"copy_observer", "exact_resolve_only"},
+         {"procedural_color_frame_accumulator_backend",
+          "armed_private_d3d12_v1"},
+         {"xenos_resolve", "preserved_and_completed_first"},
+         {"xenos_draw", "preserved"},
+         {"guest_memory_publication", "false"},
+         {"draw_suppression", "false"}});
+    EmitSkyHorizonSuppressionControl();
+    return;
+  }
   const bool observation_requested = census_requested || prototype_selected ||
                                      procedural_frame_accumulator_requested;
   const bool title_provenance_requested =
@@ -31592,6 +31647,14 @@ void UninstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system) {
     graphics_system->SetDrawOutcomeObserver(nullptr);
     graphics_system->SetIsolatedDrawRequestObserver(nullptr);
     graphics_system->SetNativeFrameAccumulatorPlanner(nullptr);
+  }
+  if (g_graphics_resolve_only_armed) {
+    EmitProceduralColorTargetProfiles();
+    g_graphics_resolve_only_armed = false;
+    g_procedural_frame_accumulator_backend_armed = false;
+    g_graphics_full_census_armed = false;
+    g_graphics_census_memory = nullptr;
+    return;
   }
   EmitShadowCasterProvenanceSummary();
   EmitVehicleDiscoverySummary();

--- a/tools/summarize-native-renderer-procedural-frame-accumulator.py
+++ b/tools/summarize-native-renderer-procedural-frame-accumulator.py
@@ -11,6 +11,7 @@ import sys
 
 SCHEMA = "pinyon-shift.native-renderer-procedural-frame-accumulator.v1"
 CONFIG = "native_renderer.discovery.command_buffer_lineage_config"
+RESOLVE_ONLY_CONFIG = "native_renderer.resolve_only.config"
 PLAN = "native_renderer.discovery.procedural_frame_accumulator_plan"
 PLAN_SUMMARY = (
     "native_renderer.discovery.procedural_frame_accumulator_plan_summary"
@@ -102,7 +103,11 @@ def exact_result_frames(events):
 
 
 def build(events, session):
-    configs = [event for event in events if event.get("event") == CONFIG]
+    configs = [
+        event
+        for event in events
+        if event.get("event") in (CONFIG, RESOLVE_ONLY_CONFIG)
+    ]
     plans = [event for event in events if event.get("event") == PLAN]
     plan_summaries = [event for event in events if event.get("event") == PLAN_SUMMARY]
     results = [event for event in events if event.get("event") == RESULT]
@@ -113,7 +118,7 @@ def build(events, session):
     failures = []
 
     if len(configs) != 1:
-        failures.append("expected one command-lineage config")
+        failures.append("expected one accumulator ingress config")
     elif configs[0].get("procedural_color_frame_accumulator_backend") != (
         "armed_private_d3d12_v1"
     ):

--- a/tools/tests/test_native_renderer_hybrid_prototype.py
+++ b/tools/tests/test_native_renderer_hybrid_prototype.py
@@ -6,6 +6,23 @@ ROOT = pathlib.Path(__file__).resolve().parents[2]
 
 
 class NativeRendererHybridPrototypeTests(unittest.TestCase):
+    def test_native_prototype_has_resolve_only_fast_path(self):
+        source = (ROOT / "src/native_renderer/graphics_hooks.cpp").read_text(
+            encoding="utf-8"
+        )
+        self.assertIn("NativeResolveOnlyPrototypeSelected", source)
+        self.assertIn('"native_renderer.resolve_only.config"', source)
+        block = source.split("if (resolve_only_requested) {", 1)[1].split(
+            "const bool observation_requested", 1
+        )[0]
+        self.assertIn("SetCopyObserver(&ObserveResolveOnlyCopy)", block)
+        self.assertIn("SetNativeFrameAccumulatorPlanner", block)
+        self.assertNotIn("SetDrawObserver", block)
+        self.assertNotIn("SetPreparedDrawObserver", block)
+        self.assertNotIn("SetIndirectBufferObserver", block)
+        self.assertIn('"xenos_draw", "preserved"', block)
+        self.assertIn('"draw_suppression", "false"', block)
+
     def test_hybrid_selector_arms_workset_and_reports_safe_authority(self):
         hooks = (ROOT / "src/native_renderer/graphics_hooks.cpp").read_text(
             encoding="utf-8"

--- a/tools/tests/test_native_renderer_procedural_frame_accumulator.py
+++ b/tools/tests/test_native_renderer_procedural_frame_accumulator.py
@@ -141,6 +141,13 @@ class ProceduralFrameAccumulatorTests(unittest.TestCase):
         result = MODULE.build(events, "session")
         self.assertEqual("complete", result["status"])
 
+    def test_qualifies_resolve_only_configuration(self):
+        events = fixture()
+        config = next(event for event in events if event.get("event") == MODULE.CONFIG)
+        config["event"] = MODULE.RESOLVE_ONLY_CONFIG
+        result = MODULE.build(events, "session")
+        self.assertEqual("complete", result["status"])
+
     def test_rejects_unproved_source_mode(self):
         events = fixture()
         for event in events:


### PR DESCRIPTION
## Summary
- install only the exact resolve-copy observer and private accumulator planner for ordinary launcher native-prototype runs with census disabled
- skip draw, prepared-draw, indirect-buffer, draw-outcome, semantic-lineage, continuous-workset, and native-shadow observation in that path
- retain the full observer graph for explicit census and qualification sessions
- preserve completed-first Xenos resolves, all Xenos draws, private-only native resources, fallback, and zero suppression
- teach the accumulator qualifier to accept the dedicated resolve-only ingress config

## Motivation
The completed launcher run processed 2,754,607 prepared observations while producing no workset request. The qualified full-frame accumulator now has an exact copy-level ingress and no longer needs this per-draw pipeline in ordinary prototype mode.

## Tests
- incremental release compile and link of pinyon_shift
- python -m unittest discover -s tools/tests -p 'test_*.py' (709 passed)
- git diff --check