### PR TITLE
fix(native-renderer): gate accumulator on exact frame source

### DIFF
--- a/docs/native-renderer/REPRIORITIZED_PLAN.md
+++ b/docs/native-renderer/REPRIORITIZED_PLAN.md
@@ -896,6 +896,17 @@ family. This prevents a later sky/world replay from becoming procedural input
 merely because it is the most recent retained target; no Xenos content is
 accepted as a native source.
 
+Accumulator source-gate checkpoint: two equivalent prototype launches crashed
+before gameplay after title-only mode-12 resolves repeatedly reached the
+accumulator without an exact private producer. A pure-Xenos run and a prototype
+run with only the accumulator disabled both remained healthy past the failure
+window, isolating the fault. Accumulator planning now requires a successfully
+recorded exact procedural replay from the same guest frame before observing a
+copy. The enabled AppData rerun exited normally after rejecting 78,646
+unqualified title callbacks at the gate, with zero backend requests, upload
+failures, allocation failures, or crashes. This keeps discovery observations
+available without creating title-screen resources and preserves Xenos output.
+
 ### C2. Static world buildings and props
 
 - Expand opaque-world material and geometry coverage.

--- a/src/native_renderer/graphics_hooks.cpp
+++ b/src/native_renderer/graphics_hooks.cpp
@@ -11307,6 +11307,9 @@ uint64_t g_procedural_frame_accumulator_backend_detail_count = 0;
 uint64_t g_procedural_frame_accumulator_backend_detail_overflow = 0;
 uint64_t g_procedural_frame_accumulator_backend_unavailable_frame = UINT64_MAX;
 uint64_t g_procedural_frame_accumulator_same_frame_yields = 0;
+uint64_t g_procedural_frame_accumulator_exact_source_frame = UINT64_MAX;
+uint64_t g_procedural_frame_accumulator_pending_source_frame = UINT64_MAX;
+uint64_t g_procedural_frame_accumulator_source_gate_yields = 0;
 bool g_graphics_census_installed = false;
 bool g_graphics_full_census_armed = false;
 rex::memory::Memory *g_graphics_census_memory = nullptr;
@@ -11604,6 +11607,9 @@ void ResetCommandBufferLineage() {
   g_procedural_frame_accumulator_backend_detail_overflow = 0;
   g_procedural_frame_accumulator_backend_unavailable_frame = UINT64_MAX;
   g_procedural_frame_accumulator_same_frame_yields = 0;
+  g_procedural_frame_accumulator_exact_source_frame = UINT64_MAX;
+  g_procedural_frame_accumulator_pending_source_frame = UINT64_MAX;
+  g_procedural_frame_accumulator_source_gate_yields = 0;
 }
 
 void ResetDependencyCensus() {
@@ -17525,6 +17531,11 @@ bool PlanProceduralFrameAccumulatorBackend(
       !observation.succeeded) {
     return false;
   }
+  if (observation.frame_sequence !=
+      g_procedural_frame_accumulator_exact_source_frame) {
+    ++g_procedural_frame_accumulator_source_gate_yields;
+    return false;
+  }
   if (observation.frame_sequence ==
       g_procedural_frame_accumulator_backend_unavailable_frame) {
     ++g_procedural_frame_accumulator_same_frame_yields;
@@ -18182,6 +18193,9 @@ void EmitProceduralColorTargetProfiles() {
         std::to_string(g_procedural_frame_accumulator_backend_statuses[3])},
        {"same_frame_yields_after_unavailable",
         std::to_string(g_procedural_frame_accumulator_same_frame_yields)},
+       {"source_gate_yields",
+        std::to_string(g_procedural_frame_accumulator_source_gate_yields)},
+       {"source_gate", "same_frame_recorded_exact_procedural_replay"},
        {"retry_policy", "next_frame"},
        {"unsupported_target",
         std::to_string(g_procedural_frame_accumulator_backend_statuses[4])},
@@ -27118,6 +27132,21 @@ void CompleteContinuousWorldWorksetReplay(
   }
 }
 
+void CompleteContinuousWorldProceduralSourceReplay(
+    const rex::system::GraphicsIsolatedDrawResult &result) {
+  const uint64_t source_frame =
+      g_procedural_frame_accumulator_pending_source_frame;
+  CompleteContinuousWorldWorksetReplay(result);
+  if (result.status == rex::system::GraphicsIsolatedDrawStatus::kRecorded &&
+      source_frame != UINT64_MAX) {
+    g_procedural_frame_accumulator_exact_source_frame = source_frame;
+  } else if (g_procedural_frame_accumulator_exact_source_frame ==
+             source_frame) {
+    g_procedural_frame_accumulator_exact_source_frame = UINT64_MAX;
+  }
+  g_procedural_frame_accumulator_pending_source_frame = UINT64_MAX;
+}
+
 void EmitContinuousWorldWorksetEvent(const char *event_name,
                                      bool final_summary,
                                      uint64_t frame_sequence) {
@@ -27776,7 +27805,13 @@ void RequestIsolatedDraw(
     request.frame_accumulator_source = exact_procedural_color_producer;
     request.frame_sequence = g_isolated_draw.frame;
     request.reference_marker_requested = true;
-    request.completion = &CompleteContinuousWorldWorksetReplay;
+    if (exact_procedural_color_producer) {
+      g_procedural_frame_accumulator_pending_source_frame =
+          g_isolated_draw.frame;
+      request.completion = &CompleteContinuousWorldProceduralSourceReplay;
+    } else {
+      request.completion = &CompleteContinuousWorldWorksetReplay;
+    }
     return;
   }
   if (g_visibility_shadow_replay.requested &&

--- a/tools/tests/test_native_renderer_continuous_world_workset.py
+++ b/tools/tests/test_native_renderer_continuous_world_workset.py
@@ -215,6 +215,16 @@ class ContinuousWorldWorksetTests(unittest.TestCase):
             "isolated_replay_frame_accumulator_source_frame_sequence_", patch
         )
         self.assertIn("unqualified_source", source)
+        self.assertIn(
+            "g_procedural_frame_accumulator_exact_source_frame", source
+        )
+        self.assertIn(
+            "CompleteContinuousWorldProceduralSourceReplay", source
+        )
+        self.assertIn(
+            '"source_gate", "same_frame_recorded_exact_procedural_replay"',
+            source,
+        )
 
     def test_exact_track_color_only_replay_is_private_and_bounded(self):
         source = (ROOT / "src/native_renderer/graphics_hooks.cpp").read_text(


### PR DESCRIPTION
## Summary
- require a successfully recorded exact procedural replay from the same guest frame before accumulator planning
- prevent title/front-end resolve traffic from reaching private accumulator resource work
- record the deterministic crash isolation and successful AppData rerun in the reprioritized roadmap

## Validation
- `python -m unittest discover -s tools/tests` (713 passed)
- incremental Release build
- AppData launch with native prototype and accumulator enabled: normal exit after the prior crash window, 78,646 source-gate yields, zero backend accumulator requests, zero upload/allocation failures, zero crashes