### PR TITLE
perf(native-renderer): gate prototype discovery work

### DIFF
--- a/docs/native-renderer/REPRIORITIZED_PLAN.md
+++ b/docs/native-renderer/REPRIORITIZED_PLAN.md
@@ -834,6 +834,14 @@ census/qualification runs retain the complete copy observer. This removes work
 that is unrelated to prototype production without repeating the invalid
 copy-only architecture, changing guest memory, or suppressing Xenos work.
 
+Prototype hot-path checkpoint: draw signatures are now computed only for the
+full census or active vehicle discovery, and the shader-constant write observer
+is installed only for its exact vehicle-shadow correlation mode. Ordinary
+prototype production still builds the prepared signature used for native
+replay selection and retains title/indirect lineage, semantic admission, and
+draw outcomes. This removes two discovery-only costs from every ordinary draw
+and constant write without changing the producer contract.
+
 ### C2. Static world buildings and props
 
 - Expand opaque-world material and geometry coverage.

--- a/src/native_renderer/graphics_hooks.cpp
+++ b/src/native_renderer/graphics_hooks.cpp
@@ -25170,7 +25170,9 @@ void ObservePreparedDraw(
     ++g_candidate_prepared_without_observation_count;
   } else {
     const uint64_t source_draw_signature =
-        DrawSignature(g_pending_candidate.sample);
+        g_shadow_caster_provenance.requested
+            ? DrawSignature(g_pending_candidate.sample)
+            : 0;
     auto sample = g_pending_candidate.sample;
     sample.vertex_shader_hash = observation.vertex_shader_hash;
     sample.pixel_shader_hash = observation.pixel_shader_hash;
@@ -28915,14 +28917,20 @@ void ObserveDraw(const rex::system::GraphicsDrawObservation &observation) {
   candidate.sample = observation;
   ConsumeTitleDrawPacket(observation.packet_physical_address,
                          candidate.title_origin);
-  const uint64_t signature = DrawSignature(observation);
-  const ActiveTitleIndirectBuffer *vehicle_indirect_origin =
-      observation.command_buffer_depth
-          ? CurrentTitleIndirectBuffer(observation)
-          : nullptr;
-  ObserveVehicleDrawArgumentCorrelations(
-      signature, observation.frame_sequence, candidate.title_origin,
-      vehicle_indirect_origin);
+  uint64_t signature = 0;
+  if (g_graphics_full_census_armed ||
+      g_vehicle_discovery_installed.load(std::memory_order_acquire)) {
+    signature = DrawSignature(observation);
+  }
+  if (g_vehicle_discovery_installed.load(std::memory_order_acquire)) {
+    const ActiveTitleIndirectBuffer *vehicle_indirect_origin =
+        observation.command_buffer_depth
+            ? CurrentTitleIndirectBuffer(observation)
+            : nullptr;
+    ObserveVehicleDrawArgumentCorrelations(
+        signature, observation.frame_sequence, candidate.title_origin,
+        vehicle_indirect_origin);
+  }
   for (uint32_t fetch_index = 0; fetch_index < 32; ++fetch_index) {
     if (!(observation.texture_fetch_mask & (uint32_t(1) << fetch_index))) {
       continue;
@@ -30807,8 +30815,13 @@ void InstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system,
   }
   g_graphics_census_installed = true;
   graphics_system->SetDrawObserver(&ObserveDraw);
+  const bool vehicle_shader_constant_observer_requested =
+      g_vehicle_discovery_installed.load(std::memory_order_acquire) &&
+      g_isolated_draw.vehicle_shadow_geometry_correlation_mode;
   graphics_system->SetShaderConstantWriteObserver(
-      &ObserveVehicleShaderConstantWrite);
+      vehicle_shader_constant_observer_requested
+          ? &ObserveVehicleShaderConstantWrite
+          : nullptr);
   graphics_system->SetIndirectBufferObserver(&ObserveIndirectBuffer);
   if (minimal_producer_graph_requested) {
     graphics_system->SetCopyObserver(&ObservePrototypeResolveCopy);
@@ -30834,6 +30847,11 @@ void InstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system,
        {"draw_outcome_observer", "retained"},
        {"isolated_draw_request_observer", "retained"},
        {"native_replay_producer", "retained"},
+       {"vehicle_shader_constant_observer",
+        vehicle_shader_constant_observer_requested ? "armed" : "disabled"},
+       {"draw_signature_scope",
+        g_graphics_full_census_armed ? "full_census"
+                                    : "producer_required_only"},
        {"xenos_draw", "preserved"},
        {"guest_memory_publication", "false"},
        {"draw_suppression", "false"}});

--- a/tools/tests/test_native_renderer_hybrid_prototype.py
+++ b/tools/tests/test_native_renderer_hybrid_prototype.py
@@ -24,6 +24,20 @@ class NativeRendererHybridPrototypeTests(unittest.TestCase):
         self.assertIn('"xenos_draw", "preserved"', source)
         self.assertNotIn("PublishIsolatedReplayTarget", source)
 
+    def test_prototype_skips_discovery_only_hotpath_work(self):
+        source = (ROOT / "src/native_renderer/graphics_hooks.cpp").read_text(
+            encoding="utf-8"
+        )
+        self.assertIn("vehicle_shader_constant_observer_requested", source)
+        self.assertIn(
+            "g_vehicle_discovery_installed.load(std::memory_order_acquire) &&",
+            source,
+        )
+        self.assertIn('"draw_signature_scope"', source)
+        self.assertIn('"producer_required_only"', source)
+        self.assertIn("g_graphics_full_census_armed ||", source)
+        self.assertIn("g_shadow_caster_provenance.requested", source)
+
     def test_hybrid_selector_arms_workset_and_reports_safe_authority(self):
         hooks = (ROOT / "src/native_renderer/graphics_hooks.cpp").read_text(
             encoding="utf-8"


### PR DESCRIPTION
## Summary
- compute source draw signatures only for full census or active vehicle discovery
- install the shader-constant observer only for exact vehicle-shadow correlation runs
- retain prepared replay signatures, semantic/indirect lineage, shadow production, and draw outcomes
- preserve Xenos authority and all fail-closed gates

## Validation
- `python -m unittest discover -s tools/tests -p 'test_*.py'` (709 tests)
- `cmake --build --preset win-amd64-release --target pinyon_shift --parallel`
