### PR TITLE
perf(native-renderer): yield unavailable accumulator frames

### DIFF
--- a/docs/native-renderer/REPRIORITIZED_PLAN.md
+++ b/docs/native-renderer/REPRIORITIZED_PLAN.md
@@ -851,6 +851,14 @@ Vehicle-only private-capture classification is skipped unless its exact
 correlation mode is armed. Producer observers, prepared signatures, native
 shadow replay, Xenos authority, and fail-closed selection remain unchanged.
 
+Accumulator availability checkpoint: exact mode-12 ingress can precede any
+same-frame isolated native color producer. After the backend reports that first
+chunk unavailable, the planner now yields the remaining accumulator callbacks
+for that frame and retries from a freshly armed first chunk on the next frame.
+This removes two guaranteed-invalid backend requests per unavailable three-copy
+frame without borrowing Xenos content, weakening producer ownership, or
+preventing later native frames from becoming eligible.
+
 ### C2. Static world buildings and props
 
 - Expand opaque-world material and geometry coverage.

--- a/src/native_renderer/graphics_hooks.cpp
+++ b/src/native_renderer/graphics_hooks.cpp
@@ -11296,6 +11296,8 @@ bool g_procedural_frame_accumulator_backend_armed = false;
 std::array<uint64_t, 6> g_procedural_frame_accumulator_backend_statuses{};
 uint64_t g_procedural_frame_accumulator_backend_detail_count = 0;
 uint64_t g_procedural_frame_accumulator_backend_detail_overflow = 0;
+uint64_t g_procedural_frame_accumulator_backend_unavailable_frame = UINT64_MAX;
+uint64_t g_procedural_frame_accumulator_same_frame_yields = 0;
 bool g_graphics_census_installed = false;
 bool g_graphics_full_census_armed = false;
 rex::memory::Memory *g_graphics_census_memory = nullptr;
@@ -11591,6 +11593,8 @@ void ResetCommandBufferLineage() {
   g_procedural_frame_accumulator_backend_statuses.fill(0);
   g_procedural_frame_accumulator_backend_detail_count = 0;
   g_procedural_frame_accumulator_backend_detail_overflow = 0;
+  g_procedural_frame_accumulator_backend_unavailable_frame = UINT64_MAX;
+  g_procedural_frame_accumulator_same_frame_yields = 0;
 }
 
 void ResetDependencyCensus() {
@@ -17449,6 +17453,11 @@ const char *ProceduralFrameAccumulatorBackendStatusName(
 void CompleteProceduralFrameAccumulatorBackend(
     const rex::system::GraphicsNativeFrameAccumulatorResult &result) {
   const uint32_t status = static_cast<uint32_t>(result.status);
+  if (result.status ==
+      rex::system::GraphicsNativeFrameAccumulatorStatus::kUnavailable) {
+    g_procedural_frame_accumulator_backend_unavailable_frame =
+        result.frame_sequence;
+  }
   if (status >= 1 &&
       status <= g_procedural_frame_accumulator_backend_statuses.size()) {
     ++g_procedural_frame_accumulator_backend_statuses[status - 1];
@@ -17501,6 +17510,11 @@ bool PlanProceduralFrameAccumulatorBackend(
   request_out = {};
   if (!g_procedural_frame_accumulator_backend_armed ||
       !observation.succeeded) {
+    return false;
+  }
+  if (observation.frame_sequence ==
+      g_procedural_frame_accumulator_backend_unavailable_frame) {
+    ++g_procedural_frame_accumulator_same_frame_yields;
     return false;
   }
   const auto transition = g_procedural_frame_accumulator_planner.Observe(
@@ -18152,6 +18166,9 @@ void EmitProceduralColorTargetProfiles() {
         std::to_string(g_procedural_frame_accumulator_backend_statuses[2])},
        {"unavailable",
         std::to_string(g_procedural_frame_accumulator_backend_statuses[3])},
+       {"same_frame_yields_after_unavailable",
+        std::to_string(g_procedural_frame_accumulator_same_frame_yields)},
+       {"retry_policy", "next_frame"},
        {"unsupported_target",
         std::to_string(g_procedural_frame_accumulator_backend_statuses[4])},
        {"allocation_failed",

--- a/tools/tests/test_native_renderer_contract.py
+++ b/tools/tests/test_native_renderer_contract.py
@@ -2142,6 +2142,18 @@ class NativeRendererContractTests(unittest.TestCase):
         self.assertIn("request_out.completion =", scanner)
         self.assertIn("preserved_and_completed_first", scanner)
         self.assertIn(
+            "g_procedural_frame_accumulator_backend_unavailable_frame =\n"
+            "        result.frame_sequence;",
+            scanner,
+        )
+        self.assertIn(
+            "observation.frame_sequence ==\n"
+            "      g_procedural_frame_accumulator_backend_unavailable_frame",
+            scanner,
+        )
+        self.assertIn('{"retry_policy", "next_frame"}', scanner)
+        self.assertIn('"same_frame_yields_after_unavailable"', scanner)
+        self.assertIn(
             "if (!g_procedural_frame_accumulator_backend_armed)", scanner
         )
 


### PR DESCRIPTION
## Summary
- remember a private accumulator backend unavailable result for the current frame
- skip only the remaining guaranteed-invalid chunk callbacks in that frame
- retry normally from the next frame's exact first chunk
- report bounded same-frame yields and document the Phase C checkpoint

## Safety
- does not substitute Xenos content for a native producer
- does not change draw selection, publication, or suppression
- preserves exact mode-3/mode-12 ingress and next-frame discovery

## Validation
- python -m pytest tools/tests -q (710 passed)
- incremental pinyon_shift.exe C++ compile and link