### PR TITLE
feat(native-renderer): add scaled accumulator qualification

### DIFF
--- a/docs/native-renderer/REPRIORITIZED_PLAN.md
+++ b/docs/native-renderer/REPRIORITIZED_PLAN.md
@@ -999,6 +999,16 @@ accounting, and sample selection remain fail-closed. The 2x presentation gate
 is still closed pending a batched AppData qualification of replay geometry and
 this backend path.
 
+Scaled-qualification harness checkpoint: a default-off census profile may arm
+the private procedural replay and exact accumulator at exactly `2x2`, but only
+when the selected output renderer is explicitly `xenos`. The harness enables
+the complete track/static continuous workset, forces Xenos authority for the
+process, records an armed-or-blocked configuration event, publishes no native
+frame, suppresses no guest draws, and restores every environment override on
+exit. Any other scale, renderer, missing census, or missing accumulator request
+fails closed. This is a diagnostic admission path only; it does not widen the
+visible prototype compatibility gate.
+
 ### C2. Static world buildings and props
 
 - Expand opaque-world material and geometry coverage.

--- a/src/native_renderer/graphics_hooks.cpp
+++ b/src/native_renderer/graphics_hooks.cpp
@@ -54,6 +54,12 @@ REXCVAR_DEFINE_BOOL(
     "Pinyon Shift",
     "Assemble exact procedural resolve tiles in a private native frame")
     .lifecycle(rex::cvar::Lifecycle::kRequiresRestart);
+REXCVAR_DEFINE_BOOL(
+    pinyon_shift_native_renderer_scaled_accumulator_qualification, false,
+    "Pinyon Shift",
+    "Qualify the private procedural accumulator at exactly 2x while Xenos "
+    "remains authoritative")
+    .lifecycle(rex::cvar::Lifecycle::kRequiresRestart);
 REXCVAR_DECLARE(std::string, pinyon_shift_native_renderer);
 
 namespace {
@@ -64,6 +70,11 @@ constexpr size_t kSignatureCapacity = 4096;
 bool NativePrototypeScaleSupported() {
   return rex::cvar::GetFlagByName("draw_resolution_scale_x") == "1" &&
          rex::cvar::GetFlagByName("draw_resolution_scale_y") == "1";
+}
+
+bool NativeScaledAccumulatorScaleSupported() {
+  return rex::cvar::GetFlagByName("draw_resolution_scale_x") == "2" &&
+         rex::cvar::GetFlagByName("draw_resolution_scale_y") == "2";
 }
 
 bool NativePrototypeSelected() {
@@ -31179,6 +31190,12 @@ void InstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system,
   g_graphics_full_census_armed = census_requested;
   const bool prototype_requested = NativePrototypeRequested();
   const bool prototype_selected = NativePrototypeSelected();
+  const bool scaled_accumulator_qualification_requested = REXCVAR_GET(
+      pinyon_shift_native_renderer_scaled_accumulator_qualification);
+  const bool scaled_accumulator_qualification_supported =
+      scaled_accumulator_qualification_requested && census_requested &&
+      NativeScaledAccumulatorScaleSupported() &&
+      REXCVAR_GET(pinyon_shift_native_renderer) == "xenos";
   if (prototype_requested) {
     pinyon_shift::diagnostics::RecordEvent(
         "native_renderer.prototype.compatibility",
@@ -31195,9 +31212,34 @@ void InstallGraphicsCensus(rex::system::IGraphicsSystem *graphics_system,
          {"xenos_draw", "preserved"},
          {"suppression", "disabled"}});
   }
-  const bool procedural_frame_accumulator_requested =
-      NativePrototypeScaleSupported() &&
+  const bool procedural_frame_accumulator_selected =
       ProceduralFrameAccumulatorSelected(prototype_selected);
+  const bool procedural_frame_accumulator_requested =
+      procedural_frame_accumulator_selected &&
+      (NativePrototypeScaleSupported() ||
+       scaled_accumulator_qualification_supported);
+  if (scaled_accumulator_qualification_requested) {
+    pinyon_shift::diagnostics::RecordEvent(
+        "native_renderer.scaled_accumulator_qualification.config",
+        {{"status", scaled_accumulator_qualification_supported &&
+                            procedural_frame_accumulator_selected
+                        ? "armed_private_2x"
+                        : "blocked_invalid_configuration"},
+         {"requires_census", "true"},
+         {"census", census_requested ? "armed" : "disabled"},
+         {"accumulator",
+          procedural_frame_accumulator_selected ? "requested" : "disabled"},
+         {"renderer", REXCVAR_GET(pinyon_shift_native_renderer)},
+         {"draw_resolution_scale_x",
+          rex::cvar::GetFlagByName("draw_resolution_scale_x")},
+         {"draw_resolution_scale_y",
+          rex::cvar::GetFlagByName("draw_resolution_scale_y")},
+         {"qualified_scale", "2x2"},
+         {"publication", "disabled"},
+         {"output_authority", "xenos"},
+         {"fallback", "xenos"},
+         {"draw_suppression", "false"}});
+  }
   const bool minimal_producer_graph_requested =
       prototype_selected && !census_requested &&
       procedural_frame_accumulator_requested;

--- a/tools/capture-native-renderer-census.ps1
+++ b/tools/capture-native-renderer-census.ps1
@@ -39,6 +39,7 @@ param(
     [switch]$VehicleDrawCorrelation,
     [switch]$ShadowCasterProvenance,
     [switch]$ProceduralFrameAccumulator,
+    [switch]$ScaledAccumulatorQualification,
     [ValidateSet(
         'baseline',
         'trackfardistance',
@@ -73,6 +74,16 @@ if ($PhaseCQualification) {
     $ContinuousTrackWorld = $true
     $ContinuousStaticWorld = $true
     $VehicleDrawCorrelation = $true
+}
+
+if ($ScaledAccumulatorQualification) {
+    if ($Scene -eq 'unmarked') {
+        $Scene = 'open_world_day'
+    }
+    $ProceduralFrameAccumulator = $true
+    $ContinuousWorldWorkset = $true
+    $ContinuousTrackWorld = $true
+    $ContinuousStaticWorld = $true
 }
 
 if (-not $StateRoot) {
@@ -259,6 +270,9 @@ $savedCensus = $env:REX_PINYON_SHIFT_NATIVE_RENDERER_CENSUS
 $savedDiscovery = $env:REX_PINYON_SHIFT_NATIVE_RENDERER_DISPATCH_DISCOVERY
 $savedProceduralFrameAccumulator =
     $env:REX_PINYON_SHIFT_NATIVE_RENDERER_PROCEDURAL_FRAME_ACCUMULATOR
+$savedScaledAccumulatorQualification =
+    $env:REX_PINYON_SHIFT_NATIVE_RENDERER_SCALED_ACCUMULATOR_QUALIFICATION
+$savedNativeRenderer = $env:REX_PINYON_SHIFT_NATIVE_RENDERER
 $savedScene = $env:PINYON_SHIFT_NATIVE_RENDERER_SCENE
 $savedIndexScan = $env:PINYON_SHIFT_NATIVE_RENDERER_INDEX_SCAN_SIGNATURE
 $savedTextureScan = $env:PINYON_SHIFT_NATIVE_RENDERER_TEXTURE_SCAN_SIGNATURE
@@ -315,6 +329,11 @@ try {
         } else { $savedDiscovery }
     $env:REX_PINYON_SHIFT_NATIVE_RENDERER_PROCEDURAL_FRAME_ACCUMULATOR =
         if ($ProceduralFrameAccumulator) { 'true' } else { $null }
+    $env:REX_PINYON_SHIFT_NATIVE_RENDERER_SCALED_ACCUMULATOR_QUALIFICATION =
+        if ($ScaledAccumulatorQualification) { 'true' } else { $null }
+    if ($ScaledAccumulatorQualification) {
+        $env:REX_PINYON_SHIFT_NATIVE_RENDERER = 'xenos'
+    }
     $env:PINYON_SHIFT_NATIVE_RENDERER_SCENE = $Scene
     $env:PINYON_SHIFT_NATIVE_RENDERER_INDEX_SCAN_SIGNATURE = $IndexScanSignature
     $env:PINYON_SHIFT_NATIVE_RENDERER_TEXTURE_SCAN_SIGNATURE = $TextureScanSignature
@@ -379,6 +398,9 @@ finally {
     $env:REX_PINYON_SHIFT_NATIVE_RENDERER_DISPATCH_DISCOVERY = $savedDiscovery
     $env:REX_PINYON_SHIFT_NATIVE_RENDERER_PROCEDURAL_FRAME_ACCUMULATOR =
         $savedProceduralFrameAccumulator
+    $env:REX_PINYON_SHIFT_NATIVE_RENDERER_SCALED_ACCUMULATOR_QUALIFICATION =
+        $savedScaledAccumulatorQualification
+    $env:REX_PINYON_SHIFT_NATIVE_RENDERER = $savedNativeRenderer
     $env:PINYON_SHIFT_NATIVE_RENDERER_SCENE = $savedScene
     $env:PINYON_SHIFT_NATIVE_RENDERER_INDEX_SCAN_SIGNATURE = $savedIndexScan
     $env:PINYON_SHIFT_NATIVE_RENDERER_TEXTURE_SCAN_SIGNATURE = $savedTextureScan

--- a/tools/tests/test_native_renderer_continuous_world_workset.py
+++ b/tools/tests/test_native_renderer_continuous_world_workset.py
@@ -385,6 +385,41 @@ class ContinuousWorldWorksetTests(unittest.TestCase):
             patch,
         )
 
+    def test_scaled_accumulator_qualification_keeps_xenos_authoritative(self):
+        source = (ROOT / "src/native_renderer/graphics_hooks.cpp").read_text(
+            encoding="utf-8"
+        )
+        capture = (
+            ROOT / "tools/capture-native-renderer-census.ps1"
+        ).read_text(encoding="utf-8")
+        self.assertIn(
+            "pinyon_shift_native_renderer_scaled_accumulator_qualification",
+            source,
+        )
+        self.assertIn("NativeScaledAccumulatorScaleSupported", source)
+        self.assertIn('== "2"', source)
+        self.assertIn(
+            'REXCVAR_GET(pinyon_shift_native_renderer) == "xenos"', source
+        )
+        self.assertIn('"armed_private_2x"', source)
+        self.assertIn('{"publication", "disabled"}', source)
+        self.assertIn('{"output_authority", "xenos"}', source)
+        self.assertIn("[switch]$ScaledAccumulatorQualification", capture)
+        qualification = capture.split(
+            "if ($ScaledAccumulatorQualification) {", 1
+        )[1]
+        self.assertIn("$ProceduralFrameAccumulator = $true", qualification)
+        self.assertIn("$ContinuousWorldWorkset = $true", qualification)
+        self.assertIn("$ContinuousTrackWorld = $true", qualification)
+        self.assertIn("$ContinuousStaticWorld = $true", qualification)
+        self.assertIn(
+            "$env:REX_PINYON_SHIFT_NATIVE_RENDERER = 'xenos'", capture
+        )
+        self.assertIn(
+            "$env:REX_PINYON_SHIFT_NATIVE_RENDERER = $savedNativeRenderer",
+            capture,
+        )
+
     def test_exact_track_color_only_replay_is_private_and_bounded(self):
         source = (ROOT / "src/native_renderer/graphics_hooks.cpp").read_text(
             encoding="utf-8"


### PR DESCRIPTION
## Summary\n- add a default-off 2x private accumulator qualification profile\n- require full census, explicit accumulator request, exact 2x2 scale, and Xenos renderer\n- enable the continuous track/static workset without publishing native output\n- restore all temporary environment overrides after launch\n\n## Validation\n- 722 Python tests\n- Release pinyon_shift build