### PR TITLE
feat(native-renderer): report isolated replay geometry

### DIFF
--- a/docs/native-renderer/REPRIORITIZED_PLAN.md
+++ b/docs/native-renderer/REPRIORITIZED_PLAN.md
@@ -952,6 +952,21 @@ offset and extent, sample selection, and render-target key agreement. This
 closes the ambiguity between a wrong source target and a wrong crop before any
 scaled replay is enabled.
 
+Resolve-region qualification (`20260901T144616Z-p15856`) proved that the live
+source and resolve both use target key `0:32:12:4`. The two visible full-width
+chunks read guest rectangles `1280x256` and `1280x208`, corresponding to
+physical `2560x512` and `2560x416` rectangles at 2x, both beginning at source
+origin `0,0` with sample select `6`. Target selection is therefore correct; the
+remaining mismatch is downstream in private replay geometry, accumulator
+row/sample mapping, or presentation.
+
+Replay-geometry implementation checkpoint: every indexed and auto-indexed
+isolated completion now reports the exact scaled logical extent, private target
+extent, and active draw scale together with request identity. The continuous
+procedural workset retains this contract in its bounded summary. This creates a
+direct replay-versus-resolve comparison before any 2x replay or output gate is
+widened; Xenos remains authoritative and suppression remains disabled.
+
 ### C2. Static world buildings and props
 
 - Expand opaque-world material and geometry coverage.

--- a/patches/rexglue/0118-d3d12-isolated-replay-geometry-result.patch
+++ b/patches/rexglue/0118-d3d12-isolated-replay-geometry-result.patch
@@ -1,0 +1,54 @@
+From 1300627243b606308ab4e28ea2c3f19f63c77b52 Mon Sep 17 00:00:00 2001
+From: "Brandon G. Neri" <arcaniteamp@gmail.com>
+Date: Tue, 1 Sep 2026 08:54:36 -0600
+Subject: [PATCH] feat(graphics): report isolated replay geometry
+
+---
+ include/rex/system/interfaces/graphics.h | 4 ++++
+ src/graphics/d3d12/command_processor.cpp | 8 ++++++++
+ 2 files changed, 12 insertions(+)
+
+diff --git a/include/rex/system/interfaces/graphics.h b/include/rex/system/interfaces/graphics.h
+index c832e29..94c9c24 100644
+--- a/include/rex/system/interfaces/graphics.h
++++ b/include/rex/system/interfaces/graphics.h
+@@ -546,6 +546,10 @@ struct GraphicsIsolatedDrawResult {
+       GraphicsIsolatedDrawStatus::kUnsupportedState;
+   uint64_t frame_sequence = 0;
+   bool frame_accumulator_source = false;
++  uint32_t logical_width = 0;
++  uint32_t logical_height = 0;
++  uint32_t draw_resolution_scale_x = 0;
++  uint32_t draw_resolution_scale_y = 0;
+   uint32_t target_width = 0;
+   uint32_t target_height = 0;
+   GraphicsIsolatedDrawTargetFailure target_failure =
+diff --git a/src/graphics/d3d12/command_processor.cpp b/src/graphics/d3d12/command_processor.cpp
+index e7a5b76..a5acc02 100644
+--- a/src/graphics/d3d12/command_processor.cpp
++++ b/src/graphics/d3d12/command_processor.cpp
+@@ -3808,6 +3808,10 @@ bool D3D12CommandProcessor::IssueDraw(xenos::PrimitiveType primitive_type, uint3
+       isolated_result.frame_sequence = isolated_draw_request.frame_sequence;
+       isolated_result.frame_accumulator_source =
+           isolated_draw_request.frame_accumulator_source;
++      isolated_result.logical_width = isolated_replay_logical_width;
++      isolated_result.logical_height = isolated_replay_logical_height;
++      isolated_result.draw_resolution_scale_x = draw_resolution_scale_x;
++      isolated_result.draw_resolution_scale_y = draw_resolution_scale_y;
+       if (memexport_used || !host_render_targets_used ||
+           !is_rasterization_done) {
+         isolated_result.status =
+@@ -4067,6 +4071,10 @@ bool D3D12CommandProcessor::IssueDraw(xenos::PrimitiveType primitive_type, uint3
+       isolated_result.frame_sequence = isolated_draw_request.frame_sequence;
+       isolated_result.frame_accumulator_source =
+           isolated_draw_request.frame_accumulator_source;
++      isolated_result.logical_width = isolated_replay_logical_width;
++      isolated_result.logical_height = isolated_replay_logical_height;
++      isolated_result.draw_resolution_scale_x = draw_resolution_scale_x;
++      isolated_result.draw_resolution_scale_y = draw_resolution_scale_y;
+       const bool isolated_index_buffer_supported =
+           primitive_processing_result.index_buffer_type ==
+               PrimitiveProcessor::ProcessedIndexBufferType::kGuestDMA ||
+-- 
+2.51.1.windows.1
+

--- a/src/native_renderer/graphics_hooks.cpp
+++ b/src/native_renderer/graphics_hooks.cpp
@@ -10090,6 +10090,13 @@ struct ContinuousWorldWorksetState {
   uint64_t reused_target_requests = 0;
   uint64_t target_reseed_requests = 0;
   uint64_t procedural_color_target_reseed_requests = 0;
+  uint64_t procedural_source_geometry_frame = UINT64_MAX;
+  uint32_t procedural_source_logical_width = 0;
+  uint32_t procedural_source_logical_height = 0;
+  uint32_t procedural_source_target_width = 0;
+  uint32_t procedural_source_target_height = 0;
+  uint32_t procedural_source_draw_scale_x = 0;
+  uint32_t procedural_source_draw_scale_y = 0;
   uint64_t frames_started = 0;
   uint64_t frames_completed = 0;
   uint64_t frames_failed = 0;
@@ -26590,8 +26597,13 @@ void CompleteIsolatedDraw(
        {"status", status},
        {"frame", std::to_string(g_isolated_draw.captured_frame)},
        {"draw", std::to_string(g_isolated_draw.captured_draw)},
+       {"logical_extent",
+        fmt::format("{}x{}", result.logical_width, result.logical_height)},
        {"target_width", std::to_string(result.target_width)},
        {"target_height", std::to_string(result.target_height)},
+       {"draw_scale",
+        fmt::format("{}x{}", result.draw_resolution_scale_x,
+                    result.draw_resolution_scale_y)},
        {"native_draw", result.status ==
                                    rex::system::GraphicsIsolatedDrawStatus::kRecorded
                                ? "isolated_only"
@@ -27210,6 +27222,19 @@ void CompleteContinuousWorldProceduralSourceReplay(
   if (result.status == rex::system::GraphicsIsolatedDrawStatus::kRecorded &&
       source_frame != UINT64_MAX) {
     g_procedural_frame_accumulator_exact_source_frame = source_frame;
+    g_continuous_world_workset.procedural_source_geometry_frame = source_frame;
+    g_continuous_world_workset.procedural_source_logical_width =
+        result.logical_width;
+    g_continuous_world_workset.procedural_source_logical_height =
+        result.logical_height;
+    g_continuous_world_workset.procedural_source_target_width =
+        result.target_width;
+    g_continuous_world_workset.procedural_source_target_height =
+        result.target_height;
+    g_continuous_world_workset.procedural_source_draw_scale_x =
+        result.draw_resolution_scale_x;
+    g_continuous_world_workset.procedural_source_draw_scale_y =
+        result.draw_resolution_scale_y;
   } else if (g_procedural_frame_accumulator_exact_source_frame ==
              source_frame) {
     g_procedural_frame_accumulator_exact_source_frame = UINT64_MAX;
@@ -27389,6 +27414,27 @@ void EmitContinuousWorldWorksetEvent(const char *event_name,
        {"procedural_color_target_reseed_requests",
         std::to_string(g_continuous_world_workset
                            .procedural_color_target_reseed_requests)},
+       {"procedural_source_geometry_frame",
+        g_continuous_world_workset.procedural_source_geometry_frame ==
+                UINT64_MAX
+            ? "none"
+            : std::to_string(
+                  g_continuous_world_workset.procedural_source_geometry_frame)},
+       {"procedural_source_logical_extent",
+        fmt::format(
+            "{}x{}",
+            g_continuous_world_workset.procedural_source_logical_width,
+            g_continuous_world_workset.procedural_source_logical_height)},
+       {"procedural_source_target_extent",
+        fmt::format(
+            "{}x{}",
+            g_continuous_world_workset.procedural_source_target_width,
+            g_continuous_world_workset.procedural_source_target_height)},
+       {"procedural_source_draw_scale",
+        fmt::format(
+            "{}x{}",
+            g_continuous_world_workset.procedural_source_draw_scale_x,
+            g_continuous_world_workset.procedural_source_draw_scale_y)},
        {"frames_started",
         std::to_string(g_continuous_world_workset.frames_started)},
        {"frames_completed", std::to_string(frames_completed)},

--- a/tools/tests/test_native_renderer_continuous_world_workset.py
+++ b/tools/tests/test_native_renderer_continuous_world_workset.py
@@ -289,6 +289,26 @@ class ContinuousWorldWorksetTests(unittest.TestCase):
         self.assertIn('"resolve_physical_rect"', source)
         self.assertIn('"resolve_destination"', source)
 
+    def test_isolated_replay_reports_scaled_geometry(self):
+        source = (ROOT / "src/native_renderer/graphics_hooks.cpp").read_text(
+            encoding="utf-8"
+        )
+        patch = (
+            ROOT
+            / "patches/rexglue/0118-d3d12-isolated-replay-geometry-result.patch"
+        ).read_text(encoding="utf-8")
+        for field in (
+            "logical_width",
+            "logical_height",
+            "draw_resolution_scale_x",
+            "draw_resolution_scale_y",
+        ):
+            self.assertIn(field, patch)
+            self.assertIn(field, source)
+        self.assertIn('"procedural_source_logical_extent"', source)
+        self.assertIn('"procedural_source_target_extent"', source)
+        self.assertIn('"procedural_source_draw_scale"', source)
+
     def test_exact_track_color_only_replay_is_private_and_bounded(self):
         source = (ROOT / "src/native_renderer/graphics_hooks.cpp").read_text(
             encoding="utf-8"

--- a/tools/tests/test_release_contract.py
+++ b/tools/tests/test_release_contract.py
@@ -43,10 +43,10 @@ class ReleaseContractTests(unittest.TestCase):
 
     def test_rexglue_patches_have_stable_order_and_no_binary_payload(self):
         patches = sorted((ROOT / "patches/rexglue").glob("*.patch"))
-        self.assertEqual(len(patches), 117)
+        self.assertEqual(len(patches), 118)
         self.assertEqual(
             patches[-1].name,
-            "0117-d3d12-resolve-region-topology-observation.patch",
+            "0118-d3d12-isolated-replay-geometry-result.patch",
         )
         self.assertEqual(len(patches), len({path.name[:4] for path in patches}))
         for path in patches:


### PR DESCRIPTION
## Summary\n- report exact logical extent and draw scale with isolated replay completion identity\n- retain procedural replay geometry in bounded workset diagnostics\n- record the authoritative 2x resolve-region qualification in the reprioritized plan\n\n## Safety\n- Xenos remains authoritative\n- native draw suppression remains disabled\n- the 1x1 prototype compatibility gate is unchanged\n\n## Validation\n- 718 Python contract tests passed\n- Release pinyon_shift target built successfully