### PR TITLE
feat(native-renderer): carry scaled accumulator request

### DIFF
--- a/docs/native-renderer/REPRIORITIZED_PLAN.md
+++ b/docs/native-renderer/REPRIORITIZED_PLAN.md
@@ -978,6 +978,15 @@ topology, non-averaging sample selection, or arithmetic overflow fails closed.
 The bounded census reports the resulting physical plan, but backend copying is
 not admitted yet and the prototype compatibility gate remains 1x1.
 
+Backend-boundary checkpoint: the title now submits an accumulator request only
+when that physical plan is ready. The request carries the exact source origin
+and extent, physical copy and padding row counts, destination geometry, and
+sample selection; the D3D12 result echoes the same contract even on a rejected
+target. This closes the previous interface ambiguity where the backend knew
+only padded destination rows and inferred a source crop. The existing copy
+implementation does not consume the new crop/sample fields yet, so scaled
+backend admission and the 1x1 compatibility gate remain unchanged.
+
 ### C2. Static world buildings and props
 
 - Expand opaque-world material and geometry coverage.

--- a/patches/rexglue/0119-d3d12-accumulator-source-layout-request.patch
+++ b/patches/rexglue/0119-d3d12-accumulator-source-layout-request.patch
@@ -1,0 +1,63 @@
+From afd3561c9b1a8e5fbd551bea0dfe1edd46697bde Mon Sep 17 00:00:00 2001
+From: "Brandon G. Neri" <arcaniteamp@gmail.com>
+Date: Tue, 1 Sep 2026 09:15:54 -0600
+Subject: [PATCH] feat(graphics): carry accumulator source layout
+
+---
+ include/rex/system/interfaces/graphics.h   | 14 ++++++++++++++
+ src/graphics/d3d12/render_target_cache.cpp |  7 +++++++
+ 2 files changed, 21 insertions(+)
+
+diff --git a/include/rex/system/interfaces/graphics.h b/include/rex/system/interfaces/graphics.h
+index 94c9c24..0236bc9 100644
+--- a/include/rex/system/interfaces/graphics.h
++++ b/include/rex/system/interfaces/graphics.h
+@@ -415,6 +415,13 @@ struct GraphicsNativeFrameAccumulatorResult {
+   uint32_t source_guest_msaa_samples = 0;
+   uint32_t draw_resolution_scale_x = 0;
+   uint32_t draw_resolution_scale_y = 0;
++  uint32_t requested_source_x = 0;
++  uint32_t requested_source_y = 0;
++  uint32_t requested_source_width = 0;
++  uint32_t requested_source_height = 0;
++  uint32_t requested_copy_row_count = 0;
++  uint32_t requested_padding_row_count = 0;
++  uint32_t requested_sample_select = 0;
+   bool native_2x_msaa = false;
+   bool committed = false;
+ };
+@@ -432,6 +439,13 @@ struct GraphicsNativeFrameAccumulatorRequest {
+   uint32_t storage_height = 0;
+   uint32_t destination_row = 0;
+   uint32_t storage_row_count = 0;
++  uint32_t source_x = 0;
++  uint32_t source_y = 0;
++  uint32_t source_width = 0;
++  uint32_t source_height = 0;
++  uint32_t copy_row_count = 0;
++  uint32_t padding_row_count = 0;
++  uint32_t sample_select = 0;
+   bool begin = false;
+   bool append = false;
+   bool commit = false;
+diff --git a/src/graphics/d3d12/render_target_cache.cpp b/src/graphics/d3d12/render_target_cache.cpp
+index 73272f1..3efce08 100644
+--- a/src/graphics/d3d12/render_target_cache.cpp
++++ b/src/graphics/d3d12/render_target_cache.cpp
+@@ -2609,6 +2609,13 @@ D3D12RenderTargetCache::ApplyIsolatedReplayFrameAccumulator(
+     const system::GraphicsNativeFrameAccumulatorRequest& request) {
+   system::GraphicsNativeFrameAccumulatorResult result;
+   result.frame_sequence = frame_sequence;
++  result.requested_source_x = request.source_x;
++  result.requested_source_y = request.source_y;
++  result.requested_source_width = request.source_width;
++  result.requested_source_height = request.source_height;
++  result.requested_copy_row_count = request.copy_row_count;
++  result.requested_padding_row_count = request.padding_row_count;
++  result.requested_sample_select = request.sample_select;
+   const auto clear_active = [&]() {
+     isolated_replay_frame_accumulator_frame_sequence_ = 0;
+     isolated_replay_frame_accumulator_committed_frame_sequence_ = 0;
+-- 
+2.51.1.windows.1
+

--- a/src/native_renderer/graphics_hooks.cpp
+++ b/src/native_renderer/graphics_hooks.cpp
@@ -17579,6 +17579,16 @@ void CompleteProceduralFrameAccumulatorBackend(
        {"draw_scale",
         fmt::format("{}x{}", result.draw_resolution_scale_x,
                     result.draw_resolution_scale_y)},
+       {"requested_source_rect",
+        fmt::format("{},{} {}x{}", result.requested_source_x,
+                    result.requested_source_y,
+                    result.requested_source_width,
+                    result.requested_source_height)},
+       {"requested_rows",
+        fmt::format("copy={};padding={}", result.requested_copy_row_count,
+                    result.requested_padding_row_count)},
+       {"requested_sample_select",
+        std::to_string(result.requested_sample_select)},
        {"native_2x_msaa", result.native_2x_msaa ? "true" : "false"},
        {"appended_row_end", std::to_string(result.appended_row_end)},
        {"committed", result.committed ? "true" : "false"},
@@ -17605,12 +17615,13 @@ ProceduralResolveCopyFromObservation(
           .written_length = observation.written_length};
 }
 
-void ObserveProceduralFrameAccumulatorPhysicalLayout(
+pinyon_shift::native_renderer::ProceduralFrameAccumulatorPhysicalLayout
+ObserveProceduralFrameAccumulatorPhysicalLayout(
     const pinyon_shift::native_renderer::
         ProceduralFrameAccumulatorTransition &transition,
     const rex::system::GraphicsCopyObservation &observation) {
   if (!transition.append || transition.cancel) {
-    return;
+    return {};
   }
   const pinyon_shift::native_renderer::
       ProceduralFrameAccumulatorSourceTopology topology{
@@ -17652,7 +17663,7 @@ void ObserveProceduralFrameAccumulatorPhysicalLayout(
   if (g_procedural_frame_accumulator_layout_detail_count ==
       kProceduralRuntimeDetailLimit) {
     ++g_procedural_frame_accumulator_layout_detail_overflow;
-    return;
+    return layout;
   }
   ++g_procedural_frame_accumulator_layout_detail_count;
   pinyon_shift::diagnostics::RecordEvent(
@@ -17681,6 +17692,7 @@ void ObserveProceduralFrameAccumulatorPhysicalLayout(
        {"backend_copy", "not_yet_admitted"},
        {"xenos_authority", "true"},
        {"suppression_allowed", "false"}});
+  return layout;
 }
 
 bool PlanProceduralFrameAccumulatorBackend(
@@ -17704,8 +17716,12 @@ bool PlanProceduralFrameAccumulatorBackend(
   const auto transition = g_procedural_frame_accumulator_planner.Observe(
       ProceduralResolveCopyFromObservation(observation));
   EmitProceduralFrameAccumulatorTransition(transition);
-  ObserveProceduralFrameAccumulatorPhysicalLayout(transition, observation);
+  const auto physical_layout =
+      ObserveProceduralFrameAccumulatorPhysicalLayout(transition, observation);
   if (!transition.actionable()) {
+    return false;
+  }
+  if (!transition.cancel && !physical_layout.ready()) {
     return false;
   }
   if (!transition.cancel &&
@@ -17716,11 +17732,18 @@ bool PlanProceduralFrameAccumulatorBackend(
            kProceduralFrameAccumulatorStorageHeight)) {
     return false;
   }
-  request_out.logical_width = transition.logical_width;
-  request_out.logical_height = transition.logical_height;
-  request_out.storage_height = kProceduralFrameAccumulatorStorageHeight;
-  request_out.destination_row = transition.destination_row;
-  request_out.storage_row_count = transition.storage_row_count;
+  request_out.logical_width = physical_layout.output_width;
+  request_out.logical_height = physical_layout.output_logical_height;
+  request_out.storage_height = physical_layout.output_storage_height;
+  request_out.destination_row = physical_layout.destination_row;
+  request_out.storage_row_count = physical_layout.destination_storage_rows;
+  request_out.source_x = physical_layout.source_x;
+  request_out.source_y = physical_layout.source_y;
+  request_out.source_width = physical_layout.source_width;
+  request_out.source_height = physical_layout.source_height;
+  request_out.copy_row_count = physical_layout.destination_copy_rows;
+  request_out.padding_row_count = physical_layout.padding_rows;
+  request_out.sample_select = physical_layout.sample_select;
   request_out.begin = transition.begin;
   request_out.append = transition.append;
   request_out.commit = transition.commit;

--- a/tools/tests/test_native_renderer_continuous_world_workset.py
+++ b/tools/tests/test_native_renderer_continuous_world_workset.py
@@ -335,6 +335,30 @@ class ContinuousWorldWorksetTests(unittest.TestCase):
         )
         self.assertIn('"backend_copy", "not_yet_admitted"', source)
 
+    def test_scaled_layout_crosses_accumulator_backend_contract(self):
+        source = (ROOT / "src/native_renderer/graphics_hooks.cpp").read_text(
+            encoding="utf-8"
+        )
+        patch = (
+            ROOT
+            / "patches/rexglue/0119-d3d12-accumulator-source-layout-request.patch"
+        ).read_text(encoding="utf-8")
+        for field in (
+            "source_x",
+            "source_y",
+            "source_width",
+            "source_height",
+            "copy_row_count",
+            "padding_row_count",
+            "sample_select",
+        ):
+            self.assertIn(field, patch)
+            self.assertIn(f"request_out.{field}", source)
+        self.assertIn("requested_source_x", patch)
+        self.assertIn('"requested_source_rect"', source)
+        self.assertIn('"requested_rows"', source)
+        self.assertIn("!physical_layout.ready()", source)
+
     def test_exact_track_color_only_replay_is_private_and_bounded(self):
         source = (ROOT / "src/native_renderer/graphics_hooks.cpp").read_text(
             encoding="utf-8"

--- a/tools/tests/test_release_contract.py
+++ b/tools/tests/test_release_contract.py
@@ -43,10 +43,10 @@ class ReleaseContractTests(unittest.TestCase):
 
     def test_rexglue_patches_have_stable_order_and_no_binary_payload(self):
         patches = sorted((ROOT / "patches/rexglue").glob("*.patch"))
-        self.assertEqual(len(patches), 118)
+        self.assertEqual(len(patches), 119)
         self.assertEqual(
             patches[-1].name,
-            "0118-d3d12-isolated-replay-geometry-result.patch",
+            "0119-d3d12-accumulator-source-layout-request.patch",
         )
         self.assertEqual(len(patches), len({path.name[:4] for path in patches}))
         for path in patches:


### PR DESCRIPTION
## Summary\n- gate accumulator requests on the exact physical layout contract\n- carry source crop, physical copy rows, padding rows, and sample selection into D3D12\n- echo the requested geometry in bounded completion diagnostics, including rejection paths\n\n## Safety\n- existing backend copy implementation is unchanged\n- native output and suppression behavior are unchanged\n- scaled prototype admission remains closed\n\n## Validation\n- 720 Python contract tests passed\n- Release pinyon_shift target built successfully