### PR TITLE
fix(graphics): stabilize scaled accumulator chunks

### DIFF
--- a/patches/rexglue/0121-d3d12-accumulator-source-frame-lifetime.patch
+++ b/patches/rexglue/0121-d3d12-accumulator-source-frame-lifetime.patch
@@ -1,0 +1,28 @@
+From 2b835fb37c7393d95ef6658ca5999623597bbc1d Mon Sep 17 00:00:00 2001
+From: "Brandon G. Neri" <arcaniteamp@gmail.com>
+Date: Tue, 1 Sep 2026 16:10:00 -0600
+Subject: [PATCH] fix(graphics): retain accumulator source for frame
+
+---
+ src/graphics/d3d12/render_target_cache.cpp | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/src/graphics/d3d12/render_target_cache.cpp b/src/graphics/d3d12/render_target_cache.cpp
+index d6f7c0a..392fd81 100644
+--- a/src/graphics/d3d12/render_target_cache.cpp
++++ b/src/graphics/d3d12/render_target_cache.cpp
+@@ -2972,7 +2972,10 @@ D3D12RenderTargetCache::ApplyIsolatedReplayFrameAccumulator(
+   result.appended_row_end =
+       isolated_replay_frame_accumulator_appended_row_end_;
+   result.committed = request.commit;
+-  isolated_replay_frame_accumulator_source_frame_sequence_ = 0;
++  // A qualified retained replay target may provide multiple resolve chunks in
++  // the same frame. Keep its source identity until target reseeding or frame
++  // cancellation clears it, while the frame-sequence check above continues to
++  // reject stale and unrelated sources.
+   return result;
+ }
+ 
+-- 
+2.51.1.windows.1
+

--- a/patches/rexglue/0122-d3d12-fixed-resolve-accumulator-copy.patch
+++ b/patches/rexglue/0122-d3d12-fixed-resolve-accumulator-copy.patch
@@ -1,0 +1,133 @@
+From 9fc4dbb8d901bed211b94d9f88cae0223e779cf6 Mon Sep 17 00:00:00 2001
+From: "Brandon G. Neri" <arcaniteamp@gmail.com>
+Date: Tue, 1 Sep 2026 16:45:00 -0600
+Subject: [PATCH] fix(graphics): use fixed resolve for 4x accumulator
+
+---
+ .../graphics/d3d12/render_target_cache.h      |  5 ++
+ src/graphics/d3d12/render_target_cache.cpp   | 87 +++++++++++++++++++
+ 2 files changed, 92 insertions(+)
+
+diff --git a/include/rex/graphics/d3d12/render_target_cache.h b/include/rex/graphics/d3d12/render_target_cache.h
+index e6d86ae..9081bbf 100644
+--- a/include/rex/graphics/d3d12/render_target_cache.h
++++ b/include/rex/graphics/d3d12/render_target_cache.h
+@@ -759,6 +759,11 @@ class D3D12RenderTargetCache final : public RenderTargetCache {
+       isolated_replay_frame_accumulator_target_;
+   D3D12_RESOURCE_STATES isolated_replay_frame_accumulator_target_state_ =
+       D3D12_RESOURCE_STATE_COPY_DEST;
++  Microsoft::WRL::ComPtr<ID3D12Resource>
++      isolated_replay_frame_accumulator_resolved_source_;
++  D3D12_RESOURCE_STATES
++      isolated_replay_frame_accumulator_resolved_source_state_ =
++          D3D12_RESOURCE_STATE_RESOLVE_DEST;
+   ID3D12RootSignature*
+       isolated_replay_frame_accumulator_2xmsaa_root_signature_ = nullptr;
+   ID3D12PipelineState*
+diff --git a/src/graphics/d3d12/render_target_cache.cpp b/src/graphics/d3d12/render_target_cache.cpp
+index 9649485..f3829cf 100644
+--- a/src/graphics/d3d12/render_target_cache.cpp
++++ b/src/graphics/d3d12/render_target_cache.cpp
+@@ -1055,6 +1055,9 @@ void D3D12RenderTargetCache::Shutdown(bool from_destructor) {
+   isolated_replay_frame_accumulator_target_.Reset();
+   isolated_replay_frame_accumulator_target_state_ =
+       D3D12_RESOURCE_STATE_COPY_DEST;
++  isolated_replay_frame_accumulator_resolved_source_.Reset();
++  isolated_replay_frame_accumulator_resolved_source_state_ =
++      D3D12_RESOURCE_STATE_RESOLVE_DEST;
+   isolated_replay_frame_accumulator_frame_sequence_ = 0;
+   isolated_replay_frame_accumulator_committed_frame_sequence_ = 0;
+   isolated_replay_frame_accumulator_width_ = 0;
+@@ -2822,6 +2825,90 @@ D3D12RenderTargetCache::ApplyIsolatedReplayFrameAccumulator(
+         source_previous_state);
+     isolated_replay_frame_accumulator_target_state_ =
+         D3D12_RESOURCE_STATE_COPY_DEST;
++  } else if (source_desc.SampleDesc.Count == 4 &&
++             request.sample_select == 6) {
++    bool recreate_resolved_source =
++        !isolated_replay_frame_accumulator_resolved_source_;
++    if (!recreate_resolved_source) {
++      const D3D12_RESOURCE_DESC current =
++          isolated_replay_frame_accumulator_resolved_source_->GetDesc();
++      recreate_resolved_source = current.Width != source_desc.Width ||
++                                 current.Height != source_desc.Height ||
++                                 current.Format != source_desc.Format;
++    }
++    if (recreate_resolved_source) {
++      D3D12_RESOURCE_DESC resolved_desc = source_desc;
++      resolved_desc.Alignment = 0;
++      resolved_desc.SampleDesc.Count = 1;
++      resolved_desc.SampleDesc.Quality = 0;
++      resolved_desc.Flags = D3D12_RESOURCE_FLAG_NONE;
++      Microsoft::WRL::ComPtr<ID3D12Resource> resolved_source;
++      HRESULT create_result = device->CreateCommittedResource(
++          &ui::d3d12::util::kHeapPropertiesDefault,
++          command_processor_.GetD3D12Provider()
++              .GetHeapFlagCreateNotZeroed(),
++          &resolved_desc, D3D12_RESOURCE_STATE_RESOLVE_DEST, nullptr,
++          IID_PPV_ARGS(&resolved_source));
++      if (FAILED(create_result)) {
++        clear_active();
++        result.status =
++            system::GraphicsNativeFrameAccumulatorStatus::kAllocationFailed;
++        return result;
++      }
++      resolved_source->SetName(
++          L"Pinyon Shift private procedural frame accumulator resolved source");
++      isolated_replay_frame_accumulator_resolved_source_ =
++          std::move(resolved_source);
++      isolated_replay_frame_accumulator_resolved_source_state_ =
++          D3D12_RESOURCE_STATE_RESOLVE_DEST;
++    }
++
++    source_previous_state = isolated_color->SetResourceState(
++        D3D12_RESOURCE_STATE_RESOLVE_SOURCE);
++    command_processor_.PushTransitionBarrier(
++        source_resource, source_previous_state,
++        D3D12_RESOURCE_STATE_RESOLVE_SOURCE);
++    command_processor_.PushTransitionBarrier(
++        isolated_replay_frame_accumulator_resolved_source_.Get(),
++        isolated_replay_frame_accumulator_resolved_source_state_,
++        D3D12_RESOURCE_STATE_RESOLVE_DEST);
++    command_processor_.SubmitBarriers();
++    command_processor_.GetDeferredCommandList().D3DResolveSubresource(
++        isolated_replay_frame_accumulator_resolved_source_.Get(), 0,
++        source_resource, 0, source_desc.Format);
++    command_processor_.PushTransitionBarrier(
++        isolated_replay_frame_accumulator_resolved_source_.Get(),
++        D3D12_RESOURCE_STATE_RESOLVE_DEST,
++        D3D12_RESOURCE_STATE_COPY_SOURCE);
++    command_processor_.PushTransitionBarrier(
++        isolated_replay_frame_accumulator_target_.Get(),
++        isolated_replay_frame_accumulator_target_state_,
++        D3D12_RESOURCE_STATE_COPY_DEST);
++    command_processor_.SubmitBarriers();
++
++    D3D12_TEXTURE_COPY_LOCATION destination{};
++    destination.pResource = isolated_replay_frame_accumulator_target_.Get();
++    destination.Type = D3D12_TEXTURE_COPY_TYPE_SUBRESOURCE_INDEX;
++    D3D12_TEXTURE_COPY_LOCATION source{};
++    source.pResource =
++        isolated_replay_frame_accumulator_resolved_source_.Get();
++    source.Type = D3D12_TEXTURE_COPY_TYPE_SUBRESOURCE_INDEX;
++    D3D12_BOX source_box{request.source_x,
++                         request.source_y,
++                         0,
++                         request.source_x + request.source_width,
++                         request.source_y + request.source_height,
++                         1};
++    command_processor_.GetDeferredCommandList().D3DCopyTextureRegion(
++        &destination, 0, request.destination_row, 0, &source, &source_box);
++    isolated_color->SetResourceState(source_previous_state);
++    command_processor_.PushTransitionBarrier(
++        source_resource, D3D12_RESOURCE_STATE_RESOLVE_SOURCE,
++        source_previous_state);
++    isolated_replay_frame_accumulator_resolved_source_state_ =
++        D3D12_RESOURCE_STATE_COPY_SOURCE;
++    isolated_replay_frame_accumulator_target_state_ =
++        D3D12_RESOURCE_STATE_COPY_DEST;
+   } else {
+     if (!isolated_replay_frame_accumulator_2xmsaa_root_signature_) {
+       D3D12_ROOT_PARAMETER root_parameters[3]{};
+-- 
+2.51.1.windows.1

--- a/tools/tests/test_native_renderer_continuous_world_workset.py
+++ b/tools/tests/test_native_renderer_continuous_world_workset.py
@@ -385,6 +385,23 @@ class ContinuousWorldWorksetTests(unittest.TestCase):
             patch,
         )
 
+    def test_accumulator_source_remains_qualified_for_same_frame_chunks(self):
+        patch = (
+            ROOT
+            / "patches/rexglue/0121-d3d12-accumulator-source-frame-lifetime.patch"
+        ).read_text(encoding="utf-8")
+        self.assertIn("may provide multiple resolve chunks", patch)
+        self.assertIn("target reseeding or frame", patch)
+        self.assertIn("frame-sequence check above", patch)
+        self.assertIn(
+            "-  isolated_replay_frame_accumulator_source_frame_sequence_ = 0;",
+            patch,
+        )
+        self.assertNotIn(
+            "+  isolated_replay_frame_accumulator_source_frame_sequence_ = 0;",
+            patch,
+        )
+
     def test_scaled_accumulator_qualification_keeps_xenos_authoritative(self):
         source = (ROOT / "src/native_renderer/graphics_hooks.cpp").read_text(
             encoding="utf-8"

--- a/tools/tests/test_native_renderer_continuous_world_workset.py
+++ b/tools/tests/test_native_renderer_continuous_world_workset.py
@@ -402,6 +402,24 @@ class ContinuousWorldWorksetTests(unittest.TestCase):
             patch,
         )
 
+    def test_exact_4x_accumulator_uses_fixed_resolve_and_region_copy(self):
+        patch = (
+            ROOT
+            / "patches/rexglue/0122-d3d12-fixed-resolve-accumulator-copy.patch"
+        ).read_text(encoding="utf-8")
+        self.assertIn("source_desc.SampleDesc.Count == 4", patch)
+        self.assertIn("request.sample_select == 6", patch)
+        self.assertIn("D3DResolveSubresource", patch)
+        self.assertIn(
+            "isolated_replay_frame_accumulator_resolved_source_", patch
+        )
+        self.assertIn("D3D12_RESOURCE_STATE_RESOLVE_DEST", patch)
+        self.assertIn("D3D12_RESOURCE_STATE_COPY_SOURCE", patch)
+        self.assertIn("D3DCopyTextureRegion", patch)
+        self.assertIn("request.source_x + request.source_width", patch)
+        self.assertIn("request.source_y + request.source_height", patch)
+        self.assertIn("request.destination_row", patch)
+
     def test_scaled_accumulator_qualification_keeps_xenos_authoritative(self):
         source = (ROOT / "src/native_renderer/graphics_hooks.cpp").read_text(
             encoding="utf-8"

--- a/tools/tests/test_release_contract.py
+++ b/tools/tests/test_release_contract.py
@@ -43,10 +43,10 @@ class ReleaseContractTests(unittest.TestCase):
 
     def test_rexglue_patches_have_stable_order_and_no_binary_payload(self):
         patches = sorted((ROOT / "patches/rexglue").glob("*.patch"))
-        self.assertEqual(len(patches), 121)
+        self.assertEqual(len(patches), 122)
         self.assertEqual(
             patches[-1].name,
-            "0121-d3d12-accumulator-source-frame-lifetime.patch",
+            "0122-d3d12-fixed-resolve-accumulator-copy.patch",
         )
         self.assertEqual(len(patches), len({path.name[:4] for path in patches}))
         for path in patches:

--- a/tools/tests/test_release_contract.py
+++ b/tools/tests/test_release_contract.py
@@ -43,10 +43,10 @@ class ReleaseContractTests(unittest.TestCase):
 
     def test_rexglue_patches_have_stable_order_and_no_binary_payload(self):
         patches = sorted((ROOT / "patches/rexglue").glob("*.patch"))
-        self.assertEqual(len(patches), 120)
+        self.assertEqual(len(patches), 121)
         self.assertEqual(
             patches[-1].name,
-            "0120-d3d12-exact-accumulator-source-copy.patch",
+            "0121-d3d12-accumulator-source-frame-lifetime.patch",
         )
         self.assertEqual(len(patches), len({path.name[:4] for path in patches}))
         for path in patches:


### PR DESCRIPTION
## Summary

- retain the exact replay source qualification across all accumulator chunks in one frame
- replace the qualified 4x MSAA average compute dispatch with fixed-function D3D12 resolve plus exact region copies
- preserve Xenos output authority, guest memory, and draw behavior
- retain the compute implementation for other MSAA selection topologies

## Evidence

- before the fixed resolve, exact 3-chunk frames recorded successfully, then DRED identified DEVICE_HUNG at a DISPATCH operation
- Release pinyon_shift build succeeds
- all 724 Python tests pass
- corrected AppData-backed xenos/private-2x run exited normally after roughly six minutes with no device-removal or nvlddmkm event
- the final run remained source-gated and did not nondeterministically re-admit the rare accumulator workload, so CI and a future deterministic qualification capture remain part of the promotion gate

## Safety

- native publication remains disabled
- output authority remains Xenos
- draw suppression remains disabled
- save files were only read through the configured AppData state root