### PR TITLE
fix(native-renderer): gate prototype on qualified draw scale

### DIFF
--- a/docs/native-renderer/REPRIORITIZED_PLAN.md
+++ b/docs/native-renderer/REPRIORITIZED_PLAN.md
@@ -907,6 +907,17 @@ unqualified title callbacks at the gate, with zero backend requests, upload
 failures, allocation failures, or crashes. This keeps discovery observations
 available without creating title-screen resources and preserves Xenos output.
 
+Draw-scale compatibility checkpoint: the next open-world transition exposed
+that the saved launcher configuration uses 2x draw resolution. Both the normal
+prototype and an accumulator-disabled prototype failed with the same crash ID,
+while an otherwise equivalent pure-Xenos control reached the saved festival,
+remained stable, and exited normally. The current private replay and output
+contracts are qualified only at 1x1 draw scale, so all prototype observers,
+replay, accumulation, and native output now fail closed to Xenos before install
+at any other scale. Scaled native replay remains required work: it must prove
+render-target extent, emulated-MSAA sample mapping, logical presentation, and
+performance independently before the compatibility gate can widen.
+
 ### C2. Static world buildings and props
 
 - Expand opaque-world material and geometry coverage.

--- a/src/native_renderer/graphics_hooks.cpp
+++ b/src/native_renderer/graphics_hooks.cpp
@@ -61,7 +61,20 @@ namespace {
 constexpr uint64_t kFrameSummaryInterval = 300;
 constexpr size_t kSignatureCapacity = 4096;
 
+bool NativePrototypeScaleSupported() {
+  return rex::cvar::GetFlagByName("draw_resolution_scale_x") == "1" &&
+         rex::cvar::GetFlagByName("draw_resolution_scale_y") == "1";
+}
+
 bool NativePrototypeSelected() {
+  const std::string mode = REXCVAR_GET(pinyon_shift_native_renderer);
+  const bool requested =
+      mode == "native_prototype" || mode == "hybrid_prototype" ||
+      mode == "comparison_native" || mode == "comparison_xenos";
+  return requested && NativePrototypeScaleSupported();
+}
+
+bool NativePrototypeRequested() {
   const std::string mode = REXCVAR_GET(pinyon_shift_native_renderer);
   return mode == "native_prototype" || mode == "hybrid_prototype" ||
          mode == "comparison_native" || mode == "comparison_xenos";
@@ -30934,8 +30947,26 @@ void InstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system,
   const bool census_requested =
       REXCVAR_GET(pinyon_shift_native_renderer_census);
   g_graphics_full_census_armed = census_requested;
+  const bool prototype_requested = NativePrototypeRequested();
   const bool prototype_selected = NativePrototypeSelected();
+  if (prototype_requested) {
+    pinyon_shift::diagnostics::RecordEvent(
+        "native_renderer.prototype.compatibility",
+        {{"status", prototype_selected ? "supported" : "fallback_xenos"},
+         {"reason", prototype_selected ? "qualified" :
+                                          "unsupported_draw_resolution_scale"},
+         {"draw_resolution_scale_x",
+          rex::cvar::GetFlagByName("draw_resolution_scale_x")},
+         {"draw_resolution_scale_y",
+          rex::cvar::GetFlagByName("draw_resolution_scale_y")},
+         {"qualified_scale", "1x1"},
+         {"prototype_observers", prototype_selected ? "armed" : "disabled"},
+         {"fallback", "xenos"},
+         {"xenos_draw", "preserved"},
+         {"suppression", "disabled"}});
+  }
   const bool procedural_frame_accumulator_requested =
+      NativePrototypeScaleSupported() &&
       ProceduralFrameAccumulatorSelected(prototype_selected);
   const bool minimal_producer_graph_requested =
       prototype_selected && !census_requested &&

--- a/src/native_renderer/guest_output_renderer.cpp
+++ b/src/native_renderer/guest_output_renderer.cpp
@@ -255,6 +255,27 @@ void InstallGuestOutputRenderer(rex::system::IGraphicsSystem *graphics_system) {
   const std::string mode = REXCVAR_GET(pinyon_shift_native_renderer);
   const bool legacy_clear =
       REXCVAR_GET(pinyon_shift_native_renderer_diagnostic_clear);
+  const bool prototype_mode =
+      mode == "native_prototype" || mode == "hybrid_prototype" ||
+      mode == "comparison_native" || mode == "comparison_xenos";
+  const std::string draw_resolution_scale_x =
+      rex::cvar::GetFlagByName("draw_resolution_scale_x");
+  const std::string draw_resolution_scale_y =
+      rex::cvar::GetFlagByName("draw_resolution_scale_y");
+  if (prototype_mode &&
+      (draw_resolution_scale_x != "1" || draw_resolution_scale_y != "1")) {
+    diagnostics::RecordEvent(
+        "native_renderer.output.failure",
+        {{"reason", "unsupported_draw_resolution_scale"},
+         {"requested_mode", mode},
+         {"draw_resolution_scale_x", draw_resolution_scale_x},
+         {"draw_resolution_scale_y", draw_resolution_scale_y},
+         {"qualified_scale", "1x1"},
+         {"fallback", "xenos"},
+         {"xenos_draw", "preserved"},
+         {"suppression", "disabled"}});
+    return;
+  }
   if (mode == "xenos" && !legacy_clear) {
     diagnostics::RecordEvent("native_renderer.output.state",
                              {{"mode", "xenos"}, {"authority", "xenos"}});

--- a/tools/tests/test_native_renderer_prototype_presentation.py
+++ b/tools/tests/test_native_renderer_prototype_presentation.py
@@ -22,6 +22,26 @@ class NativeRendererPrototypePresentationTests(unittest.TestCase):
             '"logical_scene_scale_then_title_gamma_then_title_upscale"', output
         )
 
+    def test_prototype_fails_closed_outside_qualified_draw_scale(self):
+        hooks = (ROOT / "src/native_renderer/graphics_hooks.cpp").read_text(
+            encoding="utf-8"
+        )
+        output = (ROOT / "src/native_renderer/guest_output_renderer.cpp").read_text(
+            encoding="utf-8"
+        )
+        for source in (hooks, output):
+            self.assertIn("draw_resolution_scale_x", source)
+            self.assertIn("draw_resolution_scale_y", source)
+            self.assertIn('"unsupported_draw_resolution_scale"', source)
+            self.assertIn('{"fallback", "xenos"}', source)
+        self.assertIn("NativePrototypeScaleSupported()", hooks)
+        self.assertIn('"prototype_observers"', hooks)
+        self.assertIn("if (prototype_mode &&", output)
+        self.assertLess(
+            output.index("if (prototype_mode &&"),
+            output.index("SetNativeGuestOutputRenderer"),
+        )
+
     def test_rexglue_patch_preserves_legacy_preview_and_adds_passthrough(self):
         patch = (
             ROOT


### PR DESCRIPTION
## Summary
- fail closed to Xenos when prototype modes are requested outside the qualified 1x1 draw scale
- skip prototype observers, replay, accumulation, and native output callback at unsupported scales
- report requested mode, configured scales, compatibility reason, and preserved fallback
- record the 2x crash isolation and scaled-native follow-up in the roadmap

## Validation
- `python -m unittest discover -s tools/tests` (714 passed)
- incremental Release build
- AppData 2x native-prototype request: reached open world, normal exit, compatibility fallback recorded, zero prototype observers/workset/accumulator/output callbacks installed