### PR TITLE
feat(native-renderer): replay exact procedural color producer

### DIFF
--- a/docs/native-renderer/CONTINUOUS_WORLD_WORKSET.md
+++ b/docs/native-renderer/CONTINUOUS_WORLD_WORKSET.md
@@ -19,7 +19,9 @@ census and semantic dispatch discovery so every admitted draw has:
 - a mechanically replayable prepared-draw contract;
 - either a current, selected semantic visibility decision carrying the exact
   unified track-texture provider vtable and four-method tuple, the exact
-  previously qualified sky/horizon follower signature, or, only when the
+  previously qualified sky/horizon follower signature, the exact proved
+  `82417BC0` procedural color context with a live semantic receiver and first
+  color attachment, or, only when the
   additional `-ContinuousStaticWorld` capture switch is set, exact
   `CModelPresentation` resource, asset-key, transform, member-mesh, and
   prepared-layout lineage; and
@@ -81,6 +83,10 @@ authority with suppression disabled.
 It reports the exact-family seed count separately as
 `qualified_retained_family_requests`, and reports fresh visibility candidates
 excluded by the track-provider gate as `non_track_provider_rejections`.
+The exact procedural color route is reported independently as
+`procedural_color_producer_candidates` and
+`procedural_color_producer_requests`; the v8 qualifier requires at least one
+accepted request and rejects requests that exceed exact candidates.
 When exact track-world selection is armed, accepted requests and provider-only
 identity exclusions are reported separately as `track_world_requests` and
 `track_world_identity_exclusions`.
@@ -112,6 +118,7 @@ Arm the still-default-off static-world extension for the deferred C1/C2 run:
 ```
 
 Qualification requires at least one exact track-provider visibility request,
+one exact procedural color-producer request,
 one complete frame with multiple accumulated draws, zero replay or frame
 failures, exact accounting, preserved Xenos draws, and disabled suppression.
 When `-ContinuousTrackWorld` is armed, at least one accepted semantic request

--- a/docs/native-renderer/REPRIORITIZED_PLAN.md
+++ b/docs/native-renderer/REPRIORITIZED_PLAN.md
@@ -859,6 +859,16 @@ This removes two guaranteed-invalid backend requests per unavailable three-copy
 frame without borrowing Xenos content, weakening producer ownership, or
 preventing later native frames from becoming eligible.
 
+Exact color-producer checkpoint: the accumulator no longer accepts an
+unrelated retained sky/horizon replay as sufficient producer ownership. The
+continuous workset now explicitly recognizes only the already-proved
+`82417BC0` procedural color context with a live semantic receiver and first
+color attachment, then replays its mechanically eligible tiled draws into the
+same-frame private target consumed by the three-copy accumulator. The v8
+qualifier requires distinct candidate and accepted-request accounting for this
+producer. Depth-only slot-79 track draws remain excluded as shadow work, and
+Xenos output remains the mandatory fallback until the exact producer completes.
+
 ### C2. Static world buildings and props
 
 - Expand opaque-world material and geometry coverage.

--- a/src/native_renderer/graphics_hooks.cpp
+++ b/src/native_renderer/graphics_hooks.cpp
@@ -9904,6 +9904,7 @@ struct IsolatedDrawState {
   bool prepared_track_render_model_scope = false;
   bool prepared_track_command_lineage = false;
   uint32_t prepared_track_world_resource_shared_identity_mask = 0;
+  bool prepared_procedural_color_producer = false;
   bool prepared_static_world_origin = false;
   bool prepared_static_world_exact = false;
   bool require_fresh_visibility_candidate = false;
@@ -10063,6 +10064,8 @@ struct ContinuousWorldWorksetState {
   uint64_t track_world_mechanically_rejected = 0;
   std::array<uint64_t, 15> track_world_mechanical_rejection_reasons{};
   uint64_t track_world_requests = 0;
+  uint64_t procedural_color_producer_candidates = 0;
+  uint64_t procedural_color_producer_requests = 0;
   uint64_t static_world_lineage_rejections = 0;
   uint64_t static_world_requests = 0;
   uint64_t per_frame_quota_yields = 0;
@@ -11006,7 +11009,7 @@ void ValidateAndEmitContinuousWorldWorksetConfiguration() {
        {"activation", "startup_environment_only"},
        {"default_enabled", "false"},
        {"selection",
-        "fresh_track_texture_provider_visibility_or_qualified_sky_horizon_or_optional_exact_track_or_static_world_and_mechanical"},
+        "fresh_track_texture_provider_visibility_or_qualified_sky_horizon_or_exact_procedural_color_or_optional_exact_track_or_static_world_and_mechanical"},
        {"track_world_selection",
         g_continuous_world_workset.track_world_requested
             ? "exact_track_render_model_scope_and_shared_world_resource_identity"
@@ -17559,6 +17562,7 @@ void RecordProceduralColorTargetProfile(
       !context.semantic_receiver_generation) {
     return;
   }
+  g_isolated_draw.prepared_procedural_color_producer = true;
   const pinyon_shift::native_renderer::ProceduralResolveTarget target{
       .frame_sequence = observation.frame_sequence,
       .surface_info = observation.surface_info,
@@ -25173,6 +25177,7 @@ void ObservePreparedDraw(
     const rex::system::GraphicsPreparedDrawObservation &observation) {
   g_isolated_draw.prepared_candidate_valid = false;
   g_isolated_draw.prepared_color_only_target = false;
+  g_isolated_draw.prepared_procedural_color_producer = false;
   g_isolated_draw.prepared_shadow_depth_seed_eligible = false;
   g_isolated_draw.prepared_shadow_depth_batch_member = false;
   g_isolated_draw.prepared_shadow_depth_batch_family =
@@ -27164,6 +27169,12 @@ void EmitContinuousWorldWorksetEvent(const char *event_name,
             g_continuous_world_workset.track_world_mechanical_rejection_reasons[14])},
        {"track_world_requests",
         std::to_string(g_continuous_world_workset.track_world_requests)},
+       {"procedural_color_producer_candidates",
+        std::to_string(
+            g_continuous_world_workset.procedural_color_producer_candidates)},
+       {"procedural_color_producer_requests",
+        std::to_string(
+            g_continuous_world_workset.procedural_color_producer_requests)},
        {"static_world_lineage_rejections",
         std::to_string(
             g_continuous_world_workset.static_world_lineage_rejections)},
@@ -27191,7 +27202,7 @@ void EmitContinuousWorldWorksetEvent(const char *event_name,
        {"maximum_draws_per_frame",
         std::to_string(kContinuousWorldWorksetMaximumDrawsPerFrame)},
        {"selection",
-        "fresh_track_texture_provider_visibility_or_qualified_sky_horizon_or_optional_exact_track_or_static_world_and_mechanical"},
+        "fresh_track_texture_provider_visibility_or_qualified_sky_horizon_or_exact_procedural_color_or_optional_exact_track_or_static_world_and_mechanical"},
        {"track_world_selection",
         g_continuous_world_workset.track_world_requested
             ? "exact_track_render_model_scope_and_shared_world_resource_identity"
@@ -27553,6 +27564,11 @@ void RequestIsolatedDraw(
         g_isolated_draw.prepared_track_render_model_scope &&
         (g_isolated_draw.prepared_track_world_resource_shared_identity_mask ||
          g_isolated_draw.prepared_track_command_lineage);
+    const bool exact_procedural_color_producer =
+        g_isolated_draw.prepared_procedural_color_producer;
+    if (exact_procedural_color_producer) {
+      ++g_continuous_world_workset.procedural_color_producer_candidates;
+    }
     if (exact_track_world) {
       ++g_continuous_world_workset.track_world_candidates;
       const uint32_t rejection_mask =
@@ -27584,20 +27600,21 @@ void RequestIsolatedDraw(
     }
     if (!g_isolated_draw.prepared_visibility_candidate_fresh &&
         !qualified_retained_family && !exact_static_world &&
-        !exact_track_world) {
+        !exact_track_world && !exact_procedural_color_producer) {
       ++g_continuous_world_workset.stale_or_unselected_rejections;
       return;
     }
     if (!qualified_retained_family &&
         !exact_static_world &&
         !exact_track_world &&
+        !exact_procedural_color_producer &&
         !g_isolated_draw.prepared_track_texture_provider) {
       ++g_continuous_world_workset.non_track_provider_rejections;
       return;
     }
     if (g_continuous_world_workset.track_world_requested &&
         !qualified_retained_family && !exact_static_world &&
-        !exact_track_world) {
+        !exact_track_world && !exact_procedural_color_producer) {
       ++g_continuous_world_workset.track_world_identity_exclusions;
       return;
     }
@@ -27624,6 +27641,9 @@ void RequestIsolatedDraw(
     }
     if (exact_track_world) {
       ++g_continuous_world_workset.track_world_requests;
+    }
+    if (exact_procedural_color_producer) {
+      ++g_continuous_world_workset.procedural_color_producer_requests;
     }
     if (exact_static_world) {
       ++g_continuous_world_workset.static_world_requests;

--- a/tools/summarize-native-renderer-continuous-world-workset.py
+++ b/tools/summarize-native-renderer-continuous-world-workset.py
@@ -7,10 +7,11 @@ import pathlib
 import sys
 
 
-SCHEMA = "pinyon-shift.native-renderer-continuous-world-workset.v7"
+SCHEMA = "pinyon-shift.native-renderer-continuous-world-workset.v8"
 SELECTION = (
     "fresh_track_texture_provider_visibility_or_qualified_"
-    "sky_horizon_or_optional_exact_track_or_static_world_and_mechanical"
+    "sky_horizon_or_exact_procedural_color_or_optional_exact_track_or_"
+    "static_world_and_mechanical"
 )
 TRACK_WORLD_SELECTION = (
     "exact_track_render_model_scope_and_shared_world_resource_identity"
@@ -162,6 +163,8 @@ def build(events, requested_session=None, allow_checkpoint=False):
         "non_track_provider_rejections",
         "track_world_identity_exclusions",
         "track_world_requests",
+        "procedural_color_producer_candidates",
+        "procedural_color_producer_requests",
         "static_world_lineage_rejections",
         "static_world_requests",
         "per_frame_quota_yields",
@@ -232,6 +235,7 @@ def build(events, requested_session=None, allow_checkpoint=False):
     track_provider_requests = (
         totals["requests"]
         - totals["qualified_retained_family_requests"]
+        - totals["procedural_color_producer_requests"]
         - totals["static_world_requests"]
     )
     if track_provider_requests <= 0:
@@ -256,6 +260,15 @@ def build(events, requested_session=None, allow_checkpoint=False):
         failures.append("track-world selection occurred while disabled")
     if totals["track_world_requests"] > track_provider_requests:
         failures.append("track-world requests exceed track-provider requests")
+    if not totals["procedural_color_producer_candidates"]:
+        failures.append("no exact procedural color producer was observed")
+    if not totals["procedural_color_producer_requests"]:
+        failures.append("no exact procedural color producer was replayed")
+    if (
+        totals["procedural_color_producer_requests"]
+        > totals["procedural_color_producer_candidates"]
+    ):
+        failures.append("procedural color requests exceed exact candidates")
     if static_world_requested and not totals["static_world_requests"]:
         failures.append("no exact static-world request was observed")
     if not static_world_requested and totals["static_world_requests"]:
@@ -389,6 +402,21 @@ def build(events, requested_session=None, allow_checkpoint=False):
             )
         )
     )
+    procedural_color_producer_selection_proved = (
+        totals["procedural_color_producer_requests"] > 0
+        and totals["procedural_color_producer_requests"]
+        <= totals["procedural_color_producer_candidates"]
+        and not any(
+            message
+            in failures
+            for message in (
+                "prepared selection accounting drifted",
+                "runtime workset status does not match its outcomes",
+                "no exact procedural color producer was replayed",
+                "procedural color requests exceed exact candidates",
+            )
+        )
+    )
 
     return {
         "schema": SCHEMA,
@@ -411,6 +439,9 @@ def build(events, requested_session=None, allow_checkpoint=False):
             "clean_xenos_fallback_proved": clean_fallback_proved,
             "track_provider_selection_proved": track_provider_selection_proved,
             "track_world_selection_proved": track_world_selection_proved,
+            "procedural_color_producer_selection_proved": (
+                procedural_color_producer_selection_proved
+            ),
             "static_world_selection_proved": static_world_selection_proved,
             "native_output_markers": len(exact_output_frames),
             "xenos_fallback_markers": len(output_waiting),

--- a/tools/tests/test_native_renderer_continuous_world_workset.py
+++ b/tools/tests/test_native_renderer_continuous_world_workset.py
@@ -42,9 +42,9 @@ def fixture():
         status="complete",
         final_summary="true",
         frame_sequence="900",
-        prepared_observations="20",
-        requests="8",
-        recorded="8",
+        prepared_observations="22",
+        requests="10",
+        recorded="10",
         target_creation_failures="0",
         unsupported="0",
         mechanical_rejections="4",
@@ -63,12 +63,14 @@ def fixture():
             "render_targets=0"
         ),
         track_world_requests="3",
+        procedural_color_producer_candidates="2",
+        procedural_color_producer_requests="2",
         static_world_lineage_rejections="0",
         static_world_requests="3",
         per_frame_quota_yields="2",
         fail_closed_yields="0",
         qualified_retained_family_requests="2",
-        reused_target_requests="6",
+        reused_target_requests="8",
         frames_started="2",
         frames_completed="2",
         frames_failed="0",
@@ -124,6 +126,8 @@ class ContinuousWorldWorksetTests(unittest.TestCase):
         self.assertIn("prepared_track_render_model_scope", source)
         self.assertIn("track_world_mechanically_rejected", source)
         self.assertIn("track_world_mechanical_rejection_reasons", source)
+        self.assertIn("prepared_procedural_color_producer", source)
+        self.assertIn("procedural_color_producer_requests", source)
         self.assertIn(
             ".track_command_lineage = exact_track_command", source
         )
@@ -201,6 +205,11 @@ class ContinuousWorldWorksetTests(unittest.TestCase):
         )
         self.assertTrue(
             document["qualification"]["track_world_selection_proved"]
+        )
+        self.assertTrue(
+            document["qualification"][
+                "procedural_color_producer_selection_proved"
+            ]
         )
         self.assertTrue(
             document["qualification"]["static_world_selection_proved"]
@@ -288,6 +297,23 @@ class ContinuousWorldWorksetTests(unittest.TestCase):
             "no exact track-world request was observed", document["failures"]
         )
 
+    def test_rejects_missing_exact_procedural_color_producer(self):
+        events = fixture()
+        events[-1].update(
+            procedural_color_producer_candidates="0",
+            procedural_color_producer_requests="0",
+        )
+        document = MODULE.build(events)
+        self.assertEqual("incomplete", document["status"])
+        self.assertIn(
+            "no exact procedural color producer was observed",
+            document["failures"],
+        )
+        self.assertIn(
+            "no exact procedural color producer was replayed",
+            document["failures"],
+        )
+
     def test_rejects_track_world_eligibility_accounting_drift(self):
         events = fixture()
         events[-1]["track_world_mechanically_rejected"] = "3"
@@ -314,7 +340,7 @@ class ContinuousWorldWorksetTests(unittest.TestCase):
         events = fixture()
         events[0]["track_world_selection"] = "disabled"
         events[-1].update(
-            prepared_observations="19",
+            prepared_observations="21",
             track_world_selection="disabled",
             track_world_identity_exclusions="0",
             track_world_requests="0",
@@ -329,7 +355,7 @@ class ContinuousWorldWorksetTests(unittest.TestCase):
         events = fixture()
         events[-1].update(
             status="fallback_observed",
-            recorded="7",
+            recorded="9",
             unsupported="1",
             frames_completed="1",
             frames_failed="1",

--- a/tools/tests/test_native_renderer_prototype_comparison.py
+++ b/tools/tests/test_native_renderer_prototype_comparison.py
@@ -115,7 +115,7 @@ class NativeRendererPrototypeComparisonTests(unittest.TestCase):
         )
         self.assertIn("qualified_retained_family_requests", hooks)
         self.assertIn(
-            "fresh_track_texture_provider_visibility_or_qualified_sky_horizon_or_optional_exact_track_or_static_world_and_mechanical",
+            "fresh_track_texture_provider_visibility_or_qualified_sky_horizon_or_exact_procedural_color_or_optional_exact_track_or_static_world_and_mechanical",
             hooks,
         )
         self.assertIn("static_world_requested = false", hooks)


### PR DESCRIPTION
## Summary
- recognize the proved 0x82417BC0 procedural color context as an exact native producer
- replay mechanically eligible tiled producer draws into the bounded same-frame private workset
- keep depth-only slot-79 track draws excluded as shadow work
- require exact producer candidate/request accounting in the v8 qualifier

## Safety
- preserves the 64-draw workset bound and mechanical replay gates
- preserves Xenos draws, resolves, fallback, and output authority
- adds no guest publication or suppression
- does not infer terrain identity from shaders or frequency

## Validation
- python -m pytest tools/tests -q (711 passed)
- incremental pinyon_shift.exe C++ compile and link