### PR TITLE
feat(native-renderer): plan scaled accumulator layout

### DIFF
--- a/docs/native-renderer/REPRIORITIZED_PLAN.md
+++ b/docs/native-renderer/REPRIORITIZED_PLAN.md
@@ -967,6 +967,17 @@ procedural workset retains this contract in its bounded summary. This creates a
 direct replay-versus-resolve comparison before any 2x replay or output gate is
 widened; Xenos remains authoritative and suppression remains disabled.
 
+Scaled-layout implementation checkpoint: a backend-neutral, checked-arithmetic
+contract now reconciles each logical accumulator transition with the exact live
+resolve target, guest and physical source rectangles, draw scale, destination
+mapping, and sample selection. At 2x the three proved chunks map to destination
+rows `0`, `512`, and `1024`; the final chunk copies 416 physical source rows
+from source origin and preserves 32 separate padding rows in the 1472-row
+storage allocation. A destination-row source crop, target mismatch, missing
+topology, non-averaging sample selection, or arithmetic overflow fails closed.
+The bounded census reports the resulting physical plan, but backend copying is
+not admitted yet and the prototype compatibility gate remains 1x1.
+
 ### C2. Static world buildings and props
 
 - Expand opaque-world material and geometry coverage.

--- a/src/native_renderer/graphics_hooks.cpp
+++ b/src/native_renderer/graphics_hooks.cpp
@@ -11329,6 +11329,9 @@ uint64_t g_procedural_frame_accumulator_backend_unavailable_frame = UINT64_MAX;
 uint64_t g_procedural_frame_accumulator_same_frame_yields = 0;
 uint64_t g_procedural_frame_accumulator_exact_source_frame = UINT64_MAX;
 uint64_t g_procedural_frame_accumulator_source_gate_yields = 0;
+std::array<uint64_t, 8> g_procedural_frame_accumulator_layout_statuses{};
+uint64_t g_procedural_frame_accumulator_layout_detail_count = 0;
+uint64_t g_procedural_frame_accumulator_layout_detail_overflow = 0;
 bool g_graphics_census_installed = false;
 bool g_graphics_full_census_armed = false;
 rex::memory::Memory *g_graphics_census_memory = nullptr;
@@ -11628,6 +11631,9 @@ void ResetCommandBufferLineage() {
   g_procedural_frame_accumulator_same_frame_yields = 0;
   g_procedural_frame_accumulator_exact_source_frame = UINT64_MAX;
   g_procedural_frame_accumulator_source_gate_yields = 0;
+  g_procedural_frame_accumulator_layout_statuses.fill(0);
+  g_procedural_frame_accumulator_layout_detail_count = 0;
+  g_procedural_frame_accumulator_layout_detail_overflow = 0;
 }
 
 void ResetDependencyCensus() {
@@ -17599,6 +17605,84 @@ ProceduralResolveCopyFromObservation(
           .written_length = observation.written_length};
 }
 
+void ObserveProceduralFrameAccumulatorPhysicalLayout(
+    const pinyon_shift::native_renderer::
+        ProceduralFrameAccumulatorTransition &transition,
+    const rex::system::GraphicsCopyObservation &observation) {
+  if (!transition.append || transition.cancel) {
+    return;
+  }
+  const pinyon_shift::native_renderer::
+      ProceduralFrameAccumulatorSourceTopology topology{
+          .resource_width = observation.source_resource_width,
+          .resource_height = observation.source_resource_height,
+          .host_sample_count = observation.source_sample_count,
+          .guest_msaa_samples = observation.source_guest_msaa_samples,
+          .draw_scale_x = observation.draw_resolution_scale_x,
+          .draw_scale_y = observation.draw_resolution_scale_y,
+          .target_base_tiles = observation.source_target_base_tiles,
+          .target_pitch_tiles =
+              observation.source_target_pitch_tiles_at_32bpp,
+          .resolve_base_tiles = observation.resolve_source_base_tiles,
+          .resolve_pitch_tiles = observation.resolve_source_pitch_tiles,
+          .resolve_guest_msaa_samples =
+              observation.resolve_source_guest_msaa_samples,
+          .source_guest_x = observation.resolve_guest_offset_x,
+          .source_guest_y = observation.resolve_guest_offset_y,
+          .source_guest_width = observation.resolve_guest_width,
+          .source_guest_height = observation.resolve_guest_height,
+          .source_physical_x = observation.resolve_physical_offset_x,
+          .source_physical_y = observation.resolve_physical_offset_y,
+          .source_physical_width = observation.resolve_physical_width,
+          .source_physical_height = observation.resolve_physical_height,
+          .destination_x = observation.resolve_dest_offset_x,
+          .destination_y = observation.resolve_dest_offset_y,
+          .destination_pitch = observation.resolve_dest_pitch,
+          .destination_height = observation.resolve_dest_height,
+          .sample_select = observation.resolve_sample_select,
+          .source_available = observation.source_target_available,
+          .resolve_info_valid = observation.resolve_info_valid,
+          .native_2x_msaa = observation.native_2x_msaa};
+  const auto layout = pinyon_shift::native_renderer::
+      BuildProceduralFrameAccumulatorPhysicalLayout(transition, topology);
+  const size_t status_index = size_t(layout.status);
+  if (status_index < g_procedural_frame_accumulator_layout_statuses.size()) {
+    ++g_procedural_frame_accumulator_layout_statuses[status_index];
+  }
+  if (g_procedural_frame_accumulator_layout_detail_count ==
+      kProceduralRuntimeDetailLimit) {
+    ++g_procedural_frame_accumulator_layout_detail_overflow;
+    return;
+  }
+  ++g_procedural_frame_accumulator_layout_detail_count;
+  pinyon_shift::diagnostics::RecordEvent(
+      "native_renderer.procedural_frame_accumulator.layout",
+      {{"frame", std::to_string(transition.frame_sequence)},
+       {"chunk", std::to_string(transition.chunk_count)},
+       {"status",
+        pinyon_shift::native_renderer::
+            ProceduralFrameAccumulatorLayoutStatusName(layout.status)},
+       {"output_extent",
+        fmt::format("{}x{}", layout.output_width,
+                    layout.output_logical_height)},
+       {"output_storage_height",
+        std::to_string(layout.output_storage_height)},
+       {"destination_rows",
+        fmt::format("{}+{}/{}", layout.destination_row,
+                    layout.destination_copy_rows,
+                    layout.destination_storage_rows)},
+       {"source_rect",
+        fmt::format("{},{} {}x{}", layout.source_x, layout.source_y,
+                    layout.source_width, layout.source_height)},
+       {"padding_rows", std::to_string(layout.padding_rows)},
+       {"samples",
+        fmt::format("host={};guest={};select={}", layout.host_sample_count,
+                    layout.guest_msaa_samples, layout.sample_select)},
+       {"backend_copy", "not_yet_admitted"},
+       {"xenos_authority", "true"},
+       {"suppression_allowed", "false"}});
+}
+
 bool PlanProceduralFrameAccumulatorBackend(
     const rex::system::GraphicsCopyObservation &observation,
     rex::system::GraphicsNativeFrameAccumulatorRequest &request_out) {
@@ -17620,6 +17704,7 @@ bool PlanProceduralFrameAccumulatorBackend(
   const auto transition = g_procedural_frame_accumulator_planner.Observe(
       ProceduralResolveCopyFromObservation(observation));
   EmitProceduralFrameAccumulatorTransition(transition);
+  ObserveProceduralFrameAccumulatorPhysicalLayout(transition, observation);
   if (!transition.actionable()) {
     return false;
   }
@@ -18247,6 +18332,26 @@ void EmitProceduralColorTargetProfiles() {
             g_procedural_frame_accumulator_qualified_resolve_source_modes[1])},
        {"detail_limit",
         std::to_string(kProceduralRuntimeDetailLimit)},
+       {"physical_layout_ready",
+        std::to_string(g_procedural_frame_accumulator_layout_statuses[0])},
+       {"physical_layout_no_append",
+        std::to_string(g_procedural_frame_accumulator_layout_statuses[1])},
+       {"physical_layout_missing_topology",
+        std::to_string(g_procedural_frame_accumulator_layout_statuses[2])},
+       {"physical_layout_invalid_scale",
+        std::to_string(g_procedural_frame_accumulator_layout_statuses[3])},
+       {"physical_layout_target_mismatch",
+        std::to_string(g_procedural_frame_accumulator_layout_statuses[4])},
+       {"physical_layout_region_mismatch",
+        std::to_string(g_procedural_frame_accumulator_layout_statuses[5])},
+       {"physical_layout_unsupported_samples",
+        std::to_string(g_procedural_frame_accumulator_layout_statuses[6])},
+       {"physical_layout_overflow",
+        std::to_string(g_procedural_frame_accumulator_layout_statuses[7])},
+       {"physical_layout_detail_events",
+        std::to_string(g_procedural_frame_accumulator_layout_detail_count)},
+       {"physical_layout_detail_overflow",
+        std::to_string(g_procedural_frame_accumulator_layout_detail_overflow)},
        {"backend_resource_action",
         g_procedural_frame_accumulator_backend_armed ? "private_only"
                                                      : "false"},
@@ -28994,8 +29099,10 @@ void ObserveCopy(const rex::system::GraphicsCopyObservation &observation) {
   EmitProceduralResolveAssembly(
       g_procedural_resolve_assembly_tracker.Observe(copy));
   if (!g_procedural_frame_accumulator_backend_armed) {
-    EmitProceduralFrameAccumulatorTransition(
-        g_procedural_frame_accumulator_planner.Observe(copy));
+    const auto transition =
+        g_procedural_frame_accumulator_planner.Observe(copy);
+    EmitProceduralFrameAccumulatorTransition(transition);
+    ObserveProceduralFrameAccumulatorPhysicalLayout(transition, observation);
   }
 
   ++g_dependency_census.window_resolve_count;

--- a/src/native_renderer/resolve_frame_accumulator.cpp
+++ b/src/native_renderer/resolve_frame_accumulator.cpp
@@ -5,6 +5,177 @@
 
 namespace pinyon_shift::native_renderer {
 
+namespace {
+
+bool CheckedMultiply(uint32_t left, uint32_t right, uint32_t &result_out) {
+  const uint64_t result = uint64_t(left) * right;
+  if (result > UINT32_MAX) {
+    return false;
+  }
+  result_out = uint32_t(result);
+  return true;
+}
+
+bool CheckedAdd(uint32_t left, uint32_t right, uint32_t &result_out) {
+  const uint64_t result = uint64_t(left) + right;
+  if (result > UINT32_MAX) {
+    return false;
+  }
+  result_out = uint32_t(result);
+  return true;
+}
+
+}  // namespace
+
+ProceduralFrameAccumulatorPhysicalLayout
+BuildProceduralFrameAccumulatorPhysicalLayout(
+    const ProceduralFrameAccumulatorTransition &transition,
+    const ProceduralFrameAccumulatorSourceTopology &topology) {
+  ProceduralFrameAccumulatorPhysicalLayout layout;
+  if (!transition.append || transition.cancel) {
+    return layout;
+  }
+  if (!topology.source_available || !topology.resolve_info_valid) {
+    layout.status = ProceduralFrameAccumulatorLayoutStatus::kMissingTopology;
+    return layout;
+  }
+  if (!topology.draw_scale_x || !topology.draw_scale_y ||
+      topology.draw_scale_x > 7 || topology.draw_scale_y > 7) {
+    layout.status = ProceduralFrameAccumulatorLayoutStatus::kInvalidScale;
+    return layout;
+  }
+  if (topology.target_base_tiles != topology.resolve_base_tiles ||
+      topology.target_pitch_tiles != topology.resolve_pitch_tiles ||
+      topology.guest_msaa_samples !=
+          topology.resolve_guest_msaa_samples) {
+    layout.status = ProceduralFrameAccumulatorLayoutStatus::kTargetMismatch;
+    return layout;
+  }
+  const bool supported_samples =
+      topology.host_sample_count == topology.guest_msaa_samples ||
+      (topology.guest_msaa_samples == 2 &&
+       topology.host_sample_count == 4 && !topology.native_2x_msaa);
+  // The proved family resolves all samples. Keep other resolve semantics closed
+  // until their native single-sample conversion is implemented explicitly.
+  if (!supported_samples || topology.sample_select != 6) {
+    layout.status =
+        ProceduralFrameAccumulatorLayoutStatus::kUnsupportedSamples;
+    return layout;
+  }
+
+  uint32_t output_width = 0;
+  uint32_t output_logical_height = 0;
+  uint32_t output_storage_height = 0;
+  uint32_t destination_row = 0;
+  uint32_t destination_storage_rows = 0;
+  uint32_t destination_copy_rows = 0;
+  uint32_t expected_source_x = 0;
+  uint32_t expected_source_y = 0;
+  uint32_t expected_source_width = 0;
+  uint32_t expected_source_height = 0;
+  if (!CheckedMultiply(transition.logical_width, topology.draw_scale_x,
+                       output_width) ||
+      !CheckedMultiply(transition.logical_height, topology.draw_scale_y,
+                       output_logical_height) ||
+      !CheckedMultiply(topology.destination_height, topology.draw_scale_y,
+                       output_storage_height) ||
+      !CheckedMultiply(transition.destination_row, topology.draw_scale_y,
+                       destination_row) ||
+      !CheckedMultiply(transition.storage_row_count, topology.draw_scale_y,
+                       destination_storage_rows) ||
+      !CheckedMultiply(transition.logical_row_count, topology.draw_scale_y,
+                       destination_copy_rows) ||
+      !CheckedMultiply(topology.source_guest_x, topology.draw_scale_x,
+                       expected_source_x) ||
+      !CheckedMultiply(topology.source_guest_y, topology.draw_scale_y,
+                       expected_source_y) ||
+      !CheckedMultiply(topology.source_guest_width, topology.draw_scale_x,
+                       expected_source_width) ||
+      !CheckedMultiply(topology.source_guest_height, topology.draw_scale_y,
+                       expected_source_height)) {
+    layout.status = ProceduralFrameAccumulatorLayoutStatus::kOverflow;
+    return layout;
+  }
+  uint32_t source_end_x = 0;
+  uint32_t source_end_y = 0;
+  uint32_t destination_copy_end = 0;
+  uint32_t destination_storage_end = 0;
+  if (!CheckedAdd(topology.source_physical_x,
+                  topology.source_physical_width, source_end_x) ||
+      !CheckedAdd(topology.source_physical_y,
+                  topology.source_physical_height, source_end_y) ||
+      !CheckedAdd(destination_row, destination_copy_rows,
+                  destination_copy_end) ||
+      !CheckedAdd(destination_row, destination_storage_rows,
+                  destination_storage_end)) {
+    layout.status = ProceduralFrameAccumulatorLayoutStatus::kOverflow;
+    return layout;
+  }
+  const bool region_matches =
+      topology.source_physical_x == expected_source_x &&
+      topology.source_physical_y == expected_source_y &&
+      topology.source_physical_width == expected_source_width &&
+      topology.source_physical_height == expected_source_height &&
+      topology.source_guest_width == transition.logical_width &&
+      topology.source_guest_height == transition.logical_row_count &&
+      topology.destination_x == 0 && topology.destination_y == 0 &&
+      topology.destination_pitch == transition.logical_width &&
+      topology.destination_height >= transition.logical_height &&
+      uint64_t(topology.destination_height) <
+          uint64_t(transition.logical_height) + 64 &&
+      source_end_x <= topology.resource_width &&
+      source_end_y <= topology.resource_height &&
+      destination_copy_end <= output_logical_height &&
+      destination_storage_end <= output_storage_height &&
+      (!transition.commit ||
+       destination_storage_end == output_storage_height) &&
+      destination_copy_rows <= destination_storage_rows;
+  if (!region_matches) {
+    layout.status = ProceduralFrameAccumulatorLayoutStatus::kRegionMismatch;
+    return layout;
+  }
+
+  layout.status = ProceduralFrameAccumulatorLayoutStatus::kReady;
+  layout.output_width = output_width;
+  layout.output_logical_height = output_logical_height;
+  layout.output_storage_height = output_storage_height;
+  layout.destination_row = destination_row;
+  layout.destination_storage_rows = destination_storage_rows;
+  layout.destination_copy_rows = destination_copy_rows;
+  layout.source_x = topology.source_physical_x;
+  layout.source_y = topology.source_physical_y;
+  layout.source_width = topology.source_physical_width;
+  layout.source_height = topology.source_physical_height;
+  layout.padding_rows = destination_storage_rows - destination_copy_rows;
+  layout.host_sample_count = topology.host_sample_count;
+  layout.guest_msaa_samples = topology.guest_msaa_samples;
+  layout.sample_select = topology.sample_select;
+  return layout;
+}
+
+const char *ProceduralFrameAccumulatorLayoutStatusName(
+    ProceduralFrameAccumulatorLayoutStatus status) {
+  switch (status) {
+    case ProceduralFrameAccumulatorLayoutStatus::kReady:
+      return "ready";
+    case ProceduralFrameAccumulatorLayoutStatus::kNoAppend:
+      return "no_append";
+    case ProceduralFrameAccumulatorLayoutStatus::kMissingTopology:
+      return "missing_topology";
+    case ProceduralFrameAccumulatorLayoutStatus::kInvalidScale:
+      return "invalid_scale";
+    case ProceduralFrameAccumulatorLayoutStatus::kTargetMismatch:
+      return "target_mismatch";
+    case ProceduralFrameAccumulatorLayoutStatus::kRegionMismatch:
+      return "region_mismatch";
+    case ProceduralFrameAccumulatorLayoutStatus::kUnsupportedSamples:
+      return "unsupported_samples";
+    case ProceduralFrameAccumulatorLayoutStatus::kOverflow:
+      return "overflow";
+  }
+  return "unknown";
+}
+
 void ProceduralFrameAccumulatorPlanner::Reset(uint64_t frame_sequence) {
   frame_sequence_ = frame_sequence;
   target_ = {};

--- a/src/native_renderer/resolve_frame_accumulator.h
+++ b/src/native_renderer/resolve_frame_accumulator.h
@@ -43,6 +43,84 @@ struct ProceduralFrameAccumulatorTransition {
   bool actionable() const { return begin || append || commit || cancel; }
 };
 
+enum class ProceduralFrameAccumulatorLayoutStatus : uint8_t {
+  kReady,
+  kNoAppend,
+  kMissingTopology,
+  kInvalidScale,
+  kTargetMismatch,
+  kRegionMismatch,
+  kUnsupportedSamples,
+  kOverflow,
+};
+
+// Payload-free topology captured from the authoritative Xenos resolve. This is
+// deliberately backend-neutral so layout qualification can be unit-tested
+// without creating or reading a GPU resource.
+struct ProceduralFrameAccumulatorSourceTopology {
+  uint32_t resource_width = 0;
+  uint32_t resource_height = 0;
+  uint32_t host_sample_count = 0;
+  uint32_t guest_msaa_samples = 0;
+  uint32_t draw_scale_x = 0;
+  uint32_t draw_scale_y = 0;
+  uint32_t target_base_tiles = 0;
+  uint32_t target_pitch_tiles = 0;
+  uint32_t resolve_base_tiles = 0;
+  uint32_t resolve_pitch_tiles = 0;
+  uint32_t resolve_guest_msaa_samples = 0;
+  uint32_t source_guest_x = 0;
+  uint32_t source_guest_y = 0;
+  uint32_t source_guest_width = 0;
+  uint32_t source_guest_height = 0;
+  uint32_t source_physical_x = 0;
+  uint32_t source_physical_y = 0;
+  uint32_t source_physical_width = 0;
+  uint32_t source_physical_height = 0;
+  uint32_t destination_x = 0;
+  uint32_t destination_y = 0;
+  uint32_t destination_pitch = 0;
+  uint32_t destination_height = 0;
+  uint32_t sample_select = 0;
+  bool source_available = false;
+  bool resolve_info_valid = false;
+  bool native_2x_msaa = false;
+};
+
+struct ProceduralFrameAccumulatorPhysicalLayout {
+  ProceduralFrameAccumulatorLayoutStatus status =
+      ProceduralFrameAccumulatorLayoutStatus::kNoAppend;
+  uint32_t output_width = 0;
+  uint32_t output_logical_height = 0;
+  uint32_t output_storage_height = 0;
+  uint32_t destination_row = 0;
+  uint32_t destination_storage_rows = 0;
+  uint32_t destination_copy_rows = 0;
+  uint32_t source_x = 0;
+  uint32_t source_y = 0;
+  uint32_t source_width = 0;
+  uint32_t source_height = 0;
+  uint32_t padding_rows = 0;
+  uint32_t host_sample_count = 0;
+  uint32_t guest_msaa_samples = 0;
+  uint32_t sample_select = 0;
+
+  bool ready() const {
+    return status == ProceduralFrameAccumulatorLayoutStatus::kReady;
+  }
+};
+
+// Reconciles one logical row-assembly transition with the exact authoritative
+// resolve source rectangle. It performs checked arithmetic and rejects target,
+// crop, padding, sample, and draw-scale mismatches before a backend can copy.
+ProceduralFrameAccumulatorPhysicalLayout
+BuildProceduralFrameAccumulatorPhysicalLayout(
+    const ProceduralFrameAccumulatorTransition &transition,
+    const ProceduralFrameAccumulatorSourceTopology &topology);
+
+const char *ProceduralFrameAccumulatorLayoutStatusName(
+    ProceduralFrameAccumulatorLayoutStatus status);
+
 // Produces a backend-neutral, fail-closed row-copy plan for assembling the
 // proved procedural EDRAM chunks into one private padded frame. It owns no GPU
 // resources and cannot publish, suppress, or otherwise alter guest rendering.

--- a/tests/native_renderer/resolve_frame_accumulator_test.cpp
+++ b/tests/native_renderer/resolve_frame_accumulator_test.cpp
@@ -34,6 +34,37 @@ nr::ProceduralResolveCopy Copy(uint32_t address, uint32_t length,
           .written_length = length};
 }
 
+nr::ProceduralFrameAccumulatorSourceTopology Topology(
+    uint32_t guest_height, uint32_t scale = 2) {
+  return {.resource_width = 1280 * scale,
+          .resource_height = 512 * scale,
+          .host_sample_count = 4,
+          .guest_msaa_samples = 4,
+          .draw_scale_x = scale,
+          .draw_scale_y = scale,
+          .target_base_tiles = 0,
+          .target_pitch_tiles = 32,
+          .resolve_base_tiles = 0,
+          .resolve_pitch_tiles = 32,
+          .resolve_guest_msaa_samples = 4,
+          .source_guest_x = 0,
+          .source_guest_y = 0,
+          .source_guest_width = 1280,
+          .source_guest_height = guest_height,
+          .source_physical_x = 0,
+          .source_physical_y = 0,
+          .source_physical_width = 1280 * scale,
+          .source_physical_height = guest_height * scale,
+          .destination_x = 0,
+          .destination_y = 0,
+          .destination_pitch = 1280,
+          .destination_height = 736,
+          .sample_select = 6,
+          .source_available = true,
+          .resolve_info_valid = true,
+          .native_2x_msaa = true};
+}
+
 }  // namespace
 
 int main() {
@@ -62,6 +93,62 @@ int main() {
               third.logical_row_count == 208 &&
               third.padded_height == 736 && third.chunk_count == 3,
           "the final chunk must commit 720 logical and 736 stored rows");
+
+  const auto first_layout =
+      nr::BuildProceduralFrameAccumulatorPhysicalLayout(first, Topology(256));
+  Require(first_layout.ready() && first_layout.output_width == 2560 &&
+              first_layout.output_logical_height == 1440 &&
+              first_layout.output_storage_height == 1472 &&
+              first_layout.destination_row == 0 &&
+              first_layout.destination_copy_rows == 512 &&
+              first_layout.padding_rows == 0 &&
+              first_layout.source_width == 2560 &&
+              first_layout.source_height == 512,
+          "the first 2x resolve must map exactly into physical rows");
+  const auto second_layout =
+      nr::BuildProceduralFrameAccumulatorPhysicalLayout(second, Topology(256));
+  Require(second_layout.ready() && second_layout.destination_row == 512 &&
+              second_layout.output_storage_height == 1472 &&
+              second_layout.destination_copy_rows == 512,
+          "the second 2x resolve must append after the first physical rows");
+  const auto third_layout =
+      nr::BuildProceduralFrameAccumulatorPhysicalLayout(third, Topology(208));
+  Require(third_layout.ready() && third_layout.destination_row == 1024 &&
+              third_layout.output_logical_height == 1440 &&
+              third_layout.output_storage_height == 1472 &&
+              third_layout.destination_copy_rows == 416 &&
+              third_layout.destination_storage_rows == 448 &&
+              third_layout.padding_rows == 32 &&
+              third_layout.source_y == 0 && third_layout.source_height == 416,
+          "the final 2x resolve must preserve logical rows and padded storage");
+
+  auto wrong_target = Topology(256);
+  wrong_target.resolve_pitch_tiles = 31;
+  Require(nr::BuildProceduralFrameAccumulatorPhysicalLayout(first,
+                                                             wrong_target)
+                  .status == nr::ProceduralFrameAccumulatorLayoutStatus::
+                                 kTargetMismatch,
+          "a different resolve target must fail closed");
+  auto wrong_crop = Topology(256);
+  wrong_crop.source_physical_y = 512;
+  Require(nr::BuildProceduralFrameAccumulatorPhysicalLayout(first, wrong_crop)
+                  .status == nr::ProceduralFrameAccumulatorLayoutStatus::
+                                 kRegionMismatch,
+          "a destination-row source crop must fail against resolve origin");
+  auto wrong_samples = Topology(256);
+  wrong_samples.sample_select = 0;
+  Require(nr::BuildProceduralFrameAccumulatorPhysicalLayout(first,
+                                                             wrong_samples)
+                  .status == nr::ProceduralFrameAccumulatorLayoutStatus::
+                                 kUnsupportedSamples,
+          "a non-averaging sample selection must remain unsupported");
+  auto missing_topology = Topology(256);
+  missing_topology.resolve_info_valid = false;
+  Require(nr::BuildProceduralFrameAccumulatorPhysicalLayout(first,
+                                                             missing_topology)
+                  .status == nr::ProceduralFrameAccumulatorLayoutStatus::
+                                 kMissingTopology,
+          "missing resolve geometry must fail closed");
   Require(!planner.Flush().actionable(),
           "a committed frame must not be cancelled at shutdown");
 

--- a/tools/tests/test_native_renderer_continuous_world_workset.py
+++ b/tools/tests/test_native_renderer_continuous_world_workset.py
@@ -309,6 +309,32 @@ class ContinuousWorldWorksetTests(unittest.TestCase):
         self.assertIn('"procedural_source_target_extent"', source)
         self.assertIn('"procedural_source_draw_scale"', source)
 
+    def test_scaled_accumulator_layout_reconciles_authoritative_regions(self):
+        source = (ROOT / "src/native_renderer/graphics_hooks.cpp").read_text(
+            encoding="utf-8"
+        )
+        header = (
+            ROOT / "src/native_renderer/resolve_frame_accumulator.h"
+        ).read_text(encoding="utf-8")
+        implementation = (
+            ROOT / "src/native_renderer/resolve_frame_accumulator.cpp"
+        ).read_text(encoding="utf-8")
+        native_test = (
+            ROOT / "tests/native_renderer/resolve_frame_accumulator_test.cpp"
+        ).read_text(encoding="utf-8")
+        self.assertIn("ProceduralFrameAccumulatorSourceTopology", header)
+        self.assertIn("ProceduralFrameAccumulatorPhysicalLayout", header)
+        self.assertIn("BuildProceduralFrameAccumulatorPhysicalLayout", header)
+        self.assertIn("topology.source_guest_y", implementation)
+        self.assertIn("destination_copy_rows", implementation)
+        self.assertIn("padding_rows", implementation)
+        self.assertIn("third_layout.source_y == 0", native_test)
+        self.assertIn("third_layout.padding_rows == 32", native_test)
+        self.assertIn(
+            '"native_renderer.procedural_frame_accumulator.layout"', source
+        )
+        self.assertIn('"backend_copy", "not_yet_admitted"', source)
+
     def test_exact_track_color_only_replay_is_private_and_bounded(self):
         source = (ROOT / "src/native_renderer/graphics_hooks.cpp").read_text(
             encoding="utf-8"


### PR DESCRIPTION
## Summary\n- derive an exact physical accumulator layout from authoritative Xenos resolve topology\n- separate logical copy rows from padded storage rows at every draw scale\n- reject target, crop, scale, sample-selection, and overflow mismatches before backend admission\n- emit bounded layout diagnostics while preserving Xenos authority\n\n## Safety\n- no backend copy behavior changes\n- no native output or suppression changes\n- the 1x1 prototype compatibility gate remains unchanged\n\n## Validation\n- 719 Python contract tests passed\n- native resolve-frame-accumulator executable passed\n- Release pinyon_shift target built successfully