### PR TITLE
perf(native-renderer): trim prototype copy census

### DIFF
--- a/docs/native-renderer/REPRIORITIZED_PLAN.md
+++ b/docs/native-renderer/REPRIORITIZED_PLAN.md
@@ -825,6 +825,15 @@ path is reverted; mode-12 ingress and the broad-census optimization remain.
 Future performance work must retain the minimal native replay producer graph
 and cannot substitute the authoritative Xenos target as native content.
 
+Minimal-producer checkpoint: ordinary census-off prototype runs now keep the
+draw, prepared-draw, indirect-lineage, draw-outcome, isolated-request, and
+private accumulator planner chain that creates native replay content. Only the
+broad dependency-census tail of the copy observer is bypassed; exact mode-3 and
+mode-12 resolve ingress and padded full-frame assembly remain armed. Explicit
+census/qualification runs retain the complete copy observer. This removes work
+that is unrelated to prototype production without repeating the invalid
+copy-only architecture, changing guest memory, or suppressing Xenos work.
+
 ### C2. Static world buildings and props
 
 - Expand opaque-world material and geometry coverage.

--- a/src/native_renderer/graphics_hooks.cpp
+++ b/src/native_renderer/graphics_hooks.cpp
@@ -28647,18 +28647,8 @@ void ObserveDrawOutcome(
   g_pending_candidate.valid = false;
 }
 
-void ObserveCopy(const rex::system::GraphicsCopyObservation &observation) {
-  AdvanceDependencyWindow(observation.frame_sequence);
-  if (!observation.succeeded) {
-    ++g_dependency_census.window_failed_copy_count;
-    return;
-  }
-  if (!observation.written_length) {
-    ++g_dependency_census.window_zero_length_copy_count;
-    return;
-  }
-
-  const auto copy = ProceduralResolveCopyFromObservation(observation);
+void ObserveQualifiedResolveIngress(
+    const pinyon_shift::native_renderer::ProceduralResolveCopy &copy) {
   pinyon_shift::native_renderer::ProceduralResolveTarget qualified_target;
   if (g_procedural_frame_accumulator_backend_armed &&
       pinyon_shift::native_renderer::
@@ -28672,6 +28662,32 @@ void ObserveCopy(const rex::system::GraphicsCopyObservation &observation) {
     EmitProceduralFrameAccumulatorTransition(
         g_procedural_frame_accumulator_planner.Arm(qualified_target));
   }
+}
+
+void ObservePrototypeResolveCopy(
+    const rex::system::GraphicsCopyObservation &observation) {
+  if (!observation.succeeded || !observation.written_length) {
+    return;
+  }
+  const auto copy = ProceduralResolveCopyFromObservation(observation);
+  ObserveQualifiedResolveIngress(copy);
+  EmitProceduralResolveAssembly(
+      g_procedural_resolve_assembly_tracker.Observe(copy));
+}
+
+void ObserveCopy(const rex::system::GraphicsCopyObservation &observation) {
+  AdvanceDependencyWindow(observation.frame_sequence);
+  if (!observation.succeeded) {
+    ++g_dependency_census.window_failed_copy_count;
+    return;
+  }
+  if (!observation.written_length) {
+    ++g_dependency_census.window_zero_length_copy_count;
+    return;
+  }
+
+  const auto copy = ProceduralResolveCopyFromObservation(observation);
+  ObserveQualifiedResolveIngress(copy);
   EmitProceduralResolveAssembly(
       g_procedural_resolve_assembly_tracker.Observe(copy));
   if (!g_procedural_frame_accumulator_backend_armed) {
@@ -30725,6 +30741,9 @@ void InstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system,
   const bool prototype_selected = NativePrototypeSelected();
   const bool procedural_frame_accumulator_requested =
       ProceduralFrameAccumulatorSelected(prototype_selected);
+  const bool minimal_producer_graph_requested =
+      prototype_selected && !census_requested &&
+      procedural_frame_accumulator_requested;
   const bool observation_requested = census_requested || prototype_selected ||
                                      procedural_frame_accumulator_requested;
   const bool title_provenance_requested =
@@ -30791,7 +30810,11 @@ void InstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system,
   graphics_system->SetShaderConstantWriteObserver(
       &ObserveVehicleShaderConstantWrite);
   graphics_system->SetIndirectBufferObserver(&ObserveIndirectBuffer);
-  graphics_system->SetCopyObserver(&ObserveCopy);
+  if (minimal_producer_graph_requested) {
+    graphics_system->SetCopyObserver(&ObservePrototypeResolveCopy);
+  } else {
+    graphics_system->SetCopyObserver(&ObserveCopy);
+  }
   graphics_system->SetPreparedDrawObserver(&ObservePreparedDraw);
   graphics_system->SetDrawOutcomeObserver(&ObserveDrawOutcome);
   graphics_system->SetIsolatedDrawRequestObserver(&RequestIsolatedDraw);
@@ -30799,6 +30822,21 @@ void InstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system,
       g_procedural_frame_accumulator_backend_armed
           ? &PlanProceduralFrameAccumulatorBackend
           : nullptr);
+  diagnostics::RecordEvent(
+      "native_renderer.prototype_producer_graph.config",
+      {{"status", minimal_producer_graph_requested ? "armed" : "disabled"},
+       {"copy_observer", minimal_producer_graph_requested
+                             ? "exact_resolve_ingress"
+                             : "full_dependency_census"},
+       {"draw_observer", "retained"},
+       {"prepared_draw_observer", "retained"},
+       {"indirect_buffer_observer", "retained"},
+       {"draw_outcome_observer", "retained"},
+       {"isolated_draw_request_observer", "retained"},
+       {"native_replay_producer", "retained"},
+       {"xenos_draw", "preserved"},
+       {"guest_memory_publication", "false"},
+       {"draw_suppression", "false"}});
   const std::string capacity = std::to_string(kSignatureCapacity);
   const std::string scene = CensusSceneMarker();
   diagnostics::RecordEvent("native_renderer.census.installed",

--- a/tools/tests/test_native_renderer_hybrid_prototype.py
+++ b/tools/tests/test_native_renderer_hybrid_prototype.py
@@ -6,6 +6,24 @@ ROOT = pathlib.Path(__file__).resolve().parents[2]
 
 
 class NativeRendererHybridPrototypeTests(unittest.TestCase):
+    def test_minimal_producer_graph_retains_native_replay_observers(self):
+        source = (ROOT / "src/native_renderer/graphics_hooks.cpp").read_text(
+            encoding="utf-8"
+        )
+        self.assertIn("minimal_producer_graph_requested", source)
+        self.assertIn("SetCopyObserver(&ObservePrototypeResolveCopy)", source)
+        for observer in (
+            "SetDrawObserver(&ObserveDraw)",
+            "SetPreparedDrawObserver(&ObservePreparedDraw)",
+            "SetIndirectBufferObserver(&ObserveIndirectBuffer)",
+            "SetDrawOutcomeObserver(&ObserveDrawOutcome)",
+            "SetIsolatedDrawRequestObserver(&RequestIsolatedDraw)",
+        ):
+            self.assertIn(observer, source)
+        self.assertIn('"native_replay_producer", "retained"', source)
+        self.assertIn('"xenos_draw", "preserved"', source)
+        self.assertNotIn("PublishIsolatedReplayTarget", source)
+
     def test_hybrid_selector_arms_workset_and_reports_safe_authority(self):
         hooks = (ROOT / "src/native_renderer/graphics_hooks.cpp").read_text(
             encoding="utf-8"


### PR DESCRIPTION
## Summary
- retain the full draw/prepared/indirect/outcome/request chain that creates isolated native replay content
- use exact mode-3/mode-12 resolve ingestion for ordinary census-off prototype copies
- keep the broad copy/dependency census for explicit qualification runs
- preserve Xenos draws and avoid guest-memory publication or suppression

## Validation
- `python -m unittest discover -s tools/tests -p 'test_*.py'` (708 tests)
- `cmake --build --preset win-amd64-release --target pinyon_shift --parallel`

This is the safe successor to the reverted copy-only architecture: it trims only non-producer copy work.