### PR TITLE
feat(native-renderer): report replay target failure reasons

### DIFF
--- a/docs/native-renderer/CONTINUOUS_WORLD_WORKSET.md
+++ b/docs/native-renderer/CONTINUOUS_WORLD_WORKSET.md
@@ -87,6 +87,11 @@ The exact procedural color route is reported independently as
 `procedural_color_producer_candidates` and
 `procedural_color_producer_requests`; the v8 qualifier requires at least one
 accepted request and rejects requests that exceed exact candidates.
+Target-construction failures now carry a bounded backend reason code and the
+workset summary partitions both all failures and the exact procedural subset.
+This distinguishes missing or extra guest attachments, private depth/color
+allocation failures, invalid extents or depth formats, and retained-target
+mismatches without adding payload capture or weakening Xenos fallback.
 When exact track-world selection is armed, accepted requests and provider-only
 identity exclusions are reported separately as `track_world_requests` and
 `track_world_identity_exclusions`.

--- a/docs/native-renderer/REPRIORITIZED_PLAN.md
+++ b/docs/native-renderer/REPRIORITIZED_PLAN.md
@@ -869,6 +869,16 @@ qualifier requires distinct candidate and accepted-request accounting for this
 producer. Depth-only slot-79 track draws remain excluded as shadow work, and
 Xenos output remains the mandatory fallback until the exact producer completes.
 
+Target-failure diagnostic checkpoint: the first batched AppData run after exact
+producer admission observed 318 exact candidates across nine gameplay frames.
+Each frame's first procedural replay failed target construction, while 102
+existing retained-family requests still recorded and eight frames completed.
+ReXGlue now returns a bounded fail-closed reason for every isolated target
+construction failure, and the workset partitions the exact procedural subset.
+The next run can therefore fix the specific attachment, allocation, extent, or
+retained-target incompatibility without guessing or enabling Xenos-derived
+content as a native producer.
+
 ### C2. Static world buildings and props
 
 - Expand opaque-world material and geometry coverage.

--- a/patches/rexglue/0112-d3d12-isolated-target-failure-detail.patch
+++ b/patches/rexglue/0112-d3d12-isolated-target-failure-detail.patch
@@ -1,0 +1,262 @@
+diff --git a/include/rex/system/interfaces/graphics.h b/include/rex/system/interfaces/graphics.h
+index dd3b75a..949fa4f 100644
+--- a/include/rex/system/interfaces/graphics.h
++++ b/include/rex/system/interfaces/graphics.h
+@@ -486,11 +486,29 @@ enum class GraphicsIsolatedDrawStatus : uint32_t {
+   kTargetCreationFailed = 3,
+ };
+ 
++enum class GraphicsIsolatedDrawTargetFailure : uint32_t {
++  kNone = 0,
++  kIncompatibleModes = 1,
++  kUnsupportedPath = 2,
++  kMissingDepthTarget = 3,
++  kUnexpectedDepthTarget = 4,
++  kMissingColorTarget = 5,
++  kUnexpectedAdditionalColorTarget = 6,
++  kDepthTargetCreationFailed = 7,
++  kColorTargetCreationFailed = 8,
++  kInvalidLogicalExtent = 9,
++  kDepthFormatUnavailable = 10,
++  kRetainedTargetUnavailable = 11,
++  kRetainedTargetMismatch = 12,
++};
++
+ struct GraphicsIsolatedDrawResult {
+   GraphicsIsolatedDrawStatus status =
+       GraphicsIsolatedDrawStatus::kUnsupportedState;
+   uint32_t target_width = 0;
+   uint32_t target_height = 0;
++  GraphicsIsolatedDrawTargetFailure target_failure =
++      GraphicsIsolatedDrawTargetFailure::kNone;
+ };
+ 
+ using GraphicsIsolatedDrawCompletion = void (*)(
+diff --git a/include/rex/graphics/d3d12/render_target_cache.h b/include/rex/graphics/d3d12/render_target_cache.h
+index a97b6fa..144a20e 100644
+--- a/include/rex/graphics/d3d12/render_target_cache.h
++++ b/include/rex/graphics/d3d12/render_target_cache.h
+@@ -100,12 +100,16 @@ class D3D12RenderTargetCache final : public RenderTargetCache {
+   // EndIsolatedReplayTarget restores the guest bindings without changing the
+   // guest attachments or ownership.
+   bool BeginIsolatedReplayTarget(uint32_t& width_out, uint32_t& height_out,
++                                 system::GraphicsIsolatedDrawTargetFailure&
++                                     failure_out,
+                                  uint32_t logical_width,
+                                  uint32_t logical_height,
+                                  bool stencil_seed_probe_requested,
+                                  bool depth_only_target = false,
+                                  bool color_only_target = false);
+   bool ResumeIsolatedReplayTarget(uint32_t& width_out, uint32_t& height_out,
++                                  system::GraphicsIsolatedDrawTargetFailure&
++                                      failure_out,
+                                   uint32_t logical_width,
+                                   uint32_t logical_height,
+                                   bool depth_only_target = false,
+diff --git a/src/graphics/d3d12/render_target_cache.cpp b/src/graphics/d3d12/render_target_cache.cpp
+index d1578ae..f772b81 100644
+--- a/src/graphics/d3d12/render_target_cache.cpp
++++ b/src/graphics/d3d12/render_target_cache.cpp
+@@ -1790,14 +1790,18 @@ RenderTargetCache::RenderTarget* D3D12RenderTargetCache::CreateRenderTarget(Rend
+ 
+ bool D3D12RenderTargetCache::BeginIsolatedReplayTarget(
+     uint32_t& width_out, uint32_t& height_out,
++    system::GraphicsIsolatedDrawTargetFailure& failure_out,
+     uint32_t logical_width, uint32_t logical_height,
+     bool stencil_seed_probe_requested, bool depth_only_target,
+     bool color_only_target) {
+   width_out = 0;
+   height_out = 0;
++  failure_out = system::GraphicsIsolatedDrawTargetFailure::kNone;
+   isolated_replay_active_depth_target_ = nullptr;
+   if ((depth_only_target && color_only_target) ||
+       (stencil_seed_probe_requested && color_only_target)) {
++    failure_out =
++        system::GraphicsIsolatedDrawTargetFailure::kIncompatibleModes;
+     return false;
+   }
+   if (!depth_only_target) {
+@@ -1808,18 +1812,31 @@ bool D3D12RenderTargetCache::BeginIsolatedReplayTarget(
+     isolated_replay_active_preview_height_ = 0;
+   }
+   if (GetPath() != Path::kHostRenderTargets) {
++    failure_out = system::GraphicsIsolatedDrawTargetFailure::kUnsupportedPath;
+     return false;
+   }
+   RenderTarget* const* guest_targets =
+       last_update_accumulated_render_targets();
+-  if ((!color_only_target && !guest_targets[0]) ||
+-      (color_only_target && guest_targets[0]) ||
+-      (!depth_only_target && !guest_targets[1])) {
++  if (!color_only_target && !guest_targets[0]) {
++    failure_out =
++        system::GraphicsIsolatedDrawTargetFailure::kMissingDepthTarget;
++    return false;
++  }
++  if (color_only_target && guest_targets[0]) {
++    failure_out =
++        system::GraphicsIsolatedDrawTargetFailure::kUnexpectedDepthTarget;
++    return false;
++  }
++  if (!depth_only_target && !guest_targets[1]) {
++    failure_out =
++        system::GraphicsIsolatedDrawTargetFailure::kMissingColorTarget;
+     return false;
+   }
+   for (uint32_t i = depth_only_target ? 1 : 2;
+        i <= xenos::kMaxColorRenderTargets; ++i) {
+     if (guest_targets[i]) {
++      failure_out = system::GraphicsIsolatedDrawTargetFailure::
++          kUnexpectedAdditionalColorTarget;
+       return false;
+     }
+   }
+@@ -1843,6 +1860,11 @@ bool D3D12RenderTargetCache::BeginIsolatedReplayTarget(
+   }
+   if ((!color_only_target && !isolated_replay_depth_target) ||
+       (!depth_only_target && !isolated_replay_color_target_)) {
++    failure_out = !color_only_target && !isolated_replay_depth_target
++                      ? system::GraphicsIsolatedDrawTargetFailure::
++                            kDepthTargetCreationFailed
++                      : system::GraphicsIsolatedDrawTargetFailure::
++                            kColorTargetCreationFailed;
+     if (!color_only_target) {
+       isolated_replay_depth_target.reset();
+     }
+@@ -1881,6 +1903,8 @@ bool D3D12RenderTargetCache::BeginIsolatedReplayTarget(
+         std::min(logical_height, height_out);
+     if (!isolated_replay_active_preview_width_ ||
+         !isolated_replay_active_preview_height_) {
++      failure_out =
++          system::GraphicsIsolatedDrawTargetFailure::kInvalidLogicalExtent;
+       return false;
+     }
+   }
+@@ -1949,7 +1973,9 @@ bool D3D12RenderTargetCache::BeginIsolatedReplayTarget(
+         FAILED(device->CheckFeatureSupport(D3D12_FEATURE_FORMAT_INFO,
+                                            &depth_format_info,
+                                            sizeof(depth_format_info))) ||
+         !depth_format_info.PlaneCount) {
++      failure_out =
++          system::GraphicsIsolatedDrawTargetFailure::kDepthFormatUnavailable;
+       return false;
+     }
+     for (uint32_t plane = 0; plane < depth_format_info.PlaneCount; ++plane) {
+@@ -2002,19 +2028,23 @@ bool D3D12RenderTargetCache::BeginIsolatedReplayTarget(
+ }
+ 
+ bool D3D12RenderTargetCache::ResumeIsolatedReplayTarget(
+-    uint32_t& width_out, uint32_t& height_out, uint32_t logical_width,
+-    uint32_t logical_height, bool depth_only_target,
++    uint32_t& width_out, uint32_t& height_out,
++    system::GraphicsIsolatedDrawTargetFailure& failure_out,
++    uint32_t logical_width, uint32_t logical_height, bool depth_only_target,
+     bool color_only_target) {
+   if (isolated_replay_frame_accumulator_reseed_required_) {
+     isolated_replay_frame_accumulator_reseed_required_ = false;
+     return BeginIsolatedReplayTarget(
+-        width_out, height_out, logical_width, logical_height, false,
++        width_out, height_out, failure_out, logical_width, logical_height, false,
+         depth_only_target, color_only_target);
+   }
+   width_out = 0;
+   height_out = 0;
++  failure_out = system::GraphicsIsolatedDrawTargetFailure::kNone;
+   isolated_replay_active_depth_target_ = nullptr;
+   if (depth_only_target && color_only_target) {
++    failure_out =
++        system::GraphicsIsolatedDrawTargetFailure::kIncompatibleModes;
+     return false;
+   }
+   auto& isolated_replay_depth_target =
+@@ -2023,26 +2053,49 @@ bool D3D12RenderTargetCache::ResumeIsolatedReplayTarget(
+   if (GetPath() != Path::kHostRenderTargets ||
+       (!color_only_target && !isolated_replay_depth_target) ||
+       (!depth_only_target && !isolated_replay_color_target_)) {
++    failure_out = system::GraphicsIsolatedDrawTargetFailure::
++        kRetainedTargetUnavailable;
+     isolated_replay_active_depth_target_ = nullptr;
+     return false;
+   }
+   RenderTarget* const* guest_targets =
+       last_update_accumulated_render_targets();
+-  if ((!color_only_target && !guest_targets[0]) ||
+-      (color_only_target && guest_targets[0]) ||
+-      (!depth_only_target && !guest_targets[1]) ||
+-      (!color_only_target &&
+-       guest_targets[0]->key() != isolated_replay_depth_target->key())) {
++  if (!color_only_target && !guest_targets[0]) {
++    failure_out =
++        system::GraphicsIsolatedDrawTargetFailure::kMissingDepthTarget;
++    isolated_replay_active_depth_target_ = nullptr;
++    return false;
++  }
++  if (color_only_target && guest_targets[0]) {
++    failure_out =
++        system::GraphicsIsolatedDrawTargetFailure::kUnexpectedDepthTarget;
++    isolated_replay_active_depth_target_ = nullptr;
++    return false;
++  }
++  if (!depth_only_target && !guest_targets[1]) {
++    failure_out =
++        system::GraphicsIsolatedDrawTargetFailure::kMissingColorTarget;
++    isolated_replay_active_depth_target_ = nullptr;
++    return false;
++  }
++  if (!color_only_target &&
++      guest_targets[0]->key() != isolated_replay_depth_target->key()) {
++    failure_out =
++        system::GraphicsIsolatedDrawTargetFailure::kRetainedTargetMismatch;
+     isolated_replay_active_depth_target_ = nullptr;
+     return false;
+   }
+   if (!depth_only_target &&
+       guest_targets[1]->key() != isolated_replay_color_target_->key()) {
++    failure_out =
++        system::GraphicsIsolatedDrawTargetFailure::kRetainedTargetMismatch;
+     return false;
+   }
+   for (uint32_t i = depth_only_target ? 1 : 2;
+        i <= xenos::kMaxColorRenderTargets; ++i) {
+     if (guest_targets[i]) {
++      failure_out = system::GraphicsIsolatedDrawTargetFailure::
++          kUnexpectedAdditionalColorTarget;
+       return false;
+     }
+   }
+diff --git a/src/graphics/d3d12/command_processor.cpp b/src/graphics/d3d12/command_processor.cpp
+index 3b3bf5e..a8040e7 100644
+--- a/src/graphics/d3d12/command_processor.cpp
++++ b/src/graphics/d3d12/command_processor.cpp
+@@ -3813,6 +3813,7 @@ bool D3D12CommandProcessor::IssueDraw(xenos::PrimitiveType primitive_type, uint3
+                   render_target_cache_->BeginIsolatedReplayTarget(
+                       isolated_result.target_width,
+                       isolated_result.target_height,
++                      isolated_result.target_failure,
+                       isolated_replay_logical_width,
+                       isolated_replay_logical_height,
+                       isolated_draw_request.stencil_seed_probe_requested,
+@@ -3822,6 +3823,7 @@ bool D3D12CommandProcessor::IssueDraw(xenos::PrimitiveType primitive_type, uint3
+                   render_target_cache_->ResumeIsolatedReplayTarget(
+                       isolated_result.target_width,
+                       isolated_result.target_height,
++                      isolated_result.target_failure,
+                       isolated_replay_logical_width,
+                       isolated_replay_logical_height,
+                       isolated_draw_request.depth_only_target,
+@@ -4071,6 +4073,7 @@ bool D3D12CommandProcessor::IssueDraw(xenos::PrimitiveType primitive_type, uint3
+                   render_target_cache_->BeginIsolatedReplayTarget(
+                       isolated_result.target_width,
+                       isolated_result.target_height,
++                      isolated_result.target_failure,
+                       isolated_replay_logical_width,
+                       isolated_replay_logical_height,
+                       isolated_draw_request.stencil_seed_probe_requested,
+@@ -4080,6 +4083,7 @@ bool D3D12CommandProcessor::IssueDraw(xenos::PrimitiveType primitive_type, uint3
+                   render_target_cache_->ResumeIsolatedReplayTarget(
+                       isolated_result.target_width,
+                       isolated_result.target_height,
++                      isolated_result.target_failure,
+                       isolated_replay_logical_width,
+                       isolated_replay_logical_height,
+                       isolated_draw_request.depth_only_target,

--- a/src/native_renderer/graphics_hooks.cpp
+++ b/src/native_renderer/graphics_hooks.cpp
@@ -10066,6 +10066,9 @@ struct ContinuousWorldWorksetState {
   uint64_t track_world_requests = 0;
   uint64_t procedural_color_producer_candidates = 0;
   uint64_t procedural_color_producer_requests = 0;
+  uint64_t procedural_color_producer_target_failures = 0;
+  std::array<uint64_t, 13> target_failure_reasons{};
+  std::array<uint64_t, 13> procedural_color_target_failure_reasons{};
   uint64_t static_world_lineage_rejections = 0;
   uint64_t static_world_requests = 0;
   uint64_t per_frame_quota_yields = 0;
@@ -27064,6 +27067,19 @@ void CompleteContinuousWorldWorksetReplay(
   if (result.status == rex::system::
                            GraphicsIsolatedDrawStatus::kTargetCreationFailed) {
     ++g_continuous_world_workset.target_creation_failures;
+    const size_t failure_index = size_t(result.target_failure);
+    if (failure_index <
+        g_continuous_world_workset.target_failure_reasons.size()) {
+      ++g_continuous_world_workset.target_failure_reasons[failure_index];
+      if (g_isolated_draw.prepared_procedural_color_producer) {
+        ++g_continuous_world_workset
+              .procedural_color_target_failure_reasons[failure_index];
+      }
+    }
+    if (g_isolated_draw.prepared_procedural_color_producer) {
+      ++g_continuous_world_workset
+            .procedural_color_producer_target_failures;
+    }
   } else {
     ++g_continuous_world_workset.unsupported;
   }
@@ -27175,6 +27191,54 @@ void EmitContinuousWorldWorksetEvent(const char *event_name,
        {"procedural_color_producer_requests",
         std::to_string(
             g_continuous_world_workset.procedural_color_producer_requests)},
+       {"procedural_color_producer_target_failures",
+        std::to_string(g_continuous_world_workset
+                           .procedural_color_producer_target_failures)},
+       {"target_failure_reasons",
+        fmt::format(
+            "none={};incompatible_modes={};unsupported_path={};missing_depth={};unexpected_depth={};missing_color={};additional_color={};depth_create={};color_create={};invalid_extent={};depth_format={};retained_unavailable={};retained_mismatch={}",
+            g_continuous_world_workset.target_failure_reasons[0],
+            g_continuous_world_workset.target_failure_reasons[1],
+            g_continuous_world_workset.target_failure_reasons[2],
+            g_continuous_world_workset.target_failure_reasons[3],
+            g_continuous_world_workset.target_failure_reasons[4],
+            g_continuous_world_workset.target_failure_reasons[5],
+            g_continuous_world_workset.target_failure_reasons[6],
+            g_continuous_world_workset.target_failure_reasons[7],
+            g_continuous_world_workset.target_failure_reasons[8],
+            g_continuous_world_workset.target_failure_reasons[9],
+            g_continuous_world_workset.target_failure_reasons[10],
+            g_continuous_world_workset.target_failure_reasons[11],
+            g_continuous_world_workset.target_failure_reasons[12])},
+       {"procedural_color_target_failure_reasons",
+        fmt::format(
+            "none={};incompatible_modes={};unsupported_path={};missing_depth={};unexpected_depth={};missing_color={};additional_color={};depth_create={};color_create={};invalid_extent={};depth_format={};retained_unavailable={};retained_mismatch={}",
+            g_continuous_world_workset
+                .procedural_color_target_failure_reasons[0],
+            g_continuous_world_workset
+                .procedural_color_target_failure_reasons[1],
+            g_continuous_world_workset
+                .procedural_color_target_failure_reasons[2],
+            g_continuous_world_workset
+                .procedural_color_target_failure_reasons[3],
+            g_continuous_world_workset
+                .procedural_color_target_failure_reasons[4],
+            g_continuous_world_workset
+                .procedural_color_target_failure_reasons[5],
+            g_continuous_world_workset
+                .procedural_color_target_failure_reasons[6],
+            g_continuous_world_workset
+                .procedural_color_target_failure_reasons[7],
+            g_continuous_world_workset
+                .procedural_color_target_failure_reasons[8],
+            g_continuous_world_workset
+                .procedural_color_target_failure_reasons[9],
+            g_continuous_world_workset
+                .procedural_color_target_failure_reasons[10],
+            g_continuous_world_workset
+                .procedural_color_target_failure_reasons[11],
+            g_continuous_world_workset
+                .procedural_color_target_failure_reasons[12])},
        {"static_world_lineage_rejections",
         std::to_string(
             g_continuous_world_workset.static_world_lineage_rejections)},

--- a/tools/tests/test_native_renderer_continuous_world_workset.py
+++ b/tools/tests/test_native_renderer_continuous_world_workset.py
@@ -128,6 +128,9 @@ class ContinuousWorldWorksetTests(unittest.TestCase):
         self.assertIn("track_world_mechanical_rejection_reasons", source)
         self.assertIn("prepared_procedural_color_producer", source)
         self.assertIn("procedural_color_producer_requests", source)
+        self.assertIn("procedural_color_producer_target_failures", source)
+        self.assertIn("procedural_color_target_failure_reasons", source)
+
         self.assertIn(
             ".track_command_lineage = exact_track_command", source
         )
@@ -172,6 +175,17 @@ class ContinuousWorldWorksetTests(unittest.TestCase):
         self.assertIn(
             "PINYON_SHIFT_NATIVE_RENDERER_CONTINUOUS_WORLD_WORKSET", capture
         )
+
+    def test_rexglue_reports_isolated_target_failure_detail(self):
+        patch = (
+            ROOT
+            / "patches/rexglue/0112-d3d12-isolated-target-failure-detail.patch"
+        ).read_text(encoding="utf-8")
+        self.assertIn("GraphicsIsolatedDrawTargetFailure", patch)
+        self.assertIn("kDepthTargetCreationFailed", patch)
+        self.assertIn("kColorTargetCreationFailed", patch)
+        self.assertIn("kRetainedTargetMismatch", patch)
+        self.assertIn("isolated_result.target_failure", patch)
 
     def test_exact_track_color_only_replay_is_private_and_bounded(self):
         source = (ROOT / "src/native_renderer/graphics_hooks.cpp").read_text(

--- a/tools/tests/test_release_contract.py
+++ b/tools/tests/test_release_contract.py
@@ -43,10 +43,10 @@ class ReleaseContractTests(unittest.TestCase):
 
     def test_rexglue_patches_have_stable_order_and_no_binary_payload(self):
         patches = sorted((ROOT / "patches/rexglue").glob("*.patch"))
-        self.assertEqual(len(patches), 111)
+        self.assertEqual(len(patches), 112)
         self.assertEqual(
             patches[-1].name,
-            "0111-d3d12-procedural-frame-accumulator-source-rows.patch",
+            "0112-d3d12-isolated-target-failure-detail.patch",
         )
         self.assertEqual(len(patches), len({path.name[:4] for path in patches}))
         for path in patches:


### PR DESCRIPTION
## Summary`n- expose bounded D3D12 isolated-target construction failure reasons`n- partition failures for the exact procedural color producer`n- record the diagnostic checkpoint in the reprioritized native-renderer plan`n`n## Safety`n- keeps Xenos authoritative and draw suppression disabled`n- captures no guest payloads and does not touch save data`n`n## Validation`n- full win-amd64-release build`n- python -m pytest tools/tests -q (712 passed)`n- focused native renderer and release contract tests (37 passed)`n- git diff --check