### PR TITLE
fix(native-renderer): block incomplete world publication

### DIFF
--- a/docs/native-renderer/REPRIORITIZED_PLAN.md
+++ b/docs/native-renderer/REPRIORITIZED_PLAN.md
@@ -1196,6 +1196,18 @@ accounting. It neither embeds the local catalog nor changes the normal
 prototype selector, Xenos execution, publication authority, or suppression.
 Runtime and visual proof is batched with the pending C1/C2 AppData run.
 
+Complete-scene publication correction: runtime visual evidence proved that the
+continuous workset reseeds its one retained target when attachment identity
+changes, then exposes whichever isolated family happens to finish last. That is
+the direct cause of the wrong camera and missing open world seen in the early
+prototype; it is not a presentation-scale issue. Workset replays remain private
+and fully observable, but deferred swap publication is now disabled and output
+stays Xenos-authoritative until a compositor can retain and join all required
+camera-consistent color families. This removes the misleading partial frame
+from the supported prototype path without discarding the native replay work.
+The next implementation slice is multi-target scene-family retention followed
+by an explicit complete-frame coverage gate.
+
 Representative-scene result: clean festival session
 `20260901T042139Z-p17172` exercised 6,016 exact generic model-presentation
 scopes but joined none to a `CSimpleModelRenderer`, resource graph, PM4 packet,

--- a/src/native_renderer/graphics_hooks.cpp
+++ b/src/native_renderer/graphics_hooks.cpp
@@ -11057,8 +11057,9 @@ void ValidateAndEmitContinuousWorldWorksetConfiguration() {
             : "disabled"},
        {"maximum_draws_per_frame",
         std::to_string(kContinuousWorldWorksetMaximumDrawsPerFrame)},
-       {"target_lifetime", "one_guest_frame"},
-       {"freshness_commit", "matching_swap_after_complete_accumulation"},
+        {"target_lifetime", "one_guest_frame"},
+        {"freshness_commit", "matching_swap_after_complete_accumulation"},
+        {"preview_publication", "disabled_pending_complete_scene_compositor"},
        {"semantic_lineage",
         semantic_lineage_armed ? "armed" : "unavailable"},
        {"readback", "disabled"},
@@ -11067,7 +11068,7 @@ void ValidateAndEmitContinuousWorldWorksetConfiguration() {
                            ? "continuous_world_workset"
                            : "false"},
        {"xenos_draw", "preserved"},
-       {"output_authority", "renderer_selector"},
+        {"output_authority", "xenos_until_complete_scene_compositor"},
        {"draw_suppression", "false"},
        {"suppression_eligible", "false"}});
 }
@@ -27596,11 +27597,12 @@ void EmitContinuousWorldWorksetEvent(const char *event_name,
         g_continuous_world_workset.static_world_requested
             ? "exact_presentation_resource_mesh_transform_lineage"
             : "disabled"},
-       {"freshness_commit", "matching_swap_after_complete_accumulation"},
+        {"freshness_commit", "matching_swap_after_complete_accumulation"},
+        {"preview_publication", "disabled_pending_complete_scene_compositor"},
        {"readback", "disabled"},
        {"native_draw", "continuous_world_workset"},
        {"xenos_draw", "preserved"},
-       {"output_authority", "renderer_selector"},
+        {"output_authority", "xenos_until_complete_scene_compositor"},
        {"draw_suppression", "false"},
        {"suppression_eligible", "false"}});
 }
@@ -28055,7 +28057,12 @@ void RequestIsolatedDraw(
     request.color_only_target = color_only_target;
     request.retain_target = true;
     request.reuse_target = reuse_target;
-    request.defer_preview_publication_until_swap = true;
+    // A target-family transition currently reseeds the single retained target,
+    // so the last successful replay is not proof of a complete scene. Keep the
+    // workset private until a compositor can preserve and join every required
+    // camera-consistent family. Publishing the last isolated target produces
+    // the known wrong-view / missing-world prototype.
+    request.defer_preview_publication_until_swap = false;
     request.frame_accumulator_source = exact_procedural_color_producer;
     request.frame_sequence = g_isolated_draw.frame;
     request.reference_marker_requested = true;

--- a/tools/tests/test_native_renderer_continuous_world_workset.py
+++ b/tools/tests/test_native_renderer_continuous_world_workset.py
@@ -120,7 +120,13 @@ class ContinuousWorldWorksetTests(unittest.TestCase):
         )
         self.assertIn("kContinuousWorldWorksetMaximumDrawsPerFrame = 64", source)
         self.assertIn("request.reuse_target = reuse_target", source)
-        self.assertIn("request.defer_preview_publication_until_swap = true", source)
+        self.assertIn("request.defer_preview_publication_until_swap = false", source)
+        self.assertIn(
+            '"disabled_pending_complete_scene_compositor"', source
+        )
+        self.assertIn(
+            '"xenos_until_complete_scene_compositor"', source
+        )
         self.assertIn("qualified_retained_family_requests", source)
         self.assertIn("prepared_track_texture_provider", source)
         self.assertIn("prepared_track_render_model_scope", source)


### PR DESCRIPTION
## Summary
- keep continuous native workset targets private instead of publishing the last isolated family as a complete frame
- preserve Xenos output authority until a multi-target complete-scene compositor is implemented
- document the wrong-camera/missing-world root cause and next implementation gate

## Validation
- `python -m pytest tools/tests/test_native_renderer_continuous_world_workset.py tools/tests/test_native_renderer_prototype_presentation.py -q` (35 passed)
- clean Release build from freshly prepared ReXGlue tree
- `git diff --check`