### PR TITLE
feat(native-renderer): qualify accumulator source ownership

### DIFF
--- a/docs/native-renderer/CONTINUOUS_WORLD_WORKSET.md
+++ b/docs/native-renderer/CONTINUOUS_WORLD_WORKSET.md
@@ -98,6 +98,12 @@ mode. A draw reuses the private target only when that identity is unchanged;
 an in-frame target-family transition begins a newly seeded private target and
 is reported as a reseed. This prevents sky/world retention from being reused as
 the procedural producer's target while preserving consecutive producer draws.
+Exact procedural replay requests additionally carry a one-consumer ownership
+tag into ReXGlue. Each accumulator append requires and consumes that same-frame
+tag; a sky, track, static-world, or otherwise unmarked private replay reports
+`unqualified_source` and cannot enter the procedural accumulator. This closes
+source provenance without reading guest payloads or retaining Xenos output as
+native content.
 When exact track-world selection is armed, accepted requests and provider-only
 identity exclusions are reported separately as `track_world_requests` and
 `track_world_identity_exclusions`.

--- a/docs/native-renderer/REPRIORITIZED_PLAN.md
+++ b/docs/native-renderer/REPRIORITIZED_PLAN.md
@@ -888,6 +888,14 @@ identity; target-family transitions reseed a private target, and only identical
 consecutive attachments reuse it. This is a correctness repair for continuous
 procedural accumulation, not a relaxation of native authority gates.
 
+Accumulator-source ownership checkpoint: the exact `82417BC0` replay request
+now tags its completed private color target for one same-frame accumulator
+append. ReXGlue consumes the tag on successful use and reports a distinct
+`unqualified_source` result when the latest private replay belongs to any other
+family. This prevents a later sky/world replay from becoming procedural input
+merely because it is the most recent retained target; no Xenos content is
+accepted as a native source.
+
 ### C2. Static world buildings and props
 
 - Expand opaque-world material and geometry coverage.

--- a/patches/rexglue/0113-d3d12-procedural-accumulator-source-ownership.patch
+++ b/patches/rexglue/0113-d3d12-procedural-accumulator-source-ownership.patch
@@ -1,0 +1,139 @@
+diff --git a/include/rex/graphics/d3d12/render_target_cache.h b/include/rex/graphics/d3d12/render_target_cache.h
+index 144a20e..1169a00 100644
+--- a/include/rex/graphics/d3d12/render_target_cache.h
++++ b/include/rex/graphics/d3d12/render_target_cache.h
+@@ -144,7 +144,8 @@ class D3D12RenderTargetCache final : public RenderTargetCache {
+   void EndIsolatedReplayTarget(
+       uint64_t frame_sequence,
+       bool defer_preview_publication_until_swap = false,
+-      bool depth_only_target = false);
++      bool depth_only_target = false,
++      bool frame_accumulator_source = false);
+   void CommitDeferredIsolatedReplayPreview(uint64_t frame_sequence);
+   void CancelDeferredIsolatedReplayPreview(uint64_t frame_sequence);
+   system::GraphicsIsolatedDrawPublicationResult PublishIsolatedReplayTarget(
+@@ -761,6 +762,7 @@ class D3D12RenderTargetCache final : public RenderTargetCache {
+   ID3D12PipelineState*
+       isolated_replay_frame_accumulator_2xmsaa_pipeline_ = nullptr;
+   uint64_t isolated_replay_frame_accumulator_frame_sequence_ = 0;
++  uint64_t isolated_replay_frame_accumulator_source_frame_sequence_ = 0;
+   uint64_t isolated_replay_frame_accumulator_committed_frame_sequence_ = 0;
+   uint32_t isolated_replay_frame_accumulator_width_ = 0;
+   uint32_t isolated_replay_frame_accumulator_height_ = 0;
+diff --git a/include/rex/system/interfaces/graphics.h b/include/rex/system/interfaces/graphics.h
+index 949fa4f..a0d1162 100644
+--- a/include/rex/system/interfaces/graphics.h
++++ b/include/rex/system/interfaces/graphics.h
+@@ -366,6 +366,7 @@ enum class GraphicsNativeFrameAccumulatorStatus : uint32_t {
+   kUnavailable = 4,
+   kUnsupportedTarget = 5,
+   kAllocationFailed = 6,
++  kUnqualifiedSource = 7,
+ };
+ 
+ struct GraphicsNativeFrameAccumulatorResult {
+@@ -618,6 +619,10 @@ struct GraphicsIsolatedDrawRequest {
+   // complete frame. Any failed draw in the accumulation cancels the pending
+   // preview and leaves the previous Xenos frame authoritative.
+   bool defer_preview_publication_until_swap = false;
++  // Make the completed private color replay eligible as the source of one
++  // same-frame native accumulator append. The accumulator consumes this tag;
++  // unrelated isolated replays can never become procedural input implicitly.
++  bool frame_accumulator_source = false;
+   // After the original authoritative guest draw, publish the completed private
+   // pass into the same guest color and depth/stencil resources. The backend
+   // must validate the entire pair before recording either copy. This never
+diff --git a/src/graphics/d3d12/command_processor.cpp b/src/graphics/d3d12/command_processor.cpp
+index a8040e7..a86cd12 100644
+--- a/src/graphics/d3d12/command_processor.cpp
++++ b/src/graphics/d3d12/command_processor.cpp
+@@ -3917,7 +3917,8 @@ bool D3D12CommandProcessor::IssueDraw(xenos::PrimitiveType primitive_type, uint3
+         render_target_cache_->EndIsolatedReplayTarget(
+             isolated_draw_request.frame_sequence,
+             isolated_draw_request.defer_preview_publication_until_swap,
+-            isolated_draw_request.depth_only_target);
++            isolated_draw_request.depth_only_target,
++            isolated_draw_request.frame_accumulator_source);
+         isolated_replay_recorded = true;
+         isolated_result.status =
+             system::GraphicsIsolatedDrawStatus::kRecorded;
+@@ -4177,7 +4178,8 @@ bool D3D12CommandProcessor::IssueDraw(xenos::PrimitiveType primitive_type, uint3
+         render_target_cache_->EndIsolatedReplayTarget(
+             isolated_draw_request.frame_sequence,
+             isolated_draw_request.defer_preview_publication_until_swap,
+-            isolated_draw_request.depth_only_target);
++            isolated_draw_request.depth_only_target,
++            isolated_draw_request.frame_accumulator_source);
+         isolated_replay_recorded = true;
+         isolated_result.status =
+             system::GraphicsIsolatedDrawStatus::kRecorded;
+diff --git a/src/graphics/d3d12/render_target_cache.cpp b/src/graphics/d3d12/render_target_cache.cpp
+index d71e419..8fd933c 100644
+--- a/src/graphics/d3d12/render_target_cache.cpp
++++ b/src/graphics/d3d12/render_target_cache.cpp
+@@ -1797,6 +1797,7 @@ bool D3D12RenderTargetCache::BeginIsolatedReplayTarget(
+   width_out = 0;
+   height_out = 0;
+   failure_out = system::GraphicsIsolatedDrawTargetFailure::kNone;
++  isolated_replay_frame_accumulator_source_frame_sequence_ = 0;
+   isolated_replay_active_depth_target_ = nullptr;
+   if ((depth_only_target && color_only_target) ||
+       (stencil_seed_probe_requested && color_only_target)) {
+@@ -2613,6 +2614,7 @@ D3D12RenderTargetCache::ApplyIsolatedReplayFrameAccumulator(
+     isolated_replay_frame_accumulator_logical_height_ = 0;
+     isolated_replay_frame_accumulator_appended_row_end_ = 0;
+     isolated_replay_frame_accumulator_reseed_required_ = false;
++    isolated_replay_frame_accumulator_source_frame_sequence_ = 0;
+   };
+   if (request.cancel && !request.begin && !request.append &&
+       !request.commit) {
+@@ -2648,6 +2650,13 @@ D3D12RenderTargetCache::ApplyIsolatedReplayFrameAccumulator(
+         system::GraphicsNativeFrameAccumulatorStatus::kUnavailable;
+     return result;
+   }
++  if (isolated_replay_frame_accumulator_source_frame_sequence_ !=
++          frame_sequence) {
++    clear_active();
++    result.status =
++        system::GraphicsNativeFrameAccumulatorStatus::kUnqualifiedSource;
++    return result;
++  }
+ 
+   auto* isolated_color = static_cast<D3D12RenderTarget*>(
+       isolated_replay_color_target_.get());
+@@ -2907,12 +2916,13 @@ D3D12RenderTargetCache::ApplyIsolatedReplayFrameAccumulator(
+   result.appended_row_end =
+       isolated_replay_frame_accumulator_appended_row_end_;
+   result.committed = request.commit;
++  isolated_replay_frame_accumulator_source_frame_sequence_ = 0;
+   return result;
+ }
+ 
+ void D3D12RenderTargetCache::EndIsolatedReplayTarget(
+     uint64_t frame_sequence, bool defer_preview_publication_until_swap,
+-    bool depth_only_target) {
++    bool depth_only_target, bool frame_accumulator_source) {
+   if (GetPath() != Path::kHostRenderTargets) {
+     return;
+   }
+@@ -2922,6 +2932,8 @@ void D3D12RenderTargetCache::EndIsolatedReplayTarget(
+   if (depth_only_target) {
+     return;
+   }
++  isolated_replay_frame_accumulator_source_frame_sequence_ =
++      frame_accumulator_source ? frame_sequence : 0;
+   if (defer_preview_publication_until_swap) {
+     isolated_replay_deferred_preview_frame_sequence_ = frame_sequence;
+     isolated_replay_deferred_preview_width_ =
+@@ -2972,6 +2984,10 @@ void D3D12RenderTargetCache::CancelDeferredIsolatedReplayPreview(
+     isolated_replay_frame_accumulator_appended_row_end_ = 0;
+     isolated_replay_frame_accumulator_reseed_required_ = false;
+   }
++  if (isolated_replay_frame_accumulator_source_frame_sequence_ ==
++      frame_sequence) {
++    isolated_replay_frame_accumulator_source_frame_sequence_ = 0;
++  }
+ }
+ 
+ system::GraphicsIsolatedDrawPublicationResult
+

--- a/src/native_renderer/graphics_hooks.cpp
+++ b/src/native_renderer/graphics_hooks.cpp
@@ -11302,7 +11302,7 @@ uint64_t g_procedural_frame_accumulator_qualified_resolve_arms = 0;
 std::array<uint64_t, 2>
     g_procedural_frame_accumulator_qualified_resolve_source_modes{};
 bool g_procedural_frame_accumulator_backend_armed = false;
-std::array<uint64_t, 6> g_procedural_frame_accumulator_backend_statuses{};
+std::array<uint64_t, 7> g_procedural_frame_accumulator_backend_statuses{};
 uint64_t g_procedural_frame_accumulator_backend_detail_count = 0;
 uint64_t g_procedural_frame_accumulator_backend_detail_overflow = 0;
 uint64_t g_procedural_frame_accumulator_backend_unavailable_frame = UINT64_MAX;
@@ -17455,6 +17455,8 @@ const char *ProceduralFrameAccumulatorBackendStatusName(
       return "unsupported_target";
     case Status::kAllocationFailed:
       return "allocation_failed";
+    case Status::kUnqualifiedSource:
+      return "unqualified_source";
   }
   return "unknown";
 }
@@ -17463,7 +17465,9 @@ void CompleteProceduralFrameAccumulatorBackend(
     const rex::system::GraphicsNativeFrameAccumulatorResult &result) {
   const uint32_t status = static_cast<uint32_t>(result.status);
   if (result.status ==
-      rex::system::GraphicsNativeFrameAccumulatorStatus::kUnavailable) {
+          rex::system::GraphicsNativeFrameAccumulatorStatus::kUnavailable ||
+      result.status == rex::system::GraphicsNativeFrameAccumulatorStatus::
+                           kUnqualifiedSource) {
     g_procedural_frame_accumulator_backend_unavailable_frame =
         result.frame_sequence;
   }
@@ -18183,6 +18187,8 @@ void EmitProceduralColorTargetProfiles() {
         std::to_string(g_procedural_frame_accumulator_backend_statuses[4])},
        {"allocation_failed",
         std::to_string(g_procedural_frame_accumulator_backend_statuses[5])},
+       {"unqualified_source",
+        std::to_string(g_procedural_frame_accumulator_backend_statuses[6])},
        {"detail_events",
         std::to_string(
             g_procedural_frame_accumulator_backend_detail_count)},
@@ -27767,6 +27773,7 @@ void RequestIsolatedDraw(
     request.retain_target = true;
     request.reuse_target = reuse_target;
     request.defer_preview_publication_until_swap = true;
+    request.frame_accumulator_source = exact_procedural_color_producer;
     request.frame_sequence = g_isolated_draw.frame;
     request.reference_marker_requested = true;
     request.completion = &CompleteContinuousWorldWorksetReplay;

--- a/tools/tests/test_native_renderer_continuous_world_workset.py
+++ b/tools/tests/test_native_renderer_continuous_world_workset.py
@@ -130,6 +130,11 @@ class ContinuousWorldWorksetTests(unittest.TestCase):
         self.assertIn("procedural_color_producer_requests", source)
         self.assertIn("procedural_color_producer_target_failures", source)
         self.assertIn("procedural_color_target_failure_reasons", source)
+        self.assertIn(
+            "request.frame_accumulator_source = "
+            "exact_procedural_color_producer",
+            source,
+        )
         self.assertIn("ContinuousWorldRetainedTargetIdentity", source)
         self.assertIn("current_retained_target_identity", source)
         self.assertIn("target_reseed_requests", source)
@@ -195,6 +200,21 @@ class ContinuousWorldWorksetTests(unittest.TestCase):
         self.assertIn("kColorTargetCreationFailed", patch)
         self.assertIn("kRetainedTargetMismatch", patch)
         self.assertIn("isolated_result.target_failure", patch)
+
+    def test_accumulator_requires_exact_private_source_ownership(self):
+        source = (ROOT / "src/native_renderer/graphics_hooks.cpp").read_text(
+            encoding="utf-8"
+        )
+        patch = (
+            ROOT
+            / "patches/rexglue/0113-d3d12-procedural-accumulator-source-ownership.patch"
+        ).read_text(encoding="utf-8")
+        self.assertIn("frame_accumulator_source", patch)
+        self.assertIn("kUnqualifiedSource", patch)
+        self.assertIn(
+            "isolated_replay_frame_accumulator_source_frame_sequence_", patch
+        )
+        self.assertIn("unqualified_source", source)
 
     def test_exact_track_color_only_replay_is_private_and_bounded(self):
         source = (ROOT / "src/native_renderer/graphics_hooks.cpp").read_text(

--- a/tools/tests/test_release_contract.py
+++ b/tools/tests/test_release_contract.py
@@ -43,10 +43,10 @@ class ReleaseContractTests(unittest.TestCase):
 
     def test_rexglue_patches_have_stable_order_and_no_binary_payload(self):
         patches = sorted((ROOT / "patches/rexglue").glob("*.patch"))
-        self.assertEqual(len(patches), 112)
+        self.assertEqual(len(patches), 113)
         self.assertEqual(
             patches[-1].name,
-            "0112-d3d12-isolated-target-failure-detail.patch",
+            "0113-d3d12-procedural-accumulator-source-ownership.patch",
         )
         self.assertEqual(len(patches), len({path.name[:4] for path in patches}))
         for path in patches:


### PR DESCRIPTION
## Summary`n- tag exact procedural private replays as one-use accumulator sources`n- consume the source tag on each same-frame row append`n- reject unrelated retained targets as unqualified_source`n- keep Xenos resolves, guest memory, and draw execution unchanged`n`n## Validation`n- patch 0113 applies cleanly after patch 0112`n- incremental win-amd64-release build`n- python -m pytest tools/tests -q (713 passed)`n- git diff --check`n`n## Runtime cadence`nThis is intentionally batched with the target-identity repair from PR #293. The next AppData run will validate both together.