### PR TITLE
fix(native-renderer): bind replay completion to request identity

### DIFF
--- a/docs/native-renderer/REPRIORITIZED_PLAN.md
+++ b/docs/native-renderer/REPRIORITIZED_PLAN.md
@@ -918,6 +918,14 @@ at any other scale. Scaled native replay remains required work: it must prove
 render-target extent, emulated-MSAA sample mapping, logical presentation, and
 performance independently before the compatibility gate can widen.
 
+Replay-completion ownership checkpoint: exact-source qualification no longer
+depends on one mutable title-side pending frame shared by all replay requests.
+The backend completion result now returns the request's frame sequence and
+accumulator-source role on both indexed and auto-indexed paths. The title marks
+an accumulator source only when that exact request records successfully. This
+keeps frame ownership correct if title submission and graphics completion are
+decoupled, and is required before scaled replay can safely widen.
+
 ### C2. Static world buildings and props
 
 - Expand opaque-world material and geometry coverage.

--- a/patches/rexglue/0114-isolated-replay-result-source-identity.patch
+++ b/patches/rexglue/0114-isolated-replay-result-source-identity.patch
@@ -1,0 +1,34 @@
+diff --git a/include/rex/system/interfaces/graphics.h b/include/rex/system/interfaces/graphics.h
+--- a/include/rex/system/interfaces/graphics.h
++++ b/include/rex/system/interfaces/graphics.h
+@@ -506,5 +506,7 @@ struct GraphicsIsolatedDrawResult {
+   GraphicsIsolatedDrawStatus status =
+       GraphicsIsolatedDrawStatus::kUnsupportedState;
++  uint64_t frame_sequence = 0;
++  bool frame_accumulator_source = false;
+   uint32_t target_width = 0;
+   uint32_t target_height = 0;
+   GraphicsIsolatedDrawTargetFailure target_failure =
+diff --git a/src/graphics/d3d12/command_processor.cpp b/src/graphics/d3d12/command_processor.cpp
+--- a/src/graphics/d3d12/command_processor.cpp
++++ b/src/graphics/d3d12/command_processor.cpp
+@@ -3805,6 +3805,9 @@ bool D3D12CommandProcessor::IssueDraw(PrimitiveType primitive_type,
+     SubmitBarriers();
+     if (isolated_draw_request.requested) {
+       system::GraphicsIsolatedDrawResult isolated_result;
++      isolated_result.frame_sequence = isolated_draw_request.frame_sequence;
++      isolated_result.frame_accumulator_source =
++          isolated_draw_request.frame_accumulator_source;
+       if (memexport_used || !host_render_targets_used ||
+           !is_rasterization_done) {
+         isolated_result.status =
+@@ -4061,6 +4064,9 @@ bool D3D12CommandProcessor::IssueDraw(PrimitiveType primitive_type,
+     SubmitBarriers();
+     if (isolated_draw_request.requested) {
+       system::GraphicsIsolatedDrawResult isolated_result;
++      isolated_result.frame_sequence = isolated_draw_request.frame_sequence;
++      isolated_result.frame_accumulator_source =
++          isolated_draw_request.frame_accumulator_source;
+       const bool isolated_index_buffer_supported =
+           primitive_processing_result.index_buffer_type ==
+               PrimitiveProcessor::ProcessedIndexBufferType::kGuestDMA ||

--- a/src/native_renderer/graphics_hooks.cpp
+++ b/src/native_renderer/graphics_hooks.cpp
@@ -11321,7 +11321,6 @@ uint64_t g_procedural_frame_accumulator_backend_detail_overflow = 0;
 uint64_t g_procedural_frame_accumulator_backend_unavailable_frame = UINT64_MAX;
 uint64_t g_procedural_frame_accumulator_same_frame_yields = 0;
 uint64_t g_procedural_frame_accumulator_exact_source_frame = UINT64_MAX;
-uint64_t g_procedural_frame_accumulator_pending_source_frame = UINT64_MAX;
 uint64_t g_procedural_frame_accumulator_source_gate_yields = 0;
 bool g_graphics_census_installed = false;
 bool g_graphics_full_census_armed = false;
@@ -11621,7 +11620,6 @@ void ResetCommandBufferLineage() {
   g_procedural_frame_accumulator_backend_unavailable_frame = UINT64_MAX;
   g_procedural_frame_accumulator_same_frame_yields = 0;
   g_procedural_frame_accumulator_exact_source_frame = UINT64_MAX;
-  g_procedural_frame_accumulator_pending_source_frame = UINT64_MAX;
   g_procedural_frame_accumulator_source_gate_yields = 0;
 }
 
@@ -27147,8 +27145,9 @@ void CompleteContinuousWorldWorksetReplay(
 
 void CompleteContinuousWorldProceduralSourceReplay(
     const rex::system::GraphicsIsolatedDrawResult &result) {
-  const uint64_t source_frame =
-      g_procedural_frame_accumulator_pending_source_frame;
+  const uint64_t source_frame = result.frame_accumulator_source
+                                    ? result.frame_sequence
+                                    : UINT64_MAX;
   CompleteContinuousWorldWorksetReplay(result);
   if (result.status == rex::system::GraphicsIsolatedDrawStatus::kRecorded &&
       source_frame != UINT64_MAX) {
@@ -27157,7 +27156,6 @@ void CompleteContinuousWorldProceduralSourceReplay(
              source_frame) {
     g_procedural_frame_accumulator_exact_source_frame = UINT64_MAX;
   }
-  g_procedural_frame_accumulator_pending_source_frame = UINT64_MAX;
 }
 
 void EmitContinuousWorldWorksetEvent(const char *event_name,
@@ -27819,8 +27817,6 @@ void RequestIsolatedDraw(
     request.frame_sequence = g_isolated_draw.frame;
     request.reference_marker_requested = true;
     if (exact_procedural_color_producer) {
-      g_procedural_frame_accumulator_pending_source_frame =
-          g_isolated_draw.frame;
       request.completion = &CompleteContinuousWorldProceduralSourceReplay;
     } else {
       request.completion = &CompleteContinuousWorldWorksetReplay;

--- a/tools/tests/test_native_renderer_continuous_world_workset.py
+++ b/tools/tests/test_native_renderer_continuous_world_workset.py
@@ -209,6 +209,10 @@ class ContinuousWorldWorksetTests(unittest.TestCase):
             ROOT
             / "patches/rexglue/0113-d3d12-procedural-accumulator-source-ownership.patch"
         ).read_text(encoding="utf-8")
+        result_patch = (
+            ROOT
+            / "patches/rexglue/0114-isolated-replay-result-source-identity.patch"
+        ).read_text(encoding="utf-8")
         self.assertIn("frame_accumulator_source", patch)
         self.assertIn("kUnqualifiedSource", patch)
         self.assertIn(
@@ -224,6 +228,13 @@ class ContinuousWorldWorksetTests(unittest.TestCase):
         self.assertIn(
             '"source_gate", "same_frame_recorded_exact_procedural_replay"',
             source,
+        )
+        self.assertIn("isolated_result.frame_sequence", result_patch)
+        self.assertIn("isolated_result.frame_accumulator_source", result_patch)
+        self.assertIn("result.frame_sequence", source)
+        self.assertIn("result.frame_accumulator_source", source)
+        self.assertNotIn(
+            "g_procedural_frame_accumulator_pending_source_frame", source
         )
 
     def test_exact_track_color_only_replay_is_private_and_bounded(self):

--- a/tools/tests/test_release_contract.py
+++ b/tools/tests/test_release_contract.py
@@ -43,10 +43,10 @@ class ReleaseContractTests(unittest.TestCase):
 
     def test_rexglue_patches_have_stable_order_and_no_binary_payload(self):
         patches = sorted((ROOT / "patches/rexglue").glob("*.patch"))
-        self.assertEqual(len(patches), 113)
+        self.assertEqual(len(patches), 114)
         self.assertEqual(
             patches[-1].name,
-            "0113-d3d12-procedural-accumulator-source-ownership.patch",
+            "0114-isolated-replay-result-source-identity.patch",
         )
         self.assertEqual(len(patches), len({path.name[:4] for path in patches}))
         for path in patches:


### PR DESCRIPTION
## Summary
- return isolated replay frame identity and accumulator-source role in backend completion results
- qualify exact accumulator sources from the completed request rather than mutable title state
- record the prerequisite in the reprioritized renderer plan

## Validation
- python -m unittest discover -s tools/tests (714 passed)
- Release title build
- ReXGlue runtime and D3D12 plugin Release builds
- full ReXGlue patch stack through 0114 applies cleanly